### PR TITLE
chore: cut 0.1.0 — move [Unreleased] entries under [0.1.0] heading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] — 0.1.0 candidate
+## [Unreleased]
+
+## [0.1.0] — 2026-05-01
 
 ### Added (milestones M0 — M8)
 


### PR DESCRIPTION
## Summary

- Pure section-header bump in `CHANGELOG.md`: `## [Unreleased] — 0.1.0 candidate` becomes a fresh empty `## [Unreleased]` plus `## [0.1.0] — 2026-05-01`. No entries are altered.
- `mix.exs` already declares `@version "0.1.0"` — no version-string change needed in source.
- The release workflow (`.github/workflows/release.yml`) is wired correctly: it triggers on `v*` tag pushes and runs the burrito matrix (`linux_amd64 / linux_arm64 / macos_amd64 / macos_arm64 / windows_amd64`), publishes to Hex (`HEX_API_KEY` secret required), publishes ex_doc to gh-pages, and creates a GitHub Release with SHA256SUMS.

## Sequencing

This depends on **#76** (the `#64` fix) landing first so that PR's `### Fixed` entry under `[Unreleased]` is the entry that ends up under `[0.1.0]` once this bump lands. If this is rebased onto post-#76 main, the diff stays a pure header rename.

## Cutting the tag

Per the original status report I'm **not** tagging the release. Once this PR is merged, the maintainer pushes:

```sh
git tag v0.1.0
git push origin v0.1.0
```

That fires the release workflow. No additional manual steps.

## Test plan

- [x] CHANGELOG renders cleanly (Keep-a-Changelog format preserved).
- [x] `mix.exs` `@version` already at `0.1.0`.
- [ ] After merge + tag push, verify the Burrito matrix completes for all 5 targets and the GitHub Release contains the expected artefacts + SHA256SUMS.
- [ ] After merge + tag push, verify Hex publish succeeds (or that `HEX_API_KEY` is set, if previously unconfigured).
- [ ] After merge + tag push, verify ex_doc deploys to gh-pages.

https://claude.ai/code/session_011bAhaU738pEzP52sVs8RUQ

---
_Generated by [Claude Code](https://claude.ai/code/session_011bAhaU738pEzP52sVs8RUQ)_