### PR TITLE
feat(release): drop into TUI from prod / Burrito binary

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,10 +17,11 @@ toolchain:
   [`asdf`](https://asdf-vm.com) or [`mise`](https://mise.jdx.dev); the
   `tau-toolchain` skill in `.claude/skills/` has a sandbox-aware fallback.
 - **Python 3.10** — required at compile time only, by `ex_termbox` (a
-  transitive dep of `ratatouille`, `only: [:dev]`). The vendored `waf`
-  inside `ex_termbox` uses Python-2-era idioms (`'rUb'` open mode) that
-  Python 3.11 removed; 3.10 still emits these as deprecation warnings
-  rather than errors. The pinned version lives in `.python-version`.
+  transitive dep of `ratatouille`, the TUI library). The vendored
+  `waf` inside `ex_termbox` uses Python-2-era idioms (`'rUb'` open
+  mode) that Python 3.11 removed; 3.10 still emits these as
+  deprecation warnings rather than errors. The pinned version lives
+  in `.python-version`.
 
 The recommended Python setup is [`pyenv`](https://github.com/pyenv/pyenv)
 plus a per-developer venv:

--- a/lib/tau/application.ex
+++ b/lib/tau/application.ex
@@ -61,10 +61,32 @@ defmodule Tau.Application do
           version: Application.spec(:tau, :vsn) |> to_string()
         })
 
+        maybe_dispatch_cli()
+
         {:ok, pid}
 
       other ->
         other
+    end
+  end
+
+  defp maybe_dispatch_cli do
+    case Burrito.Util.Args.get_bin_path() do
+      :not_in_burrito ->
+        :ok
+
+      _bin_path ->
+        args = Burrito.Util.Args.get_arguments() || []
+
+        Task.start(fn ->
+          exit_code =
+            case Tau.CLI.main(args) do
+              n when is_integer(n) -> n
+              _ -> 0
+            end
+
+          System.halt(exit_code)
+        end)
     end
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -64,7 +64,7 @@ defmodule Tau.MixProject do
 
       # TUI — optional, only fetched for dev. Prod builds the stub branch
       # of Tau.TUI; tests run without it. Add to your env to use the TUI.
-      {:ratatouille, "~> 0.5", only: [:dev], optional: true},
+      {:ratatouille, "~> 0.5"},
 
       # CLI argv parser
       {:optimus, "~> 0.5"},
@@ -80,8 +80,10 @@ defmodule Tau.MixProject do
       {:ex_json_schema, "~> 0.10"},
       {:nimble_options, "~> 1.1"},
 
-      # Self-contained binary distribution (release-only)
-      {:burrito, "~> 1.2", runtime: false},
+      # Self-contained binary distribution. Runtime modules
+      # (`Burrito.Util.Args`) are needed at runtime to read user
+      # argv and the `__BURRITO_BIN_PATH` context marker.
+      {:burrito, "~> 1.2"},
 
       # Dev / test
       {:mox, "~> 1.2", only: :test},
@@ -146,13 +148,40 @@ defmodule Tau.MixProject do
   defp target_atoms_to_keyword(targets) do
     targets
     |> Enum.map(fn
-      :linux_amd64 -> {:linux_amd64, [os: :linux, cpu: :x86_64]}
-      :linux_arm64 -> {:linux_arm64, [os: :linux, cpu: :aarch64]}
-      :macos_amd64 -> {:macos_amd64, [os: :darwin, cpu: :x86_64]}
-      :macos_arm64 -> {:macos_arm64, [os: :darwin, cpu: :aarch64]}
-      :windows_amd64 -> {:windows_amd64, [os: :windows, cpu: :x86_64]}
+      :linux_amd64 -> {:linux_amd64, [os: :linux, cpu: :x86_64, skip_nifs: same_target?(:linux_amd64)]}
+      :linux_arm64 -> {:linux_arm64, [os: :linux, cpu: :aarch64, skip_nifs: same_target?(:linux_arm64)]}
+      :macos_amd64 -> {:macos_amd64, [os: :darwin, cpu: :x86_64, skip_nifs: same_target?(:macos_amd64)]}
+      :macos_arm64 -> {:macos_arm64, [os: :darwin, cpu: :aarch64, skip_nifs: same_target?(:macos_arm64)]}
+      :windows_amd64 -> {:windows_amd64, [os: :windows, cpu: :x86_64, skip_nifs: same_target?(:windows_amd64)]}
       other -> {other, []}
     end)
