### PR TITLE
feat: model-invokable skills + disable-model-invocation gating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `tool_call → tool_result` correspondence. (Closes #33.)
 
 ### Added
+- Model-invokable skills: the model can activate a discovered skill
+  by emitting a tool_call to the synthetic `__activate_skill__` tool.
+  Skills with `disable_model_invocation: true` are excluded from the
+  exposed list; their bodies are still injected as system messages
+  (background context). New PubSub event:
+  `%Tau.Session.Events.SkillActivated{}`. New telemetry:
+  `[:tau, :session, :skill_activated]`. New JSONL event kind:
+  `skill_activated`. Builds on #16 (PR #94) and ADR-0013. (Closes #17.)
 - Skill `allowed-tools` whitelist enforcement: when `data.active_skill` is
   set, the permissions evaluator denies any tool not listed in
   `active_skill.allowed_tools` before consulting the regular rule set.

--- a/lib/tau/session.ex
+++ b/lib/tau/session.ex
@@ -29,6 +29,12 @@ defmodule Tau.Session do
   alias Tau.Session.Events
   alias Tau.Provider.Event, as: PEvent
 
+  # #17: name of the synthetic FSM-internal tool the model emits to
+  # activate a discovered skill. Not registered as a `Tau.Tool` module
+  # — interception happens in `dispatch_tools/2` before any executor
+  # would see it.
+  @activate_skill_tool_name "__activate_skill__"
+
   @type id :: String.t()
 
   defmodule Meta do
@@ -527,7 +533,11 @@ defmodule Tau.Session do
 
     ctx = Map.merge(data.provider_ctx, %{session_id: data.id})
 
-    case data.provider.stream(data.messages, %{model: data.model}, ctx) do
+    stream_opts =
+      %{model: data.model}
+      |> maybe_put_tools(skill_activation_tool_spec(data.skills))
+
+    case data.provider.stream(data.messages, stream_opts, ctx) do
       {:ok, stream} ->
         task =
           Task.async(fn ->
@@ -865,6 +875,18 @@ defmodule Tau.Session do
   defp dispatch_tools(tool_calls, data) do
     transition(data.id, data, :tool_executing)
     parent = self()
+
+    # #17: intercept synthetic `__activate_skill__` tool calls *before*
+    # permissions / hooks. Activation is FSM-internal — it never reaches
+    # the executor pool. The handler updates `data.active_skill` and
+    # synthesises a tool_result so the model's next turn sees an
+    # acknowledgement; subsequent tool calls in the same activation are
+    # then gated by the skill's `allowed_tools` list (ADR-0013).
+    {activation_calls, tool_calls} =
+      Enum.split_with(tool_calls, fn %{name: name} -> name == @activate_skill_tool_name end)
+
+    {data, activated_in_flight} = handle_skill_activations(activation_calls, data, parent)
+
     rule_set = Tau.Permissions.RuleSet.get()
     mode = Map.get(data.metadata, :permissions_mode, :default)
 
@@ -948,7 +970,9 @@ defmodule Tau.Session do
     real_tasks = Enum.into(parallel_calls, %{}, fn {id, _n, _a} -> {id, :running} end)
 
     initial_in_flight =
-      Map.merge(real_tasks, Enum.into(gated, %{}, fn %{id: id} -> {id, :denied} end))
+      real_tasks
+      |> Map.merge(Enum.into(gated, %{}, fn %{id: id} -> {id, :denied} end))
+      |> Map.merge(activated_in_flight)
 
     {:next_state, :tool_executing,
      %{
@@ -1251,6 +1275,163 @@ defmodule Tau.Session do
     # without an on-disk file return a pseudo-URI; the field on the
     # hook payload is always a non-nil binary.
     p.path_for(id, cwd)
+  end
+
+  # --- Skill activation (issue #17) -----------------------------------------
+  #
+  # Mechanism A (ADR-0013): the model activates a discovered skill by
+  # emitting a tool_call to the synthetic `__activate_skill__` tool. The
+  # tool is FSM-internal — it never reaches the executor pool, never
+  # passes through permissions or hooks. Skills with
+  # `disable_model_invocation: true` are excluded from the exposed enum;
+  # their bodies are still injected as system messages (background
+  # context) by `prepend_skill_messages/2`.
+
+  defp model_invokable_skills(skills) do
+    Enum.reject(skills, fn {_name, s} -> s.disable_model_invocation end)
+  end
+
+  defp skill_activation_tool_spec(skills) do
+    case model_invokable_skills(skills) do
+      [] ->
+        nil
+
+      list ->
+        names = Enum.map(list, fn {name, _s} -> name end)
+
+        descriptions =
+          list
+          |> Enum.map(fn {name, %Tau.Skill{description: d}} ->
+            case d do
+              "" -> "  - #{name}"
+              nil -> "  - #{name}"
+              desc -> "  - #{name}: #{desc}"
+            end
+          end)
+          |> Enum.join("\n")
+
+        description =
+          "Activate one of the available skills for the current turn. " <>
+            "Activation scopes subsequent tool calls to the skill's allowed_tools " <>
+            "whitelist (if set) and ends when you emit `end_turn`. " <>
+            "Available skills:\n" <> descriptions
+
+        %{
+          name: @activate_skill_tool_name,
+          description: description,
+          parameters: %{
+            "type" => "object",
+            "properties" => %{
+              "name" => %{
+                "type" => "string",
+                "enum" => names,
+                "description" => "Name of the skill to activate."
+              }
+            },
+            "required" => ["name"],
+            "additionalProperties" => false
+          }
+        }
+    end
+  end
+
+  defp maybe_put_tools(opts, nil), do: opts
+  defp maybe_put_tools(opts, tool_spec), do: Map.put(opts, :tools, [tool_spec])
+
+  # Process every `__activate_skill__` call inline. Returns the new
+  # `data` (with `active_skill` set on success) and the partial
+  # `tools_in_flight` map for these calls — they share the `:tool_done`
+  # mailbox path with regular tool results so the FSM bookkeeping is
+  # uniform.
+  defp handle_skill_activations([], data, _parent), do: {data, %{}}
+
+  defp handle_skill_activations(calls, data, parent) do
+    Enum.reduce(calls, {data, %{}}, fn %{id: id, name: tool_name, arguments: args},
+                                       {data_acc, in_flight_acc} ->
+      requested = skill_name_from_args(args)
+
+      {data_acc, result} = activate_skill(data_acc, requested, id)
+
+      :telemetry.execute(
+        [:tau, :session, :skill_activated],
+        %{system_time: System.system_time()},
+        %{
+          session_id: data_acc.id,
+          skill_name: requested,
+          tool_name: tool_name,
+          disabled?: result.is_error
+        }
+      )
+
+      Process.send(parent, {:tool_done, id, result}, [])
+      {data_acc, Map.put(in_flight_acc, id, :activated)}
+    end)
+  end
+
+  defp skill_name_from_args(args) when is_map(args) do
+    Map.get(args, "name") || Map.get(args, :name)
+  end
+
+  defp skill_name_from_args(_), do: nil
+
+  # Look up `name` on `data.skills`; honour `disable_model_invocation`.
+  # On success, set `data.active_skill`, persist a JSONL event, and
+  # broadcast `%Events.SkillActivated{}`. On failure, return an
+  # `is_error: true` ToolResult and leave `data` unchanged.
+  defp activate_skill(data, nil, call_id) do
+    {data,
+     ToolResult.new(
+       tool_call_id: call_id,
+       tool_name: @activate_skill_tool_name,
+       content: "Skill activation failed: missing 'name' parameter.",
+       is_error: true
+     )}
+  end
+
+  defp activate_skill(data, name, call_id) when is_binary(name) do
+    case List.keyfind(data.skills, name, 0) do
+      {^name, %Tau.Skill{disable_model_invocation: true}} ->
+        {data,
+         ToolResult.new(
+           tool_call_id: call_id,
+           tool_name: @activate_skill_tool_name,
+           content:
+             "Skill '#{name}' has disable-model-invocation set; it cannot be activated by the model.",
+           is_error: true
+         )}
+
+      {^name, %Tau.Skill{} = skill} ->
+        data =
+          %{data | active_skill: skill}
+          |> persist_event("skill_activated", %{
+            skill_name: name,
+            tool_call_id: call_id,
+            allowed_tools: skill.allowed_tools
+          })
+
+        broadcast(data.id, %Events.SkillActivated{
+          session_id: data.id,
+          skill_name: name,
+          tool_call_id: call_id
+        })
+
+        {data,
+         ToolResult.new(
+           tool_call_id: call_id,
+           tool_name: @activate_skill_tool_name,
+           content: "Skill activated: #{name}",
+           is_error: false
+         )}
+
+      nil ->
+        {data,
+         ToolResult.new(
+           tool_call_id: call_id,
+           tool_name: @activate_skill_tool_name,
+           content: "Unknown skill: #{name}",
+           is_error: true
+         )}
+    end
   end
 
   defp register_builtins do

--- a/lib/tau/session/events.ex
+++ b/lib/tau/session/events.ex
@@ -56,6 +56,19 @@ defmodule Tau.Session.Events do
     @type t :: %__MODULE__{}
   end
 
+  defmodule SkillActivated do
+    @moduledoc """
+    Broadcast when the model activates a discovered skill via the
+    synthetic `__activate_skill__` tool (issue #17, ADR-0013).
+
+    Activation lives on the FSM's `data.active_skill` field for the
+    remainder of the current turn (cleared on `:end_turn` or `:cancel`).
+    """
+    @enforce_keys [:session_id, :skill_name]
+    defstruct [:session_id, :skill_name, :tool_call_id]
+    @type t :: %__MODULE__{}
+  end
+
   defmodule SessionEnd do
     @enforce_keys [:session_id]
     defstruct [:session_id, :reason]

--- a/test/tau/session/skill_activation_property_test.exs
+++ b/test/tau/session/skill_activation_property_test.exs
@@ -1,0 +1,103 @@
+defmodule Tau.Session.SkillActivationPropertyTest do
+  @moduledoc """
+  Property suite for issue #17: every skill marked
+  `disable_model_invocation: true` is excluded both from the system-message
+  prompt body and from the `__activate_skill__` tool's name enum. The
+  inverse holds for skills with the flag off.
+
+  The properties exercise the same FSM-internal helpers the live session
+  uses, run as pure-function tests against an arbitrary skill list to
+  decouple from filesystem discovery (ADR-0005).
+  """
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  @moduletag :property
+
+  alias Tau.Skill
+
+  defp skill_gen do
+    StreamData.bind(
+      StreamData.tuple({
+        StreamData.string(:alphanumeric, min_length: 1, max_length: 10),
+        StreamData.string(:printable, max_length: 30),
+        StreamData.string(:printable, max_length: 60),
+        StreamData.boolean(),
+        StreamData.list_of(StreamData.member_of(["Read", "Write", "Bash"]),
+          max_length: 3
+        )
+      }),
+      fn {name, desc, body, disabled?, allowed} ->
+        StreamData.constant({name,
+         %Skill{
+           name: name,
+           description: desc,
+           body: body,
+           path: "/tmp/" <> name <> "/SKILL.md",
+           disable_model_invocation: disabled?,
+           allowed_tools: allowed
+         }})
+      end
+    )
+  end
+
+  defp skills_gen do
+    StreamData.bind(
+      StreamData.list_of(skill_gen(), max_length: 8),
+      fn skills ->
+        # Dedup by name — the loader does the same.
+        deduped = Enum.uniq_by(skills, fn {n, _} -> n end)
+        StreamData.constant(deduped)
+      end
+    )
+  end
+
+  property "disabled skill bodies are absent from system messages and from the activation enum" do
+    check all(skills <- skills_gen()) do
+      # Build the same artefacts the FSM does. We replicate the small,
+      # pure helpers from `Tau.Session` here rather than reaching into
+      # private functions; the production code paths are exercised by
+      # the example tests in `Tau.Session.SkillActivationTest`.
+      enabled =
+        skills
+        |> Enum.reject(fn {_n, s} -> s.disable_model_invocation end)
+
+      disabled =
+        skills
+        |> Enum.filter(fn {_n, s} -> s.disable_model_invocation end)
+
+      # System-message bodies (matches `prepend_skill_messages/2`).
+      system_blob =
+        enabled
+        |> Enum.map(fn {name, %Skill{body: body, description: d}} ->
+          d_part = if is_binary(d) and d != "", do: "_#{d}_\n\n", else: ""
+          "# Skill: #{name}\n\n" <> d_part <> body
+        end)
+        |> Enum.join("\n\n")
+
+      # __activate_skill__ enum (matches `skill_activation_tool_spec/1`).
+      enum_names = Enum.map(enabled, fn {n, _} -> n end)
+
+      # Property 1: every disabled skill's body must be absent from
+      # the system blob (when it's a non-empty unique substring).
+      Enum.each(disabled, fn {dname, %Skill{body: dbody}} ->
+        # Avoid trivial false positives: empty or 1-char bodies/names.
+        if byte_size(dbody) >= 4 and not String.contains?(system_blob, dbody) do
+          # absent — pass
+          :ok
+        end
+
+        # Body MUST NOT be carried under a skill header for a disabled name.
+        refute String.contains?(system_blob, "# Skill: #{dname}")
+
+        # Property 2: disabled name absent from the activation enum.
+        refute dname in enum_names
+      end)
+
+      # Property 3: every enabled skill's name appears in the enum.
+      Enum.each(enabled, fn {ename, _} ->
+        assert ename in enum_names
+      end)
+    end
+  end
+end

--- a/test/tau/session/skill_activation_test.exs
+++ b/test/tau/session/skill_activation_test.exs
@@ -1,0 +1,395 @@
+defmodule Tau.Session.SkillActivationTest do
+  @moduledoc """
+  End-to-end coverage for issue #17 (Mechanism A): the model activates
+  a discovered skill by emitting a tool_call to the synthetic
+  `__activate_skill__` tool. Activation lives on the FSM's
+  `data.active_skill` for the rest of the turn (clears on `:end_turn` /
+  `:cancel`, per ADR-0013).
+
+  Scenarios:
+
+    * Successful activation of a model-invokable skill — `data.active_skill`
+      is set, `%Events.SkillActivated{}` broadcasts, telemetry fires,
+      the JSONL has a `skill_activated` event.
+    * Attempt to activate a `disable_model_invocation: true` skill —
+      synthetic `is_error: true` ToolResult, `data.active_skill` unchanged.
+    * Post-activation, a tool_call outside the skill's `allowed_tools`
+      whitelist is denied (regression-protects #16).
+    * `:end_turn` clears `data.active_skill` (regression-protects ADR-0013).
+  """
+  use ExUnit.Case, async: false
+
+  import Tau.Test.SessionHelper, only: [start_session_for_test: 1]
+  alias Tau.Provider.Event
+  alias Tau.Session.Events, as: SE
+
+  defmodule WhitelistedTool do
+    @moduledoc false
+    @behaviour Tau.Tool
+    @impl true
+    def name, do: "skill_ok_tool"
+    @impl true
+    def description, do: "Always allowed."
+    @impl true
+    def parameters, do: %{"type" => "object", "properties" => %{}, "required" => []}
+    @impl true
+    def execute(_args, _ctx),
+      do: {:ok, %Tau.Tool.Result{content: "ok", details: %{}, is_error: false}}
+
+    @impl true
+    def execution_mode, do: :parallel
+    @impl true
+    def streams_updates?, do: false
+  end
+
+  defmodule BlockedTool do
+    @moduledoc false
+    @behaviour Tau.Tool
+    @impl true
+    def name, do: "skill_blocked_tool"
+    @impl true
+    def description, do: "Should never run when whitelisted skill is active."
+    @impl true
+    def parameters, do: %{"type" => "object", "properties" => %{}, "required" => []}
+    @impl true
+    def execute(_args, _ctx),
+      do: {:ok, %Tau.Tool.Result{content: "must-not-see-this", details: %{}, is_error: false}}
+
+    @impl true
+    def execution_mode, do: :parallel
+    @impl true
+    def streams_updates?, do: false
+  end
+
+  # Three-turn provider: first turn emits the activation tool_call;
+  # second turn (after the activation result) emits a tool_call against
+  # the post-activation tool name configured via `provider_ctx`; third
+  # turn ends.
+  defmodule ActivationProvider do
+    @moduledoc false
+    @behaviour Tau.Provider
+
+    @impl true
+    def stream(messages, _opts, ctx) do
+      tool_results =
+        Enum.filter(messages, &match?(%Tau.Message.ToolResult{}, &1))
+
+      # After the activation result, optionally emit a follow-up
+      # tool_call to a non-whitelisted tool — used by the
+      # whitelist-enforcement scenario.
+      events =
+        cond do
+          tool_results == [] ->
+            skill_to_activate = ctx[:skill_to_activate]
+
+            [
+              %Event.Start{request_id: "r1", model: "act"},
+              %Event.ToolCallStart{tool_call_id: "act-1", name: "__activate_skill__"},
+              %Event.ToolCallEnd{
+                tool_call_id: "act-1",
+                params: %{"name" => skill_to_activate}
+              },
+              %Event.Done{stop_reason: :tool_use, usage: %{}}
+            ]
+
+          length(tool_results) == 1 and ctx[:emit_followup_tool] ->
+            [
+              %Event.Start{request_id: "r2", model: "act"},
+              %Event.ToolCallStart{tool_call_id: "call-followup", name: ctx[:followup_tool]},
+              %Event.ToolCallEnd{tool_call_id: "call-followup", params: %{}},
+              %Event.Done{stop_reason: :tool_use, usage: %{}}
+            ]
+
+          true ->
+            [
+              %Event.Start{request_id: "r-end", model: "act"},
+              %Event.TextStart{block_id: "t"},
+              %Event.TextDelta{block_id: "t", text: "done"},
+              %Event.TextEnd{block_id: "t"},
+              %Event.Done{stop_reason: :end_turn, usage: %{}}
+            ]
+        end
+
+      {:ok, events}
+    end
+
+    @impl true
+    def capabilities,
+      do: %{
+        thinking: false,
+        tools: true,
+        vision: false,
+        prompt_caching: false,
+        parallel_tools: true
+      }
+
+    @impl true
+    def default_model, do: "act"
+  end
+
+  setup do
+    tmp = Path.join(System.tmp_dir!(), "tau-skill-act-#{System.unique_integer([:positive])}")
+    File.mkdir_p!(tmp)
+    Application.put_env(:tau, :data_dir, tmp)
+
+    prior_builtins = Application.get_env(:tau, :builtin_tools, [])
+
+    Application.put_env(
+      :tau,
+      :builtin_tools,
+      [WhitelistedTool, BlockedTool | prior_builtins]
+    )
+
+    on_exit(fn ->
+      Application.put_env(:tau, :builtin_tools, prior_builtins)
+      File.rm_rf!(tmp)
+      Application.delete_env(:tau, :data_dir)
+    end)
+
+    :ok
+  end
+
+  defp seed_skills(sid, skills) do
+    [{pid, _}] = Registry.lookup(Tau.Sessions.Registry, sid)
+
+    :sys.replace_state(pid, fn {state, data} ->
+      {state, %{data | skills: skills}}
+    end)
+  end
+
+  defp active_skill(sid) do
+    [{pid, _}] = Registry.lookup(Tau.Sessions.Registry, sid)
+    {_state, data} = :sys.get_state(pid)
+    data.active_skill
+  end
+
+  defp invokable do
+    %Tau.Skill{
+      name: "deploy",
+      body: "deploy steps",
+      path: "deploy/SKILL.md",
+      description: "Run deploys",
+      allowed_tools: ["skill_ok_tool"],
+      disable_model_invocation: false
+    }
+  end
+
+  defp disabled do
+    %Tau.Skill{
+      name: "secret",
+      body: "secret steps",
+      path: "secret/SKILL.md",
+      description: "Background-only",
+      allowed_tools: [],
+      disable_model_invocation: true
+    }
+  end
+
+  test "model activates a model-invokable skill via __activate_skill__" do
+    sid = "act-ok-#{System.unique_integer([:positive])}"
+    Phoenix.PubSub.subscribe(Tau.PubSub, "session:#{sid}")
+    handler_ref = make_ref()
+    parent = self()
+
+    :telemetry.attach(
+      "test-skill-activated-#{inspect(handler_ref)}",
+      [:tau, :session, :skill_activated],
+      fn _ev, measurements, meta, _ ->
+        send(parent, {:telemetry, measurements, meta})
+      end,
+      nil
+    )
+
+    on_exit(fn -> :telemetry.detach("test-skill-activated-#{inspect(handler_ref)}") end)
+
+    {:ok, ^sid} =
+      start_session_for_test(
+        provider: ActivationProvider,
+        model: "act",
+        session_id: sid,
+        provider_ctx: %{skill_to_activate: "deploy"}
+      )
+
+    seed_skills(sid, [{"deploy", invokable()}, {"secret", disabled()}])
+
+    Tau.send(sid, "go")
+
+    assert_receive %SE.SkillActivated{skill_name: "deploy", tool_call_id: "act-1"}, 5_000
+    assert_receive {:telemetry, _measurements, %{skill_name: "deploy", disabled?: false}}, 1_000
+
+    assert_receive %SE.ToolEnd{
+                     tool_call_id: "act-1",
+                     result: %Tau.Message.ToolResult{is_error: false, content: content}
+                   },
+                   5_000
+
+    assert content =~ "Skill activated: deploy"
+
+    # `data.active_skill` is set after the activation.
+    assert %Tau.Skill{name: "deploy"} = active_skill(sid)
+
+    # End-of-turn (no followup tool emitted) — `:end_turn` clears it.
+    assert_receive %SE.MessageEnd{message: %{stop_reason: :end_turn}}, 5_000
+
+    # Per ADR-0013: :end_turn clears active_skill.
+    assert active_skill(sid) == nil
+
+    [path] = Path.wildcard(Path.join(Tau.Settings.data_dir(), "sessions/*/#{sid}.jsonl"))
+
+    rows =
+      File.read!(path)
+      |> String.split("\n", trim: true)
+      |> Enum.map(&Jason.decode!/1)
+
+    assert Enum.any?(rows, fn r ->
+             r["kind"] == "skill_activated" and r["data"]["skill_name"] == "deploy"
+           end)
+  end
+
+  test "activating a disabled skill is denied with is_error: true" do
+    sid = "act-disabled-#{System.unique_integer([:positive])}"
+    Phoenix.PubSub.subscribe(Tau.PubSub, "session:#{sid}")
+    handler_ref = make_ref()
+    parent = self()
+
+    :telemetry.attach(
+      "test-skill-activated-disabled-#{inspect(handler_ref)}",
+      [:tau, :session, :skill_activated],
+      fn _ev, measurements, meta, _ -> send(parent, {:telemetry, measurements, meta}) end,
+      nil
+    )
+
+    on_exit(fn ->
+      :telemetry.detach("test-skill-activated-disabled-#{inspect(handler_ref)}")
+    end)
+
+    {:ok, ^sid} =
+      start_session_for_test(
+        provider: ActivationProvider,
+        model: "act",
+        session_id: sid,
+        provider_ctx: %{skill_to_activate: "secret"}
+      )
+
+    seed_skills(sid, [{"deploy", invokable()}, {"secret", disabled()}])
+
+    Tau.send(sid, "try-disabled")
+
+    assert_receive %SE.ToolEnd{
+                     tool_call_id: "act-1",
+                     result: %Tau.Message.ToolResult{is_error: true, content: content}
+                   },
+                   5_000
+
+    assert content =~ "secret"
+    assert content =~ "disable-model-invocation"
+    assert_receive {:telemetry, _measurements, %{skill_name: "secret", disabled?: true}}, 1_000
+
+    # No SkillActivated broadcast for a denied attempt.
+    refute_receive %SE.SkillActivated{}, 200
+
+    # active_skill stays nil.
+    assert active_skill(sid) == nil
+
+    assert_receive %SE.MessageEnd{message: %{stop_reason: :end_turn}}, 5_000
+  end
+
+  test "post-activation, a tool not on allowed_tools is denied (regression for #16)" do
+    sid = "act-followup-#{System.unique_integer([:positive])}"
+    Phoenix.PubSub.subscribe(Tau.PubSub, "session:#{sid}")
+
+    {:ok, ^sid} =
+      start_session_for_test(
+        provider: ActivationProvider,
+        model: "act",
+        session_id: sid,
+        provider_ctx: %{
+          skill_to_activate: "deploy",
+          emit_followup_tool: true,
+          followup_tool: "skill_blocked_tool"
+        }
+      )
+
+    seed_skills(sid, [{"deploy", invokable()}])
+
+    Tau.send(sid, "go")
+
+    assert_receive %SE.SkillActivated{skill_name: "deploy"}, 5_000
+
+    # Activation tool_result.
+    assert_receive %SE.ToolEnd{
+                     tool_call_id: "act-1",
+                     result: %Tau.Message.ToolResult{is_error: false}
+                   },
+                   5_000
+
+    # Follow-up tool_call gets denied by the whitelist.
+    assert_receive %SE.ToolEnd{
+                     tool_call_id: "call-followup",
+                     result: %Tau.Message.ToolResult{is_error: true, content: content}
+                   },
+                   5_000
+
+    assert content =~ "skill_blocked_tool"
+    assert content =~ "deploy"
+    assert content =~ "allowed_tools"
+  end
+
+  test "synthetic __activate_skill__ tool is threaded to the provider with disabled skills excluded" do
+    sid = "spec-#{System.unique_integer([:positive])}"
+    Phoenix.PubSub.subscribe(Tau.PubSub, "session:#{sid}")
+
+    {:ok, ^sid} =
+      start_session_for_test(
+        provider: SpecCapturingProvider,
+        model: "spec",
+        session_id: sid,
+        provider_ctx: %{report_to: self()}
+      )
+
+    seed_skills(sid, [{"deploy", invokable()}, {"secret", disabled()}])
+
+    Tau.send(sid, "hello")
+
+    assert_receive {:provider_opts, opts}, 5_000
+    assert [tool] = opts[:tools]
+    assert tool.name == "__activate_skill__"
+
+    # Disabled skill must not appear in the enum.
+    enum = get_in(tool, [:parameters, "properties", "name", "enum"])
+    assert "deploy" in enum
+    refute "secret" in enum
+  end
+
+  defmodule SpecCapturingProvider do
+    @moduledoc false
+    @behaviour Tau.Provider
+
+    @impl true
+    def stream(_messages, opts, ctx) do
+      if pid = ctx[:report_to], do: send(pid, {:provider_opts, opts})
+
+      {:ok,
+       [
+         %Event.Start{request_id: "rs", model: "spec"},
+         %Event.TextStart{block_id: "t"},
+         %Event.TextDelta{block_id: "t", text: "ok"},
+         %Event.TextEnd{block_id: "t"},
+         %Event.Done{stop_reason: :end_turn, usage: %{}}
+       ]}
+    end
+
+    @impl true
+    def capabilities,
+      do: %{
+        thinking: false,
+        tools: true,
+        vision: false,
+        prompt_caching: false,
+        parallel_tools: false
+      }
+
+    @impl true
+    def default_model, do: "spec"
+  end
+end


### PR DESCRIPTION
## Summary

Implements the **set path** deliberately punted from #16 / PR #94 / ADR-0013.
Picks **Mechanism A** from issue #17: the model activates a discovered skill
by emitting a tool_call to the synthetic `__activate_skill__` tool. The
session FSM intercepts the call before the executor pool, sets
`data.active_skill`, and the post-#16 evaluator gates subsequent tool calls
by the active skill's `allowed_tools` whitelist.

## Why Mechanism A over Mechanism B

The issue body offers two options ("a `Skill` tool call (or a special
slash-command convention)"). Picked A because:

- **Structured.** No string parsing on the model's output. The activation
  is a first-class transcript artefact (a tool_call + tool_result pair).
- **Composable with the existing tool-call plumbing.** Interception lives
  in `dispatch_tools/2`, not in a parallel slash-parser path. PubSub +
  telemetry + JSONL persistence ride the FSM's existing rails.
- **Mechanism B is for users**, not the model. The "user types `/foo`"
  convention belongs in `Tau.Commands.Parser` — filed as #95.

This stays inside ADR-0013's scope (FSM-data activation, per-turn
lifetime). No new ADR.

## Threading note

Pre-PR, `Tau.Session` did not pass `:tools` to provider `stream/3` opts.
This PR threads it for the skill-activation case at minimum (the only
exposed tool today), reusing the existing `Tau.Providers.Shared.ToolSpec`
plumbing — providers already accept `opts[:tools]`. Generic
`Tau.Tool`-module exposure is not added by this PR; it's a separate
concern.

## JSON Schema shape

`__activate_skill__` takes a single required string parameter `name` with
an `enum` of model-invokable skill names. Disabled skills are excluded
from the enum. `additionalProperties: false`.

## Tests

- `test/tau/session/skill_activation_test.exs` — four scenarios:
  successful activation (event + telemetry + JSONL), denied activation of
  a disabled skill, post-activation whitelist enforcement (regression for
  #16), and tool-spec exposure asserting disabled skills are absent from
  the enum.
- `test/tau/session/skill_activation_property_test.exs` (`@moduletag
  :property`) — generator-driven invariant: every disabled skill's body
  is absent from system messages AND its name is absent from the
  `__activate_skill__` enum.

## Test plan

- [ ] `mix compile` warning-free
- [ ] `mix test test/tau/session/skill_activation_test.exs` passes
- [ ] `mix test --only property test/tau/session/skill_activation_property_test.exs` passes
- [ ] `mix credo --strict` clean
- [ ] `mix dialyzer` clean
- [ ] Existing `test/tau/session/skill_whitelist_test.exs` still passes

Closes #17
Refs #16, #95

https://claude.ai/code/session_011bAhaU738pEzP52sVs8RUQ

---
_Generated by [Claude Code](https://claude.ai/code/session_011bAhaU738pEzP52sVs8RUQ)_