### PR TITLE
feat(hyperagents-eval): integrate work loop with evolutionary loop

### DIFF
--- a/.claude/hyperagents-eval/chain.py
+++ b/.claude/hyperagents-eval/chain.py
@@ -101,6 +101,129 @@ def latest_record_id(work_dir: Path):
     return files[-1].name if files else None
 
 
+def pin_task_in_eval_config(sibling_dir: Path, task_body: str) -> bool:
+    """Append `task_body` to <sibling>/eval_config.json's `tasks` list if absent.
+
+    Returns True if the task was newly added (caller may then write a
+    parent_scores signal); False if it was already present.
+    """
+    cfg_path = sibling_dir / "eval_config.json"
+    if not cfg_path.is_file():
+        return False
+    cfg = json.loads(cfg_path.read_text(encoding="utf-8"))
+    tasks = cfg.get("tasks") or []
+    # Deduplicate by exact body match — the eval probe list grows monotonically
+    # so a task that surfaced evolutionary pressure stays in the regression set.
+    if task_body in tasks:
+        return False
+    tasks.append(task_body)
+    cfg["tasks"] = tasks
+    cfg_path.write_text(json.dumps(cfg, indent=2) + "\n", encoding="utf-8")
+    return True
+
+
+def write_parent_scores_signal(sibling_dir: Path, gen_id: str,
+                               task_body: str, record_summary: dict) -> Path:
+    """Write `runs/<gen_id>/scores.json` reflecting the just-finished task.
+
+    The meta-agent reads this file during mutation to know what its parent
+    just did poorly. Format mirrors role_eval.py's emit shape.
+    """
+    runs_dir = sibling_dir / "runs" / gen_id
+    runs_dir.mkdir(parents=True, exist_ok=True)
+    out = {
+        "version": 1,
+        "primary": float(record_summary.get("primary", 0.0)),
+        "metrics": {
+            "pass_rate": float(record_summary.get("primary", 0.0)),
+            "tokens": int(record_summary.get("tokens", 0) or 0),
+            "task_verdicts": [{
+                "task": task_body[:1500],
+                "passed": bool(record_summary.get("passed", False)),
+                "why": record_summary.get("why", "")[:800],
+            }],
+            "role": record_summary.get("role", "implementer"),
+        },
+        "n_examples": 1,
+        "evaluator_version": "tau-role-eval@1.0.0+chain-signal",
+        "wall_clock_s": float(record_summary.get("wall_clock_s", 0.0) or 0.0),
+        "notes": record_summary.get("notes", "chain-emitted signal"),
+    }
+    sf = runs_dir / "scores.json"
+    sf.write_text(json.dumps(out, indent=2) + "\n", encoding="utf-8")
+    return sf
+
+
+def drive_admit_cycle(sibling: str, run_timeout_s: int) -> dict:
+    """Drive `/hyperagents:step --name <sibling>` through one full
+    select → mutate → eval → admit cycle.
+
+    Spawned as a single `claude -p` session that calls the slash command
+    repeatedly until `pending.next` settles at `done` or `error`. Returns
+    a summary dict including whether a new generation was admitted.
+    """
+    archive = ARCHIVE_BASE / sibling
+    archive_json = archive / "archive.json"
+    pending_json = archive / "pending.json"
+
+    before_entries = []
+    if archive_json.is_file():
+        before_entries = json.loads(archive_json.read_text(encoding="utf-8")).get("entries") or []
+    before_count = len(before_entries)
+
+    prompt = (
+        f"Drive `/hyperagents:step --name {sibling}` to completion: invoke it "
+        f"repeatedly, in sequence, until that sibling's `pending.json` settles "
+        f"at `next: done` or `next: error`. Each step is its own slash-command "
+        f"invocation. Do not skip steps. Report each step's commit message in "
+        f"order, then a final summary line: ADMITTED <new-gen-id> | NO-ADMIT | "
+        f"ERROR <message>."
+    )
+    cmd = [
+        "claude", "-p",
+        "--output-format", "json",
+        "--dangerously-skip-permissions",
+    ]
+    rc = -1
+    stdout = ""
+    stderr = ""
+    try:
+        r = subprocess.run(
+            cmd, input=prompt, capture_output=True, text=True,
+            timeout=run_timeout_s,
+        )
+        rc = r.returncode
+        # claude -p --output-format json returns a JSON envelope with 'result'
+        try:
+            obj = json.loads(r.stdout or "")
+            stdout = obj.get("result", "") or ""
+        except (json.JSONDecodeError, ValueError, TypeError):
+            stdout = r.stdout or ""
+        stderr = (r.stderr or "")[:800]
+    except subprocess.TimeoutExpired as e:
+        stdout = (e.stdout or "") if isinstance(e.stdout, str) else (e.stdout or b"").decode("utf-8", "replace")
+        stderr = "timeout"
+
+    after_entries = []
+    if archive_json.is_file():
+        after_entries = json.loads(archive_json.read_text(encoding="utf-8")).get("entries") or []
+
+    admitted = len(after_entries) > before_count
+    new_gen_id = after_entries[-1].get("id") if admitted else None
+    new_primary = after_entries[-1].get("primary_score") if admitted else None
+
+    return {
+        "admitted": admitted,
+        "new_gen_id": new_gen_id,
+        "new_primary_score": new_primary,
+        "rc": rc,
+        "before_gen_count": before_count,
+        "after_gen_count": len(after_entries),
+        "claude_stdout_tail": stdout[-1500:],
+        "stderr_tail": stderr,
+    }
+
+
 def main():
     p = argparse.ArgumentParser()
     p.add_argument("task", help="task body text, or '@PATH' to read from file")
