### PR TITLE
feat(coding-agent): tau-context MCP server (Phase 1B Team C of #191)

### DIFF
--- a/docs/spec/SPEC-CODING-AGENT.md
+++ b/docs/spec/SPEC-CODING-AGENT.md
@@ -340,11 +340,24 @@ test/tau/coding_agent/workspace_test.exs         # worktree create/cleanup
 test/tau/session/coding_agent_streaming_test.exs # FSM drives Replay end-to-end
 ```
 
+Phase 1B Team C (this PR — landed):
+
+```
+lib/tau/coding_agent/tau_context.ex              # Bandit child-spec + start_link
+lib/tau/coding_agent/tau_context/auth.ex         # bearer-token mint + Plug auth
+lib/tau/coding_agent/tau_context/router.ex       # JSON-RPC 2.0 router (Plug)
+lib/tau/coding_agent/tau_context/tools.ex        # tools/list + tools/call
+test/tau/coding_agent/tau_context_test.exs       # supervisor + lifecycle
+test/tau/coding_agent/tau_context/auth_test.exs  # auth Plug contract
+test/tau/coding_agent/tau_context/auth_routing_test.exs # mount-point routing
+test/tau/coding_agent/tau_context/router_test.exs # JSON-RPC dispatch
+test/tau/coding_agent/tau_context/tools_test.exs  # tool implementations
+```
+
 Phase 1B / Phase 2 (planned):
 
 ```
 lib/tau/coding_agents/claude_code.ex             # first real adapter (Team A)
-lib/tau/mcp/servers/tau_context.ex               # tau-context MCP server (Team C)
 lib/tau/cost.ex                                  # adapter-tagged line items (Team D)
 lib/tau/tools/builtin/delegate.ex                # tool surface (Phase 2)
 ```

--- a/lib/tau/coding_agent/dispatcher.ex
+++ b/lib/tau/coding_agent/dispatcher.ex
@@ -65,6 +65,8 @@ defmodule Tau.CodingAgent.Dispatcher do
   use GenServer, restart: :temporary
 
   alias Tau.CodingAgent.Event
+  alias Tau.CodingAgent.TauContext
+  alias Tau.Settings.Cache, as: SettingsCache
 
   @default_inactivity_timeout_ms 120_000
   @cancel_exit_status -2
@@ -92,6 +94,7 @@ defmodule Tau.CodingAgent.Dispatcher do
       :drain_pid,
       :drain_ref,
       :inactivity_timer,
+      :tau_context_pid,
       cancelled?: false,
       done_emitted?: false,
       events_count: 0
@@ -175,6 +178,12 @@ defmodule Tau.CodingAgent.Dispatcher do
 
   @impl true
   def handle_continue(:start_adapter, state) do
+    # SPEC-CODING-AGENT [C5-B4]: the per-run tau-context MCP server
+    # MUST be reachable BEFORE the adapter invokes its first MCP
+    # tool. Start it (when enabled) and merge the resulting entry
+    # into `task.mcp_servers` BEFORE calling adapter.start/2.
+    state = maybe_start_tau_context(state)
+
     case safe_start(state.adapter, state.task, state.ctx) do
       {:ok, stream} ->
         {drain_pid, drain_ref} = spawn_drainer(stream, self())
@@ -318,9 +327,77 @@ defmodule Tau.CodingAgent.Dispatcher do
   def handle_info(_other, state), do: {:noreply, state}
 
   @impl true
-  def terminate(_reason, _state), do: :ok
+  def terminate(_reason, state) do
+    stop_tau_context(state)
+    :ok
+  end
 
   # ── internals ─────────────────────────────────────────────────
+
+  # SPEC-CODING-AGENT §4 B4: read the
+  # `coding_agent.expose_tau_context` setting (default true).
+  # Start a per-run MCP server and thread its mcp_servers entry
+  # into `task.mcp_servers` for the adapter to forward to the
+  # child subprocess. Failure to start the server is NOT fatal:
+  # we log via telemetry and continue with the original task —
+  # the agent simply won't see tau context tools.
+  defp maybe_start_tau_context(state) do
+    if expose_tau_context?() do
+      args = [
+        owner: self(),
+        session_id: Map.get(state.ctx, :session_id),
+        cwd: Map.get(state.task, :workspace),
+        max_depth: Map.get(state.ctx, :tau_context_max_depth, 2)
+      ]
+
+      case TauContext.start_link(args) do
+        {:ok, pid} ->
+          entry = TauContext.mcp_servers_entry(pid)
+          existing = state.task |> Map.get(:mcp_servers, []) |> List.wrap()
+          task = Map.put(state.task, :mcp_servers, [entry | existing])
+          %{state | task: task, tau_context_pid: pid}
+
+        {:error, reason} ->
+          :telemetry.execute(
+            [:tau, :coding_agent, :tau_context, :start_failed],
+            %{system_time: System.system_time()},
+            %{reason: reason, adapter: state.adapter}
+          )
+
+          state
+      end
+    else
+      state
+    end
+  end
+
+  defp stop_tau_context(%State{tau_context_pid: nil}), do: :ok
+
+  defp stop_tau_context(%State{tau_context_pid: pid}) when is_pid(pid) do
+    if Process.alive?(pid) do
+      TauContext.stop(pid)
+    end
+
+    :ok
+  end
+
+  defp expose_tau_context? do
+    settings =
+      try do
+        SettingsCache.get()
+      rescue
+        _ -> %{}
+      catch
+        _, _ -> %{}
+      end
+
+    settings
+    |> Map.get(:coding_agent, %{})
+    |> case do
+      %{} = ca -> Map.get(ca, :expose_tau_context, Map.get(ca, "expose_tau_context", true))
+      _ -> true
+    end
+  end
 
   defp safe_start(adapter, task, ctx) do
     adapter.start(task, ctx)

--- a/lib/tau/coding_agent/tau_context.ex
+++ b/lib/tau/coding_agent/tau_context.ex
@@ -1,0 +1,330 @@
+defmodule Tau.CodingAgent.TauContext do
+  @moduledoc """
+  Per-run `tau-context` MCP server (SPEC-CODING-AGENT §4 B4).
+
+  Each `Tau.CodingAgent.Dispatcher` run that opts in (default:
+  on, via `coding_agent.expose_tau_context = true` in settings)
+  starts one of these alongside the coding-agent subprocess.
+  The server:
+
+    * mints a per-run secret token (`Auth.mint/0`),
+    * starts a Cowboy listener bound to `127.0.0.1` on an
+      ephemeral port (the OS picks; we read it back from
+      `:ranch.get_port/1`),
+    * publishes its live state into a `:persistent_term` key the
+      `Router` Plug reads on every request,
+    * exposes the four tau-side tools (`Tools.catalog/0`),
+    * shuts down cleanly when its owner (the dispatcher) exits.
+
+  ## D-032 enforcement
+
+  The dispatcher passes its pid; we `Process.monitor/1` it. If
+  the dispatcher dies for any reason — supervisor restart, user
+  cancel, BEAM crash — we stop, taking the listener with us.
+  Conversely, our crash does NOT take down the dispatcher; the
+  dispatcher treats absence of a TauContext as "feature
+  disabled" and continues.
+
+  ## D-035 conformance
+
+  Both `start_link/1` and `stop/1` are total — failure to bind
+  a port returns a tagged tuple rather than raising. The router
+  itself rescues across the request boundary.
+
+  ## Public mcp_servers entry
+
+  `mcp_servers_entry/1` returns the map a coding-agent adapter
+  threads into its `--mcp-config` invocation:
+
+      %{
+        "name" => "tau-context",
+        "url"  => "http://127.0.0.1:54321/mcp",
+        "token" => "<secret>",
+        "transport" => "http"
+      }
+
+  The adapter is free to translate this into whatever
+  per-CLI configuration shape it needs; this contract is the
+  one Phase 1B Team A's ClaudeCode adapter consumes.
+  """
+
+  use GenServer, restart: :temporary
+
+  alias Tau.CodingAgent.TauContext.{Auth, Router}
+
+  @default_max_depth 2
+  @default_server_name "tau-context"
+
+  defmodule State do
+    @moduledoc false
+
+    @enforce_keys [:token, :state_ref, :name]
+    defstruct [
+      :token,
+      :state_ref,
+      :name,
+      :ref,
+      :port,
+      :url,
+      :owner,
+      :owner_ref,
+      :session_id,
+      :cwd,
+      max_depth: 2
+    ]
+
+    @type t :: %__MODULE__{
+            token: String.t(),
+            state_ref: term(),
+            name: String.t(),
+            ref: term() | nil,
+            port: non_neg_integer() | nil,
+            url: String.t() | nil,
+            owner: pid() | nil,
+            owner_ref: reference() | nil,
+            session_id: String.t() | nil,
+            cwd: String.t() | nil,
+            max_depth: non_neg_integer()
+          }
+  end
+
+  # ── public API ────────────────────────────────────────────────
+
+  @doc """
+  Start a TauContext server.
+
+  ## Options
+
+    * `:owner`      — pid of the dispatcher (monitored; required for
+      production use, but optional for tests).
+    * `:session_id` — tau session id this run is bound to. The
+      `tau_session_status` tool reads from this.
+    * `:cwd`        — workspace cwd, used as the default search
+      root for `tau_memory_query`. Defaults to the session's cwd
+      (via `Tau.Session.snapshot/1`), or `File.cwd!/0`.
+    * `:max_depth`  — recursive delegation cap (default 2).
+    * `:name`       — friendly name embedded in the `mcp_servers`
+      entry. Defaults to `"tau-context"`.
+
+  Returns the pid of the lifecycle process; the listener has
+  already been bound (synchronous bind in `init/1`) so callers
+  can safely call `mcp_servers_entry/1` immediately.
+  """
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(opts) do
+    GenServer.start_link(__MODULE__, opts)
+  end
+
+  @doc """
+  Return the `mcp_servers` entry to thread into a coding-agent
+  task struct.
+  """
+  @spec mcp_servers_entry(pid()) :: map()
+  def mcp_servers_entry(pid) when is_pid(pid) do
+    GenServer.call(pid, :mcp_servers_entry)
+  end
+
+  @doc "Return the listener URL (test convenience)."
+  @spec url(pid()) :: String.t()
+  def url(pid) when is_pid(pid), do: GenServer.call(pid, :url)
+
+  @doc "Return the per-run token (test convenience)."
+  @spec token(pid()) :: String.t()
+  def token(pid) when is_pid(pid), do: GenServer.call(pid, :token)
+
+  @doc "Return the bound port (test convenience)."
+  @spec port_number(pid()) :: non_neg_integer()
+  def port_number(pid) when is_pid(pid), do: GenServer.call(pid, :port)
+
+  @doc """
+  Cooperative stop. Releases the listener port and persistent_term
+  key, then exits `:normal`. Returns `:ok` whether the process was
+  alive or already gone — this is a cleanup helper, not a
+  supervision signal.
+  """
+  @spec stop(pid()) :: :ok
+  def stop(pid) when is_pid(pid) do
+    if Process.alive?(pid) do
+      GenServer.stop(pid, :normal, 5_000)
+    else
+      :ok
+    end
+  end
+
+  # ── GenServer callbacks ───────────────────────────────────────
+
+  @impl true
+  def init(opts) do
+    Process.flag(:trap_exit, true)
+
+    owner = Keyword.get(opts, :owner)
+    session_id = Keyword.get(opts, :session_id)
+    cwd = Keyword.get(opts, :cwd) || maybe_session_cwd(session_id)
+    max_depth = Keyword.get(opts, :max_depth, @default_max_depth)
+    name = Keyword.get(opts, :name, @default_server_name)
+
+    token = Auth.mint()
+    state_ref = make_state_ref()
+
+    case start_listener(state_ref) do
+      {:ok, ref, port} ->
+        owner_ref = if is_pid(owner), do: Process.monitor(owner), else: nil
+
+        state = %State{
+          token: token,
+          state_ref: state_ref,
+          name: name,
+          ref: ref,
+          port: port,
+          url: "http://127.0.0.1:#{port}/mcp",
+          owner: owner,
+          owner_ref: owner_ref,
+          session_id: session_id,
+          cwd: cwd,
+          max_depth: max_depth
+        }
+
+        publish_state(state)
+
+        :telemetry.execute(
+          [:tau, :coding_agent, :tau_context, :start],
+          %{system_time: System.system_time()},
+          %{port: port, session_id: session_id, owner: owner}
+        )
+
+        {:ok, state}
+
+      {:error, reason} ->
+        {:stop, {:listener_bind_failed, reason}}
+    end
+  end
+
+  @impl true
+  def handle_call(:mcp_servers_entry, _from, state) do
+    {:reply, build_mcp_entry(state), state}
+  end
+
+  def handle_call(:url, _from, state), do: {:reply, state.url, state}
+  def handle_call(:token, _from, state), do: {:reply, state.token, state}
+  def handle_call(:port, _from, state), do: {:reply, state.port, state}
+
+  @impl true
+  def handle_info({:DOWN, ref, :process, _pid, _reason}, %State{owner_ref: ref} = state) do
+    # Dispatcher died — take the listener down with it.
+    {:stop, :normal, state}
+  end
+
+  def handle_info(_msg, state), do: {:noreply, state}
+
+  @impl true
+  def terminate(_reason, state) do
+    stop_listener(state.ref)
+    unpublish_state(state.state_ref)
+
+    if state.owner_ref do
+      Process.demonitor(state.owner_ref, [:flush])
+    end
+
+    :telemetry.execute(
+      [:tau, :coding_agent, :tau_context, :stop],
+      %{system_time: System.system_time()},
+      %{port: state.port, session_id: state.session_id}
+    )
+
+    :ok
+  end
+
+  # ── internals ─────────────────────────────────────────────────
+
+  defp build_mcp_entry(%State{} = s) do
+    %{
+      "name" => s.name,
+      "url" => s.url,
+      "token" => s.token,
+      "transport" => "http"
+    }
+  end
+
+  defp publish_state(%State{} = s) do
+    :persistent_term.put(s.state_ref, %{
+      token: s.token,
+      session_id: s.session_id,
+      cwd: s.cwd,
+      max_depth: s.max_depth
+    })
+  end
+
+  defp unpublish_state(state_ref) do
+    try do
+      :persistent_term.erase(state_ref)
+    rescue
+      _ -> :ok
+    catch
+      _, _ -> :ok
+    end
+
+    :ok
+  end
+
+  defp make_state_ref do
+    {__MODULE__, make_ref()}
+  end
+
+  defp start_listener(state_ref) do
+    ref = make_ref()
+
+    cowboy_opts = [
+      ip: {127, 0, 0, 1},
+      port: 0,
+      ref: ref
+    ]
+
+    plug_opts = [state_ref: state_ref]
+
+    case Plug.Cowboy.http(Router, plug_opts, cowboy_opts) do
+      {:ok, _pid} ->
+        port = :ranch.get_port(ref)
+        {:ok, ref, port}
+
+      {:error, {:already_started, _pid}} ->
+        # Vanishingly unlikely given fresh `make_ref/0`, but be
+        # explicit so we don't leak a half-started listener.
+        _ = Plug.Cowboy.shutdown(ref)
+        {:error, :ref_already_started}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  rescue
+    e -> {:error, {:cowboy_raised, Exception.message(e)}}
+  catch
+    kind, reason -> {:error, {:cowboy_threw, kind, reason}}
+  end
+
+  defp stop_listener(nil), do: :ok
+
+  defp stop_listener(ref) do
+    try do
+      Plug.Cowboy.shutdown(ref)
+    rescue
+      _ -> :ok
+    catch
+      _, _ -> :ok
+    end
+
+    :ok
+  end
+
+  defp maybe_session_cwd(nil), do: nil
+
+  defp maybe_session_cwd(id) when is_binary(id) do
+    case Tau.Session.snapshot(id) do
+      {:ok, %{cwd: cwd}} when is_binary(cwd) -> cwd
+      _ -> nil
+    end
+  rescue
+    _ -> nil
+  catch
+    _, _ -> nil
+  end
+end

--- a/lib/tau/coding_agent/tau_context/auth.ex
+++ b/lib/tau/coding_agent/tau_context/auth.ex
@@ -1,0 +1,97 @@
+defmodule Tau.CodingAgent.TauContext.Auth do
+  @moduledoc """
+  Per-run bearer-token auth for the `tau-context` MCP server
+  (SPEC-CODING-AGENT §4 B4).
+
+  Each `Tau.CodingAgent.TauContext` GenServer mints one
+  cryptographically random token at `start_link/1`. The token is
+  passed to the coding-agent subprocess via the `mcp_servers`
+  field of the task struct; downstream the adapter is expected
+  to plumb it into the agent's `--mcp-config` so the agent can
+  present it back as either:
+
+    * `Authorization: Bearer <token>` header, or
+    * `?token=<token>` query string parameter.
+
+  The token is **never** logged, never persisted, and lives only
+  in the running TauContext process and its child Cowboy listener.
+
+  ## Rationale
+
+  127.0.0.1-only binding stops remote attackers, but on a shared
+  host any local process could speak to the listener if the URL
+  is known. The token closes that gap. It MUST be a
+  high-entropy random value (256 bits here — `:crypto.strong_rand_bytes(32)`)
+  to defeat brute-force scanning of `/etc/hosts`-style port
+  guessing.
+
+  ## D-035 (no raise on bad input)
+
+  `extract_token/1` returns `nil` when the request carries no
+  recognisable credentials. Callers MUST emit a JSON-RPC error
+  response rather than raising.
+  """
+
+  @typedoc "Opaque token value. Treat as a secret."
+  @type token :: String.t()
+
+  @doc """
+  Mint a fresh per-run token.
+
+  256 bits, URL-safe Base64 encoded so it survives unmodified
+  through query strings and header values.
+  """
+  @spec mint() :: token()
+  def mint do
+    :crypto.strong_rand_bytes(32) |> Base.url_encode64(padding: false)
+  end
+
+  @doc """
+  Constant-time comparison.
+
+  Avoids leaking the expected token's prefix through timing
+  side-channels. Both arguments are coerced to binaries; `nil`
+  on the presented side returns `false` without dereferencing.
+  """
+  @spec verify(token() | nil, token()) :: boolean()
+  def verify(nil, _expected), do: false
+
+  def verify(presented, expected)
+      when is_binary(presented) and is_binary(expected) do
+    :crypto.hash_equals(presented, expected)
+  rescue
+    _ -> false
+  end
+
+  def verify(_presented, _expected), do: false
+
+  @doc """
+  Pull a candidate token from a `Plug.Conn`.
+
+  Order of precedence: Authorization header first, then `token`
+  query parameter. Returns `nil` if neither is present.
+  """
+  @spec extract_token(Plug.Conn.t()) :: token() | nil
+  def extract_token(%Plug.Conn{} = conn) do
+    header_token(conn) || query_token(conn)
+  end
+
+  defp header_token(conn) do
+    case Plug.Conn.get_req_header(conn, "authorization") do
+      ["Bearer " <> tok | _] -> tok
+      ["bearer " <> tok | _] -> tok
+      _ -> nil
+    end
+  end
+
+  defp query_token(%Plug.Conn{query_params: %Plug.Conn.Unfetched{}} = conn) do
+    conn |> Plug.Conn.fetch_query_params() |> query_token()
+  end
+
+  defp query_token(%Plug.Conn{query_params: params}) when is_map(params) do
+    case Map.get(params, "token") do
+      tok when is_binary(tok) and byte_size(tok) > 0 -> tok
+      _ -> nil
+    end
+  end
+end

--- a/lib/tau/coding_agent/tau_context/router.ex
+++ b/lib/tau/coding_agent/tau_context/router.ex
@@ -1,0 +1,349 @@
+defmodule Tau.CodingAgent.TauContext.Router do
+  @moduledoc """
+  Plug handler for the per-run `tau-context` MCP server.
+
+  Implements the subset of MCP (JSON-RPC 2.0 over HTTP) that
+  a coding-agent subprocess needs:
+
+    * `initialize`  → server capabilities + serverInfo
+    * `tools/list`  → `Tools.catalog/0`
+    * `tools/call`  → `Tools.call/3`
+    * `ping`        → empty result (heartbeat)
+    * `notifications/*` → 204, no response body
+
+  All other endpoints / methods return JSON-RPC errors. The Plug
+  itself never raises on bad input (D-035): malformed JSON, bad
+  method names, missing fields all surface as structured
+  `{"error": {...}}` responses.
+
+  ## Auth
+
+  Every request is checked against the per-run token. Missing or
+  wrong token → `401 Unauthorized`, JSON-RPC error code -32_001.
+
+  ## Routing
+
+  * `GET  /healthz`  → 200, plain text (no auth — used by the
+    GenServer to confirm the listener is up before the dispatcher
+    advances). Bound to 127.0.0.1 only so this is not a remote
+    information leak.
+  * `POST /mcp`      → JSON-RPC dispatch.
+  * everything else  → 404.
+
+  ## How `state` arrives
+
+  `Plug.Cowboy.child_spec/1` accepts `init_options` (Plug "opts").
+  The TauContext GenServer passes a `%{state_ref: ref}` map at
+  startup. The `state_ref` is a `:persistent_term` key the
+  router reads to obtain the live state map. Using a
+  persistent_term (rather than a closure or genserver call)
+  keeps the request handler lock-free and survives GenServer
+  message-box backpressure.
+  """
+
+  @behaviour Plug
+
+  alias Plug.Conn
+  alias Tau.CodingAgent.TauContext.{Auth, Tools}
+
+  @rpc_version "2.0"
+
+  @impl Plug
+  def init(opts) when is_map(opts), do: opts
+  def init(opts) when is_list(opts), do: Map.new(opts)
+
+  @impl Plug
+  def call(%Conn{} = conn, opts) do
+    case {conn.method, conn.path_info} do
+      {"GET", ["healthz"]} ->
+        send_text(conn, 200, "ok")
+
+      {"POST", ["mcp"]} ->
+        handle_mcp(conn, opts)
+
+      {"GET", ["mcp"]} ->
+        # MCP HTTP transport SSE-style GETs are not implemented;
+        # return a structured 405 so the client gets a useful
+        # signal rather than 404.
+        send_json(conn, 405, %{
+          "jsonrpc" => @rpc_version,
+          "error" => %{"code" => -32_601, "message" => "GET not supported; use POST"}
+        })
+
+      _ ->
+        send_text(conn, 404, "not found")
+    end
+  rescue
+    # D-035 hard guard. Should be unreachable given the per-handler
+    # try/catches below, but a Plug crash here would take down the
+    # whole listener and cascade into the dispatcher. Surface a
+    # JSON-RPC error instead.
+    e ->
+      send_json(conn, 500, %{
+        "jsonrpc" => @rpc_version,
+        "error" => %{
+          "code" => -32_603,
+          "message" => "router exception: " <> Exception.message(e)
+        }
+      })
+  end
+
+  # ── MCP POST handler ──────────────────────────────────────────
+
+  defp handle_mcp(conn, opts) do
+    state = load_state(opts)
+
+    with :ok <- authorize(conn, state),
+         {:ok, body, conn} <- read_request_body(conn),
+         {:ok, decoded} <- decode_json(body) do
+      respond_rpc(conn, decoded, state)
+    else
+      {:error, :unauthorized} ->
+        send_json(conn, 401, %{
+          "jsonrpc" => @rpc_version,
+          "error" => %{"code" => -32_001, "message" => "unauthorized"}
+        })
+
+      {:error, :body_too_large} ->
+        send_json(conn, 413, %{
+          "jsonrpc" => @rpc_version,
+          "error" => %{"code" => -32_600, "message" => "request body too large"}
+        })
+
+      {:error, {:parse_error, reason}} ->
+        send_json(conn, 400, %{
+          "jsonrpc" => @rpc_version,
+          "id" => nil,
+          "error" => %{
+            "code" => -32_700,
+            "message" => "parse error: " <> inspect(reason)
+          }
+        })
+
+      {:error, reason} ->
+        send_json(conn, 400, %{
+          "jsonrpc" => @rpc_version,
+          "id" => nil,
+          "error" => %{"code" => -32_600, "message" => "bad request: " <> inspect(reason)}
+        })
+    end
+  end
+
+  defp authorize(conn, state) do
+    expected = state[:token]
+
+    cond do
+      not is_binary(expected) or expected == "" ->
+        # No token configured — refuse rather than fall open.
+        {:error, :unauthorized}
+
+      Auth.verify(Auth.extract_token(conn), expected) ->
+        :ok
+
+      true ->
+        {:error, :unauthorized}
+    end
+  end
+
+  defp read_request_body(conn, acc \\ "") do
+    case Conn.read_body(conn, length: 1_048_576, read_length: 1_048_576) do
+      {:ok, chunk, conn} ->
+        body = acc <> chunk
+
+        if byte_size(body) > 4 * 1_048_576 do
+          {:error, :body_too_large}
+        else
+          {:ok, body, conn}
+        end
+
+      {:more, chunk, conn} ->
+        body = acc <> chunk
+
+        if byte_size(body) > 4 * 1_048_576 do
+          {:error, :body_too_large}
+        else
+          read_request_body(conn, body)
+        end
+
+      {:error, reason} ->
+        {:error, {:read_body_error, reason}}
+    end
+  end
+
+  defp decode_json(""), do: {:ok, %{}}
+
+  defp decode_json(body) do
+    case Jason.decode(body) do
+      {:ok, decoded} -> {:ok, decoded}
+      {:error, e} -> {:error, {:parse_error, Exception.message(e)}}
+    end
+  end
+
+  # ── JSON-RPC dispatch ─────────────────────────────────────────
+
+  # Single request.
+  defp respond_rpc(conn, %{"jsonrpc" => "2.0"} = req, state) do
+    case dispatch(req, state) do
+      :no_response ->
+        # Notification — JSON-RPC says respond with empty body.
+        Conn.send_resp(conn, 204, "")
+
+      response ->
+        send_json(conn, 200, response)
+    end
+  end
+
+  # Batch request (rare for MCP but spec-allowed).
+  defp respond_rpc(conn, requests, state) when is_list(requests) do
+    responses =
+      requests
+      |> Enum.map(&dispatch(&1, state))
+      |> Enum.reject(&(&1 == :no_response))
+
+    if responses == [] do
+      Conn.send_resp(conn, 204, "")
+    else
+      send_json(conn, 200, responses)
+    end
+  end
+
+  defp respond_rpc(conn, _other, _state) do
+    send_json(conn, 400, %{
+      "jsonrpc" => @rpc_version,
+      "id" => nil,
+      "error" => %{"code" => -32_600, "message" => "not a JSON-RPC 2.0 envelope"}
+    })
+  end
+
+  defp dispatch(%{"method" => method, "id" => id} = req, state) do
+    handle_method(method, Map.get(req, "params", %{}), id, state)
+  rescue
+    e ->
+      rpc_error(id, -32_603, "internal error: " <> Exception.message(e))
+  catch
+    kind, reason ->
+      rpc_error(id, -32_603, "internal throw: #{inspect({kind, reason})}")
+  end
+
+  defp dispatch(%{"method" => method} = req, state) do
+    # No id → notification. Side-effect tools are forbidden via
+    # notifications because we can't surface their result; only
+    # known no-op notifications are accepted.
+    _ = handle_notification(method, Map.get(req, "params", %{}), state)
+    :no_response
+  end
+
+  defp dispatch(_other, _state) do
+    rpc_error(nil, -32_600, "missing 'method'")
+  end
+
+  defp handle_method("initialize", params, id, _state) do
+    client_proto = (is_map(params) and params["protocolVersion"]) || "2024-11-05"
+
+    rpc_result(id, %{
+      "protocolVersion" => client_proto,
+      "capabilities" => %{
+        "tools" => %{"listChanged" => false}
+      },
+      "serverInfo" => %{
+        "name" => "tau-context",
+        "version" => tau_version()
+      }
+    })
+  end
+
+  defp handle_method("tools/list", _params, id, _state) do
+    rpc_result(id, %{"tools" => Tools.catalog()})
+  end
+
+  defp handle_method("tools/call", params, id, state) when is_map(params) do
+    name = params["name"]
+    args = params["arguments"] || %{}
+
+    cond do
+      not is_binary(name) ->
+        rpc_error(id, -32_602, "missing or invalid 'name'")
+
+      not is_map(args) ->
+        rpc_error(id, -32_602, "'arguments' must be an object")
+
+      true ->
+        case Tools.call(name, args, state) do
+          {:ok, text} when is_binary(text) ->
+            rpc_result(id, %{
+              "content" => [%{"type" => "text", "text" => text}],
+              "isError" => false
+            })
+
+          {:error, %{code: code, message: msg}} ->
+            rpc_error(id, code, msg)
+
+          other ->
+            rpc_error(id, -32_603, "unexpected tool return: " <> inspect(other))
+        end
+    end
+  end
+
+  defp handle_method("tools/call", _params, id, _state),
+    do: rpc_error(id, -32_602, "'params' must be an object")
+
+  defp handle_method("ping", _params, id, _state), do: rpc_result(id, %{})
+
+  defp handle_method(method, _params, id, _state),
+    do: rpc_error(id, -32_601, "method not found: " <> method)
+
+  defp handle_notification(_method, _params, _state), do: :ok
+
+  # ── JSON-RPC envelopes ────────────────────────────────────────
+
+  defp rpc_result(id, result) do
+    %{"jsonrpc" => @rpc_version, "id" => id, "result" => result}
+  end
+
+  defp rpc_error(id, code, message) do
+    %{
+      "jsonrpc" => @rpc_version,
+      "id" => id,
+      "error" => %{"code" => code, "message" => message}
+    }
+  end
+
+  # ── plug helpers ──────────────────────────────────────────────
+
+  defp send_text(conn, status, body) do
+    conn
+    |> Conn.put_resp_content_type("text/plain")
+    |> Conn.send_resp(status, body)
+  end
+
+  defp send_json(conn, status, payload) do
+    body =
+      case Jason.encode(payload) do
+        {:ok, b} -> b
+        _ -> ~s({"error":"json encode failed"})
+      end
+
+    conn
+    |> Conn.put_resp_content_type("application/json")
+    |> Conn.send_resp(status, body)
+  end
+
+  defp load_state(opts) do
+    case opts[:state_ref] do
+      nil ->
+        # No state registered — return an empty state so dispatch
+        # can still produce a JSON-RPC error.
+        %{token: nil, session_id: nil, cwd: nil, max_depth: 2}
+
+      key ->
+        :persistent_term.get(key, %{token: nil, session_id: nil, cwd: nil, max_depth: 2})
+    end
+  end
+
+  defp tau_version do
+    case Application.spec(:tau, :vsn) do
+      nil -> "0.0.0"
+      v -> to_string(v)
+    end
+  end
+end

--- a/lib/tau/coding_agent/tau_context/router.ex
+++ b/lib/tau/coding_agent/tau_context/router.ex
@@ -277,9 +277,6 @@ defmodule Tau.CodingAgent.TauContext.Router do
 
           {:error, %{code: code, message: msg}} ->
             rpc_error(id, code, msg)
-
-          other ->
-            rpc_error(id, -32_603, "unexpected tool return: " <> inspect(other))
         end
     end
   end

--- a/lib/tau/coding_agent/tau_context/tools.ex
+++ b/lib/tau/coding_agent/tau_context/tools.ex
@@ -1,0 +1,403 @@
+defmodule Tau.CodingAgent.TauContext.Tools do
+  @moduledoc """
+  The four tau-side tools exposed to a coding-agent subprocess
+  over the per-run MCP server (SPEC-CODING-AGENT §4 B4).
+
+  Each tool function returns one of:
+
+    * `{:ok, content}` — `content` is the string returned to the
+      agent under the MCP `tools/call` result shape
+      `%{"content" => [%{"type" => "text", "text" => content}]}`.
+    * `{:error, reason}` — surfaced to the agent as a JSON-RPC
+      error response.
+
+  Tools that depend on optional tau capabilities (memory,
+  recursive delegation) gracefully degrade to a structured
+  `{"available": false, "reason": "..."}` JSON body wrapped in
+  `{:ok, _}` so the agent gets a structured signal rather than
+  a hard error. The exception is `tau_session_status/1`, which
+  is backed by `Tau.Session.snapshot/1` and is always available
+  when the session id is valid.
+
+  ## Why a plain module not a behaviour
+
+  The MCP server itself sits at the boundary; the tools are
+  pure (or near-pure) computation against in-BEAM data. Wrapping
+  each one in a `Tau.Tool` impl would duplicate the JSON-Schema
+  declaration and force a registry round-trip. The agent never
+  sees these tools through `Tau.Tools.Registry` — they are
+  exposed exclusively over the per-run MCP listener.
+
+  ## D-035 (no raise)
+
+  Every public function in this module catches its own errors
+  and returns a tagged tuple. Callers in `Router` rely on this
+  invariant.
+  """
+
+  alias Tau.Memory.Loader, as: MemoryLoader
+
+  @typedoc """
+  Snapshot of the live `TauContext` state passed in on every
+  call. The router reads this out of `:persistent_term` (so it
+  is lock-free and immutable for the duration of one request).
+  Keys:
+
+    * `:token`      — the per-run secret (handled by the router;
+      tools never touch it directly).
+    * `:session_id` — bound tau session id, or `nil`.
+    * `:cwd`        — workspace path, used as the default
+      memory-cascade root.
+    * `:max_depth`  — recursive-delegation cap.
+  """
+  @type state :: %{
+          optional(:token) => String.t() | nil,
+          optional(:session_id) => String.t() | nil,
+          optional(:cwd) => String.t() | nil,
+          optional(:max_depth) => non_neg_integer()
+        }
+
+  @default_max_depth 2
+
+  # ── tool catalog ──────────────────────────────────────────────
+
+  @doc """
+  Static JSON-RPC `tools/list` payload.
+
+  The shape mirrors the MCP `tools/list` result: each entry has
+  `name`, `description`, and an `inputSchema` (a JSON Schema
+  object). Centralised here so `Router` doesn't drift from the
+  dispatch table.
+  """
+  @spec catalog() :: [map()]
+  def catalog do
+    [
+      %{
+        "name" => "tau_session_status",
+        "description" =>
+          "Return the current tau session's id, message count, and FSM state. " <>
+            "Use to confirm the parent session is alive before issuing further " <>
+            "delegated work.",
+        "inputSchema" => %{
+          "type" => "object",
+          "properties" => %{},
+          "additionalProperties" => false
+        }
+      },
+      %{
+        "name" => "tau_memory_query",
+        "description" =>
+          "Read from tau's memory cascade (TAU.md / CLAUDE.md hierarchy). " <>
+            "Returns an availability flag plus matching entries when memory " <>
+            "is configured for the running session.",
+        "inputSchema" => %{
+          "type" => "object",
+          "properties" => %{
+            "query" => %{"type" => "string", "description" => "Free-text query."}
+          },
+          "required" => ["query"],
+          "additionalProperties" => false
+        }
+      },
+      %{
+        "name" => "tau_memory_write",
+        "description" =>
+          "Best-effort write to tau memory. May report unavailable if no " <>
+            "writable memory layer is configured (current default).",
+        "inputSchema" => %{
+          "type" => "object",
+          "properties" => %{
+            "kind" => %{"type" => "string"},
+            "key" => %{"type" => "string"},
+            "body" => %{"type" => "string"}
+          },
+          "required" => ["kind", "key", "body"],
+          "additionalProperties" => false
+        }
+      },
+      %{
+        "name" => "tau_delegate",
+        "description" =>
+          "Enqueue a recursive coding-agent delegation. Subject to a " <>
+            "max-depth limit (default 2) measured from the originating " <>
+            "session to defend against runaway recursion.",
+        "inputSchema" => %{
+          "type" => "object",
+          "properties" => %{
+            "prompt" => %{"type" => "string"},
+            "agent" => %{
+              "type" => "string",
+              "description" => "Adapter name, e.g. \"claude_code\"."
+            },
+            "depth" => %{
+              "type" => "integer",
+              "minimum" => 0,
+              "description" => "Current depth; 0 if unknown."
+            }
+          },
+          "required" => ["prompt"],
+          "additionalProperties" => true
+        }
+      }
+    ]
+  end
+
+  # ── dispatch ──────────────────────────────────────────────────
+
+  @doc """
+  Dispatch a parsed `tools/call` payload.
+
+  `state` is the `TauContext`'s state snapshot (carries
+  `session_id`, `cwd`, `max_depth`). Returns the same
+  `{:ok, content} | {:error, reason}` shape as the individual
+  tool functions.
+  """
+  @spec call(String.t(), map(), state()) ::
+          {:ok, String.t()} | {:error, %{code: integer(), message: String.t()}}
+  def call("tau_session_status", _args, state), do: tau_session_status(state)
+
+  def call("tau_memory_query", %{"query" => q}, state) when is_binary(q),
+    do: tau_memory_query(q, state)
+
+  def call("tau_memory_query", _args, _state),
+    do: {:error, %{code: -32_602, message: "missing or invalid 'query'"}}
+
+  def call("tau_memory_write", %{"kind" => k, "key" => key, "body" => body}, state)
+      when is_binary(k) and is_binary(key) and is_binary(body),
+      do: tau_memory_write(k, key, body, state)
+
+  def call("tau_memory_write", _args, _state),
+    do: {:error, %{code: -32_602, message: "missing or invalid memory_write args"}}
+
+  def call("tau_delegate", args, state) when is_map(args),
+    do: tau_delegate(args, state)
+
+  def call(name, _args, _state) when is_binary(name),
+    do: {:error, %{code: -32_601, message: "unknown tool: #{name}"}}
+
+  def call(_name, _args, _state),
+    do: {:error, %{code: -32_602, message: "invalid tool name"}}
+
+  # ── tool: tau_session_status ──────────────────────────────────
+
+  @doc false
+  @spec tau_session_status(state()) :: {:ok, String.t()}
+  def tau_session_status(%{session_id: nil}) do
+    {:ok,
+     encode(%{
+       "available" => false,
+       "reason" => "no session bound to this tau-context server"
+     })}
+  end
+
+  def tau_session_status(%{session_id: id}) when is_binary(id) do
+    case Tau.Session.snapshot(id) do
+      {:ok, snap} ->
+        {:ok,
+         encode(%{
+           "available" => true,
+           "session_id" => snap.id,
+           "state" => Atom.to_string(snap.state),
+           "message_count" => snap.message_count,
+           "provider" => safe_inspect(snap.provider),
+           "model" => snap.model,
+           "cwd" => snap.cwd
+         })}
+
+      {:error, :not_found} ->
+        {:ok,
+         encode(%{
+           "available" => false,
+           "reason" => "session #{id} not registered (already stopped?)",
+           "session_id" => id
+         })}
+    end
+  rescue
+    e ->
+      {:ok,
+       encode(%{
+         "available" => false,
+         "reason" => "snapshot error: " <> Exception.message(e)
+       })}
+  catch
+    kind, reason ->
+      {:ok,
+       encode(%{
+         "available" => false,
+         "reason" => "snapshot threw: #{inspect({kind, reason})}"
+       })}
+  end
+
+  def tau_session_status(_state),
+    do: {:ok, encode(%{"available" => false, "reason" => "invalid state"})}
+
+  # ── tool: tau_memory_query ────────────────────────────────────
+
+  @doc false
+  @spec tau_memory_query(String.t(), state()) :: {:ok, String.t()}
+  def tau_memory_query(query, state) when is_binary(query) do
+    cwd =
+      Map.get(state, :cwd) ||
+        (Map.get(state, :session_id) && session_cwd(Map.get(state, :session_id))) ||
+        File.cwd!()
+
+    case safe_memory_load(cwd) do
+      {:ok, []} ->
+        {:ok,
+         encode(%{
+           "available" => true,
+           "query" => query,
+           "results" => [],
+           "reason" => "no memory files in cascade"
+         })}
+
+      {:ok, entries} ->
+        matches = filter_memory(entries, query)
+
+        {:ok,
+         encode(%{
+           "available" => true,
+           "query" => query,
+           "results" => matches
+         })}
+
+      {:error, reason} ->
+        {:ok, encode(%{"available" => false, "reason" => reason, "query" => query})}
+    end
+  end
+
+  defp safe_memory_load(cwd) do
+    if Code.ensure_loaded?(MemoryLoader) and
+         function_exported?(MemoryLoader, :load, 1) do
+      try do
+        entries = MemoryLoader.load(cwd)
+        normalised = Enum.map(entries, fn {path, body} -> %{path: path, body: body} end)
+        {:ok, normalised}
+      rescue
+        e -> {:error, "memory loader failed: " <> Exception.message(e)}
+      catch
+        kind, reason -> {:error, "memory loader threw: #{inspect({kind, reason})}"}
+      end
+    else
+      {:error, "Tau.Memory.Loader not available"}
+    end
+  end
+
+  defp filter_memory(entries, query) do
+    needle = String.downcase(query)
+
+    entries
+    |> Enum.flat_map(fn %{path: path, body: body} ->
+      body
+      |> String.split("\n")
+      |> Enum.with_index(1)
+      |> Enum.filter(fn {line, _i} ->
+        String.contains?(String.downcase(line), needle)
+      end)
+      |> Enum.map(fn {line, i} ->
+        %{"path" => to_string(path), "line" => i, "text" => line}
+      end)
+    end)
+    |> Enum.take(50)
+  end
+
+  # ── tool: tau_memory_write ────────────────────────────────────
+
+  @doc false
+  @spec tau_memory_write(String.t(), String.t(), String.t(), state()) :: {:ok, String.t()}
+  def tau_memory_write(kind, key, body, _state)
+      when is_binary(kind) and is_binary(key) and is_binary(body) do
+    # No writable memory layer ships in tau today — the loader is
+    # read-only and ADR-0006 removed the cache. Surface this as a
+    # structured "available: false" rather than fail loudly: a
+    # future Phase 2 task may wire a `Tau.Memory.Writer` here
+    # without changing the MCP surface.
+    {:ok,
+     encode(%{
+       "available" => false,
+       "reason" => "no writable memory layer configured (ADR-0006)",
+       "kind" => kind,
+       "key" => key,
+       "body_size" => byte_size(body)
+     })}
+  end
+
+  # ── tool: tau_delegate ────────────────────────────────────────
+
+  @doc false
+  @spec tau_delegate(map(), state()) ::
+          {:ok, String.t()} | {:error, %{code: integer(), message: String.t()}}
+  def tau_delegate(args, state) do
+    prompt = Map.get(args, "prompt")
+    agent = Map.get(args, "agent", "claude_code")
+    depth = args |> Map.get("depth", 0) |> coerce_int(0)
+    max_depth = Map.get(state, :max_depth, @default_max_depth) |> coerce_int(@default_max_depth)
+
+    cond do
+      not is_binary(prompt) or byte_size(prompt) == 0 ->
+        {:error, %{code: -32_602, message: "missing or empty 'prompt'"}}
+
+      depth >= max_depth ->
+        {:ok,
+         encode(%{
+           "available" => false,
+           "reason" => "max delegation depth reached",
+           "depth" => depth,
+           "max_depth" => max_depth
+         })}
+
+      true ->
+        # Recursive delegation is gated on Phase 2 (Delegate tool
+        # surface). For Phase 1B Team C we record intent and
+        # return a structured "queued: false" so the agent can
+        # plan without crashing.
+        {:ok,
+         encode(%{
+           "available" => false,
+           "reason" => "recursive delegation not wired (Phase 2)",
+           "would_delegate" => %{
+             "agent" => agent,
+             "depth" => depth + 1,
+             "max_depth" => max_depth,
+             "prompt_size" => byte_size(prompt)
+           }
+         })}
+    end
+  end
+
+  # ── helpers ───────────────────────────────────────────────────
+
+  defp session_cwd(session_id) do
+    case Tau.Session.snapshot(session_id) do
+      {:ok, %{cwd: cwd}} when is_binary(cwd) -> cwd
+      _ -> nil
+    end
+  rescue
+    _ -> nil
+  catch
+    _, _ -> nil
+  end
+
+  defp coerce_int(n, _default) when is_integer(n) and n >= 0, do: n
+
+  defp coerce_int(s, default) when is_binary(s) do
+    case Integer.parse(s) do
+      {n, _} when n >= 0 -> n
+      _ -> default
+    end
+  end
+
+  defp coerce_int(_, default), do: default
+
+  defp encode(map) do
+    case Jason.encode(map) do
+      {:ok, json} -> json
+      _ -> ~s({"available":false,"reason":"json encode failed"})
+    end
+  end
+
+  defp safe_inspect(nil), do: nil
+  defp safe_inspect(v) when is_binary(v), do: v
+  defp safe_inspect(v) when is_atom(v), do: Atom.to_string(v)
+  defp safe_inspect(v), do: inspect(v)
+end

--- a/lib/tau/coding_agent/tau_context/tools.ex
+++ b/lib/tau/coding_agent/tau_context/tools.ex
@@ -396,8 +396,9 @@ defmodule Tau.CodingAgent.TauContext.Tools do
     end
   end
 
+  # `snap.provider` is `module() | nil` per `Tau.Session.snapshot/1`.
+  # Narrow clauses match dialyzer's inference; broader fallthroughs
+  # (binaries, arbitrary terms) were unreachable per the spec.
   defp safe_inspect(nil), do: nil
-  defp safe_inspect(v) when is_binary(v), do: v
   defp safe_inspect(v) when is_atom(v), do: Atom.to_string(v)
-  defp safe_inspect(v), do: inspect(v)
 end

--- a/mix.exs
+++ b/mix.exs
@@ -64,6 +64,13 @@ defmodule Tau.MixProject do
       # PubSub for session event fanout
       {:phoenix_pubsub, "~> 2.1"},
 
+      # HTTP listener for the per-run `tau-context` MCP server that
+      # tau spawns alongside each coding-agent subprocess
+      # (SPEC-CODING-AGENT §4 B4). Bound to 127.0.0.1 only, with a
+      # per-run secret token for auth.
+      {:plug, "~> 1.14"},
+      {:plug_cowboy, "~> 2.6"},
+
       # Filesystem watcher
       {:file_system, "~> 1.0"},
 

--- a/test/tau/coding_agent/tau_context/auth_routing_test.exs
+++ b/test/tau/coding_agent/tau_context/auth_routing_test.exs
@@ -1,0 +1,77 @@
+defmodule Tau.CodingAgent.TauContext.AuthRoutingTest do
+  @moduledoc """
+  Auth gate over the full router. Asserts:
+
+    * Missing token → 401.
+    * Wrong token → 401.
+    * Correct token via header → 200.
+    * Correct token via ?token= query → 200.
+  """
+
+  use ExUnit.Case, async: true
+
+  alias Tau.CodingAgent.TauContext.{Auth, Router}
+
+  setup do
+    token = Auth.mint()
+    state_ref = {__MODULE__, make_ref()}
+
+    :persistent_term.put(state_ref, %{
+      token: token,
+      session_id: nil,
+      cwd: nil,
+      max_depth: 2
+    })
+
+    on_exit(fn -> :persistent_term.erase(state_ref) end)
+
+    %{token: token, opts: Router.init(state_ref: state_ref)}
+  end
+
+  defp post_body do
+    Jason.encode!(%{"jsonrpc" => "2.0", "id" => 1, "method" => "ping"})
+  end
+
+  test "missing token → 401", %{opts: opts} do
+    conn =
+      :post
+      |> Plug.Test.conn("/mcp", post_body())
+      |> Plug.Conn.put_req_header("content-type", "application/json")
+      |> Router.call(opts)
+
+    assert conn.status == 401
+    assert Jason.decode!(conn.resp_body)["error"]["code"] == -32_001
+  end
+
+  test "wrong token → 401", %{opts: opts} do
+    conn =
+      :post
+      |> Plug.Test.conn("/mcp", post_body())
+      |> Plug.Conn.put_req_header("content-type", "application/json")
+      |> Plug.Conn.put_req_header("authorization", "Bearer wrong-secret")
+      |> Router.call(opts)
+
+    assert conn.status == 401
+  end
+
+  test "correct token via header → 200", %{opts: opts, token: tok} do
+    conn =
+      :post
+      |> Plug.Test.conn("/mcp", post_body())
+      |> Plug.Conn.put_req_header("content-type", "application/json")
+      |> Plug.Conn.put_req_header("authorization", "Bearer " <> tok)
+      |> Router.call(opts)
+
+    assert conn.status == 200
+  end
+
+  test "correct token via query parameter → 200", %{opts: opts, token: tok} do
+    conn =
+      :post
+      |> Plug.Test.conn("/mcp?token=#{tok}", post_body())
+      |> Plug.Conn.put_req_header("content-type", "application/json")
+      |> Router.call(opts)
+
+    assert conn.status == 200
+  end
+end

--- a/test/tau/coding_agent/tau_context/auth_test.exs
+++ b/test/tau/coding_agent/tau_context/auth_test.exs
@@ -1,0 +1,98 @@
+defmodule Tau.CodingAgent.TauContext.AuthTest do
+  use ExUnit.Case, async: true
+
+  alias Tau.CodingAgent.TauContext.Auth
+
+  describe "mint/0" do
+    test "produces a high-entropy URL-safe token" do
+      tok = Auth.mint()
+      assert is_binary(tok)
+      assert byte_size(tok) >= 40
+      # URL-safe alphabet only — no '+' / '/' / '='.
+      assert Regex.match?(~r/^[A-Za-z0-9_\-]+$/, tok)
+    end
+
+    test "subsequent mints differ" do
+      assert Auth.mint() != Auth.mint()
+    end
+  end
+
+  describe "verify/2" do
+    test "true for an exact match" do
+      tok = Auth.mint()
+      assert Auth.verify(tok, tok)
+    end
+
+    test "false for a mismatch" do
+      a = Auth.mint()
+      b = Auth.mint()
+      refute Auth.verify(a, b)
+    end
+
+    test "false for nil" do
+      refute Auth.verify(nil, "anything")
+    end
+
+    test "false for non-binary" do
+      refute Auth.verify(:atom, "expected")
+      refute Auth.verify(123, "expected")
+    end
+
+    test "false on length mismatch (constant-time still rejects)" do
+      refute Auth.verify("short", "much-longer-token")
+    end
+  end
+
+  describe "extract_token/1" do
+    test "reads Authorization: Bearer <tok>" do
+      conn =
+        :get
+        |> Plug.Test.conn("/mcp")
+        |> Plug.Conn.put_req_header("authorization", "Bearer abc123")
+
+      assert Auth.extract_token(conn) == "abc123"
+    end
+
+    test "lowercase 'bearer' is also accepted" do
+      conn =
+        :get
+        |> Plug.Test.conn("/mcp")
+        |> Plug.Conn.put_req_header("authorization", "bearer abc123")
+
+      assert Auth.extract_token(conn) == "abc123"
+    end
+
+    test "falls back to ?token= query parameter" do
+      conn = Plug.Test.conn(:get, "/mcp?token=qtok123")
+      assert Auth.extract_token(conn) == "qtok123"
+    end
+
+    test "returns nil when neither is present" do
+      conn = Plug.Test.conn(:get, "/mcp")
+      assert Auth.extract_token(conn) == nil
+    end
+
+    test "header takes precedence over query" do
+      conn =
+        :get
+        |> Plug.Test.conn("/mcp?token=fromquery")
+        |> Plug.Conn.put_req_header("authorization", "Bearer fromheader")
+
+      assert Auth.extract_token(conn) == "fromheader"
+    end
+
+    test "empty token query parameter returns nil" do
+      conn = Plug.Test.conn(:get, "/mcp?token=")
+      assert Auth.extract_token(conn) == nil
+    end
+
+    test "non-bearer Authorization is ignored" do
+      conn =
+        :get
+        |> Plug.Test.conn("/mcp")
+        |> Plug.Conn.put_req_header("authorization", "Basic dXNlcjpwYXNz")
+
+      assert Auth.extract_token(conn) == nil
+    end
+  end
+end

--- a/test/tau/coding_agent/tau_context/router_test.exs
+++ b/test/tau/coding_agent/tau_context/router_test.exs
@@ -1,0 +1,222 @@
+defmodule Tau.CodingAgent.TauContext.RouterTest do
+  @moduledoc """
+  Exercises the Plug router directly via `Plug.Test`, asserting:
+
+    * `initialize` returns server capabilities.
+    * `tools/list` enumerates the catalog.
+    * `tools/call` dispatches and wraps the result in MCP
+      content shape.
+    * Unknown method → JSON-RPC -32601.
+    * Malformed JSON → -32700.
+    * Bad envelope → -32600.
+    * Missing token → 401.
+    * Wrong token → 401.
+    * Notifications (no id) return 204.
+
+  D-035: every error path returns a structured response; no
+  test expects a raise.
+  """
+
+  use ExUnit.Case, async: true
+
+  alias Tau.CodingAgent.TauContext.{Auth, Router}
+
+  setup do
+    token = Auth.mint()
+    state_ref = {__MODULE__, make_ref()}
+
+    :persistent_term.put(state_ref, %{
+      token: token,
+      session_id: nil,
+      cwd: nil,
+      max_depth: 2
+    })
+
+    on_exit(fn -> :persistent_term.erase(state_ref) end)
+
+    %{token: token, state_ref: state_ref, opts: Router.init(state_ref: state_ref)}
+  end
+
+  defp post_rpc(body, %{opts: opts, token: token}) do
+    :post
+    |> Plug.Test.conn("/mcp", Jason.encode!(body))
+    |> Plug.Conn.put_req_header("content-type", "application/json")
+    |> Plug.Conn.put_req_header("authorization", "Bearer " <> token)
+    |> Router.call(opts)
+  end
+
+  defp decode_resp(conn), do: Jason.decode!(conn.resp_body)
+
+  describe "initialize" do
+    test "returns capabilities + serverInfo", ctx do
+      req = %{
+        "jsonrpc" => "2.0",
+        "id" => 1,
+        "method" => "initialize",
+        "params" => %{"protocolVersion" => "2024-11-05"}
+      }
+
+      conn = post_rpc(req, ctx)
+      assert conn.status == 200
+      decoded = decode_resp(conn)
+      assert decoded["jsonrpc"] == "2.0"
+      assert decoded["id"] == 1
+      assert decoded["result"]["serverInfo"]["name"] == "tau-context"
+      assert is_map(decoded["result"]["capabilities"])
+    end
+  end
+
+  describe "tools/list" do
+    test "returns the 4-tool catalog", ctx do
+      req = %{"jsonrpc" => "2.0", "id" => 2, "method" => "tools/list"}
+
+      conn = post_rpc(req, ctx)
+      assert conn.status == 200
+      decoded = decode_resp(conn)
+      assert length(decoded["result"]["tools"]) == 4
+
+      names = Enum.map(decoded["result"]["tools"], & &1["name"])
+      assert "tau_session_status" in names
+    end
+  end
+
+  describe "tools/call" do
+    test "dispatches tau_session_status and wraps content", ctx do
+      req = %{
+        "jsonrpc" => "2.0",
+        "id" => 3,
+        "method" => "tools/call",
+        "params" => %{"name" => "tau_session_status", "arguments" => %{}}
+      }
+
+      conn = post_rpc(req, ctx)
+      assert conn.status == 200
+      decoded = decode_resp(conn)
+      assert decoded["result"]["isError"] == false
+      assert [%{"type" => "text", "text" => text}] = decoded["result"]["content"]
+      inner = Jason.decode!(text)
+      assert inner["available"] == false
+    end
+
+    test "unknown tool name → -32601", ctx do
+      req = %{
+        "jsonrpc" => "2.0",
+        "id" => 4,
+        "method" => "tools/call",
+        "params" => %{"name" => "tau_nope", "arguments" => %{}}
+      }
+
+      conn = post_rpc(req, ctx)
+      assert conn.status == 200
+      decoded = decode_resp(conn)
+      assert decoded["error"]["code"] == -32_601
+    end
+
+    test "missing name → -32602", ctx do
+      req = %{
+        "jsonrpc" => "2.0",
+        "id" => 5,
+        "method" => "tools/call",
+        "params" => %{}
+      }
+
+      conn = post_rpc(req, ctx)
+      assert conn.status == 200
+      decoded = decode_resp(conn)
+      assert decoded["error"]["code"] == -32_602
+    end
+  end
+
+  describe "ping" do
+    test "returns empty result", ctx do
+      req = %{"jsonrpc" => "2.0", "id" => 6, "method" => "ping"}
+      conn = post_rpc(req, ctx)
+      assert conn.status == 200
+      assert decode_resp(conn)["result"] == %{}
+    end
+  end
+
+  describe "unknown method" do
+    test "returns -32601 method-not-found", ctx do
+      req = %{"jsonrpc" => "2.0", "id" => 7, "method" => "fictional"}
+      conn = post_rpc(req, ctx)
+      assert conn.status == 200
+      decoded = decode_resp(conn)
+      assert decoded["error"]["code"] == -32_601
+    end
+  end
+
+  describe "notifications (no id)" do
+    test "returns 204 with no body", ctx do
+      req = %{"jsonrpc" => "2.0", "method" => "notifications/initialized"}
+      conn = post_rpc(req, ctx)
+      assert conn.status == 204
+      assert conn.resp_body == ""
+    end
+  end
+
+  describe "malformed input" do
+    test "non-JSON body → -32700 parse error", %{opts: opts, token: token} do
+      conn =
+        :post
+        |> Plug.Test.conn("/mcp", "not-json")
+        |> Plug.Conn.put_req_header("content-type", "application/json")
+        |> Plug.Conn.put_req_header("authorization", "Bearer " <> token)
+        |> Router.call(opts)
+
+      assert conn.status == 400
+      decoded = decode_resp(conn)
+      assert decoded["error"]["code"] == -32_700
+    end
+
+    test "missing 'method' → -32600", ctx do
+      req = %{"jsonrpc" => "2.0", "id" => 99}
+      conn = post_rpc(req, ctx)
+      decoded = decode_resp(conn)
+      assert decoded["error"]["code"] == -32_600
+    end
+
+    test "not a JSON-RPC 2.0 envelope → 400 -32600", %{opts: opts, token: token} do
+      conn =
+        :post
+        |> Plug.Test.conn("/mcp", Jason.encode!(%{"foo" => "bar"}))
+        |> Plug.Conn.put_req_header("content-type", "application/json")
+        |> Plug.Conn.put_req_header("authorization", "Bearer " <> token)
+        |> Router.call(opts)
+
+      assert conn.status == 400
+      assert decode_resp(conn)["error"]["code"] == -32_600
+    end
+  end
+
+  describe "routing" do
+    test "GET /healthz returns 200 ok without auth", %{opts: opts} do
+      conn =
+        :get
+        |> Plug.Test.conn("/healthz")
+        |> Router.call(opts)
+
+      assert conn.status == 200
+      assert conn.resp_body == "ok"
+    end
+
+    test "GET /mcp returns 405", %{opts: opts, token: token} do
+      conn =
+        :get
+        |> Plug.Test.conn("/mcp")
+        |> Plug.Conn.put_req_header("authorization", "Bearer " <> token)
+        |> Router.call(opts)
+
+      assert conn.status == 405
+    end
+
+    test "unknown path returns 404", %{opts: opts} do
+      conn =
+        :get
+        |> Plug.Test.conn("/nope")
+        |> Router.call(opts)
+
+      assert conn.status == 404
+    end
+  end
+end

--- a/test/tau/coding_agent/tau_context/tools_test.exs
+++ b/test/tau/coding_agent/tau_context/tools_test.exs
@@ -1,0 +1,203 @@
+defmodule Tau.CodingAgent.TauContext.ToolsTest do
+  @moduledoc """
+  Exercises each of the four tau-side tools.
+
+  Goals:
+
+    * `catalog/0` returns 4 tool entries with valid JSON-Schema
+      input.
+    * `tau_session_status` gracefully reports `available: false`
+      when no session id is bound, and structured success when
+      a real session is available.
+    * `tau_memory_query` returns `available: true` against this
+      repo's TAU.md cascade, and gracefully degrades when given
+      a directory with no memory files.
+    * `tau_memory_write` returns `available: false` (no
+      writable layer in tau today).
+    * `tau_delegate` enforces max_depth and rejects empty
+      prompt.
+
+  D-035: every public function returns a tagged tuple; no test
+  expects a raise.
+  """
+
+  # `async: false` because the live-session test (`returns structured success
+  # when a real session is reachable`) uses the real Sessions supervisor +
+  # Persistence layer, both of which read shared Application env. The pure
+  # tool tests are unaffected; concurrency here was never load-bearing.
+  use ExUnit.Case, async: false
+
+  alias Tau.CodingAgent.TauContext.Tools
+
+  defp decode!(json), do: Jason.decode!(json)
+
+  describe "catalog/0" do
+    test "returns exactly the 4 expected tools" do
+      catalog = Tools.catalog()
+      assert length(catalog) == 4
+
+      names = Enum.map(catalog, & &1["name"])
+
+      assert "tau_session_status" in names
+      assert "tau_memory_query" in names
+      assert "tau_memory_write" in names
+      assert "tau_delegate" in names
+    end
+
+    test "each tool has a description and an inputSchema object" do
+      for tool <- Tools.catalog() do
+        assert is_binary(tool["description"])
+        assert byte_size(tool["description"]) > 10
+        assert is_map(tool["inputSchema"])
+        assert tool["inputSchema"]["type"] == "object"
+      end
+    end
+  end
+
+  describe "call/3 — tau_session_status" do
+    test "available: false when no session id is bound" do
+      state = %{session_id: nil, cwd: nil, max_depth: 2}
+      assert {:ok, json} = Tools.call("tau_session_status", %{}, state)
+      decoded = decode!(json)
+      assert decoded["available"] == false
+      assert is_binary(decoded["reason"])
+    end
+
+    test "available: false (not_found) when session id has no live process" do
+      state = %{session_id: "does-not-exist-xyz", cwd: nil, max_depth: 2}
+      assert {:ok, json} = Tools.call("tau_session_status", %{}, state)
+      decoded = decode!(json)
+      assert decoded["available"] == false
+      assert decoded["session_id"] == "does-not-exist-xyz"
+    end
+
+    test "returns structured success when a real session is reachable" do
+      session_id = start_real_session!()
+      state = %{session_id: session_id, cwd: System.tmp_dir!(), max_depth: 2}
+
+      assert {:ok, json} = Tools.call("tau_session_status", %{}, state)
+      decoded = decode!(json)
+      assert decoded["available"] == true
+      assert decoded["session_id"] == session_id
+      assert is_binary(decoded["state"])
+      assert is_integer(decoded["message_count"])
+    end
+  end
+
+  describe "call/3 — tau_memory_query" do
+    test "available: true (empty results OK) against an empty cwd" do
+      empty = Path.join(System.tmp_dir!(), "tau-mem-test-#{System.unique_integer([:positive])}")
+      File.mkdir_p!(empty)
+
+      state = %{session_id: nil, cwd: empty, max_depth: 2}
+
+      assert {:ok, json} = Tools.call("tau_memory_query", %{"query" => "anything"}, state)
+      decoded = decode!(json)
+      # Loader still returns ~/.tau/TAU.md if present so we don't
+      # require an empty results list; just confirm structure.
+      assert decoded["available"] == true
+      assert decoded["query"] == "anything"
+      assert is_list(decoded["results"])
+
+      File.rm_rf!(empty)
+    end
+
+    test "missing 'query' arg returns a JSON-RPC -32602 error" do
+      state = %{session_id: nil, cwd: nil, max_depth: 2}
+      assert {:error, %{code: -32_602}} = Tools.call("tau_memory_query", %{}, state)
+    end
+  end
+
+  describe "call/3 — tau_memory_write" do
+    test "always returns available: false (no writable layer)" do
+      state = %{session_id: nil, cwd: nil, max_depth: 2}
+
+      assert {:ok, json} =
+               Tools.call(
+                 "tau_memory_write",
+                 %{"kind" => "note", "key" => "k", "body" => "hello"},
+                 state
+               )
+
+      decoded = decode!(json)
+      assert decoded["available"] == false
+      assert decoded["kind"] == "note"
+      assert decoded["key"] == "k"
+      assert decoded["body_size"] == 5
+    end
+
+    test "missing args returns -32602" do
+      state = %{session_id: nil, cwd: nil, max_depth: 2}
+      assert {:error, %{code: -32_602}} = Tools.call("tau_memory_write", %{}, state)
+    end
+  end
+
+  describe "call/3 — tau_delegate" do
+    test "empty prompt is rejected with -32602" do
+      state = %{session_id: nil, cwd: nil, max_depth: 2}
+      assert {:error, %{code: -32_602}} = Tools.call("tau_delegate", %{"prompt" => ""}, state)
+    end
+
+    test "max_depth reached returns available: false, depth recorded" do
+      state = %{session_id: nil, cwd: nil, max_depth: 2}
+
+      assert {:ok, json} =
+               Tools.call("tau_delegate", %{"prompt" => "go", "depth" => 2}, state)
+
+      decoded = decode!(json)
+      assert decoded["available"] == false
+      assert decoded["reason"] =~ "max delegation depth"
+      assert decoded["depth"] == 2
+      assert decoded["max_depth"] == 2
+    end
+
+    test "under-depth returns available: false with would_delegate" do
+      # available: false because the underlying delegation queue
+      # isn't wired in Phase 1B Team C — but the SHAPE confirms
+      # the agent gets a structured plan rather than a hard error.
+      state = %{session_id: nil, cwd: nil, max_depth: 2}
+
+      assert {:ok, json} =
+               Tools.call(
+                 "tau_delegate",
+                 %{"prompt" => "do thing", "agent" => "claude_code", "depth" => 0},
+                 state
+               )
+
+      decoded = decode!(json)
+      assert decoded["available"] == false
+      assert decoded["would_delegate"]["agent"] == "claude_code"
+      assert decoded["would_delegate"]["depth"] == 1
+    end
+
+    test "non-integer depth coerces to default" do
+      state = %{session_id: nil, cwd: nil, max_depth: 2}
+
+      assert {:ok, json} =
+               Tools.call("tau_delegate", %{"prompt" => "x", "depth" => "bad"}, state)
+
+      decoded = decode!(json)
+      # 0 < 2 so it proceeds to would_delegate.
+      assert decoded["would_delegate"]["depth"] == 1
+    end
+  end
+
+  describe "call/3 — unknown tool" do
+    test "returns -32601 method-not-found" do
+      state = %{session_id: nil, cwd: nil, max_depth: 2}
+      assert {:error, %{code: -32_601}} = Tools.call("tau_does_not_exist", %{}, state)
+    end
+  end
+
+  # ── helpers ───────────────────────────────────────────────────
+
+  defp start_real_session! do
+    {:ok, id} =
+      Tau.Test.SessionHelper.start_session_for_test(
+        provider: Tau.Providers.Replay,
+        cwd: System.tmp_dir!()
+      )
+
+    id
+  end
+end

--- a/test/tau/coding_agent/tau_context_test.exs
+++ b/test/tau/coding_agent/tau_context_test.exs
@@ -1,0 +1,126 @@
+defmodule Tau.CodingAgent.TauContextTest do
+  @moduledoc """
+  Lifecycle test for the per-run tau-context MCP server
+  (SPEC-CODING-AGENT §4 B4).
+
+  Asserts:
+
+    * `start_link/1` binds a port on 127.0.0.1 synchronously.
+    * `mcp_servers_entry/1` returns a usable URL + token.
+    * The bound port closes when `stop/1` returns.
+    * `Process.monitor` on the owner is honored — owner exit
+      stops the listener (D-032).
+  """
+
+  use ExUnit.Case, async: true
+
+  alias Tau.CodingAgent.TauContext
+
+  describe "start_link/1" do
+    test "binds an ephemeral port on 127.0.0.1 and exposes the mcp_servers entry" do
+      {:ok, pid} = TauContext.start_link([])
+      entry = TauContext.mcp_servers_entry(pid)
+
+      assert is_map(entry)
+      assert entry["name"] == "tau-context"
+      assert String.starts_with?(entry["url"], "http://127.0.0.1:")
+      assert String.ends_with?(entry["url"], "/mcp")
+      assert is_binary(entry["token"])
+      assert byte_size(entry["token"]) >= 40
+      assert entry["transport"] == "http"
+
+      assert TauContext.port_number(pid) > 0
+
+      TauContext.stop(pid)
+    end
+
+    test "port is actually listening on 127.0.0.1" do
+      {:ok, pid} = TauContext.start_link([])
+      port = TauContext.port_number(pid)
+
+      # Open a TCP socket to confirm the listener is up.
+      {:ok, sock} =
+        :gen_tcp.connect(~c"127.0.0.1", port, [:binary, active: false], 1_000)
+
+      :ok = :gen_tcp.close(sock)
+      TauContext.stop(pid)
+    end
+
+    test "two servers get distinct ports and distinct tokens" do
+      {:ok, a} = TauContext.start_link([])
+      {:ok, b} = TauContext.start_link([])
+
+      assert TauContext.port_number(a) != TauContext.port_number(b)
+      assert TauContext.token(a) != TauContext.token(b)
+
+      TauContext.stop(a)
+      TauContext.stop(b)
+    end
+  end
+
+  describe "stop/1" do
+    test "releases the bound port" do
+      {:ok, pid} = TauContext.start_link([])
+      port = TauContext.port_number(pid)
+
+      :ok = TauContext.stop(pid)
+      refute Process.alive?(pid)
+
+      # Give Cowboy a beat to release the listener.
+      :timer.sleep(50)
+
+      # Re-binding the same port on 127.0.0.1 must succeed.
+      case :gen_tcp.listen(port, ifaddr: {127, 0, 0, 1}, reuseaddr: true) do
+        {:ok, sock} -> :gen_tcp.close(sock)
+        # A non-eaddrinuse error is also acceptable (the port may
+        # still be in TIME_WAIT). What matters is that the listener
+        # is no longer holding the socket.
+        {:error, :eaddrinuse} -> flag_port_still_held(port)
+        {:error, _other} -> :ok
+      end
+    end
+
+    defp flag_port_still_held(port) do
+      flunk("port #{port} still held by tau-context after stop/1")
+    end
+  end
+
+  describe "owner monitoring (D-032)" do
+    test "tau-context stops when its owner exits" do
+      parent = self()
+
+      owner =
+        spawn(fn ->
+          receive do
+            :exit_now -> :ok
+          end
+        end)
+
+      {:ok, pid} = TauContext.start_link(owner: owner)
+      ref = Process.monitor(pid)
+
+      send(parent, {:ready, pid})
+
+      send(owner, :exit_now)
+
+      assert_receive {:DOWN, ^ref, :process, ^pid, :normal}, 1_000
+    end
+  end
+
+  describe "options" do
+    test "session_id and cwd flow into the persistent_term state" do
+      {:ok, pid} =
+        TauContext.start_link(
+          session_id: "sess-abc",
+          cwd: "/tmp",
+          max_depth: 4
+        )
+
+      # We don't expose the state directly; instead exercise it via
+      # the router-visible URL. Confirm the GenServer is alive and
+      # returns the expected friendly URL.
+      assert TauContext.url(pid) =~ "127.0.0.1"
+      TauContext.stop(pid)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Phase 1B Team C of #191 (SPEC-CODING-AGENT §4 B4): each dispatcher
run optionally spawns a per-run MCP server alongside the coding-agent
subprocess. The server is bound to 127.0.0.1 on an ephemeral port,
authenticated by a per-run 256-bit token, and exposes four tau-side
tools to the agent over JSON-RPC 2.0 / HTTP.

- Tools surfaced: `tau_session_status`, `tau_memory_query`,
  `tau_memory_write`, `tau_delegate`. Each returns structured
  `{available: false, reason: ...}` when the underlying tau
  capability isn't yet wired (e.g. ADR-0006 removed the writable
  memory layer); `tau_session_status` is always live against
  `Tau.Session.snapshot/1`.
- Default-on per the user's Q1=C resolution: settings
  `coding_agent.expose_tau_context = true` (default) starts the
  server; setting it to `false` skips and passes empty `mcp_servers`.

### Transport

Chose option **(b) HTTP** (Plug + Plug.Cowboy on 127.0.0.1 ephemeral
port). Rationale: stdio proxy under Burrito would require an embedded
binary; HTTP needs only one cowboy listener. Adapter consumes the
emitted `mcp_servers` entry `{name, url, token, transport}` from the
task struct.

### Deps added

- \`plug ~> 1.14\`
- \`plug_cowboy ~> 2.6\`

Both were already pulled in by \`bypass\` (test-only) as transitive
deps, so this is essentially promoting them to prod deps — no
mix.lock change.

### Modifications to shared files

\`lib/tau/coding_agent/dispatcher.ex\` (well-localized, ~70 LoC):

- \`maybe_start_tau_context/1\` called from \`handle_continue/2\`
  BEFORE \`adapter.start/2\` (per [C5-B4]: the server MUST be
  reachable before the first MCP tool call).
- \`stop_tau_context/1\` called from \`terminate/2\` (server
  goes down with the dispatcher; D-032).
- New \`State\` field \`:tau_context_pid\`.
- Failure-to-start is non-fatal: telemetry event emitted, dispatcher
  continues with original task.

Phase 1B Team A's ClaudeCode adapter touches \`lib/tau/coding_agents/claude_code.ex\`
(new file) and reads \`task.mcp_servers\` to thread into \`--mcp-config\`;
no conflict with my dispatcher edits is anticipated.

### Spec / D-NNN

- Touches SPEC-CODING-AGENT §4 B4 source-map; no new constraint surfaced.
- Enforces **D-035** (no raise) across the JSON-RPC + HTTP boundary:
  every error path returns a structured \`{error: {code, message}}\`
  response.
- Honours **D-032** via owner-monitor: dispatcher death takes the
  listener down within one BEAM scheduler tick.
- AC progress: this is **AC-2 prerequisite infrastructure**; the
  end-to-end Claude-Code round-trip (AC-2) lands once Team A's adapter
  consumes the mcp_servers entry.

### Out of scope (stubbed; awaiting other capabilities)

- Full \`tau_memory_query\` / \`tau_memory_write\` — depends on a
  writable memory layer (ADR-0006 deferred).
- \`tau_delegate\` — Phase 2 (Delegate tool surface) wires the actual
  recursive dispatch; this PR returns \`available: false\` with a
  structured \`would_delegate\` shape so the agent can plan.
- Federation across sessions — each TauContext is per-run; out of
  scope per the spec.

## Test plan

- [x] \`mix compile --warnings-as-errors\` passes
- [x] \`mix format --check-formatted\` clean on new/modified files
- [x] \`mix credo --strict\` clean on the four new modules + the
  modified dispatcher
- [x] 52 new tests across \`test/tau/coding_agent/tau_context*\`
  (auth, tools, router, auth-routing, lifecycle)
- [x] Full suite green: 471 tests + 38 properties, 0 failures
- [x] Port-binding integration test: open a TCP socket to the
  bound port; close cleanly on stop

Closes one prerequisite of #191.

🤖 Generated with [Claude Code](https://claude.com/claude-code)