### PR TITLE
chore: format pass + unused-var fix (post-0.2.0 CI green-up)

### DIFF
--- a/lib/tau/cli.ex
+++ b/lib/tau/cli.ex
@@ -31,32 +31,70 @@ defmodule Tau.CLI do
     Application.ensure_all_started(:tau)
 
     case Optimus.parse!(spec(), argv) do
-      {[:run], parsed} -> run_cmd(parsed) |> halt()
-      {[:resume], parsed} -> resume_cmd(parsed) |> halt()
-      {[:sessions, :list], _} -> sessions_list() |> halt()
-      {[:sessions, :show], parsed} -> sessions_show(parsed) |> halt()
-      {[:config], parsed} -> Tau.CLI.Config.show(opts_with_json(parsed)) |> halt()
-      {[:config, :get], parsed} -> config_get(parsed) |> halt()
-      {[:config, :set], parsed} -> config_set(parsed) |> halt()
-      {[:mcp], parsed} -> Tau.CLI.MCP.list(opts_with_json(parsed)) |> halt()
-      {[:mcp, :list], parsed} -> Tau.CLI.MCP.list(opts_with_json(parsed)) |> halt()
-      {[:mcp, :status], parsed} -> Tau.CLI.MCP.status(opts_with_json(parsed)) |> halt()
-      {[:mcp, :reload], parsed} -> Tau.CLI.MCP.reload(opts_with_json(parsed)) |> halt()
-      {[:extensions], parsed} -> Tau.CLI.Extensions.list(opts_with_json(parsed)) |> halt()
-      {[:extensions, :list], parsed} -> Tau.CLI.Extensions.list(opts_with_json(parsed)) |> halt()
+      {[:run], parsed} ->
+        run_cmd(parsed) |> halt()
+
+      {[:resume], parsed} ->
+        resume_cmd(parsed) |> halt()
+
+      {[:sessions, :list], _} ->
+        sessions_list() |> halt()
+
+      {[:sessions, :show], parsed} ->
+        sessions_show(parsed) |> halt()
+
+      {[:config], parsed} ->
+        Tau.CLI.Config.show(opts_with_json(parsed)) |> halt()
+
+      {[:config, :get], parsed} ->
+        config_get(parsed) |> halt()
+
+      {[:config, :set], parsed} ->
+        config_set(parsed) |> halt()
+
+      {[:mcp], parsed} ->
+        Tau.CLI.MCP.list(opts_with_json(parsed)) |> halt()
+
+      {[:mcp, :list], parsed} ->
+        Tau.CLI.MCP.list(opts_with_json(parsed)) |> halt()
+
+      {[:mcp, :status], parsed} ->
+        Tau.CLI.MCP.status(opts_with_json(parsed)) |> halt()
+
+      {[:mcp, :reload], parsed} ->
+        Tau.CLI.MCP.reload(opts_with_json(parsed)) |> halt()
+
+      {[:extensions], parsed} ->
+        Tau.CLI.Extensions.list(opts_with_json(parsed)) |> halt()
+
+      {[:extensions, :list], parsed} ->
+        Tau.CLI.Extensions.list(opts_with_json(parsed)) |> halt()
+
       {[:extensions, :reload], parsed} ->
         Tau.CLI.Extensions.reload(opts_with_json(parsed)) |> halt()
-      {[:version], _} -> version_cmd() |> halt()
-      {[:doctor], _} -> doctor_cmd() |> halt()
-      {[:init], parsed} -> init_cmd(parsed) |> halt()
-      {[:tui], _} -> tui_cmd() |> halt()
-      {[], _} -> tui_cmd() |> halt()
-      _ -> :ok
+
+      {[:version], _} ->
+        version_cmd() |> halt()
+
+      {[:doctor], _} ->
+        doctor_cmd() |> halt()
+
+      {[:init], parsed} ->
+        init_cmd(parsed) |> halt()
+
+      {[:tui], _} ->
+        tui_cmd() |> halt()
+
+      {[], _} ->
+        tui_cmd() |> halt()
+
+      _ ->
+        :ok
     end
   end
 
   defp opts_with_json(parsed) do
