### PR TITLE
feat: parent FSM tracks child sessions, cascades cancel/stop (#92)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `tool_call → tool_result` correspondence. (Closes #33.)
 
 ### Added
+- Parent session FSM tracks `child_session_ids`; `Tau.cancel/1` and
+  `Tau.stop/1` cascade to children before tearing down the parent's
+  own work. New API: `Tau.register_child/2`, `Tau.unregister_child/2`
+  (cast helpers used by the upcoming Agent tool). `Tau.snapshot/1`
+  surfaces the set. New telemetry:
+  `[:tau, :session, :child_registered | :child_unregistered]`.
+  Foundation for ADR-0014 (subagents are sessions). (Refs #18,
+  closes #92.)
 - `Tau.start_session(tools_whitelist: ["Read", "Grep"])` restricts a
   session's tools at spawn time. The whitelist filter applies before
   the permissions evaluator; missing tools synthesise an `is_error`

--- a/lib/tau.ex
+++ b/lib/tau.ex
@@ -139,4 +139,35 @@ defmodule Tau do
   """
   @spec snapshot(session_id()) :: {:ok, Tau.Session.snapshot()} | {:error, :not_found}
   defdelegate snapshot(session_id), to: Session
+
+  @doc """
+  Register `child_id` as a child of `parent_id` so that `Tau.cancel/1`
+  and `Tau.stop/1` on the parent cascade to it (ADR-0014, issue #92).
+
+  Intended for the upcoming `Agent` tool: after a successful
+  `Tau.start_session/1` for a sub-agent, the spawn task casts
+  `{:register_child, child_id}` to its parent FSM via this helper. Returns
+  `:ok` even if the parent isn't currently registered (cast semantics).
+  """
+  @spec register_child(session_id(), session_id()) :: :ok
+  def register_child(parent_id, child_id) when is_binary(parent_id) and is_binary(child_id) do
+    case Registry.lookup(Tau.Sessions.Registry, parent_id) do
+      [{pid, _}] -> :gen_statem.cast(pid, {:register_child, child_id})
+      _ -> :ok
+    end
+  end
+
+  @doc """
+  Drop `child_id` from `parent_id`'s child-cascade set. Called by the
+  `Agent` tool's spawn task when it observes the child's
+  `%Tau.Session.Events.SessionEnd{}` so a subsequent `Tau.cancel/1` on
+  the parent doesn't `Tau.cancel/1` an already-stopped session.
+  """
+  @spec unregister_child(session_id(), session_id()) :: :ok
+  def unregister_child(parent_id, child_id) when is_binary(parent_id) and is_binary(child_id) do
+    case Registry.lookup(Tau.Sessions.Registry, parent_id) do
+      [{pid, _}] -> :gen_statem.cast(pid, {:unregister_child, child_id})
+      _ -> :ok
+    end
+  end
 end

--- a/lib/tau/session.ex
+++ b/lib/tau/session.ex
@@ -272,7 +272,8 @@ defmodule Tau.Session do
           skills: [{String.t(), Tau.Skill.t()}],
           metadata: map(),
           permissions_mode: atom(),
-          tools_whitelist: [String.t()] | :all
+          tools_whitelist: [String.t()] | :all,
+          child_session_ids: MapSet.t(String.t())
         }
 
   @doc """
@@ -300,7 +301,8 @@ defmodule Tau.Session do
          skills: data.skills,
          metadata: data.metadata,
          permissions_mode: Map.get(data.metadata, :permissions_mode, :default),
-         tools_whitelist: data.tools_whitelist
+         tools_whitelist: data.tools_whitelist,
+         child_session_ids: data.child_session_ids
        }}
     end
   end
@@ -442,7 +444,19 @@ defmodule Tau.Session do
           # Foundation for ADR-0014/15 subagent personas (the parent's
           # `Agent` tool plumbs the child skill's `allowed_tools` through
           # this opt). `:all` preserves today's behaviour.
-          tools_whitelist: opts[:tools_whitelist] || :all
+          tools_whitelist: opts[:tools_whitelist] || :all,
+          # ADR-0014 (#92): set of currently-running child session ids
+          # spawned by this session via the `Agent` tool. Populated by
+          # `{:register_child, _}` casts from the spawn task and emptied
+          # by `{:unregister_child, _}` when a child reports `%SessionEnd{}`.
+          # `Tau.cancel/1` and `Tau.stop/1` cascade across this set before
+          # tearing down the parent's own provider/tool/command tasks so
+          # children get a clean shutdown path (flush JSONL, emit
+          # `%SessionEnd{reason: :user}`) rather than being reaped from
+          # above. Supervisor is `:one_for_one`; a parent crash does *not*
+          # propagate to children — that's the whole point of explicit
+          # cascade on the user-driven shutdown paths.
+          child_session_ids: MapSet.new()
         }
 
         {:ok, :awaiting_user, data}
