### PR TITLE
ci: enforce --warnings-as-errors and credo --strict on lint job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,9 +47,29 @@ jobs:
 
       - run: mix deps.get 2>&1 | tee /tmp/deps.log
       - run: mix format --check-formatted 2>&1 | tee /tmp/format.log
-      - run: mix compile 2>&1 | tee /tmp/compile.log
+      - run: mix compile --warnings-as-errors 2>&1 | tee /tmp/compile.log
         id: compile_step
         continue-on-error: true
+      - run: mix credo --strict 2>&1 | tee /tmp/credo.log
+        id: credo_step
+        continue-on-error: true
+      - name: Push lint logs to ci-log branch on failure
+        if: steps.compile_step.outcome == 'failure' || steps.credo_step.outcome == 'failure'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -ex
+          git config user.email "ci@local"
+          git config user.name "ci"
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
+          mkdir -p .ci-logs
+          tail -300 /tmp/compile.log > .ci-logs/lint-compile.log || echo "no compile log"
+          tail -300 /tmp/credo.log   > .ci-logs/lint-credo.log   || echo "no credo log"
+          git checkout --orphan ci-log/lint 2>&1 || true
+          git rm -rf --cached . 2>&1 || true
+          git add -f .ci-logs/lint-compile.log .ci-logs/lint-credo.log
+          git commit -m "ci-log: lint on ${{ github.sha }} (compile=${{ steps.compile_step.outcome }} credo=${{ steps.credo_step.outcome }})" 2>&1 || true
+          git push origin ci-log/lint --force 2>&1 || true
       - name: Comment compile log on PR (on failure)
         if: steps.compile_step.outcome == 'failure' && github.event_name == 'pull_request'
         env:
@@ -63,10 +83,25 @@ jobs:
             echo '```'
           } > /tmp/comment.md
           gh pr comment ${{ github.event.pull_request.number }} --body-file /tmp/comment.md
+      - name: Comment credo log on PR (on failure)
+        if: steps.credo_step.outcome == 'failure' && github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          {
+            echo "## Lint job — credo --strict failure on \`${{ github.sha }}\`"
+            echo
+            echo '```'
+            tail -120 /tmp/credo.log
+            echo '```'
+          } > /tmp/comment.md
+          gh pr comment ${{ github.event.pull_request.number }} --body-file /tmp/comment.md
       - name: Fail the job if compile failed
         if: steps.compile_step.outcome == 'failure'
         run: exit 1
-      - run: mix credo --strict || true
+      - name: Fail the job if credo failed
+        if: steps.credo_step.outcome == 'failure'
+        run: exit 1
 
   test:
     name: test (Elixir ${{ matrix.elixir }} · OTP ${{ matrix.otp }})


### PR DESCRIPTION
## Summary

- Flip both lint gates from tolerated to enforced: `mix compile --warnings-as-errors` and `mix credo --strict` (no `|| true`). CLAUDE.md non-negotiable already required compile to be warning-free; this commit makes CI uphold it.
- Add a `ci-log/lint` orphan-branch push step (mirrors the existing `ci-log/test-…` pattern) so a non-PR push that fails lint still leaves a readable tail in `.ci-logs/lint-compile.log` and `.ci-logs/lint-credo.log`. PR-comment plumbing is preserved and extended to credo.
- Backlog hygiene done in the same session: closed `#52` (test FSM leaks, fixed in f201275), `#53` (dead Memory.Cache, fixed in f201275), `#60` (bash deadline drift, fixed in 1615ef6) — all already-fixed-but-still-open.

Closes #13, #14.

## Test plan

- [x] CI green on `claude/status-report-next-steps-iaf1d`: lint, test (Elixir 1.17.3 + 1.18.1), dialyzer, escript all pass on commit `ae35f40`.
- [x] No `ci-log/lint` branch was created — confirms `--warnings-as-errors` and `--strict` both pass on the current tree.
- [ ] Verify the failure path the next time lint actually fails: confirm `ci-log/lint` is force-pushed with a fresh tail of compile + credo logs.

https://claude.ai/code/session_01JQH97sbJjYF9TzAFgfC18W

---
_Generated by [Claude Code](https://claude.ai/code/session_01JQH97sbJjYF9TzAFgfC18W)_