### PR TITLE
feat(session): tool-iteration cap (AC-6, D-027, [C24])

### DIFF
--- a/docs/MISSION.md
+++ b/docs/MISSION.md
@@ -24,7 +24,7 @@ blocker is not the priority.
 `docs/spec/SPEC-USER-TURN.md` defines:
 
 - 43 boundary constraints (`[Cn-Bm]`, 24 marked non-obvious).
-- 19 runtime invariants (`D-001`–`D-019`) with detection methods.
+- 20 runtime invariants (`D-001`–`D-019` plus `D-027`; `D-005` superseded by `D-027`) with detection methods.
 - 7 acceptance criteria (`AC-1`–`AC-7`).
 - A source map (Appendix B) tying constraints to file:line.
 

--- a/docs/MISSION.md
+++ b/docs/MISSION.md
@@ -23,7 +23,7 @@ blocker is not the priority.
 
 `docs/spec/SPEC-USER-TURN.md` defines:
 
-- 42 boundary constraints (`[Cn-Bm]`, 23 marked non-obvious).
+- 43 boundary constraints (`[Cn-Bm]`, 24 marked non-obvious).
 - 19 runtime invariants (`D-001`–`D-019`) with detection methods.
 - 7 acceptance criteria (`AC-1`–`AC-7`).
 - A source map (Appendix B) tying constraints to file:line.
@@ -85,8 +85,11 @@ elsewhere.
 The runtime-invariant namespace is defined in `SPEC-USER-TURN.md` §6:
 
 ```
-D-001 … D-019  taken
-D-020 +        free
+D-001 … D-019  taken (SPEC-USER-TURN.md)
+D-020 … D-025  taken (SPEC-TUI-HEADLESS.md)
+D-026           free
+D-027           taken (SPEC-USER-TURN.md — tool-iteration cap, AC-6)
+D-028 +        free
 ```
 
 References to D-NNN appear across `lib/tau/`, `test/tau/`, commit messages,

--- a/docs/spec/SPEC-USER-TURN.md
+++ b/docs/spec/SPEC-USER-TURN.md
@@ -250,7 +250,12 @@ POST
   - On is_error: true, content is a printable error string (NOT a raw struct).
     (Closes [C16].)
 INV (iteration cap)
-  - A single user-turn MUST NOT exceed N tool-call iterations
+  - A single user-turn MUST complete at most N tool-call iterations
+    before either (a) the model emits stop_reason: :end_turn (clean
+    exit) or (b) the FSM aborts with stop_reason: :tool_loop_aborted
+    (cap reached). "At most N" means N dispatches may complete; the
+    (N+1)th attempt triggers the abort path. The check is
+    `data.tool_iterations >= cap` evaluated before each dispatch.
     (default N=20, configurable via Tau.Settings or per-session opt).
     Cap precedence: opts[:max_tool_iterations] > Settings.Cache
     [:session, :max_tool_iterations] > default 20. Cap snapshotted at
@@ -340,7 +345,7 @@ Each entry: id, statement, severity, detection_method, source_constraint.
 | D-002 | `Tau.start_session/1` MUST resolve a non-nil model before reaching `:start_provider` | high | property test: start_session([]) ; assert data.model != nil | [C29] |
 | D-003 | `Ratatouille.run` quit_events MUST NOT include bare `{:ch, ?q}` — quit must be context-aware | medium | source-level: refute regex match; manual-test gate | [C7] |
 | D-004 | TUI MUST `Phoenix.PubSub.subscribe/2` BEFORE `Tau.start_session/1` returns | high | property test: capture SessionStart event from TUI side | [C6] |
-| D-005 | Session FSM MUST cap tool-call iterations per turn (default 20) | high | property test: replay model that loops on tool; assert turn ends within N | [C24] |
+| D-005 | _Superseded by D-027 (same invariant, fully specified there). Retained as placeholder; references to D-005 in code comments and commit history point here._ | — | _see D-027_ | [C24] |
 | D-006 | When `Tau.send/2` returns non-:ok, TUI MUST surface to user | medium | review criterion + property test on submit/1 | [C15] |
 | D-007 | `Settings.Cache` values consumed in a turn are snapshotted at `:start_provider` | medium | property test: mutate settings during a Replay turn; assert in-flight uses old | [C5] |
 | D-008 | Watcher degraded mode emits `[:tau, :settings, :watcher_degraded]` telemetry | low | unit test: start watcher without inotify; assert telemetry | [C8] |

