### PR TITLE
fix: 3 more compile errors/warnings (post-0.2.0 CI green-up, round 2)

### DIFF
--- a/lib/tau/providers/anthropic.ex
+++ b/lib/tau/providers/anthropic.ex
@@ -347,7 +347,7 @@ defmodule Tau.Providers.Anthropic do
 
   # --- Auth & transport plumbing -------------------------------------------
 
-  defp api_key(opts \\ %{}) do
+  defp api_key(opts) do
     # Resolution order (first non-nil wins):
     #
     #   1. `opts[:api_key]` — per-call override; literal string or

--- a/lib/tau/session.ex
+++ b/lib/tau/session.ex
@@ -803,43 +803,6 @@ defmodule Tau.Session do
      }}
   end
 
-  # ADR-0017: drive the cooperative-then-brutal cancellation handshake
-  # for the in-flight provider stream task. Returns `:cooperative` if
-  # the task drained on its own within the 250ms grace period (in
-  # which case the stream observed the flag, halted, and Stream.resource
-  # called its cleanup hook), `:brutal_kill` if we had to shut it
-  # down forcibly, or `:noop` if no provider task was active.
-  # Pairs with `[:tau, :provider, :request, :start]`.
-  defp cancel_provider_task(%{provider_task: nil}), do: :noop
-
-  defp cancel_provider_task(%{provider_task: task} = data) do
-    if not Process.alive?(task.pid) do
-      :noop
-    else
-      if data.cancel_flag, do: :counters.add(data.cancel_flag, 1, 1)
-
-      mechanism =
-        case Task.yield(task, 250) do
-          {:ok, _} -> :cooperative
-          {:exit, _} -> :cooperative
-          nil -> brutal_kill_provider_task(task)
-        end
-
-      :telemetry.execute(
-        [:tau, :provider, :request, mechanism],
-        %{system_time: System.system_time()},
-        %{provider: data.provider, model: data.model, session_id: data.id}
-      )
-
-      mechanism
-    end
-  end
-
-  defp brutal_kill_provider_task(task) do
-    Task.shutdown(task, :brutal_kill)
-    :brutal_kill
-  end
-
   def handle_event(:cast, :stop, _state, data) do
     # ADR-0014 (#92): cascade `Tau.stop/1` to children before terminating.
     # Each child runs its own `terminate/3` which broadcasts `%SessionEnd{}`
@@ -906,6 +869,43 @@ defmodule Tau.Session do
   def handle_event(_type, _event, _state, data), do: {:keep_state, data}
 
   # --- Helpers --------------------------------------------------------------
+
+  # ADR-0017: drive the cooperative-then-brutal cancellation handshake
+  # for the in-flight provider stream task. Returns `:cooperative` if
+  # the task drained on its own within the 250ms grace period (in
+  # which case the stream observed the flag, halted, and Stream.resource
+  # called its cleanup hook), `:brutal_kill` if we had to shut it
+  # down forcibly, or `:noop` if no provider task was active.
+  # Pairs with `[:tau, :provider, :request, :start]`.
+  defp cancel_provider_task(%{provider_task: nil}), do: :noop
+
+  defp cancel_provider_task(%{provider_task: task} = data) do
+    if not Process.alive?(task.pid) do
+      :noop
+    else
+      if data.cancel_flag, do: :counters.add(data.cancel_flag, 1, 1)
+
+      mechanism =
+        case Task.yield(task, 250) do
+          {:ok, _} -> :cooperative
+          {:exit, _} -> :cooperative
+          nil -> brutal_kill_provider_task(task)
+        end
+
+      :telemetry.execute(
+        [:tau, :provider, :request, mechanism],
+        %{system_time: System.system_time()},
+        %{provider: data.provider, model: data.model, session_id: data.id}
+      )
+
+      mechanism
+    end
+  end
+
+  defp brutal_kill_provider_task(task) do
+    Task.shutdown(task, :brutal_kill)
+    :brutal_kill
+  end
 
   # Common path that handles a user_message after any slash-command
   # expansion has resolved. Called both by the synchronous

--- a/lib/tau/tools/builtin/agent.ex
+++ b/lib/tau/tools/builtin/agent.ex
@@ -26,7 +26,7 @@ defmodule Tau.Tools.Builtin.Agent do
        `provider_ctx`; `:tools_whitelist` from the skill's `allowed_tools`
        (or `:all`); `:active_skill` + `:persona_lifetime: :session` per
        ADR-0015 so the persona stays pinned for the child's life.
-    5. Subscribe to `"session:#{child_id}"` PubSub, register the child
+    5. Subscribe to `"session:\#{child_id}"` PubSub, register the child
        with the parent FSM (cascade-cancel via `Tau.register_child/2`),
        monitor the parent's pid (cascade in the OTHER direction —
        parent dies → cancel child), send the brief.


### PR DESCRIPTION
## Summary

Three more failures exposed by the 0.2.0 release-workflow CI. All three are landing in one PR; same branch as #111 (rebased atop #111's merge).

1. **ERROR — `lib/tau/tools/builtin/agent.ex:29`** — `undefined variable "child_id"`. The Agent tool's moduledoc had `"session:#{child_id}"` which Elixir tried to evaluate at compile time. Escaped to `"session:\#{child_id}"` so it reads as a literal string.

2. **WARNING — `lib/tau/providers/anthropic.ex:350`** — `default values for the optional arguments in api_key/1 are never used`. Only one callsite (line 63) and it always passes `opts`. Dropped the `\\ %{}` default.

3. **WARNING — `lib/tau/session.ex`** — `clauses with the same name and arity should be grouped together`. PR #107 (cooperative cancellation, ADR-0017) inserted `defp cancel_provider_task/1` and `defp brutal_kill_provider_task/1` between `handle_event(:cast, :cancel)` and `handle_event(:cast, :stop)`. Moved the two helpers down past the catch-all so all `handle_event/4` clauses are contiguous.

## Locally verified

- `mix format --check-formatted` clean.
- `Code.string_to_quoted!/1` clean on every `lib/**/*.ex` and `test/**/*.exs`.
- Cannot run `mix compile` here (`mix deps.get` is sandbox-blocked) — relying on CI.

## Re-trigger plan

Same as #111: the v0.2.0 tag still points at `9e6a41e` and the release is empty. Move the tag to current main once this lands, or cut v0.2.1.

https://claude.ai/code/session_011bAhaU738pEzP52sVs8RUQ

---
_Generated by [Claude Code](https://claude.ai/code/session_011bAhaU738pEzP52sVs8RUQ)_