### PR TITLE
feat: per-provider token-bucket rate limiter (ADR-0011, closes #39)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Per-provider token-bucket rate limiter — one `Tau.Providers.RateLimiter`
+  GenServer per configured provider, supervised by
+  `Tau.Providers.RateLimiter.Supervisor`. Provider `stream/3` calls now
+  acquire a permit before sending; 429 responses halve the bucket; settings
+  reload re-sizes buckets without restart. New telemetry:
+  `[:tau, :provider, :rate_limit, :acquired | :throttled | :rejected | :halved]`.
+  See ADR-0011. (Refs #19, closes #39.)
 - `Tau.Providers.Shared.ToolSpec.adapt/2` — pure cross-provider tool-schema
   normaliser. Each provider's `build_body` now hands its tools list through
   `adapt/2` so callers pass `Tau.Tool` modules or raw normalised maps and the

--- a/docs/adr/0011-per-provider-rate-limiter-is-stateful-genserver.md
+++ b/docs/adr/0011-per-provider-rate-limiter-is-stateful-genserver.md
@@ -1,0 +1,153 @@
+# ADR-0011: Per-provider rate limiter is a stateful GenServer (not an ETS-owner)
+
+- **Status:** Accepted
+- **Date:** 2026-05-01
+- **Deciders:** the agent loop, with no objection from @smug-haus
+- **Related:**
+  - Issue: #39 (sub-issue of #19)
+  - Code: `lib/tau/providers/rate_limiter.ex`,
+    `lib/tau/providers/rate_limiter/token_bucket.ex`,
+    `lib/tau/providers/rate_limiter/supervisor.ex`
+  - Prior: ADR-0002 (settings come from `Tau.Settings.Cache`, not
+    `Application.get_env/2` for runtime state), ADR-0004 (PubSub is
+    the cross-process event channel), ADR-0010 (cost tracker owns
+    ETS, *not* GenServer state — the contrasting pattern), CLAUDE.md
+    non-negotiable #1 (process-per-subsystem with the per-entity
+    carve-out).
+
+## Context
+
+Issue #39 calls for per-provider request budgeting: a token-bucket
+rate limiter sits between `Tau.Session` and the provider's HTTP
+client, gating outgoing calls and reacting to upstream `429`
+responses by halving the bucket. Five providers ship today
+(Anthropic, OpenAI Chat, OpenAI Responses, Gemini, Bedrock); each
+has its own RPM/TPM ceiling that the limiter has to honour
+independently.
+
+Two questions arose during design.
+
+**(1) Why is this a GenServer, when ADR-0010 just made the cost
+tracker an ETS-owner?** Cost counters fan in from many writers
+(every session, every turn) and fan out to many readers. That
+topology is the one place ADR-0010 calls out as ETS-shaped:
+writes are independent (`update_counter` commutes), reads are
+scans, and a GenServer mailbox would serialise an
+embarrassingly-parallel workload.
+
+The rate limiter is the opposite shape:
+
+- **Writes are not commutative.** `take(bucket, n)` depends on
+  `last_refill_ms` *and* on every prior `take` since that refill.
+  The token-bucket refill is `min(size, current + elapsed_ms *
+  rate / 1000)`, then subtract the request — the arithmetic
+  cannot be expressed as a CRDT-style merge.
+- **Reads and writes are 1:1.** Every provider call is exactly
+  one `acquire/3` plus one `record_response/2`. The mailbox is
+  *not* the bottleneck the upstream API is.
+- **Wait queues are intrinsically serial.** When the bucket is
+  empty, callers block on `GenServer.call/3` until refill. The
+  GenServer mailbox *is* the wait queue — that's the Right Tool.
+  Reimplementing it on top of ETS would be a hand-rolled mutex.
+
+So this is a true stateful GenServer in the non-negotiable #1
+sense. It's not a "Manager" GenServer (one process owning all
+providers' state) — it's *one process per provider*, the
+explicit carve-out CLAUDE.md grants for per-entity processes.
+
+**(2) On settings reload, restart the limiter or update in
+place?** The natural Elixir reflex is "let it crash; supervise;
+restart". But restarting a limiter throws away its in-flight
+wait queue — every blocked caller wakes up with `:noproc` and
+reissues, *flooding the upstream right after a config change*.
+That's a self-inflicted thundering herd at exactly the moment
+the operator is most likely to be tuning the limiter.
+
+Restarting is also unnecessary: `RateLimiter` runs the
+token-bucket arithmetic in pure functions
+(`Tau.Providers.RateLimiter.TokenBucket`); resizing a bucket is
+a one-line state transformation that preserves
+`current_tokens` and `last_refill_ms`. The supervisor handles
+the *add new provider* and *remove configured provider* cases;
+existing limiters self-update via their own `"settings"`
+subscription (mirroring `Tau.Permissions.RuleSet`).
+
+Pushback on the issue body's suggestion: the issue sketch
+proposes `Application.get_env(:tau, :rate_limits)` for reading
+config. That's forbidden by ADR-0002 — runtime config goes
+through `Tau.Settings.Cache` (which publishes to
+`:persistent_term` and broadcasts on PubSub).
+
+## Decision
+
+`Tau.Providers.RateLimiter` is a `GenServer`, one instance per
+configured provider, supervised by
+`Tau.Providers.RateLimiter.Supervisor` (a small static
+`Supervisor` shell wrapping a `DynamicSupervisor` and a
+reconciliation `GenServer`).
+
+Specifics:
+
+- **Pure core.** `Tau.Providers.RateLimiter.TokenBucket`
+  implements `take/3`, `refill/2`, `halve/1`, `resize/3` as
+  pure functions on a `%TokenBucket{size, current, rate_per_sec,
+  last_refill_ms}` struct. The property suite pins these.
+- **Process shape.** The GenServer holds
+  `%{provider, rpm_bucket, tpm_bucket, half_until}`. `acquire/3`
+  is a `GenServer.call/3` with caller-supplied timeout.
+  `record_response/2` is a `cast`.
+- **Naming.** Limiters register under a new
+  `Tau.Providers.RateLimiter.Registry` (added to
+  `Tau.Registries`) keyed by provider module.
+- **Settings reload.** Each limiter subscribes to PubSub topic
+  `"settings"` in its `init/1`. On `{:settings_reloaded,
+  settings}` it resizes its buckets in place via
+  `TokenBucket.resize/3`. The supervisor *also* subscribes —
+  it reconciles the set of running children against the new
+  config (start new, stop removed, leave existing alone).
+- **429 handling.** When `record_response/2` is called with
+  `%{status: 429}`, the limiter halves both buckets and sets
+  `half_until = now + 60s`. Subsequent reloads within that
+  window keep the halved size as a floor.
+- **Telemetry.** `[:tau, :provider, :rate_limit, :acquired |
+  :throttled | :rejected | :halved]`.
+
+## Consequences
+
+- The mailbox is the wait queue: blocked `acquire` calls park
+  on `GenServer.call/3` and are woken when refill makes a
+  permit available.
+- Settings reload is non-disruptive. Operators can tune RPM /
+  TPM live without flushing wait queues.
+- Crashing a limiter loses its bucket state and waiters — they
+  see `:noproc` from the call. The supervisor restarts the
+  child fresh from the current settings.
+- The implementation does NOT use a tokenizer to estimate
+  token counts pre-flight. `Tau.Providers.Shared.TokenEstimate`
+  uses `byte_size / 4` over the messages — within ~30% of real
+  for English prose, fine for budget gating. A real tokenizer
+  is filed as a follow-up.
+- Provider `stream/3` callers see one new synchronous error:
+  `{:error, :rate_limited}` (mirroring the existing
+  `{:error, :missing_api_key}` pattern).
+
+## Alternatives considered
+
+- **ETS-owner shape (mirroring ADR-0010).** Rejected: bucket
+  arithmetic is intrinsically serial, and a wait queue on top
+  of ETS is a hand-rolled mutex.
+- **One Manager GenServer for all providers.** Rejected by
+  CLAUDE.md non-negotiable #1.
+- **Crash-and-restart on settings reload.** Rejected: drops
+  the in-flight wait queue, causing a thundering herd.
+- **`Application.get_env/2` for config (issue body
+  suggested).** Rejected per ADR-0002.
+
+## Notes
+
+The choice mirrors `Tau.Sessions.Supervisor` (per-session FSM
+under a DynamicSupervisor) and `Tau.MCP.Supervisor`: per-entity
+processes named via `Registry`, supervised dynamically,
+reconciled against settings. The "reconcile, don't restart"
+pattern is the shared idiom for "long-lived state that should
+survive a config change".

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -64,6 +64,7 @@ get rewritten away by the next refactor. ADRs survive.
 | [0008](0008-user-code-never-runs-synchronously-in-the-fsm.md) | User code never runs synchronously inside the session FSM | Accepted |
 | [0009](0009-user-messages-queue-during-active-turn.md) | User messages queue (postpone) during an active turn | Accepted |
 | [0010](0010-cost-tracker-owns-ets-not-state.md) | Cost tracker owns an ETS table, not GenServer state | Accepted |
+| [0011](0011-per-provider-rate-limiter-is-stateful-genserver.md) | Per-provider rate limiter is a stateful GenServer (not an ETS-owner) | Accepted |
 
 (New ADRs append here. Keep the table sorted by ADR number.)
 

--- a/lib/tau/application.ex
+++ b/lib/tau/application.ex
@@ -18,11 +18,14 @@ defmodule Tau.Application do
     5. **Permissions.RuleSet** — subscribes to settings PubSub,
        compiles rules from Settings.Cache.
     6. **Finch** — HTTP client, used by providers.
-    7. **Task supervisors** — for tool dispatch.
-    8. **Extensions.Loader** — registers tools/hooks/commands
+    7. **Providers.RateLimiter.Supervisor** — per-provider token-bucket
+       limiters (ADR-0011). Boots after Finch (limiters wrap Finch
+       sends) and before the task supervisors.
+    8. **Task supervisors** — for tool dispatch.
+    9. **Extensions.Loader** — registers tools/hooks/commands
        defined by extensions.
-    9. **MCP.Supervisor** — MCP server connections.
-    10. **Sessions.Supervisor** — dynamic supervisor for session
+    10. **MCP.Supervisor** — MCP server connections.
+    11. **Sessions.Supervisor** — dynamic supervisor for session
         FSMs (must be last; it's the only consumer of all the
         above).
 
@@ -43,6 +46,7 @@ defmodule Tau.Application do
       Tau.Settings.Watcher,
       Tau.Permissions.RuleSet,
       {Finch, name: Tau.Providers.Finch},
+      Tau.Providers.RateLimiter.Supervisor,
       {Task.Supervisor, name: Tau.Tools.TaskSupervisor},
       Tau.Extensions.Loader,
       Tau.MCP.Supervisor,

--- a/lib/tau/providers/anthropic.ex
+++ b/lib/tau/providers/anthropic.ex
@@ -57,18 +57,31 @@ defmodule Tau.Providers.Anthropic do
         {:error, :missing_api_key}
 
       key ->
-        {system, user_messages} = split_system(messages)
-        body = build_body(system, user_messages, opts)
+        est = Tau.Providers.Shared.TokenEstimate.estimate(messages)
 
-        request =
-          Finch.build(
-            :post,
-            "#{base_url()}/v1/messages",
-            headers(key),
-            Jason.encode!(body)
-          )
+        case Tau.Providers.RateLimiter.acquire(__MODULE__, est) do
+          {:error, :rate_limit_timeout} ->
+            {:error, :rate_limited}
 
-        {:ok, FinchStream.run(request, &decode/2, %{partial: %{}, started?: false, model: nil})}
+          :ok ->
+            {system, user_messages} = split_system(messages)
+            body = build_body(system, user_messages, opts)
+
+            request =
+              Finch.build(
+                :post,
+                "#{base_url()}/v1/messages",
+                headers(key),
+                Jason.encode!(body)
+              )
+
+            {:ok,
+             FinchStream.run(
+               request,
+               &decode/2,
+               %{partial: %{}, started?: false, model: nil, provider: __MODULE__}
+             )}
+        end
     end
   end
 

--- a/lib/tau/providers/bedrock.ex
+++ b/lib/tau/providers/bedrock.ex
@@ -39,34 +39,47 @@ defmodule Tau.Providers.Bedrock do
         {:error, :missing_aws_credentials}
 
       creds ->
-        region = region()
-        model = opts[:model] || @default_model
+        est = Tau.Providers.Shared.TokenEstimate.estimate(messages)
 
-        url =
-          "https://bedrock-runtime.#{region}.amazonaws.com/model/#{model}/invoke-with-response-stream"
+        case Tau.Providers.RateLimiter.acquire(__MODULE__, est) do
+          {:error, :rate_limit_timeout} ->
+            {:error, :rate_limited}
 
-        body = Jason.encode!(build_payload(messages, opts))
+          :ok ->
+            region = region()
+            model = opts[:model] || @default_model
 
-        headers =
-          sigv4_sign(
-            :post,
-            url,
-            [{"content-type", "application/json"}],
-            body,
-            creds,
-            region,
-            "bedrock"
-          )
+            url =
+              "https://bedrock-runtime.#{region}.amazonaws.com/model/#{model}/invoke-with-response-stream"
 
-        request = Finch.build(:post, url, headers, body)
+            body = Jason.encode!(build_payload(messages, opts))
 
-        {:ok,
-         FinchStream.run(
-           request,
-           &decode_aws_chunk/2,
-           %{aws: AwsEventStream.new(), model: model, started?: false},
-           mode: :raw
-         )}
+            headers =
+              sigv4_sign(
+                :post,
+                url,
+                [{"content-type", "application/json"}],
+                body,
+                creds,
+                region,
+                "bedrock"
+              )
+
+            request = Finch.build(:post, url, headers, body)
+
+            {:ok,
+             FinchStream.run(
+               request,
+               &decode_aws_chunk/2,
+               %{
+                 aws: AwsEventStream.new(),
+                 model: model,
+                 started?: false,
+                 provider: __MODULE__
+               },
+               mode: :raw
+             )}
+        end
     end
   end
 

--- a/lib/tau/providers/gemini.ex
+++ b/lib/tau/providers/gemini.ex
@@ -33,18 +33,31 @@ defmodule Tau.Providers.Gemini do
         {:error, :missing_api_key}
 
       key ->
-        model = opts[:model] || @default_model
-        body = build_body(messages, opts)
+        est = Tau.Providers.Shared.TokenEstimate.estimate(messages)
 
-        request =
-          Finch.build(
-            :post,
-            "#{base_url()}/v1beta/models/#{model}:streamGenerateContent?alt=sse&key=#{key}",
-            [{"content-type", "application/json"}, {"accept", "text/event-stream"}],
-            Jason.encode!(body)
-          )
+        case Tau.Providers.RateLimiter.acquire(__MODULE__, est) do
+          {:error, :rate_limit_timeout} ->
+            {:error, :rate_limited}
 
-        {:ok, FinchStream.run(request, &decode/2, %{model: model, started?: false})}
+          :ok ->
+            model = opts[:model] || @default_model
+            body = build_body(messages, opts)
+
+            request =
+              Finch.build(
+                :post,
+                "#{base_url()}/v1beta/models/#{model}:streamGenerateContent?alt=sse&key=#{key}",
+                [{"content-type", "application/json"}, {"accept", "text/event-stream"}],
+                Jason.encode!(body)
+              )
+
+            {:ok,
+             FinchStream.run(
+               request,
+               &decode/2,
+               %{model: model, started?: false, provider: __MODULE__}
+             )}
+        end
     end
   end
 

--- a/lib/tau/providers/openai/chat.ex
+++ b/lib/tau/providers/openai/chat.ex
@@ -32,17 +32,30 @@ defmodule Tau.Providers.OpenAI.Chat do
         {:error, :missing_api_key}
 
       key ->
-        body = build_body(messages, opts)
+        est = Tau.Providers.Shared.TokenEstimate.estimate(messages)
 
-        request =
-          Finch.build(
-            :post,
-            base_url() <> "/v1/chat/completions",
-            headers(key),
-            Jason.encode!(body)
-          )
+        case Tau.Providers.RateLimiter.acquire(__MODULE__, est) do
+          {:error, :rate_limit_timeout} ->
+            {:error, :rate_limited}
 
-        {:ok, FinchStream.run(request, &decode/2, %{tool_calls: %{}, model: nil})}
+          :ok ->
+            body = build_body(messages, opts)
+
+            request =
+              Finch.build(
+                :post,
+                base_url() <> "/v1/chat/completions",
+                headers(key),
+                Jason.encode!(body)
+              )
+
+            {:ok,
+             FinchStream.run(
+               request,
+               &decode/2,
+               %{tool_calls: %{}, model: nil, provider: __MODULE__}
+             )}
+        end
     end
   end
 

--- a/lib/tau/providers/openai/responses.ex
+++ b/lib/tau/providers/openai/responses.ex
@@ -32,17 +32,30 @@ defmodule Tau.Providers.OpenAI.Responses do
         {:error, :missing_api_key}
 
       key ->
-        body = build_body(messages, opts)
+        est = Tau.Providers.Shared.TokenEstimate.estimate(messages)
 
-        request =
-          Finch.build(
-            :post,
-            base_url() <> "/v1/responses",
-            headers(key),
-            Jason.encode!(body)
-          )
+        case Tau.Providers.RateLimiter.acquire(__MODULE__, est) do
+          {:error, :rate_limit_timeout} ->
+            {:error, :rate_limited}
 
-        {:ok, FinchStream.run(request, &decode/2, %{model: nil, started?: false})}
+          :ok ->
+            body = build_body(messages, opts)
+
+            request =
+              Finch.build(
+                :post,
+                base_url() <> "/v1/responses",
+                headers(key),
+                Jason.encode!(body)
+              )
+
+            {:ok,
+             FinchStream.run(
+               request,
+               &decode/2,
+               %{model: nil, started?: false, provider: __MODULE__}
+             )}
+        end
     end
   end
 

--- a/lib/tau/providers/rate_limiter.ex
+++ b/lib/tau/providers/rate_limiter.ex
@@ -1,0 +1,341 @@
+defmodule Tau.Providers.RateLimiter do
+  @moduledoc """
+  Per-provider token-bucket rate limiter (ADR-0011).
+
+  One GenServer per configured provider, registered under
+  `Tau.Providers.RateLimiter.Registry` keyed by provider module. The
+  process holds two `Tau.Providers.RateLimiter.TokenBucket` structs
+  (RPM = requests-per-minute, TPM = tokens-per-minute) and serialises
+  `acquire/3` calls through its mailbox — that's the wait queue.
+
+  ## Public API
+
+  - `acquire(provider, est_tokens, timeout)` — `:ok` once the budget is
+    available, or `{:error, :rate_limit_timeout}` if `timeout` elapses.
+    Block-and-wake — caller parks on `GenServer.call/3`.
+  - `record_response(provider, response_meta)` — fire-and-forget cast.
+    On `status: 429`, halves both buckets and arms a 60-second floor
+    so a settings reload during the floor doesn't undo the throttle.
+  - `state(provider)` — test-only introspection. Returns the limiter's
+    state map. Documented as test-only; production callers go through
+    telemetry.
+
+  ## Settings
+
+  On `init/1` the limiter reads its config from `Tau.Settings.Cache`
+  (ADR-0002) and subscribes to the `"settings"` PubSub topic. On
+  `{:settings_reloaded, settings}` it resizes its buckets in place via
+  `TokenBucket.resize/3` — preserving `current` and `last_refill_ms` so
+  the wait queue isn't flushed by a config change.
+
+  ## Settings shape
+
+      %{
+        "rate_limits" => %{
+          "Tau.Providers.Anthropic" => %{
+            "rpm" => 50,
+            "tpm" => 40_000
+          }
+        }
+      }
+
+  Both `rpm` and `tpm` default to `0` (which `TokenBucket` treats as
+  "no gating"). Atom and string keys are both accepted.
+  """
+
+  use GenServer
+
+  alias Tau.Providers.RateLimiter.TokenBucket
+
+  @default_429_floor_ms 60_000
+
+  # --- Public API -----------------------------------------------------------
+
+  @doc """
+  Start a rate limiter for `provider`. Registers under
+  `Tau.Providers.RateLimiter.Registry`.
+
+  `opts` accepts:
+    * `:rpm` and `:tpm` — explicit bucket sizes; if absent, falls back
+      to `Tau.Settings.Cache.get/0`.
+    * `:name` — override the registry-name (test-only).
+  """
+  @spec start_link({module(), keyword()}) :: GenServer.on_start()
+  def start_link({provider, opts}) when is_atom(provider) do
+    name = opts[:name] || via(provider)
+    GenServer.start_link(__MODULE__, {provider, opts}, name: name)
+  end
+
+  @doc """
+  Block until `est_tokens` of TPM and one RPM permit are available, or
+  `timeout` elapses.
+
+  Returns `:ok | {:error, :rate_limit_timeout}`. If no limiter is running
+  for `provider`, returns `:ok` (no gating configured).
+  """
+  @spec acquire(module(), non_neg_integer(), timeout()) ::
+          :ok | {:error, :rate_limit_timeout}
+  def acquire(provider, est_tokens, timeout \\ 30_000)
+      when is_atom(provider) and is_integer(est_tokens) and est_tokens >= 0 do
+    case Registry.lookup(Tau.Providers.RateLimiter.Registry, provider) do
+      [{pid, _}] ->
+        try do
+          GenServer.call(pid, {:acquire, est_tokens, timeout, monotonic_now()}, timeout + 1_000)
+        catch
+          :exit, {:timeout, _} -> {:error, :rate_limit_timeout}
+          :exit, {:noproc, _} -> :ok
+        end
+
+      [] ->
+        :ok
+    end
+  end
+
+  @doc """
+  Record a provider response so the limiter can react.
+
+  Fire-and-forget cast. `response_meta` should carry at least
+  `:status` (HTTP status integer). On 429, halves both buckets and
+  arms a 60-second floor.
+  """
+  @spec record_response(module(), map()) :: :ok
+  def record_response(provider, %{} = meta) when is_atom(provider) do
+    case Registry.lookup(Tau.Providers.RateLimiter.Registry, provider) do
+      [{pid, _}] -> GenServer.cast(pid, {:record_response, meta})
+      [] -> :ok
+    end
+  end
+
+  @doc """
+  Test-only introspection. Returns the current bucket state.
+  """
+  @spec state(module()) :: map() | :no_limiter
+  def state(provider) when is_atom(provider) do
+    case Registry.lookup(Tau.Providers.RateLimiter.Registry, provider) do
+      [{pid, _}] -> GenServer.call(pid, :state)
+      [] -> :no_limiter
+    end
+  end
+
+  @doc false
+  def via(provider), do: {:via, Registry, {Tau.Providers.RateLimiter.Registry, provider}}
+
+  # --- GenServer ------------------------------------------------------------
+
+  @impl true
+  def init({provider, opts}) do
+    Phoenix.PubSub.subscribe(Tau.PubSub, "settings")
+
+    {rpm, tpm} = bucket_sizes(provider, opts)
+    now = monotonic_now()
+
+    state = %{
+      provider: provider,
+      rpm_bucket: TokenBucket.new(rpm, div(rpm, 60), now),
+      tpm_bucket: TokenBucket.new(tpm, div(tpm, 60), now),
+      half_until: 0
+    }
+
+    {:ok, state}
+  end
+
+  @impl true
+  def handle_call({:acquire, est_tokens, timeout, started_at}, from, state) do
+    now = monotonic_now()
+    {request_status, rpm} = TokenBucket.take(state.rpm_bucket, 1, now)
+    {token_status, tpm} = TokenBucket.take(state.tpm_bucket, est_tokens, now)
+
+    cond do
+      request_status == :ok and token_status == :ok ->
+        wait_ms = now - started_at
+        new_state = %{state | rpm_bucket: rpm, tpm_bucket: tpm}
+        emit_acquired(state.provider, wait_ms, est_tokens, rpm, tpm, wait_ms > 0)
+        {:reply, :ok, new_state}
+
+      true ->
+        wait_ms =
+          [wait_for(request_status), wait_for(token_status)]
+          |> Enum.reject(&is_nil/1)
+          |> max_wait()
+
+        elapsed = now - started_at
+        remaining = timeout - elapsed
+
+        cond do
+          remaining <= 0 ->
+            emit_rejected(state.provider, elapsed)
+            {:reply, {:error, :rate_limit_timeout}, state}
+
+          wait_ms == :infinity or wait_ms > remaining ->
+            Process.send_after(
+              self(),
+              {:retry_acquire, from, est_tokens, timeout, started_at},
+              remaining
+            )
+
+            {:noreply, state}
+
+          true ->
+            Process.send_after(
+              self(),
+              {:retry_acquire, from, est_tokens, timeout, started_at},
+              max(1, wait_ms)
+            )
+
+            {:noreply, state}
+        end
+    end
+  end
+
+  def handle_call(:state, _from, state), do: {:reply, state, state}
+
+  @impl true
+  def handle_cast({:record_response, %{status: 429}}, state) do
+    rpm = TokenBucket.halve(state.rpm_bucket)
+    tpm = TokenBucket.halve(state.tpm_bucket)
+    half_until = monotonic_now() + @default_429_floor_ms
+
+    :telemetry.execute(
+      [:tau, :provider, :rate_limit, :halved],
+      %{system_time: System.system_time()},
+      %{provider: state.provider, new_size: rpm.size, tpm_size: tpm.size}
+    )
+
+    {:noreply, %{state | rpm_bucket: rpm, tpm_bucket: tpm, half_until: half_until}}
+  end
+
+  def handle_cast({:record_response, _}, state), do: {:noreply, state}
+
+  @impl true
+  def handle_info({:retry_acquire, from, est_tokens, timeout, started_at}, state) do
+    now = monotonic_now()
+    {request_status, rpm} = TokenBucket.take(state.rpm_bucket, 1, now)
+    {token_status, tpm} = TokenBucket.take(state.tpm_bucket, est_tokens, now)
+
+    if request_status == :ok and token_status == :ok do
+      wait_ms = now - started_at
+      emit_acquired(state.provider, wait_ms, est_tokens, rpm, tpm, true)
+      GenServer.reply(from, :ok)
+      {:noreply, %{state | rpm_bucket: rpm, tpm_bucket: tpm}}
+    else
+      elapsed = now - started_at
+      remaining = timeout - elapsed
+
+      if remaining <= 0 do
+        emit_rejected(state.provider, elapsed)
+        GenServer.reply(from, {:error, :rate_limit_timeout})
+        {:noreply, state}
+      else
+        next_wait =
+          [wait_for(request_status), wait_for(token_status)]
+          |> Enum.reject(&is_nil/1)
+          |> max_wait()
+
+        sleep_for =
+          case next_wait do
+            :infinity -> remaining
+            n -> min(n, remaining)
+          end
+
+        Process.send_after(
+          self(),
+          {:retry_acquire, from, est_tokens, timeout, started_at},
+          max(1, sleep_for)
+        )
+
+        {:noreply, state}
+      end
+    end
+  end
+
+  def handle_info({:settings_reloaded, settings}, state) do
+    {rpm_size, tpm_size} = sizes_from_settings(state.provider, settings)
+    now = monotonic_now()
+
+    rpm_target = ceiling_during_half(rpm_size, state.rpm_bucket.size, state.half_until, now)
+    tpm_target = ceiling_during_half(tpm_size, state.tpm_bucket.size, state.half_until, now)
+
+    rpm = TokenBucket.resize(state.rpm_bucket, rpm_target, div(rpm_target, 60))
+    tpm = TokenBucket.resize(state.tpm_bucket, tpm_target, div(tpm_target, 60))
+
+    {:noreply, %{state | rpm_bucket: rpm, tpm_bucket: tpm}}
+  end
+
+  def handle_info(_, state), do: {:noreply, state}
+
+  # --- helpers --------------------------------------------------------------
+
+  defp wait_for({:ok, _}), do: nil
+  defp wait_for({:wait, ms, _}), do: ms
+
+  defp max_wait([]), do: 0
+
+  defp max_wait(list) do
+    if Enum.member?(list, :infinity) do
+      :infinity
+    else
+      Enum.max(list)
+    end
+  end
+
+  defp emit_acquired(provider, wait_ms, est_tokens, rpm, tpm, throttled?) do
+    measurements = %{wait_ms: wait_ms, tokens_taken: est_tokens}
+
+    metadata = %{
+      provider: provider,
+      bucket_remaining: trunc(rpm.current),
+      tpm_remaining: trunc(tpm.current)
+    }
+
+    if throttled? do
+      :telemetry.execute([:tau, :provider, :rate_limit, :throttled], measurements, metadata)
+    end
+
+    :telemetry.execute([:tau, :provider, :rate_limit, :acquired], measurements, metadata)
+  end
+
+  defp emit_rejected(provider, wait_ms) do
+    :telemetry.execute(
+      [:tau, :provider, :rate_limit, :rejected],
+      %{wait_ms: wait_ms},
+      %{provider: provider}
+    )
+  end
+
+  defp bucket_sizes(provider, opts) do
+    case {opts[:rpm], opts[:tpm]} do
+      {rpm, tpm} when is_integer(rpm) and is_integer(tpm) -> {rpm, tpm}
+      _ -> sizes_from_settings(provider, Tau.Settings.Cache.get())
+    end
+  end
+
+  @doc false
+  def sizes_from_settings(provider, settings) when is_atom(provider) do
+    providers =
+      Map.get(settings, :rate_limits) ||
+        Map.get(settings, "rate_limits") ||
+        %{}
+
+    key_atom = provider
+    key_str = to_string(provider)
+
+    cfg =
+      Map.get(providers, key_atom) ||
+        Map.get(providers, key_str) ||
+        %{}
+
+    rpm = Map.get(cfg, :rpm) || Map.get(cfg, "rpm") || 0
+    tpm = Map.get(cfg, :tpm) || Map.get(cfg, "tpm") || 0
+    {rpm, tpm}
+  end
+
+  defp ceiling_during_half(new_target, current_size, half_until, now) do
+    if now < half_until and new_target > current_size do
+      current_size
+    else
+      new_target
+    end
+  end
+
+  defp monotonic_now, do: System.monotonic_time(:millisecond)
+end

--- a/lib/tau/providers/rate_limiter/supervisor.ex
+++ b/lib/tau/providers/rate_limiter/supervisor.ex
@@ -1,0 +1,151 @@
+defmodule Tau.Providers.RateLimiter.Supervisor do
+  @moduledoc """
+  Dynamic supervisor for `Tau.Providers.RateLimiter` GenServers
+  (one per configured provider) — ADR-0011.
+
+  On boot, reads the current settings from `Tau.Settings.Cache` and
+  starts a limiter for every provider listed under
+  `:rate_limits`. Subscribes to the `"settings"` PubSub topic; on
+  reload, *reconciles* the running set against the new config:
+
+    * **Add** — new provider key → start a new limiter under this
+      DynamicSupervisor.
+    * **Remove** — provider key dropped from settings → terminate
+      the corresponding child.
+    * **Same** — provider already running → leave it alone. The
+      limiter has its own `"settings"` subscription and resizes its
+      buckets in place.
+
+  This keeps the supervisor's job small (lifecycle reconciliation
+  only) while letting the limiters preserve their wait queues
+  across config changes.
+  """
+
+  use Supervisor
+
+  alias Tau.Providers.RateLimiter
+
+  @doc false
+  def start_link(opts) do
+    Supervisor.start_link(__MODULE__, opts, name: __MODULE__)
+  end
+
+  @impl true
+  def init(_opts) do
+    children = [
+      {DynamicSupervisor, strategy: :one_for_one, name: __MODULE__.Dynamic},
+      {__MODULE__.Reconciler, []}
+    ]
+
+    Supervisor.init(children, strategy: :one_for_all)
+  end
+
+  @doc """
+  Start (or no-op if already running) a limiter for `provider`.
+  """
+  @spec ensure_started(module(), keyword()) ::
+          {:ok, pid()} | {:ok, pid(), term()} | {:error, term()}
+  def ensure_started(provider, opts \\ []) when is_atom(provider) do
+    case Registry.lookup(Tau.Providers.RateLimiter.Registry, provider) do
+      [{pid, _}] ->
+        {:ok, pid}
+
+      [] ->
+        DynamicSupervisor.start_child(
+          __MODULE__.Dynamic,
+          {RateLimiter, {provider, opts}}
+        )
+    end
+  end
+
+  @doc """
+  Stop the limiter for `provider`, if running.
+  """
+  @spec stop(module()) :: :ok
+  def stop(provider) when is_atom(provider) do
+    case Registry.lookup(Tau.Providers.RateLimiter.Registry, provider) do
+      [{pid, _}] -> DynamicSupervisor.terminate_child(__MODULE__.Dynamic, pid)
+      [] -> :ok
+    end
+
+    :ok
+  end
+
+  @doc """
+  Currently-running provider modules.
+  """
+  @spec running() :: [module()]
+  def running do
+    Registry.select(Tau.Providers.RateLimiter.Registry, [
+      {{:"$1", :_, :_}, [], [:"$1"]}
+    ])
+  end
+
+  defmodule Reconciler do
+    @moduledoc false
+    use GenServer
+
+    def start_link(_), do: GenServer.start_link(__MODULE__, [])
+
+    @impl true
+    def init(_) do
+      Phoenix.PubSub.subscribe(Tau.PubSub, "settings")
+      reconcile(Tau.Settings.Cache.get())
+      {:ok, %{}}
+    end
+
+    @impl true
+    def handle_info({:settings_reloaded, settings}, state) do
+      reconcile(settings)
+      {:noreply, state}
+    end
+
+    def handle_info(_, state), do: {:noreply, state}
+
+    @doc false
+    def reconcile_now do
+      reconcile(Tau.Settings.Cache.get())
+    end
+
+    defp reconcile(settings) do
+      configured = configured_providers(settings)
+      running = MapSet.new(Tau.Providers.RateLimiter.Supervisor.running())
+
+      Enum.each(MapSet.difference(configured, running), &start_one/1)
+
+      Enum.each(
+        MapSet.difference(running, configured),
+        &Tau.Providers.RateLimiter.Supervisor.stop/1
+      )
+    end
+
+    defp start_one(provider) do
+      _ = Tau.Providers.RateLimiter.Supervisor.ensure_started(provider, [])
+    end
+
+    defp configured_providers(settings) do
+      providers =
+        Map.get(settings, :rate_limits) ||
+          Map.get(settings, "rate_limits") ||
+          %{}
+
+      providers
+      |> Map.keys()
+      |> Enum.map(&to_module/1)
+      |> Enum.reject(&is_nil/1)
+      |> MapSet.new()
+    end
+
+    defp to_module(m) when is_atom(m), do: m
+
+    defp to_module(s) when is_binary(s) do
+      try do
+        String.to_existing_atom("Elixir." <> s)
+      rescue
+        ArgumentError -> nil
+      end
+    end
+
+    defp to_module(_), do: nil
+  end
+end

--- a/lib/tau/providers/rate_limiter/token_bucket.ex
+++ b/lib/tau/providers/rate_limiter/token_bucket.ex
@@ -1,0 +1,139 @@
+defmodule Tau.Providers.RateLimiter.TokenBucket do
+  @moduledoc """
+  Pure token-bucket arithmetic for `Tau.Providers.RateLimiter`.
+
+  No process state. The owning GenServer threads `%TokenBucket{}` through
+  its own state and calls into this module on every request. ADR-0011
+  splits the math out so the property suite can pin the invariants
+  (non-negative current count, monotonic refill, idempotent halve)
+  without spinning up a process.
+
+  ## Shape
+
+      %TokenBucket{
+        size:           non_neg_integer(),    # max capacity (refills up to here)
+        current:        float() | non_neg_integer(),
+        rate_per_sec:   non_neg_integer(),    # refill rate
+        last_refill_ms: integer()             # System.monotonic_time(:millisecond)
+      }
+
+  `current` is allowed to be a float between refills so that a fractional
+  refill (`elapsed_ms * rate_per_sec / 1000`) doesn't drop tokens to
+  rounding. Callers see integer tokens via `take/3`'s contract.
+  """
+
+  defstruct size: 0, current: 0, rate_per_sec: 0, last_refill_ms: 0
+
+  @type t :: %__MODULE__{
+          size: non_neg_integer(),
+          current: number(),
+          rate_per_sec: non_neg_integer(),
+          last_refill_ms: integer()
+        }
+
+  @doc """
+  Construct a fresh bucket with `current = size`.
+
+  `now_ms` defaults to `System.monotonic_time(:millisecond)`. Tests inject.
+  """
+  @spec new(non_neg_integer(), non_neg_integer(), integer()) :: t()
+  def new(size, rate_per_sec, now_ms \\ System.monotonic_time(:millisecond))
+      when is_integer(size) and size >= 0 and is_integer(rate_per_sec) and rate_per_sec >= 0 do
+    %__MODULE__{
+      size: size,
+      current: size,
+      rate_per_sec: rate_per_sec,
+      last_refill_ms: now_ms
+    }
+  end
+
+  @doc """
+  Add elapsed-time refill, capped at `size`.
+
+  `now_ms` is monotonic. If the clock somehow goes backwards (it shouldn't,
+  but BEAM monotonic time is per-scheduler) we treat negative deltas as 0.
+  """
+  @spec refill(t(), integer()) :: t()
+  def refill(%__MODULE__{rate_per_sec: 0} = b, _now_ms), do: b
+
+  def refill(%__MODULE__{} = b, now_ms) do
+    delta_ms = max(0, now_ms - b.last_refill_ms)
+    add = delta_ms * b.rate_per_sec / 1000
+    new_current = min(b.size, b.current + add)
+    %__MODULE__{b | current: new_current, last_refill_ms: now_ms}
+  end
+
+  @doc """
+  Attempt to take `n` tokens.
+
+  Returns `{:ok, bucket}` if budget was available; `{:wait, wait_ms,
+  bucket}` if the caller should park for `wait_ms` milliseconds and then
+  retry. The bucket is unchanged on `:wait` — the GenServer serialises
+  waiters via its mailbox.
+
+  `n = 0` always succeeds without touching the bucket.
+
+  Refills internally before checking, so callers don't need to call
+  `refill/2` themselves. Pass `now_ms` for testability.
+  """
+  @spec take(t(), non_neg_integer(), integer()) ::
+          {:ok, t()} | {:wait, non_neg_integer() | :infinity, t()}
+  def take(%__MODULE__{} = b, 0, _now_ms), do: {:ok, b}
+
+  def take(%__MODULE__{size: 0} = b, _n, _now_ms) do
+    # Bucket fully disabled (size 0). Treat as unlimited — there's no
+    # configured limit. Callers that disable a bucket via size:0 mean
+    # "no gating".
+    {:ok, b}
+  end
+
+  def take(%__MODULE__{} = b, n, now_ms) when is_integer(n) and n > 0 do
+    b = refill(b, now_ms)
+
+    if b.current >= n do
+      {:ok, %__MODULE__{b | current: b.current - n}}
+    else
+      missing = n - b.current
+
+      wait_ms =
+        if b.rate_per_sec == 0 do
+          :infinity
+        else
+          ceil(missing * 1000 / b.rate_per_sec)
+        end
+
+      {:wait, wait_ms, b}
+    end
+  end
+
+  @doc """
+  Halve the bucket's `size`, clipping `current` to the new ceiling.
+
+  Floors at size = 1 to avoid driving the bucket to zero (which would be
+  indistinguishable from "no gating" per `take/3`'s zero-size arm).
+  """
+  @spec halve(t()) :: t()
+  def halve(%__MODULE__{size: size} = b) do
+    new_size = max(1, div(size, 2))
+    new_current = min(b.current, new_size)
+    %__MODULE__{b | size: new_size, current: new_current}
+  end
+
+  @doc """
+  Resize the bucket in place (used on settings reload).
+
+  Preserves `current` (clipped to `new_size`) and `last_refill_ms`. ADR-0011
+  explains why we resize rather than restart.
+  """
+  @spec resize(t(), non_neg_integer(), non_neg_integer()) :: t()
+  def resize(%__MODULE__{} = b, new_size, new_rate_per_sec)
+      when is_integer(new_size) and new_size >= 0 and is_integer(new_rate_per_sec) and
+             new_rate_per_sec >= 0 do
+    %__MODULE__{
+      b
+      | size: new_size,
+        current: min(b.current, new_size),
+        rate_per_sec: new_rate_per_sec
+    }
+  end
+end

--- a/lib/tau/providers/shared/finch_stream.ex
+++ b/lib/tau/providers/shared/finch_stream.ex
@@ -21,6 +21,14 @@ defmodule Tau.Providers.Shared.FinchStream do
   Provider modules supply a `decode/2` that turns parsed events (SSE map
   or raw binary) into `Tau.Provider.Event` structs and an opaque partial
   state.
+
+  ## Rate-limiter feedback
+
+  If `init_partial` carries a `:provider` key (a module that implements
+  `Tau.Provider`), the engine fire-and-forgets a
+  `Tau.Providers.RateLimiter.record_response/2` call when an HTTP 429 is
+  observed (per ADR-0011). Providers that don't want this behaviour
+  simply omit `:provider` from their partial state.
   """
 
   alias Tau.Provider.Event
@@ -104,6 +112,7 @@ defmodule Tau.Providers.Shared.FinchStream do
 
   defp handle({:status, n}, s, _decoder) do
     err = %Event.Error{reason: {:http_status, n}, retryable?: n in [408, 429, 500, 502, 503, 504]}
+    maybe_notify_rate_limiter(s, n)
     %{s | status: n, pending: s.pending ++ [err], finished?: true}
   end
 
@@ -135,4 +144,10 @@ defmodule Tau.Providers.Shared.FinchStream do
   defp handle({:error, reason}, s, _) do
     %{s | pending: s.pending ++ [%Event.Error{reason: reason, retryable?: true}], finished?: true}
   end
+
+  defp maybe_notify_rate_limiter(%{partial: %{provider: provider}}, status) when is_atom(provider) do
+    Tau.Providers.RateLimiter.record_response(provider, %{status: status})
+  end
+
+  defp maybe_notify_rate_limiter(_, _), do: :ok
 end

--- a/lib/tau/providers/shared/token_estimate.ex
+++ b/lib/tau/providers/shared/token_estimate.ex
@@ -1,0 +1,61 @@
+defmodule Tau.Providers.Shared.TokenEstimate do
+  @moduledoc """
+  Cheap pre-flight token estimate shared across providers.
+
+  Used by the rate limiter (ADR-0011) to take a TPM permit before the
+  HTTP send — we don't have a real tokenizer integrated yet, and pulling
+  one in (tiktoken, gpt-tokenizer) is a dependency decision that #39
+  intentionally defers. The heuristic is `byte_size(text) / 4` summed
+  over every string-shaped piece of every message, which is within
+  ~30% of real for English prose and is fine for budget gating where
+  the upstream API has the final say (and we react to its 429s).
+
+  A future PR can swap this for a real tokenizer without touching
+  callers — the contract is "given messages, return non_neg_integer()".
+  """
+
+  alias Tau.Message.{Assistant, ToolResult, User}
+
+  @bytes_per_token 4
+
+  @doc """
+  Estimate the token cost of a list of messages.
+
+  Walks every `User`, `Assistant`, and `ToolResult` and sums the byte
+  size of every string content piece. Image data is *not* counted
+  (image tokenisation is wildly model-specific; the rate limiter
+  cares about RPM more than TPM here, and TPM is advisory).
+  """
+  @spec estimate([term()]) :: non_neg_integer()
+  def estimate(messages) when is_list(messages) do
+    bytes = Enum.reduce(messages, 0, &(&2 + bytes_in(&1)))
+    div(bytes, @bytes_per_token)
+  end
+
+  def estimate(_), do: 0
+
+  defp bytes_in(%User{content: c}), do: bytes_in_content(c)
+  defp bytes_in(%Assistant{content: c}), do: bytes_in_content(c)
+  defp bytes_in(%ToolResult{content: c}), do: bytes_in_content(c)
+  defp bytes_in(s) when is_binary(s), do: byte_size(s)
+  defp bytes_in(_), do: 0
+
+  defp bytes_in_content(s) when is_binary(s), do: byte_size(s)
+
+  defp bytes_in_content(blocks) when is_list(blocks) do
+    Enum.reduce(blocks, 0, fn b, acc -> acc + bytes_in_block(b) end)
+  end
+
+  defp bytes_in_content(_), do: 0
+
+  defp bytes_in_block(%{type: :text, text: t}) when is_binary(t), do: byte_size(t)
+  defp bytes_in_block(%{type: :thinking, text: t}) when is_binary(t), do: byte_size(t)
+
+  defp bytes_in_block(%{type: :tool_call, name: n, arguments: a}) do
+    name_bytes = if is_binary(n), do: byte_size(n), else: 0
+    args_bytes = if is_map(a), do: byte_size(Jason.encode!(a)), else: 0
+    name_bytes + args_bytes
+  end
+
+  defp bytes_in_block(_), do: 0
+end

--- a/lib/tau/registries.ex
+++ b/lib/tau/registries.ex
@@ -25,6 +25,10 @@ defmodule Tau.Registries do
     * `Tau.Sessions.Registry` — `:unique`, keyed by `session_id`. Session
       FSMs register themselves here on init so callers can address them
       by id without holding pid references.
+
+    * `Tau.Providers.RateLimiter.Registry` — `:unique`, keyed by provider
+      module. One `Tau.Providers.RateLimiter` GenServer registers per
+      configured provider (ADR-0011).
   """
   use Supervisor
 
@@ -40,7 +44,8 @@ defmodule Tau.Registries do
       {Registry, keys: :unique, name: Tau.Commands.Registry},
       {Registry, keys: :unique, name: Tau.Skills.Registry},
       {Registry, keys: :unique, name: Tau.Sessions.Registry},
-      {Registry, keys: :unique, name: Tau.MCP.Registry}
+      {Registry, keys: :unique, name: Tau.MCP.Registry},
+      {Registry, keys: :unique, name: Tau.Providers.RateLimiter.Registry}
     ]
 
     Supervisor.init(children, strategy: :one_for_one)

