### PR TITLE
docs: warn CLAUDE.md that worktree isolation leaks for absolute paths

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,6 +148,15 @@ Worktree-isolated agents create their own branch and commit
 there; on return they hand back the branch name + path. Pull /
 merge from the parent worktree as the next step.
 
+**Worktree isolation is leaky for absolute paths.** Isolation
+isolates the git refs (HEAD, commits, branches) but file-system
+writes on absolute paths like `/home/user/tau/lib/...` bypass the
+worktree CWD and land on the **parent** tree. Brief isolated
+agents to use **relative paths** for `Read`/`Edit`/`Write`. As a
+coordinator, periodically `git checkout main && git reset --hard
+origin/main` between dispatches to discard any leaked edits in
+the parent.
+
 **Single-agent foreground work** (no parallel siblings) does not
 need isolation — the parent and child can't race a single
 working tree.


### PR DESCRIPTION
Nine-line addition to CLAUDE.md. Subagents dispatched with `isolation: "worktree"` get isolated git refs (HEAD, branch, commits) but their `Read`/`Edit`/`Write` calls on absolute paths like `/home/user/tau/lib/...` land on the **parent** tree, not the worktree. Same session that codified the worktree-isolation rule (PR #81) just hit the leaked-edit case in practice.

Brief isolated agents to use **relative paths** and periodically reset the parent tree between dispatches.

https://claude.ai/code/session_011bAhaU738pEzP52sVs8RUQ

---
_Generated by [Claude Code](https://claude.ai/code/session_011bAhaU738pEzP52sVs8RUQ)_