--- a/docs/spec/SPEC-USER-TURN.md
+++ b/docs/spec/SPEC-USER-TURN.md
@@ -100,6 +100,7 @@ Each question lists raw constraints. Format: `[Cn-Bm]` = constraint number + bou
 - **★ [C24-B6]** Tool-call iteration in a single turn is **unbounded**. `Tau.Session` (lib/tau/session.ex:1056-1066) loops while `tool_calls != []`. A model that always emits a tool call (e.g., a buggy persona that loops on `Bash`) consumes API calls and tokens without limit. No `max_tool_iterations` guard visible in the FSM.
 - **[C25-B5]** Rate limiter on 429: halves both buckets and arms a fixed 60-second floor (lib/tau/providers/rate_limiter.ex:50, 198). NOT exponential, no max-retry. Per-call bound is `acquire/3` timeout (default 30s) → FSM falls back to `:awaiting_user` with a rate_limit_timeout error. Persistent 429 produces continuous 60s holds; user sees repeated "rate_limit_timeout" errors with no escalation. Acceptable for v1, but [C25] flag remains for a future "max consecutive 429s" guard.
 - **★ [C26-B5]** Compactor failure: `compactor.compact(...)` returns `{:error, _}` and the FSM silently drops it (`{:error, _} -> data`, lib/tau/session.ex:1094). No telemetry, no log. `should_compact?` refires next turn → silent loop on a persistent failure. Confirmed via OQ-4 reading.
+- **★ [C50-B6]** Tool-call iteration cap value is read from `opts[:max_tool_iterations]` at session init, falling back to `get_in(Settings.Cache.get(), [:session, :max_tool_iterations])`, then defaulting to 20. The cap is snapshotted at session start, not re-read each turn (D-007 consistency). A new session inherits any settings change, but in-flight sessions use their init-time cap. This is the correct behaviour for D-007 compliance; naming it as a constraint so future callers know the precedence order.
 - **[C27-B5]** Fallback chain is bounded by chain length (ADR-0012). OK.
 - **[C28-B4]** Session resume replays JSONL. Fork chains (ADR-0007) reference parent events; cycle in fork chain would diverge replay. Verify acyclic invariant.
 
@@ -130,7 +131,7 @@ Each question lists raw constraints. Format: `[Cn-Bm]` = constraint number + bou
 
 ### L0 yield
 
-**42 raw constraints**, of which **23 are non-obvious (★)**. Threshold (5–12) exceeded — appropriate for a 5/5 triage component.
+**43 raw constraints**, of which **24 are non-obvious (★)**. Threshold (5–12) exceeded — appropriate for a 5/5 triage component.
 
 ## 4. Boundary contracts (from L0)
 
@@ -250,10 +251,17 @@ POST
     (Closes [C16].)
 INV (iteration cap)
   - A single user-turn MUST NOT exceed N tool-call iterations
-    (default N=20, configurable via Tau.Settings). On overflow: emit
-    [:tau, :session, :tool_iteration_cap] telemetry, finalize an Assistant
-    message with stop_reason: :tool_loop_aborted, return to :awaiting_user.
-    (Closes [C24].)
+    (default N=20, configurable via Tau.Settings or per-session opt).
+    Cap precedence: opts[:max_tool_iterations] > Settings.Cache
+    [:session, :max_tool_iterations] > default 20. Cap snapshotted at
+    session init (D-007 compliance — mid-session settings reloads do
+    NOT change the cap for in-flight sessions). ([C50])
+    On overflow: emit [:tau, :session, :tool_iteration_cap] telemetry
+    with measurements %{iterations: N, cap: K} (N = completed dispatches
+    in the aborted turn, equals K at abort boundary) and metadata
+    %{session_id: id}, append and persist an Assistant message with
+    stop_reason: :tool_loop_aborted, broadcast MessageEnd, return to
+    :awaiting_user. (Closes [C24], implements D-027 / AC-6.)
 INV (permissions :ask in headless)
   - When permissions evaluator returns :ask and no UI subscriber answered
     within timeout: treat as :deny, emit telemetry. The current FSM behavior