--- a/lib/tau/telemetry/handlers.ex
+++ b/lib/tau/telemetry/handlers.ex
@@ -9,6 +9,7 @@ defmodule Tau.Telemetry.Handlers do
       [:tau, :session, :transition]
       [:tau, :provider, :request, :start | :stop | :exception]
       [:tau, :provider, :event]
+      [:tau, :provider, :rate_limit, :acquired | :throttled | :rejected | :halved]
       [:tau, :tool, :execute, :start | :stop | :exception]
       [:tau, :tool, :bash, :stderr]
       [:tau, :hook, :run, :start | :stop | :exception]
@@ -64,6 +65,10 @@ defmodule Tau.Telemetry.Handlers do
       [:tau, :provider, :request, :stop],
       [:tau, :provider, :request, :exception],
       [:tau, :provider, :event],
+      [:tau, :provider, :rate_limit, :acquired],
+      [:tau, :provider, :rate_limit, :throttled],
+      [:tau, :provider, :rate_limit, :rejected],
+      [:tau, :provider, :rate_limit, :halved],
       [:tau, :tool, :execute, :start],
       [:tau, :tool, :execute, :stop],
       [:tau, :tool, :execute, :exception],

--- a/test/tau/providers/rate_limiter/token_bucket_property_test.exs
+++ b/test/tau/providers/rate_limiter/token_bucket_property_test.exs
@@ -1,0 +1,109 @@
+defmodule Tau.Providers.RateLimiter.TokenBucketPropertyTest do
+  @moduledoc """
+  Properties that pin `Tau.Providers.RateLimiter.TokenBucket` (the pure
+  core that ADR-0011 promises to keep stable).
+
+  Invariants tested:
+
+    * `take/3` never produces a negative `current` count.
+    * `refill/2` is monotonic in time — given t1 ≤ t2,
+      `refill(b, t2).current >= refill(b, t1).current`.
+    * `halve/1` halves the size each call (with a floor at 1) — two
+      halves in the same instant equals dividing by 4.
+  """
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  alias Tau.Providers.RateLimiter.TokenBucket
+
+  @moduletag :property
+
+  defp bucket_gen do
+    StreamData.bind(
+      StreamData.tuple({
+        StreamData.integer(0..10_000),
+        StreamData.integer(0..1_000)
+      }),
+      fn {size, rate} ->
+        StreamData.constant(TokenBucket.new(size, rate, 0))
+      end
+    )
+  end
+
+  property "take/3 never produces negative current" do
+    check all(
+            b <- bucket_gen(),
+            n <- StreamData.integer(0..50_000),
+            t <- StreamData.integer(0..1_000_000)
+          ) do
+      case TokenBucket.take(b, n, t) do
+        {:ok, b2} ->
+          assert b2.current >= 0
+
+        {:wait, _, b2} ->
+          # On :wait the bucket isn't decremented; it may have been
+          # refilled but `current` must still be >= 0.
+          assert b2.current >= 0
+      end
+    end
+  end
+
+  property "refill/2 is monotonic in time" do
+    check all(
+            b <- bucket_gen(),
+            t1 <- StreamData.integer(0..1_000_000),
+            dt <- StreamData.integer(0..1_000_000)
+          ) do
+      t2 = t1 + dt
+      r1 = TokenBucket.refill(b, t1)
+      r2 = TokenBucket.refill(b, t2)
+      assert r2.current >= r1.current or r2.current == b.size
+    end
+  end
+
+  property "halve/1 applied twice in the same instant is dividing by 4 (with floor)" do
+    check all(size <- StreamData.integer(2..10_000)) do
+      b = TokenBucket.new(size, 0, 0)
+      once = TokenBucket.halve(b)
+      twice = TokenBucket.halve(once)
+
+      expected_once = max(1, div(size, 2))
+      expected_twice = max(1, div(expected_once, 2))
+
+      assert once.size == expected_once
+      assert twice.size == expected_twice
+    end
+  end
+
+  property "take/3 with n=0 is a no-op" do
+    check all(
+            b <- bucket_gen(),
+            t <- StreamData.integer(0..1_000_000)
+          ) do
+      assert {:ok, b2} = TokenBucket.take(b, 0, t)
+      assert b2 == b
+    end
+  end
+
+  property "halve/1 floors at size = 1" do
+    check all(size <- StreamData.integer(0..3)) do
+      b = TokenBucket.new(size, 0, 0)
+      h = TokenBucket.halve(b)
+      assert h.size >= 1
+    end
+  end
+
+  property "resize/3 preserves last_refill_ms and clips current" do
+    check all(
+            b <- bucket_gen(),
+            new_size <- StreamData.integer(0..10_000),
+            new_rate <- StreamData.integer(0..1_000)
+          ) do
+      r = TokenBucket.resize(b, new_size, new_rate)
+      assert r.last_refill_ms == b.last_refill_ms
+      assert r.current <= new_size
+      assert r.size == new_size
+      assert r.rate_per_sec == new_rate
+    end
+  end
+end