@@ -674,7 +688,44 @@ defmodule Tau.Session do
     finalize_assistant(assembler, data)
   end
 
+  # ADR-0014 (#92): bookkeeping casts from the (future) `Agent` tool task.
+  # On a successful `Tau.start_session/1` for a child, the spawn task casts
+  # `{:register_child, child_id}` to its parent FSM. When the child's
+  # `%SessionEnd{}` is observed (the spawn task is subscribed to the child
+  # topic), it casts `{:unregister_child, child_id}` so the cancel cascade
+  # doesn't `Tau.cancel/1` an already-stopped session. Both clauses are
+  # state-agnostic — child wiring is independent of the parent's turn state.
+  def handle_event(:cast, {:register_child, child_id}, _state, data)
+      when is_binary(child_id) do
+    :telemetry.execute(
+      [:tau, :session, :child_registered],
+      %{system_time: System.system_time()},
+      %{session_id: data.id, child_id: child_id}
+    )
+
+    {:keep_state, %{data | child_session_ids: MapSet.put(data.child_session_ids, child_id)}}
+  end
+
+  def handle_event(:cast, {:unregister_child, child_id}, _state, data)
+      when is_binary(child_id) do
+    :telemetry.execute(
+      [:tau, :session, :child_unregistered],
+      %{system_time: System.system_time()},
+      %{session_id: data.id, child_id: child_id}
+    )
+
+    {:keep_state, %{data | child_session_ids: MapSet.delete(data.child_session_ids, child_id)}}
+  end
+
   def handle_event(:cast, :cancel, _state, data) do
+    # ADR-0014 (#92): cascade to children first so each child's FSM gets
+    # a chance to flush persistence and emit `%SessionEnd{reason: :user}`
+    # on its own topic before this parent's tools/provider are torn down.
+    # Casts are fire-and-forget; children live under
+    # `Tau.Sessions.Supervisor` (`:one_for_one`) and are not linked to
+    # the parent — their cleanup happens on their own scheduler slot.
+    cascade_to_children(data, :cancel)
+
     if data.provider_task && Process.alive?(data.provider_task.pid) do
       Task.shutdown(data.provider_task, :brutal_kill)
     end
@@ -709,6 +760,10 @@ defmodule Tau.Session do
   end
 
   def handle_event(:cast, :stop, _state, data) do
+    # ADR-0014 (#92): cascade `Tau.stop/1` to children before terminating.
+    # Each child runs its own `terminate/3` which broadcasts `%SessionEnd{}`
+    # on the child's topic.
+    cascade_to_children(data, :stop)
     {:stop, :normal, data}
   end
 
@@ -1290,6 +1345,22 @@ defmodule Tau.Session do
 
   defp broadcast(id, event) do
     Phoenix.PubSub.broadcast(Tau.PubSub, "session:#{id}", event)
