### PR TITLE
chore: tighten mix lint alias (refs #149)

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -187,7 +187,12 @@ defmodule Tau.MixProject do
   defp aliases do
     [
       "test.property": ["test --only property"],
-      lint: ["format --check-formatted", "credo --strict", "dialyzer"],
+      lint: [
+        "compile --warnings-as-errors",
+        "format --check-formatted",
+        "credo --strict",
+        "dialyzer"
+      ],
       "tau.gen.schema": ["run priv/scripts/gen_settings_schema.exs"]
     ]
   end


### PR DESCRIPTION
Adds `compile --warnings-as-errors` to the `mix lint` alias so a developer running `mix lint` locally gets the same compile-strictness CI applies. The previous alias only ran format/credo/dialyzer; warnings-as-errors was CI-only.

CI already runs `mix compile --warnings-as-errors` directly. This change makes `mix lint` match that gate.

Refs #149.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
