### PR TITLE
fix(bedrock): start :aws_credentials lazily, not at boot

### DIFF
--- a/lib/tau/providers/bedrock.ex
+++ b/lib/tau/providers/bedrock.ex
@@ -184,6 +184,8 @@ defmodule Tau.Providers.Bedrock do
         }
 
       Code.ensure_loaded?(:aws_credentials) ->
+        Application.ensure_all_started(:aws_credentials)
+
         case :aws_credentials.get_credentials() do
           :undefined -> nil
           c -> c

--- a/mix.exs
+++ b/mix.exs
@@ -36,7 +36,8 @@ defmodule Tau.MixProject do
   def application do
     [
       mod: {Tau.Application, []},
-      extra_applications: [:logger, :crypto, :ssl, :inets]
+      extra_applications: [:logger, :crypto, :ssl, :inets],
+      included_applications: [:aws_credentials]
     ]
   end
 


### PR DESCRIPTION
On boot, `:aws_credentials` was probing every credential provider (env, file, ECS, EC2 metadata, EKS), adding ~9s of timeouts and noisy `[error]` logs on non-AWS hosts. Bedrock is opt-in; this overhead applies to every Tau startup regardless.

Move `:aws_credentials` from auto-started deps to `included_applications`. `Tau.Providers.Bedrock` calls `Application.ensure_all_started(:aws_credentials)` lazily before its first credential lookup; the env-vars branch above remains the cheap path.

Tests still green: `35 properties, 315 tests, 0 failures, 2 skipped`. Production binary boot is now silent (verified with `BURRITO_TARGET=linux_arm64 MIX_ENV=prod mix release tau`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
