### PR TITLE
feat: Agent tool — sub-agent spawn primitive (refs #32, tests pending)

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -15,7 +15,9 @@ config :tau,
     Tau.Tools.Builtin.Read,
     Tau.Tools.Builtin.Write,
     Tau.Tools.Builtin.Edit,
-    Tau.Tools.Builtin.Bash
+    Tau.Tools.Builtin.Bash,
+    # ADR-0014/0015 — sub-agent spawn primitive (#32).
+    Tau.Tools.Builtin.Agent
   ]
 
 config :logger, :console,

--- a/lib/tau.ex
+++ b/lib/tau.ex
@@ -53,6 +53,15 @@ defmodule Tau do
       runtime provider config that must not bleed across sessions
       (replay fixtures in tests, per-session routing tags, etc.).
       See ADR-0002.
+    * `:active_skill` — `%Tau.Skill{}` to pin as the session's active
+      skill from turn one. Used by `Tau.Tools.Builtin.Agent` (ADR-0015)
+      to pre-install a sub-agent persona without round-tripping
+      through `__activate_skill__`. Defaults to `nil`.
+    * `:persona_lifetime` — `:turn` (default, ADR-0013) or `:session`
+      (ADR-0015). `:turn` clears `data.active_skill` on `:end_turn`;
+      `:session` pins it for the session's life so a sub-agent cannot
+      dismiss its own persona. Has no effect when `:active_skill` is
+      `nil`.
   """
   @spec start_session(keyword()) :: {:ok, session_id()} | {:error, term()}
   def start_session(opts \\ []) do

--- a/lib/tau/permissions/mode.ex
+++ b/lib/tau/permissions/mode.ex
@@ -1,0 +1,107 @@
+defmodule Tau.Permissions.Mode do
+  @moduledoc """
+  Pure helpers for the permissions-mode lattice (ADR-0015).
+
+  The harness models its permissions modes as a partial order from
+  most-permissive to most-restrictive:
+
+      :bypass  >  :auto  >  :default  >  {:accept_edits, :dont_ask, :plan}
+
+  `:accept_edits`, `:dont_ask`, and `:plan` each restrict different
+  operations and are therefore unordered against each other; for the
+  ceiling check used by sub-agent spawn (ADR-0014/0015) any of them is
+  treated as strictly below `:default`.
+
+  The `Agent` tool computes its child's effective permissions mode via
+  `clamp/2`: a child can never request a mode more permissive than its
+  parent's. This module is the canonical place to evolve the lattice;
+  the evaluator (`Tau.Permissions.Evaluator`) consumes the **resolved**
+  mode and is unconcerned with how it was negotiated.
+  """
+
+  @typedoc """
+  Concrete permissions modes recognised by `Tau.Permissions.Evaluator`.
+  """
+  @type mode :: :bypass | :auto | :default | :accept_edits | :dont_ask | :plan
+
+  # Lattice rank: lower numbers are MORE permissive. `:accept_edits`,
+  # `:dont_ask`, and `:plan` share the same restrictiveness tier — none
+  # of them dominates either of the others. Strict ordering against
+  # `:default` and above is preserved.
+  @ranks %{
+    bypass: 0,
+    auto: 1,
+    default: 2,
+    accept_edits: 3,
+    dont_ask: 3,
+    plan: 3
+  }
+
+  @doc """
+  Return `true` iff `m` is a recognised mode atom.
+  """
+  @spec mode?(term()) :: boolean()
+  def mode?(m), do: is_map_key(@ranks, m)
+
+  @doc """
+  Clamp `requested` against `parent` so the result is no more permissive
+  than `parent`. Concretely:
+
+    * if `requested` is at or below `parent` in the lattice, it stands
+      (the child may ask for *stricter* than its parent);
+    * otherwise `parent` wins (the child cannot escalate).
+
+  Unknown / `nil` `requested` returns `parent` unchanged. An unknown
+  `parent` falls back to `:default` — the safer choice when callers
+  pass something the evaluator won't recognise.
+
+  ## Examples
+
+      iex> Tau.Permissions.Mode.clamp(:bypass, :plan)
+      :plan
+      iex> Tau.Permissions.Mode.clamp(:plan, :default)
+      :plan
+      iex> Tau.Permissions.Mode.clamp(:default, :default)
+      :default
+      iex> Tau.Permissions.Mode.clamp(nil, :auto)
+      :auto
+  """
+  @spec clamp(term(), term()) :: mode()
+  def clamp(requested, parent) do
+    parent = normalise_parent(parent)
+
+    cond do
+      not mode?(requested) ->
+        parent
+
+      requested == parent ->
+        parent
+
+      at_or_below?(requested, parent) ->
+        requested
+
+      true ->
+        parent
+    end
+  end
+
+  @doc """
+  Return `true` iff `child` is at or below `parent` in the lattice (i.e.
+  the spawn would not escalate). Same family as `clamp/2`'s decision
+  rule, exposed for tests and ceilings-only callers.
+  """
+  @spec at_or_below?(mode(), mode()) :: boolean()
+  def at_or_below?(child, parent) when is_map_key(@ranks, child) and is_map_key(@ranks, parent) do
+    Map.fetch!(@ranks, child) >= Map.fetch!(@ranks, parent)
+  end
+
+  @doc """
+  Lattice rank for a mode (lower = more permissive). Useful for
+  property tests asserting the clamp invariant.
+  """
+  @spec rank(mode()) :: 0..3
+  def rank(m) when is_map_key(@ranks, m), do: Map.fetch!(@ranks, m)
+
+  defp normalise_parent(p) when is_map_key(@ranks, p), do: p
+  defp normalise_parent(_), do: :default
+end

--- a/lib/tau/session.ex
+++ b/lib/tau/session.ex
@@ -434,9 +434,18 @@ defmodule Tau.Session do
           # ADR-0013 (#16): currently-active skill, or nil. When set,
           # `Tau.Permissions.Evaluator` denies any tool not on
           # `active_skill.allowed_tools` before consulting the rule set.
-          # Per-turn lifetime: cleared in `finalize_assistant/2` when the
-          # assistant returns `stop_reason == :end_turn` and on `:cancel`.
-          active_skill: nil,
+          # Per-turn lifetime by default: cleared in `finalize_assistant/2`
+          # when the assistant returns `stop_reason == :end_turn` and on
+          # `:cancel`. ADR-0015 sub-agents may pre-pin a persona at start
+          # time via the `:active_skill` opt + `:persona_lifetime: :session`
+          # so the persona survives `:end_turn` and stays live for the
+          # session's whole life (the child can't dismiss it).
+          active_skill: opts[:active_skill],
+          # ADR-0015: `:turn` (default) clears `active_skill` on
+          # `:end_turn`; `:session` pins it for the session's life. Only
+          # the `Agent` tool sets `:session` today; everything else
+          # behaves exactly like ADR-0013.
+          persona_lifetime: opts[:persona_lifetime] || :turn,
           # #91: spawn-time tool whitelist (`:all` or `[String.t()]`).
           # Filter applies in `dispatch_tools/2` before
           # `Tau.Permissions.Evaluator`; calls outside the list synthesise
@@ -887,11 +896,22 @@ defmodule Tau.Session do
     # that asked for the call.
     data = %{data | provider: data.original_provider, fallback_chain_remaining: []}
 
-    # ADR-0013 (#16): skill activation is per-turn. The skill's lifetime
-    # ends when the model decides the task is complete (`:end_turn`).
-    # Tool-call turns keep the active skill so subsequent dispatch is
-    # still gated; only `:end_turn` clears it.
-    data = if msg.stop_reason == :end_turn, do: %{data | active_skill: nil}, else: data
+    # ADR-0013 (#16): skill activation is per-turn by default. The
+    # skill's lifetime ends when the model decides the task is complete
+    # (`:end_turn`). Tool-call turns keep the active skill so subsequent
+    # dispatch is still gated; only `:end_turn` clears it.
+    #
+    # ADR-0015 sub-agent persona: when `:persona_lifetime` is `:session`
+    # (set by `Tau.Tools.Builtin.Agent` at start time) the persona is
+    # pinned for the session's whole life — `:end_turn` does NOT clear
+    # it. The child can't dismiss its own persona this way, which is
+    # the safety property the ADR demands.
+    data =
+      if msg.stop_reason == :end_turn and Map.get(data, :persona_lifetime, :turn) == :turn do
+        %{data | active_skill: nil}
+      else
+        data
+      end
 
     tool_calls = Enum.filter(msg.content, &match?(%{type: :tool_call}, &1))
 

--- a/lib/tau/telemetry/handlers.ex
+++ b/lib/tau/telemetry/handlers.ex
@@ -9,6 +9,7 @@ defmodule Tau.Telemetry.Handlers do
       [:tau, :session, :transition]
       [:tau, :session, :tool_whitelisted]
       [:tau, :session, :child_registered | :child_unregistered]
+      [:tau, :session, :subagent, :start | :stop | :exception]
       [:tau, :provider, :request, :start | :stop | :exception]
       [:tau, :provider, :event]
       [:tau, :provider, :rate_limit, :acquired | :throttled | :rejected | :halved]
@@ -19,6 +20,7 @@ defmodule Tau.Telemetry.Handlers do
       [:tau, :mcp, :rpc, :start | :stop | :exception]
       [:tau, :mcp, :stderr]
       [:tau, :permissions, :decision]
+      [:tau, :permissions, :ceiling_clamped]
       [:tau, :compaction, :start | :stop]
       [:tau, :settings, :reloaded]
       [:tau, :extensions, :reloaded]
@@ -67,6 +69,9 @@ defmodule Tau.Telemetry.Handlers do
       [:tau, :session, :tool_whitelisted],
       [:tau, :session, :child_registered],
       [:tau, :session, :child_unregistered],
+      [:tau, :session, :subagent, :start],
+      [:tau, :session, :subagent, :stop],
+      [:tau, :session, :subagent, :exception],
       [:tau, :provider, :request, :start],
       [:tau, :provider, :request, :stop],
       [:tau, :provider, :request, :exception],
@@ -88,6 +93,7 @@ defmodule Tau.Telemetry.Handlers do
       [:tau, :mcp, :rpc, :exception],
       [:tau, :mcp, :stderr],
       [:tau, :permissions, :decision],
+      [:tau, :permissions, :ceiling_clamped],
       [:tau, :compaction, :start],
       [:tau, :compaction, :stop],
       [:tau, :settings, :reloaded],

--- a/lib/tau/tools/builtin/agent.ex
+++ b/lib/tau/tools/builtin/agent.ex
@@ -1,0 +1,487 @@
+defmodule Tau.Tools.Builtin.Agent do
+  @moduledoc """
+  Spawn a sub-agent — an isolated child `Tau.Session` — and await its
+  result.
+
+  This is the v1.0 sub-agents centerpiece (ADR-0014, ADR-0015, issue #32).
+  The model emits an `Agent` tool call with a brief; this tool stands up
+  a child session under `Tau.Sessions.Supervisor`, sends the brief, and
+  returns the child's first `:end_turn` assistant text as the parent's
+  `ToolResult.content`. The parent's transcript records the
+  ToolResult; the child's full transcript stays addressable by its
+  session id.
+
+  ## Algorithm
+
+    1. Resolve `subagent_type` → `%Tau.Skill{}` via `data.skills`
+       (snapshot of the parent). Unknown name → `is_error` ToolResult.
+       Omitted → `general-purpose` (no persona, full tools).
+    2. Dispatch the `:subagent_start` hook (declared on `Tau.Hook`
+       since day one). `:halt`/`:deny` → `is_error` ToolResult.
+    3. Compute the child's permissions mode: `Tau.Permissions.Mode.clamp/2`
+       against the parent. The child can request stricter, never
+       broader. A clamp emits `[:tau, :permissions, :ceiling_clamped]`
+       telemetry.
+    4. `Tau.start_session/1` with inherited `cwd`, `provider`, `model`,
+       `provider_ctx`; `:tools_whitelist` from the skill's `allowed_tools`
+       (or `:all`); `:active_skill` + `:persona_lifetime: :session` per
+       ADR-0015 so the persona stays pinned for the child's life.
+    5. Subscribe to `"session:#{child_id}"` PubSub, register the child
+       with the parent FSM (cascade-cancel via `Tau.register_child/2`),
+       monitor the parent's pid (cascade in the OTHER direction —
+       parent dies → cancel child), send the brief.
+    6. Await the child's `%MessageEnd{stop_reason: :end_turn}`. Return
+       its assistant text as the parent's ToolResult content. On
+       `%SessionEnd{}` before `:end_turn` (the child crashed or was
+       cancelled), return `is_error: true`.
+
+  ## Telemetry
+
+  Span semantics (CLAUDE.md non-negotiable #5):
+
+    * `[:tau, :session, :subagent, :start]`
+    * `[:tau, :session, :subagent, :stop]`
+    * `[:tau, :session, :subagent, :exception]`
+
+  Plus `[:tau, :permissions, :ceiling_clamped]` when the requested mode
+  was clamped against the parent.
+
+  ## OTP placement
+
+    * The Agent tool's `execute/2` runs inside a per-call task spawned
+      under `Tau.Tools.TaskSupervisor` by the session FSM's parallel
+      tool dispatcher (#33). No new supervisor.
+    * No `Manager`/`Service` GenServer (CLAUDE.md non-negotiable #1) —
+      the child session FSM IS the per-spawn process.
+    * Cancellation cascade is parent-FSM-driven (#92) plus a
+      `Process.monitor/1` from inside this task on the parent's pid
+      (ADR-0008: tool tasks own their own monitors, not the FSM).
+
+  ## See also
+
+    * `docs/adr/0014-subagents-are-sessions.md`
+    * `docs/adr/0015-subagent-persona-is-a-skill.md`
+    * `Tau.Permissions.Mode` — the clamp helper.
+    * Issue #32 — the spec body.
+  """
+
+  @behaviour Tau.Tool
+
+  alias Tau.Message.Assistant
+  alias Tau.Session.Events, as: SE
+  alias Tau.Tool.Result
+
+  @general_purpose "general-purpose"
+
+  # Bounded await for the child's `:end_turn`. Sub-agents are model
+  # turns; their unbounded counterpart is the parent's. We use a
+  # generous default and let the parent FSM cascade `:cancel` if the
+  # parent itself is cancelled or crashes.
+  @await_timeout_ms 10 * 60 * 1000
+
+  @impl Tau.Tool
+  def name, do: "Agent"
+
+  @impl Tau.Tool
+  def description do
+    "Spawn a sub-agent with an isolated session, optional persona (`subagent_type` resolves to a skill), " <>
+      "and an inherited-or-tighter permissions mode. The sub-agent runs to its first `:end_turn` and " <>
+      "returns its assistant text as this tool's result. Sub-agent crashes never crash the parent — they " <>
+      "surface as `is_error: true`. Use for delegated read-only investigation (`Explore`), planning, or " <>
+      "any task the parent wants to do in a fresh context with restricted tools."
+  end
+
+  @impl Tau.Tool
+  def parameters do
+    %{
+      "type" => "object",
+      "properties" => %{
+        "description" => %{
+          "type" => "string",
+          "description" =>
+            "The brief sent as the sub-agent's first user message. Required."
+        },
+        "system_prompt" => %{
+          "type" => "string",
+          "description" =>
+            "Optional addendum prepended to the sub-agent's brief. Layered on top of the resolved skill body."
+        },
+        "subagent_type" => %{
+          "type" => "string",
+          "description" =>
+            "Optional skill name to install as the sub-agent's persona. Resolves against the parent's skills registry. Omit for a general-purpose sub-agent (full tools, no persona)."
+        },
+        "permissions_mode" => %{
+          "type" => "string",
+          "enum" => ["default", "accept_edits", "plan", "auto", "dont_ask", "bypass"],
+          "description" =>
+            "Optional. Requested permissions mode for the sub-agent. Clamped against the parent — the child can never escalate."
+        }
+      },
+      "required" => ["description"],
+      "additionalProperties" => false
+    }
+  end
+
+  @impl Tau.Tool
+  def execution_mode, do: :parallel
+
+  @impl Tau.Tool
+  def streams_updates?, do: false
+
+  @impl Tau.Tool
+  def execute(%{"description" => description} = params, ctx) do
+    started = System.monotonic_time(:millisecond)
+    subagent_type = Map.get(params, "subagent_type")
+    requested_mode = parse_mode(Map.get(params, "permissions_mode"))
+    system_prompt = Map.get(params, "system_prompt")
+
+    with {:ok, parent_snap} <- snapshot_parent(ctx.session_id),
+         {:ok, skill} <- resolve_skill(subagent_type, parent_snap.skills),
+         :cont <- run_subagent_start_hook(ctx, parent_snap, params, skill) do
+      parent_mode = Map.get(parent_snap.metadata || %{}, :permissions_mode, :default)
+      child_mode = clamp_with_telemetry(requested_mode, parent_mode, ctx, subagent_type)
+
+      brief = build_brief(description, system_prompt)
+      whitelist = whitelist_from(skill)
+
+      :telemetry.execute(
+        [:tau, :session, :subagent, :start],
+        %{system_time: System.system_time()},
+        %{
+          parent_session_id: ctx.session_id,
+          parent_tool_call_id: ctx.tool_call_id,
+          subagent_type: subagent_type,
+          permissions_mode: child_mode
+        }
+      )
+
+      child_metadata = %{
+        parent_session_id: ctx.session_id,
+        parent_tool_call_id: ctx.tool_call_id,
+        subagent_type: subagent_type || @general_purpose,
+        permissions_mode: child_mode
+      }
+
+      start_opts =
+        [
+          cwd: parent_snap.cwd,
+          provider: parent_snap.provider,
+          model: parent_snap.model,
+          metadata: child_metadata,
+          tools_whitelist: whitelist,
+          # Only pin a persona when one was actually resolved. A
+          # `general-purpose` sub-agent runs without an active_skill so
+          # the global rule set is the only gate (modulo the clamped
+          # mode + whitelist).
+          active_skill: skill,
+          persona_lifetime:
+            if(skill, do: :session, else: :turn)
+        ]
+        |> maybe_inherit_provider_ctx(ctx, parent_snap)
+
+      with {:ok, child_id} <- Tau.start_session(start_opts) do
+        # Subscribe BEFORE sending the brief so we don't race the
+        # child's MessageEnd — `Tau.start_session/1` is synchronous;
+        # the FSM is registered and broadcasting before we proceed.
+        Phoenix.PubSub.subscribe(Tau.PubSub, "session:#{child_id}")
+        :ok = Tau.register_child(ctx.session_id, child_id)
+
+        parent_pid =
+          case Registry.lookup(Tau.Sessions.Registry, ctx.session_id) do
+            [{pid, _}] -> pid
+            _ -> nil
+          end
+
+        # ADR-0008: monitor lives in this tool task, NOT the FSM.
+        parent_ref = parent_pid && Process.monitor(parent_pid)
+
+        :ok = Tau.send(child_id, brief)
+
+        result = await_child(child_id, ctx, parent_ref, started)
+
+        # Best-effort: drop the child from the parent's cascade set.
+        # Cast semantics — silently no-ops if the parent is already
+        # gone, which matches the contract of `Tau.unregister_child/2`.
+        Tau.unregister_child(ctx.session_id, child_id)
+        if parent_ref, do: Process.demonitor(parent_ref, [:flush])
+
+        :telemetry.execute(
+          [:tau, :session, :subagent, :stop],
+          %{duration: System.monotonic_time(:millisecond) - started},
+          %{
+            parent_session_id: ctx.session_id,
+            child_session_id: child_id,
+            subagent_type: subagent_type,
+            is_error: result.is_error
+          }
+        )
+
+        {:ok, result}
+      else
+        {:error, reason} ->
+          :telemetry.execute(
+            [:tau, :session, :subagent, :exception],
+            %{duration: System.monotonic_time(:millisecond) - started},
+            %{
+              parent_session_id: ctx.session_id,
+              subagent_type: subagent_type,
+              error: inspect(reason)
+            }
+          )
+
+          {:ok,
+           Result.error("Failed to spawn sub-agent: #{inspect(reason)}",
+             details: %{
+               kind: :spawn_error,
+               subagent_type: subagent_type
+             }
+           )}
+      end
+    else
+      {:error, {:unknown_subagent_type, name}} ->
+        {:ok,
+         Result.error("Unknown subagent_type: #{name}",
+           details: %{kind: :unknown_subagent_type, subagent_type: name}
+         )}
+
+      {:error, :parent_not_found} ->
+        {:ok,
+         Result.error("Parent session not found",
+           details: %{kind: :parent_not_found}
+         )}
+
+      {:halt, reason} ->
+        :telemetry.execute(
+          [:tau, :session, :subagent, :exception],
+          %{duration: System.monotonic_time(:millisecond) - started},
+          %{
+            parent_session_id: ctx.session_id,
+            subagent_type: subagent_type,
+            error: "hook_halt: #{inspect(reason)}"
+          }
+        )
+
+        {:ok,
+         Result.error("Sub-agent spawn blocked by hook: #{inspect(reason)}",
+           details: %{kind: :hook_halt}
+         )}
+
+      {:deny, reason} ->
+        :telemetry.execute(
+          [:tau, :session, :subagent, :exception],
+          %{duration: System.monotonic_time(:millisecond) - started},
+          %{
+            parent_session_id: ctx.session_id,
+            subagent_type: subagent_type,
+            error: "hook_deny: #{reason}"
+          }
+        )
+
+        {:ok,
+         Result.error("Sub-agent spawn denied by hook: #{reason}",
+           details: %{kind: :hook_deny}
+         )}
+    end
+  end
+
+  # --- Internals ------------------------------------------------------------
+
+  defp snapshot_parent(parent_id) do
+    case Tau.snapshot(parent_id) do
+      {:ok, snap} -> {:ok, snap}
+      {:error, :not_found} -> {:error, :parent_not_found}
+    end
+  end
+
+  # `subagent_type == nil` → no persona. `general-purpose` is special-cased
+  # so the model can name it explicitly without us looking it up as a
+  # skill (it doesn't need to exist on disk).
+  defp resolve_skill(nil, _skills), do: {:ok, nil}
+  defp resolve_skill(@general_purpose, _skills), do: {:ok, nil}
+
+  defp resolve_skill(name, skills) when is_binary(name) and is_list(skills) do
+    case List.keyfind(skills, name, 0) do
+      {^name, %Tau.Skill{} = skill} -> {:ok, skill}
+      _ -> {:error, {:unknown_subagent_type, name}}
+    end
+  end
+
+  defp run_subagent_start_hook(ctx, parent_snap, params, skill) do
+    payload = %{
+      session_id: ctx.session_id,
+      parent_session_id: ctx.session_id,
+      parent_tool_call_id: ctx.tool_call_id,
+      cwd: parent_snap.cwd,
+      permission_mode: Map.get(parent_snap.metadata || %{}, :permissions_mode, :default),
+      hook_event_name: "subagent_start",
+      transcript_path: nil,
+      metadata: parent_snap.metadata || %{},
+      subagent_type: Map.get(params, "subagent_type"),
+      brief: Map.get(params, "description"),
+      system_prompt: Map.get(params, "system_prompt"),
+      permissions_mode: parse_mode(Map.get(params, "permissions_mode")),
+      skill_name: skill && skill.name
+    }
+
+    case Tau.Hooks.Dispatcher.run(:subagent_start, payload) do
+      {:cont, _payload} -> :cont
+      {:halt, _} = h -> h
+      {:deny, _} = d -> d
+    end
+  end
+
+  defp clamp_with_telemetry(nil, parent_mode, _ctx, _subagent_type), do: parent_mode
+
+  defp clamp_with_telemetry(requested, parent_mode, ctx, subagent_type) do
+    effective = Tau.Permissions.Mode.clamp(requested, parent_mode)
+
+    if effective != requested do
+      :telemetry.execute(
+        [:tau, :permissions, :ceiling_clamped],
+        %{system_time: System.system_time()},
+        %{
+          parent_session_id: ctx.session_id,
+          parent_tool_call_id: ctx.tool_call_id,
+          subagent_type: subagent_type,
+          requested: requested,
+          parent: parent_mode,
+          effective: effective
+        }
+      )
+    end
+
+    effective
+  end
+
+  defp parse_mode(nil), do: nil
+
+  defp parse_mode(s) when is_binary(s) do
+    try do
+      atom = String.to_existing_atom(s)
+      if Tau.Permissions.Mode.mode?(atom), do: atom, else: nil
+    rescue
+      _ -> nil
+    end
+  end
+
+  defp parse_mode(a) when is_atom(a), do: a
+
+  # Skill `allowed_tools` of `[]` means "no whitelist declared" (matches
+  # the loader contract); `:all` is the right value to pass on then so
+  # the child has full tool access.
+  defp whitelist_from(nil), do: :all
+  defp whitelist_from(%Tau.Skill{allowed_tools: []}), do: :all
+  defp whitelist_from(%Tau.Skill{allowed_tools: list}) when is_list(list), do: list
+
+  defp build_brief(description, nil), do: description
+  defp build_brief(description, ""), do: description
+
+  defp build_brief(description, system_prompt) when is_binary(system_prompt) do
+    system_prompt <> "\n\n" <> description
+  end
+
+  # Inherit the parent's `provider_ctx` so child runs see the same
+  # replay fixtures / per-session routing tags. The parent snapshot
+  # doesn't expose `provider_ctx` directly (deliberate — see
+  # `Tau.Session.snapshot/1`'s typespec for what's promised), so we
+  # read it through the registered pid the same way `snapshot/1` does.
+  defp maybe_inherit_provider_ctx(opts, ctx, _parent_snap) do
+    case Registry.lookup(Tau.Sessions.Registry, ctx.session_id) do
+      [{pid, _}] ->
+        {_state, data} = :sys.get_state(pid)
+        Keyword.put(opts, :provider_ctx, data.provider_ctx || %{})
+
+      _ ->
+        opts
+    end
+  end
+
+  # --- Awaiting the child's :end_turn --------------------------------------
+
+  defp await_child(child_id, ctx, parent_ref, started) do
+    receive do
+      %SE.MessageEnd{session_id: ^child_id, message: %Assistant{} = msg} ->
+        cond do
+          msg.stop_reason == :end_turn ->
+            content = extract_text(msg)
+
+            Result.text(content,
+              details: %{
+                kind: :subagent_result,
+                child_session_id: child_id,
+                stop_reason: :end_turn,
+                duration_ms: System.monotonic_time(:millisecond) - started
+              }
+            )
+
+          msg.stop_reason in [:error, :aborted] ->
+            Result.error(
+              "Sub-agent ended without :end_turn (stop_reason: #{inspect(msg.stop_reason)}). " <>
+                (msg.error_message || ""),
+              details: %{
+                kind: :subagent_failed,
+                child_session_id: child_id,
+                stop_reason: msg.stop_reason
+              }
+            )
+
+          true ->
+            # `:tool_use` etc. — keep waiting for the next MessageEnd.
+            await_child(child_id, ctx, parent_ref, started)
+        end
+
+      %SE.SessionEnd{session_id: ^child_id, reason: reason} ->
+        Result.error(
+          "Sub-agent session ended before :end_turn (#{inspect(reason)})",
+          details: %{
+            kind: :subagent_session_end,
+            child_session_id: child_id,
+            reason: inspect(reason)
+          }
+        )
+
+      %SE.Cancelled{session_id: ^child_id} ->
+        # Cancelled returns to :awaiting_user; the FSM does NOT
+        # terminate. Wait for the eventual SessionEnd cascaded by the
+        # parent, or another MessageEnd if the parent un-cancels.
+        await_child(child_id, ctx, parent_ref, started)
+
+      {:DOWN, ^parent_ref, :process, _pid, _reason} ->
+        # Parent died. Cascade-cancel the child to flush its persistence
+        # then return an is_error. The FSM cancel cast is fire-and-
+        # forget; a real shutdown is observed via `%SessionEnd{}` on
+        # the child's topic — but our parent is already gone, so the
+        # tool task is on borrowed time too. Return promptly.
+        Tau.cancel(child_id)
+
+        Result.error(
+          "Sub-agent aborted: parent session terminated",
+          details: %{kind: :parent_down, child_session_id: child_id}
+        )
+    after
+      @await_timeout_ms ->
+        Tau.cancel(child_id)
+
+        Result.error(
+          "Sub-agent timed out after #{@await_timeout_ms}ms",
+          details: %{
+            kind: :subagent_timeout,
+            child_session_id: child_id,
+            timeout_ms: @await_timeout_ms
+          }
+        )
+    end
+  end
+
+  defp extract_text(%Assistant{content: blocks}) when is_list(blocks) do
+    blocks
+    |> Enum.flat_map(fn
+      %{type: :text, text: t} when is_binary(t) -> [t]
+      _ -> []
+    end)
+    |> Enum.join("")
+  end
+
+  defp extract_text(_), do: ""
+end


### PR DESCRIPTION
## Summary

Salvaged work from a timed-out agent run on issue #32 (the v1.0 sub-agents centerpiece). The agent completed the implementation but exhausted its budget before writing tests; rather than discard 600+ lines of coherent work, I'm landing the implementation now and queuing tests as a follow-up.

**Implements ADR-0014** (subagents are sessions) and **ADR-0015** (subagent persona is a Tau.Skill, permissions clamp). Builds on:
- ADR-0013 / #16 — `:active_skill` per-turn enforcement (PR #94).
- #91 — `:tools_whitelist` session option (PR #99).
- #92 — parent FSM `child_session_ids` cascade (PR #100).
- #66 — credential vault (PR #102).

## Files

**New:**
- `lib/tau/tools/builtin/agent.ex` (487 LOC) — JSON Schema, hook dispatch (`:subagent_start`), skill resolution from `data.skills`, permissions clamp via `Tau.Permissions.Mode.clamp/2`, child spawn via `Tau.start_session/1`, `Phoenix.PubSub.subscribe/2` on `"session:#{child_id}"`, `Tau.register_child/2` for cascade, `Process.monitor/1` on the parent's pid, await first `%MessageEnd{stop_reason: :end_turn}` from the child.
- `lib/tau/permissions/mode.ex` (107 LOC) — pure clamp helper. Order most-permissive to least: `:bypass > :auto > :default > :accept_edits > :dont_ask > :plan`. Telemetry on every actual clamp.

**Modified:**
- `lib/tau.ex` — `start_session` opt threading (`:active_skill`, `:persona_lifetime`).
- `lib/tau/session.ex` — `:active_skill` init opt; `:persona_lifetime: :session` branch in `finalize_assistant/2` to keep the skill pinned.
- `lib/tau/telemetry/handlers.ex` — new events: `[:tau, :session, :subagent, :start | :stop | :exception]`, `[:tau, :permissions, :ceiling_clamped]`.
- `config/config.exs` — register `Agent` in `:builtin_tools`.

## ⚠️ Tests pending

This PR does NOT include tests. A follow-up PR will add at minimum:
- Happy-path: parent + Replay child → ToolResult with assembled assistant text.
- Crash isolation: child crashes → parent gets `is_error`, parent's session continues.
- Cancel cascade: parent cancel → child receives `%Cancelled{}` (verifies #92 integration).
- Permissions clamp: parent in `:plan` + child requesting `:bypass` → effective `:plan`, telemetry fires.
- Whitelist enforcement: skill `allowed_tools: ["Read"]` → child rejecting `Write` (verifies #91 integration).
- Parallel fan-out: 3 simultaneous Agent calls → 3 ToolResult blocks (verifies #33 integration).

I'm dispatching a focused tests-only agent immediately after this merges.

## Reviewer notes

- The agent run that produced this hit "API Error: Stream idle timeout - partial response received" at 76 tool calls. The branch was never pushed; I salvaged from the worktree on disk.
- Visual review of the moduledoc + permissions/mode.ex matches the brief (ADR-0014/0015 alignment, parent monitor in tool task per ADR-0008, no new GenServer).

Refs #32, #18

https://claude.ai/code/session_011bAhaU738pEzP52sVs8RUQ

---
_Generated by [Claude Code](https://claude.ai/code/session_011bAhaU738pEzP52sVs8RUQ)_