--- a/test/tau/providers/rate_limiter_429_test.exs
+++ b/test/tau/providers/rate_limiter_429_test.exs
@@ -1,0 +1,73 @@
+defmodule Tau.Providers.RateLimiter429Test do
+  @moduledoc """
+  End-to-end-ish: drives the rate limiter with a synthetic 429 cast and
+  verifies the bucket halves. Uses `Tau.Providers.RateLimiter.state/1`
+  for introspection (test-only API documented in the limiter moduledoc).
+  """
+  use ExUnit.Case, async: false
+
+  alias Tau.Providers.RateLimiter
+
+  defmodule FakeProviderForFiveTwentyNine do
+    @moduledoc false
+  end
+
+  setup do
+    on_exit(fn ->
+      case RateLimiter.state(FakeProviderForFiveTwentyNine) do
+        :no_limiter -> :ok
+        _ -> Tau.Providers.RateLimiter.Supervisor.stop(FakeProviderForFiveTwentyNine)
+      end
+    end)
+
+    :ok
+  end
+
+  test "429 record_response halves bucket; next acquire sees the smaller cap" do
+    {:ok, _} =
+      Tau.Providers.RateLimiter.Supervisor.ensure_started(
+        FakeProviderForFiveTwentyNine,
+        rpm: 600,
+        tpm: 6_000
+      )
+
+    original = RateLimiter.state(FakeProviderForFiveTwentyNine)
+    assert original.rpm_bucket.size == 600
+    assert original.tpm_bucket.size == 6_000
+
+    RateLimiter.record_response(FakeProviderForFiveTwentyNine, %{status: 429})
+    Process.sleep(20)
+
+    halved = RateLimiter.state(FakeProviderForFiveTwentyNine)
+    assert halved.rpm_bucket.size == 300
+    assert halved.tpm_bucket.size == 3_000
+
+    # And acquire still works against the smaller cap.
+    assert :ok = RateLimiter.acquire(FakeProviderForFiveTwentyNine, 100, 1_000)
+  end
+
+  test "telemetry :halved fires on 429" do
+    {:ok, _} =
+      Tau.Providers.RateLimiter.Supervisor.ensure_started(
+        FakeProviderForFiveTwentyNine,
+        rpm: 200,
+        tpm: 2_000
+      )
+
+    test_pid = self()
+    handler_id = "rl-429-#{:erlang.unique_integer([:positive])}"
+
+    :telemetry.attach(
+      handler_id,
+      [:tau, :provider, :rate_limit, :halved],
+      fn _event, _m, meta, _ -> send(test_pid, {:halved, meta}) end,
+      nil
+    )
+
+    on_exit(fn -> :telemetry.detach(handler_id) end)
+
+    RateLimiter.record_response(FakeProviderForFiveTwentyNine, %{status: 429})
+
+    assert_receive {:halved, %{provider: FakeProviderForFiveTwentyNine, new_size: 100}}, 500
+  end
+end

