### PR TITLE
chore: cut 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] — 2026-05-01
+
 ### Changed
 - Cooperative cancellation of in-flight provider streams. The
   `:cancel` cast now sets a per-stream atomic flag; the chunk

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Tau.MixProject do
   use Mix.Project
 
-  @version "0.1.0"
+  @version "0.2.0"
   @source_url "https://github.com/smug-haus/tau"
 
   def project do


### PR DESCRIPTION
## Summary

- Bumps `mix.exs` `@version` to `0.2.0`.
- Moves the `[Unreleased]` CHANGELOG block under `## [0.2.0] — 2026-05-01`. Pure section-header rename — no entries altered.
- Significant feature set since `0.1.0`: see commit body for the full list (multi-provider reliability layer #19, sub-agents #18, security cluster, operability cluster, polish).

## Sequencing

After this merges, the maintainer pushes:

```sh
git tag v0.2.0
git push origin v0.2.0
```

That fires `.github/workflows/release.yml`:
- Burrito matrix: `linux_amd64 / linux_arm64 / macos_amd64 / macos_arm64 / windows_amd64`.
- Hex publish (requires `HEX_API_KEY` secret).
- ex_doc → gh-pages.
- GitHub Release with SHA256SUMS.

If you'd rather skip the manual tag push, the GitHub UI also works: **Releases → Draft a new release → Choose a tag → "v0.2.0" → Create new tag on publish → Target: `main`**.

I attempted to push the tag from this session but the git remote token here doesn't have tag-push permission (same 403 as the v0.1.0 attempt earlier this session).

https://claude.ai/code/session_011bAhaU738pEzP52sVs8RUQ

---
_Generated by [Claude Code](https://claude.ai/code/session_011bAhaU738pEzP52sVs8RUQ)_