### PR TITLE
docs: codify coordinator mode + worktree isolation in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,6 +117,41 @@ iex -S mix                         # REPL: Tau.start_session/1 etc.
 - **Do not** check shell output via screen scraping in `Bash` tool callers.
   Tools return structured `details` for that.
 
+## You are the coordinator
+
+For this repo you operate as a **coordinator**, not a hands-on
+implementer. Implement directly only when the task is small,
+self-contained, and faster to do than to brief. For anything
+non-trivial — multi-file changes, new behaviours, anything
+crossing a subsystem boundary — you delegate to subagents and
+integrate their results.
+
+**Default to delegation.** If a task touches more than two files
+or involves design choices, dispatch a subagent. If the task is
+"go read X" or "rename Y in one file", do it yourself.
+
+**Plan before you delegate.** For anything multi-step, dispatch
+the `Plan` subagent first, hand its output to one or more
+`general-purpose` subagents as their brief, and use yourself
+only to integrate / merge / decide.
+
+**Always isolate parallel work in worktrees.** When you dispatch
+two or more subagents that may both edit files, **every** dispatch
+MUST set `isolation: "worktree"` on the Agent tool call.
+Subagents share the working tree by default; without isolation,
+two parallel agents on different branches will clobber each
+other's edits and `git checkout`s — branches end up at HEAD with
+no commits, edits land on the wrong branch, and the working tree
+is left half-applied. (This bit me once; don't repeat it.)
+
+Worktree-isolated agents create their own branch and commit
+there; on return they hand back the branch name + path. Pull /
+merge from the parent worktree as the next step.
+
+**Single-agent foreground work** (no parallel siblings) does not
+need isolation — the parent and child can't race a single
+working tree.
+
 ## When to use sub-agents
 
 - `Explore` for read-only codebase queries that span multiple files. Don't
@@ -124,7 +159,9 @@ iex -S mix                         # REPL: Tau.start_session/1 etc.
 - `Plan` for anything that touches a behaviour contract or the supervision
   tree. Talk to it before making the change, not after.
 - `general-purpose` for end-to-end tasks that include both research and
-  edits.
+  edits — these implementation agents almost always want
+  `isolation: "worktree"` because in a coordinator session you
+  often have several running at once.
 - Don't spawn an agent for a single-file rename or a comment fix.
 
 ## Style


### PR DESCRIPTION
## Summary

Two new rules in `CLAUDE.md`'s agent-guidance section, learned the hard way during this session:

1. **You are the coordinator.** Default to delegation. Implement directly only when the task is small and self-contained. For multi-file work or design-loaded tasks, dispatch a `Plan` subagent first, then `general-purpose` agents for implementation.
2. **Always isolate parallel work in worktrees.** Every Agent dispatch that may run in parallel with siblings MUST set `isolation: "worktree"`. Subagents share the parent's working tree by default — without isolation, two agents on different branches clobber each other's edits and `git checkout`s, leaving branches at HEAD with no commits and the working tree half-applied.

The latter rule is the one that bit this session: I dispatched #37 and #39 in parallel without worktree isolation, and the two agents fought for the same working tree. Their branches ended up empty / corrupt and I had to abort + redispatch.

Pure docs PR — touches only `CLAUDE.md`. `TAU.md` doesn't get the same change because the harness-runtime audience there doesn't dispatch subagents (CLAUDE.md `@import`s `TAU.md` so the design-philosophy half stays shared, but the coordinator/worktree guidance is Claude-Code-specific).

## Test plan

- [x] Renders cleanly in GitHub markdown.
- N/A — no code changes.

https://claude.ai/code/session_011bAhaU738pEzP52sVs8RUQ

---
_Generated by [Claude Code](https://claude.ai/code/session_011bAhaU738pEzP52sVs8RUQ)_