### PR TITLE
docs: ADR-0014/0015 — subagent design

### DIFF
--- a/docs/adr/0014-subagents-are-sessions.md
+++ b/docs/adr/0014-subagents-are-sessions.md
@@ -1,0 +1,199 @@
+# ADR-0014: Subagents are sessions, spawned by the `Agent` tool
+
+- **Status:** Proposed
+- **Date:** 2026-05-01
+- **Deciders:** the agent loop, with no objection from @smug-haus
+- **Related:**
+  - Issues: #18 (tracker), #32 (Agent tool), #34 (coordination — deferred),
+    #16 (skill `allowed_tools` enforcement, prerequisite)
+  - Code: `lib/tau/session.ex`, `lib/tau/sessions/supervisor.ex`,
+    `lib/tau/registries.ex` (`Tau.Sessions.Registry`),
+    `lib/tau/hook.ex` (declares `:subagent_start`),
+    `lib/tau/tools/builtin/` (where the `Agent` tool will live)
+  - Prior ADRs: ADR-0008 (user code never runs synchronously in the
+    FSM), ADR-0009 (queue user messages during active turns),
+    ADR-0010 (cost tracker), ADR-0012 (provider fallback is FSM-internal)
+
+## Context
+
+The harness needs to let one model session delegate work to a child:
+the analogue of Claude Code's `Task` tool, the pattern called out
+explicitly in `CLAUDE.md` (the parent agent acts as a coordinator,
+the child does the actual digging or planning). Today there is no
+delegation primitive.
+
+Two shapes were on the table:
+
+1. **Subagents as a new entity** — a `Tau.Subagent` behaviour, its
+   own dynamic supervisor, its own registry, its own persistence
+   namespace, its own lifecycle events.
+2. **Subagents as full sessions** — a child `Tau.Session` under the
+   existing `Tau.Sessions.Supervisor`, registered in the existing
+   `Tau.Sessions.Registry`, with subagent-ness encoded in metadata
+   on the session header.
+
+Several existing facts in the codebase point at (2):
+
+- `Tau.Session.fork/2` already creates a new session whose
+  persistence header references a `parent_event_id` from another
+  session. The "child of another session" shape is implemented; we
+  just haven't used it for live spawns yet.
+- `Tau.Session.Meta.metadata` reserves keys like `:forked_from` for
+  tagging provenance — a `:parent_session_id`/`:subagent_type` pair
+  fits the same niche without a schema change.
+- `Tau.Sessions.Supervisor` is a `DynamicSupervisor` with
+  `:one_for_one`; child crash isolation is already what we want.
+- `Tau.Sessions.Registry` is `:unique` keyed by session id; child
+  sessions register the same way, and `Tau.cancel/1` /
+  `Tau.snapshot/1` work on them with no extra plumbing.
+- The hook contract (`lib/tau/hook.ex:14`) already declares
+  `:subagent_start` as a lifecycle hook — the design has been
+  earmarked, just not implemented.
+
+A second supervisor / registry would duplicate machinery for no
+behavioural difference: subagents stream, persist, broadcast, and
+cancel exactly like top-level sessions. The only thing that's
+genuinely new is _how_ they get spawned (by a tool call, not by
+`Tau.start_session/1` from outside) and _what_ the parent does
+with the result.
+
+## Decision
+
+**A subagent is a `Tau.Session` whose metadata names its parent.**
+Spawning is the job of a built-in tool, `Tau.Tools.Builtin.Agent`.
+The parent's session FSM does not learn a new state; it sees the
+spawn as one of its tool calls.
+
+Concretely:
+
+1. **Spawn point** — `Tau.Tools.Builtin.Agent` (`:parallel` execution
+   mode) takes the model-supplied `description`,
+   `system_prompt`, `subagent_type`, and an optional `model`/
+   `provider`. Inside its `execute/2` it:
+   - dispatches the `:subagent_start` hook with payload
+     `%{parent_session_id, parent_tool_call_id, subagent_type,
+        brief, permissions_mode}` (hook may halt or rewrite);
+   - calls `Tau.start_session/1` with computed opts (see ADR-0015
+     for how `subagent_type`, permissions, and `:tools_whitelist`
+     are derived);
+   - subscribes to the child's `"session:<child_id>"` PubSub topic;
+   - sends the brief as the child's first user message;
+   - awaits the child's first `%MessageEnd{stop_reason: :end_turn}`
+     and returns its assembled assistant text as the
+     `Tau.Tool.Result.content`.
+
+2. **Same supervisor, same registry** — the child is started by the
+   existing `Tau.Sessions.Supervisor.start_session/1`. No new
+   supervisor, no new registry. Subagent-ness is purely a metadata
+   convention.
+
+3. **Reserved metadata keys** added to `Tau.Session.Meta`'s contract:
+   - `:parent_session_id` — id of the spawning session.
+   - `:parent_tool_call_id` — the parent's tool call that spawned
+     this child (so persistence can link back to the exact event).
+   - `:subagent_type` — the skill name resolving the persona
+     (see ADR-0015).
+   These travel through the session header and are JSON-encodable
+   per the existing `Meta.metadata` rules.
+
+4. **Result delivery: synchronous handoff (v1).** The parent's tool
+   turn blocks on the child's first `:end_turn`. The child's
+   assistant text becomes the parent's `ToolResult.content`. Three
+   delivery modes were considered (synchronous handoff,
+   fork-and-await, fire-and-forget — see #18 critic comment); v1
+   ships the first. Multiple parallel `Agent` tool calls in a
+   single assistant turn already give us "fork-and-await" via
+   the existing `:parallel` tool fan-out.
+
+5. **Cancellation cascade.** `Tau.Session` data grows a
+   `child_session_ids :: MapSet.t(String.t())` field. When the
+   `Agent` tool task starts a child it casts
+   `{:register_child, child_id}` to the parent FSM; on
+   `Tau.cancel/1` or `:stop` the parent iterates the set and calls
+   `Tau.cancel/1` on each child before tearing down its own tool
+   tasks. The `Agent` tool task itself uses `Process.monitor/1` on
+   the parent FSM; if the parent dies before the child finishes,
+   the task observes `:DOWN` and calls `Tau.cancel/1` on the child
+   to flush its persistence.
+
+6. **Persistence — same JSONL backend, parent linkage in the
+   header.** `Tau.Persistence.Jsonl.open/2` already accepts
+   `:parent_event_id`; subagents pass their parent's tool call id.
+   Tree-walking the chain is the same code path used by `fork/2`.
+   `Tau.list_sessions/1` already surfaces children because they
+   live in the same persistence root.
+
+7. **Telemetry.** New events under
+   `[:tau, :session, :subagent, :start | :stop | :exception]`,
+   emitted by the `Agent` tool task. The hook
+   `:subagent_start` is already declared. No new lifecycle states
+   on the FSM.
+
+## Consequences
+
+- The session FSM stays unchanged in shape: same states
+  (`:awaiting_user | :provider_streaming | :tool_executing |
+   :stopped`), same callback module. The only `data` change is
+  the `child_session_ids` set and a new `handle_event` clause for
+  `{:register_child, _}`.
+- Tools, hooks, persistence, telemetry, and TUI subscribers
+  (`Tau.stream/2`) work on subagents with no special-casing —
+  they're sessions, the harness already understands them.
+- A subagent crash never crashes the parent: child crashes are
+  contained by `Tau.Sessions.Supervisor`'s `:one_for_one`; the
+  `Agent` tool task observes the child's `%SessionEnd{}` and
+  returns `is_error: true` to the parent's transcript.
+- Deep nesting (subagent-of-subagent) works for free, since
+  children are sessions and can themselves call `Agent`. We expose
+  no recursion-depth limit at the architectural level; if abuse
+  shows up in practice, a limit lands as a new ADR or a settings
+  knob, not a structural change here.
+- `Tau.snapshot/1`, `Tau.cancel/1`, `Tau.stop/1` work on subagent
+  ids out of the box. Tools that introspect "the session I'm
+  running in" via `ctx.session_id` already get the right id when
+  they're called inside a subagent.
+- The parent's transcript gains a `tool_result` whose `content`
+  is the child's final assistant text. The full child transcript
+  remains addressable by `child_session_id` — callers (TUI,
+  forensics, evals) walk parent → children via metadata.
+- Cost is tracked per session, so `Tau.Cost.summary/1` (ADR-0010)
+  needs no change to bill subagent token usage to its own
+  session id; aggregation across a parent/children tree is a
+  follow-up reporting concern, not an architectural one.
+
+## Alternatives considered
+
+- **A separate `Tau.Subagents.Supervisor` and `Tau.Subagents.Registry`.**
+  Rejected: zero behavioural distinction from sessions, would
+  require parallel implementations of `cancel`, `snapshot`,
+  persistence, and stream subscription. Two registries to look
+  up by id is worse, not better.
+- **A `Tau.Subagent` behaviour with its own callbacks.** Rejected:
+  the work a subagent does is a session loop. A new behaviour
+  would be a misleading parallel hierarchy; nothing about
+  delegation needs an extensibility seam at the
+  agent-implementation level. The seam that does need extension
+  — the persona — is a `Tau.Skill` (ADR-0015).
+- **Child as a function call inside the parent FSM** (run the
+  child's loop in-process, no PubSub round-trip). Rejected:
+  violates ADR-0008 (no user code synchronously in the FSM) and
+  forecloses on observability — the TUI/CLI can already subscribe
+  to a session topic and watch a subagent stream live.
+- **Fire-and-forget / async result mode in v1.** Rejected for v1.
+  The `Agent` tool's blocking await maps directly onto the
+  model's mental model of a tool call ("I called it, I get a
+  result"); progress streaming and async modes (#34) are cleaner
+  to add once the synchronous baseline is in.
+
+## Notes
+
+- This ADR sets the supervision/persistence/lifecycle shape.
+  Persona resolution (`subagent_type` → skill, `allowed_tools`
+  whitelist, permission inheritance) is ADR-0015.
+- Inter-agent message-passing beyond "child returns one summary"
+  (issue #34) is intentionally out of scope. Reopen the
+  conversation with a new ADR superseding the relevant section
+  here when a real use case appears.
+- The `Agent` tool's parameter shape is owned by issue #32. ADRs
+  pin _what_ the spawn produces and _where_ it lives in the tree;
+  the JSON Schema can iterate without an ADR rewrite.

--- a/docs/adr/0015-subagent-persona-is-a-skill.md
+++ b/docs/adr/0015-subagent-persona-is-a-skill.md
@@ -1,0 +1,224 @@
+# ADR-0015: Subagent persona is a `Tau.Skill`; the spawn never loosens parent permissions
+
+- **Status:** Proposed
+- **Date:** 2026-05-01
+- **Deciders:** the agent loop, with no objection from @smug-haus
+- **Related:**
+  - Issues: #32 (Agent tool), #16 (skill `allowed_tools` enforcement,
+    prerequisite), #18 (tracker)
+  - Code: `lib/tau/skill.ex`, `lib/tau/skills/`,
+    `lib/tau/permissions/evaluator.ex` (mode definitions),
+    `lib/tau/session.ex` (`dispatch_tools/2`, `:permissions_mode`
+    metadata)
+  - Prior ADRs: ADR-0005 (skills are read-only at session start),
+    ADR-0013 (skill activation lives on the session FSM, scoped to one
+    turn — this ADR extends that activation model to a per-session
+    lifetime for subagent personas), ADR-0014 (subagents are sessions)
+
+## Context
+
+Once the `Agent` tool exists (ADR-0014), two questions remain:
+
+1. **Persona.** A subagent should behave differently from its
+   parent: an `Explore` agent reads and reports; a `Plan` agent
+   designs but doesn't write; a `general-purpose` agent has the
+   full kit. Where does the persona — system prompt addendum,
+   tool whitelist, default model — come from?
+2. **Permissions.** A child running with a more permissive mode
+   than its parent (e.g. parent in `:plan`, child in `:bypass`)
+   would let the model trivially escape the parent's safety
+   posture by spawning a subagent. We need an inheritance rule
+   the model can't subvert.
+
+For the persona question, the harness already has an extensible,
+filesystem-discovered, read-only-at-load primitive that carries
+exactly the fields a persona needs:
+
+```elixir
+%Tau.Skill{
+  name: String.t(),
+  body: String.t(),
+  description: String.t(),
+  allowed_tools: [String.t()],   # tool whitelist
+  disable_model_invocation: bool, # never auto-invoked
+  paths: [String.t()],           # discovery roots
+  path: Path.t()
+}
+```
+
+`Tau.Skills.Loader.discover/1` already finds them in
+`<cwd>/.claude/agents/<name>.md` and the equivalent user/managed
+roots, parses frontmatter, and registers them in
+`Tau.Skills.Registry`. ADR-0005 codifies the load contract: pure,
+per-session, side-effect-free.
+
+A skill _is_ a persona: a markdown body to inject into the
+prompt, a tool whitelist, a name. We don't need a parallel
+"agent definitions" registry; we need to use what's there.
+
+For the permissions question, `Tau.Permissions.Evaluator` already
+defines a mode lattice
+(`:bypass | :auto | :default | :accept_edits | :dont_ask | :plan`).
+The natural rule is: a subagent's effective mode is at most as
+permissive as its parent's. The Agent tool can _request_ a stricter
+mode for the child (typical: `:plan` for an `Explore` subagent, so
+the child literally cannot write); it can never _request_ a
+broader one.
+
+## Decision
+
+**`subagent_type` resolves to a skill name; the resolved skill
+supplies the system prompt addendum and the child's tool
+whitelist. Permissions are inherited and may only be tightened.**
+
+Specifics:
+
+1. **Persona = skill lookup.** The `Agent` tool's `subagent_type`
+   parameter is a skill name. At spawn time the tool calls
+   `Tau.Skills.Loader.lookup/2` (or its eventual equivalent
+   keyed off the same registry skills load into). If found, the
+   skill's `body` is the system prompt addendum (joined onto the
+   tool's `system_prompt` parameter), and the skill's
+   `allowed_tools` list is the child's tool whitelist. If
+   `subagent_type` is omitted, the child runs as a `general-purpose`
+   subagent — full tool access (subject to permissions) and no
+   added persona.
+
+2. **Active-skill activation in the child.** The child session is
+   started with the resolved skill installed as its
+   `:active_skill` from turn one. This activates the same
+   `allowed_tools`-enforcement path ADR-0013 builds for normal
+   skill invocations (the work landed in #16): `Tau.Permissions.Evaluator`
+   consults the active-skill whitelist before falling through to
+   global rules. Because subagents cannot dismiss their persona —
+   the harness pins it for the lifetime of the session, not "until
+   the model says it's done" — there's an explicit option
+   `:persona_lifetime: :session` (default for subagents) that
+   distinguishes from the per-turn lifetime ADR-0013 uses for
+   model-driven skill invocations.
+
+3. **Permissions are inherited; tightening is allowed,
+   loosening is not.** The Agent tool's `permissions_mode`
+   parameter is optional. Effective child mode is computed by:
+
+   ```elixir
+   parent_mode = parent_session.metadata[:permissions_mode] || :default
+   requested  = params["permissions_mode"]  # optional, atom-coerced
+   child_mode = clamp(requested || parent_mode, ceiling: parent_mode)
+   ```
+
+   where `clamp(_, ceiling: parent)` returns the requested mode if
+   the lattice places it at or below the parent, otherwise returns
+   the parent. The lattice (most permissive → most restrictive):
+
+   ```text
+   :bypass  >  :auto  >  :default  >  :accept_edits
+                                    \  :dont_ask
+                                     \ :plan
+   ```
+
+   `:accept_edits`, `:dont_ask`, and `:plan` are not strictly
+   ordered against each other (they restrict different operations);
+   for ceiling purposes, any of the three is "more restrictive
+   than `:default`" and ceiling-comparable accordingly. The
+   evaluator already encodes which tools each mode allows; the
+   ceiling check is a small lookup over a fixed lattice and lives
+   in `Tau.Permissions.Evaluator` (or a small sibling module if
+   the evaluator stays purely match-based).
+
+4. **`:tools_whitelist` plumbed as a session option.** A new
+   session opt `:tools_whitelist :: [String.t()] | :all` is
+   accepted by `Tau.start_session/1` and stored in the FSM data.
+   `dispatch_tools/2` filters the model's tool calls against it
+   before evaluating permissions; calls outside the list become
+   synthesised `is_error: true` ToolResults the same way deny
+   rules already do. (This is the same machinery #16 needs for
+   skill-active dispatch; the option just exposes it on the start
+   path.) `:all` is the default and matches today's behaviour.
+
+5. **Failure modes — fail closed.**
+   - `subagent_type` names a skill that does not exist → the
+     `Agent` tool returns `is_error: true` with
+     `"Unknown subagent_type: #{name}"`. We do not fall back to
+     `general-purpose` silently; a misnamed persona is a model
+     mistake the parent should see.
+   - Skill's `allowed_tools` references a tool that isn't
+     registered → the unknown name is dropped from the effective
+     whitelist; load-time telemetry already surfaces this case
+     for normal skill activation.
+   - Requested permissions mode above the parent's ceiling →
+     downgraded to the parent's mode, with a `:telemetry.execute`
+     event under `[:tau, :permissions, :ceiling_clamped]` so the
+     downgrade is observable.
+
+## Consequences
+
+- Subagent personas live as ordinary markdown files in
+  `.claude/agents/<name>.md` (or wherever skills already
+  discover from). Anyone who can write a skill can write an
+  agent persona; nothing new to learn, nothing new to load.
+- The parent's safety posture is monotonic across delegation:
+  a `:plan` parent can spawn a `:plan` child (or stricter), but
+  never a `:bypass` child. Models cannot escalate by delegating.
+- The `Agent` tool gains no persona-management code of its own —
+  it looks up a skill and plumbs flags through. Adding a new
+  subagent type is a markdown file, not a code change.
+- `:tools_whitelist` as a session opt is independently useful
+  (sandboxed sessions in tests, restricted skill activations
+  per #16) — we get a single mechanism that works for both
+  cases instead of one for skills and another for subagents.
+- The decision binds subagent persona to the skill format. If we
+  later want richer persona metadata (default model, default
+  provider, suggested temperature), the right move is to add
+  fields to `Tau.Skill` (one struct, used by both code paths)
+  rather than fork a separate "agent definition" type.
+- The mode ceiling rule means UI hints — "this delegate call
+  would have run in `:bypass` but was clamped to `:plan`" —
+  fall out of the existing telemetry. No model-visible
+  surface change.
+
+## Alternatives considered
+
+- **A separate `Tau.Agent.Definition` registry, keyed by
+  `subagent_type`, with its own loader/discovery roots.**
+  Rejected: parallel infrastructure to the skill loader for
+  identical machinery. The skill struct already carries every
+  field a persona needs.
+- **Spawn-time personas defined inline by the model
+  (`system_prompt`, `allowed_tools` passed as Agent-tool args
+  with no skill lookup).** Considered, partially adopted — the
+  Agent tool _does_ accept `system_prompt` directly and treats
+  it as an addendum to the resolved skill. But making this the
+  _only_ mode would push prompt engineering into every callsite
+  and lose the discoverable, version-controlled persona library
+  that skills give us. The merged model — skill as default,
+  inline as override — keeps both ergonomics.
+- **Permissions ceiling = parent mode strictly (no requesting
+  stricter modes from the spawn).** Rejected: the typical use
+  case for `Explore` subagents is precisely "I want this child
+  to be unable to write even though I can". Refusing tightening
+  forecloses on the most useful ergonomic.
+- **No ceiling at all — let the model ask for whatever mode it
+  wants.** Rejected on safety grounds. The mode is a property
+  of the user's intent, not the model's. The child's ceiling
+  must be the parent's mode; otherwise the safety posture is
+  decorative.
+- **Persona via slash-command-style file commands rather than
+  skills.** Slash commands (per ADR-0008) are user-driven, run
+  in a Task, return a string the model never sees as
+  "personality". Wrong shape for personas, which need to colour
+  the model's whole subagent session.
+
+## Notes
+
+- This ADR builds on the active-skill enforcement path that landed
+  with #16 / ADR-0013. Without that, the whitelist is decorative
+  and the mode-clamp is the only real protection — with it, the
+  child's `dispatch_tools/2` filters before evaluating permissions.
+- The `:persona_lifetime` distinction (per-turn vs per-session)
+  is small and lives next to the active-skill machinery; it
+  doesn't merit its own ADR.
+- Recursion: a subagent spawning its own subagent inherits the
+  ceiling chain naturally — each Agent-tool call clamps against
+  its immediate parent, so the deepest descendant cannot exceed
+  the most restrictive ancestor.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -67,6 +67,8 @@ get rewritten away by the next refactor. ADRs survive.
 | [0011](0011-per-provider-rate-limiter-is-stateful-genserver.md) | Per-provider rate limiter is a stateful GenServer (not an ETS-owner) | Accepted |
 | [0012](0012-provider-fallback-is-fsm-internal-retry.md) | Provider fallback is an FSM-internal retry, not a wrapper provider | Accepted |
 | [0013](0013-skill-activation-is-fsm-scoped.md) | Skill activation lives on the session FSM, scoped to one turn | Accepted |
+| [0014](0014-subagents-are-sessions.md) | Subagents are sessions, spawned by the `Agent` tool | Proposed |
+| [0015](0015-subagent-persona-is-a-skill.md) | Subagent persona is a `Tau.Skill`; permissions inherit and may only tighten | Proposed |
 
 (New ADRs append here. Keep the table sorted by ADR number.)
 


### PR DESCRIPTION
## Summary

- **ADR-0014** — *Subagents are sessions, spawned by the `Agent` tool.* Reuses `Tau.Sessions.Supervisor` / `Tau.Sessions.Registry`; subagent-ness is metadata. Synchronous handoff in v1; the `Agent` tool blocks on the child's first `:end_turn` and returns the assistant text as a `ToolResult`. Cancellation cascades via a new `child_session_ids` set on the parent's FSM data plus a parent-monitor inside the `Agent` tool task.
- **ADR-0015** — *Subagent persona is a `Tau.Skill`; permissions inherit and may only tighten.* `subagent_type` resolves to a skill name; the skill's `body` becomes the system prompt addendum and `allowed_tools` becomes the child's whitelist. Permissions clamp against the parent's mode using the existing evaluator lattice — no escalation by delegation. Builds on ADR-0013's per-turn active-skill enforcement, extending it to a `:persona_lifetime: :session` lifetime for subagent personas.
- README index updated; both ADRs marked **Proposed**. No code changes.

(Originally filed as ADR-0013/0014 — renumbered to 0014/0015 after #94 landed and claimed 0013 for skill activation. The two designs are complementary, not in conflict.)

## Issue updates (alongside this PR)

- #18 (tracker) — design comment + updated checklist with the new dependency graph.
- #32 (Agent tool) — body rewritten with v1 spec, dependency graph, acceptance criteria.
- #91 (new) — session option `:tools_whitelist` for spawn-time tool restriction.
- #92 (new) — parent FSM `child_session_ids` tracking + cascade cancel/stop.

## Dependency order to land the work

#91 + #92 (parallel) → #32. (The active-skill enforcement piece, originally #16, has now landed via ADR-0013 / #94.)

## Test plan

- [ ] Read ADR-0014 end-to-end and confirm the supervision/persistence/lifecycle shape matches the existing non-negotiables in `CLAUDE.md` (every stateful subsystem is a process under a supervisor; no new GenServer that wraps stateless logic).
- [ ] Read ADR-0015 end-to-end and confirm the skill reuse doesn't violate ADR-0005 (skills discovery is per-session and pure) — personas are read at child start, same path as today.
- [ ] Confirm the cancellation-cascade story (parent-monitor inside the `Agent` tool task + `child_session_ids` on the parent) matches ADR-0008 (no user code synchronously in the FSM).
- [ ] Sanity-check the permissions ceiling lattice against `Tau.Permissions.Evaluator`'s existing modes (`:bypass | :auto | :default | :accept_edits | :dont_ask | :plan`).
- [ ] Decide whether to flip both ADRs to **Accepted** in this PR or leave them Proposed until the implementation lands.

https://claude.ai/code/session_01RJSbyBgkCnwP2uCwnLKAN5