+  end
+
+  # ADR-0014 (#92): walk the child set and cast the chosen lifecycle
+  # operation. Both `Tau.cancel/1` and `Tau.stop/1` are :ok-or-:ok casts
+  # against a registry lookup — a child id that's already gone is a
+  # silent no-op (this is exactly the case we want when a child finished
+  # naturally between its `%SessionEnd{}` broadcast and the parent's
+  # cancel landing). Recursion is implicit: each child runs the same
+  # cascade against its own descendants.
+  defp cascade_to_children(%{child_session_ids: ids}, op) when op in [:cancel, :stop] do
+    Enum.each(ids, fn child_id ->
+      case op do
+        :cancel -> Tau.cancel(child_id)
+        :stop -> Tau.stop(child_id)
+      end
+    end)
   end
 
   # ADR-0009: telemetry pairs but does not span — postponed events

--- a/lib/tau/telemetry/handlers.ex
+++ b/lib/tau/telemetry/handlers.ex
@@ -8,6 +8,7 @@ defmodule Tau.Telemetry.Handlers do
       [:tau, :session, :start | :stop]
       [:tau, :session, :transition]
       [:tau, :session, :tool_whitelisted]
+      [:tau, :session, :child_registered | :child_unregistered]
       [:tau, :provider, :request, :start | :stop | :exception]
       [:tau, :provider, :event]
       [:tau, :provider, :rate_limit, :acquired | :throttled | :rejected | :halved]
@@ -64,6 +65,8 @@ defmodule Tau.Telemetry.Handlers do
       [:tau, :session, :stop],
       [:tau, :session, :transition],
       [:tau, :session, :tool_whitelisted],
+      [:tau, :session, :child_registered],
+      [:tau, :session, :child_unregistered],
       [:tau, :provider, :request, :start],
       [:tau, :provider, :request, :stop],
       [:tau, :provider, :request, :exception],

--- a/test/tau/session/child_cascade_property_test.exs
+++ b/test/tau/session/child_cascade_property_test.exs
@@ -1,0 +1,118 @@
+defmodule Tau.Session.ChildCascadePropertyTest do
+  @moduledoc """
+  Property suite for issue #92 / ADR-0014.
+
+  Property: for any tree of sessions wired together via
+  `Tau.register_child/2`, calling `Tau.stop/1` on any node terminates
+  every descendant (each emits `%SessionEnd{}` on its own PubSub topic).
+
+  Trees are sized small (depth ≤ 3, fan-out ≤ 3) — the property exercises
+  the cascade *shape* rather than throughput. A larger bound would just
+  multiply session FSMs without changing the invariant under test, and
+  the per-node startup is dominated by `Tau.Persistence.Jsonl.open/2`'s
+  filesystem work.
+  """
+  use ExUnit.Case, async: false
+  use ExUnitProperties
+
+  @moduletag :property
+
+  import Tau.Test.SessionHelper, only: [start_session_for_test: 1]
+  alias Tau.Session.Events, as: SE
+
+  defmodule InertProvider do
+    @moduledoc false
+    @behaviour Tau.Provider
+
+    @impl true
+    def stream(_messages, _opts, _ctx), do: {:ok, []}
+
+    @impl true
+    def capabilities,
+      do: %{
+        thinking: false,
+        tools: false,
+        vision: false,
+        prompt_caching: false,
+        parallel_tools: false
+      }
+
+    @impl true
+    def default_model, do: "inert"
+  end
+
+  setup do
+    tmp =
+      Path.join(System.tmp_dir!(), "tau-child-cascade-prop-#{System.unique_integer([:positive])}")
+
+    File.mkdir_p!(tmp)
+    Application.put_env(:tau, :data_dir, tmp)
+
+    on_exit(fn ->
+      File.rm_rf!(tmp)
+      Application.delete_env(:tau, :data_dir)
+    end)
+
+    :ok
+  end
+
+  # Tree: %{id: String.t(), children: [tree]}. Depth bound matches the
+  # acceptance criteria in #92 (depth ≤ 3).
+  defp tree_gen(depth) when depth <= 0 do
+    StreamData.constant([])
+  end
+
+  defp tree_gen(depth) do
+    StreamData.bind(StreamData.integer(0..3), fn n ->
+      StreamData.bind(StreamData.list_of(tree_gen(depth - 1), length: n), fn subs ->
+        StreamData.constant(subs)
+      end)
+    end)
+  end
+
+  defp build(tree_children) do
+    sid = start_node()
+    children = Enum.map(tree_children, &build/1)
+
+    Enum.each(children, fn %{id: child_id} ->
+      :ok = Tau.register_child(sid, child_id)
+    end)
+
+    %{id: sid, children: children}
+  end
+
+  defp start_node do
+    sid =
+      "ccp-#{System.unique_integer([:positive])}-#{:crypto.strong_rand_bytes(3) |> Base.url_encode64(padding: false)}"
+
+    {:ok, ^sid} =
+      start_session_for_test(
+        session_id: sid,
+        provider: InertProvider,
+        model: "inert"
+      )
+
+    sid
+  end
+
+  defp flatten(%{id: id, children: children}) do
+    [id | Enum.flat_map(children, &flatten/1)]
+  end
+
+  property "Tau.stop/1 on any node terminates every descendant" do
+    check all(tree_children <- tree_gen(3), max_runs: 8) do
+      tree = build(tree_children)
+      ids = flatten(tree)
+
+      Enum.each(ids, fn id ->
+        Phoenix.PubSub.subscribe(Tau.PubSub, "session:#{id}")
+      end)
+
+      :ok = Tau.stop(tree.id)
+
+      Enum.each(ids, fn id ->
+        assert_receive %SE.SessionEnd{session_id: ^id}, 2_000
+      end)
+    end
+  end
+end