@@ -347,8 +355,9 @@ Each entry: id, statement, severity, detection_method, source_constraint.
 | D-017 | `Tau.Providers.Anthropic` MUST support both API-key auth (`x-api-key` header) AND Claude Code OAuth auth (`Authorization: Bearer <token>` + `anthropic-beta: oauth-2025-04-20` header). OAuth credentials sourced from `~/.claude/.credentials.json` (top-level key `claudeAiOauth.accessToken`). Auth precedence (first non-nil wins): explicit `:api_key` opt → `Application.get_env` API key → `ANTHROPIC_API_KEY` env (vault) → Claude Code OAuth file. | high | unit test: stub each source; assert correct header shape; integration test with a Bypass server checking both code paths | [C46], [C47] |
 | D-018 | Expired OAuth token (`expiresAt < now`) MUST surface a clear, actionable error to the user — "Your Claude Code OAuth token expired; run `claude /login` to renew" — NOT a generic 401 or silent failure. Tau v1 does NOT refresh tokens itself (avoids the race with Claude Code's own refresh). | medium | unit test: stub credentials with past `expiresAt`; assert error message contains "expired" and the renewal command | [C48] |
 | D-019 | `tau doctor` MUST report which auth path is configured (api_key vs oauth vs none) and, for OAuth, the `subscriptionType` and time-to-expiry. | low | unit test on doctor output | [C46] (debuggability) |
+| D-027 | Session FSM MUST cap tool-call iterations per turn at `max_tool_iterations` (default 20, readable from `opts[:max_tool_iterations]` or `Settings.Cache.get()[:session][:max_tool_iterations]`). When the cap is exceeded, the FSM MUST emit `[:tau, :session, :tool_iteration_cap]` telemetry with measurements `%{iterations: N, cap: K}` — where `N` is the count of completed dispatches in the aborted turn (equals `K` at the abort boundary; resets to 0 at the start of the next turn) — and metadata `%{session_id: id}`, then abort the turn with `stop_reason: :tool_loop_aborted`. The per-turn counter resets to 0 on every return to `:awaiting_user`. | high | property test `test/tau/session/tool_iteration_cap_property_test.exs`: drives a session backed by bespoke `AlwaysToolCallProvider` (a `Tau.Provider` behaviour implementation that always emits a `tool_call` event stream, independent of Replay); asserts turn terminates within `max_tool_iterations` with `stop_reason: :tool_loop_aborted` and that the telemetry event fires with `iterations == cap` | [C24], [C50] |
 
-19 D-xxx entries. Each is enforceable. None require speculation.
+20 D-xxx entries. Each is enforceable. None require speculation.
 
 ## 7. Acceptance criteria — "working TUI"
 
@@ -386,7 +395,7 @@ These are the bar for closing the umbrella issue (#153/#149) and unblocking the 
 - This test runs in CI on every PR and is a blocking gate.
 
 ### AC-6: Tool-iteration safety
-- A property test runs a Replay session whose canned response always emits a tool_call. The session terminates within `max_tool_iterations` (default 20) with `stop_reason: :tool_loop_aborted`.
+- A property test runs a session backed by a bespoke `AlwaysToolCallProvider` (a `Tau.Provider` behaviour implementation that always emits a `tool_call` event stream). The session terminates within `max_tool_iterations` (default 20) with `stop_reason: :tool_loop_aborted`.
 
 ### AC-7: Resume sanity
 - After AC-2, `tau sessions list` shows the session. `tau sessions show <id>` prints the JSONL events. `tau resume <id>` opens a TUI for the resumed session whose transcript pane includes the prior turn.
@@ -456,5 +465,7 @@ For each constraint, the file:line where it lives in the current codebase:
 | C35 | `lib/tau/tui/app.ex:228-237` (on_session_end no unsubscribe) |
 | L1-C43 | `lib/tau/session.ex` :stopped transition |
 | L1-C45 | `lib/tau/tui/app.ex:18-21` (no monitor on FSM pid) |
+
+| C50 | `lib/tau/session.ex` init/1 — `max_tool_iterations` resolution (opts → Settings.Cache → 20) |
 
 Other constraints map to sites named in their text.

--- a/lib/tau/cli.ex
+++ b/lib/tau/cli.ex
@@ -312,7 +312,9 @@ defmodule Tau.CLI do
         )
 
       {:error, _} = err ->
-        IO.puts("provider Tau.Providers.Anthropic: " <> Tau.Providers.Anthropic.Auth.describe_error(err))
+        IO.puts(
+          "provider Tau.Providers.Anthropic: " <> Tau.Providers.Anthropic.Auth.describe_error(err)
+        )
     end
 
     0

--- a/lib/tau/message.ex
+++ b/lib/tau/message.ex
@@ -43,7 +43,7 @@ defmodule Tau.Message.Assistant do
   ]
 
   @type stop_reason ::
