### PR TITLE
docs: document Bash cancellation limits on Windows (closes #27)

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,13 @@ sandbox blocks `mix deps.get` from reaching `repo.hex.pm` via Erlang's
 httpc (curl works, Erlang doesn't). Verify on GitHub Actions per
 `.github/workflows/ci.yml`.
 
+Known limitations: cancelling a `Bash` tool call kills only the direct
+`bash` PID — descendants survive on every platform until `:erlexec`
+returns (Linux/macOS, #12), and Windows has no equivalent at all
+(#27). If descendant cleanup matters, wrap your script in a
+`taskkill`/`trap`-aware shim. See `lib/tau/tools/builtin/bash.ex`
+moduledoc.
+
 ## Design philosophy
 
 - **No shortcuts.** Every stateful subsystem is a process under a supervisor.


### PR DESCRIPTION
## Summary

- Adds a Known limitations note to README's Status section calling out that cancelling a `Bash` tool call only kills the direct `bash` PID; descendants leak on every platform until `:erlexec` returns (#12) and Windows has no equivalent at all (#27).
- Points readers at `lib/tau/tools/builtin/bash.ex` moduledoc, which already carries the full caveat (no code change needed there).

Pure docs PR — no code, no tests.

## Test plan

- [x] `git diff` confirms only README.md changed.
- [ ] Render README on GitHub and verify the new paragraph reads cleanly in the Status section.

Closes #27

https://claude.ai/code/session_011bAhaU738pEzP52sVs8RUQ

---
_Generated by [Claude Code](https://claude.ai/code/session_011bAhaU738pEzP52sVs8RUQ)_