### PR TITLE
feat: argument-aware :accept_edits for Bash (closes #22)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the status bar continues to work. (Closes #26.)
 
 ### Changed
+- `:accept_edits` permissions mode is now argument-aware for Bash:
+  destructive commands (`rm -rf`, `sudo`, `dd`, `mkfs`, `shred`, fork
+  bombs, raw disk writes) deny; non-destructive commands auto-allow.
+  Other tools under `:accept_edits` retain `:ask` semantics. New
+  pure helper `Tau.Permissions.Heuristics.destructive_bash?/1`.
+  (Closes #22.)
 - `Tau.Session` now dispatches a turn's parallel tool calls through a
   single `Task.Supervisor.async_stream_nolink/4` iterator under
   `Tau.Tools.TaskSupervisor` instead of one `async_nolink/2` Task per

--- a/lib/tau/permissions/evaluator.ex
+++ b/lib/tau/permissions/evaluator.ex
@@ -10,7 +10,9 @@ defmodule Tau.Permissions.Evaluator do
 
     * `:default`        — fall through to `:ask` when no rule matches
     * `:accept_edits`   — auto-allow tool calls that don't include
-                         destructive shells; deny rules still apply
+                         destructive shells (Bash commands run through
+                         `Tau.Permissions.Heuristics.destructive_bash?/1`);
+                         deny rules still apply
     * `:plan`           — read-only: only Read/Grep/etc. allowed
     * `:auto`           — auto-allow non-destructive; ask on writes
     * `:dont_ask`       — only pre-approved tools; default deny otherwise
@@ -65,7 +67,7 @@ defmodule Tau.Permissions.Evaluator do
         :ask
 
       true ->
-        default_for_mode(mode, tool_name)
+        default_for_mode(mode, tool_name, args)
     end
   end
 
@@ -86,16 +88,19 @@ defmodule Tau.Permissions.Evaluator do
     end)
   end
 
-  defp default_for_mode(:default, _), do: :ask
-  defp default_for_mode(:dont_ask, _), do: :deny
-  defp default_for_mode(:plan, tool) when tool in ["Read", "Grep", "Glob"], do: :allow
-  defp default_for_mode(:plan, _), do: :deny
+  defp default_for_mode(:default, _, _), do: :ask
+  defp default_for_mode(:dont_ask, _, _), do: :deny
+  defp default_for_mode(:plan, tool, _) when tool in ["Read", "Grep", "Glob"], do: :allow
+  defp default_for_mode(:plan, _, _), do: :deny
 
-  defp default_for_mode(:accept_edits, tool) when tool in ["Read", "Write", "Edit", "Grep"],
+  defp default_for_mode(:accept_edits, tool, _) when tool in ["Read", "Write", "Edit", "Grep"],
     do: :allow
 
-  defp default_for_mode(:accept_edits, "Bash"), do: :ask
-  defp default_for_mode(:auto, tool) when tool in ["Read", "Grep", "Glob"], do: :allow
-  defp default_for_mode(:auto, _), do: :ask
-  defp default_for_mode(_, _), do: :ask
+  defp default_for_mode(:accept_edits, "Bash", args) do
+    if Tau.Permissions.Heuristics.destructive_bash?(args), do: :deny, else: :allow
+  end
+
+  defp default_for_mode(:auto, tool, _) when tool in ["Read", "Grep", "Glob"], do: :allow
+  defp default_for_mode(:auto, _, _), do: :ask
+  defp default_for_mode(_, _, _), do: :ask
 end

--- a/lib/tau/permissions/heuristics.ex
+++ b/lib/tau/permissions/heuristics.ex
@@ -1,0 +1,63 @@
+defmodule Tau.Permissions.Heuristics do
+  @moduledoc """
+  Pure heuristics over tool-call arguments.
+
+  Used by `Tau.Permissions.Evaluator` to make `:accept_edits` mode
+  argument-aware on `Bash`: a non-destructive shell command (e.g.
+  `npm test`, `ls -la`) auto-allows; a destructive one (e.g.
+  `rm -rf /`, `sudo …`, `dd …`, fork bombs, raw disk writes) denies.
+
+  False positives on legitimate `rm`/`sudo` usage are acceptable here
+  because this gate only steers the `:accept_edits` auto-allow path —
+  callers that hit a false positive get `:deny`, then fall through to
+  an interactive prompt the same way `:ask` would have. False
+  negatives, in contrast, would silently let a destructive command
+  through under `:accept_edits`, which is what we are protecting
+  against.
+
+  See issue #22.
+  """
+
+  # Pre-compiled patterns. Compiled once at module-load via the
+  # `Macro.escape/1` trick: `Regex.compile!/1` is allowed in module
+  # attributes because it's a regular function call evaluated at
+  # compile time.
+  @patterns [
+    ~r/rm\s+-r/,
+    ~r/rm\s+-f/,
+    ~r/sudo\s+/,
+    ~r/dd\s+/,
+    ~r/mkfs\s/,
+    ~r/shred\s/,
+    # Classic bash fork bomb. Match the literal sequence; whitespace
+    # inside the brace block is part of the canonical form.
+    ~r/:\(\)\{ :\|:&\};:/,
+    # Raw write to a primary disk device.
+    ~r/>\s*\/dev\/sd[a-z]/
+  ]
+
+  @doc """
+  Returns `true` when `args` carries a `command` string matching one
+  of the destructive-shell patterns.
+
+  Accepts the canonical `Bash` tool argument shape — a map with a
+  string `"command"` key — and tolerates the atom `:command` key for
+  callers that haven't normalised yet. Anything else (`nil`, missing
+  key, non-string command) returns `false`.
+  """
+  @spec destructive_bash?(map() | nil) :: boolean()
+  def destructive_bash?(nil), do: false
+
+  def destructive_bash?(args) when is_map(args) do
+    case command(args) do
+      cmd when is_binary(cmd) -> Enum.any?(@patterns, &Regex.match?(&1, cmd))
+      _ -> false
+    end
+  end
+
+  def destructive_bash?(_), do: false
+
+  defp command(%{"command" => cmd}), do: cmd
+  defp command(%{command: cmd}), do: cmd
+  defp command(_), do: nil
+end

--- a/test/tau/permissions/evaluator_test.exs
+++ b/test/tau/permissions/evaluator_test.exs
@@ -51,6 +51,47 @@ defmodule Tau.Permissions.EvaluatorTest do
     test ":dont_ask defaults to deny on no match" do
       assert Evaluator.evaluate({}, "Bash", %{}, %{}, :dont_ask) == :deny
     end
+
+    test ":accept_edits + non-Bash tool retains :ask for unknown tools" do
+      # Read/Write/Edit/Grep auto-allow under :accept_edits; anything
+      # else (here: WebFetch) falls through to :ask.
+      assert Evaluator.evaluate({}, "WebFetch", %{}, %{}, :accept_edits) == :ask
+    end
+
+    test ":accept_edits + Bash + destructive command denies" do
+      assert Evaluator.evaluate({}, "Bash", %{"command" => "rm -rf /"}, %{}, :accept_edits) ==
+               :deny
+
+      assert Evaluator.evaluate({}, "Bash", %{"command" => "sudo apt install"}, %{},
+               :accept_edits
+             ) == :deny
+
+      assert Evaluator.evaluate({}, "Bash", %{"command" => ":(){ :|:&};:"}, %{}, :accept_edits) ==
+               :deny
+    end
+
+    test ":accept_edits + Bash + non-destructive command allows" do
+      assert Evaluator.evaluate({}, "Bash", %{"command" => "npm test"}, %{}, :accept_edits) ==
+               :allow
+
+      assert Evaluator.evaluate({}, "Bash", %{"command" => "ls -la"}, %{}, :accept_edits) ==
+               :allow
+    end
+
+    test ":accept_edits + Bash + missing command falls through to allow" do
+      # No command argument means nothing to inspect; the heuristic
+      # returns false, so the auto-allow fires. Higher layers should
+      # have already rejected calls without a command via the tool
+      # schema.
+      assert Evaluator.evaluate({}, "Bash", %{}, %{}, :accept_edits) == :allow
+    end
+
+    test ":accept_edits respects rule-set deny ahead of heuristic" do
+      rs = rule_set(%{deny: ["Bash(npm *)"]})
+
+      assert Evaluator.evaluate(rs, "Bash", %{"command" => "npm test"}, %{}, :accept_edits) ==
+               :deny
+    end
   end
 
   describe "matchers" do

--- a/test/tau/permissions/heuristics_property_test.exs
+++ b/test/tau/permissions/heuristics_property_test.exs
@@ -1,0 +1,158 @@
+defmodule Tau.Permissions.HeuristicsPropertyTest do
+  @moduledoc """
+  Property + example coverage for issue #22:
+  `Tau.Permissions.Heuristics.destructive_bash?/1` must flag every
+  command containing one of the canonical destructive patterns and
+  let benign commands through.
+
+  We deliberately accept false positives (e.g. a comment containing
+  `rm -rf` would also flag) because the consumer is the
+  `:accept_edits` auto-allow gate — a flag flips `:allow` to `:deny`,
+  which falls through to an interactive prompt; it never escalates to
+  destructive action. False negatives, on the other hand, would
+  silently auto-allow a destructive command, so the property is
+  "every member of the catalogue, embedded anywhere, is flagged".
+  """
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  alias Tau.Permissions.Heuristics
+
+  @moduletag :property
+
+  # Canonical destructive patterns. Each entry is a literal string
+  # that must trigger the heuristic — these mirror the regex set in
+  # `Heuristics`.
+  @destructive [
+    "rm -r /tmp/x",
+    "rm -rf /var/log",
+    "rm -f /etc/hosts",
+    "sudo apt-get install evil",
+    "dd if=/dev/zero of=/dev/sda",
+    "mkfs.ext4 /dev/sda1",
+    "shred /etc/passwd",
+    ":(){ :|:&};:",
+    "echo data > /dev/sda",
+    "cat /tmp/x > /dev/sdb"
+  ]
+
+  # Plausibly-benign commands that must NOT flag.
+  @benign [
+    "npm test",
+    "ls -la",
+    "git status",
+    "echo hello",
+    "mix test",
+    "cargo build --release",
+    "python -m pytest",
+    "make",
+    "grep -r foo .",
+    "cat README.md"
+  ]
+
+  property "every destructive pattern is flagged when embedded in a command" do
+    check all(
+            base <- StreamData.member_of(@destructive),
+            prefix <- StreamData.string(:alphanumeric, max_length: 8),
+            suffix <- StreamData.string(:alphanumeric, max_length: 8)
+          ) do
+      cmd = "#{prefix} #{base} #{suffix}"
+      assert Heuristics.destructive_bash?(%{"command" => cmd}),
+             "expected destructive flag for: #{inspect(cmd)}"
+    end
+  end
+
+  property "benign commands are not flagged" do
+    check all(cmd <- StreamData.member_of(@benign)) do
+      refute Heuristics.destructive_bash?(%{"command" => cmd})
+    end
+  end
+
+  property "atom :command key is honoured" do
+    check all(cmd <- StreamData.member_of(@destructive)) do
+      assert Heuristics.destructive_bash?(%{command: cmd})
+    end
+  end
+
+  describe "examples from issue #22" do
+    test "rm -r" do
+      assert Heuristics.destructive_bash?(%{"command" => "rm -r /tmp/x"})
+    end
+
+    test "rm -f" do
+      assert Heuristics.destructive_bash?(%{"command" => "rm -f /etc/hosts"})
+    end
+
+    test "rm -rf" do
+      assert Heuristics.destructive_bash?(%{"command" => "rm -rf /"})
+    end
+
+    test "sudo" do
+      assert Heuristics.destructive_bash?(%{"command" => "sudo rm /etc/x"})
+    end
+
+    test "dd" do
+      assert Heuristics.destructive_bash?(%{"command" => "dd if=/dev/zero of=/dev/sda"})
+    end
+
+    test "mkfs" do
+      assert Heuristics.destructive_bash?(%{"command" => "mkfs.ext4 /dev/sda1"})
+    end
+
+    test "shred" do
+      assert Heuristics.destructive_bash?(%{"command" => "shred -u secrets.txt"})
+    end
+
+    test "fork bomb" do
+      assert Heuristics.destructive_bash?(%{"command" => ":(){ :|:&};:"})
+    end
+
+    test "raw disk write" do
+      assert Heuristics.destructive_bash?(%{"command" => "echo wipe > /dev/sda"})
+    end
+
+    test "raw disk write with whitespace variation" do
+      assert Heuristics.destructive_bash?(%{"command" => "cat x >/dev/sdb"})
+    end
+  end
+
+  describe "non-destructive examples" do
+    test "npm test" do
+      refute Heuristics.destructive_bash?(%{"command" => "npm test"})
+    end
+
+    test "ls -la" do
+      refute Heuristics.destructive_bash?(%{"command" => "ls -la"})
+    end
+
+    test "git status" do
+      refute Heuristics.destructive_bash?(%{"command" => "git status"})
+    end
+
+    test "rm without destructive flags is not flagged" do
+      # Bare `rm foo.txt` has no `-r` / `-f`, so the heuristic does
+      # not fire. Single-file `rm` falls through to `:allow` under
+      # `:accept_edits`; that's a deliberate choice — see
+      # Heuristics moduledoc on false-positive tolerance.
+      refute Heuristics.destructive_bash?(%{"command" => "rm foo.txt"})
+    end
+  end
+
+  describe "edge cases" do
+    test "nil args" do
+      refute Heuristics.destructive_bash?(nil)
+    end
+
+    test "empty map" do
+      refute Heuristics.destructive_bash?(%{})
+    end
+
+    test "non-string command value" do
+      refute Heuristics.destructive_bash?(%{"command" => 42})
+    end
+
+    test "missing command key" do
+      refute Heuristics.destructive_bash?(%{"path" => "/tmp/x"})
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- New pure helper `Tau.Permissions.Heuristics.destructive_bash?/1` matches `args["command"]` against the destructive-shell catalogue from #22 (`rm -r`, `rm -f`, `sudo `, `dd `, `mkfs `, `shred `, classic fork bomb, raw disk writes to `/dev/sd[a-z]`).
- `Tau.Permissions.Evaluator.default_for_mode/3` now threads tool arguments through; `:accept_edits` + `Bash` routes through the heuristic — destructive → `:deny`, non-destructive → `:allow`. Other tools under `:accept_edits` retain prior `:ask`/`:allow` semantics.
- Property + example coverage in `test/tau/permissions/heuristics_property_test.exs` (every catalogue entry flagged regardless of surrounding text; benign commands not flagged; atom/string command keys; nil/missing/non-string edge cases). Evaluator examples extended for `:accept_edits` cases including rule-set deny precedence.

## Design notes
- False positives are acceptable here because flipping `:allow` to `:deny` falls through to an interactive prompt — never destructive action. False negatives would silently auto-allow a destructive command, which is the failure we are protecting against. The regex set deliberately errs on the side of over-flagging (e.g. bare `sudo ` anywhere in the command, including comments, fires).
- `rm` without `-r`/`-f` (e.g. `rm foo.txt`) does **not** flag — consistent with the issue's pattern set; single-file deletes auto-allow under `:accept_edits`.
- Settings extension (the issue's "stretch" — user-extensible destructive list as a generic matcher) is punted; file a follow-up issue if wanted.

## Test plan
- [ ] `mix test test/tau/permissions/heuristics_property_test.exs`
- [ ] `mix test test/tau/permissions/evaluator_test.exs`
- [ ] `mix test --only property`
- [ ] `mix format --check-formatted && mix credo --strict && mix dialyzer`

Closes #22

https://claude.ai/code/session_011bAhaU738pEzP52sVs8RUQ

---
_Generated by [Claude Code](https://claude.ai/code/session_011bAhaU738pEzP52sVs8RUQ)_