-          :stop | :length | :tool_use | :error | :aborted | :stop_sequence
+          :stop | :length | :tool_use | :error | :aborted | :stop_sequence | :tool_loop_aborted
 
   @type t :: %__MODULE__{
           content: [map()],

--- a/lib/tau/providers/anthropic/auth.ex
+++ b/lib/tau/providers/anthropic/auth.ex
@@ -45,17 +45,18 @@ defmodule Tau.Providers.Anthropic.Auth do
   @required_scope "user:inference"
 
   @type api_key :: {:api_key, String.t()}
-  @type oauth :: {:oauth, %{
-          access_token: String.t(),
-          expires_at: integer(),
-          scopes: [String.t()],
-          subscription_type: String.t()
-        }}
+  @type oauth ::
+          {:oauth,
+           %{
+             access_token: String.t(),
+             expires_at: integer(),
+             scopes: [String.t()],
+             subscription_type: String.t()
+           }}
 
   @type ok :: {:ok, api_key() | oauth()}
   @type error ::
-          {:error,
-           :no_auth | :oauth_expired | :oauth_missing_scope | :oauth_malformed}
+          {:error, :no_auth | :oauth_expired | :oauth_missing_scope | :oauth_malformed}
 
   @doc """
   Resolve auth from opts, app env, vault, then Claude Code OAuth file.
@@ -113,11 +114,13 @@ defmodule Tau.Providers.Anthropic.Auth do
   defp fetch_oauth_block(%{"claudeAiOauth" => block}) when is_map(block), do: {:ok, block}
   defp fetch_oauth_block(_), do: {:error, :oauth_malformed}
 
-  defp parse_oauth_block(%{
-         "accessToken" => access_token,
-         "expiresAt" => expires_at,
-         "scopes" => scopes
-       } = block)
+  defp parse_oauth_block(
+         %{
+           "accessToken" => access_token,
+           "expiresAt" => expires_at,
+           "scopes" => scopes
+         } = block
+       )
        when is_binary(access_token) and is_integer(expires_at) and is_list(scopes) do
     {:ok,
      %{

--- a/lib/tau/session.ex
+++ b/lib/tau/session.ex
@@ -28,6 +28,7 @@ defmodule Tau.Session do
   alias Tau.Message.{Assembler, Assistant, ToolResult, User}
   alias Tau.Session.Events
   alias Tau.Provider.Event, as: PEvent
+  alias Tau.Settings.Cache, as: SettingsCache
 
   # #17: name of the synthetic FSM-internal tool the model emits to
   # activate a discovered skill. Not registered as a `Tau.Tool` module
@@ -273,7 +274,9 @@ defmodule Tau.Session do
           metadata: map(),
           permissions_mode: atom(),
           tools_whitelist: [String.t()] | :all,
-          child_session_ids: MapSet.t(String.t())
+          child_session_ids: MapSet.t(String.t()),
+          tool_iterations: non_neg_integer(),
+          max_tool_iterations: pos_integer()
         }
 
   @doc """
@@ -302,7 +305,9 @@ defmodule Tau.Session do
          metadata: data.metadata,
          permissions_mode: Map.get(data.metadata, :permissions_mode, :default),
          tools_whitelist: data.tools_whitelist,
-         child_session_ids: data.child_session_ids
+         child_session_ids: data.child_session_ids,
+         tool_iterations: Map.get(data, :tool_iterations, 0),
+         max_tool_iterations: Map.get(data, :max_tool_iterations, 20)
        }}
     end
   end