--- a/test/tau/providers/rate_limiter_test.exs
+++ b/test/tau/providers/rate_limiter_test.exs
@@ -1,0 +1,118 @@
+defmodule Tau.Providers.RateLimiterTest do
+  @moduledoc """
+  Behavioural tests for the `Tau.Providers.RateLimiter` GenServer
+  (ADR-0011, #39).
+
+  Each test starts its own fake-provider limiter under the running
+  `Tau.Providers.RateLimiter.Supervisor.Dynamic` so they don't collide
+  with any limiter that booted from the loaded settings.
+  """
+  use ExUnit.Case, async: false
+
+  alias Tau.Providers.RateLimiter
+
+  defmodule FakeProvider do
+    @moduledoc false
+  end
+
+  defmodule FakeProvider2 do
+    @moduledoc false
+  end
+
+  setup do
+    on_exit(fn ->
+      RateLimiter
+      |> apply(:state, [FakeProvider])
+      |> case do
+        :no_limiter -> :ok
+        _ -> Tau.Providers.RateLimiter.Supervisor.stop(FakeProvider)
+      end
+
+      RateLimiter
+      |> apply(:state, [FakeProvider2])
+      |> case do
+        :no_limiter -> :ok
+        _ -> Tau.Providers.RateLimiter.Supervisor.stop(FakeProvider2)
+      end
+    end)
+
+    :ok
+  end
+
+  describe "acquire/3 with available budget" do
+    test "returns :ok immediately and emits :acquired telemetry" do
+      {:ok, _pid} =
+        Tau.Providers.RateLimiter.Supervisor.ensure_started(FakeProvider, rpm: 600, tpm: 6_000)
+
+      ref = make_ref()
+
+      :telemetry.attach_many(
+        "rl-test-#{inspect(ref)}",
+        [
+          [:tau, :provider, :rate_limit, :acquired],
+          [:tau, :provider, :rate_limit, :throttled],
+          [:tau, :provider, :rate_limit, :rejected]
+        ],
+        fn event, m, meta, _ -> send(self(), {ref, event, m, meta}) end,
+        nil
+      )
+
+      send(self(), {ref, :primer, %{}, %{}})
+      _ = receive(do: ({^ref, :primer, _, _} -> :ok))
+
+      assert :ok = RateLimiter.acquire(FakeProvider, 100, 1_000)
+
+      :telemetry.detach("rl-test-#{inspect(ref)}")
+    end
+
+    test "no limiter for provider returns :ok (no gating)" do
+      assert :ok = RateLimiter.acquire(:nonexistent_provider, 100, 100)
+    end
+  end
+
+  describe "acquire/3 starvation" do
+    test "with zero budget and zero refill returns :rate_limit_timeout quickly" do
+      # rpm: 0 == "no gating" per TokenBucket spec, so use a tiny budget
+      # with a high request count.
+      {:ok, _} =
+        Tau.Providers.RateLimiter.Supervisor.ensure_started(FakeProvider, rpm: 60, tpm: 60)
+
+      # Drain the rpm bucket. rate_per_sec = 60/60 = 1, so refill is
+      # 1 token/sec — easy to starve.
+      Enum.each(1..60, fn _ -> RateLimiter.acquire(FakeProvider, 0, 5_000) end)
+
+      # Now ask for one more with a 50ms timeout — should reject.
+      assert {:error, :rate_limit_timeout} = RateLimiter.acquire(FakeProvider, 0, 50)
+    end
+  end
+
+  describe "record_response/2" do
+    test "halves bucket on 429" do
+      {:ok, _} =
+        Tau.Providers.RateLimiter.Supervisor.ensure_started(FakeProvider2, rpm: 100, tpm: 1_000)
+
+      before_state = RateLimiter.state(FakeProvider2)
+      assert before_state.rpm_bucket.size == 100
+
+      RateLimiter.record_response(FakeProvider2, %{status: 429})
+      # Cast — give it a moment to land.
+      Process.sleep(20)
+
+      after_state = RateLimiter.state(FakeProvider2)
+      assert after_state.rpm_bucket.size == 50
+      assert after_state.tpm_bucket.size == 500
+      assert after_state.half_until > 0
+    end
+
+    test "non-429 status is a no-op" do
+      {:ok, _} =
+        Tau.Providers.RateLimiter.Supervisor.ensure_started(FakeProvider2, rpm: 100, tpm: 1_000)
+
+      RateLimiter.record_response(FakeProvider2, %{status: 200})
+      Process.sleep(20)
+
+      after_state = RateLimiter.state(FakeProvider2)
+      assert after_state.rpm_bucket.size == 100
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- New `Tau.Providers.RateLimiter` GenServer (one per configured provider, registered in a new `Tau.Providers.RateLimiter.Registry`) supervised by `Tau.Providers.RateLimiter.Supervisor`. Pure `Tau.Providers.RateLimiter.TokenBucket` carries the math; the GenServer carries the wait queue.
- All five provider `stream/3` entry points (Anthropic, OpenAI Chat, OpenAI Responses, Gemini, Bedrock) now `acquire/3` a permit before the Finch send. Synchronous `{:error, :rate_limited}` mirrors the existing `{:error, :missing_api_key}` shape. Limited to `stream/3`; `build_body/2` left untouched for #37 deconfliction.
- HTTP 429 in `Tau.Providers.Shared.FinchStream` casts `record_response/2` which halves both buckets and arms a 60-second floor. Settings reload re-sizes existing buckets in place via `TokenBucket.resize/3` (preserving wait queue); the supervisor reconciles add/remove against config.
- New telemetry: `[:tau, :provider, :rate_limit, :acquired | :throttled | :rejected | :halved]`. Listed in `Tau.Telemetry.Handlers`.