--- a/test/tau/session/child_cascade_test.exs
+++ b/test/tau/session/child_cascade_test.exs
@@ -1,0 +1,172 @@
+defmodule Tau.Session.ChildCascadeTest do
+  @moduledoc """
+  Coverage for issue #92 / ADR-0014: the parent session FSM tracks its
+  spawned subagent ids in `data.child_session_ids` and cascades
+  `Tau.cancel/1` and `Tau.stop/1` across that set so children get a
+  clean shutdown path (flush JSONL, broadcast `%SessionEnd{}`) before
+  the parent tears down its own work.
+
+  Cases:
+
+    1. `Tau.register_child/2` from each child puts ids in the parent's
+       set; `Tau.snapshot/1` surfaces it.
+    2. `Tau.cancel(parent)` results in a `%SessionEnd{}` on every
+       descendant's PubSub topic plus one on the parent's.
+    3. `Tau.unregister_child/2` shrinks the set when a child finishes
+       naturally — a subsequent cancel does not try to cancel a
+       phantom id.
+    4. `Tau.stop(parent)` cascades `:stop` the same way.
+  """
+  use ExUnit.Case, async: false
+
+  import Tau.Test.SessionHelper, only: [start_session_for_test: 1]
+  alias Tau.Session.Events, as: SE
+
+  # Minimal provider stub — sessions never start a turn in these tests
+  # (no `Tau.send/2`), so `stream/3` would be unused even if called. We
+  # still need a behaviour-conforming module so `Tau.start_session/1`
+  # accepts it and the FSM's init path runs cleanly.
+  defmodule InertProvider do
+    @moduledoc false
+    @behaviour Tau.Provider
+
+    @impl true
+    def stream(_messages, _opts, _ctx), do: {:ok, []}
+
+    @impl true
+    def capabilities,
+      do: %{
+        thinking: false,
+        tools: false,
+        vision: false,
+        prompt_caching: false,
+        parallel_tools: false
+      }
+
+    @impl true
+    def default_model, do: "inert"
+  end
+
+  setup do
+    tmp = Path.join(System.tmp_dir!(), "tau-child-cascade-#{System.unique_integer([:positive])}")
+    File.mkdir_p!(tmp)
+    Application.put_env(:tau, :data_dir, tmp)
+
+    on_exit(fn ->
+      File.rm_rf!(tmp)
+      Application.delete_env(:tau, :data_dir)
+    end)
+
+    :ok
+  end
+
+  defp start_node(opts \\ []) do
+    sid =
+      "cc-#{System.unique_integer([:positive])}-#{:crypto.strong_rand_bytes(3) |> Base.url_encode64(padding: false)}"
+
+    {:ok, ^sid} =
+      start_session_for_test(
+        Keyword.merge(
+          [session_id: sid, provider: InertProvider, model: "inert"],
+          opts
+        )
+      )
+
+    sid
+  end
+
+  defp child_set(sid) do
+    {:ok, snap} = Tau.snapshot(sid)
+    snap.child_session_ids
+  end
+
+  defp await_session_end(sid, timeout \\ 1_000) do
+    receive do
+      %SE.SessionEnd{session_id: ^sid} = e -> e
+    after
+      timeout -> flunk("Did not receive SessionEnd for #{sid} within #{timeout}ms")
+    end
+  end
+
+  test "register_child + snapshot reflect the cascade set" do
+    parent = start_node()
+    a = start_node()
+    b = start_node()
+
+    assert MapSet.size(child_set(parent)) == 0
+
+    :ok = Tau.register_child(parent, a)
+    :ok = Tau.register_child(parent, b)
+
+    # Snapshot is read via :sys.get_state under the hood, which
+    # synchronises against the cast — the prior casts are guaranteed
+    # to have been processed by the time the snapshot returns.
+    set = child_set(parent)
+    assert MapSet.size(set) == 2
+    assert MapSet.member?(set, a)
+    assert MapSet.member?(set, b)
+  end
+
+  test "cancel(parent) cascades to all registered children" do
+    parent = start_node()
+    a = start_node()
+    b = start_node()
+
+    Phoenix.PubSub.subscribe(Tau.PubSub, "session:#{parent}")
+    Phoenix.PubSub.subscribe(Tau.PubSub, "session:#{a}")
+    Phoenix.PubSub.subscribe(Tau.PubSub, "session:#{b}")
+
+    :ok = Tau.register_child(parent, a)
+    :ok = Tau.register_child(parent, b)
+    # Force the casts to drain.
+    _ = child_set(parent)
+
+    :ok = Tau.cancel(parent)
+
+    # `:cancel` does not terminate the FSM — it returns the session to
+    # `:awaiting_user`. Each cancelled FSM broadcasts `%Cancelled{}`
+    # on its topic; the cascade hits parent + children + (recursively)
+    # any descendant.
+    assert_receive %SE.Cancelled{session_id: ^parent, reason: :user}, 1_000
+    assert_receive %SE.Cancelled{session_id: ^a, reason: :user}, 1_000
+    assert_receive %SE.Cancelled{session_id: ^b, reason: :user}, 1_000
+  end
+
+  test "unregister_child shrinks the set so cancel skips finished children" do
+    parent = start_node()
+    a = start_node()
+    b = start_node()
+
+    :ok = Tau.register_child(parent, a)
+    :ok = Tau.register_child(parent, b)
+    assert MapSet.size(child_set(parent)) == 2
+
+    :ok = Tau.unregister_child(parent, a)
+    set = child_set(parent)
+    assert MapSet.size(set) == 1
+    refute MapSet.member?(set, a)
+    assert MapSet.member?(set, b)
+  end
+
+  test "stop(parent) cascades :stop to children — every node emits SessionEnd" do
+    parent = start_node()
+    a = start_node()
+    b = start_node()
+
+    Phoenix.PubSub.subscribe(Tau.PubSub, "session:#{parent}")
+    Phoenix.PubSub.subscribe(Tau.PubSub, "session:#{a}")
+    Phoenix.PubSub.subscribe(Tau.PubSub, "session:#{b}")
+
+    :ok = Tau.register_child(parent, a)
+    :ok = Tau.register_child(parent, b)
+    _ = child_set(parent)
+
+    :ok = Tau.stop(parent)
+
+    # Every node — including the parent — broadcasts %SessionEnd{} via
+    # its terminate/3 callback.
+    _ = await_session_end(parent)
+    _ = await_session_end(a)
+    _ = await_session_end(b)
+  end
+end


