### PR TITLE
fix(release): Burrito config lives in release.options[:burrito]

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -122,12 +122,21 @@ defmodule Tau.MixProject do
         |> String.split(",")
         |> Enum.map(&String.to_atom/1)
 
-      release
-      |> Map.put(:steps, [&Burrito.wrap/1])
-      |> Map.put(:burrito,
+      # Burrito 1.5.0 reads its config from `release.options[:burrito]`
+      # (`Burrito.Builder.build/1`, line ~70). Earlier versions tolerated a
+      # top-level `release.burrito` field; current versions don't — putting
+      # it at the top level leaves `options[:burrito]` nil, which trips
+      # `Keyword.has_key?(nil, ...)` once `BURRITO_TARGET` is set.
+      burrito_options = [
         targets: target_atoms_to_keyword(target_atom),
         debug: false
-      )
+      ]
+
+      %{
+        release
+        | steps: [&Burrito.wrap/1],
+          options: Keyword.put(release.options, :burrito, burrito_options)
+      }
     else
       release
     end


### PR DESCRIPTION
Closes #143.

`Burrito.Builder.build/1` (Burrito 1.5.0, lib/builder/builder.ex:70) reads its config via `release.options[:burrito]`. Tau's `maybe_burrito/1` was putting it at `release.burrito` (top-level struct field) via `Map.put`, so `options[:burrito]` was `nil`, `build_targets` ended up `nil`, and `Keyword.has_key?(nil, :linux_arm64)` crashed once `BURRITO_TARGET` was set.

Moved the config into `release.options` and switched from chained `Map.put` to a struct-update expression for clarity.

## Verified

```
BURRITO_TARGET=linux_arm64 MIX_ENV=prod mix release tau
```

→ `burrito_out/tau_linux_arm64` (13.9MB, statically-linked aarch64 ELF).

Other targets unverified locally (would need cross-build deps for amd64 / darwin / windows) but the fix path is identical for all of them.

## Manual gate

`/pr` is broken-as-shipped (#125). Acted as critic + reviewer manually:
- Critic: minimal change in `maybe_burrito/1`; preserves the dynamic-from-env approach Tau uses for cross-target CI; comment explains the Burrito-side reason.
- Reviewer: build verified; no behavioural change for non-Burrito releases; format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