@@ -497,7 +502,18 @@ defmodule Tau.Session do
           # above. Supervisor is `:one_for_one`; a parent crash does *not*
           # propagate to children — that's the whole point of explicit
           # cascade on the user-driven shutdown paths.
-          child_session_ids: MapSet.new()
+          child_session_ids: MapSet.new(),
+          # D-005 / AC-6 (SPEC-USER-TURN [C24]): tool-call iteration cap.
+          # Counts tool-dispatch rounds within a single user turn; reset to
+          # 0 when the FSM returns to :awaiting_user (clean end_turn OR
+          # tool_loop_aborted). Capped at max_tool_iterations; overflow
+          # emits [:tau, :session, :tool_iteration_cap] telemetry and aborts
+          # the turn with stop_reason: :tool_loop_aborted.
+          tool_iterations: 0,
+          max_tool_iterations:
+            opts[:max_tool_iterations] ||
+              get_in(SettingsCache.get(), [:session, :max_tool_iterations]) ||
+              20
         }
 
         {:ok, :awaiting_user, data}
@@ -884,7 +900,10 @@ defmodule Tau.Session do
          command_task: nil,
          # ADR-0013 (#16): cancel ends the current turn — drop any
          # active skill alongside it.
-         active_skill: nil
+         active_skill: nil,
+         # D-027: reset per-turn tool-iteration counter on every
+         # return to :awaiting_user, including cancellation.
+         tool_iterations: 0
      }}
   end
 
@@ -1088,11 +1107,65 @@ defmodule Tau.Session do
         # ADR-0017: drop the now-stale cancel flag — the stream that
         # owned it has finished. The next turn's :start_provider
         # allocates a fresh one. Same applies to ADR-0012's stream_ref.
+        # D-005: reset the per-turn tool-iteration counter on clean
+        # return to :awaiting_user.
         {:next_state, :awaiting_user,
-         %{data | provider_task: nil, assembler: nil, cancel_flag: nil, stream_ref: nil}}
+         %{
+           data
+           | provider_task: nil,
+             assembler: nil,
+             cancel_flag: nil,
+             stream_ref: nil,
+             tool_iterations: 0
+         }}
 
       true ->
-        dispatch_tools(tool_calls, data)
+        # D-005 / AC-6 (SPEC-USER-TURN [C24]): enforce the per-turn
+        # tool-call iteration cap before dispatching the next round.
+        # Check against the already-dispatched count so that cap=N allows
+        # exactly N dispatches (tool_iterations counts rounds dispatched).
+        cap = data.max_tool_iterations
+
+        if data.tool_iterations >= cap do
+          aborted_iter = data.tool_iterations
+
+          :telemetry.execute(
+            [:tau, :session, :tool_iteration_cap],
+            %{iterations: aborted_iter, cap: cap},
+            %{session_id: data.id}
+          )
+
+          abort_msg =
+            Assistant.new(
+              stop_reason: :tool_loop_aborted,
+              content: [
+                %{
+                  type: :text,
+                  text:
+                    "Tool-call iteration cap (#{cap}) exceeded. Turn aborted to prevent runaway loops."
+                }
+              ]
+            )
+
+          data =
+            data
+            |> append_message(abort_msg)
+            |> persist_event("assistant_message", message_to_data(abort_msg))
+
+          broadcast(data.id, %Events.MessageEnd{session_id: data.id, message: abort_msg})
+
+          {:next_state, :awaiting_user,
+           %{
+             data
+             | provider_task: nil,
+               assembler: nil,
+               cancel_flag: nil,
+               stream_ref: nil,
+               tool_iterations: 0
+           }}
+        else
+          dispatch_tools(tool_calls, %{data | tool_iterations: data.tool_iterations + 1})
+        end
     end
   end
 

--- a/lib/tau/tui/app.ex
+++ b/lib/tau/tui/app.ex
@@ -293,15 +293,20 @@ if Code.ensure_loaded?(Ratatouille.Runtime) do
       transcript_lines =
         for block <- msg.content do
           case block do
-            %{type: :text, text: t} -> "[assistant] " <> t
+            %{type: :text, text: t} ->
+              "[assistant] " <> t
+
             # Thinking models (Qwen3, DeepSeek-R1) emit chain-of-thought
             # via Thinking* events. Surface them so a long think doesn't
             # look like the TUI is hung.
             %{type: :thinking, text: t} when is_binary(t) and t != "" ->
               "[thinking] " <> t
 
