### PR TITLE
fix(tui): correct Ratatouille runtime API (run/2 doesn't exist)

### DIFF
--- a/lib/tau/tui/app.ex
+++ b/lib/tau/tui/app.ex
@@ -67,12 +67,20 @@ if Code.ensure_loaded?(Ratatouille.Runtime) do
     @impl true
     def subscribe(_model), do: Subscription.interval(@tick_interval, :tick)
 
-    @doc "Run the TUI loop (blocking)."
+    @doc "Run the TUI loop (blocking until the user quits)."
     def run do
-      Ratatouille.Runtime.run(__MODULE__,
-        interval: @tick_interval,
-        quit_events: [{:ch, ?q}, {:key, 3}]
-      )
+      {:ok, runtime} =
+        Ratatouille.Runtime.start_link(
+          app: __MODULE__,
+          interval: @tick_interval,
+          quit_events: [{:ch, ?q}, {:key, 3}]
+        )
+
+      ref = Process.monitor(runtime)
+
+      receive do
+        {:DOWN, ^ref, :process, ^runtime, _reason} -> :ok
+      end
     end
 
     # --- Helpers --------------------------------------------------------


### PR DESCRIPTION
`Tau.TUI.App.run/0` was calling `Ratatouille.Runtime.run/2`, which doesn't exist in any Ratatouille 0.5.x — only `start_link/1` and `run/1` (the latter takes a `Ratatouille.Runtime.State` struct, not a module + opts).

The compiler had been warning about this on every build:

```
warning: Ratatouille.Runtime.run/2 is undefined or private. Did you mean:
      * run/1
```

— but the warning never failed CI, and the only code path that actually invoked `run/0` is the Burrito-binary TUI launch (#147), which the test suite didn't exercise. So the bug shipped: starting the prod binary with no args dispatches to `tui_cmd` → `Tau.TUI.start/0` → `Tau.TUI.App.run/0`, which raises `UndefinedFunctionError`. The Task swallowed the crash, `System.halt(0)` fired, and the binary appeared to exit "cleanly" with only the inotify warning visible.

Switched to `Ratatouille.Runtime.start_link/1` (the documented API) plus `Process.monitor` to block until the runtime exits.

## Test-coverage gap (called out separately)

This bug should have been caught by:
- A unit test that calls `Tau.TUI.App.run/0` against a mocked Ratatouille — or simply by `mix compile --warnings-as-errors` in CI.
- An integration smoke test that builds the prod release / Burrito binary and verifies it doesn't immediately exit on no-args invocation.

Filing as a separate follow-up — covering the gap is in scope for that issue, not this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
