### PR TITLE
refactor: parallel tool dispatch via Task.Supervisor.async_stream_nolink/4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   is stringified before storage so the existing `to_string/1` call in
   the status bar continues to work. (Closes #26.)
 
+### Changed
+- `Tau.Session` now dispatches a turn's parallel tool calls through a
+  single `Task.Supervisor.async_stream_nolink/4` iterator under
+  `Tau.Tools.TaskSupervisor` instead of one `async_nolink/2` Task per
+  call plus an ad-hoc `spawn_link` watcher. Honours
+  `max_concurrency: System.schedulers_online()` and `on_timeout: :kill_task`;
+  the `:tool_done` mailbox-message contract is unchanged. Tool worker
+  exits (`{:exit, _}` from the stream) still synthesise an
+  `is_error: true` `ToolResult` so the FSM never loses a
+  `tool_call → tool_result` correspondence. (Closes #33.)
+
 ### Added
 - Provider fallback chains — sessions retry against the next provider
   in `settings.providers.fallback_chains[primary]` on a retryable

--- a/lib/tau/session.ex
+++ b/lib/tau/session.ex
@@ -412,6 +412,12 @@ defmodule Tau.Session do
           # settings reload between turns is picked up automatically.
           fallback_chain_remaining: [],
           tools_in_flight: %{},
+          # #33: pid of the per-turn parallel-tool dispatcher (a child of
+          # Tau.Tools.TaskSupervisor that drives Task.Supervisor.async_stream_nolink/4
+          # over the turn's tool calls). Stored so :cancel can brutal-kill
+          # the iterator; orphaned tool tasks remain under the supervisor
+          # and complete or are reaped naturally.
+          tool_dispatcher: nil,
           # ADR-0008: slash-command tasks (user code) run isolated under
           # Tau.Tools.TaskSupervisor, never inline in the FSM.
           command_task: nil
@@ -647,9 +653,13 @@ defmodule Tau.Session do
       Task.shutdown(data.provider_task, :brutal_kill)
     end
 
-    Enum.each(data.tools_in_flight, fn {_id, t} ->
-      if Process.alive?(t.pid), do: Task.shutdown(t, :brutal_kill)
-    end)
+    # #33: with async_stream_nolink the dispatcher owns the tool tasks.
+    # Brutal-killing it stops the iterator; in-flight tool processes under
+    # Tau.Tools.TaskSupervisor finish on their own (no link to dispatcher)
+    # and any late `:tool_done` messages drop into the catch-all clause.
+    if data.tool_dispatcher && Process.alive?(data.tool_dispatcher) do
+      Process.exit(data.tool_dispatcher, :brutal_kill)
+    end
 
     if data.command_task && Process.alive?(data.command_task) do
       Process.exit(data.command_task, :brutal_kill)
@@ -659,7 +669,14 @@ defmodule Tau.Session do
     persist_event(data, "cancellation", %{reason: "user"})
 
     {:next_state, :awaiting_user,
-     %{data | provider_task: nil, tools_in_flight: %{}, assembler: nil, command_task: nil}}
+     %{
+       data
+       | provider_task: nil,
+         tools_in_flight: %{},
+         tool_dispatcher: nil,
+         assembler: nil,
+         command_task: nil
+     }}
   end
 
   def handle_event(:cast, :stop, _state, data) do
@@ -710,7 +727,12 @@ defmodule Tau.Session do
     })
 
     if map_size(tools) == 0 do
-      handle_event(:internal, :start_provider, :provider_streaming, %{data | tools_in_flight: tools})
+      handle_event(
+        :internal,
+        :start_provider,
+        :provider_streaming,
+        %{data | tools_in_flight: tools, tool_dispatcher: nil}
+      )
     else
       {:keep_state, %{data | tools_in_flight: tools}}
     end
@@ -856,9 +878,11 @@ defmodule Tau.Session do
       })
     end)
 