-            %{type: :tool_call, name: n} -> "[tool_call] " <> n <> "(...)"
-            _ -> nil
+            %{type: :tool_call, name: n} ->
+              "[tool_call] " <> n <> "(...)"
+
+            _ ->
+              nil
           end
         end
         |> Enum.reject(&is_nil/1)

--- a/test/support/tui_pty_helper.ex
+++ b/test/support/tui_pty_helper.ex
@@ -72,8 +72,12 @@ defmodule Tau.Test.TuiPtyHelper do
           sess = %{tmux_name: name, binary: binary, opts: opts}
 
           case wait_for_ready(sess, Keyword.get(opts, :ready_timeout_ms, @ready_default)) do
-            :ok -> {:ok, sess}
-            err -> _ = quit(sess); err
+            :ok ->
+              {:ok, sess}
+
+            err ->
+              _ = quit(sess)
+              err
           end
 
         {out, code} ->

--- a/test/tau/providers/anthropic/auth_headers_test.exs
+++ b/test/tau/providers/anthropic/auth_headers_test.exs
@@ -97,6 +97,7 @@ defmodule Tau.Providers.Anthropic.AuthHeadersTest do
 
         beta = headers["anthropic-beta"]
         assert is_binary(beta)
+
         assert beta =~ "oauth-2025-04-20",
                "Anthropic Messages API requires the oauth-2025-04-20 beta header for OAuth tokens; got #{inspect(beta)}"
 

--- a/test/tau/providers/anthropic/auth_test.exs
+++ b/test/tau/providers/anthropic/auth_test.exs
@@ -23,17 +23,18 @@ defmodule Tau.Providers.Anthropic.AuthTest do
 
   defp write_oauth(path, overrides) do
     base = %{
-      "claudeAiOauth" => Map.merge(
-        %{
-          "accessToken" => "sk-ant-oat01-test-token",
-          "refreshToken" => "sk-ant-ort01-test-refresh",
-          "expiresAt" => :os.system_time(:millisecond) + @future_ms_offset,
-          "scopes" => ["user:inference", "user:profile"],
-          "subscriptionType" => "max",
-          "rateLimitTier" => "default"
-        },
-        overrides
-      )
+      "claudeAiOauth" =>
+        Map.merge(
+          %{
+            "accessToken" => "sk-ant-oat01-test-token",
+            "refreshToken" => "sk-ant-ort01-test-refresh",
+            "expiresAt" => :os.system_time(:millisecond) + @future_ms_offset,
+            "scopes" => ["user:inference", "user:profile"],
+            "subscriptionType" => "max",
+            "rateLimitTier" => "default"
+          },
+          overrides
+        )
     }
 
     File.write!(path, Jason.encode!(base))

