### PR TITLE
fix: TUI handles Cancelled and SessionEnd events (closes #26)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- TUI: `Tau.TUI.App.update/2` now handles
+  `%Tau.Session.Events.Cancelled{}` and
+  `%Tau.Session.Events.SessionEnd{}`. Previously both fell through to
+  the catch-all clause, so pressing ESC produced no UI feedback and a
+  terminating session left the status bar reading `streaming`. Status
+  is stringified before storage so the existing `to_string/1` call in
+  the status bar continues to work. (Closes #26.)
+
 ### Added
 - Provider fallback chains — sessions retry against the next provider
   in `settings.providers.fallback_chains[primary]` on a retryable

--- a/lib/tau/tui/app.ex
+++ b/lib/tau/tui/app.ex
@@ -42,6 +42,8 @@ if Code.ensure_loaded?(Ratatouille.Runtime) do
         %Tau.Session.Events.MessageEnd{} = e -> on_message_end(model, e)
         %Tau.Session.Events.ToolStart{} = e -> on_tool_start(model, e)
         %Tau.Session.Events.ToolEnd{} = e -> on_tool_end(model, e)
+        %Tau.Session.Events.Cancelled{} = e -> on_cancelled(model, e)
+        %Tau.Session.Events.SessionEnd{} = e -> on_session_end(model, e)
         _ -> model
       end
     end
@@ -160,6 +162,28 @@ if Code.ensure_loaded?(Ratatouille.Runtime) do
           else: c |> inspect() |> String.slice(0..160)
 
       %{model | tool_output: model.tool_output ++ [prefix <> " " <> summary]}
+    end
+
+    defp on_cancelled(model, %{reason: reason}) do
+      reason_str = inspect(reason)
+
+      %{
+        model
+        | status: "cancelled: " <> reason_str,
+          transcript: model.transcript ++ ["[cancelled: " <> reason_str <> "]"],
+          last_assistant: nil
+      }
+    end
+
+    defp on_session_end(model, %{reason: reason}) do
+      reason_str = inspect(reason)
+
+      %{
+        model
+        | status: "ended: " <> reason_str,
+          transcript: model.transcript ++ ["[session ended: " <> reason_str <> "]"],
+          last_assistant: nil
+      }
     end
   end
 end

--- a/test/tau/tui/app_test.exs
+++ b/test/tau/tui/app_test.exs
@@ -1,0 +1,52 @@
+if Code.ensure_loaded?(Ratatouille.Runtime) do
+  defmodule Tau.TUI.AppTest do
+    @moduledoc """
+    Verifies #26: `Tau.TUI.App.update/2` reacts to `Cancelled` and
+    `SessionEnd` PubSub events. Without these clauses ESC produces no
+    UI feedback and a terminating session leaves the bar reading
+    `streaming`.
+
+    Drives `update/2` directly with a hand-built model state so the
+    test does not depend on Ratatouille's runtime loop.
+    """
+    use ExUnit.Case, async: true
+
+    alias Tau.Session.Events
+    alias Tau.TUI.App
+
+    defp model do
+      %{
+        session_id: "sess-test",
+        input: "",
+        transcript: [],
+        tool_output: [],
+        status: :streaming,
+        last_assistant: "partial"
+      }
+    end
+
+    describe "update/2 — Cancelled" do
+      test "moves status into a cancelled string and appends a transcript line" do
+        event = %Events.Cancelled{session_id: "sess-test", reason: :user_request}
+
+        next = App.update(model(), event)
+
+        assert next.status == "cancelled: :user_request"
+        assert List.last(next.transcript) == "[cancelled: :user_request]"
+        assert next.last_assistant == nil
+      end
+    end
+
+    describe "update/2 — SessionEnd" do
+      test "moves status into an ended string and appends a transcript line" do
+        event = %Events.SessionEnd{session_id: "sess-test", reason: :normal}
+
+        next = App.update(model(), event)
+
+        assert next.status == "ended: :normal"
+        assert List.last(next.transcript) == "[session ended: :normal]"
+        assert next.last_assistant == nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Adds explicit `update/2` clauses in `Tau.TUI.App` for `%Tau.Session.Events.Cancelled{}` and `%Tau.Session.Events.SessionEnd{}`. Previously both fell through to the catch-all, so ESC produced no UI feedback and a terminating session left the status bar stuck on `streaming`.
- New `on_cancelled/2` / `on_session_end/2` helpers store a stringified status (`"cancelled: <reason>"` / `"ended: <reason>"`) so the existing `to_string(model.status)` call in `status_bar/1` keeps working, append a transcript line summarising the event, and clear `last_assistant` to drop any partial in-flight text.
- Bumps `CHANGELOG.md` with a new `[Unreleased] ### Fixed` section referencing #26.

## Test plan

- [x] New `test/tau/tui/app_test.exs` drives `Tau.TUI.App.update/2` directly with hand-built model state and asserts:
  - `Cancelled{reason: :user_request}` -> `status == "cancelled: :user_request"`, transcript line `"[cancelled: :user_request]"`, `last_assistant == nil`.
  - `SessionEnd{reason: :normal}` -> `status == "ended: :normal"`, transcript line `"[session ended: :normal]"`, `last_assistant == nil`.
- [x] Both the module and its test are guarded by `Code.ensure_loaded?(Ratatouille.Runtime)`, matching the existing layout, so they compile only when the optional `:ratatouille` dep is present.
- [ ] CI runs `mix format --check-formatted`, `mix credo --strict`, `mix dialyzer`, `mix test` (validated remotely; `mix` not available in the dev sandbox).

Closes #26

https://claude.ai/code/session_011bAhaU738pEzP52sVs8RUQ

---
_Generated by [Claude Code](https://claude.ai/code/session_011bAhaU738pEzP52sVs8RUQ)_