### PR TITLE
chore: gitignore .claude/worktrees/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ coverage.json
 
 # Tau runtime data (when developing against the local cwd)
 /.tau/settings.local.json
+
+# Claude Code agent worktrees (created by Agent calls with isolation: "worktree")
+/.claude/worktrees/


### PR DESCRIPTION
One-line `.gitignore` addition: Claude Code's `Agent` tool creates an isolated git worktree at `.claude/worktrees/<id>/` when called with `isolation: "worktree"` (the pattern CLAUDE.md PR #81 just made mandatory for parallel subagents). The directory contains a separate checkout — never committable content for this repo. Without the rule, the parent worktree's `git status` flags the directory as untracked every time a worktree-isolated agent is in flight.

https://claude.ai/code/session_011bAhaU738pEzP52sVs8RUQ

---
_Generated by [Claude Code](https://claude.ai/code/session_011bAhaU738pEzP52sVs8RUQ)_