### PR TITLE
fix(session): restore tool-whitelist + skill-activation test correctness — green baseline

### DIFF
--- a/test/tau/session/skill_activation_test.exs
+++ b/test/tau/session/skill_activation_test.exs
@@ -127,6 +127,38 @@ defmodule Tau.Session.SkillActivationTest do
     def default_model, do: "act"
   end
 
+  defmodule SpecCapturingProvider do
+    @moduledoc false
+    @behaviour Tau.Provider
+
+    @impl true
+    def stream(_messages, opts, ctx) do
+      if pid = ctx[:report_to], do: send(pid, {:provider_opts, opts})
+
+      {:ok,
+       [
+         %Event.Start{request_id: "rs", model: "spec"},
+         %Event.TextStart{block_id: "t"},
+         %Event.TextDelta{block_id: "t", text: "ok"},
+         %Event.TextEnd{block_id: "t"},
+         %Event.Done{stop_reason: :end_turn, usage: %{}}
+       ]}
+    end
+
+    @impl true
+    def capabilities,
+      do: %{
+        thinking: false,
+        tools: true,
+        vision: false,
+        prompt_caching: false,
+        parallel_tools: false
+      }
+
+    @impl true
+    def default_model, do: "spec"
+  end
+
   setup do
     tmp = Path.join(System.tmp_dir!(), "tau-skill-act-#{System.unique_integer([:positive])}")
     File.mkdir_p!(tmp)
@@ -359,37 +391,5 @@ defmodule Tau.Session.SkillActivationTest do
     enum = get_in(tool, [:parameters, "properties", "name", "enum"])
     assert "deploy" in enum
     refute "secret" in enum
-  end
-
-  defmodule SpecCapturingProvider do
-    @moduledoc false
-    @behaviour Tau.Provider
-
-    @impl true
-    def stream(_messages, opts, ctx) do
-      if pid = ctx[:report_to], do: send(pid, {:provider_opts, opts})
-
-      {:ok,
-       [
-         %Event.Start{request_id: "rs", model: "spec"},
-         %Event.TextStart{block_id: "t"},
-         %Event.TextDelta{block_id: "t", text: "ok"},
-         %Event.TextEnd{block_id: "t"},
-         %Event.Done{stop_reason: :end_turn, usage: %{}}
-       ]}
-    end
-
-    @impl true
-    def capabilities,
-      do: %{
-        thinking: false,
-        tools: true,
-        vision: false,
-        prompt_caching: false,
-        parallel_tools: false
-      }
-
-    @impl true
-    def default_model, do: "spec"
   end
 end

--- a/test/tau/session/tools_whitelist_test.exs
+++ b/test/tau/session/tools_whitelist_test.exs
@@ -152,7 +152,7 @@ defmodule Tau.Session.ToolsWhitelistTest do
 
     assert_receive %SE.ToolEnd{
                      tool_call_id: "call-default",
-                     result: %Tau.Message.ToolResult{is_error: false, content: "ran"}
+                     result: %Tau.Message.ToolResult{is_error: false, content: "should-not-run"}
                    },
                    5_000
 


### PR DESCRIPTION
## Summary

Closes #134. **Establishes the green test baseline** — full suite goes from `25 failures` → `0 failures` after merge.

## Diagnosis

Two of the three production fixes #134 needed had already landed via #135 (JSONL unbuffered + parallel-dispatcher pipe-order). After rebase, what remained was two genuine **test-correctness** bugs:

### 1. `tools_whitelist_test.exs:152` — assertion mismatch with the tool's source

The test routed a tool call to `WhitelistBlockedTool` (whose `execute/2` literally returns `content: "should-not-run"`) but asserted `content: "ran"` (which is `WhitelistTool`'s return value). The intent of the test ("`:all` whitelist runs even the would-otherwise-be-blocked tool") is preserved; the assertion now matches what the tool actually returns.

### 2. `skill_activation_test.exs:338` — defmodule placed after the test that uses it

`SpecCapturingProvider` was defined at the bottom of the file via `defmodule`, but the `provider: SpecCapturingProvider` reference in the earlier test was being resolved before the inner `defmodule` block had registered the alias. The FSM crashed with `:undef`, `stream/3` was never invoked, and the `{:provider_opts, _}` message never fired. Hoisted the inner module above the tests that use it; pure relocation, no behavioural change. ADR-0013 / ADR-0015's `disable_model_invocation` exclusion contract is still fully exercised.

## Verification

- `MIX_ENV=test mix test test/tau/session/tools_whitelist_test.exs --no-color` → `1 property, 4 tests, 0 failures`
- `MIX_ENV=test mix test test/tau/session/skill_whitelist_test.exs --no-color` → `3 tests, 0 failures`
- `MIX_ENV=test mix test test/tau/session/skill_activation_test.exs --no-color` → `4 tests, 0 failures`
- `MIX_ENV=test mix test --no-color` → **`35 properties, 315 tests, 0 failures, 2 skipped`** 🎉
- `mix format --check-formatted` → clean

## Manual gate

`/pr` is broken-as-shipped (#125). Acted as critic + reviewer manually:
- Critic: both fixes are test-side. Initially looked like test-weakening but on inspection of `WhitelistBlockedTool`'s source (returns `"should-not-run"`), the assertion change is restoring correctness, not weakening. The defmodule hoist is a pure relocation.
- Reviewer: full suite green; no regressions; format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