-    [json: !!(parsed.flags[:json] || (parsed.options[:json] in [true, "true"]))]
+    [json: !!(parsed.flags[:json] || parsed.options[:json] in [true, "true"])]
   end
 
   defp config_get(parsed) do

--- a/lib/tau/command/spec.ex
+++ b/lib/tau/command/spec.ex
@@ -90,7 +90,9 @@ defmodule Tau.Command.Spec do
 
   defp tokenize(<<?', rest::binary>>, :bare, acc, toks), do: tokenize(rest, :sq, acc, toks)
   defp tokenize(<<?", rest::binary>>, :bare, acc, toks), do: tokenize(rest, :dq, acc, toks)
-  defp tokenize(<<c::utf8, rest::binary>>, :bare, acc, toks), do: tokenize(rest, :bare, [c | acc], toks)
+
+  defp tokenize(<<c::utf8, rest::binary>>, :bare, acc, toks),
+    do: tokenize(rest, :bare, [c | acc], toks)
 
   defp tokenize(<<?', rest::binary>>, :sq, acc, toks), do: tokenize(rest, :bare, acc, toks)
   defp tokenize(<<c::utf8, rest::binary>>, :sq, acc, toks), do: tokenize(rest, :sq, [c | acc], toks)

--- a/lib/tau/command/spec.ex
+++ b/lib/tau/command/spec.ex
@@ -178,21 +178,22 @@ defmodule Tau.Command.Spec do
   defp lookup_named(raw_name, spec) do
     atom_name = atomise(raw_name)
 
-    cond do
-      entry = Enum.find(spec, fn e -> e.kind in [:flag, :option] and e.name == atom_name end) ->
-        {entry, false}
-
-      String.starts_with?(raw_name, "no-") and
-          (entry =
-             Enum.find(spec, fn e ->
-               e.kind == :flag and e.name == atomise(String.replace_prefix(raw_name, "no-", ""))
-             end)) ->
-        {entry, true}
-
-      true ->
-        {nil, false}
+    case Enum.find(spec, fn e -> e.kind in [:flag, :option] and e.name == atom_name end) do
+      %{} = entry -> {entry, false}
+      nil -> lookup_no_prefix(raw_name, spec)
     end
   end
+
+  defp lookup_no_prefix("no-" <> rest, spec) do
+    flag_name = atomise(rest)
+
+    case Enum.find(spec, fn e -> e.kind == :flag and e.name == flag_name end) do
+      %{} = entry -> {entry, true}
+      nil -> {nil, false}
+    end
+  end
+
+  defp lookup_no_prefix(_, _), do: {nil, false}
 
   defp atomise(name) when is_binary(name) do
     name

--- a/lib/tau/providers/shared/finch_stream.ex
+++ b/lib/tau/providers/shared/finch_stream.ex
@@ -183,7 +183,8 @@ defmodule Tau.Providers.Shared.FinchStream do
     %{s | pending: s.pending ++ [%Event.Error{reason: reason, retryable?: true}], finished?: true}
   end
 
-  defp maybe_notify_rate_limiter(%{partial: %{provider: provider}}, status) when is_atom(provider) do
+  defp maybe_notify_rate_limiter(%{partial: %{provider: provider}}, status)
+       when is_atom(provider) do
     Tau.Providers.RateLimiter.record_response(provider, %{status: status})
   end
 

--- a/lib/tau/session.ex
+++ b/lib/tau/session.ex
@@ -1161,9 +1161,7 @@ defmodule Tau.Session do
     initial_in_flight =
       real_tasks
       |> Map.merge(Enum.into(gated, %{}, fn %{id: id} -> {id, :denied} end))
-      |> Map.merge(
-        Enum.into(whitelisted_out, %{}, fn %{id: id} -> {id, :whitelist_filtered} end)
-      )
+      |> Map.merge(Enum.into(whitelisted_out, %{}, fn %{id: id} -> {id, :whitelist_filtered} end))
       |> Map.merge(activated_in_flight)
 
     {:next_state, :tool_executing,

--- a/lib/tau/tools/builtin/agent.ex
+++ b/lib/tau/tools/builtin/agent.ex
@@ -98,8 +98,7 @@ defmodule Tau.Tools.Builtin.Agent do
       "properties" => %{
         "description" => %{
           "type" => "string",
-          "description" =>
-            "The brief sent as the sub-agent's first user message. Required."
+          "description" => "The brief sent as the sub-agent's first user message. Required."
         },
         "system_prompt" => %{
           "type" => "string",
@@ -175,8 +174,7 @@ defmodule Tau.Tools.Builtin.Agent do
           # the global rule set is the only gate (modulo the clamped
           # mode + whitelist).
           active_skill: skill,
-          persona_lifetime:
-            if(skill, do: :session, else: :turn)
+          persona_lifetime: if(skill, do: :session, else: :turn)
         ]
         |> maybe_inherit_provider_ctx(ctx, parent_snap)
 

--- a/test/tau/cli/init_test.exs
+++ b/test/tau/cli/init_test.exs
@@ -139,7 +139,6 @@ defmodule Tau.CLI.InitTest do
       body = File.read!(Path.join([cwd, ".tau", "settings.local.json"]))
       refute body =~ "sk-test-123"
     end
-
   end
 
   describe "schema validation" do

--- a/test/tau/permissions/evaluator_test.exs
+++ b/test/tau/permissions/evaluator_test.exs
@@ -62,9 +62,8 @@ defmodule Tau.Permissions.EvaluatorTest do
       assert Evaluator.evaluate({}, "Bash", %{"command" => "rm -rf /"}, %{}, :accept_edits) ==
                :deny
 
-      assert Evaluator.evaluate({}, "Bash", %{"command" => "sudo apt install"}, %{},
-               :accept_edits
-             ) == :deny
+      assert Evaluator.evaluate({}, "Bash", %{"command" => "sudo apt install"}, %{}, :accept_edits) ==
+               :deny
 
       assert Evaluator.evaluate({}, "Bash", %{"command" => ":(){ :|:&};:"}, %{}, :accept_edits) ==
                :deny

--- a/test/tau/permissions/heuristics_property_test.exs
+++ b/test/tau/permissions/heuristics_property_test.exs
@@ -57,6 +57,7 @@ defmodule Tau.Permissions.HeuristicsPropertyTest do
             suffix <- StreamData.string(:alphanumeric, max_length: 8)
           ) do
       cmd = "#{prefix} #{base} #{suffix}"
+
       assert Heuristics.destructive_bash?(%{"command" => cmd}),
              "expected destructive flag for: #{inspect(cmd)}"
     end

--- a/test/tau/provider_test.exs
+++ b/test/tau/provider_test.exs
@@ -16,7 +16,13 @@ defmodule Tau.ProviderTest do
 
     @impl true
     def capabilities,
-      do: %{thinking: false, tools: false, vision: false, prompt_caching: false, parallel_tools: false}
+      do: %{
+        thinking: false,
+        tools: false,
+        vision: false,
+        prompt_caching: false,
+        parallel_tools: false
+      }
 
     @impl true
     def default_model, do: "sync-err"
@@ -32,14 +38,21 @@ defmodule Tau.ProviderTest do
 
     @impl true
     def capabilities,
-      do: %{thinking: false, tools: false, vision: false, prompt_caching: false, parallel_tools: false}
+      do: %{
+        thinking: false,
+        tools: false,
+        vision: false,
+        prompt_caching: false,
+        parallel_tools: false
+      }
 
     @impl true
     def default_model, do: "native"
 
     @impl true
     def chat(_msgs, _opts, _ctx) do
-      {:ok, Tau.Message.Assistant.new(content: [%{type: :text, text: "native"}], stop_reason: :stop)}
+      {:ok,
+       Tau.Message.Assistant.new(content: [%{type: :text, text: "native"}], stop_reason: :stop)}
     end
   end
 

--- a/test/tau/session/parallel_tool_dispatch_test.exs
+++ b/test/tau/session/parallel_tool_dispatch_test.exs
@@ -79,7 +79,13 @@ defmodule Tau.Session.ParallelToolDispatchTest do
 
     @impl true
     def capabilities,
-      do: %{thinking: false, tools: true, vision: false, prompt_caching: false, parallel_tools: true}
+      do: %{
+        thinking: false,
+        tools: true,
+        vision: false,
+        prompt_caching: false,
+        parallel_tools: true
+      }
 
     @impl true
     def default_model, do: "p33"

--- a/test/tau/session/skill_activation_property_test.exs
+++ b/test/tau/session/skill_activation_property_test.exs
@@ -28,15 +28,17 @@ defmodule Tau.Session.SkillActivationPropertyTest do
         )
       }),
       fn {name, desc, body, disabled?, allowed} ->
-        StreamData.constant({name,
-         %Skill{
-           name: name,
-           description: desc,
-           body: body,
-           path: "/tmp/" <> name <> "/SKILL.md",
-           disable_model_invocation: disabled?,
-           allowed_tools: allowed
-         }})
+        StreamData.constant(
+          {name,
+           %Skill{
+             name: name,
+             description: desc,
+             body: body,
+             path: "/tmp/" <> name <> "/SKILL.md",
+             disable_model_invocation: disabled?,
+             allowed_tools: allowed
+           }}
+        )
       end
     )
   end

