### PR TITLE
fix(session,tui): D-009 + D-002 + D-004 — first-turn visibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,6 +170,14 @@ jobs:
         env:
           MIX_TEST_PROPERTY_BUDGET_FACTOR: "5"
 
+      - name: Run binary smoke gate (AC-5 / SPEC-USER-TURN)
+        # Builds the host-architecture Burrito binary and runs
+        # `tau run "ping" --provider replay --model replay`. Fails CI
+        # if the prod binary cannot complete a one-shot turn against
+        # the Replay provider — the floor for "the binary actually
+        # works." Per docs/spec/SPEC-USER-TURN.md AC-5.
+        run: mix test --only smoke --include smoke --trace
+
       - name: Upload coverage
         if: matrix.elixir == '1.18.1'
         uses: actions/upload-artifact@v4

--- a/lib/tau/session.ex
+++ b/lib/tau/session.ex
@@ -314,7 +314,14 @@ defmodule Tau.Session do
     end
   end
 
-  defp generate_id do
+  @doc """
+  Generate a fresh session id (UUIDv7 if available, prefixed random
+  bytes otherwise). Public so callers that need to subscribe to
+  `"session:<id>"` PubSub events BEFORE `start_session/1` returns can
+  pre-allocate the id and pass it via `:session_id` (D-004).
+  """
+  @spec generate_id() :: id()
+  def generate_id do
     case Code.ensure_loaded?(Uniq.UUID) do
       true -> apply(Uniq.UUID, :uuid7, [])
       _ -> "sess_" <> (:crypto.strong_rand_bytes(10) |> Base.url_encode64(padding: false))
@@ -360,7 +367,11 @@ defmodule Tau.Session do
     id = Keyword.fetch!(opts, :session_id)
     cwd = opts[:cwd] || File.cwd!()
     provider = opts[:provider] || Tau.Provider.default()
-    model = opts[:model]
+    # D-002 (SPEC-USER-TURN [C29]): resolve nil model to the provider's
+    # default at session init, NOT at stream-call time. Without this,
+    # `data.model` stays nil through telemetry, persistence header, and
+    # the assembler — all of which expect a real model id.
+    model = opts[:model] || provider.default_model()
     metadata = opts[:metadata] || %{}
     provider_ctx = opts[:provider_ctx] || %{}
     persistence = opts[:persistence] || Tau.Persistence.impl()
@@ -649,7 +660,20 @@ defmodule Tau.Session do
 
       {:error, reason} ->
         # Synchronous provider error — emit and return to awaiting_user.
-        msg = Assistant.new(stop_reason: :error, error_message: inspect(reason))
+        # D-009 (SPEC-USER-TURN [C12]/[C19]): the assistant message MUST
+        # carry a non-empty content block so render paths that iterate
+        # `msg.content` (e.g. `Tau.TUI.App.on_message_end/2`) surface the
+        # error to the user. Without the text block the TUI silently drops
+        # the error, presenting "TUI does nothing" to the user.
+        reason_str = inspect(reason)
+
+        msg =
+          Assistant.new(
+            stop_reason: :error,
+            error_message: reason_str,
+            content: [%{type: :text, text: "Error: " <> reason_str}]
+          )
+
         broadcast(data.id, %Events.MessageEnd{session_id: data.id, message: msg})
         {:next_state, :awaiting_user, %{data | cancel_flag: nil, stream_ref: nil}}
     end

--- a/lib/tau/tui/app.ex
+++ b/lib/tau/tui/app.ex
@@ -17,8 +17,14 @@ if Code.ensure_loaded?(Ratatouille.Runtime) do
 
     @impl true
     def init(_context) do
-      {:ok, session_id} = Tau.start_session([])
+      # D-004 (SPEC-USER-TURN [C6]): subscribe to PubSub BEFORE
+      # `Tau.start_session/1` returns. `Session.init/1` synchronously
+      # broadcasts `%Events.SessionStart{}` from inside FSM init; if we
+      # subscribe after start_session returns, that event is already
+      # gone. Pre-generate the id, subscribe, then start.
+      session_id = Tau.Session.generate_id()
       Phoenix.PubSub.subscribe(Tau.PubSub, "session:" <> session_id)