-    tasks =
-      Enum.into(allowed, %{}, fn %{id: id, name: name, arguments: args} ->
-        # :pre_tool_use hook may rewrite args or veto.
+    # Run :pre_tool_use synchronously per call. Hook-vetoed calls synthesise
+    # a tool_result on the spot; survivors form the parallel batch handed to
+    # the dispatcher (#33).
+    {_hook_denied, parallel_calls} =
+      Enum.reduce(allowed, {[], []}, fn %{id: id, name: name, arguments: args}, {denied, kept} ->
         case Tau.Hooks.Dispatcher.run(
                :pre_tool_use,
                hook_payload(data, :pre_tool_use, %{
@@ -868,7 +892,7 @@ defmodule Tau.Session do
                })
              ) do
           {:halt, reason} ->
-            denied =
+            result =
               ToolResult.new(
                 tool_call_id: id,
                 tool_name: name,
@@ -876,11 +900,11 @@ defmodule Tau.Session do
                 is_error: true
               )
 
-            Process.send(parent, {:tool_done, id, denied}, [])
-            {id, :hook_blocked}
+            Process.send(parent, {:tool_done, id, result}, [])
+            {[id | denied], kept}
 
           {:deny, reason} ->
-            denied =
+            result =
               ToolResult.new(
                 tool_call_id: id,
                 tool_name: name,
@@ -888,77 +912,105 @@ defmodule Tau.Session do
                 is_error: true
               )
 
-            Process.send(parent, {:tool_done, id, denied}, [])
-            {id, :hook_denied}
+            Process.send(parent, {:tool_done, id, result}, [])
+            {[id | denied], kept}
 
           {:cont, payload} ->
-            args = Map.get(payload, :tool_input, args)
-            spawn_tool_task(name, id, args, data, parent)
+            rewritten_args = Map.get(payload, :tool_input, args)
+            {denied, [{id, name, rewritten_args} | kept]}
         end
       end)
 
-    # Filter out the synthesised :hook_blocked / :hook_denied entries — they
-    # already reported via :tool_done.
-    real_tasks =
-      tasks
-      |> Enum.reject(fn {_id, v} -> v in [:hook_blocked, :hook_denied] end)
-      |> Enum.into(%{})
+    parallel_calls = Enum.reverse(parallel_calls)
+
+    dispatcher_pid =
+      case parallel_calls do
+        [] -> nil
+        _ -> spawn_parallel_dispatcher(parallel_calls, data, parent)
+      end
+
+    real_tasks = Enum.into(parallel_calls, %{}, fn {id, _n, _a} -> {id, :running} end)
 
     initial_in_flight =
       Map.merge(real_tasks, Enum.into(gated, %{}, fn %{id: id} -> {id, :denied} end))
 
     {:next_state, :tool_executing,
-     %{data | tools_in_flight: initial_in_flight, provider_task: nil, assembler: nil}}
+     %{
+       data
+       | tools_in_flight: initial_in_flight,
+         tool_dispatcher: dispatcher_pid,
+         provider_task: nil,
+         assembler: nil
+     }}
   end
 
