### PR TITLE
fix(providers): surface HTTP non-2xx response body in Event.Error

### DIFF
--- a/lib/tau/message/assembler.ex
+++ b/lib/tau/message/assembler.ex
@@ -131,6 +131,13 @@ defmodule Tau.Message.Assembler do
   defp strip_internals(%{type: :tool_call} = b), do: Map.drop(b, [:_args_buf])
   defp strip_internals(b), do: Map.drop(b, [:id])
 
+  defp format_reason({:http_status, n, %{type: type, message: msg}}) when is_binary(type),
+    do: "HTTP #{n} (#{type}): #{msg}"
+
+  defp format_reason({:http_status, n, %{body: body}}) when is_binary(body),
+    do: "HTTP #{n}: #{body}"
+
+  defp format_reason({:http_status, n, _other}), do: "HTTP #{n}"
   defp format_reason({:http_status, n}), do: "HTTP #{n}"
   defp format_reason({type, msg}) when is_binary(type), do: "#{type}: #{msg}"
   defp format_reason(other), do: inspect(other)

--- a/lib/tau/providers/shared/finch_stream.ex
+++ b/lib/tau/providers/shared/finch_stream.ex
@@ -103,6 +103,7 @@ defmodule Tau.Providers.Shared.FinchStream do
       pending: [],
       finished?: false,
       status: nil,
+      error_body: nil,
       cancel_flag: cancel_flag
     }
   end
@@ -161,9 +162,11 @@ defmodule Tau.Providers.Shared.FinchStream do
   defp handle({:status, n}, s, _decoder) when n in 200..299, do: %{s | status: n}
 
   defp handle({:status, n}, s, _decoder) do
-    err = %Event.Error{reason: {:http_status, n}, retryable?: n in [408, 429, 500, 502, 503, 504]}
+    # Don't emit the Error event yet — buffer the body chunks so the
+    # rendered error includes Anthropic's structured `error.type` and
+    # `error.message`. The Error is finalised on :done / :end below.
     maybe_notify_rate_limiter(s, n)
-    %{s | status: n, pending: s.pending ++ [err], finished?: true}
+    %{s | status: n, error_body: ""}
   end
 
   defp handle({:headers, _}, s, _), do: s
@@ -185,14 +188,45 @@ defmodule Tau.Providers.Shared.FinchStream do
     %{s | partial: partial, pending: s.pending ++ events}
   end
 
+  defp handle({:data, chunk}, %{status: n} = s, _decoder) when is_integer(n) and n not in 200..299 do
+    %{s | error_body: (s.error_body || "") <> chunk}
+  end
+
   defp handle({:data, _chunk}, s, _decoder), do: s
 
-  defp handle(:done, s, _), do: s
+  defp handle(:done, s, _), do: finalise_error_if_pending(s)
 
-  defp handle(:end, s, _), do: %{s | finished?: true}
+  defp handle(:end, s, _), do: %{finalise_error_if_pending(s) | finished?: true}
 
   defp handle({:error, reason}, s, _) do
     %{s | pending: s.pending ++ [%Event.Error{reason: reason, retryable?: true}], finished?: true}
+  end
+
+  defp finalise_error_if_pending(%{status: n, error_body: body} = s)
+       when is_integer(n) and n not in 200..299 and is_binary(body) do
+    err = %Event.Error{
+      reason: build_error_reason(n, body),
+      retryable?: n in [408, 429, 500, 502, 503, 504]
+    }
+
+    %{s | pending: s.pending ++ [err], error_body: nil}
+  end
+
+  defp finalise_error_if_pending(s), do: s
+
+  defp build_error_reason(status, body) do
+    case Jason.decode(body) do
+      {:ok, %{"error" => %{"type" => type, "message" => msg}}} ->
+        {:http_status, status, %{type: type, message: msg}}
+
+      {:ok, %{"type" => type, "message" => msg}} ->
+        {:http_status, status, %{type: type, message: msg}}
+
+      _ ->
+        # Non-JSON body — surface the first 500 chars verbatim so the
+        # user sees rate-limit detail even from a non-Anthropic source.
+        {:http_status, status, %{body: String.slice(body, 0, 500)}}
+    end
   end
 
   defp maybe_notify_rate_limiter(%{partial: %{provider: provider}}, status)