+      {:ok, ^session_id} = Tau.start_session(session_id: session_id)
 
       %{
         session_id: session_id,

--- a/test/tau/cli/binary_smoke_test.exs
+++ b/test/tau/cli/binary_smoke_test.exs
@@ -1,0 +1,103 @@
+defmodule Tau.CLI.BinarySmokeTest do
+  @moduledoc """
+  AC-5 (SPEC-USER-TURN): Burrito binary smoke gate.
+
+  Builds the host-architecture Burrito binary in `setup_all` and
+  invokes `tau run "ping" --provider replay --model replay`.
+  Asserts:
+    * Exit code 0.
+    * stdout contains a known token from `Tau.Providers.Replay.default_events/0`.
+    * stderr is silent of error markers.
+
+  This is the thinnest possible "the binary actually works" gate.
+  Tagged `:smoke` so it is opt-in for fast `mix test` runs but
+  REQUIRED in CI per `docs/spec/SPEC-USER-TURN.md` AC-5. Without this
+  test, every PR can be unit-correct and ship a non-functional
+  binary — see `project_state_2026_05_03_evening` memory.
+  """
+  use ExUnit.Case, async: false
+
+  @moduletag :smoke
+  @moduletag timeout: 180_000
+
+  setup_all do
+    target = host_burrito_target()
+    binary = Path.expand("burrito_out/tau_#{target}", File.cwd!())
+
+    {:ok, _} =
+      build_burrito(target)
+      |> case do
+        :ok -> {:ok, %{binary: binary, target: target}}
+        {:error, reason} -> {:error, reason}
+      end
+
+    # No on_exit cleanup: `tau maintenance uninstall` is interactive
+    # (prompts y/n) and System.cmd cannot supply stdin. The Burrito
+    # extraction cache is per-version under `~/.local/share/.burrito/`;
+    # leaving it between runs is harmless and keeps subsequent runs
+    # fast (skips ERTS re-extraction).
+
+    %{binary: binary, target: target}
+  end
+
+  test "tau run --provider replay produces canonical Replay output", %{binary: binary} do
+    {output, exit_code} =
+      System.cmd(binary, ["run", "ping", "--provider", "replay", "--model", "replay"],
+        stderr_to_stdout: false
+      )
+
+    assert exit_code == 0,
+           "binary exited #{exit_code}; output:\n#{output}"
+
+    assert output =~ "(replay) hello",
+           "expected Replay default fixture token in stdout; got:\n#{output}"
+
+    refute output =~ ~r/\(EXIT\)/,
+           "stdout contained an Erlang (EXIT) trace:\n#{output}"
+
+    refute output =~ ~r/:noproc/,
+           "stdout contained :noproc:\n#{output}"
+  end
+
+  defp host_burrito_target do
+    case {:os.type(), :erlang.system_info(:system_architecture) |> to_string()} do
+      {{:unix, :linux}, arch} ->
+        cond do
+          String.contains?(arch, "aarch64") -> "linux_arm64"
+          String.contains?(arch, "x86_64") -> "linux_amd64"
+          true -> raise "unsupported linux arch: #{arch}"
+        end
+
+      {{:unix, :darwin}, arch} ->
+        cond do
+          String.contains?(arch, "aarch64") -> "macos_arm64"
+          String.contains?(arch, "x86_64") -> "macos_amd64"
+          true -> raise "unsupported darwin arch: #{arch}"
+        end
+
+      other ->
+        raise "unsupported host: #{inspect(other)}"
+    end
+  end
+
+  defp build_burrito(target) do
+    env = [
+      {"MIX_ENV", "prod"},
+      {"BURRITO_TARGET", target},
+      {"HEX_HTTP_TIMEOUT", "120"}
+    ]
+
+    case System.cmd("mix", ["release", "tau", "--overwrite"],
+           env: env,
+           stderr_to_stdout: true,
+           parallelism: true,
+           into: ""
+         ) do
+      {_output, 0} ->
+        :ok
+
+      {output, code} ->
+        {:error, "mix release tau exited #{code}; output:\n#{output}"}
+    end
+  end
+end

--- a/test/tau/session/model_default_test.exs
+++ b/test/tau/session/model_default_test.exs
@@ -1,0 +1,54 @@
+defmodule Tau.Session.ModelDefaultTest do
+  @moduledoc """
+  D-002 (SPEC-USER-TURN [C29]): `Tau.start_session/1` MUST resolve a
+  non-nil model before reaching `:start_provider`. The resolution
+  happens at session init using `provider.default_model()`. Without
+  this, `data.model` stays nil through telemetry, persistence, and
+  the assembler — which is the silent stall behind the user-reported
+  "TUI does nothing" symptom (post AC-1 manual verification).
+  """
+  use ExUnit.Case, async: false
+
+  import Tau.Test.SessionHelper, only: [start_session_for_test: 1]
+
+  setup do
+    tmp = Path.join(System.tmp_dir!(), "tau-model-default-#{System.unique_integer([:positive])}")
+    File.mkdir_p!(tmp)
+    Application.put_env(:tau, :data_dir, tmp)
+
+    on_exit(fn ->
+      File.rm_rf!(tmp)
+      Application.delete_env(:tau, :data_dir)
+    end)
+
+    %{data_dir: tmp}
+  end
+
+  test "start_session with no model resolves to the provider's default" do
+    {:ok, sid} = start_session_for_test(provider: Tau.Providers.Replay)
+
+    {:ok, snap} = Tau.snapshot(sid)
+
+    assert snap.model == Tau.Providers.Replay.default_model(),
+           "Expected model resolved to provider default; got #{inspect(snap.model)}"
+
+    refute is_nil(snap.model), "data.model MUST NOT be nil"
+  end
+
+  test "start_session with explicit model preserves the explicit value" do
+    {:ok, sid} = start_session_for_test(provider: Tau.Providers.Replay, model: "custom-model")
+
+    {:ok, snap} = Tau.snapshot(sid)
+
+    assert snap.model == "custom-model"
+  end
+
+  test "start_session with no provider uses default provider's default model" do
+    {:ok, sid} = start_session_for_test([])
+
+    {:ok, snap} = Tau.snapshot(sid)
+
+    assert snap.model == snap.provider.default_model(),
+           "Expected default-provider's default_model; got #{inspect(snap.model)} for provider #{inspect(snap.provider)}"
+  end
+end

--- a/test/tau/session/session_id_pre_subscribe_test.exs
+++ b/test/tau/session/session_id_pre_subscribe_test.exs
@@ -1,0 +1,48 @@
+defmodule Tau.Session.SessionIdPreSubscribeTest do
+  @moduledoc """
+  D-004 (SPEC-USER-TURN [C6]): a subscriber that allocates a session
+  id, subscribes to `"session:<id>"`, and THEN calls
+  `Tau.start_session(session_id: id)` MUST receive the
+  `%Events.SessionStart{}` event. The TUI flow depends on this:
+  `Session.init/1` broadcasts SessionStart synchronously from inside
+  FSM init, so post-hoc subscription misses the event.
+  """
+  use ExUnit.Case, async: false
+
+  import Tau.Test.SessionHelper, only: [start_session_for_test: 1]
+  alias Tau.Session.Events, as: SE
+
+  setup do
+    tmp = Path.join(System.tmp_dir!(), "tau-presub-#{System.unique_integer([:positive])}")
+    File.mkdir_p!(tmp)
+    Application.put_env(:tau, :data_dir, tmp)
+
+    on_exit(fn ->
+      File.rm_rf!(tmp)
+      Application.delete_env(:tau, :data_dir)
+    end)
+
+    %{data_dir: tmp}
+  end
+
+  test "Tau.Session.generate_id/0 is exposed as a public function" do
+    assert function_exported?(Tau.Session, :generate_id, 0)
+    id = Tau.Session.generate_id()
+    assert is_binary(id)
+    assert byte_size(id) > 0
+  end
+
+  test "subscribe-before-start receives SessionStart" do
+    sid = Tau.Session.generate_id()
+    Phoenix.PubSub.subscribe(Tau.PubSub, "session:#{sid}")
+
+    {:ok, ^sid} =
+      start_session_for_test(
+        session_id: sid,
+        provider: Tau.Providers.Replay,
+        model: "replay"
+      )
+
+    assert_receive %SE.SessionStart{session_id: ^sid}, 1_000
+  end
+end

--- a/test/tau/session/sync_provider_error_test.exs
+++ b/test/tau/session/sync_provider_error_test.exs
@@ -1,0 +1,105 @@
+defmodule Tau.Session.SyncProviderErrorTest do
+  @moduledoc """
+  D-009 (SPEC-USER-TURN [C12]/[C19]): when a provider's `stream/3`
+  returns `{:error, reason}` synchronously, the FSM emits a
+  `MessageEnd` whose Assistant message has:
+
+    * `stop_reason: :error`
+    * `error_message: inspect(reason)`
+    * `content: [%{type: :text, text: "Error: " <> inspect(reason)}]`
+
+  The non-empty content block is the structural fix: render paths
+  that iterate `msg.content` (the TUI's `on_message_end/2`, the
+  CLI's `tau run` reducer) surface the error visibly. Without it,
+  the user sees nothing.
+  """
+  use ExUnit.Case, async: false
+
+  import Tau.Test.SessionHelper, only: [start_session_for_test: 1]
+  alias Tau.Session.Events, as: SE
+
+  defmodule SyncFailureProvider do
+    @moduledoc false
+    @behaviour Tau.Provider
+
+    @impl true
+    def stream(_messages, _opts, _ctx), do: {:error, :sync_fail}
+
+    @impl true
+    def capabilities,
+      do: %{
+        thinking: false,
+        tools: false,
+        vision: false,
+        prompt_caching: false,
+        parallel_tools: false
+      }
+
+    @impl true
+    def default_model, do: "sync-fail"
+  end
+
+  setup do
+    tmp = Path.join(System.tmp_dir!(), "tau-sync-err-#{System.unique_integer([:positive])}")
+    File.mkdir_p!(tmp)
+    Application.put_env(:tau, :data_dir, tmp)
+
+    on_exit(fn ->
+      File.rm_rf!(tmp)
+      Application.delete_env(:tau, :data_dir)
+    end)
+
+    %{data_dir: tmp}
+  end
+
+  test "synchronous provider error produces a non-empty content text block" do
+    sid = "sync-err-#{System.unique_integer([:positive])}"
+    Phoenix.PubSub.subscribe(Tau.PubSub, "session:#{sid}")
+
+    {:ok, ^sid} =
+      start_session_for_test(
+        session_id: sid,
+        provider: SyncFailureProvider,
+        model: "sync-fail"
+      )
+
+    Tau.send(sid, "trigger sync error")
+
+    assert_receive %SE.MessageEnd{message: msg}, 2_000
+
+    assert msg.stop_reason == :error,
+           "Assistant.stop_reason should be :error, got #{inspect(msg.stop_reason)}"
+
+    assert is_list(msg.content) and msg.content != [],
+           "Assistant.content MUST be non-empty so render paths surface the error " <>
+             "(D-009 / SPEC-USER-TURN [C12]/[C19]); got #{inspect(msg.content)}"
+
+    text_blocks = Enum.filter(msg.content, &match?(%{type: :text}, &1))
+
+    assert text_blocks != [], "Assistant.content MUST include at least one :text block"
+
+    assert Enum.any?(text_blocks, fn %{text: t} -> String.contains?(t, "Error") end),
+           "the :text block MUST surface the error keyword for human visibility"
+
+    assert msg.error_message != nil and msg.error_message != "",
+           "error_message remains populated for diagnostic consumers"
+  end
+
+  test "the FSM returns to :awaiting_user after a sync error (does not hang)" do
+    sid = "sync-err-state-#{System.unique_integer([:positive])}"
+
+    {:ok, ^sid} =
+      start_session_for_test(
+        session_id: sid,
+        provider: SyncFailureProvider,
+        model: "sync-fail"
+      )
+
+    Tau.send(sid, "trigger sync error")
+    # Allow the cast to be processed.
+    Process.sleep(200)
+
+    {:ok, snap} = Tau.snapshot(sid)
+    assert snap.state == :awaiting_user
+  end
+end

--- a/test/tau/tui/app_test.exs
+++ b/test/tau/tui/app_test.exs
@@ -49,6 +49,84 @@ if Code.ensure_loaded?(Ratatouille.Runtime) do
       end
     end
 
+    describe "update/2 — MessageEnd render path (D-009 / SPEC-USER-TURN AC-3)" do
+      # These tests close the loop on D-009: the FSM-side test
+      # (test/tau/session/sync_provider_error_test.exs) proves the
+      # broadcast carries non-empty content; THIS suite proves the TUI's
+      # update/2 produces a visible transcript line from that content.
+      # Without these, D-009 is a half-fix.
+
+      test "synchronous-error MessageEnd produces a visible transcript line" do
+        # Mirrors the shape constructed at lib/tau/session.ex :start_provider
+        # error branch (D-009).
+        msg = %Tau.Message.Assistant{
+          content: [%{type: :text, text: "Error: :sync_fail"}],
+          timestamp: DateTime.utc_now(),
+          stop_reason: :error,
+          error_message: ":sync_fail"
+        }
+
+        event = %Events.MessageEnd{session_id: "sess-test", message: msg}
+
+        next = App.update(model(), event)
+
+        assert next.status == :idle
+        assert next.last_assistant == nil
+
+        last_line = List.last(next.transcript)
+        assert is_binary(last_line) and last_line != "",
+               "transcript MUST gain a non-empty line; got #{inspect(last_line)}"
+
+        assert String.contains?(last_line, "Error"),
+               "transcript line MUST surface the error keyword for AC-3; got #{inspect(last_line)}"
+      end
+
+      test "Replay-style success MessageEnd produces an assistant transcript line" do
+        # Mirrors the canonical Replay default fixture
+        # (lib/tau/providers/replay.ex default_events/0).
+        msg = %Tau.Message.Assistant{
+          content: [%{type: :text, text: "(replay) hello"}],
+          timestamp: DateTime.utc_now(),
+          stop_reason: :stop
+        }
+
+        event = %Events.MessageEnd{session_id: "sess-test", message: msg}
+
+        next = App.update(model(), event)
+
+        assert next.status == :idle
+
+        assert "[assistant] (replay) hello" in next.transcript,
+               "transcript MUST contain the assistant line for AC-2 render path; " <>
+                 "got #{inspect(next.transcript)}"
+      end
+
+      test "empty-content MessageEnd produces no transcript line — regression guard" do
+        # Pre-D-009 shape: the synchronous-error branch produced an
+        # empty content list. Locks in: if anyone reverts D-009, the
+        # transcript silently drops the user's turn — and this test
+        # turns that silent failure into a loud one.
+        msg = %Tau.Message.Assistant{
+          content: [],
+          timestamp: DateTime.utc_now(),
+          stop_reason: :error,
+          error_message: "this would be invisible without D-009"
+        }
+
+        event = %Events.MessageEnd{session_id: "sess-test", message: msg}
+
+        next = App.update(model(), event)
+
+        # The render iterates content and reduces to []; transcript is
+        # unchanged. THIS is the silent failure D-009 prevents — kept
+        # here as a regression guard, not a desired behaviour.
+        assert next.transcript == [],
+               "(D-009 regression guard) empty content currently produces NO transcript line; " <>
+                 "if this assertion fails, the render path was changed — verify the new path " <>
+                 "still surfaces errors and update D-009's invariant accordingly"
+      end
+    end
+
     describe "run/0 — supervised Ratatouille subtree" do
       test "emits [:tau, :tui, :start] with Ratatouille.Runtime.Supervisor metadata" do
         parent = self()


### PR DESCRIPTION
## Summary

Four SPEC-USER-TURN items that together unblock AC-1 (first-run smoke), AC-2 (single-turn round-trip), AC-3 (provider error visibility), and add AC-5 (CI binary smoke gate).

**Stacks on PR #154** (the supervised-Ratatouille fix). Targets PR #154's branch initially; rebase onto main once #154 lands.

### What's here

**D-009 — synchronous provider error produces non-empty content** [SPEC-USER-TURN [C12]/[C19]]
- `lib/tau/session.ex` `:start_provider` `{:error, reason}` branch now constructs the Assistant message with `content: [%{type: :text, text: "Error: " <> inspect(reason)}]` alongside the existing `error_message` field.
- Before: render paths iterated `msg.content` (empty list) → silent failure → user-reported "TUI does nothing."
- After: TUI's `on_message_end` and CLI `tau run` reducer surface the error.
- Test: `test/tau/session/sync_provider_error_test.exs`.

**D-002 — model resolution at session init** [SPEC-USER-TURN [C29]]
- `lib/tau/session.ex` `init/1` resolves nil model to `provider.default_model()` so `data.model` is non-nil through telemetry, persistence header, and assembler.
- `Tau.Providers.Anthropic` was silently substituting at stream-call time; downstream consumers (telemetry, persistence) saw nil.
- Test: `test/tau/session/model_default_test.exs` (3 cases: provider default, explicit override, default-provider default).

**D-004 — TUI subscribes BEFORE start_session returns** [SPEC-USER-TURN [C6]]
- `Tau.Session.generate_id/0` is now public so callers can pre-allocate.
- `Tau.TUI.App.init/1` now: (1) generates id, (2) subscribes to `"session:<id>"`, (3) starts session with that id.
- Before: `Session.init/1` broadcasts `SessionStart` synchronously inside FSM init; TUI subscribed after `start_session` returned and missed the event.
- Test: `test/tau/session/session_id_pre_subscribe_test.exs`.

**AC-5 — Burrito binary smoke gate** [SPEC-USER-TURN AC-5]
- `test/tau/cli/binary_smoke_test.exs` (tagged `:smoke`): builds the host-arch Burrito binary in `setup_all`, invokes `tau run "ping" --provider replay --model replay`, asserts exit 0 + canonical Replay output + no error markers.
- `.github/workflows/ci.yml` extended with a "Run binary smoke gate" step after the property suite.
- Closes the gap that allowed PR #147 → #154 to ship a non-functional binary: a regression that breaks the binary entry-point now fails CI with a diagnostic reason.
- Test runs ~20s on warm cache, ~60s cold. Tagged `:smoke`, excluded from default `mix test` so unit-test cycles stay fast.

**Incidental** — `mix.exs`: `mix format` reformatted long lines in `target_atoms_to_keyword/1`. No functional change.

### End-to-end verification

Driving the Replay provider through the prod release post-fix:

```
post_start: {:awaiting_user, "replay"}                                # D-002
got_session_start_for: "019df01e-e149-77be-b60a-50d167c95822"         # D-004
got_message_end: {:stop, [text: "(replay) hello"]}                    # D-009 path
```

Pty smoke against the Burrito binary continues to enter Ratatouille's render loop (alternate-screen ANSI emitted; renderer on stack). No EventManager error.

Smoke test (AC-5):
```
$ mix test test/tau/cli/binary_smoke_test.exs --include smoke
Including tags: [:smoke]
.
Finished in 20.8 seconds
1 test, 0 failures
```

### Test plan

- [x] `mix test`: 35 properties, 331 tests, 0 failures.
- [x] `mix test --include smoke`: smoke gate green.
- [x] `mix format --check-formatted` clean.
- [x] `mix compile --warnings-as-errors` clean.
- [x] Prod release builds; Burrito binary builds.
- [x] `bin/tau eval` end-to-end Replay turn completes.
- [x] Pty smoke shows TUI render alternate-screen sequence.
- [x] CI workflow updated; smoke step added.
- [ ] **Human-in-the-loop on aarch64 with `ANTHROPIC_API_KEY`:** open a real terminal, run `./burrito_out/tau_linux_arm64`, type "say hello", confirm a response renders. (AC-2 manual gate.)
- [ ] **Human-in-the-loop without API key:** confirm the transcript shows an "Error" line within 5 seconds of submitting. (AC-3 manual gate.)

### Spec alignment

Per `.claude/rules/spec-before-code.md`: this PR advances **D-002**, **D-004**, **D-009**, and adds **AC-5** as a CI gate. Contributes to **AC-1**, **AC-2**, **AC-3**. No new constraints surfaced during implementation; no SPEC amendment required.

### Refs

- SPEC: `docs/spec/SPEC-USER-TURN.md` (PR #156).
- Closes #153 jointly with PR #154.
- Refs #149, #155.

🤖 Generated with [Claude Code](https://claude.com/claude-code)