See [ADR-0011](docs/adr/0011-per-provider-rate-limiter-is-stateful-genserver.md) — explicitly contrasts the GenServer choice against ADR-0010's ETS-owner pattern, and pushes back on the issue body's `Application.get_env/2` suggestion (config comes from `Tau.Settings.Cache` per ADR-0002).

## Files touched

- `docs/adr/0011-per-provider-rate-limiter-is-stateful-genserver.md` (new), `docs/adr/README.md` (index)
- `lib/tau/providers/rate_limiter.ex` (new), `lib/tau/providers/rate_limiter/{supervisor,token_bucket}.ex` (new)
- `lib/tau/providers/shared/token_estimate.ex` (new)
- `lib/tau/{application,registries}.ex`, `lib/tau/telemetry/handlers.ex`
- `lib/tau/providers/{anthropic,bedrock,gemini}.ex`, `lib/tau/providers/openai/{chat,responses}.ex`
- `lib/tau/providers/shared/finch_stream.ex` (429 notify)
- `test/tau/providers/rate_limiter/token_bucket_property_test.exs` (`@moduletag :property`)
- `test/tau/providers/rate_limiter_test.exs`, `test/tau/providers/rate_limiter_429_test.exs`
- `CHANGELOG.md`

## Test plan

- [ ] `mix test --only property` exercises the `TokenBucket` invariants (non-negative `current`, monotonic refill, halve idempotence-modulo-floor).
- [ ] `mix test test/tau/providers/rate_limiter_test.exs` covers `acquire/3` happy path, starvation → `:rate_limit_timeout`, `record_response/2` halving on 429, and that no-limiter providers see `:ok`.
- [ ] `mix test test/tau/providers/rate_limiter_429_test.exs` drives a synthetic 429 cast and asserts `state/1` reflects halved sizes plus `[:tau, :provider, :rate_limit, :halved]` telemetry.
- [ ] `mix compile` warning-free; `mix format --check-formatted` clean.

## Notes

- `est_tokens` is a deliberate v1 heuristic (`byte_size/4` over message content). A real tokenizer dependency is filed as a follow-up — issue #39 explicitly OKs the heuristic.
- Test-only `RateLimiter.state/1` introspection is documented as such in the moduledoc.
- Merge after #80 (cost tracker) — already merged.
- #37 (tool-schema normalization) shipped in parallel; this PR confines its provider edits to `stream/3` only, leaving `build_body/2` untouched.

https://claude.ai/code/session_011bAhaU738pEzP52sVs8RUQ


---
_Generated by [Claude Code](https://claude.ai/code/session_011bAhaU738pEzP52sVs8RUQ)_