@@ -114,6 +237,10 @@ def main():
     p.add_argument("--stub-mode", action="store_true")
     p.add_argument("--skip-implementer", action="store_true",
                    help="don't run implementer; chain starts from critic on the latest pending record")
+    p.add_argument("--no-evolve", action="store_true",
+                   help="don't trigger an admit cycle on non-READY ship decisions (default: evolve)")
+    p.add_argument("--evolve-timeout-s", type=int, default=5400,
+                   help="wall-clock cap for the admit-cycle claude session (default 5400s = 90min)")
     args = p.parse_args()
 
     task = args.task
@@ -179,13 +306,61 @@ def main():
     print(f"           wall={rev_b.get('wall_clock_s')}s  tokens={rev_b.get('tokens')}  reviewed_base_sha={rev_b.get('reviewed_base_sha')}")
     print(f"\nship decision: ", end="")
     if rev_b.get("verdict") == "PASS" and len(blocking) == 0:
+        ship = "READY"
         print("READY (reviewer PASS + no BLOCKING critic findings)")
     elif rev_b.get("verdict") == "PASS" and len(blocking) > 0:
+        ship = "HOLD"
         print(f"HOLD (reviewer PASS but {len(blocking)} BLOCKING critic findings unaddressed)")
     elif rev_b.get("verdict") in ("FAIL", "PARTIAL"):
+        ship = "BLOCK"
         print(f"BLOCK (reviewer {rev_b.get('verdict')})")
     else:
+        ship = "UNKNOWN"
         print("UNKNOWN (no reviewer verdict)")
+
+    # Evolution trigger: a non-READY ship decision IS the signal — pin the
+    # task as a regression probe, write the failure as parent_scores, and
+    # drive one admit-cycle on the implementer. The mutation candidate is
+    # judged against the same task that just failed; if it does better,
+    # it replaces the current operator.
+    if not args.no_evolve and ship in {"HOLD", "BLOCK"}:
+        impl_sibling = role_paths["implementer"].split("/", 1)[0]
+        impl_gen     = role_paths["implementer"].split("/", 1)[1]
+        sibling_dir  = ARCHIVE_BASE / impl_sibling
+        impl_passed  = (ship == "READY")  # by construction here: False
+        signal = {
+            "primary":      (impl_b.get("passed_count", 0) / max(impl_b.get("tasks_count", 1), 1))
+                            if "passed_count" in impl_b else (0.0 if not impl_passed else 1.0),
+            "passed":       impl_passed,
+            "tokens":       impl_b.get("tokens", 0),
+            "wall_clock_s": impl_b.get("wall_clock_s", 0.0),
+            "role":         "implementer",
+            "why": (
+                f"ship={ship}; reviewer={rev_b.get('verdict')}; "
+                f"critic BLOCKING={len(blocking)}"
+            ),
+            "notes": "chain triggered admit cycle on this signal",
+        }
+        added = pin_task_in_eval_config(sibling_dir, (rec.get("task") or {}).get("body", ""))
+        scores_path = write_parent_scores_signal(
+            sibling_dir, impl_gen, (rec.get("task") or {}).get("body", ""), signal,
+        )
+        print(f"\n[chain] evolution trigger: ship={ship}")
+        print(f"[chain] eval_config probe { 'appended' if added else 'already present' }")
+        print(f"[chain] parent_scores written: {scores_path}")
+        print(f"[chain] driving /hyperagents:step --name {impl_sibling}  "
+              f"(timeout {args.evolve_timeout_s}s)")
+        result = drive_admit_cycle(impl_sibling, args.evolve_timeout_s)
+        print(f"[chain] cycle rc={result['rc']}")
+        print(f"[chain] gens: {result['before_gen_count']} -> {result['after_gen_count']}")
+        if result["admitted"]:
+            print(f"[chain] ADMITTED new gen: {result['new_gen_id']} "
+                  f"primary={result.get('new_primary_score')}")
+        else:
+            print(f"[chain] NO admission this cycle")
+        tail = result.get("claude_stdout_tail") or ""
+        if tail:
+            print(f"[chain] cycle tail: {tail[-600:]}")
     return 0
 
 


