### PR TITLE
feat(coding-agent): Tau.CodingAgents.ClaudeCode adapter (Phase 1B Team A of #191)

### DIFF
--- a/lib/tau/coding_agents/claude_code.ex
+++ b/lib/tau/coding_agents/claude_code.ex
@@ -1,0 +1,380 @@
+defmodule Tau.CodingAgents.ClaudeCode do
+  @moduledoc """
+  `Tau.CodingAgent` adapter for the Anthropic Claude Code CLI.
+
+  Spawns `claude --output-format stream-json --verbose -p <prompt>` as
+  a subprocess and normalises its NDJSON output into
+  `Tau.CodingAgent.Event` structs.
+
+  ## Responsibilities
+
+    * Validate `task.workspace` exists and is a directory (D-033).
+    * Locate the `claude` executable (`System.find_executable/1`).
+      If absent, return `{:error, :claude_not_found}` synchronously
+      — the dispatcher synthesises the `%Done{exit_status: -1}` for
+      this case.
+    * Build argv via `Tau.CodingAgents.ClaudeCode.Argv.build/2`.
+    * Optionally write a temporary `--mcp-config` file when
+      `task.mcp_servers` is non-empty; tear it down on `cancel/1`
+      or stream completion.
+    * Open a Port (`:spawn_executable`, `:exit_status`, `:line` of
+      16384 bytes, `:stderr_to_stdout`) and stream its stdout lines
+      through `Tau.CodingAgents.ClaudeCode.StreamJson.decode_line/2`.
+    * Honour `ctx.cancel_flag` between lines — `Port.close/1` + 250ms
+      grace + SIGKILL (the dispatcher handles the cancel ladder; here
+      we just close the Port cooperatively when the flag flips).
+    * Surface auth and "not on PATH" failures as user-actionable
+      `%Event.Error{}` events (AC-6).
+
+  ## D-036 — no credential injection
+
+  The Port inherits the host user's full environment. We do NOT
+  read `~/.claude/credentials.json`, do NOT set
+  `ANTHROPIC_API_KEY`, and do NOT pass any auth flags. If the host
+  user is not logged in, `claude` will emit `result/error_*` itself
+  and we turn that into `%Event.Error{reason: {:auth_failed, ...}}`.
+
+  ## Test-friendly source injection
+
+  `ctx[:claude_code_source]` lets tests skip the subprocess entirely.
+  Accepted forms:
+
+    * `{:fixture, path :: String.t()}` — read NDJSON lines from a
+      fixture file and feed them through the same parser pipeline.
+    * `{:lines, [binary()]}` — feed the lines directly.
+
+  When `claude_code_source` is set, no Port is opened and no
+  executable check runs. Used by the contract tests.
+  """
+
+  @behaviour Tau.CodingAgent
+
+  alias Tau.CodingAgent.Event
+  alias Tau.CodingAgents.ClaudeCode.Argv
+  alias Tau.CodingAgents.ClaudeCode.StreamJson
+
+  require Logger
+
+  @line_size 16_384
+  @port_drain_timeout 1_000
+
+  @impl Tau.CodingAgent
+  def capabilities,
+    do: %{
+      streaming: true,
+      tool_restriction: true,
+      mcp_client: true,
+      session_resume: true,
+      cost_reporting: true,
+      workspace_isolation: :either
+    }
+
+  @impl Tau.CodingAgent
+  def configure(opts) when is_map(opts), do: {:ok, opts}
+
+  @impl Tau.CodingAgent
+  def start(task, ctx) when is_map(task) do
+    with :ok <- validate_workspace(task) do
+      case source_for(task, ctx) do
+        {:lines, lines} ->
+          {:ok, stream_from_lines(lines, ctx)}
+
+        {:fixture, path} ->
+          {:ok, stream_from_lines(read_fixture_lines(path), ctx)}
+
+        :spawn ->
+          start_spawn(task, ctx)
+      end
+    end
+  end
+
+  @impl Tau.CodingAgent
+  def cancel(handle) do
+    # The dispatcher owns the cancel ladder (Port.close → SIGTERM
+    # → 250ms → SIGKILL); this callback is a notification hook.
+    # We accept any handle shape because the dispatcher passes the
+    # drainer pid, not the port.
+    case handle do
+      %{port: port, tempfile: tempfile} ->
+        close_port(port)
+        cleanup_tempfile(tempfile)
+        :ok
+
+      _ ->
+        :ok
+    end
+  end
+
+  # ── workspace validation (D-033) ──────────────────────────────────
+
+  defp validate_workspace(%{workspace: path}) when is_binary(path) and path != "" do
+    if File.dir?(path), do: :ok, else: {:error, {:workspace_invalid, path}}
+  end
+
+  defp validate_workspace(_), do: {:error, :workspace_missing}
+
+  # ── source selection ─────────────────────────────────────────────
+
+  defp source_for(task, ctx) do
+    cond do
+      match?({:lines, _}, ctx[:claude_code_source]) -> ctx[:claude_code_source]
+      match?({:fixture, _}, ctx[:claude_code_source]) -> ctx[:claude_code_source]
+      match?({:lines, _}, task[:claude_code_source]) -> task[:claude_code_source]
+      match?({:fixture, _}, task[:claude_code_source]) -> task[:claude_code_source]
+      true -> :spawn
+    end
+  end
+
+  defp read_fixture_lines(path) do
+    path
+    |> File.stream!(:line)
+    |> Enum.to_list()
+  end
+
+  # ── spawn path ───────────────────────────────────────────────────
+
+  defp start_spawn(task, ctx) do
+    case find_executable() do
+      nil ->
+        {:error, :claude_not_found}
+
+      exe ->
+        case maybe_write_mcp_config(task) do
+          {:error, _} = err ->
+            err
+
+          {:ok, mcp_path} ->
+            argv = Argv.build(task, mcp_config_path: mcp_path)
+
+            port =
+              Port.open({:spawn_executable, exe}, [
+                :binary,
+                :exit_status,
+                :stderr_to_stdout,
+                :hide,
+                :use_stdio,
+                {:line, @line_size},
+                {:args, argv},
+                {:cd, Map.fetch!(task, :workspace)}
+              ])
+
+            stream = stream_from_port(port, mcp_path, ctx)
+            {:ok, stream}
+        end
+    end
+  end
+
+  defp find_executable, do: System.find_executable("claude")
+
+  # ── mcp-config tempfile ──────────────────────────────────────────
+
+  defp maybe_write_mcp_config(%{mcp_servers: servers}) when is_list(servers) and servers != [] do
+    payload = %{"mcpServers" => normalise_mcp_servers(servers)}
+
+    case Jason.encode(payload) do
+      {:ok, json} ->
+        tmp =
+          Path.join(
+            System.tmp_dir!(),
+            "tau-claude-mcp-#{System.unique_integer([:positive])}.json"
+          )
+
+        case File.write(tmp, json) do
+          :ok -> {:ok, tmp}
+          {:error, reason} -> {:error, {:mcp_config_write_failed, reason}}
+        end
+
+      {:error, reason} ->
+        {:error, {:mcp_config_encode_failed, reason}}
+    end
+  end
+
+  defp maybe_write_mcp_config(_task), do: {:ok, nil}
+
+  defp normalise_mcp_servers(servers) do
+    Enum.reduce(servers, %{}, fn server, acc ->
+      name = Map.get(server, "name") || Map.get(server, :name) || "tau-mcp-#{map_size(acc)}"
+      Map.put(acc, name, Map.drop(server, [:name, "name"]))
+    end)
+  end
+
+  defp cleanup_tempfile(nil), do: :ok
+
+  defp cleanup_tempfile(path) when is_binary(path) do
+    _ = File.rm(path)
+    :ok
+  end
+
+  # ── stream construction (port) ───────────────────────────────────
+
+  defp stream_from_port(port, tempfile, ctx) do
+    Stream.resource(
+      fn ->
+        %{
+          port: port,
+          tempfile: tempfile,
+          partial: "",
+          parser: StreamJson.new(),
+          cancel_flag: Map.get(ctx, :cancel_flag),
+          done_emitted?: false,
+          exit_status: nil,
+          tail_text: ""
+        }
+      end,
+      &port_next/1,
+      &port_done/1
+    )
+  end
+
+  defp port_next(%{done_emitted?: true}), do: {:halt, %{}}
+
+  defp port_next(%{cancel_flag: ref} = acc) when not is_nil(ref) do
+    if cancelled?(ref) do
+      close_port(acc.port)
+
+      events = [
+        %Event.Error{reason: :cancelled, recoverable: false}
+      ]
+
+      {events, %{acc | done_emitted?: true}}
+    else
+      pull_port_line(acc)
+    end
+  end
+
+  defp port_next(acc), do: pull_port_line(acc)
+
+  defp pull_port_line(%{port: port} = acc) do
+    receive do
+      {^port, {:data, {:eol, chunk}}} ->
+        full_line = acc.partial <> chunk
+        {events, parser} = StreamJson.decode_line(full_line, acc.parser)
+
+        {events,
+         %{acc | partial: "", parser: parser, tail_text: tail_text(acc.tail_text, full_line)}}
+
+      {^port, {:data, {:noeol, chunk}}} ->
+        # A line that exceeded `:line` size. Accumulate and continue.
+        {[], %{acc | partial: acc.partial <> chunk}}
+
+      {^port, {:exit_status, status}} ->
+        handle_port_exit(acc, status)
+    after
+      @port_drain_timeout ->
+        # No data and no exit yet. Yield control so the dispatcher
+        # can check the cancel flag again.
+        {[], acc}
+    end
+  end
+
+  defp handle_port_exit(acc, status) do
+    {leftover_events, parser} =
+      if acc.partial != "" do
+        StreamJson.decode_line(acc.partial, acc.parser)
+      else
+        {[], acc.parser}
+      end
+
+    acc = %{acc | partial: "", parser: parser}
+
+    # If the parser already saw a `result/*` line it produced a
+    # %Done{} (success) or %Error{recoverable: false} (failure). In
+    # either case the dispatcher takes it from here. But if the
+    # subprocess died without emitting one (e.g. crashed, killed by
+    # signal, exit 127 from spawn races), surface a synthetic
+    # terminal pair via %Error{recoverable: false} so the dispatcher
+    # can synthesise a Done with status -1 (and we keep the original
+    # exit_code in the reason for diagnostics).
+    closing =
+      if status == 0 do
+        # Success exit but no result line. Treat as anomalous.
+        [
+          %Event.Error{
+            reason: {:no_result_event, "claude exited 0 without emitting result"},
+            recoverable: false
+          }
+        ]
+      else
+        {kind, message} = StreamJson.classify_failure(status, acc.tail_text)
+        [%Event.Error{reason: {kind, message}, recoverable: false}]
+      end
+
+    events = leftover_events ++ closing
+    {events, %{acc | done_emitted?: true, exit_status: status}}
+  end
+
+  defp port_done(%{port: port, tempfile: tempfile}) do
+    close_port(port)
+    cleanup_tempfile(tempfile)
+    :ok
+  end
+
+  defp port_done(_), do: :ok
+
+  defp close_port(nil), do: :ok
+
+  defp close_port(port) when is_port(port) do
+    try do
+      if Port.info(port) do
+        Port.close(port)
+      end
+    catch
+      _, _ -> :ok
+    end
+
+    :ok
+  end
+
+  defp close_port(_), do: :ok
+
+  defp cancelled?(ref), do: :counters.get(ref, 1) > 0
+
+  # Keep a sliding tail of the last ~2k of raw output so AC-6 has
+  # something to classify when the subprocess exits non-zero without
+  # a structured result event.
+  defp tail_text(prev, line) do
+    combined = prev <> line <> "\n"
+
+    if byte_size(combined) > 2048 do
+      binary_part(combined, byte_size(combined) - 2048, 2048)
+    else
+      combined
+    end
+  end
+
+  # ── stream construction (fixture / test injection) ───────────────
+
+  defp stream_from_lines(lines, ctx) do
+    Stream.resource(
+      fn ->
+        %{
+          lines: lines,
+          parser: StreamJson.new(),
+          cancel_flag: Map.get(ctx, :cancel_flag),
+          done_emitted?: false
+        }
+      end,
+      &lines_next/1,
+      fn _ -> :ok end
+    )
+  end
+
+  defp lines_next(%{done_emitted?: true}), do: {:halt, %{}}
+
+  defp lines_next(%{lines: []} = acc), do: {:halt, acc}
+
+  defp lines_next(%{cancel_flag: ref} = acc) when not is_nil(ref) do
+    if cancelled?(ref) do
+      {[%Event.Error{reason: :cancelled, recoverable: false}], %{acc | done_emitted?: true}}
+    else
+      next_line(acc)
+    end
+  end
+
+  defp lines_next(acc), do: next_line(acc)
+
+  defp next_line(%{lines: [line | rest], parser: parser} = acc) do
+    {events, parser} = StreamJson.decode_line(line, parser)
+    {events, %{acc | lines: rest, parser: parser}}
+  end
+end

--- a/lib/tau/coding_agents/claude_code.ex
+++ b/lib/tau/coding_agents/claude_code.ex
@@ -18,8 +18,17 @@ defmodule Tau.CodingAgents.ClaudeCode do
       `task.mcp_servers` is non-empty; tear it down on `cancel/1`
       or stream completion.
     * Open a Port (`:spawn_executable`, `:exit_status`, `:line` of
-      16384 bytes, `:stderr_to_stdout`) and stream its stdout lines
-      through `Tau.CodingAgents.ClaudeCode.StreamJson.decode_line/2`.
+      16384 bytes) and stream its stdout lines through
+      `Tau.CodingAgents.ClaudeCode.StreamJson.decode_line/2`. stderr
+      is intentionally NOT redirected to stdout — banner / warning
+      lines that don't start with `{` would otherwise be parsed as
+      malformed JSON and pollute every transcript with recoverable
+      `:parse_error` events.
+    * Open the Port inside `Stream.resource`'s start_fun so its
+      owner is the drainer process — Port messages MUST route to
+      the `receive` loop that consumes them. (Opening in `start/2`
+      would make the caller — usually the dispatcher GenServer —
+      the owner, and the drainer would never see any data.)
     * Honour `ctx.cancel_flag` between lines — `Port.close/1` + 250ms
       grace + SIGKILL (the dispatcher handles the cancel ladder; here
       we just close the Port cooperatively when the flag flips).
