### PR TITLE
feat: cross-provider tool-schema normalization (closes #37)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `Tau.Providers.Shared.ToolSpec.adapt/2` — pure cross-provider tool-schema
+  normaliser. Each provider's `build_body` now hands its tools list through
+  `adapt/2` so callers pass `Tau.Tool` modules or raw normalised maps and the
+  helper produces the provider-native shape. Gemini's reduced JSON-Schema
+  subset is handled by a dedicated down-shifter; lossy transforms log a
+  warning once. (Refs #19, closes #37.)
 - `Tau.Cost` / `Tau.Cost.Tracker` — per-provider token aggregation. The
   tracker is a lifecycle anchor for the `:tau_cost_counters` ETS table
   and a telemetry handler on `[:tau, :provider, :request, :stop]`;

--- a/lib/tau/providers/anthropic.ex
+++ b/lib/tau/providers/anthropic.ex
@@ -28,7 +28,7 @@ defmodule Tau.Providers.Anthropic do
 
   alias Tau.Message.{Assistant, ToolResult, User}
   alias Tau.Provider.Event
-  alias Tau.Providers.Shared.FinchStream
+  alias Tau.Providers.Shared.{FinchStream, ToolSpec}
 
   @api_url "https://api.anthropic.com"
   @api_version "2023-06-01"
@@ -235,7 +235,7 @@ defmodule Tau.Providers.Anthropic do
     body
     |> maybe_put(:system, system_field(system, opts))
     |> maybe_put(:temperature, opts[:temperature])
-    |> maybe_put(:tools, opts[:tools])
+    |> maybe_put(:tools, ToolSpec.adapt(opts[:tools], __MODULE__))
     |> maybe_put(:tool_choice, tool_choice(opts[:tool_choice]))
     |> maybe_put(:thinking, thinking(opts))
     |> maybe_put(:stop_sequences, opts[:stop_sequences])

--- a/lib/tau/providers/bedrock.ex
+++ b/lib/tau/providers/bedrock.ex
@@ -20,7 +20,7 @@ defmodule Tau.Providers.Bedrock do
 
   alias Tau.Message.{Assistant, ToolResult, User}
   alias Tau.Provider.Event
-  alias Tau.Providers.Shared.{AwsEventStream, FinchStream}
+  alias Tau.Providers.Shared.{AwsEventStream, FinchStream, ToolSpec}
 
   @default_model "anthropic.claude-3-5-sonnet-20241022-v2:0"
 
@@ -108,11 +108,17 @@ defmodule Tau.Providers.Bedrock do
   # --- Body -----------------------------------------------------------------
 
   defp build_payload(messages, opts) do
-    %{
+    base = %{
       anthropic_version: "bedrock-2023-05-31",
       max_tokens: opts[:max_tokens] || 8192,
       messages: Enum.map(messages, &to_anthropic/1)
     }
+
+    case ToolSpec.adapt(opts[:tools], __MODULE__) do
+      nil -> base
+      [] -> base
+      tools -> Map.put(base, :tools, tools)
+    end
   end
 
   defp to_anthropic(%User{content: c}) when is_binary(c), do: %{role: "user", content: c}

--- a/lib/tau/providers/gemini.ex
+++ b/lib/tau/providers/gemini.ex
@@ -13,7 +13,7 @@ defmodule Tau.Providers.Gemini do
 
   alias Tau.Message.{Assistant, ToolResult, User}
   alias Tau.Provider.Event
-  alias Tau.Providers.Shared.FinchStream
+  alias Tau.Providers.Shared.{FinchStream, ToolSpec}
 
   @api_url "https://generativelanguage.googleapis.com"
   @default_model "gemini-2.0-flash"
@@ -103,10 +103,10 @@ defmodule Tau.Providers.Gemini do
       contents: Enum.map(messages, &to_gemini/1)
     }
 
-    case opts[:tools] do
+    case ToolSpec.adapt(opts[:tools], __MODULE__) do
       nil -> body
       [] -> body
-      tools -> Map.put(body, :tools, [%{functionDeclarations: tools}])
+      decls -> Map.put(body, :tools, [%{functionDeclarations: decls}])
     end
   end
 

--- a/lib/tau/providers/openai/chat.ex
+++ b/lib/tau/providers/openai/chat.ex
@@ -12,7 +12,7 @@ defmodule Tau.Providers.OpenAI.Chat do
 
   alias Tau.Message.{Assistant, ToolResult, User}
   alias Tau.Provider.Event
-  alias Tau.Providers.Shared.FinchStream
+  alias Tau.Providers.Shared.{FinchStream, ToolSpec}
 
   @api_url "https://api.openai.com"
   @default_model "gpt-4o-mini"
@@ -138,7 +138,7 @@ defmodule Tau.Providers.OpenAI.Chat do
     body
     |> maybe_put(:temperature, opts[:temperature])
     |> maybe_put(:max_tokens, opts[:max_tokens])
-    |> maybe_put(:tools, opts[:tools])
+    |> maybe_put(:tools, ToolSpec.adapt(opts[:tools], __MODULE__))
     |> maybe_put(:tool_choice, openai_tool_choice(opts[:tool_choice]))
   end
 

--- a/lib/tau/providers/openai/responses.ex
+++ b/lib/tau/providers/openai/responses.ex
@@ -12,7 +12,7 @@ defmodule Tau.Providers.OpenAI.Responses do
 
   alias Tau.Message.{Assistant, ToolResult, User}
   alias Tau.Provider.Event
-  alias Tau.Providers.Shared.FinchStream
+  alias Tau.Providers.Shared.{FinchStream, ToolSpec}
 
   @api_url "https://api.openai.com"
   @default_model "gpt-4o-mini"
@@ -84,7 +84,7 @@ defmodule Tau.Providers.OpenAI.Responses do
     |> maybe_put(:temperature, opts[:temperature])
     |> maybe_put(:max_output_tokens, opts[:max_tokens])
     |> maybe_put(:reasoning, reasoning(opts[:reasoning]))
-    |> maybe_put(:tools, opts[:tools])
+    |> maybe_put(:tools, ToolSpec.adapt(opts[:tools], __MODULE__))
   end
 
   defp reasoning(nil), do: nil

--- a/lib/tau/providers/shared/tool_spec.ex
+++ b/lib/tau/providers/shared/tool_spec.ex
@@ -1,0 +1,100 @@
+defmodule Tau.Providers.Shared.ToolSpec do
+  @moduledoc """
+  Pure cross-provider tool-schema normaliser.
+
+  Each provider expects a different on-the-wire shape for tool/function
+  declarations:
+
+    * Anthropic — `%{name, description, input_schema}`
+    * OpenAI Chat — `%{type: "function", function: %{name, description, parameters}}`
+    * OpenAI Responses — `%{type: "function", name, description, parameters}`
+    * Gemini — `%{name, description, parameters}` after a JSON-Schema
+      down-shift (see `Tau.Providers.Shared.ToolSpec.GeminiSubset`)
+    * Bedrock — Anthropic-on-Bedrock uses the Anthropic shape
+
+  Callers (notably each provider's `build_body/*`) hand `adapt/2` a list
+  whose elements are either `Tau.Tool` modules or already-normalised
+  maps with `:name`/`:description`/`:parameters` keys. The helper
+  produces the provider-native shape; `nil` and `[]` pass through as
+  themselves so callers can keep the "omit when absent" pattern.
+
+  Pure module — no processes, no side effects beyond a single
+  `Logger.warning/2` from the Gemini down-shifter on lossy input.
+  """
+
+  alias Tau.Providers.Shared.ToolSpec.GeminiSubset
+
+  @typedoc """
+  Either a `Tau.Tool` implementation module or a raw map carrying
+  `:name`, `:description`, and `:parameters` keys (string keys also
+  accepted).
+  """
+  @type tool_input :: module() | map()
+
+  @doc """
+  Adapt a list of tool inputs to `provider`'s native tool-spec shape.
+
+  Returns `nil` when given `nil`, `[]` when given `[]`, otherwise a
+  list of provider-native maps.
+  """
+  @spec adapt([tool_input()] | nil, module()) :: [map()] | nil
+  def adapt(nil, _provider), do: nil
+  def adapt([], _provider), do: []
+
+  def adapt(tools, provider) when is_list(tools) and is_atom(provider) do
+    tools
+    |> Enum.map(&extract/1)
+    |> Enum.map(&shape(&1, provider))
+  end
+
+  # --- generic-form extraction ---------------------------------------------
+
+  # Modules implementing Tau.Tool — pull canonical fields from callbacks.
+  defp extract(mod) when is_atom(mod) do
+    %{
+      name: mod.name(),
+      description: mod.description(),
+      parameters: mod.parameters()
+    }
+  end
+
+  # Already-normalised maps. Accept both atom and string keys; output
+  # is always atom-keyed so downstream pattern matching is uniform.
+  defp extract(%{} = map) do
+    %{
+      name: fetch(map, :name),
+      description: fetch(map, :description),
+      parameters: fetch(map, :parameters)
+    }
+  end
+
+  defp fetch(map, key) when is_atom(key) do
+    Map.get(map, key) || Map.get(map, Atom.to_string(key))
+  end
+
+  # --- per-provider shaping -------------------------------------------------
+
+  defp shape(generic, Tau.Providers.Anthropic), do: anthropic_shape(generic)
+
+  defp shape(%{name: n, description: d, parameters: p}, Tau.Providers.OpenAI.Chat) do
+    %{type: "function", function: %{name: n, description: d, parameters: p}}
+  end
+
+  defp shape(%{name: n, description: d, parameters: p}, Tau.Providers.OpenAI.Responses) do
+    %{type: "function", name: n, description: d, parameters: p}
+  end
+
+  defp shape(%{name: n, description: d, parameters: p}, Tau.Providers.Gemini) do
+    %{name: n, description: d, parameters: GeminiSubset.downshift(p)}
+  end
+
+  # Bedrock: today, only Anthropic-on-Bedrock is wired up (see
+  # Tau.Providers.Bedrock @moduledoc). Mirror Anthropic's shape;
+  # additional inner-model branches can dispatch on `opts[:model]` here
+  # when added.
+  defp shape(generic, Tau.Providers.Bedrock), do: anthropic_shape(generic)
+
+  defp anthropic_shape(%{name: n, description: d, parameters: p}) do
+    %{name: n, description: d, input_schema: p}
+  end
+end

--- a/lib/tau/providers/shared/tool_spec/gemini_subset.ex
+++ b/lib/tau/providers/shared/tool_spec/gemini_subset.ex
@@ -1,0 +1,71 @@
+defmodule Tau.Providers.Shared.ToolSpec.GeminiSubset do
+  @moduledoc """
+  Down-shifter from a generic JSON-Schema tool spec to the reduced subset
+  Gemini's `functionDeclarations` accepts.
+
+  Gemini's schema dialect is a strict subset of JSON Schema:
+
+    * `oneOf` (and the related `anyOf`) are not supported and must be
+      removed — composing a working subset is beyond the scope of this
+      adapter, so we strip them and emit a one-shot warning.
+    * `additionalProperties` cannot be a schema (only `false` or absent)
+      — we clamp any non-`false` value to `false`.
+
+  Other constructs Gemini doesn't support (e.g. `$ref`, `format`-specific
+  keywords) are left in place: the model server will reject them with a
+  clearer error than anything we could synthesise here. ADR-0003 stays
+  in force — we never silently coerce types or relax invalid schemas.
+  """
+
+  require Logger
+
+  @doc """
+  Down-shift a JSON-Schema map to Gemini's accepted subset.
+
+  Returns the rewritten schema. Idempotent: re-running on output produces
+  the same map.
+  """
+  @spec downshift(map() | nil) :: map() | nil
+  def downshift(nil), do: nil
+
+  def downshift(schema) when is_map(schema) do
+    {result, lossy?} = walk(schema, false)
+
+    if lossy? do
+      Logger.warning(
+        "Tau.Providers.Shared.ToolSpec.GeminiSubset: dropped unsupported keywords " <>
+          "(oneOf/anyOf or schema-valued additionalProperties) while down-shifting tool " <>
+          "schema for Gemini. The remaining schema is a subset of the original."
+      )
+    end
+
+    result
+  end
+
+  # --- recursive walk -------------------------------------------------------
+
+  defp walk(%{} = map, lossy?) do
+    Enum.reduce(map, {%{}, lossy?}, fn {k, v}, {acc, l} ->
+      cond do
+        k in ["oneOf", "anyOf", :oneOf, :anyOf] ->
+          {acc, true}
+
+        k in ["additionalProperties", :additionalProperties] and is_map(v) ->
+          {Map.put(acc, k, false), true}
+
+        true ->
+          {v2, l2} = walk(v, l)
+          {Map.put(acc, k, v2), l2}
+      end
+    end)
+  end
+
+  defp walk(list, lossy?) when is_list(list) do
+    Enum.reduce(list, {[], lossy?}, fn elem, {acc, l} ->
+      {e2, l2} = walk(elem, l)
+      {acc ++ [e2], l2}
+    end)
+  end
+
+  defp walk(other, lossy?), do: {other, lossy?}
+end

--- a/test/tau/providers/shared/tool_spec/gemini_subset_test.exs
+++ b/test/tau/providers/shared/tool_spec/gemini_subset_test.exs
@@ -1,0 +1,146 @@
+defmodule Tau.Providers.Shared.ToolSpec.GeminiSubsetTest do
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  import ExUnit.CaptureLog
+
+  alias Tau.Providers.Shared.ToolSpec.GeminiSubset
+
+  describe "downshift/1" do
+    test "nil passes through" do
+      assert GeminiSubset.downshift(nil) == nil
+    end
+
+    test "schema without oneOf/additionalProperties is unchanged and silent" do
+      schema = %{"type" => "object", "properties" => %{"x" => %{"type" => "string"}}}
+
+      log =
+        capture_log(fn ->
+          assert GeminiSubset.downshift(schema) == schema
+        end)
+
+      assert log == ""
+    end
+
+    test "strips top-level oneOf and warns" do
+      schema = %{
+        "type" => "object",
+        "oneOf" => [%{"required" => ["a"]}, %{"required" => ["b"]}],
+        "properties" => %{"a" => %{"type" => "string"}, "b" => %{"type" => "string"}}
+      }
+
+      log =
+        capture_log(fn ->
+          out = GeminiSubset.downshift(schema)
+          refute Map.has_key?(out, "oneOf")
+          assert out["type"] == "object"
+          assert out["properties"] == schema["properties"]
+        end)
+
+      assert log =~ "ToolSpec.GeminiSubset"
+    end
+
+    test "strips nested oneOf inside properties" do
+      schema = %{
+        "type" => "object",
+        "properties" => %{
+          "x" => %{
+            "type" => "object",
+            "oneOf" => [%{"required" => ["a"]}, %{"required" => ["b"]}]
+          }
+        }
+      }
+
+      capture_log(fn ->
+        out = GeminiSubset.downshift(schema)
+        refute Map.has_key?(out["properties"]["x"], "oneOf")
+      end)
+    end
+
+    test "strips anyOf the same way as oneOf" do
+      schema = %{"type" => "object", "anyOf" => [%{}, %{}]}
+
+      capture_log(fn ->
+        out = GeminiSubset.downshift(schema)
+        refute Map.has_key?(out, "anyOf")
+      end)
+    end
+
+    test "clamps schema-valued additionalProperties to false and warns" do
+      schema = %{
+        "type" => "object",
+        "additionalProperties" => %{"type" => "string"}
+      }
+
+      log =
+        capture_log(fn ->
+          out = GeminiSubset.downshift(schema)
+          assert out["additionalProperties"] == false
+        end)
+
+      assert log =~ "ToolSpec.GeminiSubset"
+    end
+
+    test "leaves additionalProperties: false untouched" do
+      schema = %{"type" => "object", "additionalProperties" => false}
+
+      log =
+        capture_log(fn ->
+          assert GeminiSubset.downshift(schema) == schema
+        end)
+
+      assert log == ""
+    end
+
+    test "handles atom keys equivalently" do
+      schema = %{type: "object", oneOf: [%{}, %{}]}
+
+      capture_log(fn ->
+        out = GeminiSubset.downshift(schema)
+        refute Map.has_key?(out, :oneOf)
+        assert out[:type] == "object"
+      end)
+    end
+  end
+
+  describe "idempotency" do
+    @describetag :property
+
+    property "down-shift twice equals down-shift once" do
+      check all(schema <- schema_with_lossy_keywords()) do
+        first =
+          capture_log(fn -> Process.put({__MODULE__, :first}, GeminiSubset.downshift(schema)) end)
+
+        once = Process.get({__MODULE__, :first})
+
+        twice_log =
+          capture_log(fn -> Process.put({__MODULE__, :twice}, GeminiSubset.downshift(once)) end)
+
+        twice = Process.get({__MODULE__, :twice})
+
+        # Second pass over already-clean schema must not warn.
+        assert twice_log == ""
+        assert once == twice
+        _ = first
+      end
+    end
+  end
+
+  defp schema_with_lossy_keywords do
+    StreamData.fixed_map(%{
+      "type" => StreamData.constant("object"),
+      "oneOf" => StreamData.list_of(StreamData.constant(%{}), max_length: 2),
+      "additionalProperties" =>
+        StreamData.one_of([
+          StreamData.constant(false),
+          StreamData.fixed_map(%{"type" => StreamData.constant("string")})
+        ]),
+      "properties" =>
+        StreamData.map_of(
+          StreamData.string(:alphanumeric, min_length: 1, max_length: 4),
+          StreamData.fixed_map(%{"type" => StreamData.constant("string")}),
+          max_length: 3
+        )
+    })
+  end
+end

--- a/test/tau/providers/shared/tool_spec_test.exs
+++ b/test/tau/providers/shared/tool_spec_test.exs
@@ -1,0 +1,184 @@
+defmodule Tau.Providers.Shared.ToolSpecTest do
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  alias Tau.Providers.Shared.ToolSpec
+
+  @sample %{
+    name: "Read",
+    description: "Read a file",
+    parameters: %{
+      "type" => "object",
+      "properties" => %{"path" => %{"type" => "string"}},
+      "required" => ["path"]
+    }
+  }
+
+  describe "adapt/2 — empty inputs" do
+    test "nil passes through as nil for every provider" do
+      for provider <- providers() do
+        assert ToolSpec.adapt(nil, provider) == nil
+      end
+    end
+
+    test "empty list passes through as empty list" do
+      for provider <- providers() do
+        assert ToolSpec.adapt([], provider) == []
+      end
+    end
+  end
+
+  describe "adapt/2 — Anthropic shape" do
+    test "produces %{name, description, input_schema}" do
+      assert [tool] = ToolSpec.adapt([@sample], Tau.Providers.Anthropic)
+      assert tool.name == "Read"
+      assert tool.description == "Read a file"
+      assert tool.input_schema == @sample.parameters
+      refute Map.has_key?(tool, :parameters)
+      refute Map.has_key?(tool, :function)
+      refute Map.has_key?(tool, :type)
+    end
+  end
+
+  describe "adapt/2 — OpenAI Chat shape" do
+    test "wraps in %{type: \"function\", function: %{name, description, parameters}}" do
+      assert [tool] = ToolSpec.adapt([@sample], Tau.Providers.OpenAI.Chat)
+      assert tool.type == "function"
+      assert tool.function.name == "Read"
+      assert tool.function.description == "Read a file"
+      assert tool.function.parameters == @sample.parameters
+      refute Map.has_key?(tool, :input_schema)
+      refute Map.has_key?(tool, :name)
+    end
+  end
+
+  describe "adapt/2 — OpenAI Responses shape" do
+    test "flat %{type: \"function\", name, description, parameters}" do
+      assert [tool] = ToolSpec.adapt([@sample], Tau.Providers.OpenAI.Responses)
+      assert tool.type == "function"
+      assert tool.name == "Read"
+      assert tool.description == "Read a file"
+      assert tool.parameters == @sample.parameters
+      refute Map.has_key?(tool, :function)
+      refute Map.has_key?(tool, :input_schema)
+    end
+  end
+
+  describe "adapt/2 — Gemini shape" do
+    test "produces %{name, description, parameters} after subset down-shift" do
+      assert [tool] = ToolSpec.adapt([@sample], Tau.Providers.Gemini)
+      assert tool.name == "Read"
+      assert tool.description == "Read a file"
+      # Plain schema with no oneOf/additionalProperties is unchanged.
+      assert tool.parameters == @sample.parameters
+      refute Map.has_key?(tool, :input_schema)
+      refute Map.has_key?(tool, :type)
+      refute Map.has_key?(tool, :function)
+    end
+  end
+
+  describe "adapt/2 — Bedrock shape" do
+    test "Anthropic-on-Bedrock uses Anthropic shape" do
+      assert [tool] = ToolSpec.adapt([@sample], Tau.Providers.Bedrock)
+      assert tool.name == "Read"
+      assert tool.description == "Read a file"
+      assert tool.input_schema == @sample.parameters
+    end
+  end
+
+  describe "adapt/2 — Tau.Tool module input" do
+    test "extracts canonical fields via behaviour callbacks" do
+      [tool] = ToolSpec.adapt([Tau.Tools.Builtin.Read], Tau.Providers.Anthropic)
+      assert tool.name == Tau.Tools.Builtin.Read.name()
+      assert tool.description == Tau.Tools.Builtin.Read.description()
+      assert tool.input_schema == Tau.Tools.Builtin.Read.parameters()
+    end
+  end
+
+  describe "adapt/2 — string-keyed map input" do
+    test "accepts string keys interchangeably with atom keys" do
+      string_keyed = %{
+        "name" => "Edit",
+        "description" => "edit a file",
+        "parameters" => %{"type" => "object"}
+      }
+
+      [tool] = ToolSpec.adapt([string_keyed], Tau.Providers.Anthropic)
+      assert tool.name == "Edit"
+      assert tool.description == "edit a file"
+      assert tool.input_schema == %{"type" => "object"}
+    end
+  end
+
+  # --- property tests -------------------------------------------------------
+
+  describe "properties" do
+    @describetag :property
+
+    property "adapt/2 is total for every supported provider" do
+      check all(
+              tools <- StreamData.list_of(tool_map_gen(), max_length: 4),
+              provider <- StreamData.member_of(providers())
+            ) do
+        result = ToolSpec.adapt(tools, provider)
+        assert is_list(result)
+        assert length(result) == length(tools)
+      end
+    end
+
+    property "Anthropic adapt is idempotent on its own output (atom-key fields)" do
+      check all(tools <- StreamData.list_of(tool_map_gen(), min_length: 1, max_length: 3)) do
+        first = ToolSpec.adapt(tools, Tau.Providers.Anthropic)
+
+        # Re-feed: each output map already has :name/:description/:parameters
+        # if we rename :input_schema → :parameters. This proves the helper
+        # round-trips a normalised map without losing or mutating fields.
+        reshaped =
+          Enum.map(first, fn %{name: n, description: d, input_schema: s} ->
+            %{name: n, description: d, parameters: s}
+          end)
+
+        again = ToolSpec.adapt(reshaped, Tau.Providers.Anthropic)
+        assert first == again
+      end
+    end
+  end
+
+  # --- helpers --------------------------------------------------------------
+
+  defp providers do
+    [
+      Tau.Providers.Anthropic,
+      Tau.Providers.OpenAI.Chat,
+      Tau.Providers.OpenAI.Responses,
+      Tau.Providers.Gemini,
+      Tau.Providers.Bedrock
+    ]
+  end
+
+  defp tool_map_gen do
+    StreamData.fixed_map(%{
+      name: StreamData.string(:alphanumeric, min_length: 1, max_length: 16),
+      description: StreamData.string(:alphanumeric, max_length: 32),
+      parameters: schema_gen()
+    })
+  end
+
+  defp schema_gen do
+    StreamData.fixed_map(%{
+      "type" => StreamData.constant("object"),
+      "properties" => properties_gen()
+    })
+  end
+
+  defp properties_gen do
+    StreamData.map_of(
+      StreamData.string(:alphanumeric, min_length: 1, max_length: 8),
+      StreamData.fixed_map(%{
+        "type" =>
+          StreamData.member_of(["string", "integer", "number", "boolean", "array", "object"])
+      }),
+      max_length: 4
+    )
+  end
+end


### PR DESCRIPTION
## Summary

Adds `Tau.Providers.Shared.ToolSpec.adapt/2` — a pure cross-provider
tool-schema normaliser. Each provider's `build_body` (and Bedrock's
`build_payload`) now hands its tools list through `adapt/2` instead of
splatting `opts[:tools]` verbatim onto the wire.

Per-provider native shapes:

- **Anthropic** / **Anthropic-on-Bedrock** — `%{name, description, input_schema}`
- **OpenAI Chat** — `%{type: "function", function: %{name, description, parameters}}`
- **OpenAI Responses** — `%{type: "function", name, description, parameters}`
- **Gemini** — `%{name, description, parameters}` after a JSON-Schema down-shift
  via `Tau.Providers.Shared.ToolSpec.GeminiSubset` (strips `oneOf`/`anyOf`,
  clamps schema-valued `additionalProperties` to `false`, single
  `Logger.warning/2` on lossy input).

Inputs accepted by `adapt/2`:

- `Tau.Tool` modules — extracted via `name/0` / `description/0` / `parameters/0`
- Already-normalised maps with `:name` / `:description` / `:parameters`
  (atom or string keys) — passed through with provider-specific reshaping

`nil` and `[]` pass through as themselves so callers keep their
"omit when absent" pattern.

### Punted to a follow-up

- **No new `@callback adapt_tool_spec/1` on `Tau.Provider`.** Issue #37
  said "shared helper first, optional callback if needed"; the helper
  alone covers every provider we ship. A callback can be added later if
  a non-AWS Bedrock inner-model branch ever needs to override.
- **No `Tau.Session` wiring.** The session FSM does not yet thread the
  registered tool list into `opts` for the provider. That's a separate
  issue.

### Hard constraints honoured

- ADR-0003: schemas are not silently relaxed. `oneOf`/`anyOf` are
  removed (with a warning) because Gemini rejects them; we never
  coerce types.
- No new HTTP/JSON dependencies; no `IO.puts` (Logger only).
- `ToolSpec` is a pure module — no process, no ETS, no app env.

## Files touched

- **New**: `lib/tau/providers/shared/tool_spec.ex`
- **New**: `lib/tau/providers/shared/tool_spec/gemini_subset.ex`
- **New**: `test/tau/providers/shared/tool_spec_test.exs`
- **New**: `test/tau/providers/shared/tool_spec/gemini_subset_test.exs`
- **Modified**: `lib/tau/providers/anthropic.ex` (alias + `build_body`)
- **Modified**: `lib/tau/providers/openai/chat.ex` (alias + `build_body`)
- **Modified**: `lib/tau/providers/openai/responses.ex` (alias + `build_body`)
- **Modified**: `lib/tau/providers/gemini.ex` (alias + tools-case)
- **Modified**: `lib/tau/providers/bedrock.ex` (alias + `build_payload` —
  Anthropic-on-Bedrock now actually emits `tools`, was previously
  silently dropped)
- **Modified**: `CHANGELOG.md` (`[Unreleased]` → `### Added`)

## Test plan

- [ ] CI: `mix compile` warning-free
- [ ] CI: `mix format --check-formatted`
- [ ] CI: `mix credo --strict`
- [ ] CI: `mix dialyzer`
- [ ] CI: `mix test` (per-provider example shape assertions, `nil`/`[]`
      passthrough, `Tau.Tool` module input, string-keyed map input)
- [ ] CI: `mix test --only property` (`adapt/2` totality across providers,
      Anthropic idempotency, Gemini-subset idempotency, log-warning
      assertion via `ExUnit.CaptureLog`)

Closes #37
Refs #19

https://claude.ai/code/session_011bAhaU738pEzP52sVs8RUQ

---
_Generated by [Claude Code](https://claude.ai/code/session_011bAhaU738pEzP52sVs8RUQ)_