--- a/test/tau/providers/anthropic/http_error_stream_test.exs
+++ b/test/tau/providers/anthropic/http_error_stream_test.exs
@@ -28,7 +28,7 @@ defmodule Tau.Providers.Anthropic.HttpErrorStreamTest do
     %{bypass: bypass}
   end
 
-  test "HTTP 429 response yields %Event.Error{reason: {:http_status, 429}} in stream",
+  test "HTTP 429 response yields %Event.Error{reason: {:http_status, 429, _}} in stream",
        %{bypass: bypass} do
     Bypass.expect_once(bypass, "POST", "/v1/messages", fn conn ->
       conn
@@ -54,10 +54,10 @@ defmodule Tau.Providers.Anthropic.HttpErrorStreamTest do
     events = Enum.to_list(stream)
 
     assert Enum.any?(events, fn
-             %Event.Error{reason: {:http_status, 429}} -> true
+             %Event.Error{reason: {:http_status, 429, _}} -> true
              _ -> false
            end),
-           "Expected at least one %Event.Error{reason: {:http_status, 429}} in stream; got: #{inspect(events)}"
+           "Expected at least one %Event.Error{reason: {:http_status, 429, _}} in stream; got: #{inspect(events)}"
   end
 
   test "HTTP 429 Event.Error has retryable?: true", %{bypass: bypass} do
@@ -83,15 +83,15 @@ defmodule Tau.Providers.Anthropic.HttpErrorStreamTest do
 
     error_event =
       Enum.find(events, fn
-        %Event.Error{reason: {:http_status, 429}} -> true
+        %Event.Error{reason: {:http_status, 429, _}} -> true
         _ -> false
       end)
 
-    assert %Event.Error{reason: {:http_status, 429}, retryable?: true} = error_event,
+    assert %Event.Error{reason: {:http_status, 429, _}, retryable?: true} = error_event,
            "Expected retryable?: true for 429; got: #{inspect(error_event)}"
   end
 
-  test "HTTP 500 response yields retryable %Event.Error{reason: {:http_status, 500}}",
+  test "HTTP 500 response yields retryable %Event.Error{reason: {:http_status, 500, _}}",
        %{bypass: bypass} do
     Bypass.expect_once(bypass, "POST", "/v1/messages", fn conn ->
       conn
@@ -114,13 +114,13 @@ defmodule Tau.Providers.Anthropic.HttpErrorStreamTest do
     events = Enum.to_list(stream)
 
     assert Enum.any?(events, fn
-             %Event.Error{reason: {:http_status, 500}, retryable?: true} -> true
+             %Event.Error{reason: {:http_status, 500, _}, retryable?: true} -> true
              _ -> false
            end),
            "Expected retryable %Event.Error for 500; got: #{inspect(events)}"
   end
 
-  test "HTTP 401 response yields non-retryable %Event.Error{reason: {:http_status, 401}}",
+  test "HTTP 401 response yields non-retryable %Event.Error{reason: {:http_status, 401, _}}",
        %{bypass: bypass} do
     Bypass.expect_once(bypass, "POST", "/v1/messages", fn conn ->
       conn
@@ -143,7 +143,7 @@ defmodule Tau.Providers.Anthropic.HttpErrorStreamTest do
     events = Enum.to_list(stream)
 
     assert Enum.any?(events, fn
-             %Event.Error{reason: {:http_status, 401}, retryable?: false} -> true
+             %Event.Error{reason: {:http_status, 401, _}, retryable?: false} -> true
              _ -> false
            end),
            "Expected non-retryable %Event.Error for 401; got: #{inspect(events)}"


### PR DESCRIPTION
Symptom: TUI showed only `Error: HTTP 429` on rate-limit with no subtype info (rate_limit_error / quota_exceeded / tokens_per_minute).

Root cause: `FinchStream.handle({:status, n}, ...)` emitted the Error event immediately and set `finished?: true` — subsequent `{:data, body}` chunks carrying Anthropic's structured `{"type": ..., "message": ...}` got dropped.

Fix: buffer non-2xx body chunks, finalise the Error event on `:done`/`:end` with reason `{:http_status, n, %{type, message}}`. `Message.Assembler.format_reason/1` renders the new shape as `"HTTP 429 (rate_limit_error): <message>"`.

Test plan:
- [x] `mix test` — 37 properties, 389 tests, 0 failures
- [x] `mix format --check-formatted` — exit 0
- [x] `mix compile --warnings-as-errors` — exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)