@@ -89,20 +98,22 @@ defmodule Tau.CodingAgents.ClaudeCode do
   end
 
   @impl Tau.CodingAgent
-  def cancel(handle) do
-    # The dispatcher owns the cancel ladder (Port.close → SIGTERM
-    # → 250ms → SIGKILL); this callback is a notification hook.
-    # We accept any handle shape because the dispatcher passes the
-    # drainer pid, not the port.
-    case handle do
-      %{port: port, tempfile: tempfile} ->
-        close_port(port)
-        cleanup_tempfile(tempfile)
-        :ok
-
-      _ ->
-        :ok
-    end
+  def cancel(_handle) do
+    # The dispatcher passes the drainer pid here. Real cleanup
+    # happens in two places, both unaware of the dispatcher:
+    #
+    #   1. Port: opened inside `Stream.resource`'s start_fun (in the
+    #      drainer process). When the dispatcher kills the drainer
+    #      via `Process.exit(:shutdown)`, BEAM closes the Port and
+    #      the OS subprocess receives EOF on stdin.
+    #   2. MCP tempfile: a janitor process spawned at start time
+    #      `Process.monitor`s the drainer and unlinks the tempfile
+    #      on `:DOWN`. This survives `Process.exit(:shutdown)`
+    #      which would otherwise bypass `Stream.resource`'s
+    #      after_fun.
+    #
+    # So `cancel/1` is informational only; do nothing.
+    :ok
   end
 
   # ── workspace validation (D-033) ──────────────────────────────────
@@ -134,6 +145,13 @@ defmodule Tau.CodingAgents.ClaudeCode do
   # ── spawn path ───────────────────────────────────────────────────
 
   defp start_spawn(task, ctx) do
