### PR TITLE
feat: declarative arg parsing for slash commands (closes #15)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `Tau.Command.command_spec/1` macro for declarative argument parsing
+  on slash commands (positional `arg`, boolean `flag`, keyword `option`).
+  Pre-parser tokenises the tail string and binds it to the spec before
+  invoking `execute/2`. Missing/unknown args return tagged errors that
+  surface to the model. Commands without a spec continue to receive the
+  raw tail string (backwards-compatible). (Closes #15.)
+
 ### Tests
 - Property suite: thinking-block signature byte-exact preservation audit
   (`test/tau/persistence/thinking_roundtrip_property_test.exs`). Pins

--- a/lib/tau/command.ex
+++ b/lib/tau/command.ex
@@ -12,6 +12,42 @@ defmodule Tau.Command do
     2. Markdown files at `~/.tau/commands/*.md` or `<cwd>/.tau/commands/*.md`
        (loaded by `Tau.Commands.Files`).
     3. Skills (with frontmatter) — see `Tau.Skill`.
+
+  ## Argument specs (#15)
+
+  By default, `execute/2` is invoked with the raw tail string. Authors
+  who want positional/flag/option parsing can declare a spec with the
+  `command_spec/1` macro after `use Tau.Command`:
+
+      defmodule MyExt.DeployCommand do
+        use Tau.Command
+
+        @impl Tau.Command
+        def name, do: "/deploy"
+
+        @impl Tau.Command
+        def description, do: "Deploy to an environment."
+
+        command_spec do
+          arg :env, required: true
+          flag :no_cache, default: false
+          option :branch, default: "main"
+        end
+
+        @impl Tau.Command
+        def execute(%{env: env, no_cache: nc, branch: b}, _ctx) do
+          # ...
+        end
+      end
+
+  When the macro is present, the session FSM tokenises the tail string,
+  binds it against the spec via `Tau.Command.Spec`, and passes the
+  resulting map to `execute/2`. Bind failures (missing required arg,
+  unknown flag/option) are surfaced to the model as a friendly error
+  string and `execute/2` is not called.
+
+  Commands without a `command_spec` continue to receive the raw tail
+  string at `execute(args_string, ctx)` — fully backwards-compatible.
   """
 
   @type result ::
@@ -24,5 +60,89 @@ defmodule Tau.Command do
 
   @callback name() :: String.t()
   @callback description() :: String.t()
-  @callback execute(args :: String.t(), ctx :: Context.t()) :: result()
+  @callback execute(args :: String.t() | map(), ctx :: Context.t()) :: result()
+
+  @doc """
+  Optional callback synthesised by `command_spec/1`. Returns the spec
+  list consumed by `Tau.Command.Spec.bind/2`. Absent → the FSM passes
+  the raw tail string to `execute/2`.
+  """
+  @callback parameters() :: [Tau.Command.Spec.entry()]
+
+  @optional_callbacks [parameters: 0]
+
+  @doc false
+  defmacro __using__(_opts) do
+    quote do
+      @behaviour Tau.Command
+      import Tau.Command, only: [command_spec: 1]
+    end
+  end
+
+  @doc """
+  Declare an argument spec for this command.
+
+  Lowers to a `parameters/0` callback returning a list of entry maps.
+  Three macro forms are recognised inside the block:
+
+    * `arg :name, required: bool, default: term` — positional argument.
+    * `flag :name, default: bool` — boolean flag (`--name` / `--no-name`).
+    * `option :name, default: term` — keyword option
+      (`--name=value` or `--name value`).
+
+  Compile-time only. The spec is plain data — there is no per-call cost
+  beyond a `parameters/0` lookup.
+  """
+  defmacro command_spec(do: block) do
+    entries = collect_entries(block)
+
+    quote do
+      @impl Tau.Command
+      def parameters, do: unquote(Macro.escape(entries))
+    end
+  end
+
+  # --- compile-time spec collection ----------------------------------------
+
+  defp collect_entries({:__block__, _, stmts}), do: Enum.map(stmts, &entry_from_call/1)
+  defp collect_entries(stmt), do: [entry_from_call(stmt)]
+
+  defp entry_from_call({:arg, _, [name | rest]}) when is_atom(name) do
+    opts = optslist(rest)
+
+    base = %{
+      kind: :arg,
+      name: name,
+      required: Keyword.get(opts, :required, false)
+    }
+
+    case Keyword.fetch(opts, :default) do
+      {:ok, default} -> Map.put(base, :default, default)
+      :error -> base
+    end
+  end
+
+  defp entry_from_call({:flag, _, [name | rest]}) when is_atom(name) do
+    opts = optslist(rest)
+    %{kind: :flag, name: name, default: Keyword.get(opts, :default, false)}
+  end
+
+  defp entry_from_call({:option, _, [name | rest]}) when is_atom(name) do
+    opts = optslist(rest)
+    %{kind: :option, name: name, default: Keyword.get(opts, :default)}
+  end
+
+  defp entry_from_call(other) do
+    raise ArgumentError,
+          "unsupported entry in command_spec: #{Macro.to_string(other)}. " <>
+            "Use `arg`, `flag`, or `option`."
+  end
+
+  defp optslist([]), do: []
+  defp optslist([opts]) when is_list(opts), do: opts
+
+  defp optslist(other) do
+    raise ArgumentError,
+          "command_spec entry options must be a keyword list, got: #{inspect(other)}"
+  end
 end

--- a/lib/tau/command/spec.ex
+++ b/lib/tau/command/spec.ex
@@ -1,0 +1,280 @@
+defmodule Tau.Command.Spec do
+  @moduledoc """
+  Pure tokeniser + binder for slash-command argument specs (#15).
+
+  A spec is a list of entries, each a map of one of three shapes:
+
+      %{kind: :arg,    name: atom, required: bool, default: term}
+      %{kind: :flag,   name: atom, default: bool}
+      %{kind: :option, name: atom, default: term}
+
+  The author declares the spec via the `command_spec/1` macro on
+  `Tau.Command`; the macro lowers to a `parameters/0` callback returning
+  this list. The session FSM (`spawn_command_task/4`) invokes
+  `tokenize/1` + `bind/2` before calling `execute/2`, so the command body
+  receives a bound map instead of a raw tail string.
+
+  ## Tokeniser scope
+
+  Shell-like, deliberately small:
+
+    * whitespace splits tokens
+    * single-quoted strings preserve their content verbatim
+    * double-quoted strings preserve their content verbatim
+    * a backslash before a double-quote inside a `"..."` escapes it
+    * unterminated quotes return `{:error, :unterminated_quote}`
+
+  Not supported (out of scope for slash-command tails): heredocs, command
+  substitution, glob expansion, variable interpolation, ANSI-C `$'...'`.
+
+  ## Binding rules
+
+    1. Walk tokens left-to-right.
+    2. `--<name>=<value>` and `--<name> <value>` bind to `option` entries.
+    3. `--<name>` / `--no-<name>` bind to `flag` entries (`--no-<name>`
+       sets `false`; otherwise `true`).
+    4. Bare tokens fill `arg` entries in declaration order.
+    5. After the walk: `arg` entries with `required: true` and no token
+       yield `{:error, {:missing_arg, name}}`. Optional `arg`s, `flag`s,
+       and `option`s fall back to their `:default` (or `nil` / `false`).
+    6. An unknown `--name` or a surplus positional yields
+       `{:error, {:unknown_token, token}}`.
+  """
+
+  @type entry ::
+          %{kind: :arg, name: atom(), required: boolean(), default: term()}
+          | %{kind: :flag, name: atom(), default: boolean()}
+          | %{kind: :option, name: atom(), default: term()}
+
+  @type spec :: [entry()]
+
+  @type bind_error ::
+          {:missing_arg, atom()}
+          | {:unknown_token, String.t()}
+          | {:missing_value, atom()}
+          | :unterminated_quote
+
+  # --- Tokeniser ------------------------------------------------------------
+
+  @doc """
+  Tokenise a tail string into a flat list of binary tokens.
+
+  Returns `{:ok, tokens}` or `{:error, :unterminated_quote}`.
+  """
+  @spec tokenize(String.t()) :: {:ok, [String.t()]} | {:error, :unterminated_quote}
+  def tokenize(s) when is_binary(s), do: tokenize(s, :ws, [], [])
+
+  # state: :ws | :bare | :sq | :dq
+  # acc:   reverse-list of chars in the current token
+  # toks:  reverse-list of completed tokens
+
+  defp tokenize(<<>>, :ws, _acc, toks), do: {:ok, Enum.reverse(toks)}
+
+  defp tokenize(<<>>, :bare, acc, toks),
+    do: {:ok, Enum.reverse([acc_to_token(acc) | toks])}
+
+  defp tokenize(<<>>, :sq, _acc, _toks), do: {:error, :unterminated_quote}
+  defp tokenize(<<>>, :dq, _acc, _toks), do: {:error, :unterminated_quote}
+
+  defp tokenize(<<c::utf8, rest::binary>>, :ws, _acc, toks) when c in [?\s, ?\t, ?\n, ?\r] do
+    tokenize(rest, :ws, [], toks)
+  end
+
+  defp tokenize(<<?', rest::binary>>, :ws, _acc, toks), do: tokenize(rest, :sq, [], toks)
+  defp tokenize(<<?", rest::binary>>, :ws, _acc, toks), do: tokenize(rest, :dq, [], toks)
+  defp tokenize(<<c::utf8, rest::binary>>, :ws, _acc, toks), do: tokenize(rest, :bare, [c], toks)
+
+  defp tokenize(<<c::utf8, rest::binary>>, :bare, acc, toks) when c in [?\s, ?\t, ?\n, ?\r] do
+    tokenize(rest, :ws, [], [acc_to_token(acc) | toks])
+  end
+
+  defp tokenize(<<?', rest::binary>>, :bare, acc, toks), do: tokenize(rest, :sq, acc, toks)
+  defp tokenize(<<?", rest::binary>>, :bare, acc, toks), do: tokenize(rest, :dq, acc, toks)
+  defp tokenize(<<c::utf8, rest::binary>>, :bare, acc, toks), do: tokenize(rest, :bare, [c | acc], toks)
+
+  defp tokenize(<<?', rest::binary>>, :sq, acc, toks), do: tokenize(rest, :bare, acc, toks)
+  defp tokenize(<<c::utf8, rest::binary>>, :sq, acc, toks), do: tokenize(rest, :sq, [c | acc], toks)
+
+  defp tokenize(<<?", rest::binary>>, :dq, acc, toks), do: tokenize(rest, :bare, acc, toks)
+
+  defp tokenize(<<?\\, ?", rest::binary>>, :dq, acc, toks),
+    do: tokenize(rest, :dq, [?" | acc], toks)
+
+  defp tokenize(<<?\\, ?\\, rest::binary>>, :dq, acc, toks),
+    do: tokenize(rest, :dq, [?\\ | acc], toks)
+
+  defp tokenize(<<c::utf8, rest::binary>>, :dq, acc, toks), do: tokenize(rest, :dq, [c | acc], toks)
+
+  defp acc_to_token(acc), do: acc |> Enum.reverse() |> List.to_string()
+
+  # --- Binder ---------------------------------------------------------------
+
+  @doc """
+  Bind tokens to a spec.
+
+  Returns `{:ok, map}` on success, where each entry's `:name` is a key
+  with its bound (or default) value. Otherwise returns a tagged
+  `{:error, reason}` — see `t:bind_error/0`.
+  """
+  @spec bind(spec(), [String.t()]) :: {:ok, map()} | {:error, bind_error()}
+  def bind(spec, tokens) when is_list(spec) and is_list(tokens) do
+    do_bind(tokens, spec, %{})
+  end
+
+  defp do_bind([], spec, acc), do: finalise(spec, acc)
+
+  defp do_bind([token | rest], spec, acc) do
+    cond do
+      String.starts_with?(token, "--") ->
+        bind_long_flag_or_option(token, rest, spec, acc)
+
+      true ->
+        case next_positional(spec, acc) do
+          nil -> {:error, {:unknown_token, token}}
+          %{name: name} -> do_bind(rest, spec, Map.put(acc, name, token))
+        end
+    end
+  end
+
+  defp bind_long_flag_or_option("--" <> tail, rest, spec, acc) do
+    case String.split(tail, "=", parts: 2) do
+      [raw_name, value] ->
+        bind_named(raw_name, {:explicit, value}, rest, spec, acc)
+
+      [raw_name] ->
+        bind_named(raw_name, :implicit, rest, spec, acc)
+    end
+  end
+
+  defp bind_named(raw_name, value_form, rest, spec, acc) do
+    {looked_up, negated?} = lookup_named(raw_name, spec)
+
+    case {looked_up, value_form, negated?} do
+      {nil, _, _} ->
+        {:error, {:unknown_token, "--" <> raw_name}}
+
+      {%{kind: :flag, name: name}, :implicit, true} ->
+        do_bind(rest, spec, Map.put(acc, name, false))
+
+      {%{kind: :flag, name: name}, :implicit, false} ->
+        do_bind(rest, spec, Map.put(acc, name, true))
+
+      {%{kind: :flag}, {:explicit, _}, _} ->
+        {:error, {:unknown_token, "--" <> raw_name}}
+
+      {%{kind: :option, name: name}, {:explicit, value}, _} ->
+        do_bind(rest, spec, Map.put(acc, name, value))
+
+      {%{kind: :option, name: name}, :implicit, _} ->
+        case rest do
+          [next | rest2] -> do_bind(rest2, spec, Map.put(acc, name, next))
+          [] -> {:error, {:missing_value, name}}
+        end
+    end
+  end
+
+  defp lookup_named(raw_name, spec) do
+    atom_name = atomise(raw_name)
+
+    cond do
+      entry = Enum.find(spec, fn e -> e.kind in [:flag, :option] and e.name == atom_name end) ->
+        {entry, false}
+
+      String.starts_with?(raw_name, "no-") and
+          (entry =
+             Enum.find(spec, fn e ->
+               e.kind == :flag and e.name == atomise(String.replace_prefix(raw_name, "no-", ""))
+             end)) ->
+        {entry, true}
+
+      true ->
+        {nil, false}
+    end
+  end
+
+  defp atomise(name) when is_binary(name) do
+    name
+    |> String.replace("-", "_")
+    |> String.to_atom()
+  end
+
+  defp next_positional(spec, acc) do
+    Enum.find(spec, fn
+      %{kind: :arg, name: name} -> not Map.has_key?(acc, name)
+      _ -> false
+    end)
+  end
+
+  defp finalise(spec, acc) do
+    Enum.reduce_while(spec, {:ok, acc}, fn entry, {:ok, acc} ->
+      case finalise_entry(entry, acc) do
+        {:ok, acc} -> {:cont, {:ok, acc}}
+        {:error, _} = err -> {:halt, err}
+      end
+    end)
+  end
+
+  defp finalise_entry(%{kind: :arg, name: name, required: true} = e, acc) do
+    if Map.has_key?(acc, name) do
+      {:ok, acc}
+    else
+      case Map.fetch(e, :default) do
+        {:ok, value} -> {:ok, Map.put(acc, name, value)}
+        :error -> {:error, {:missing_arg, name}}
+      end
+    end
+  end
+
+  defp finalise_entry(%{kind: :arg, name: name} = e, acc) do
+    if Map.has_key?(acc, name) do
+      {:ok, acc}
+    else
+      {:ok, Map.put(acc, name, Map.get(e, :default))}
+    end
+  end
+
+  defp finalise_entry(%{kind: :flag, name: name} = e, acc) do
+    if Map.has_key?(acc, name) do
+      {:ok, acc}
+    else
+      {:ok, Map.put(acc, name, Map.get(e, :default, false))}
+    end
+  end
+
+  defp finalise_entry(%{kind: :option, name: name} = e, acc) do
+    if Map.has_key?(acc, name) do
+      {:ok, acc}
+    else
+      {:ok, Map.put(acc, name, Map.get(e, :default))}
+    end
+  end
+
+  # --- High-level entry point ----------------------------------------------
+
+  @doc """
+  Tokenise `tail` and bind to `spec`. Convenience for the FSM call site.
+  """
+  @spec parse(spec(), String.t()) :: {:ok, map()} | {:error, bind_error()}
+  def parse(spec, tail) when is_list(spec) and is_binary(tail) do
+    case tokenize(tail) do
+      {:ok, tokens} -> bind(spec, tokens)
+      {:error, _} = err -> err
+    end
+  end
+
+  @doc """
+  Format a `bind_error` as a friendly message for the model.
+  """
+  @spec format_error(bind_error()) :: String.t()
+  def format_error({:missing_arg, name}),
+    do: "Missing required argument: #{name}"
+
+  def format_error({:unknown_token, token}),
+    do: "Unknown argument: #{token}"
+
+  def format_error({:missing_value, name}),
+    do: "Option --#{name} requires a value"
+
+  def format_error(:unterminated_quote),
+    do: "Unterminated quoted string in arguments"
+end

--- a/lib/tau/session.ex
+++ b/lib/tau/session.ex
@@ -1697,7 +1697,10 @@ defmodule Tau.Session do
       Task.Supervisor.start_child(Tau.Tools.TaskSupervisor, fn ->
         result =
           try do
-            mod.execute(args, ctx)
+            case prepare_command_args(mod, args) do
+              {:ok, prepared} -> mod.execute(prepared, ctx)
+              {:error, _} = err -> err
+            end
           rescue
             e -> {:crashed, Exception.message(e)}
           catch
@@ -1738,10 +1741,32 @@ defmodule Tau.Session do
           | content: "(slash command timed out after #{ms}ms)\n\n" <> msg.content
         }
 
+      # #15: spec-parse failure surfaced from prepare_command_args/2.
+      {:error, reason} ->
+        %Tau.Message.User{
+          msg
+          | content:
+              "(slash command argument error: #{Tau.Command.Spec.format_error(reason)})\n\n" <>
+                msg.content
+        }
+
       _ ->
         msg
     end
   end
+
+  # #15: if the command module declares a `parameters/0` spec, tokenise
+  # the tail string and bind it before invoking `execute/2`. Otherwise
+  # pass the raw tail (backwards-compatible).
+  defp prepare_command_args(mod, args) when is_binary(args) do
+    if function_exported?(mod, :parameters, 0) do
+      Tau.Command.Spec.parse(mod.parameters(), args)
+    else
+      {:ok, args}
+    end
+  end
+
+  defp prepare_command_args(_mod, args), do: {:ok, args}
 
   defp invoke_file_command(path, args, msg) do
     case File.read(path) do

--- a/test/tau/command/spec_test.exs
+++ b/test/tau/command/spec_test.exs
@@ -1,0 +1,280 @@
+defmodule Tau.Command.SpecTest do
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  alias Tau.Command.Spec
+
+  # ---------------------------------------------------------------------------
+  # Fixture command modules
+  # ---------------------------------------------------------------------------
+
+  defmodule DeployCommand do
+    use Tau.Command
+
+    @impl Tau.Command
+    def name, do: "/deploy"
+
+    @impl Tau.Command
+    def description, do: "Deploy to an environment."
+
+    command_spec do
+      arg(:env, required: true)
+      flag(:no_cache, default: false)
+      option(:branch, default: "main")
+    end
+
+    @impl Tau.Command
+    def execute(args, _ctx), do: {:replace, inspect(args)}
+  end
+
+  defmodule OptionalArgCommand do
+    use Tau.Command
+
+    @impl Tau.Command
+    def name, do: "/note"
+
+    @impl Tau.Command
+    def description, do: "Optional positional."
+
+    command_spec do
+      arg(:title, default: "untitled")
+    end
+
+    @impl Tau.Command
+    def execute(args, _ctx), do: {:replace, inspect(args)}
+  end
+
+  defmodule LegacyCommand do
+    @behaviour Tau.Command
+
+    @impl Tau.Command
+    def name, do: "/legacy"
+
+    @impl Tau.Command
+    def description, do: "Old-style command without a spec."
+
+    @impl Tau.Command
+    def execute(args, _ctx), do: {:replace, args}
+  end
+
+  # ---------------------------------------------------------------------------
+  # Macro compiles a spec correctly
+  # ---------------------------------------------------------------------------
+
+  describe "command_spec/1" do
+    test "compiles to a parameters/0 callback returning the entry list" do
+      assert function_exported?(DeployCommand, :parameters, 0)
+
+      assert DeployCommand.parameters() == [
+               %{kind: :arg, name: :env, required: true},
+               %{kind: :flag, name: :no_cache, default: false},
+               %{kind: :option, name: :branch, default: "main"}
+             ]
+    end
+
+    test "single-entry block compiles" do
+      assert OptionalArgCommand.parameters() == [
+               %{kind: :arg, name: :title, required: false, default: "untitled"}
+             ]
+    end
+
+    test "command without a spec does not export parameters/0" do
+      refute function_exported?(LegacyCommand, :parameters, 0)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Tokeniser
+  # ---------------------------------------------------------------------------
+
+  describe "tokenize/1" do
+    test "splits on whitespace" do
+      assert Spec.tokenize("a b  c") == {:ok, ["a", "b", "c"]}
+    end
+
+    test "empty string → []" do
+      assert Spec.tokenize("") == {:ok, []}
+    end
+
+    test "double-quoted strings preserve inner whitespace" do
+      assert Spec.tokenize(~s(/foo "hello world" --x)) ==
+               {:ok, ["/foo", "hello world", "--x"]}
+    end
+
+    test "single-quoted strings preserve inner whitespace" do
+      assert Spec.tokenize("'a b' c") == {:ok, ["a b", "c"]}
+    end
+
+    test "escaped double-quote inside double-quoted string" do
+      assert Spec.tokenize(~S("he said \"hi\"")) == {:ok, [~s(he said "hi")]}
+    end
+
+    test "unterminated double quote → error" do
+      assert Spec.tokenize(~s("oops)) == {:error, :unterminated_quote}
+    end
+
+    test "unterminated single quote → error" do
+      assert Spec.tokenize("'oops") == {:error, :unterminated_quote}
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Binder
+  # ---------------------------------------------------------------------------
+
+  describe "bind/2" do
+    test "binds positional, flag, and option" do
+      assert {:ok, %{env: "production", no_cache: true, branch: "feature"}} =
+               Spec.parse(DeployCommand.parameters(), "production --no-cache --branch=feature")
+    end
+
+    test "supports --option <value> form (space-separated)" do
+      assert {:ok, %{branch: "feature"}} =
+               Spec.parse(DeployCommand.parameters(), "production --branch feature")
+    end
+
+    test "--no-<flag> sets the flag to false" do
+      assert {:ok, %{no_cache: false}} =
+               Spec.parse(DeployCommand.parameters(), "production --no-no_cache")
+    end
+
+    test "missing required arg returns {:error, {:missing_arg, name}}" do
+      assert {:error, {:missing_arg, :env}} =
+               Spec.parse(DeployCommand.parameters(), "--branch=feature")
+    end
+
+    test "unknown long flag returns {:error, {:unknown_token, ...}}" do
+      assert {:error, {:unknown_token, "--whatever"}} =
+               Spec.parse(DeployCommand.parameters(), "production --whatever")
+    end
+
+    test "surplus positional returns {:error, {:unknown_token, ...}}" do
+      assert {:error, {:unknown_token, "extra"}} =
+               Spec.parse(DeployCommand.parameters(), "production extra")
+    end
+
+    test "option without a value returns {:error, {:missing_value, name}}" do
+      assert {:error, {:missing_value, :branch}} =
+               Spec.parse(DeployCommand.parameters(), "production --branch")
+    end
+
+    test "explicit value on a flag is rejected" do
+      assert {:error, {:unknown_token, "--no_cache"}} =
+               Spec.parse(DeployCommand.parameters(), "production --no_cache=foo")
+    end
+
+    test "defaults applied when arg/flag/option not given" do
+      assert {:ok, %{env: "stage", no_cache: false, branch: "main"}} =
+               Spec.parse(DeployCommand.parameters(), "stage")
+    end
+
+    test "optional positional with default" do
+      assert {:ok, %{title: "untitled"}} =
+               Spec.parse(OptionalArgCommand.parameters(), "")
+    end
+
+    test "single + double-quoted positional bound verbatim" do
+      assert {:ok, %{title: "hello world"}} =
+               Spec.parse(OptionalArgCommand.parameters(), ~s("hello world"))
+    end
+  end
+
+  describe "format_error/1" do
+    test "missing_arg" do
+      assert Spec.format_error({:missing_arg, :env}) == "Missing required argument: env"
+    end
+
+    test "unknown_token" do
+      assert Spec.format_error({:unknown_token, "--x"}) == "Unknown argument: --x"
+    end
+
+    test "missing_value" do
+      assert Spec.format_error({:missing_value, :branch}) ==
+               "Option --branch requires a value"
+    end
+
+    test "unterminated_quote" do
+      assert Spec.format_error(:unterminated_quote) ==
+               "Unterminated quoted string in arguments"
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Property: random spec + random tail → either parses or returns a tagged
+  # error. Never raises.
+  # ---------------------------------------------------------------------------
+
+  @moduletag :property
+
+  defp name_gen do
+    StreamData.bind(
+      StreamData.string(?a..?z, min_length: 1, max_length: 8),
+      fn s -> StreamData.constant(String.to_atom(s)) end
+    )
+  end
+
+  defp arg_entry_gen do
+    StreamData.bind(name_gen(), fn name ->
+      StreamData.bind(StreamData.boolean(), fn req ->
+        StreamData.constant(%{kind: :arg, name: name, required: req})
+      end)
+    end)
+  end
+
+  defp flag_entry_gen do
+    StreamData.bind(name_gen(), fn name ->
+      StreamData.constant(%{kind: :flag, name: name, default: false})
+    end)
+  end
+
+  defp option_entry_gen do
+    StreamData.bind(name_gen(), fn name ->
+      StreamData.constant(%{kind: :option, name: name, default: nil})
+    end)
+  end
+
+  defp entry_gen do
+    StreamData.one_of([arg_entry_gen(), flag_entry_gen(), option_entry_gen()])
+  end
+
+  # Strip duplicate names (the macro can't produce them, and the binder's
+  # behaviour with duplicates is unspecified).
+  defp spec_gen do
+    StreamData.bind(StreamData.list_of(entry_gen(), max_length: 5), fn entries ->
+      StreamData.constant(Enum.uniq_by(entries, & &1.name))
+    end)
+  end
+
+  defp tail_gen do
+    StreamData.string(:printable, max_length: 60)
+  end
+
+  property "parse/2 always returns {:ok, _} or {:error, _} — never raises" do
+    check all(spec <- spec_gen(), tail <- tail_gen(), max_runs: 200) do
+      result =
+        try do
+          Spec.parse(spec, tail)
+        rescue
+          e -> {:raised, Exception.message(e)}
+        end
+
+      assert match?({:ok, %{}}, result) or match?({:error, _}, result),
+             "got #{inspect(result)} for spec=#{inspect(spec)} tail=#{inspect(tail)}"
+    end
+  end
+
+  property "successful parse always populates every spec name as a key" do
+    check all(spec <- spec_gen(), tail <- tail_gen(), max_runs: 200) do
+      case Spec.parse(spec, tail) do
+        {:ok, bound} ->
+          for entry <- spec do
+            assert Map.has_key?(bound, entry.name),
+                   "expected #{inspect(entry.name)} in #{inspect(bound)}"
+          end
+
+        {:error, _} ->
+          :ok
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Add `Tau.Command.command_spec/1` macro: a compile-time DSL with `arg`, `flag`, and `option` entries that lowers to an optional `parameters/0` callback returning a list of `%{kind, name, ...}` maps. Pure data, no runtime parser dep.
- Add `Tau.Command.Spec` with a small shell-like tokeniser (`'...'`, `"..."`, `\"`/`\\` escapes inside double quotes; heredocs / substitution / globbing are out of scope) and a left-to-right binder that returns `{:ok, map}` or a tagged `{:error, _}` (`:missing_arg` / `:unknown_token` / `:missing_value` / `:unterminated_quote`).
- Wire `Tau.Session.spawn_command_task/4` through a new `prepare_command_args/2`: spec-using commands get the bound map, legacy commands (no `parameters/0`) keep getting the raw tail string. Spec-parse failures propagate via `apply_command_result/2` as a friendly error string prepended to the user message — same convention as the existing `:crashed` / `:timeout` paths.

## Test plan

- [x] `test/tau/command/spec_test.exs` — macro compilation, binder semantics (positional / flag / `--no-` / option both `=` and space-separated / surplus / unknown / missing required / quoted positionals), tokeniser quote handling, backwards compat for legacy commands.
- [x] Property test (`@moduletag :property`): random spec + random tail always returns `{:ok, _}` or `{:error, _}` and never raises; successful parses populate every spec name as a map key.

Closes #15

https://claude.ai/code/session_011bAhaU738pEzP52sVs8RUQ

---
_Generated by [Claude Code](https://claude.ai/code/session_011bAhaU738pEzP52sVs8RUQ)_