### PR DESCRIPTION
## Summary

Lays the cascade plumbing ADR-0014 needs for the (forthcoming) `Agent` tool, split out from #32 per #92.

- **`lib/tau/session.ex`** — `data` map gains `child_session_ids :: MapSet.t(String.t())`. Two new `:cast` handlers maintain the set: `{:register_child, child_id}` and `{:unregister_child, child_id}`. Each emits a telemetry event (`[:tau, :session, :child_registered]` / `[:tau, :session, :child_unregistered]`) carrying `%{session_id (parent), child_id}`. The existing `:cancel` and `:stop` clauses cascade across the set first, *before* tearing down the parent's own provider/tool/command tasks, so children get a clean shutdown path on their own scheduler slot.
- **`lib/tau.ex`** — public helpers `Tau.register_child/2` and `Tau.unregister_child/2` (cast helpers, the upcoming `Agent` tool task is the intended caller). `Tau.snapshot/1` surfaces `child_session_ids` (additive — the snapshot type spec gains one field).
- **`lib/tau/telemetry/handlers.ex`** — registers the two new event names.
- **Tests** — `test/tau/session/child_cascade_test.exs` covers register + snapshot, cancel cascade, unregister shrinks the set, and stop cascade. Property suite `child_cascade_property_test.exs` (`@moduletag :property`) builds random trees of depth 0–3 with fan-out 0–3, calls `Tau.stop/1` on the root, and asserts every descendant emits `%SessionEnd{}`.
- **`CHANGELOG.md`** — entry under `[Unreleased] ### Added`.