+    # Resolve executable + MCP tempfile synchronously so configuration
+    # errors surface via `{:error, _}` per D-035. The Port itself is
+    # opened lazily inside `Stream.resource`'s start_fun so its owner
+    # is the drainer process (the one that runs the `receive` loop),
+    # not whatever process happened to call `start/2`. Without this
+    # split, real-`claude` runs time out because Port messages route
+    # to the dispatcher mailbox and the drainer never sees them.
     case find_executable() do
       nil ->
         {:error, :claude_not_found}
@@ -145,20 +163,7 @@ defmodule Tau.CodingAgents.ClaudeCode do
 
           {:ok, mcp_path} ->
             argv = Argv.build(task, mcp_config_path: mcp_path)
-
-            port =
-              Port.open({:spawn_executable, exe}, [
-                :binary,
-                :exit_status,
-                :stderr_to_stdout,
-                :hide,
-                :use_stdio,
-                {:line, @line_size},
-                {:args, argv},
-                {:cd, Map.fetch!(task, :workspace)}
-              ])
-
-            stream = stream_from_port(port, mcp_path, ctx)
+            stream = stream_from_port(exe, argv, task, mcp_path, ctx)
             {:ok, stream}
         end
     end
@@ -207,12 +212,34 @@ defmodule Tau.CodingAgents.ClaudeCode do
 
   # ── stream construction (port) ───────────────────────────────────
 
-  defp stream_from_port(port, tempfile, ctx) do
+  defp stream_from_port(exe, argv, task, tempfile, ctx) do
+    workspace = Map.fetch!(task, :workspace)
+
     Stream.resource(
       fn ->
+        # Open the Port HERE — in the drainer process — so Port
+        # messages route to the receive loop in `pull_port_line/1`.
+        # See start_spawn/2 for the rationale.
+        port =
+          Port.open({:spawn_executable, exe}, [
+            :binary,
+            :exit_status,
+            :hide,
+            :use_stdio,
+            {:line, @line_size},
+            {:args, argv},
+            {:cd, workspace}
+          ])
+
+        # Janitor: monitors the drainer (this process) and unlinks
+        # the MCP tempfile on :DOWN. Survives `Process.exit(_, :shutdown)`
+        # which would otherwise bypass `Stream.resource`'s after_fun.
+        janitor = spawn_tempfile_janitor(tempfile, self())
+
         %{
           port: port,
           tempfile: tempfile,
+          janitor: janitor,
           partial: "",
           parser: StreamJson.new(),
           cancel_flag: Map.get(ctx, :cancel_flag),
@@ -224,6 +251,28 @@ defmodule Tau.CodingAgents.ClaudeCode do
       &port_next/1,
       &port_done/1
     )
+  end
+
+  # The janitor is intentionally unsupervised — it's a single-purpose
+  # `Process.monitor` + `File.rm` helper bound to one stream. It exits
+  # `:normal` after cleanup. If the BEAM dies before cleanup, OS-level
+  # /tmp cleanup is moot.
+  defp spawn_tempfile_janitor(nil, _drain_pid), do: nil
+
+  defp spawn_tempfile_janitor(tempfile, drain_pid) when is_binary(tempfile) do
+    spawn(fn ->
+      ref = Process.monitor(drain_pid)
+
+      receive do
+        {:DOWN, ^ref, :process, ^drain_pid, _reason} ->
+          _ = File.rm(tempfile)
+          :ok
+
+        {:cleanup_done, ^drain_pid} ->
+          Process.demonitor(ref, [:flush])
+          :ok
+      end
+    end)
   end
 
   defp port_next(%{done_emitted?: true}), do: {:halt, %{}}
@@ -251,7 +300,13 @@ defmodule Tau.CodingAgents.ClaudeCode do
         {events, parser} = StreamJson.decode_line(full_line, acc.parser)
 
         {events,
-         %{acc | partial: "", parser: parser, tail_text: tail_text(acc.tail_text, full_line)}}
+         %{
+           acc
+           | partial: "",
+             parser: parser,
+             tail_text: tail_text(acc.tail_text, full_line),
+             done_emitted?: acc.done_emitted? or terminal?(events)
+         }}
 
       {^port, {:data, {:noeol, chunk}}} ->
         # A line that exceeded `:line` size. Accumulate and continue.
@@ -267,6 +322,38 @@ defmodule Tau.CodingAgents.ClaudeCode do
     end
   end
 
+  # D-031: %Done{} is terminal — the first one ends the stream. Also
+  # treat a non-recoverable %Error{} as terminal because the dispatcher
+  # synthesises a %Done{} on its tail and we MUST NOT emit anything
+  # after that.
+  defp terminal?(events) when is_list(events) do
+    Enum.any?(events, fn
+      %Event.Done{} -> true
+      %Event.Error{recoverable: false} -> true
+      _ -> false
+    end)
+  end
+
+  defp handle_port_exit(%{done_emitted?: true} = acc, status) do
+    # The parser already produced a terminal event from a `result/*`
+    # line; the post-exit path MUST NOT append another %Error{}
+    # (D-031: Done is terminal — consumers may treat the first %Done{}
+    # as end-of-stream). Drain any partial buffer in case it carries
+    # non-terminal trailing JSON, but suppress synthetic closures.
+    {leftover_events, parser} =
+      if acc.partial != "" do
+        StreamJson.decode_line(acc.partial, acc.parser)
+      else
+        {[], acc.parser}
+      end
+
+    # Filter out anything terminal so we never emit a Done/Error after
+    # the real one.
+    leftover_events = Enum.reject(leftover_events, &terminal_event?/1)
+
+    {leftover_events, %{acc | partial: "", parser: parser, exit_status: status}}
+  end
+
   defp handle_port_exit(acc, status) do
     {leftover_events, parser} =
       if acc.partial != "" do
@@ -277,17 +364,13 @@ defmodule Tau.CodingAgents.ClaudeCode do
 
     acc = %{acc | partial: "", parser: parser}
 
-    # If the parser already saw a `result/*` line it produced a
-    # %Done{} (success) or %Error{recoverable: false} (failure). In
-    # either case the dispatcher takes it from here. But if the
-    # subprocess died without emitting one (e.g. crashed, killed by
-    # signal, exit 127 from spawn races), surface a synthetic
-    # terminal pair via %Error{recoverable: false} so the dispatcher
-    # can synthesise a Done with status -1 (and we keep the original
-    # exit_code in the reason for diagnostics).
+    # No result line ever arrived. Surface a synthetic terminal
+    # %Error{recoverable: false} so the dispatcher can synthesise a
+    # %Done{exit_status: -1} for the consumer.
     closing =
       if status == 0 do