--- a/test/tau/session/update_provider_test.exs
+++ b/test/tau/session/update_provider_test.exs
@@ -41,7 +41,13 @@ defmodule Tau.Session.UpdateProviderTest do
 
     @impl true
     def capabilities,
-      do: %{thinking: false, tools: false, vision: false, prompt_caching: false, parallel_tools: false}
+      do: %{
+        thinking: false,
+        tools: false,
+        vision: false,
+        prompt_caching: false,
+        parallel_tools: false
+      }
 
     @impl true
     def default_model, do: "alt"

--- a/test/tau/settings/schema_test.exs
+++ b/test/tau/settings/schema_test.exs
@@ -101,8 +101,7 @@ defmodule Tau.Settings.SchemaTest do
         }
       }
 
-      assert {:ok,
-              %{Tau.Providers.Anthropic => [Tau.Providers.OpenAI.Chat]}} =
+      assert {:ok, %{Tau.Providers.Anthropic => [Tau.Providers.OpenAI.Chat]}} =
                Schema.resolve_fallback_chains(settings)
     end
 


### PR DESCRIPTION
## Summary

Two-commit fix for the CI failures the v0.2.0 release workflow exposed:

1. **`mix format`** on 13 files. Across this session's ~28 PRs, agents hand-formatted to ~100 col without running `mix format`. The drift accumulated; CI's `mix format --check-formatted` gate failed on every burrito target. Pure formatting — zero semantics change.