+  end
+
+  defp same_target?(target) do
+    host =
+      case {:os.type(), :erlang.system_info(:system_architecture)} do
+        {{:unix, :linux}, arch} when is_list(arch) ->
+          cond do
+            arch |> to_string() |> String.contains?("aarch64") -> :linux_arm64
+            arch |> to_string() |> String.contains?("x86_64") -> :linux_amd64
+            true -> :unknown
+          end
+
+        {{:unix, :darwin}, arch} when is_list(arch) ->
+          cond do
+            arch |> to_string() |> String.contains?("aarch64") -> :macos_arm64
+            arch |> to_string() |> String.contains?("x86_64") -> :macos_amd64
+            true -> :unknown
+          end
+
+        {{:win32, _}, _} ->
+          :windows_amd64
+
+        _ ->
+          :unknown
+      end
+
+    host == target
   end
 
   defp aliases do


### PR DESCRIPTION
The Burrito-wrapped binary previously did nothing useful — it was the stock `bin/tau` Erlang launcher with no TUI compiled in. Running `tau_linux_arm64` resulted in a hung process the user had to SIGTERM.

This PR makes the binary actually usable as the user-facing entry point: no args drops into the Ratatouille TUI, args dispatch to the existing CLI subcommands (`doctor`, `version`, `run`, `resume`, `sessions`, `mcp`, `extensions`, `config`, `init`).

## Changes

**`mix.exs`**
- Promote `ratatouille` from `only: [:dev], optional: true` → runtime dep across all envs. The TUI is now compiled into prod releases.
- Promote `burrito` from `runtime: false` → runtime dep, so `Burrito.Util.Args` is available at runtime to detect Burrito-context and read user argv (passed via `:init.get_plain_arguments()`).
- Add `skip_nifs:` in `target_atoms_to_keyword/1` keyed off whether the target matches the host. When self-hosting (e.g., aarch64-linux building for aarch64-linux), Burrito reuses the host-compiled `priv/termbox_bindings.so` instead of trying to recompile via Zig 0.15.2 (whose linker rejects waf-emitted `-h` flags).

**`lib/tau/application.ex`**
- After supervision tree starts, `maybe_dispatch_cli/0` checks `Burrito.Util.Args.get_bin_path/0`. If `:not_in_burrito` (library / mix run / non-Burrito release), no-op. If we're inside a Burrito wrapper, spawn a Task that runs `Tau.CLI.main/1` with `Burrito.Util.Args.get_arguments/0` as argv, then `System.halt/1` with the exit code. This is the path that turns `bin/tau ... start` into "drop into Tau.CLI.main".

**`CONTRIBUTING.md`**
- Removed the stale "ratatouille is `only: [:dev]`" note from the Python build-prereq paragraph. Python 3.10 is now needed for prod releases too (it always was, just hidden behind the `:dev`-only declaration).

## Verification

- `mix test` → `35 properties, 317 tests, 0 failures, 2 skipped` ✓
- `mix compile` (default `:dev`) → clean ✓
- `mix escript.build` → clean ✓
- `MIX_ENV=prod mix release tau` (standard Erlang release) → clean ✓
- `BURRITO_TARGET=linux_arm64 MIX_ENV=prod mix release tau` → produces `burrito_out/tau_linux_arm64` (~14MB, statically-linked aarch64 ELF) ✓
- `burrito_out/tau_linux_arm64 doctor` → runs the doctor subcommand and exits cleanly ✓
- `burrito_out/tau_linux_arm64 version` → prints `tau 0.2.0` and exits ✓
- No-args (TUI launch) verified up to the OTP-app-boot point; full TUI render requires a real terminal.

## Known follow-ups (separate issues)

- #136 is now closed by the prereq stack (pyenv + Python 3.10) and the `skip_nifs:` host-target detection. Leaving the issue open until the user closes it as observed-fixed.
- #146 (inotify-tools warning) is still loud on hosts without it. Separate concern.
- The `mix.lock` churn from initial `mix deps.get` is intentionally not in this PR. Whether to commit `mix.lock` is #118.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
