### PR TITLE
feat: Tau.Provider.chat/4 non-streaming convenience (closes #36)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `Tau.Provider.chat/4` — provider-agnostic non-streaming entry point
+  that drains `stream/3` through `Tau.Message.Assembler` and returns
+  the assembled `%Assistant{}`. Provider modules can override via the
+  optional `@callback chat/3` for native non-SSE endpoints. (Refs #19,
+  closes #36.)
+
 ## [0.1.0] — 2026-05-01
 
 ### Added (milestones M0 — M8)

--- a/lib/tau/provider.ex
+++ b/lib/tau/provider.ex
@@ -64,9 +64,68 @@ defmodule Tau.Provider do
 
   @callback configure(map()) :: {:ok, map()} | {:error, term()}
 
-  @optional_callbacks [configure: 1]
+  @doc """
+  Non-streaming convenience: drains `stream/3` and returns the
+  assembled `%Tau.Message.Assistant{}`. Optional override for
+  providers with a native non-SSE endpoint (e.g. private deployments
+  that prefer a single request/response). Callers that want to stay
+  provider-agnostic should call `Tau.Provider.chat/4` instead, which
+  dispatches to this callback if defined and falls back to a default
+  drain otherwise.
+  """
+  @callback chat(messages(), stream_opts(), ctx()) ::
+              {:ok, Tau.Message.Assistant.t()} | {:error, term()}
+
+  @optional_callbacks [configure: 1, chat: 3]
 
   @doc "Look up the configured default provider."
   @spec default() :: module()
   def default, do: Application.get_env(:tau, :default_provider, Tau.Providers.Anthropic)
+
+  @doc """
+  Provider-agnostic non-streaming entry point.
+
+  If `provider` exports `chat/3`, delegates. Otherwise drains
+  `provider.stream/3` through `Tau.Message.Assembler` and returns
+  the final assistant message.
+
+  Error surface (default-impl):
+
+    * Synchronous `{:error, reason}` from `stream/3` surfaces
+      unchanged — these are configuration errors (missing API
+      key, malformed model id) that the caller should fix.
+    * An in-stream `%Tau.Provider.Event.Error{}` produces
+      `{:error, reason}` carrying the original event's reason.
+      Streaming callers see partial content and a synthetic
+      `%Assistant{stop_reason: :error}`; non-streaming callers
+      get a clean tagged tuple instead.
+
+  Provider overrides are free to choose their own error semantics
+  (e.g. retrying internally before returning).
+  """
+  @spec chat(module(), messages(), stream_opts(), ctx()) ::
+          {:ok, Tau.Message.Assistant.t()} | {:error, term()}
+  def chat(provider, messages, opts \\ %{}, ctx \\ %{}) do
+    if function_exported?(provider, :chat, 3) do
+      provider.chat(messages, opts, ctx)
+    else
+      drain_stream(provider, messages, opts, ctx)
+    end
+  end
+
+  defp drain_stream(provider, messages, opts, ctx) do
+    with {:ok, stream} <- provider.stream(messages, opts, ctx) do
+      assembler =
+        Enum.reduce(
+          stream,
+          Tau.Message.Assembler.new(provider: provider, model: opts[:model]),
+          fn ev, acc -> Tau.Message.Assembler.step(acc, ev) end
+        )
+
+      case assembler do
+        %{error: nil} = a -> {:ok, Tau.Message.Assembler.assistant(a)}
+        %{error: reason} -> {:error, reason}
+      end
+    end
+  end
 end

--- a/test/tau/provider_test.exs
+++ b/test/tau/provider_test.exs
@@ -1,0 +1,97 @@
+defmodule Tau.ProviderTest do
+  @moduledoc """
+  Covers the `Tau.Provider.chat/4` provider-agnostic entry point
+  (#36): default-impl drain, native-override delegation, and error
+  surface.
+  """
+  use ExUnit.Case, async: true
+
+  alias Tau.Provider.Event
+
+  defmodule SyncErrorProvider do
+    @behaviour Tau.Provider
+
+    @impl true
+    def stream(_msgs, _opts, _ctx), do: {:error, :missing_api_key}
+
+    @impl true
+    def capabilities,
+      do: %{thinking: false, tools: false, vision: false, prompt_caching: false, parallel_tools: false}
+
+    @impl true
+    def default_model, do: "sync-err"
+  end
+
+  defmodule NativeChatProvider do
+    @behaviour Tau.Provider
+
+    @impl true
+    def stream(_msgs, _opts, _ctx) do
+      raise "stream/3 should not be called when chat/3 is defined"
+    end
+
+    @impl true
+    def capabilities,
+      do: %{thinking: false, tools: false, vision: false, prompt_caching: false, parallel_tools: false}
+
+    @impl true
+    def default_model, do: "native"
+
+    @impl true
+    def chat(_msgs, _opts, _ctx) do
+      {:ok, Tau.Message.Assistant.new(content: [%{type: :text, text: "native"}], stop_reason: :stop)}
+    end
+  end
+
+  describe "Tau.Provider.chat/4 default implementation" do
+    test "drains a Replay stream into an assembled %Assistant{}" do
+      fixture = [
+        %Event.Start{request_id: "r", model: "replay"},
+        %Event.TextStart{block_id: "b"},
+        %Event.TextDelta{block_id: "b", text: "hello "},
+        %Event.TextDelta{block_id: "b", text: "world"},
+        %Event.TextEnd{block_id: "b"},
+        %Event.Done{stop_reason: :stop, usage: %{output_tokens: 2}}
+      ]
+
+      {:ok, msg} =
+        Tau.Provider.chat(
+          Tau.Providers.Replay,
+          [Tau.Message.User.new("hi")],
+          %{model: "replay"},
+          %{replay_fixture: fixture}
+        )
+
+      assert %Tau.Message.Assistant{stop_reason: :stop} = msg
+      assert [%{type: :text, text: "hello world"}] = msg.content
+      assert msg.usage == %{output_tokens: 2}
+    end
+
+    test "in-stream %Event.Error{} surfaces as {:error, reason}" do
+      fixture = [
+        %Event.Start{request_id: "r", model: "replay"},
+        %Event.Error{reason: {:http_status, 503}, retryable?: true}
+      ]
+
+      assert {:error, {:http_status, 503}} =
+               Tau.Provider.chat(
+                 Tau.Providers.Replay,
+                 [Tau.Message.User.new("hi")],
+                 %{},
+                 %{replay_fixture: fixture}
+               )
+    end
+
+    test "synchronous {:error, _} from stream/3 surfaces unchanged" do
+      assert {:error, :missing_api_key} =
+               Tau.Provider.chat(SyncErrorProvider, [Tau.Message.User.new("hi")], %{}, %{})
+    end
+  end
+
+  describe "Tau.Provider.chat/4 native override" do
+    test "delegates to provider.chat/3 when exported, bypassing stream/3" do
+      assert {:ok, msg} = Tau.Provider.chat(NativeChatProvider, [], %{}, %{})
+      assert [%{type: :text, text: "native"}] = msg.content
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Closes #36 (sub-issue of #19, multi-provider reliability tracker).
- Adds `@callback chat/3` to `Tau.Provider` as `@optional_callbacks`, plus a default-impl `Tau.Provider.chat/4` that drains `stream/3` through `Tau.Message.Assembler` and returns the final `%Tau.Message.Assistant{}`.
- Six existing providers (Anthropic, OpenAI Chat / Responses, Gemini, Bedrock, Replay) pick up the convenience entry point with zero code changes; native non-SSE endpoints can override.

## Error surface

- Synchronous `{:error, reason}` from `stream/3` surfaces unchanged (configuration errors).
- In-stream `%Event.Error{}` produces `{:error, reason}` carrying the original event's reason. Streaming callers still observe the in-band error via the assembler; non-streaming callers get a clean tagged tuple.

This matches the recipe in the issue body (`%{error: nil}` → `{:ok, _}`, `%{error: reason}` → `{:error, reason}`).

## Test plan

- [x] `Tau.ProviderTest` (new file) covers four cases:
  - Drains a Replay stream into a complete `%Assistant{}` with the right text + usage.
  - In-stream `%Event.Error{}` → `{:error, {:http_status, 503}}`.
  - Synchronous `{:error, _}` from `stream/3` surfaces unchanged.
  - Native `chat/3` override is preferred over `stream/3` when defined.
- [ ] CI — `mix compile --warnings-as-errors`, `mix format --check-formatted`, `mix credo --strict`, `mix test`.

## Files

- `lib/tau/provider.ex` — `chat/3` callback + `Tau.Provider.chat/4` + helper `drain_stream/4`.
- `test/tau/provider_test.exs` (new).
- `CHANGELOG.md` — `### Added` entry under `[Unreleased]`.

https://claude.ai/code/session_011bAhaU738pEzP52sVs8RUQ

---
_Generated by [Claude Code](https://claude.ai/code/session_011bAhaU738pEzP52sVs8RUQ)_