2. **Unused-variable warning** in `Tau.Command.Spec.lookup_named/2`. `mix compile --warnings-as-errors` (the lint gate from PR #75) flagged a `variable "entry" is unused` from a `cond` clause that used a bind-in-guard pattern inside an `and` expression. Elixir's binding tracker doesn't always carry that through, even though the runtime works. Restructured as `case`-based dispatch + a `lookup_no_prefix/2` helper that pattern-matches on `"no-" <> rest`.

## Locally verified

- `mix format --check-formatted` clean on Elixir 1.18.1 / OTP 27.
- `Code.string_to_quoted!/1` clean on every changed file.
- Cannot run `mix compile` / `mix credo` / `mix dialyzer` / `mix test` in this sandbox (`mix deps.get` is blocked by the egress proxy — see `.claude/skills/tau-toolchain/SKILL.md`). Relying on CI for those gates.

## Next: re-trigger the release

Once this lands on main, the v0.2.0 release needs to re-run against the new HEAD. Two options:

- **Move the tag** (destructive): `git tag -d v0.2.0; git push --delete origin v0.2.0; git tag v0.2.0 origin/main; git push origin v0.2.0`. Re-fires the workflow.
- **Cut v0.2.1 instead**: bump `mix.exs` + CHANGELOG header, push tag `v0.2.1`. Cleaner; preserves the v0.2.0 entry as "release attempt that failed CI".

I lean toward the move-tag path since v0.2.0 is currently a prerelease with no assets — nothing for users to depend on yet.

https://claude.ai/code/session_011bAhaU738pEzP52sVs8RUQ

---
_Generated by [Claude Code](https://claude.ai/code/session_011bAhaU738pEzP52sVs8RUQ)_