--- a/test/tau/session/tool_iteration_cap_property_test.exs
+++ b/test/tau/session/tool_iteration_cap_property_test.exs
@@ -1,0 +1,180 @@
+defmodule Tau.Session.ToolIterationCapPropertyTest do
+  @moduledoc """
+  Property suite for D-005 / AC-6 (SPEC-USER-TURN [C24]).
+
+  Invariant: a session whose provider always emits a tool_call MUST
+  terminate the current turn within `max_tool_iterations` with
+  `stop_reason: :tool_loop_aborted`, regardless of the configured cap
+  value (N = 1..10 for test speed).
+
+  Also asserts that `[:tau, :session, :tool_iteration_cap]` telemetry
+  is emitted exactly once per aborted turn with the correct measurements.
+  """
+  use ExUnit.Case, async: false
+  use ExUnitProperties
+
+  @moduletag :property
+
+  import Tau.Test.SessionHelper, only: [start_session_for_test: 1]
+  alias Tau.Session.Events, as: SE
+
+  # Provider that ALWAYS emits a single tool_call regardless of how
+  # many tool_results have already accumulated in the message list.
+  # This simulates a buggy or looping model.
+  defmodule AlwaysToolCallProvider do
+    @moduledoc false
+    @behaviour Tau.Provider
+
+    alias Tau.Message.ToolResult
+    alias Tau.Provider.Event.{Done, Start, ToolCallEnd, ToolCallStart}
+
+    @impl true
+    def stream(messages, _opts, ctx) do
+      # Use a unique call_id derived from message count so each call
+      # has a distinct id (required by Assembler dedup logic).
+      call_n = Enum.count(messages, &match?(%ToolResult{}, &1))
+      call_id = "loop-call-#{call_n}"
+      tool_name = Map.get(ctx, :tool_name, "loop_tool")
+
+      events = [
+        %Start{request_id: "r-#{call_n}", model: "loopy"},
+        %ToolCallStart{tool_call_id: call_id, name: tool_name},
+        %ToolCallEnd{tool_call_id: call_id, params: %{}},
+        %Done{stop_reason: :tool_use, usage: %{}}
+      ]
+
+      {:ok, events}
+    end
+
+    @impl true
+    def capabilities,
+      do: %{
+        thinking: false,
+        tools: true,
+        vision: false,
+        prompt_caching: false,
+        parallel_tools: false
+      }
+
+    @impl true
+    def default_model, do: "loopy"
+  end
+
+  # Minimal tool implementation: always succeeds, no side-effects.
+  defmodule LoopTool do
+    @moduledoc false
+    @behaviour Tau.Tool
+
+    alias Tau.Tool.Result
+
+    @impl true
+    def name, do: "loop_tool"
+    @impl true
+    def description, do: "Always succeeds; used to drive iteration cap tests."
+    @impl true
+    def parameters, do: %{"type" => "object", "properties" => %{}, "required" => []}
+
+    @impl true
+    def execute(_args, _ctx),
+      do: {:ok, %Result{content: "loop result", details: %{}, is_error: false}}
+
+    @impl true
+    def execution_mode, do: :parallel
+    @impl true
+    def streams_updates?, do: false
+  end
+
+  setup do
+    tmp =
+      Path.join(
+        System.tmp_dir!(),
+        "tau-tool-iter-cap-prop-#{System.unique_integer([:positive])}"
+      )
+
+    File.mkdir_p!(tmp)
+    Application.put_env(:tau, :data_dir, tmp)
+
+    prior_builtins = Application.get_env(:tau, :builtin_tools, [])
+    Application.put_env(:tau, :builtin_tools, [LoopTool | prior_builtins])
+
+    on_exit(fn ->
+      Application.put_env(:tau, :builtin_tools, prior_builtins)
+      File.rm_rf!(tmp)
+      Application.delete_env(:tau, :data_dir)
+    end)
+
+    :ok
+  end
+
+  property "session always terminates within max_tool_iterations with stop_reason: :tool_loop_aborted" do
+    check all(cap <- StreamData.integer(1..10), max_runs: 8) do
+      sid =
+        "tool-cap-prop-#{cap}-#{System.unique_integer([:positive])}-#{:crypto.strong_rand_bytes(3) |> Base.url_encode64(padding: false)}"
+
+      Phoenix.PubSub.subscribe(Tau.PubSub, "session:#{sid}")
+
+      test_pid = self()
+      handler_id = "tool-iter-cap-handler-#{sid}"
+
+      :telemetry.attach(
+        handler_id,
+        [:tau, :session, :tool_iteration_cap],
+        fn _event, measurements, metadata, _ ->
+          send(test_pid, {:cap_telemetry, measurements, metadata})
+        end,
+        nil
+      )
+
+      try do
+        {:ok, ^sid} =
+          start_session_for_test(
+            session_id: sid,
+            provider: AlwaysToolCallProvider,
+            model: "loopy",
+            max_tool_iterations: cap
+          )
+
+        :ok = Tau.send(sid, "go")
+
+        # Wait for the aborted MessageEnd — allow generous time (cap * 2s).
+        timeout_ms = max(cap * 2_000, 5_000)
+
+        assert_receive %SE.MessageEnd{
+                         session_id: ^sid,
+                         message: %Tau.Message.Assistant{stop_reason: :tool_loop_aborted}
+                       },
+                       timeout_ms
+
+        # Exactly one cap telemetry event per aborted turn.
+        assert_receive {:cap_telemetry, %{iterations: actual_iter, cap: ^cap}, %{session_id: ^sid}},
+                       1_000
+
+        # iterations in telemetry == cap: exactly cap completed dispatches occurred,
+        # then the (cap+1)th attempt was blocked (D-027 semantics).
+        assert actual_iter == cap
+
+        # Session returns to :awaiting_user — snapshot should show tool_iterations reset.
+        {:ok, snap} = Tau.snapshot(sid)
+        assert snap.tool_iterations == 0
+      after
+        # Detach the handler immediately after the iteration to prevent stale
+        # {:cap_telemetry, ...} messages from bleeding into subsequent iterations.
+        :telemetry.detach(handler_id)
+        Phoenix.PubSub.unsubscribe(Tau.PubSub, "session:#{sid}")
+
+        # Drain any residual cap_telemetry messages from this sid that arrived
+        # between the assert_receive and the detach.
+        drain_cap_telemetry(sid)
+      end
+    end
+  end
+
+  defp drain_cap_telemetry(sid) do
+    receive do
+      {:cap_telemetry, _measurements, %{session_id: ^sid}} ->
+        drain_cap_telemetry(sid)
+    after
+      0 -> :ok
+    end
+  end
+end