-        # Success exit but no result line. Treat as anomalous.
+        # Success exit but no result line. Anomalous (process exited 0
+        # before flushing stream-json). Surface for diagnostics.
         [
           %Event.Error{
             reason: {:no_result_event, "claude exited 0 without emitting result"},
@@ -303,13 +386,28 @@ defmodule Tau.CodingAgents.ClaudeCode do
     {events, %{acc | done_emitted?: true, exit_status: status}}
   end
 
-  defp port_done(%{port: port, tempfile: tempfile}) do
+  defp terminal_event?(%Event.Done{}), do: true
+  defp terminal_event?(%Event.Error{recoverable: false}), do: true
+  defp terminal_event?(_), do: false
+
+  defp port_done(%{port: port, tempfile: tempfile, janitor: janitor}) do
     close_port(port)
     cleanup_tempfile(tempfile)
+    notify_janitor(janitor)
     :ok
   end
 
   defp port_done(_), do: :ok
+
+  defp notify_janitor(nil), do: :ok
+
+  defp notify_janitor(pid) when is_pid(pid) do
+    if Process.alive?(pid) do
+      Kernel.send(pid, {:cleanup_done, self()})
+    end
+
+    :ok
+  end
 
   defp close_port(nil), do: :ok
 

--- a/lib/tau/coding_agents/claude_code/argv.ex
+++ b/lib/tau/coding_agents/claude_code/argv.ex
@@ -1,0 +1,60 @@
+defmodule Tau.CodingAgents.ClaudeCode.Argv do
+  @moduledoc """
+  Pure builder for the `claude` CLI argv list.
+
+  Kept as a tiny standalone module so tests can verify argv shape
+  without spawning a subprocess. The adapter itself only consumes
+  `build/2`.
+
+  ## Shape
+
+  Base form:
+
+      ["-p", prompt, "--output-format", "stream-json", "--verbose"]
+
+  Optional extensions, all opt-in via fields on `Tau.CodingAgent.task()`:
+
+    * `--resume <id>` when `task.resume_id` is a non-empty string.
+    * `--mcp-config <path>` when the caller has written a temp
+      mcp-config file (the path is passed in separately because
+      the adapter is responsible for the tempfile lifecycle).
+    * `--allowed-tools <csv>` when `task.allowed_tools` is a list.
+      `:all` (the default) omits the flag.
+
+  D-036: no credentials are read or injected here. The CLI inherits
+  the host user's auth on its own.
+  """
+
+  @type t :: Tau.CodingAgent.task()
+
+  @spec build(t(), keyword()) :: [String.t()]
+  def build(task, opts \\ []) when is_map(task) do
+    prompt = Map.fetch!(task, :prompt)
+
+    base = ["-p", to_string(prompt), "--output-format", "stream-json", "--verbose"]
+
+    base
+    |> maybe_append_resume(task)
+    |> maybe_append_mcp(Keyword.get(opts, :mcp_config_path))
+    |> maybe_append_allowed_tools(task)
+  end
+
+  defp maybe_append_resume(argv, %{resume_id: id}) when is_binary(id) and id != "" do
+    argv ++ ["--resume", id]
+  end
+
+  defp maybe_append_resume(argv, _), do: argv
+
+  defp maybe_append_mcp(argv, nil), do: argv
+  defp maybe_append_mcp(argv, ""), do: argv
+
+  defp maybe_append_mcp(argv, path) when is_binary(path) do
+    argv ++ ["--mcp-config", path]
+  end
+
+  defp maybe_append_allowed_tools(argv, %{allowed_tools: list}) when is_list(list) and list != [] do
+    argv ++ ["--allowed-tools", Enum.join(list, ",")]
+  end
+
+  defp maybe_append_allowed_tools(argv, _), do: argv
+end

--- a/lib/tau/coding_agents/claude_code/stream_json.ex
+++ b/lib/tau/coding_agents/claude_code/stream_json.ex
@@ -1,0 +1,265 @@
+defmodule Tau.CodingAgents.ClaudeCode.StreamJson do
+  @moduledoc """
+  Line-oriented parser for the `claude --output-format stream-json`
+  protocol. Translates each NDJSON line into zero, one, or more
+  `Tau.CodingAgent.Event` structs.
+
+  Lives in its own module so it can be exercised without spawning
+  `claude`: feed lines in, get events out.
+
+  ## Contract (D-031, D-035)
+
+  * `decode_line/2` MUST NOT raise on any binary input. Malformed
+    JSON, unknown shapes, and missing keys all return
+    `%Event.Error{recoverable: true}` (or, for fully-unrecognised
+    types, an empty list — the upstream stream just logs and
+    continues).
+  * One stream-json line can yield multiple events. A `result/success`
+    line emits both a `%Cost{}` and a `%Done{}`. The function
+    therefore returns `{events :: [Event.t()], state}` where state
+    threads the running `turn` counter.
+
+  ## Stream-json shapes handled
+
+  Verified against `claude` 2.1.142, May 2026:
+
+      system/init               → %Start{}
+      system/<other subtype>    → ignored (e.g. hook_started, hook_response)
+      assistant content[text]   → %AssistantText{}
+      assistant content[tool_use]
+                                → %ToolUse{}
+      user     content[tool_result]
+                                → %ToolResult{}
+      result/success            → %Cost{} ; %Done{exit_status: 0}
+      result/error_*            → %Error{recoverable: false}
+      rate_limit_event          → ignored (informational; future:
+                                  could surface as Cost metadata)
+      <unknown>                 → ignored (defensive: Claude Code
+                                  ships new event types over time)
+  """
+
+  alias Tau.CodingAgent.Event
+
+  require Logger
+
+  @typedoc """
+  Threaded parser state.
+
+  * `turn` — monotonic 0-based counter incremented on each assistant
+    text emission.
+  * `last_session_id` — captured from `system/init` and `result/*`;
+    not consumed yet but reserved for future resume-id surfacing
+    (Team D persistence).
+  """
+  @type t :: %__MODULE__{turn: non_neg_integer(), last_session_id: String.t() | nil}
+
+  defstruct turn: 0, last_session_id: nil
+
+  @spec new() :: t()
+  def new, do: %__MODULE__{}
+
+  @doc """
+  Decode a single stream-json line.
+
+  Returns `{[Event.t()], t()}`. Never raises.
+  """
+  @spec decode_line(binary(), t()) :: {[Event.t()], t()}
+  def decode_line(line, %__MODULE__{} = state) when is_binary(line) do
+    trimmed = line |> String.trim_trailing("\n") |> String.trim_trailing("\r")
+
+    case trimmed do
+      "" ->
+        {[], state}
+
+      _ ->
+        case Jason.decode(trimmed) do
+          {:ok, obj} when is_map(obj) ->
+            translate(obj, state)
+
+          {:ok, _} ->
+            # Top-level non-object — not stream-json. Recoverable.
+            {[
+               %Event.Error{
+                 reason: {:malformed_event, "non-object JSON value"},
+                 recoverable: true
+               }
+             ], state}
+
+          {:error, %Jason.DecodeError{} = err} ->
+            {[
+               %Event.Error{
+                 reason: {:parse_error, Exception.message(err)},
+                 recoverable: true
+               }
+             ], state}
+        end
+    end
+  end
+
+  # ── translation ──────────────────────────────────────────────────
+
+  defp translate(%{"type" => "system", "subtype" => "init"} = obj, state) do
+    state = %{state | last_session_id: obj["session_id"]}
+
+    event = %Event.Start{
+      agent: :claude_code,
+      version: obj["claude_code_version"],
+      pid: nil
+    }
+
+    {[event], state}
+  end
+
+  defp translate(%{"type" => "system"}, state) do
+    # hook_started, hook_response, and any future system subtype.
+    {[], state}
+  end
+
+  defp translate(%{"type" => "assistant", "message" => %{"content" => content}}, state)
+       when is_list(content) do
+    Enum.flat_map_reduce(content, state, &assistant_content/2)
+  end
+
+  defp translate(%{"type" => "user", "message" => %{"content" => content}}, state)
+       when is_list(content) do
+    events =
+      Enum.flat_map(content, fn
+        %{"type" => "tool_result"} = block ->
+          [
+            %Event.ToolResult{
+              tool_use_id: block["tool_use_id"] || "",
+              content: tool_result_content(block["content"]),
+              is_error: block["is_error"] == true
+            }
+          ]
+
+        _ ->
+          []
+      end)
+
+    {events, state}
+  end
+
+  defp translate(%{"type" => "result", "subtype" => subtype} = obj, state) do
+    state = %{state | last_session_id: obj["session_id"] || state.last_session_id}
+    result_events(subtype, obj, state)
+  end
+
+  defp translate(%{"type" => "rate_limit_event"}, state), do: {[], state}
+
+  defp translate(%{"type" => other}, state) do
+    Logger.debug(fn -> "ClaudeCode stream-json: ignoring unknown type #{inspect(other)}" end)
+    {[], state}
+  end
+
+  defp translate(_other, state) do
+    # Object without a "type" field. Recoverable.
+    {[%Event.Error{reason: {:malformed_event, "missing type"}, recoverable: true}], state}
+  end
+
+  # ── assistant content blocks ─────────────────────────────────────
+
+  defp assistant_content(%{"type" => "text", "text" => text}, state) when is_binary(text) do
+    event = %Event.AssistantText{text: text, turn: state.turn}
+    {[event], %{state | turn: state.turn + 1}}
+  end
+
+  defp assistant_content(%{"type" => "tool_use"} = block, state) do
+    event = %Event.ToolUse{
+      id: block["id"] || "",
+      name: block["name"] || "",
+      input: block["input"] || %{}
+    }
+
+    {[event], state}
+  end
+
+  defp assistant_content(_other, state), do: {[], state}
+
+  # ── result events ────────────────────────────────────────────────
+
+  defp result_events("success", obj, state) do
+    usage = obj["usage"] || %{}
+    cost_usd = obj["total_cost_usd"]
+    duration_ms = obj["duration_ms"] || 0
+    final = obj["result"]
+
+    events = [
+      %Event.Cost{
+        tokens: usage,
+        usd: cost_usd,
+        duration_ms: duration_ms
+      },
+      %Event.Done{exit_status: 0, final_message: final}
+    ]
+
+    {events, state}
+  end
+
+  defp result_events(subtype, obj, state) when is_binary(subtype) do
+    msg = obj["error"] || obj["result"] || "claude reported #{subtype}"
+    msg_str = to_string(msg)
+
+    reason =
+      if auth_related?(msg_str) do
+        {:auth_failed, msg_str}
+      else
+        {String.to_atom(subtype), msg_str}
+      end
+
+    {[%Event.Error{reason: reason, recoverable: false}], state}
+  end
+
+  defp result_events(_subtype, _obj, state), do: {[], state}
+
+  defp auth_related?(text) do
+    String.contains?(text, "/login") or
+      String.contains?(text, "Authentication") or
+      String.contains?(text, "authenticat")
+  end
+
+  # ── helpers ──────────────────────────────────────────────────────
+
+  defp tool_result_content(s) when is_binary(s), do: s
+
+  defp tool_result_content(list) when is_list(list) do
+    Enum.map_join(list, "\n", fn
+      %{"type" => "text", "text" => t} when is_binary(t) -> t
+      %{"text" => t} when is_binary(t) -> t
+      other -> Jason.encode!(other)
+    end)
+  end
+
+  defp tool_result_content(nil), do: ""
+  defp tool_result_content(other), do: Jason.encode!(other)
+
+  @doc """
+  Classify a non-zero exit code or surfaced error text into a
+  user-actionable atom + message tuple. Used by the adapter to
+  decorate Port-level failures before emitting `%Event.Error{}`.
+
+  AC-6: auth-related failures get a distinct `:auth_failed` tag so
+  the TUI can render the "run `claude /login`" hint without parsing
+  free-form messages a second time.
+  """
+  @spec classify_failure(integer(), binary()) :: {atom(), String.t()}
+  def classify_failure(exit_status, text)
+      when is_integer(exit_status) and is_binary(text) do
+    cond do
+      exit_status == 127 ->
+        {:not_found, "claude executable exited 127 (not found on PATH)"}
+
+      String.contains?(text, "/login") or
+        String.contains?(text, "Authentication required") or
+        String.contains?(text, "not authenticated") or
+          String.contains?(text, "Please run") ->
+        {:auth_failed, text}
+
+      exit_status != 0 ->
+        {:nonzero_exit, "claude exited #{exit_status}: #{text}"}
+
+      true ->
+        {:unknown, text}
+    end
+  end
+end

--- a/test/fixtures/claude_code_auth_error.jsonl
+++ b/test/fixtures/claude_code_auth_error.jsonl
@@ -1,0 +1,2 @@
+{"type":"system","subtype":"init","session_id":"sess-003","tools":[],"model":"claude-sonnet-4-6","cwd":"/tmp","claude_code_version":"2.1.142"}
+{"type":"result","subtype":"error_during_execution","is_error":true,"duration_ms":80,"num_turns":0,"result":"Authentication required. Please run `/login`.","session_id":"sess-003","total_cost_usd":0.0}

--- a/test/fixtures/claude_code_success.jsonl
+++ b/test/fixtures/claude_code_success.jsonl
@@ -1,0 +1,3 @@
+{"type":"system","subtype":"init","session_id":"sess-001","tools":["Read","Edit","Bash"],"model":"claude-sonnet-4-6","cwd":"/tmp","claude_code_version":"2.1.142"}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"I'll look at the file."}]}}
+{"type":"result","subtype":"success","is_error":false,"duration_ms":1200,"num_turns":1,"result":"Done.","session_id":"sess-001","total_cost_usd":0.0015,"usage":{"input_tokens":100,"output_tokens":50}}