### PR DESCRIPTION
## Summary

Closes the architectural gap you've flagged repeatedly: \`chain.py\` previously ran the work loop (implementer → critic → reviewer → record) and **stopped there**, leaving evolution as a separate manual cycle. This PR wires the two loops together — every \`chain.py\` task that doesn't ship READY immediately drives an admit cycle on the responsible operator, using the just-failed task as the eval probe.

## Mechanism

After the existing implementer/critic/reviewer phases complete and \`ship_decision\` is computed:

- **READY** — no evolutionary pressure; return as before.
- **HOLD** (reviewer PASS but critic BLOCKING) — signal: implementer produced working code but didn't satisfy spec/quality bar.
- **BLOCK** (reviewer FAIL/PARTIAL) — signal: implementer produced broken code.

For HOLD or BLOCK (default; opt out with \`--no-evolve\`):

1. **Pin the task as a regression probe.** Append the just-run task body to the implementer sibling's \`eval_config.json\` \`tasks\` list (idempotent). The task stays in the eval set across future cycles.
2. **Write parent_scores signal.** Emit \`runs/<current-gen>/scores.json\` reflecting the failure (pass_rate, why, role). The meta-agent reads this during mutation, so it sees its parent's most-recent real-work failure — not stale prior-eval scores.
3. **Drive the admit cycle.** Spawn one \`claude -p\` session that runs \`/hyperagents:step --name <sibling>\` repeatedly until \`pending.next\` settles at \`done\` or \`error\`. Covers all four phases (select → mutate → eval → admit). The eval phase re-uses the just-amended \`eval_config.json\`, so the mutation candidate is judged on the same task that just failed (plus prior probes).
4. **Report.** Snapshot \`archive.json\` before/after. If a new generation appears, print \`ADMITTED <gen-id> primary=<score>\`; else \`NO admission this cycle\`.

## Why this is the right shape

This is the integration you've framed across multiple turns: "the evolutionary pressures for the implementer come from signals emitted by critic and/or reviewer as the implementer is doing actual work." With this PR, that statement is structurally enforced — a failed reviewer verdict or a BLOCKING critic finding **is** the trigger; no separate manual \`/hyperagents:step\` call is needed; and the task that produced the signal is also the probe the mutation is judged against.

## What it does NOT do (out of scope for this PR)

- Doesn't speciate \`tau-critic\` or \`tau-reviewer\` on signal. The current heuristic mutates only the implementer because BLOCK/HOLD is almost always implementer-attributable. Critic over-strictness or reviewer under-strictness would need a separate signal extraction (e.g., compare critic findings to reviewer verdict for misalignment). Follow-up issue.
- Doesn't run evolution **concurrently** with work — it runs **immediately after**. True concurrency would double cost and require the mutation candidate to also have the work signal, which it can't have until the work finishes. So this is the tightest sequential coupling possible.
- Doesn't change role_eval.py, settings.json, or the chain's prior interface. Pure addition; \`--no-evolve\` preserves the old behaviour.

## Test plan

- [x] \`python3 .claude/hyperagents-eval/chain.py --help\` lists the new \`--no-evolve\` and \`--evolve-timeout-s\` flags.
- [x] Syntax-checks clean (\`python3 -c \"import ast; ast.parse(...)\"\`).
- [ ] End-to-end: run \`chain.py\` on a task we expect to BLOCK (e.g., issue #146 settings watcher noise — known to require novel approach), confirm admit cycle fires and either admits a better gen or returns NO-ADMIT with diagnostic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)