### PR TITLE
fix: postpone user_message casts during an active turn (ADR-0009)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Repo wiped of unrelated Clojure AoC2020 content.
 
+### Fixed
+- Session FSM: `{:user_message, _}` casts that arrive while the session
+  is mid-turn (`:provider_streaming` / `:tool_executing`) are now
+  postponed via `:gen_statem`'s built-in `:postpone` action and
+  re-delivered on return to `:awaiting_user`, preserving cast order
+  and preventing interleaving with the active provider stream or
+  tool execution. New telemetry:
+  `[:tau, :session, :user_message, :enqueued | :delivered]`. See
+  ADR-0009. (Closes #64.)
+
 ### Notes
 - Local toolchain in the dev sandbox is Elixir 1.17.3 / OTP 25.3.
   `mix format --check-formatted` is clean across all 80+ files.

--- a/docs/adr/0009-user-messages-queue-during-active-turn.md
+++ b/docs/adr/0009-user-messages-queue-during-active-turn.md
@@ -1,0 +1,144 @@
+# ADR-0009: User messages queue (postpone) during an active turn
+
+- **Status:** Accepted
+- **Date:** 2026-05-01
+- **Deciders:** the agent loop, with no objection from @smug-haus
+- **Related:**
+  - Issue: #64
+  - Code: `lib/tau/session.ex` (`handle_event(:cast, {:user_message, _}, …)`)
+  - Prior: ADR-0008 (user code never runs synchronously inside the FSM)
+
+## Context
+
+`Tau.Session` is a `:gen_statem` with four user-visible states:
+`:awaiting_user`, `:provider_streaming`, `:tool_executing`, and the
+implicit `:stopped` (gen_statem terminates immediately on `:stop`).
+
+Until this ADR, the user-message handler matched any state:
+
+```elixir
+def handle_event(:cast, {:user_message, msg}, _state, data) do
+  case classify_slash_command(msg) do
+    {:async, mod, args, msg} -> spawn_command_task(mod, args, msg, data)
+    {:sync, msg}             -> process_user_message(msg, data)
+  end
+end
+```
+
+A user cast that arrived during `:provider_streaming` or
+`:tool_executing` would append to `data.messages`, persist a
+`"user_message"` event, and call `start_provider` again — racing with
+the still-live `provider_task` and the `:provider_event` /
+`:tool_done` traffic already in the mailbox (#64). Even when no race
+manifested, the second user message could land mid-tool-call and end
+up adjacent to a `tool_call` block in the transcript without its
+matching `tool_result`, which providers reject.
+
+ADR-0008 already established that follow-up user messages **must
+queue, not drop**: a user typing while a slash-command worker is in
+flight has their input postponed. We need the same guarantee
+covering provider-streaming and tool-executing — not just slash
+commands.
+
+## Decision
+
+The session FSM accepts `{:user_message, _}` casts only in
+`:awaiting_user`. In every other state (and while
+`data.command_task != nil`, per ADR-0008) the cast is **postponed**
+via gen_statem's built-in `:postpone` action; gen_statem re-delivers
+postponed events on the next state transition, so the message lands
+naturally on entry into `:awaiting_user` without the FSM maintaining
+its own queue.
+
+Specifics:
+
+- Two clauses fire on `{:cast, {:user_message, _}}`:
+
+  1. A guard clause matching anything other than `:awaiting_user`
+     (or `:awaiting_user` while `command_task != nil`) returns
+     `{:keep_state_and_data, [{:postpone, true}]}` and emits
+     `[:tau, :session, :user_message, :enqueued]` telemetry.
+  2. The existing accept clause matches only `:awaiting_user` (and
+     `command_task == nil`) and proceeds with `classify_slash_command`
+     + dispatch as before, emitting
+     `[:tau, :session, :user_message, :delivered]` telemetry.
+
+- Telemetry pairs but **does not span**: there is no monotonic
+  `duration` measurement linking enqueue to delivery, because
+  postponed events are re-delivered through the gen_statem mailbox
+  and not labeled. Each event carries `session_id`, `from_state`
+  (the state we postponed in / delivered in), and the canonical
+  `system_time` measurement.
+
+- Cancellation interaction: postponed events **survive** a `:cancel`
+  cast. The existing cancel handler returns
+  `{:next_state, :awaiting_user, …}`, which triggers gen_statem's
+  postpone-redelivery. The user's queued follow-up runs immediately
+  after cancel, on a clean turn. This matches user intent: cancel
+  ends *this* turn, not all queued input.
+
+- Stopped-state interaction: `:stop` returns `{:stop, :normal, _}`,
+  terminating the process and dropping the mailbox (including any
+  postponed events). This is correct — stopping ends the session.
+
+- Snapshot interaction: `Tau.Session.snapshot/1` does not expose
+  postponed messages. Postponed events live in the gen_statem's
+  internal queue, not in `data`, and there is no public API to
+  introspect them. If a future TUI panel needs "show pending input",
+  we'll switch to an explicit queue field at that time.
+
+## Consequences
+
+- A `{:user_message, _}` cast in flight during a tool call or
+  provider stream lands in order on the next return to
+  `:awaiting_user`. No race on the provider task, no orphaned
+  `tool_call` blocks.
+- Per-source FIFO is preserved: gen_statem postpones reorder nothing
+  — events come back in arrival order on the next transition.
+- The session's `data` struct gains nothing new — no
+  `pending_user_messages` field to keep in sync with the mailbox.
+- No callers see a behavioural break. The cast contract is unchanged
+  (`:gen_statem.cast/2` returns `:ok` regardless of whether delivery
+  is immediate or postponed).
+- The runtime cost is one extra clause-match per user_message cast
+  arriving in a non-idle state. Postponed events sit in the
+  gen_statem internal queue and are O(n) on the next state-change
+  scan; bounded by the user's typing rate, this is unmeasurable.
+- Postponed events are not visible to `:sys.get_status/1` callers
+  outside of the postpone-internal queue. Operators debugging a
+  stuck session will see them via `erlang:process_info(pid,
+  :messages)`.
+
+## Alternatives considered
+
+- **Explicit `pending_user_messages` queue field on `data`,
+  drained on entry into `:awaiting_user`.** This is what the
+  status-report draft proposed. It works, but reimplements what
+  gen_statem already does for free — and it diverges from
+  ADR-0008's `:postpone` pattern that's already in this module
+  for the slash-command-task case, which would be confusing to
+  read. The only thing this approach buys us is introspectability
+  via `snapshot/1`, which no caller needs today.
+
+- **Drop or error the cast when busy.** A drop loses user input
+  silently; a synchronous error tuple is incompatible with
+  `:gen_statem.cast/2`'s fire-and-forget contract. Both punt the
+  ordering problem onto callers who shouldn't have to know the
+  FSM's current state.
+
+- **Block the sender (turn the cast into a `call`).** Couples the
+  caller's lifecycle to the session and re-introduces every
+  problem ADR-0008 was written to solve (a slow provider stream
+  blocks the API caller).
+
+## Notes
+
+The same shape ports cleanly to other "owner-private" cast events
+that should respect turn boundaries — e.g. compaction-trigger casts,
+should we ever expose them. The pattern is: only accept in
+`:awaiting_user`; postpone elsewhere.
+
+The `[:tau, :session, :user_message, :delivered]` event fires on the
+clause that previously had no telemetry; it's the canonical hook for
+"a user turn began" and supersedes ad-hoc inferences from
+`[:tau, :session, :transition]` with `to: :provider_streaming`.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -62,6 +62,7 @@ get rewritten away by the next refactor. ADRs survive.
 | [0006](0006-defer-tau-memory-cache-until-measured.md) | Defer `Tau.Memory.Cache` until measurements justify it | Accepted |
 | [0007](0007-compaction-summaries-survive-recompaction.md) | Compaction summaries are pinned across re-compaction | Accepted |
 | [0008](0008-user-code-never-runs-synchronously-in-the-fsm.md) | User code never runs synchronously inside the session FSM | Accepted |
+| [0009](0009-user-messages-queue-during-active-turn.md) | User messages queue (postpone) during an active turn | Accepted |
 
 (New ADRs append here. Keep the table sorted by ADR number.)
 

--- a/lib/tau/session.ex
+++ b/lib/tau/session.ex
@@ -424,12 +424,24 @@ defmodule Tau.Session do
   # ADR-0008: while a slash-command task is in flight, postpone any
   # subsequent user_message casts. They get re-delivered when the FSM
   # next transitions, which guarantees order without dropping input.
-  def handle_event(:cast, {:user_message, _}, _state, %{command_task: t} = _data)
+  def handle_event(:cast, {:user_message, _}, state, %{command_task: t} = data)
       when t != nil do
+    emit_user_message_telemetry(:enqueued, data, state)
     {:keep_state_and_data, [{:postpone, true}]}
   end
 
-  def handle_event(:cast, {:user_message, msg}, _state, data) do
+  # ADR-0009: outside :awaiting_user (provider streaming or tool
+  # executing) postpone the cast so the next provider turn doesn't
+  # interleave with the current one.
+  def handle_event(:cast, {:user_message, _}, state, data)
+      when state != :awaiting_user do
+    emit_user_message_telemetry(:enqueued, data, state)
+    {:keep_state_and_data, [{:postpone, true}]}
+  end
+
+  def handle_event(:cast, {:user_message, msg}, :awaiting_user, %{command_task: nil} = data) do
+    emit_user_message_telemetry(:delivered, data, :awaiting_user)
+
     case classify_slash_command(msg) do
       {:async, mod, args, msg} ->
         spawn_command_task(mod, args, msg, data)
@@ -939,6 +951,18 @@ defmodule Tau.Session do
 
   defp broadcast(id, event) do
     Phoenix.PubSub.broadcast(Tau.PubSub, "session:#{id}", event)
+  end
+
+  # ADR-0009: telemetry pairs but does not span — postponed events
+  # may emit :enqueued multiple times if the FSM transitions through
+  # several non-idle states before reaching :awaiting_user. Each
+  # :enqueued reflects a real postpone-and-rewind decision.
+  defp emit_user_message_telemetry(event, data, state) do
+    :telemetry.execute(
+      [:tau, :session, :user_message, event],
+      %{system_time: System.system_time()},
+      %{session_id: data.id, from_state: state}
+    )
   end
 
   # --- Hook payload --------------------------------------------------------

--- a/test/tau/session/user_message_queue_test.exs
+++ b/test/tau/session/user_message_queue_test.exs
@@ -1,0 +1,143 @@
+defmodule Tau.Session.UserMessageQueueTest do
+  @moduledoc """
+  Verifies #64 / ADR-0009: `{:user_message, _}` casts that arrive
+  while the FSM is not in `:awaiting_user` are postponed and
+  re-delivered in cast order on the next return to idle.
+
+  The property exercises the FIFO guarantee end-to-end through the
+  Replay provider; the unit test pins the telemetry contract
+  (`:enqueued` / `:delivered`).
+  """
+  use ExUnit.Case, async: false
+  use ExUnitProperties
+
+  import Tau.Test.SessionHelper, only: [start_session_for_test: 1]
+  alias Tau.Provider.Event
+  alias Tau.Session.Events, as: SE
+
+  @moduletag :property
+
+  setup do
+    tmp = Path.join(System.tmp_dir!(), "tau-uqueue-#{System.unique_integer([:positive])}")
+    File.mkdir_p!(tmp)
+    Application.put_env(:tau, :data_dir, tmp)
+
+    on_exit(fn ->
+      File.rm_rf!(tmp)
+      Application.delete_env(:tau, :data_dir)
+    end)
+
+    :ok
+  end
+
+  property "user_messages cast during a turn persist in cast order" do
+    # Each run starts a real session under Tau.Sessions.Supervisor
+    # and writes JSONL, so max_runs is intentionally small.
+    check all(n <- StreamData.integer(2..5), max_runs: 8) do
+      fixture = [
+        %Event.Start{request_id: "r", model: "replay"},
+        %Event.TextStart{block_id: "b"},
+        %Event.TextDelta{block_id: "b", text: "ack"},
+        %Event.TextEnd{block_id: "b"},
+        %Event.Done{stop_reason: :stop, usage: %{}}
+      ]
+
+      sid = "uqueue-prop-#{System.unique_integer([:positive])}"
+      Phoenix.PubSub.subscribe(Tau.PubSub, "session:#{sid}")
+
+      {:ok, ^sid} =
+        start_session_for_test(
+          provider: Tau.Providers.Replay,
+          model: "replay",
+          session_id: sid,
+          provider_ctx: %{replay_fixture: fixture}
+        )
+
+      msgs = for i <- 1..n, do: "msg-#{i}"
+      Enum.each(msgs, &Tau.send(sid, &1))
+
+      # Drain N MessageEnd events — one per turn the FSM completes.
+      for _ <- 1..n do
+        receive do
+          %SE.MessageEnd{} -> :ok
+        after
+          5_000 -> flunk("timed out waiting for turn to complete")
+        end
+      end
+
+      Phoenix.PubSub.unsubscribe(Tau.PubSub, "session:#{sid}")
+
+      user_contents =
+        sid
+        |> jsonl_path()
+        |> File.read!()
+        |> String.split("\n", trim: true)
+        |> Enum.map(&Jason.decode!/1)
+        |> Enum.filter(&(&1["kind"] == "user_message"))
+        |> Enum.map(&get_in(&1, ["data", "content"]))
+
+      assert user_contents == msgs,
+             "user_message JSONL order should match cast order; got #{inspect(user_contents)}"
+    end
+  end
+
+  test "casts during :provider_streaming emit :enqueued; idle casts emit :delivered" do
+    fixture = [
+      %Event.Start{request_id: "r", model: "replay"},
+      %Event.TextStart{block_id: "b"},
+      %Event.TextDelta{block_id: "b", text: "ack"},
+      %Event.TextEnd{block_id: "b"},
+      %Event.Done{stop_reason: :stop, usage: %{}}
+    ]
+
+    sid = "uqueue-tel-#{System.unique_integer([:positive])}"
+    parent = self()
+    handler_id = "uqueue-h-#{System.unique_integer([:positive])}"
+
+    :telemetry.attach_many(
+      handler_id,
+      [
+        [:tau, :session, :user_message, :enqueued],
+        [:tau, :session, :user_message, :delivered]
+      ],
+      fn evt, _m, meta, _ -> send(parent, {:tel, List.last(evt), meta}) end,
+      nil
+    )
+
+    on_exit(fn -> :telemetry.detach(handler_id) end)
+
+    Phoenix.PubSub.subscribe(Tau.PubSub, "session:#{sid}")
+
+    {:ok, ^sid} =
+      start_session_for_test(
+        provider: Tau.Providers.Replay,
+        model: "replay",
+        session_id: sid,
+        provider_ctx: %{replay_fixture: fixture}
+      )
+
+    # Cast both messages in tight succession. The first cast is the
+    # head of the mailbox, so the FSM processes it from :awaiting_user
+    # and transitions to :provider_streaming before pulling the second
+    # cast — which therefore lands during streaming and is postponed.
+    Tau.send(sid, "first")
+    Tau.send(sid, "second")
+
+    assert_receive {:tel, :delivered, %{from_state: :awaiting_user, session_id: ^sid}}, 1_000
+    assert_receive {:tel, :enqueued, %{from_state: :provider_streaming, session_id: ^sid}}, 1_000
+
+    # Drain the two turns.
+    for _ <- 1..2 do
+      assert_receive %SE.MessageEnd{}, 5_000
+    end
+
+    # The postponed "second" was re-delivered on entry into
+    # :awaiting_user; that fired a second :delivered event.
+    assert_receive {:tel, :delivered, %{from_state: :awaiting_user, session_id: ^sid}}, 1_000
+  end
+
+  defp jsonl_path(sid) do
+    [path] = Path.wildcard(Path.join(Tau.Settings.data_dir(), "sessions/*/#{sid}.jsonl"))
+    path
+  end
+end


### PR DESCRIPTION
## Summary

- Closes #64. The session FSM accepted `{:user_message, _}` casts in any state — a cast during `:provider_streaming` or `:tool_executing` would append to `data.messages`, persist a `"user_message"` event, and re-enter `start_provider`, racing with the still-live provider task and in-flight `:provider_event` / `:tool_done` traffic.
- New ADR-0009 documents the decision: use `:gen_statem`'s built-in `:postpone` action (mirroring ADR-0008's slash-command-task pattern) rather than a manual `pending_user_messages` queue.
- Three handler clauses now: (1) ADR-0008 `command_task != nil` → postpone; (2) ADR-0009 `state != :awaiting_user` → postpone; (3) `:awaiting_user` + `command_task: nil` → accept. All three emit `[:tau, :session, :user_message, :enqueued | :delivered]` telemetry.

## Why `:postpone` over a manual queue

- gen_statem already preserves arrival order on postpone-and-rewind. Reimplementing FIFO inside `data` would diverge from the existing ADR-0008 path in the same module.
- Restart drops the mailbox, which is the correct behaviour: a session restart starts fresh, queued user input from the previous incarnation shouldn't survive.
- Cancel returns to `:awaiting_user` — postponed events re-attempt and are delivered, which matches user intent (cancel ends *this* turn, not all queued input).
- Tradeoff: postponed messages aren't visible via `Tau.Session.snapshot/1`. Today no caller needs that; if a TUI panel later wants "show pending input" we'd switch to an explicit queue field. Documented in the ADR.

## Test plan

- [x] Property test (`test/tau/session/user_message_queue_test.exs` under `@moduletag :property`) — N rapid casts produce N `user_message` JSONL entries in cast order, end-to-end through the Replay provider.
- [x] Telemetry unit test in the same file — pins `:enqueued` (with `from_state: :provider_streaming`) and `:delivered` (with `from_state: :awaiting_user`) using deterministic mailbox ordering.
- [ ] CI — `mix compile --warnings-as-errors`, `mix format --check-formatted`, `mix credo --strict`, `mix test`, `mix test --only property` (the lint gates from PR #75 are now in place).

## Files

- `docs/adr/0009-user-messages-queue-during-active-turn.md` (new) + index entry in `docs/adr/README.md`.
- `lib/tau/session.ex` — three clauses + `emit_user_message_telemetry/3` helper.
- `test/tau/session/user_message_queue_test.exs` (new).
- `CHANGELOG.md` — `### Fixed` entry under `[Unreleased]`.

The 0.1.0 release CHANGELOG bump is intentionally **not** in this PR — that's a separate logical change and ships in a follow-up branch once this lands.

https://claude.ai/code/session_011bAhaU738pEzP52sVs8RUQ

---
_Generated by [Claude Code](https://claude.ai/code/session_011bAhaU738pEzP52sVs8RUQ)_