### PR TITLE
fix: rate-limiter type bug + Zig 0.15.2 + re-escape moduledoc (post-0.2.0 round 3)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Setup Zig (Burrito needs it for cross-compilation of the launcher)
         uses: mlugg/setup-zig@v1
         with:
-          version: "0.13.0"
+          version: "0.15.2"
 
       - name: Setup 7zip (Windows)
         if: runner.os == 'Windows'

--- a/lib/tau/providers/rate_limiter.ex
+++ b/lib/tau/providers/rate_limiter.ex
@@ -142,11 +142,13 @@ defmodule Tau.Providers.RateLimiter do
   @impl true
   def handle_call({:acquire, est_tokens, timeout, started_at}, from, state) do
     now = monotonic_now()
-    {request_status, rpm} = TokenBucket.take(state.rpm_bucket, 1, now)
-    {token_status, tpm} = TokenBucket.take(state.tpm_bucket, est_tokens, now)
+    request_result = TokenBucket.take(state.rpm_bucket, 1, now)
+    token_result = TokenBucket.take(state.tpm_bucket, est_tokens, now)
 
     cond do
-      request_status == :ok and token_status == :ok ->
+      elem(request_result, 0) == :ok and elem(token_result, 0) == :ok ->
+        {:ok, rpm} = request_result
+        {:ok, tpm} = token_result
         wait_ms = now - started_at
         new_state = %{state | rpm_bucket: rpm, tpm_bucket: tpm}
         emit_acquired(state.provider, wait_ms, est_tokens, rpm, tpm, wait_ms > 0)
@@ -154,7 +156,7 @@ defmodule Tau.Providers.RateLimiter do
 
       true ->
         wait_ms =
-          [wait_for(request_status), wait_for(token_status)]
+          [wait_for(request_result), wait_for(token_result)]
           |> Enum.reject(&is_nil/1)
           |> max_wait()
 
@@ -209,10 +211,12 @@ defmodule Tau.Providers.RateLimiter do
   @impl true
   def handle_info({:retry_acquire, from, est_tokens, timeout, started_at}, state) do
     now = monotonic_now()
-    {request_status, rpm} = TokenBucket.take(state.rpm_bucket, 1, now)
-    {token_status, tpm} = TokenBucket.take(state.tpm_bucket, est_tokens, now)
+    request_result = TokenBucket.take(state.rpm_bucket, 1, now)
+    token_result = TokenBucket.take(state.tpm_bucket, est_tokens, now)
 
-    if request_status == :ok and token_status == :ok do
+    if elem(request_result, 0) == :ok and elem(token_result, 0) == :ok do
+      {:ok, rpm} = request_result
+      {:ok, tpm} = token_result
       wait_ms = now - started_at
       emit_acquired(state.provider, wait_ms, est_tokens, rpm, tpm, true)
       GenServer.reply(from, :ok)
@@ -227,7 +231,7 @@ defmodule Tau.Providers.RateLimiter do
         {:noreply, state}
       else
         next_wait =
-          [wait_for(request_status), wait_for(token_status)]
+          [wait_for(request_result), wait_for(token_result)]
           |> Enum.reject(&is_nil/1)
           |> max_wait()
 

--- a/lib/tau/tools/builtin/agent.ex
+++ b/lib/tau/tools/builtin/agent.ex
@@ -26,7 +26,7 @@ defmodule Tau.Tools.Builtin.Agent do
        `provider_ctx`; `:tools_whitelist` from the skill's `allowed_tools`
        (or `:all`); `:active_skill` + `:persona_lifetime: :session` per
        ADR-0015 so the persona stays pinned for the child's life.
-    5. Subscribe to `"session:#{child_id}"` PubSub, register the child
+    5. Subscribe to `"session:\#{child_id}"` PubSub, register the child
        with the parent FSM (cascade-cancel via `Tau.register_child/2`),
        monitor the parent's pid (cascade in the OTHER direction —
        parent dies → cancel child), send the brief.


### PR DESCRIPTION
## Summary

Round 3 of post-0.2.0 CI fixes.

1. **`lib/tau/providers/rate_limiter.ex` — typing violation that was also a real runtime bug.** The compiler flagged `wait_for(request_status)` as receiving `:ok` instead of the expected `{:ok, _}` / `{:wait, _, _}`. Root cause: `{request_status, rpm} = TokenBucket.take(...)` destructured a 2-tuple, but `take/3` returns *either* `{:ok, b}` (2-tuple) *or* `{:wait, ms, b}` (3-tuple). On the wait path the destructure would crash at runtime; even on the OK path, `request_status` was just `:ok` (atom) so `wait_for/1` would never match its tuple-shaped clauses. Fixed by binding the whole result, using `elem(_, 0)` for the status check, `{:ok, _} = result` only on the OK branch, and passing the whole tuple to `wait_for/1` on the wait branch. Same fix in `handle_call/3` and `handle_info/2`.

2. **`.github/workflows/release.yml` — Zig version mismatch.** Burrito 1.4.x requires Zig `0.15.2`; the workflow pinned `0.13.0`. Bumped.

3. **`lib/tau/tools/builtin/agent.ex` — moduledoc interpolation came back.** PR #112 fixed `"session:#{child_id}"` → `"session:\#{child_id}"` but the unescaped form reappeared (possibly from a rebase/conflict resolve). Re-escaped.

## Locally verified

- `mix format --check-formatted` clean.
- `Code.string_to_quoted!/1` clean on all `.ex`/`.exs`.
- Cannot run `mix compile` here — relying on CI.

https://claude.ai/code/session_011bAhaU738pEzP52sVs8RUQ

---
_Generated by [Claude Code](https://claude.ai/code/session_011bAhaU738pEzP52sVs8RUQ)_