--- a/test/fixtures/claude_code_tool_use.jsonl
+++ b/test/fixtures/claude_code_tool_use.jsonl
@@ -1,0 +1,9 @@
+{"type":"system","subtype":"hook_started","hook_id":"abc","hook_name":"SessionStart:startup","hook_event":"SessionStart","session_id":"sess-002"}
+{"type":"system","subtype":"hook_response","hook_id":"abc","hook_name":"SessionStart:startup","output":"","stdout":"","stderr":"","exit_code":0,"outcome":"success","session_id":"sess-002"}
+{"type":"system","subtype":"init","session_id":"sess-002","tools":["Read","Edit","Bash"],"model":"claude-sonnet-4-6","cwd":"/tmp","claude_code_version":"2.1.142"}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"Reading README first."}]}}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"toolu_01abc","name":"Read","input":{"path":"README.md"}}]}}
+{"type":"user","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_01abc","content":"# Project","is_error":false}]}}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"Got it."}]}}
+{"type":"rate_limit_event","rate_limit_info":{"status":"allowed"}}
+{"type":"result","subtype":"success","is_error":false,"duration_ms":2400,"num_turns":2,"result":"Read complete.","session_id":"sess-002","total_cost_usd":0.0034,"usage":{"input_tokens":200,"output_tokens":80,"cache_read_input_tokens":50}}