## Judgment calls

- **Children before parent.** The cascade fires *before* the parent's own `provider_task`/`tools_in_flight`/`command_task` teardown, matching the issue's "children should flush their JSONL transcripts and emit `%SessionEnd{reason: :user}` events, not be reaped from above" framing. Order doesn't strictly matter for correctness (children are independent FSMs under the same `:one_for_one` supervisor), but doing it first means a slow child shutdown overlaps with the parent's teardown rather than serialising behind it.
- **Cancel emits `%Cancelled{}`, not `%SessionEnd{}`.** The issue's acceptance criterion ("3 `%SessionEnd{}` events on cancel") is loose with respect to the actual code: `:cancel` returns the FSM to `:awaiting_user` after broadcasting `%Cancelled{reason: :user}`; only `:stop` runs `terminate/3` and broadcasts `%SessionEnd{}`. The example tests assert `%Cancelled{}` for the cancel scenario and `%SessionEnd{}` for the stop scenario; the property test uses `Tau.stop/1` to get clean `%SessionEnd{}` semantics.
- **Telemetry shape.** `[:tau, :session, :child_registered | :child_unregistered]` — no span (registration is a single discrete event), `system_time` measurement, `%{session_id, child_id}` metadata. Mirrors the existing `[:tau, :session, :skill_activated]` shape.
- **Property depth bound.** `0..3` levels deep, `0..3` fan-out — the property exercises cascade *shape*, not throughput. Larger bounds just multiply session FSMs (each is a real `:gen_statem` + JSONL handle) without changing the invariant under test. `max_runs: 8` keeps the property suite under a second per run.

## ADR

ADR-0014 already mandates this cascade; no new ADR. Documented choices in this PR description per CLAUDE.md guidance.

## Conflict warning

A parallel worktree-isolated agent is implementing #91 (`tools_whitelist`) and also touches `init/1`'s `data` map and `Tau.snapshot/1`. Whichever lands second will need to rebase those two regions.

## Test plan

- [ ] `mix test test/tau/session/child_cascade_test.exs`
- [ ] `mix test --only property test/tau/session/child_cascade_property_test.exs`
- [ ] `mix format --check-formatted`
- [ ] `mix credo --strict`
- [ ] `mix dialyzer`

Closes #92
Refs #18

https://claude.ai/code/session_011bAhaU738pEzP52sVs8RUQ

---
_Generated by [Claude Code](https://claude.ai/code/session_011bAhaU738pEzP52sVs8RUQ)_