### PR TITLE
feat: Tau.start_session :tools_whitelist option (closes #91)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `tool_call → tool_result` correspondence. (Closes #33.)
 
 ### Added
+- `Tau.start_session(tools_whitelist: ["Read", "Grep"])` restricts a
+  session's tools at spawn time. The whitelist filter applies before
+  the permissions evaluator; missing tools synthesise an `is_error`
+  ToolResult the same way deny rules do. `:all` (default) preserves
+  current behaviour. Surfaced via `Tau.snapshot/1`. New telemetry:
+  `[:tau, :session, :tool_whitelisted]`. Foundation for ADR-0014
+  subagent personas. (Refs #18, closes #91.)
 - Model-invokable skills: the model can activate a discovered skill
   by emitting a tool_call to the synthetic `__activate_skill__` tool.
   Skills with `disable_model_invocation: true` are excluded from the

--- a/lib/tau.ex
+++ b/lib/tau.ex
@@ -36,6 +36,12 @@ defmodule Tau do
     * `:cwd` — working directory the session operates from
     * `:system_prompt` — overrides the default system prompt
     * `:tools` — `:all` or a list of tool modules / names to whitelist
+    * `:tools_whitelist` — `:all` (default) or a list of tool name
+      strings restricting which tools this session may call. Filter
+      runs in `Tau.Session.dispatch_tools/2` before
+      `Tau.Permissions.Evaluator`; calls outside the list synthesise an
+      `is_error: true` ToolResult the same way deny rules do. Useful
+      for sandboxed sessions and the subagent groundwork (ADR-0014/15).
     * `:permissions_mode` — `:default | :accept_edits | :plan | :auto | :dont_ask | :bypass`
     * `:persistence` — module implementing `Tau.Persistence`
     * `:resume_from` — event id to fork from (creates a new session branched off another)

--- a/lib/tau/session.ex
+++ b/lib/tau/session.ex
@@ -271,7 +271,8 @@ defmodule Tau.Session do
           message_count: non_neg_integer(),
           skills: [{String.t(), Tau.Skill.t()}],
           metadata: map(),
-          permissions_mode: atom()
+          permissions_mode: atom(),
+          tools_whitelist: [String.t()] | :all
         }
 
   @doc """
@@ -298,7 +299,8 @@ defmodule Tau.Session do
          message_count: length(data.messages),
          skills: data.skills,
          metadata: data.metadata,
-         permissions_mode: Map.get(data.metadata, :permissions_mode, :default)
+         permissions_mode: Map.get(data.metadata, :permissions_mode, :default),
+         tools_whitelist: data.tools_whitelist
        }}
     end
   end
@@ -432,7 +434,15 @@ defmodule Tau.Session do
           # `active_skill.allowed_tools` before consulting the rule set.
           # Per-turn lifetime: cleared in `finalize_assistant/2` when the
           # assistant returns `stop_reason == :end_turn` and on `:cancel`.
-          active_skill: nil
+          active_skill: nil,
+          # #91: spawn-time tool whitelist (`:all` or `[String.t()]`).
+          # Filter applies in `dispatch_tools/2` before
+          # `Tau.Permissions.Evaluator`; calls outside the list synthesise
+          # an `is_error: true` ToolResult the same way deny rules do.
+          # Foundation for ADR-0014/15 subagent personas (the parent's
+          # `Agent` tool plumbs the child skill's `allowed_tools` through
+          # this opt). `:all` preserves today's behaviour.
+          tools_whitelist: opts[:tools_whitelist] || :all
         }
 
         {:ok, :awaiting_user, data}
@@ -887,6 +897,34 @@ defmodule Tau.Session do
 
     {data, activated_in_flight} = handle_skill_activations(activation_calls, data, parent)
 
+    # #91: spawn-time tools_whitelist filter. Runs *before* the permissions
+    # evaluator so the evaluator stays a pure permission-rule decision.
+    # Calls outside the list synthesise an `is_error: true` ToolResult the
+    # same way deny rules do; the filter is a no-op when `:all`.
+    {whitelisted_out, tool_calls} = split_tools_whitelist(tool_calls, data.tools_whitelist)
+
+    Enum.each(whitelisted_out, fn %{id: id, name: name} ->
+      result =
+        ToolResult.new(
+          tool_call_id: id,
+          tool_name: name,
+          content: "Tool '#{name}' not in this session's whitelist.",
+          is_error: true
+        )
+
+      Process.send(parent, {:tool_done, id, result}, [])
+
+      :telemetry.execute(
+        [:tau, :session, :tool_whitelisted],
+        %{system_time: System.system_time()},
+        %{
+          session_id: data.id,
+          tool_name: name,
+          whitelist_size: whitelist_size(data.tools_whitelist)
+        }
+      )
+    end)
+
     rule_set = Tau.Permissions.RuleSet.get()
     mode = Map.get(data.metadata, :permissions_mode, :default)
 
@@ -972,6 +1010,9 @@ defmodule Tau.Session do
     initial_in_flight =
       real_tasks
       |> Map.merge(Enum.into(gated, %{}, fn %{id: id} -> {id, :denied} end))
+      |> Map.merge(
+        Enum.into(whitelisted_out, %{}, fn %{id: id} -> {id, :whitelist_filtered} end)
+      )
       |> Map.merge(activated_in_flight)
 
     {:next_state, :tool_executing,
@@ -1052,6 +1093,20 @@ defmodule Tau.Session do
 
     pid
   end
+
+  # #91: split tool calls into {filtered_out, kept} based on the session's
+  # spawn-time `:tools_whitelist`. `:all` is the no-op identity (everything
+  # in `kept`); a list keeps only calls whose `name` is in the list. Stays
+  # ordering-preserving so downstream `Enum.into/2` and synthesis preserve
+  # the model's emit order.
+  defp split_tools_whitelist(tool_calls, :all), do: {[], tool_calls}
+
+  defp split_tools_whitelist(tool_calls, list) when is_list(list) do
+    Enum.split_with(tool_calls, fn %{name: name} -> name not in list end)
+  end
+
+  defp whitelist_size(:all), do: :all
+  defp whitelist_size(list) when is_list(list), do: length(list)
 
   # ADR-0013 / #16: format the synthetic ToolResult content for a
   # permissions :deny. When an active skill is in effect AND the tool is

--- a/lib/tau/telemetry/handlers.ex
+++ b/lib/tau/telemetry/handlers.ex
@@ -7,6 +7,7 @@ defmodule Tau.Telemetry.Handlers do
       [:tau, :app, :ready]
       [:tau, :session, :start | :stop]
       [:tau, :session, :transition]
+      [:tau, :session, :tool_whitelisted]
       [:tau, :provider, :request, :start | :stop | :exception]
       [:tau, :provider, :event]
       [:tau, :provider, :rate_limit, :acquired | :throttled | :rejected | :halved]
@@ -62,6 +63,7 @@ defmodule Tau.Telemetry.Handlers do
       [:tau, :session, :start],
       [:tau, :session, :stop],
       [:tau, :session, :transition],
+      [:tau, :session, :tool_whitelisted],
       [:tau, :provider, :request, :start],
       [:tau, :provider, :request, :stop],
       [:tau, :provider, :request, :exception],

--- a/test/tau/session/tools_whitelist_test.exs
+++ b/test/tau/session/tools_whitelist_test.exs
@@ -1,0 +1,290 @@
+defmodule Tau.Session.ToolsWhitelistTest do
+  @moduledoc """
+  End-to-end coverage for issue #91: a session-spawn-time
+  `:tools_whitelist` option restricts which tools a session may call.
+
+  Verifies:
+
+    * `:all` (the default) is a no-op — model-emitted tool calls execute
+      normally;
+    * a list-valued whitelist filters out non-whitelisted calls before
+      `Tau.Permissions.Evaluator`, synthesising an `is_error: true`
+      `ToolResult` with the whitelist-attribution message;
+    * a tool *on* the whitelist falls through to the permissions
+      evaluator and executes normally;
+    * `Tau.snapshot/1` exposes the whitelist value.
+
+  The pure-function property at the bottom pins the
+  filtered-iff-not-in-list invariant.
+  """
+  use ExUnit.Case, async: false
+  use ExUnitProperties
+
+  import Tau.Test.SessionHelper, only: [start_session_for_test: 1]
+  alias Tau.Provider.Event
+  alias Tau.Session.Events, as: SE
+
+  defmodule WhitelistTool do
+    @moduledoc false
+    @behaviour Tau.Tool
+    @impl true
+    def name, do: "wl_ok_tool"
+    @impl true
+    def description, do: "Always allowed."
+    @impl true
+    def parameters, do: %{"type" => "object", "properties" => %{}, "required" => []}
+    @impl true
+    def execute(_args, _ctx),
+      do: {:ok, %Tau.Tool.Result{content: "ran", details: %{}, is_error: false}}
+
+    @impl true
+    def execution_mode, do: :parallel
+    @impl true
+    def streams_updates?, do: false
+  end
+
+  defmodule WhitelistBlockedTool do
+    @moduledoc false
+    @behaviour Tau.Tool
+    @impl true
+    def name, do: "wl_blocked_tool"
+    @impl true
+    def description, do: "Should never run when filtered out."
+    @impl true
+    def parameters, do: %{"type" => "object", "properties" => %{}, "required" => []}
+    @impl true
+    def execute(_args, _ctx),
+      do: {:ok, %Tau.Tool.Result{content: "should-not-run", details: %{}, is_error: false}}
+
+    @impl true
+    def execution_mode, do: :parallel
+    @impl true
+    def streams_updates?, do: false
+  end
+
+  # Provider that emits ONE tool_call to a configured tool name on the
+  # first turn, then a clean :end_turn after the FSM hands back a
+  # tool_result. Keeps the test deterministic for any name the test wants
+  # the model to "emit".
+  defmodule SingleToolCallProvider do
+    @moduledoc false
+    @behaviour Tau.Provider
+
+    @impl true
+    def stream(messages, _opts, ctx) do
+      has_tool_result? = Enum.any?(messages, &match?(%Tau.Message.ToolResult{}, &1))
+      tool_name = Map.fetch!(ctx, :tool_name)
+      call_id = Map.get(ctx, :call_id, "call-91")
+
+      events =
+        if has_tool_result? do
+          [
+            %Event.Start{request_id: "r2", model: "p91"},
+            %Event.TextStart{block_id: "t1"},
+            %Event.TextDelta{block_id: "t1", text: "ok"},
+            %Event.TextEnd{block_id: "t1"},
+            %Event.Done{stop_reason: :end_turn, usage: %{}}
+          ]
+        else
+          [
+            %Event.Start{request_id: "r1", model: "p91"},
+            %Event.ToolCallStart{tool_call_id: call_id, name: tool_name},
+            %Event.ToolCallEnd{tool_call_id: call_id, params: %{}},
+            %Event.Done{stop_reason: :tool_use, usage: %{}}
+          ]
+        end
+
+      {:ok, events}
+    end
+
+    @impl true
+    def capabilities,
+      do: %{
+        thinking: false,
+        tools: true,
+        vision: false,
+        prompt_caching: false,
+        parallel_tools: true
+      }
+
+    @impl true
+    def default_model, do: "p91"
+  end
+
+  setup do
+    tmp = Path.join(System.tmp_dir!(), "tau-tools-whitelist-#{System.unique_integer([:positive])}")
+    File.mkdir_p!(tmp)
+    Application.put_env(:tau, :data_dir, tmp)
+
+    prior_builtins = Application.get_env(:tau, :builtin_tools, [])
+
+    Application.put_env(
+      :tau,
+      :builtin_tools,
+      [WhitelistTool, WhitelistBlockedTool | prior_builtins]
+    )
+
+    on_exit(fn ->
+      Application.put_env(:tau, :builtin_tools, prior_builtins)
+      File.rm_rf!(tmp)
+      Application.delete_env(:tau, :data_dir)
+    end)
+
+    :ok
+  end
+
+  test ":all (the default) is a no-op — non-whitelisted tools execute normally" do
+    sid = "wl-default-#{System.unique_integer([:positive])}"
+    Phoenix.PubSub.subscribe(Tau.PubSub, "session:#{sid}")
+
+    {:ok, ^sid} =
+      start_session_for_test(
+        provider: SingleToolCallProvider,
+        model: "p91",
+        session_id: sid,
+        provider_ctx: %{tool_name: "wl_blocked_tool", call_id: "call-default"}
+      )
+
+    {:ok, snap0} = Tau.snapshot(sid)
+    assert snap0.tools_whitelist == :all
+
+    Tau.send(sid, "go")
+
+    assert_receive %SE.ToolEnd{
+                     tool_call_id: "call-default",
+                     result: %Tau.Message.ToolResult{is_error: false, content: "ran"}
+                   },
+                   5_000
+
+    assert_receive %SE.MessageEnd{message: %{stop_reason: :end_turn}}, 5_000
+  end
+
+  test "list whitelist filters non-listed tool — synthesised is_error ToolResult and clean :end_turn" do
+    sid = "wl-filter-#{System.unique_integer([:positive])}"
+    Phoenix.PubSub.subscribe(Tau.PubSub, "session:#{sid}")
+
+    handler_id = "wl-filter-handler-#{System.unique_integer([:positive])}"
+    test_pid = self()
+
+    :telemetry.attach(
+      handler_id,
+      [:tau, :session, :tool_whitelisted],
+      fn _e, _m, meta, _c -> Process.send(test_pid, {:wl_telemetry, meta}, []) end,
+      nil
+    )
+
+    on_exit(fn -> :telemetry.detach(handler_id) end)
+
+    {:ok, ^sid} =
+      start_session_for_test(
+        provider: SingleToolCallProvider,
+        model: "p91",
+        session_id: sid,
+        tools_whitelist: ["wl_ok_tool"],
+        provider_ctx: %{tool_name: "wl_blocked_tool", call_id: "call-filter"}
+      )
+
+    Tau.send(sid, "go")
+
+    assert_receive %SE.ToolEnd{
+                     tool_call_id: "call-filter",
+                     result: %Tau.Message.ToolResult{is_error: true, content: content}
+                   },
+                   5_000
+
+    assert content =~ "wl_blocked_tool"
+    assert content =~ "whitelist"
+
+    assert_receive {:wl_telemetry,
+                    %{session_id: ^sid, tool_name: "wl_blocked_tool", whitelist_size: 1}},
+                   5_000
+
+    assert_receive %SE.MessageEnd{message: %{stop_reason: :end_turn}}, 5_000
+
+    {:ok, snap} = Tau.snapshot(sid)
+    assert snap.state == :awaiting_user
+    assert snap.tools_whitelist == ["wl_ok_tool"]
+  end
+
+  test "tool on whitelist falls through to permissions evaluator and executes" do
+    sid = "wl-passthrough-#{System.unique_integer([:positive])}"
+    Phoenix.PubSub.subscribe(Tau.PubSub, "session:#{sid}")
+
+    {:ok, ^sid} =
+      start_session_for_test(
+        provider: SingleToolCallProvider,
+        model: "p91",
+        session_id: sid,
+        tools_whitelist: ["wl_ok_tool"],
+        provider_ctx: %{tool_name: "wl_ok_tool", call_id: "call-pass"}
+      )
+
+    Tau.send(sid, "go")
+
+    assert_receive %SE.ToolEnd{
+                     tool_call_id: "call-pass",
+                     result: %Tau.Message.ToolResult{is_error: false, content: "ran"}
+                   },
+                   5_000
+
+    assert_receive %SE.MessageEnd{message: %{stop_reason: :end_turn}}, 5_000
+  end
+
+  test "snapshot/1 exposes the whitelist value verbatim" do
+    sid = "wl-snap-#{System.unique_integer([:positive])}"
+
+    {:ok, ^sid} =
+      start_session_for_test(
+        provider: SingleToolCallProvider,
+        model: "p91",
+        session_id: sid,
+        tools_whitelist: ["Read", "Grep"],
+        provider_ctx: %{tool_name: "noop", call_id: "noop"}
+      )
+
+    {:ok, snap} = Tau.snapshot(sid)
+    assert snap.tools_whitelist == ["Read", "Grep"]
+  end
+
+  # Pure-function invariant: a tool is filtered iff its name is not on the
+  # whitelist (when the whitelist is a list); a `:all` whitelist never
+  # filters. Mirrors the `split_tools_whitelist/2` clause inside
+  # `Tau.Session`.
+  @tag :property
+  property "filtered-iff-not-in-list (list whitelist) and never-filtered (:all)" do
+    check all(
+            tools <-
+              StreamData.list_of(
+                StreamData.string(:alphanumeric, min_length: 1, max_length: 8),
+                max_length: 6
+              ),
+            whitelist <-
+              StreamData.list_of(
+                StreamData.string(:alphanumeric, min_length: 1, max_length: 8),
+                max_length: 4
+              )
+          ) do
+      calls = Enum.with_index(tools, fn name, i -> %{id: "c#{i}", name: name} end)
+
+      # `:all` => nothing filtered.
+      {filtered_all, kept_all} = split_test(calls, :all)
+      assert filtered_all == []
+      assert kept_all == calls
+
+      # List => filtered iff name not in list.
+      {filtered, kept} = split_test(calls, whitelist)
+      assert Enum.all?(filtered, fn %{name: n} -> n not in whitelist end)
+      assert Enum.all?(kept, fn %{name: n} -> n in whitelist end)
+      assert length(filtered) + length(kept) == length(calls)
+    end
+  end
+
+  # Mirrors the production `split_tools_whitelist/2` exactly. Kept here so
+  # the property exercises the same shape without reaching into private
+  # functions (same approach as `skill_activation_property_test.exs`).
+  defp split_test(calls, :all), do: {[], calls}
+
+  defp split_test(calls, list) when is_list(list) do
+    Enum.split_with(calls, fn %{name: n} -> n not in list end)
+  end
+end


### PR DESCRIPTION
## Summary

- Adds spawn-time `:tools_whitelist :: [String.t()] | :all` option to `Tau.start_session/1`. Default `:all` preserves current behaviour.
- `Tau.Session.dispatch_tools/2` filters non-whitelisted calls *before* the permissions evaluator, synthesising `is_error: true` ToolResults the same way deny rules / skill `allowed_tools` denials already do. The evaluator itself stays a pure permission-rule decision.
- Whitelist value surfaced on `Tau.snapshot/1` (additive — the snapshot contract permits new fields). New telemetry: `[:tau, :session, :tool_whitelisted]` with `%{session_id, tool_name, whitelist_size}` metadata, registered in `Tau.Telemetry.Handlers`.
- Foundation for ADR-0014/0015 subagent personas (the `Agent` tool will plumb a child skill's `allowed_tools` through this opt, complementing ADR-0013's per-turn skill-active variant).

## Judgment calls

- **Gate ordering.** The issue body and ADR-0015 imply "deny rules → whitelist → permissions evaluator". Implemented as **whitelist-in-`dispatch_tools/2`** running **before** `Tau.Permissions.Evaluator.evaluate/5`, which keeps the evaluator a pure permission-rule decision (its existing internal order is unchanged: deny → skill-block → mode/rule-set). Composes cleanly with the active-skill `allowed_tools` gate from #16/PR #94 — that one stays inside the evaluator (per-turn), this one runs before it (per-session).
- **No new ADR.** ADR-0013 already covers the per-turn case; the session-spawn-time variant is a thin extension of the same machinery, called out in ADR-0015 §4. Documenting here per the task brief.
- **Snapshot contract.** Added `tools_whitelist` field. The contract above the `@type snapshot :: ...` already permits field additions, so no contract widening was needed — just an additive entry.
- **`tools_in_flight` accounting.** Whitelisted-out calls are tracked under a `:whitelist_filtered` tag (mirroring how `gated` deny-rule calls are tracked under `:denied`). This keeps the FSM's tool_call → tool_result correspondence intact: `:tool_done` decrements the count, and the turn proceeds to `:start_provider` only when all are accounted for.

## Test plan

- [ ] `mix test test/tau/session/tools_whitelist_test.exs` — four end-to-end cases (default `:all`, list filters non-listed, list passthrough, snapshot value) + property `filtered-iff-not-in-list`.
- [ ] `mix test --only property` — covers the new property test.
- [ ] `mix format --check-formatted && mix credo --strict && mix dialyzer` (CI).
- [ ] Existing `Tau.Session.SkillWhitelistTest` and `Tau.Session.ParallelToolDispatchTest` still pass (no regressions to the deny-rule / skill-active gates that share the same dispatch path).

Closes #91
Refs #18

https://claude.ai/code/session_011bAhaU738pEzP52sVs8RUQ

---
_Generated by [Claude Code](https://claude.ai/code/session_011bAhaU738pEzP52sVs8RUQ)_