### PR TITLE
test(tui): regression test for Ratatouille runtime API

### DIFF
--- a/test/tau/tui/app_test.exs
+++ b/test/tau/tui/app_test.exs
@@ -48,5 +48,66 @@ if Code.ensure_loaded?(Ratatouille.Runtime) do
         assert next.last_assistant == nil
       end
     end
+
+    describe "run/0 — Ratatouille runtime API contract" do
+      # Regression for the bug fixed in PR #148: `run/0` was calling
+      # `Ratatouille.Runtime.run/2`, which doesn't exist. The compile-time
+      # warning never failed the build (warnings-as-errors didn't trigger
+      # in the env that compiled this module pre-#147), so the bug shipped
+      # in the prod / Burrito binary and the TUI exited silently.
+      #
+      # This test invokes `run/0` in a child process and asserts the
+      # process does NOT die with `:undef`. TTY-required errors from
+      # ex_termbox (the binding it tries to load when no real terminal
+      # is present) are acceptable — they prove the API call landed; we
+      # just don't have a tty to render into.
+
+      test "invokes a real Ratatouille.Runtime function (not :undef)" do
+        # Belt: confirm the documented API exists at all.
+        assert function_exported?(Ratatouille.Runtime, :start_link, 1),
+               "Ratatouille.Runtime.start_link/1 not exported — pinned dep changed shape"
+
+        # Suspenders: actually call run/0 and confirm it doesn't raise UndefinedFunctionError.
+        parent = self()
+
+        pid =
+          spawn(fn ->
+            try do
+              Tau.TUI.App.run()
+              send(parent, {:exit_reason, :ok})
+            rescue
+              e -> send(parent, {:exit_reason, e})
+            catch
+              :exit, reason -> send(parent, {:exit_reason, {:exit, reason}})
+            end
+          end)
+
+        ref = Process.monitor(pid)
+
+        receive do
+          {:exit_reason, %UndefinedFunctionError{} = e} ->
+            flunk(
+              "Tau.TUI.App.run/0 called a non-existent function: " <>
+                Exception.message(e)
+            )
+
+          {:exit_reason, _other} ->
+            :ok
+
+          {:DOWN, ^ref, :process, ^pid, {:undef, _} = reason} ->
+            flunk("Tau.TUI.App.run/0 died with :undef — #{inspect(reason)}")
+
+          {:DOWN, ^ref, :process, ^pid, _other} ->
+            :ok
+        after
+          1_500 ->
+            # The runtime started successfully and is now blocking on terminal
+            # input. That's the success case for THIS test — kill it and
+            # finish.
+            Process.exit(pid, :kill)
+            :ok
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Adds a regression test for the bug fixed in #148. `Tau.TUI.App.run/0` was calling `Ratatouille.Runtime.run/2` (a function that doesn't exist in any Ratatouille 0.5.x). The compile-time warning never tripped warnings-as-errors, the prod-binary launch path had no tests, and the bug shipped silently.

The test invokes `run/0` in a child process and asserts the process does NOT die with `UndefinedFunctionError` / `:undef`. TTY-required errors from ex_termbox in a headless test environment are explicitly tolerated — the goal is to fail fast if the Ratatouille API contract is violated again, not to render a real TUI in CI.

Belt-and-suspenders: the test also asserts `function_exported?(Ratatouille.Runtime, :start_link, 1)` so a future Ratatouille major version that drops or renames that function fails the suite at known scope rather than at "user runs the binary."

Total suite is now `35 properties, 318 tests, 0 failures, 2 skipped`.

Refs #149.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