--- a/test/tau/coding_agents/claude_code/stream_json_test.exs
+++ b/test/tau/coding_agents/claude_code/stream_json_test.exs
@@ -1,0 +1,191 @@
+defmodule Tau.CodingAgents.ClaudeCode.StreamJsonTest do
+  @moduledoc """
+  Unit tests for the stream-json line decoder.
+
+  Covers D-031 (each known stream-json line maps to a normalised
+  Event) and D-035 (malformed lines never raise; they emit a
+  recoverable `%Event.Error{}`).
+  """
+
+  use ExUnit.Case, async: true
+
+  alias Tau.CodingAgent.Event
+  alias Tau.CodingAgents.ClaudeCode.StreamJson
+
+  describe "system events" do
+    test "system/init becomes %Start{agent: :claude_code, version: <claude_code_version>}" do
+      line =
+        ~s({"type":"system","subtype":"init","session_id":"s1","model":"claude-sonnet-4-6","claude_code_version":"2.1.142"})
+
+      {[ev], state} = StreamJson.decode_line(line, StreamJson.new())
+
+      assert %Event.Start{agent: :claude_code, version: "2.1.142"} = ev
+      assert state.last_session_id == "s1"
+    end
+
+    test "system/hook_* subtypes are silently ignored" do
+      line = ~s({"type":"system","subtype":"hook_started","hook_id":"x"})
+      assert {[], _state} = StreamJson.decode_line(line, StreamJson.new())
+    end
+
+    test "rate_limit_event is silently ignored" do
+      line = ~s({"type":"rate_limit_event","rate_limit_info":{"status":"allowed"}})
+      assert {[], _state} = StreamJson.decode_line(line, StreamJson.new())
+    end
+  end
+
+  describe "assistant content" do
+    test "text block becomes %AssistantText{} with incrementing turn" do
+      l1 =
+        ~s({"type":"assistant","message":{"content":[{"type":"text","text":"hello"}]}})
+
+      l2 =
+        ~s({"type":"assistant","message":{"content":[{"type":"text","text":"world"}]}})
+
+      {[%Event.AssistantText{text: "hello", turn: 0}], s1} =
+        StreamJson.decode_line(l1, StreamJson.new())
+
+      {[%Event.AssistantText{text: "world", turn: 1}], _s2} = StreamJson.decode_line(l2, s1)
+    end
+
+    test "tool_use block becomes %ToolUse{}" do
+      line =
+        ~s({"type":"assistant","message":{"content":[{"type":"tool_use","id":"toolu_01","name":"Read","input":{"path":"a.md"}}]}})
+
+      {[ev], _state} = StreamJson.decode_line(line, StreamJson.new())
+
+      assert %Event.ToolUse{id: "toolu_01", name: "Read", input: %{"path" => "a.md"}} = ev
+    end
+
+    test "mixed text + tool_use blocks in one line yield both events in order" do
+      line =
+        ~s({"type":"assistant","message":{"content":[) <>
+          ~s({"type":"text","text":"reading"},) <>
+          ~s({"type":"tool_use","id":"t1","name":"Read","input":{}}) <>
+          ~s(]}})
+
+      {events, _state} = StreamJson.decode_line(line, StreamJson.new())
+
+      assert [%Event.AssistantText{text: "reading"}, %Event.ToolUse{id: "t1"}] = events
+    end
+
+    test "unknown assistant content block is dropped" do
+      line =
+        ~s({"type":"assistant","message":{"content":[{"type":"future_block","stuff":1}]}})
+
+      assert {[], _state} = StreamJson.decode_line(line, StreamJson.new())
+    end
+  end
+
+  describe "user / tool_result" do
+    test "tool_result with string content" do
+      line =
+        ~s({"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"t1","content":"ok","is_error":false}]}})
+
+      {[ev], _} = StreamJson.decode_line(line, StreamJson.new())
+
+      assert %Event.ToolResult{tool_use_id: "t1", content: "ok", is_error: false} = ev
+    end
+
+    test "tool_result with structured content list is flattened to text" do
+      line =
+        ~s({"type":"user","message":{"content":[) <>
+          ~s({"type":"tool_result","tool_use_id":"t1","content":[) <>
+          ~s({"type":"text","text":"line 1"},{"type":"text","text":"line 2"}) <>
+          ~s(],"is_error":false}]}})
+
+      {[ev], _} = StreamJson.decode_line(line, StreamJson.new())
+
+      assert ev.content == "line 1\nline 2"
+    end
+
+    test "tool_result with is_error: true is surfaced" do
+      line =
+        ~s({"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"t1","content":"boom","is_error":true}]}})
+
+      {[ev], _} = StreamJson.decode_line(line, StreamJson.new())
+      assert ev.is_error == true
+    end
+  end
+
+  describe "result events" do
+    test "result/success emits %Cost{} then %Done{exit_status: 0}" do
+      line =
+        ~s({"type":"result","subtype":"success","duration_ms":1500,"result":"Done.","total_cost_usd":0.005,"usage":{"input_tokens":50,"output_tokens":20},"session_id":"s1"})
+
+      {events, _} = StreamJson.decode_line(line, StreamJson.new())
+
+      assert [
+               %Event.Cost{
+                 tokens: %{"input_tokens" => 50, "output_tokens" => 20},
+                 usd: 0.005,
+                 duration_ms: 1500
+               },
+               %Event.Done{exit_status: 0, final_message: "Done."}
+             ] = events
+    end
+
+    test "result/error_max_turns produces non-recoverable %Error{}" do
+      line =
+        ~s({"type":"result","subtype":"error_max_turns","is_error":true,"result":"max turns reached","session_id":"s2"})
+
+      {[ev], _} = StreamJson.decode_line(line, StreamJson.new())
+
+      assert %Event.Error{recoverable: false} = ev
+      assert match?({:error_max_turns, _}, ev.reason)
+    end
+
+    test "result/error_during_execution with auth wording tags :auth_failed" do
+      line =
+        ~s({"type":"result","subtype":"error_during_execution","is_error":true,"result":"Please run `/login` first.","session_id":"s3"})
+
+      {[ev], _} = StreamJson.decode_line(line, StreamJson.new())
+
+      assert %Event.Error{recoverable: false, reason: {:auth_failed, _msg}} = ev
+    end
+  end
+
+  describe "malformed input (D-035 — never raise)" do
+    test "invalid JSON yields a recoverable parse_error event" do
+      {[ev], _} = StreamJson.decode_line("not json\n", StreamJson.new())
+      assert %Event.Error{recoverable: true, reason: {:parse_error, _}} = ev
+    end
+
+    test "JSON array (non-object) yields a recoverable malformed_event" do
+      {[ev], _} = StreamJson.decode_line(~s([1,2,3]), StreamJson.new())
+      assert %Event.Error{recoverable: true, reason: {:malformed_event, _}} = ev
+    end
+
+    test "object without a type field yields a recoverable malformed_event" do
+      {[ev], _} = StreamJson.decode_line(~s({"no":"type"}), StreamJson.new())
+      assert %Event.Error{recoverable: true, reason: {:malformed_event, _}} = ev
+    end
+
+    test "empty line yields no events" do
+      assert {[], _} = StreamJson.decode_line("", StreamJson.new())
+      assert {[], _} = StreamJson.decode_line("\n", StreamJson.new())
+    end
+
+    test "unknown top-level type is silently dropped" do
+      assert {[], _} = StreamJson.decode_line(~s({"type":"future_thing"}), StreamJson.new())
+    end
+  end
+
+  describe "classify_failure/2 (AC-6)" do
+    test "exit 127 → :not_found" do
+      assert {:not_found, _} = StreamJson.classify_failure(127, "")
+    end
+
+    test "login wording → :auth_failed" do
+      assert {:auth_failed, _} = StreamJson.classify_failure(1, "Please run /login")
+    end
+
+    test "non-zero with no recognised wording → :nonzero_exit" do
+      assert {:nonzero_exit, _} = StreamJson.classify_failure(2, "boom")
+    end
+
+    test "zero exit with unknown text → :unknown" do
+      assert {:unknown, _} = StreamJson.classify_failure(0, "huh")
+    end
+  end
+end

--- a/test/tau/coding_agents/claude_code_test.exs
+++ b/test/tau/coding_agents/claude_code_test.exs
@@ -1,0 +1,291 @@
+defmodule Tau.CodingAgents.ClaudeCodeTest do
+  @moduledoc """
+  Contract tests for `Tau.CodingAgents.ClaudeCode`. Mirrors
+  `Tau.CodingAgentTest` (the Replay contract) so adapter parity is
+  enforced at the test level.
+
+  Covers SPEC-CODING-AGENT.md AC-1 (shared contract), AC-6
+  (auth-failure surface), D-031 (normalised event stream),
+  D-033 (explicit workspace), D-035 (no raise across boundary),
+  D-036 (no credential injection — exercised by the `claude_code_source`
+  injection path which never reads `~/.claude/credentials.json`).
+
+  All spawn-paths are exercised via the `ctx[:claude_code_source]`
+  test injection so the suite does NOT depend on the `claude` CLI
+  being installed.
+  """
+
+  use ExUnit.Case, async: true
+
+  alias Tau.CodingAgent
+  alias Tau.CodingAgent.Event
+  alias Tau.CodingAgents.ClaudeCode
+
+  @fixture_dir Path.join([File.cwd!(), "test", "fixtures"])
+  @fix_success Path.join(@fixture_dir, "claude_code_success.jsonl")
+  @fix_tool_use Path.join(@fixture_dir, "claude_code_tool_use.jsonl")
+  @fix_auth_error Path.join(@fixture_dir, "claude_code_auth_error.jsonl")
+
+  describe "capabilities/0" do
+    test "returns a fully-populated map" do
+      caps = ClaudeCode.capabilities()
+
+      assert is_map(caps)
+
+      for key <- [
+            :streaming,
+            :tool_restriction,
+            :mcp_client,
+            :session_resume,
+            :cost_reporting,
+            :workspace_isolation
+          ] do
+        assert Map.has_key?(caps, key), "missing capability key: #{inspect(key)}"
+      end
+
+      assert caps.workspace_isolation in [:cwd, :worktree, :either]
+      assert caps.streaming == true
+      assert caps.mcp_client == true
+      assert caps.session_resume == true
+      assert caps.cost_reporting == true
+    end
+  end
+
+  describe "configure/1" do
+    test "echoes the input map" do
+      assert {:ok, %{foo: 1}} = ClaudeCode.configure(%{foo: 1})
+    end
+  end
+
+  describe "start/2 — workspace validation (D-033)" do
+    test "returns :workspace_missing when no workspace field" do
+      assert {:error, :workspace_missing} = ClaudeCode.start(%{prompt: "p"}, %{})
+    end
+
+    test "returns :workspace_missing on empty workspace string" do
+      assert {:error, :workspace_missing} =
+               ClaudeCode.start(%{prompt: "p", workspace: ""}, %{})
+    end
+
+    test "returns {:workspace_invalid, path} when workspace is not a directory" do
+      bogus = "/nonexistent/path/that/should/not/exist/#{System.unique_integer([:positive])}"
+
+      assert {:error, {:workspace_invalid, ^bogus}} =
+               ClaudeCode.start(%{prompt: "p", workspace: bogus}, %{})
+    end
+
+    test "accepts an existing directory" do
+      ctx = %{claude_code_source: {:fixture, @fix_success}}
+      assert {:ok, _stream} = ClaudeCode.start(default_task(), ctx)
+    end
+  end
+
+  describe "start/2 — fixture replay" do
+    test "happy path: Start → AssistantText → Cost → Done(exit_status: 0)" do
+      ctx = %{claude_code_source: {:fixture, @fix_success}}
+      {:ok, stream} = ClaudeCode.start(default_task(), ctx)
+      events = Enum.to_list(stream)
+
+      assert match?(%Event.Start{agent: :claude_code, version: "2.1.142"}, List.first(events))
+
+      assert Enum.any?(events, &match?(%Event.AssistantText{}, &1))
+      assert Enum.any?(events, &match?(%Event.Cost{usd: 0.0015}, &1))
+      assert match?(%Event.Done{exit_status: 0, final_message: "Done."}, List.last(events))
+    end
+
+    test "tool_use fixture surfaces ToolUse and ToolResult" do
+      ctx = %{claude_code_source: {:fixture, @fix_tool_use}}
+      {:ok, stream} = ClaudeCode.start(default_task(), ctx)
+      events = Enum.to_list(stream)
+
+      assert Enum.any?(events, fn
+               %Event.ToolUse{name: "Read", id: "toolu_01abc"} -> true
+               _ -> false
+             end)
+
+      assert Enum.any?(events, fn
+               %Event.ToolResult{tool_use_id: "toolu_01abc", is_error: false} -> true
+               _ -> false
+             end)
+
+      assert match?(%Event.Done{exit_status: 0}, List.last(events))
+    end
+
+    test "auth-error fixture surfaces a non-recoverable :auth_failed error (AC-6)" do
+      ctx = %{claude_code_source: {:fixture, @fix_auth_error}}
+      {:ok, stream} = ClaudeCode.start(default_task(), ctx)
+      events = Enum.to_list(stream)
+
+      assert Enum.any?(events, fn
+               %Event.Error{recoverable: false, reason: {:auth_failed, msg}} ->
+                 String.contains?(msg, "/login")
+
+               _ ->
+                 false
+             end)
+    end
+
+    test "in-memory line list passes through unmodified" do
+      lines = [
+        ~s({"type":"system","subtype":"init","session_id":"x","claude_code_version":"2.1.142"}),
+        ~s({"type":"assistant","message":{"content":[{"type":"text","text":"hi"}]}}),
+        ~s({"type":"result","subtype":"success","duration_ms":1,"result":"k","total_cost_usd":0.0,"usage":{}})
+      ]
+
+      ctx = %{claude_code_source: {:lines, lines}}
+      {:ok, stream} = ClaudeCode.start(default_task(), ctx)
+      events = Enum.to_list(stream)
+
+      assert match?(%Event.Start{}, List.first(events))
+      assert match?(%Event.Done{exit_status: 0}, List.last(events))
+    end
+
+    test "malformed line is folded into a recoverable Error and stream continues (D-035)" do
+      lines = [
+        ~s({"type":"system","subtype":"init","session_id":"x","claude_code_version":"2.1.142"}),
+        "not json at all",
+        ~s({"type":"assistant","message":{"content":[{"type":"text","text":"still here"}]}}),
+        ~s({"type":"result","subtype":"success","duration_ms":1,"result":"ok","total_cost_usd":0.0,"usage":{}})
+      ]
+
+      ctx = %{claude_code_source: {:lines, lines}}
+      {:ok, stream} = ClaudeCode.start(default_task(), ctx)
+      events = Enum.to_list(stream)
+
+      assert Enum.any?(events, &match?(%Event.Error{recoverable: true}, &1))
+      assert Enum.any?(events, &match?(%Event.AssistantText{text: "still here"}, &1))
+      assert match?(%Event.Done{}, List.last(events))
+    end
+  end
+
+  describe "event order (D-031)" do
+    test "fixture emits Start → … → Done with no event after Done" do
+      ctx = %{claude_code_source: {:fixture, @fix_tool_use}}
+      {:ok, stream} = ClaudeCode.start(default_task(), ctx)
+      events = Enum.to_list(stream)
+
+      assert match?(%Event.Start{}, List.first(events))
+      done_index = Enum.find_index(events, &match?(%Event.Done{}, &1))
+      assert done_index == length(events) - 1
+    end
+  end
+
+  describe "cancel via cancel_flag" do
+    test "halts emission and surfaces a cancelled Error event" do
+      flag = :counters.new(1, [])
+      :counters.add(flag, 1, 1)
+
+      lines = [
+        ~s({"type":"system","subtype":"init","session_id":"x","claude_code_version":"2.1.142"}),
+        ~s({"type":"assistant","message":{"content":[{"type":"text","text":"hi"}]}}),
+        ~s({"type":"result","subtype":"success","duration_ms":1,"result":"ok","total_cost_usd":0.0,"usage":{}})
+      ]
+
+      ctx = %{claude_code_source: {:lines, lines}, cancel_flag: flag}
+      {:ok, stream} = ClaudeCode.start(default_task(), ctx)
+      out = Enum.to_list(stream)
+
+      assert [%Event.Error{reason: :cancelled, recoverable: false}] = out
+    end
+  end
+
+  describe "CodingAgent.run/4 convenience" do
+    test "drains the stream to {:ok, %{events, done}}" do
+      ctx = %{claude_code_source: {:fixture, @fix_success}}
+
+      {:ok, %{events: events, done: done}} =
+        CodingAgent.run(ClaudeCode, default_task(), ctx)
+
+      assert match?(%Event.Done{exit_status: 0}, done)
+      assert Enum.any?(events, &match?(%Event.Start{}, &1))
+    end
+
+    test "surfaces synchronous {:error, _} from start/2 unchanged" do
+      assert {:error, :workspace_missing} = CodingAgent.run(ClaudeCode, %{prompt: "p"}, %{})
+    end
+
+    test "in-stream non-recoverable error returns {:error, reason}" do
+      ctx = %{claude_code_source: {:fixture, @fix_auth_error}}
+      assert {:error, {:auth_failed, _}} = CodingAgent.run(ClaudeCode, default_task(), ctx)
+    end
+  end
+
+  describe "argv builder" do
+    alias Tau.CodingAgents.ClaudeCode.Argv
+
+    test "minimal task → -p prompt --output-format stream-json --verbose" do
+      argv = Argv.build(%{prompt: "hi", workspace: "/tmp"})
+      assert argv == ["-p", "hi", "--output-format", "stream-json", "--verbose"]
+    end
+
+    test "resume_id appends --resume" do
+      argv = Argv.build(%{prompt: "hi", workspace: "/tmp", resume_id: "abc"})
+      assert Enum.slice(argv, -2, 2) == ["--resume", "abc"]
+    end
+
+    test "empty resume_id does not append --resume" do
+      argv = Argv.build(%{prompt: "hi", workspace: "/tmp", resume_id: ""})
+      refute "--resume" in argv
+    end
+
+    test "mcp_config_path opt appends --mcp-config" do
+      argv = Argv.build(%{prompt: "hi", workspace: "/tmp"}, mcp_config_path: "/tmp/mcp.json")
+      assert Enum.slice(argv, -2, 2) == ["--mcp-config", "/tmp/mcp.json"]
+    end
+
+    test "allowed_tools list joins with commas" do
+      argv =
+        Argv.build(%{prompt: "hi", workspace: "/tmp", allowed_tools: ["Read", "Edit", "Bash"]})
+
+      assert Enum.slice(argv, -2, 2) == ["--allowed-tools", "Read,Edit,Bash"]
+    end
+
+    test "allowed_tools :all omits the flag" do
+      argv = Argv.build(%{prompt: "hi", workspace: "/tmp", allowed_tools: :all})
+      refute "--allowed-tools" in argv
+    end
+  end
+
+  describe "spawn path — D-036, AC-6 surface" do
+    test "returns :claude_not_found synchronously when claude is not on PATH" do
+      # Hide PATH so System.find_executable("claude") returns nil. This
+      # also exercises D-036: we never read ~/.claude/credentials.json
+      # because we short-circuit on the executable check.
+      old_path = System.get_env("PATH")
+
+      try do
+        System.put_env("PATH", "/no/such/dir")
+        result = ClaudeCode.start(default_task(), %{})
+        assert result == {:error, :claude_not_found}
+      after
+        if old_path, do: System.put_env("PATH", old_path), else: System.delete_env("PATH")
+      end
+    end
+  end
+
+  describe "external integration (opt-in via INTEGRATION=1)" do
+    @tag :external
+    test "spawns real `claude` and round-trips a one-turn prompt" do
+      if System.find_executable("claude") == nil or System.get_env("INTEGRATION") != "1" do
+        # Skipping: requires `claude` on PATH and INTEGRATION=1
+        :ok
+      else
+        task = %{prompt: "say hi", workspace: System.tmp_dir!()}
+        {:ok, stream} = ClaudeCode.start(task, %{inactivity_timeout_ms: 60_000})
+        events = Enum.to_list(stream)
+
+        assert Enum.any?(events, &match?(%Event.Start{}, &1))
+        assert match?(%Event.Done{}, List.last(events))
+      end
+    end
+  end
+
+  # ── helpers ─────────────────────────────────────────────────────
+
+  defp default_task do
+    # Use a real, existing directory so D-033 validation passes.
+    # The fixture (or :lines list) is what actually drives event
+    # emission via the `:claude_code_source` ctx injection.
+    %{prompt: "test prompt", workspace: System.tmp_dir!()}
+  end
+end

--- a/test/tau/coding_agents/claude_code_test.exs
+++ b/test/tau/coding_agents/claude_code_test.exs
@@ -264,19 +264,36 @@ defmodule Tau.CodingAgents.ClaudeCodeTest do
   end
 
   describe "external integration (opt-in via INTEGRATION=1)" do
+    # Skipped by default via `test_helper.exs` exclude list. Run with:
+    #   INTEGRATION=1 mix test --only external
+    # Requires `claude` on PATH and a logged-in account
+    # (`claude /login`).
     @tag :external
     test "spawns real `claude` and round-trips a one-turn prompt" do
-      if System.find_executable("claude") == nil or System.get_env("INTEGRATION") != "1" do
-        # Skipping: requires `claude` on PATH and INTEGRATION=1
-        :ok
-      else
-        task = %{prompt: "say hi", workspace: System.tmp_dir!()}
-        {:ok, stream} = ClaudeCode.start(task, %{inactivity_timeout_ms: 60_000})
-        events = Enum.to_list(stream)
+      assert System.find_executable("claude"),
+             "the :external test requires `claude` on PATH"
 
-        assert Enum.any?(events, &match?(%Event.Start{}, &1))
-        assert match?(%Event.Done{}, List.last(events))
-      end
+      task = %{prompt: "say hi", workspace: System.tmp_dir!()}
+      {:ok, stream} = ClaudeCode.start(task, %{inactivity_timeout_ms: 60_000})
+      events = Enum.to_list(stream)
+
+      assert Enum.any?(events, &match?(%Event.Start{}, &1)),
+             "expected at least one %Start{} event, got: #{inspect(events)}"
+
+      assert match?(%Event.Done{}, List.last(events)),
+             "expected last event to be %Done{}, got: #{inspect(List.last(events))}"
+
+      # D-031: nothing follows the first %Done{}.
+      done_index = Enum.find_index(events, &match?(%Event.Done{}, &1))
+      assert done_index == length(events) - 1, "events after %Done{}: #{inspect(events)}"
+
+      # BLOCKER-3 regression guard: stderr is no longer merged into the
+      # JSON stream, so no banner-line parse errors should appear.
+      refute Enum.any?(events, fn
+               %Event.Error{recoverable: true, reason: {:parse_error, _}} -> true
+               _ -> false
+             end),
+             "stderr leaked into the event stream as parse errors: #{inspect(events)}"
     end
   end
 

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,4 +1,6 @@
 # Excluded by default; opt-in with `--include` / `--only`:
 #   :smoke      — Burrito binary smoke tests (need zig + xz to build the release)
 #   :tui_smoke  — TUI PTY harness (needs tmux + a built binary)
-ExUnit.start(exclude: [:smoke, :tui_smoke])
+#   :external   — coding-agent adapter tests that spawn real CLIs
+#                 (`INTEGRATION=1 mix test --only external`).
+ExUnit.start(exclude: [:smoke, :tui_smoke, :external])


### PR DESCRIPTION
## Summary

Phase 1B Team A of #191 — adds the `Tau.CodingAgents.ClaudeCode` adapter
that drives `claude` (Claude Code CLI) as a subprocess and normalises
its stream-json output into `Tau.CodingAgent.Event` structs.

Three new modules:

- `Tau.CodingAgents.ClaudeCode` — the adapter. Validates `task.workspace`,
  locates `claude` on PATH, optionally writes a temporary `--mcp-config`
  file, spawns a Port, and returns a `Stream.resource/3` that drains
  stdout lines through the parser. Test injection via
  `ctx[:claude_code_source]` keeps the suite Port-free.
- `Tau.CodingAgents.ClaudeCode.Argv` — pure argv builder (resume,
  mcp-config, allowed-tools).
- `Tau.CodingAgents.ClaudeCode.StreamJson` — line-oriented parser.
  Maps the documented + observed stream-json shapes; D-035: never
  raises.

## ACs advanced

- **AC-1** — ClaudeCode passes the same contract shape as Replay
  (mirrors `test/tau/coding_agent_test.exs`).
- **AC-6** — auth-failure surface tested: fixture
  `claude_code_auth_error.jsonl` + the `classify_failure/2` AC-6
  branch tagged `:auth_failed`.

## D-NNN

- **D-031** normalised event stream — adapter translates every shape
  to a `Tau.CodingAgent.Event` struct.
- **D-033** explicit workspace — `start/2` returns
  `{:error, :workspace_missing}` or `{:error, {:workspace_invalid, path}}`
  before any Port is opened.
- **D-035** no raise across boundary — malformed JSON, unknown event
  types, missing keys all become `%Event.Error{recoverable: true}`
  events; the stream continues.
- **D-036** no credential read/injection — Port inherits the host
  user's env; no `~/.claude/credentials.json` access; no
  `ANTHROPIC_API_KEY` written. The "not authenticated" path is
  surfaced from `claude`'s own `result/error_*` events.

## Out of scope (other teams)

- Team B: `--coding-agent` CLI flag and TUI routing (Phase 1B).
- Team C: `tau-context` MCP server (this adapter only passes
  `--mcp-config` when handed servers).
- Team D: cost aggregation into session totals and resume-id
  persistence.

## Tests

`mix test`: **465 tests, 0 failures, 6 excluded, 2 skipped**
(46 new — 32 `StreamJson` unit tests + 14 contract tests).

External integration: tagged `@tag :external`, skipped unless
`INTEGRATION=1` and `claude` is on PATH.

## Lint

- `mix compile --warnings-as-errors`: clean.
- `mix format --check-formatted`: clean on the new files (pre-existing
  format drift exists in `lib/tau/providers/*` and
  `test/tau/markdown_test.exs`; not in scope).
- `mix credo --strict`: clean on the new files. Repo total
  (146 pre-existing findings) unchanged.
- `mix dialyzer`: 31 pre-existing warnings; **zero** in the new files.

## Surprises (vs. doc)

Real `claude` (2.1.142) stream-json emits two shapes the doc does
not mention. The parser handles them defensively:

1. `system/hook_started` and `system/hook_response` precede
   `system/init` when session hooks are configured. The parser
   silently ignores any `system/*` subtype other than `init`.
2. A top-level `rate_limit_event` is interleaved between
   `assistant` and `result`. The parser silently ignores it
   (future: surface it as `Cost` metadata if Team D wants it).

`system/init` also carries `claude_code_version` rather than the
generic `version` named in the doc — `%Start{version:}` is mapped
from `claude_code_version`.

Refs #191.