-  defp spawn_tool_task(name, id, args, data, parent) do
-    task =
-      Task.Supervisor.async_nolink(Tau.Tools.TaskSupervisor, fn ->
-        run_tool(name, id, args, data)
+  # #33: single iterator over the parallel batch via
+  # Task.Supervisor.async_stream_nolink/4. One process per turn drives the
+  # stream; per-tool tasks run concurrently under Tau.Tools.TaskSupervisor.
+  # Crash isolation: an exiting tool task surfaces as `{:exit, reason}` from
+  # the stream — we synthesise an `is_error: true` ToolResult so the FSM
+  # never loses a tool_call → tool_result correspondence. `ordered: true`
+  # so we can zip the input call back onto each result (needed to recover
+  # the call id on `{:exit, _}`); throughput is unchanged because tool
+  # tasks still run concurrently up to `max_concurrency`.
+  defp spawn_parallel_dispatcher(parallel_calls, data, parent) do
+    {:ok, pid} =
+      Task.Supervisor.start_child(Tau.Tools.TaskSupervisor, fn ->
+        Enum.each(parallel_calls, fn {id, name, args} ->
+          broadcast(data.id, %Events.ToolStart{
+            session_id: data.id,
+            tool_call_id: id,
+            name: name,
+            arguments: args
+          })
+        end)
+
+        parallel_calls
+        |> Task.Supervisor.async_stream_nolink(
+          Tau.Tools.TaskSupervisor,
+          fn {id, name, args} -> run_tool(name, id, args, data) end,
+          max_concurrency: System.schedulers_online(),
+          timeout: :infinity,
+          on_timeout: :kill_task,
+          ordered: true
+        )
+        |> Stream.zip(parallel_calls)
+        |> Enum.each(fn {stream_result, {id, name, _args}} ->
+          result =
+            case stream_result do
+              {:ok, %ToolResult{} = r} ->
+                r
+
+              {:exit, reason} ->
+                ToolResult.new(
+                  tool_call_id: id,
+                  tool_name: name,
+                  content: "Tool task crashed: #{inspect(reason)}",
+                  is_error: true
+                )
+            end
+
+          # :post_tool_use hook may rewrite the result.
+          post_event = if result.is_error, do: :post_tool_use_failure, else: :post_tool_use
+
+          result =
+            case Tau.Hooks.Dispatcher.run(
+                   post_event,
+                   hook_payload(data, post_event, %{
+                     tool_name: name,
+                     tool_call_id: id,
+                     result: result
+                   })
+                 ) do
+              {:cont, %{result: rewritten}} when is_struct(rewritten, ToolResult) -> rewritten
+              _ -> result
+            end
+
+          Process.send(parent, {:tool_done, id, result}, [])
+        end)
       end)
 
-    broadcast(data.id, %Events.ToolStart{
-      session_id: data.id,
-      tool_call_id: id,
-      name: name,
-      arguments: args
-    })
-
-    # Convert task completion into our :tool_done message.
-    spawn_link(fn ->
-      result =
-        try do
-          Task.await(task, :infinity)
-        catch
-          :exit, reason ->
-            ToolResult.new(
-              tool_call_id: id,
-              tool_name: name,
-              content: "Tool task crashed: #{inspect(reason)}",
-              is_error: true
-            )
-        end
-
-      # :post_tool_use hook may rewrite the result.
-      post_event = if result.is_error, do: :post_tool_use_failure, else: :post_tool_use
-
-      result =
-        case Tau.Hooks.Dispatcher.run(
-               post_event,
-               hook_payload(data, post_event, %{
-                 tool_name: name,
-                 tool_call_id: id,
-                 result: result
-               })
-             ) do
-          {:cont, %{result: rewritten}} when is_struct(rewritten, ToolResult) -> rewritten
-          _ -> result
-        end
-
-      Process.send(parent, {:tool_done, id, result}, [])
-    end)
-
-    {id, task}
+    pid
   end
 
   defp run_tool(name, call_id, args, data) do

--- a/test/tau/session/parallel_tool_dispatch_test.exs
+++ b/test/tau/session/parallel_tool_dispatch_test.exs
@@ -1,0 +1,151 @@
+defmodule Tau.Session.ParallelToolDispatchTest do
+  @moduledoc """
+  Regression coverage for #33: parallel tool dispatch via
+  `Task.Supervisor.async_stream_nolink/4`.
+
+  Verifies that when a tool task crashes mid-flight (the worker process
+  exits without `{:ok, _}`), the dispatcher synthesises a synthetic
+  `is_error: true` `ToolResult` keyed to the original `tool_call_id`,
+  preserving the FSM's tool_call → tool_result correspondence. Without
+  this, the next provider turn would see a tool_call with no matching
+  tool_result and the loop would wedge.
+  """
+  use ExUnit.Case, async: false
+
+  import Tau.Test.SessionHelper, only: [start_session_for_test: 1]
+  alias Tau.Provider.Event
+  alias Tau.Session.Events, as: SE
+
+  defmodule CrashingTool do
+    @moduledoc false
+    @behaviour Tau.Tool
+
+    @impl true
+    def name, do: "crash_tool_for_33"
+
+    @impl true
+    def description, do: "Test tool that exits its worker process."
+
+    @impl true
+    def parameters,
+      do: %{"type" => "object", "properties" => %{}, "required" => []}
+
+    @impl true
+    def execute(_args, _ctx) do
+      # Exit the async_stream worker without rescue. async_stream_nolink
+      # surfaces this as `{:exit, :crash_for_33}` to the dispatcher.
+      Process.exit(self(), :crash_for_33)
+    end
+
+    @impl true
+    def execution_mode, do: :parallel
+
+    @impl true
+    def streams_updates?, do: false
+  end
+
+  defmodule ProviderWithToolCall do
+    @moduledoc false
+    @behaviour Tau.Provider
+
+    # First call: emit a tool_call. Second call (after the synthetic
+    # tool_result): emit a clean text response so the FSM can return
+    # to :awaiting_user without hanging.
+    @impl true
+    def stream(messages, _opts, _ctx) do
+      has_tool_result? =
+        Enum.any?(messages, &match?(%Tau.Message.ToolResult{}, &1))
+
+      events =
+        if has_tool_result? do
+          [
+            %Event.Start{request_id: "r2", model: "p33"},
+            %Event.TextStart{block_id: "t1"},
+            %Event.TextDelta{block_id: "t1", text: "ok-after-crash"},
+            %Event.TextEnd{block_id: "t1"},
+            %Event.Done{stop_reason: :stop, usage: %{}}
+          ]
+        else
+          [
+            %Event.Start{request_id: "r1", model: "p33"},
+            %Event.ToolCallStart{tool_call_id: "call-33", name: "crash_tool_for_33"},
+            %Event.ToolCallEnd{tool_call_id: "call-33", params: %{}},
+            %Event.Done{stop_reason: :tool_use, usage: %{}}
+          ]
+        end
+
+      {:ok, events}
+    end
+
+    @impl true
+    def capabilities,
+      do: %{thinking: false, tools: true, vision: false, prompt_caching: false, parallel_tools: true}
+
+    @impl true
+    def default_model, do: "p33"
+  end
+
+  setup do
+    tmp = Path.join(System.tmp_dir!(), "tau-tool-dispatch-#{System.unique_integer([:positive])}")
+    File.mkdir_p!(tmp)
+    Application.put_env(:tau, :data_dir, tmp)
+
+    # Make the FSM register CrashingTool at session boot.
+    prior_builtins = Application.get_env(:tau, :builtin_tools, [])
+    Application.put_env(:tau, :builtin_tools, [CrashingTool | prior_builtins])
+
+    on_exit(fn ->
+      Application.put_env(:tau, :builtin_tools, prior_builtins)
+      File.rm_rf!(tmp)
+      Application.delete_env(:tau, :data_dir)
+    end)
+
+    :ok
+  end
+
+  test "tool worker exit surfaces as synthetic is_error tool_result" do
+    sid = "tool-crash-#{System.unique_integer([:positive])}"
+    Phoenix.PubSub.subscribe(Tau.PubSub, "session:#{sid}")
+
+    {:ok, ^sid} =
+      start_session_for_test(
+        provider: ProviderWithToolCall,
+        model: "p33",
+        session_id: sid
+      )
+
+    Tau.send(sid, "please use the crashing tool")
+
+    # The dispatcher should synthesise a ToolResult keyed to "call-33".
+    assert_receive %SE.ToolEnd{
+                     tool_call_id: "call-33",
+                     result: %Tau.Message.ToolResult{is_error: true, content: content}
+                   },
+                   5_000
+
+    assert content =~ "Tool task crashed"
+    assert content =~ "crash_for_33"
+
+    # Second turn (after the synthetic result is fed back) finalises cleanly.
+    assert_receive %SE.MessageEnd{message: %{content: [%{text: "ok-after-crash"}]}}, 5_000
+
+    {:ok, snap} = Tau.snapshot(sid)
+    assert snap.state == :awaiting_user
+
+    # JSONL records the synthetic tool_result with is_error: true.
+    [path] = Path.wildcard(Path.join(Tau.Settings.data_dir(), "sessions/*/#{sid}.jsonl"))
+
+    rows =
+      File.read!(path)
+      |> String.split("\n", trim: true)
+      |> Enum.map(&Jason.decode!/1)
+
+    tool_result =
+      Enum.find(rows, fn r ->
+        r["kind"] == "tool_result" and r["data"]["tool_call_id"] == "call-33"
+      end)
+
+    assert tool_result
+    assert tool_result["data"]["is_error"] == true
+  end
+end


### PR DESCRIPTION
## Summary

- Replaces per-call `Task.Supervisor.async_nolink/2` + `spawn_link` watcher in `Tau.Session.dispatch_tools/2` with a single per-turn dispatcher under `Tau.Tools.TaskSupervisor` that drives `Task.Supervisor.async_stream_nolink/4` over the parallel batch. Honours `max_concurrency: System.schedulers_online()` and `on_timeout: :kill_task`.
- Crash isolation preserved: `{:exit, reason}` from the stream becomes a synthetic `%Tau.Message.ToolResult{is_error: true}` keyed to the original `tool_call_id`. Uses `ordered: true` (deviation from the issue's suggested `ordered: false`) so `Stream.zip` can pair each result back with its input call — required to recover the id on `{:exit, _}`. Tool tasks still run concurrently up to `max_concurrency`; throughput is unchanged.
- The `:tool_done` mailbox-message contract, permission-denied paths, and `:pre_tool_use`/`:post_tool_use[_failure]` hook flow are unchanged.
- Dispatcher pid tracked in `data.tool_dispatcher` so `:cancel` can brutal-kill the iterator; orphaned tool tasks remain supervised and any late `:tool_done` messages drop into the FSM's catch-all clause.
- The session moduledoc already promised `async_stream_nolink` — this PR makes the docs honest.

## Test plan

- [ ] CI green (`mix format --check-formatted`, `mix credo --strict`, `mix dialyzer`, `mix test`)
- [ ] `Tau.Session.ParallelToolDispatchTest` exercises the synthetic-ToolResult-on-exit path end-to-end through the FSM (tool worker calls `Process.exit(self(), _)`; asserts `ToolEnd` carries `is_error: true`, JSONL records `tool_result` with the original `tool_call_id`, and the session returns to `:awaiting_user`).
- [ ] Existing session tests (`provider_fallback_test.exs`, `update_provider_test.exs`, `user_message_queue_test.exs`, `compaction_replay_test.exs`) still pass.

Closes #33

https://claude.ai/code/session_011bAhaU738pEzP52sVs8RUQ

---
_Generated by [Claude Code](https://claude.ai/code/session_011bAhaU738pEzP52sVs8RUQ)_