--- a/test/tau/tui/app_test.exs
+++ b/test/tau/tui/app_test.exs
@@ -74,6 +74,7 @@ if Code.ensure_loaded?(Ratatouille.Runtime) do
         assert next.last_assistant == nil
 
         last_line = List.last(next.transcript)
+
         assert is_binary(last_line) and last_line != "",
                "transcript MUST gain a non-empty line; got #{inspect(last_line)}"
 


### PR DESCRIPTION
## Summary

Closes the AC-6 acceptance criterion in `docs/spec/SPEC-USER-TURN.md` (tool-iteration safety) by addressing `[C24]` at `lib/tau/session.ex` — the previously unbounded tool-iteration dispatch site.

**Substantive changes:**
- `lib/tau/session.ex`: per-turn tool-call iteration counter + cap check before each `dispatch_tools/2` call. Cap evaluated as `data.tool_iterations >= cap`; on cap-exceeded, append an Assistant message with `stop_reason: :tool_loop_aborted`, emit `[:tau, :session, :tool_iteration_cap]` telemetry, broadcast `MessageEnd`, return to `:awaiting_user`. Counter resets on every `:awaiting_user` transition (clean end, cancel, abort).
- `lib/tau/message.ex`: `:tool_loop_aborted` added to `Tau.Message.Assistant.stop_reason()`.
- `test/tau/session/tool_iteration_cap_property_test.exs`: new property test driving a session backed by `AlwaysToolCallProvider` (a `Tau.Provider` impl that always emits a `tool_call` event stream — Replay does not emit `tool_call`); asserts the turn terminates within `max_tool_iterations` with `stop_reason: :tool_loop_aborted` and the telemetry event fires with `iterations == cap`.

**Spec amendments:**
- `D-027` added with full detection method and reset invariant.
- `D-005` superseded (was a placeholder for the same invariant). Single source of truth is now D-027.
- `[C50]` added to §3 with B2 boundary mapping.
- §4 B2 contract wording clarified: "at most N dispatches; (N+1)th attempt triggers abort" replaces the ambiguous "MUST NOT exceed N".
- `docs/MISSION.md` updated: '20 runtime invariants (D-001–D-019 plus D-027; D-005 superseded by D-027)' replaces the stale 'D-001–D-019' range claim.

## Factory provenance

This PR was produced through `/.claude/hyperagents-eval/chain.py` (implementer → critic → reviewer) with 3 revise passes (`revise.py`). The audit trail lives in `.claude/work-records/wr-20260514T000017-9ba975.json` on the companion `factory/harness-nested-worktree-fix` PR.

Final gate state (rev3):
- Reviewer: **PASS** — 396 tests, 0 failures, 0 errors.
- Critic: 3 BLOCKING spec/doc consistency issues — all resolved in the follow-up commit `docs(spec): resolve AC-6 critic findings on D-005/D-027 redundancy` on this same branch.

## Test plan

- [x] `mix compile --warnings-as-errors`
- [x] `mix format --check-formatted`
- [x] `mix test` — 36 properties, 360 tests, 0 failures, 6 excluded, 2 skipped
- [x] `mix credo --strict` — exit 14, identical to `main` (pre-existing tech debt, no AC-6 regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)