### PR TITLE
feat(commands): manual /&lt;skill-name&gt; slash-command activation (#95)

### DIFF
--- a/lib/tau/commands/parser.ex
+++ b/lib/tau/commands/parser.ex
@@ -32,4 +32,23 @@ defmodule Tau.Commands.Parser do
       _ -> :error
     end
   end
+
+  @doc """
+  Look up a slash-stripped command name against a skills list.
+
+  `name` is the raw slash-command token with the leading slash removed
+  (e.g. `"deploy"` from `"/deploy"`). `skills` is the session's
+  `data.skills` keyword list of `{name, %Tau.Skill{}}` pairs.
+
+  Returns `{:ok, %Tau.Skill{}}` when a matching skill is found,
+  `:error` otherwise.
+  """
+  @spec lookup_skill(String.t(), [{String.t(), Tau.Skill.t()}]) ::
+          {:ok, Tau.Skill.t()} | :error
+  def lookup_skill(name, skills) when is_binary(name) and is_list(skills) do
+    case List.keyfind(skills, name, 0) do
+      {^name, %Tau.Skill{} = skill} -> {:ok, skill}
+      _ -> :error
+    end
+  end
 end

--- a/lib/tau/session.ex
+++ b/lib/tau/session.ex
@@ -563,9 +563,13 @@ defmodule Tau.Session do
   def handle_event(:cast, {:user_message, msg}, :awaiting_user, %{command_task: nil} = data) do
     emit_user_message_telemetry(:delivered, data, :awaiting_user)
 
-    case classify_slash_command(msg) do
+    case classify_slash_command(msg, data.skills) do
       {:async, mod, args, msg} ->
         spawn_command_task(mod, args, msg, data)
+
+      {:skill_activation, skill, rewritten_msg} ->
+        data = activate_skill_via_slash(data, skill)
+        process_user_message(rewritten_msg, data)
 
       {:sync, msg} ->
         process_user_message(msg, data)
@@ -1785,6 +1789,37 @@ defmodule Tau.Session do
 
   defp skill_name_from_args(_), do: nil
 
+  # Issue #95: user-initiated slash-command skill activation.
+  #
+  # Called when `classify_slash_command/2` matches the slash-command name
+  # against `data.skills`. Sets `data.active_skill`, persists a JSONL
+  # `skill_activated` event, broadcasts `%Events.SkillActivated{}`, and
+  # emits telemetry — reusing the same side-effects as model-initiated
+  # activation, but without a tool_call_id (nil).
+  defp activate_skill_via_slash(data, %Tau.Skill{name: name} = skill) do
+    data =
+      %{data | active_skill: skill}
+      |> persist_event("skill_activated", %{
+        skill_name: name,
+        tool_call_id: nil,
+        allowed_tools: skill.allowed_tools
+      })
+
+    broadcast(data.id, %Events.SkillActivated{
+      session_id: data.id,
+      skill_name: name,
+      tool_call_id: nil
+    })
+
+    :telemetry.execute(
+      [:tau, :session, :skill_activated],
+      %{},
+      %{session_id: data.id, skill_name: name, disabled?: false}
+    )
+
+    data
+  end
+
   # Look up `name` on `data.skills`; honour `disable_model_invocation`.
   # On success, set `data.active_skill`, persist a JSONL event, and
   # broadcast `%Events.SkillActivated{}`. On failure, return an
@@ -2066,9 +2101,10 @@ defmodule Tau.Session do
   # `{:sync, msg}` (caller proceeds directly with the rewritten
   # message).
 
-  defp classify_slash_command(%Tau.Message.User{content: c} = msg) when is_binary(c) do
+  defp classify_slash_command(%Tau.Message.User{content: c} = msg, skills)
+       when is_binary(c) do
     case Tau.Commands.Parser.parse(c) do
-      {:command, name, args} ->
+      {:command, "/" <> bare_name = name, args} ->
         case Tau.Commands.Parser.lookup(name) do
           {:ok, mod} when is_atom(mod) ->
             if function_exported?(mod, :execute, 2) do
@@ -2081,10 +2117,18 @@ defmodule Tau.Session do
             {:sync, invoke_file_command(path, args, msg)}
 
           :error ->
-            # Unknown slash command; pass through verbatim — the model
-            # can handle it as a stylistic preface or report that it's
-            # unknown.
-            {:sync, msg}
+            # Not a built-in command — check the session's loaded skills.
+            case Tau.Commands.Parser.lookup_skill(bare_name, skills) do
+              {:ok, skill} ->
+                rewritten = %Tau.Message.User{msg | content: args}
+                {:skill_activation, skill, rewritten}
+
+              :error ->
+                # Unknown slash command; pass through verbatim — the model
+                # can handle it as a stylistic preface or report that it's
+                # unknown.
+                {:sync, msg}
+            end
         end
 
       _ ->
@@ -2092,7 +2136,7 @@ defmodule Tau.Session do
     end
   end
 
-  defp classify_slash_command(msg), do: {:sync, msg}
+  defp classify_slash_command(msg, _skills), do: {:sync, msg}
 
   defp spawn_command_task(mod, args, msg, data) do
     parent = self()

--- a/test/tau/session/slash_skill_activation_test.exs
+++ b/test/tau/session/slash_skill_activation_test.exs
@@ -1,0 +1,267 @@
+defmodule Tau.Session.SlashSkillActivationTest do
+  @moduledoc """
+  Tests for issue #95: user-initiated slash-command skill activation path.
+
+  A user may type `/<skill-name> [args]` to activate a skill directly,
+  bypassing the model-invokable `__activate_skill__` synthetic tool.
+  This path is universally available — both `disable_model_invocation:
+  true` AND `false` skills can be activated this way.
+
+  Scenarios:
+    - Typing `/skill-name` activates the skill and sets `data.active_skill`.
+    - The rewritten user message strips the slash-command prefix (args only).
+    - Skills with `disable_model_invocation: true` are activatable via slash.
+    - The `%Events.SkillActivated{}` is broadcast and telemetry fires.
+    - An unrecognised `/foo` still passes through verbatim (regression guard).
+    - The model-invokable `__activate_skill__` tool path continues to work
+      alongside the slash path (non-regression).
+  """
+  use ExUnit.Case, async: false
+  use ExUnitProperties
+
+  import Tau.Test.SessionHelper, only: [start_session_for_test: 1]
+  alias Tau.Commands.Parser
+  alias Tau.Provider.Event
+  alias Tau.Session.Events, as: SE
+
+  @moduletag :property
+
+  # ---------------------------------------------------------------------------
+  # Helpers shared across tests
+  # ---------------------------------------------------------------------------
+
+  defp seed_skills(sid, skills) do
+    [{pid, _}] = Registry.lookup(Tau.Sessions.Registry, sid)
+
+    :sys.replace_state(pid, fn {state, data} ->
+      {state, %{data | skills: skills}}
+    end)
+  end
+
+  defp setup_tmp do
+    tmp = Path.join(System.tmp_dir!(), "tau-slash-skill-#{System.unique_integer([:positive])}")
+    File.mkdir_p!(tmp)
+    Application.put_env(:tau, :data_dir, tmp)
+
+    on_exit(fn ->
+      File.rm_rf!(tmp)
+      Application.delete_env(:tau, :data_dir)
+    end)
+
+    :ok
+  end
+
+  defp end_turn_provider do
+    Tau.Providers.Replay
+  end
+
+  defp end_turn_fixture do
+    [
+      %Event.Start{request_id: "r1", model: "replay"},
+      %Event.TextStart{block_id: "t"},
+      %Event.TextDelta{block_id: "t", text: "ok"},
+      %Event.TextEnd{block_id: "t"},
+      %Event.Done{stop_reason: :end_turn, usage: %{}}
+    ]
+  end
+
+  defp invokable_skill(name) do
+    %Tau.Skill{
+      name: name,
+      body: "body for #{name}",
+      path: "/tmp/#{name}/SKILL.md",
+      description: "Invokable skill #{name}",
+      allowed_tools: [],
+      disable_model_invocation: false
+    }
+  end
+
+  defp manual_only_skill(name) do
+    %Tau.Skill{
+      name: name,
+      body: "body for #{name}",
+      path: "/tmp/#{name}/SKILL.md",
+      description: "Manual-only skill #{name}",
+      allowed_tools: [],
+      disable_model_invocation: true
+    }
+  end
+
+  # ---------------------------------------------------------------------------
+  # Property: Parser.lookup_skill/2 always finds a skill by exact name
+  # ---------------------------------------------------------------------------
+
+  property "Parser.lookup_skill/2 finds a skill by exact name and returns :error for unknown" do
+    check all(
+            name <- StreamData.string(:alphanumeric, min_length: 1, max_length: 20),
+            other_name <-
+              StreamData.string(:alphanumeric, min_length: 1, max_length: 20)
+              |> StreamData.filter(&(&1 != name))
+          ) do
+      skill = invokable_skill(name)
+      skills = [{name, skill}]
+
+      assert {:ok, ^skill} = Parser.lookup_skill(name, skills)
+      assert :error = Parser.lookup_skill(other_name, skills)
+      assert :error = Parser.lookup_skill(name, [])
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Integration: slash activation sets active_skill and rewrites message
+  # ---------------------------------------------------------------------------
+
+  setup do
+    setup_tmp()
+  end
+
+  test "typing /skill-name activates the skill and sets data.active_skill" do
+    sid = "slash-act-#{System.unique_integer([:positive])}"
+    Phoenix.PubSub.subscribe(Tau.PubSub, "session:#{sid}")
+
+    {:ok, ^sid} =
+      start_session_for_test(
+        provider: end_turn_provider(),
+        model: "replay",
+        session_id: sid,
+        provider_ctx: %{replay_fixture: end_turn_fixture()}
+      )
+
+    seed_skills(sid, [{"deploy", invokable_skill("deploy")}])
+
+    Tau.send(sid, "/deploy some args here")
+
+    assert_receive %SE.SkillActivated{skill_name: "deploy", tool_call_id: nil}, 5_000
+    assert_receive %SE.MessageEnd{}, 5_000
+
+    # active_skill may have been cleared by :end_turn (per ADR-0013).
+    # We verify it was set at some point via the SkillActivated broadcast above.
+    # A snapshot of the JSONL confirms the event was persisted.
+    [path] = Path.wildcard(Path.join(Tau.Settings.data_dir(), "sessions/*/#{sid}.jsonl"))
+
+    rows =
+      File.read!(path)
+      |> String.split("\n", trim: true)
+      |> Enum.map(&Jason.decode!/1)
+
+    assert Enum.any?(rows, fn r ->
+             r["kind"] == "skill_activated" and r["data"]["skill_name"] == "deploy"
+           end)
+  end
+
+  test "the rewritten message strips the slash command prefix — args are the content" do
+    sid = "slash-rewrite-#{System.unique_integer([:positive])}"
+    Phoenix.PubSub.subscribe(Tau.PubSub, "session:#{sid}")
+
+    # Use a provider that captures the messages it receives so we can inspect
+    # the content of the user message after rewriting.
+    parent = self()
+
+    {:ok, ^sid} =
+      start_session_for_test(
+        provider: end_turn_provider(),
+        model: "replay",
+        session_id: sid,
+        provider_ctx: %{replay_fixture: end_turn_fixture(), report_to: parent}
+      )
+
+    seed_skills(sid, [{"greet", invokable_skill("greet")}])
+
+    Tau.send(sid, "/greet hello world")
+
+    assert_receive %SE.MessageEnd{}, 5_000
+
+    # Inspect the persisted user_message row — its content must be the
+    # stripped args, not the full slash-command string.
+    [path] = Path.wildcard(Path.join(Tau.Settings.data_dir(), "sessions/*/#{sid}.jsonl"))
+
+    rows =
+      File.read!(path)
+      |> String.split("\n", trim: true)
+      |> Enum.map(&Jason.decode!/1)
+
+    user_rows = Enum.filter(rows, &(&1["kind"] == "user_message"))
+    assert user_rows != []
+
+    last_user = List.last(user_rows)
+    # Content must be the args only ("hello world"), not "/greet hello world".
+    assert last_user["data"]["content"] == "hello world"
+  end
+
+  test "disable_model_invocation: true skill is still activatable via slash" do
+    sid = "slash-disabled-#{System.unique_integer([:positive])}"
+    Phoenix.PubSub.subscribe(Tau.PubSub, "session:#{sid}")
+
+    {:ok, ^sid} =
+      start_session_for_test(
+        provider: end_turn_provider(),
+        model: "replay",
+        session_id: sid,
+        provider_ctx: %{replay_fixture: end_turn_fixture()}
+      )
+
+    seed_skills(sid, [{"secret", manual_only_skill("secret")}])
+
+    Tau.send(sid, "/secret run this manually")
+
+    assert_receive %SE.SkillActivated{skill_name: "secret", tool_call_id: nil}, 5_000
+    assert_receive %SE.MessageEnd{}, 5_000
+  end
+
+  test "unrecognised slash command passes through verbatim (no skill match)" do
+    sid = "slash-unknown-#{System.unique_integer([:positive])}"
+    Phoenix.PubSub.subscribe(Tau.PubSub, "session:#{sid}")
+
+    {:ok, ^sid} =
+      start_session_for_test(
+        provider: end_turn_provider(),
+        model: "replay",
+        session_id: sid,
+        provider_ctx: %{replay_fixture: end_turn_fixture()}
+      )
+
+    # No skills seeded — /unknown should pass through as-is.
+    seed_skills(sid, [])
+
+    Tau.send(sid, "/unknown foo bar")
+
+    assert_receive %SE.MessageEnd{}, 5_000
+
+    [path] = Path.wildcard(Path.join(Tau.Settings.data_dir(), "sessions/*/#{sid}.jsonl"))
+
+    rows =
+      File.read!(path)
+      |> String.split("\n", trim: true)
+      |> Enum.map(&Jason.decode!/1)
+
+    user_rows = Enum.filter(rows, &(&1["kind"] == "user_message"))
+    last_user = List.last(user_rows)
+    # Content is the full unmodified message.
+    assert last_user["data"]["content"] == "/unknown foo bar"
+  end
+
+  test "slash activation coexists with model-invokable __activate_skill__ tool" do
+    # Regression: both activation paths must work. This test exercises
+    # the slash path; model path is covered by SkillActivationTest.
+    sid = "slash-coexist-#{System.unique_integer([:positive])}"
+    Phoenix.PubSub.subscribe(Tau.PubSub, "session:#{sid}")
+
+    {:ok, ^sid} =
+      start_session_for_test(
+        provider: end_turn_provider(),
+        model: "replay",
+        session_id: sid,
+        provider_ctx: %{replay_fixture: end_turn_fixture()}
+      )
+
+    seed_skills(sid, [
+      {"visible", invokable_skill("visible")},
+      {"manual", manual_only_skill("manual")}
+    ])
+
+    # Both visible and manual are slash-activatable.
+    Tau.send(sid, "/visible do something")
+    assert_receive %SE.SkillActivated{skill_name: "visible"}, 5_000
+    assert_receive %SE.MessageEnd{}, 5_000
+  end
+end


### PR DESCRIPTION
Closes #95.

Adds the user-driven skill-activation path called out in #17 but deferred from that PR. Typing `/<skill-name> <rest>` in the TUI now activates the named skill (sets `data.active_skill`) and dispatches the rest of the message as the turn's input. Complements the existing model-invokable `__activate_skill__` synthetic-tool path.

## Factory provenance

Parallel team run alongside #24 (docs) and #125 (revise iter 2). chain.py rev 0; critic 0 BLOCKING; reviewer PASS — 389 tests pass (+5 over baseline from the new `test/tau/session/slash_skill_activation_test.exs`); credo + format clean.

## Test plan

- [x] `mix test test/tau/commands/ test/tau/session/slash_skill_activation_test.exs` — 12 tests, 0 failures
- [x] `mix test` — 389 tests, 0 failures
- [x] Model-invokable path (existing `__activate_skill__`) still works
- [x] Slash-command path activates AND rewrites user input

🤖 Generated with [Claude Code](https://claude.com/claude-code)