### PR TITLE
feat(coding-agent): --coding-agent flag + FSM extension + worktree workspace (Phase 1B Team B of #191)

### DIFF
--- a/.claude/rules/spec-before-code.md
+++ b/.claude/rules/spec-before-code.md
@@ -25,7 +25,7 @@ The current spec catalog:
   Mandatory for any PR touching `lib/tau/coding_agent.ex`,
   `lib/tau/coding_agent/`, `lib/tau/coding_agents/`, `lib/tau/cli.ex`
   (the `--coding-agent` flag), or `lib/tau/tools/builtin/delegate.ex`
-  (Phase 2). Triage score 4/5; D-031..D-036 live here.
+  (Phase 2). Triage score 4/5; D-031..D-037 live here.
 
 Future SPECs land here as new components reach triage threshold.
 

--- a/docs/spec/SPEC-CODING-AGENT.md
+++ b/docs/spec/SPEC-CODING-AGENT.md
@@ -128,6 +128,29 @@ expressing the change.
       }
 ```
 
+**Session-mode integration shape (Phase 1B Team B, resolved 2026-05-15
+toward "FSM-extended").** The session FSM (`lib/tau/session.ex`,
+`:gen_statem`) hosts a new `:coding_agent_streaming` state **parallel
+to** the existing `:provider_streaming` state. The transition rules:
+
+* `:awaiting_user` + user submits + `data.coding_agent != nil` →
+  `:coding_agent_streaming` (skipping `:start_provider`).
+* `:coding_agent_streaming` consumes the dispatcher's normalized
+  events: `Event.AssistantText` folds into a `%Tau.Message.Assistant{}`
+  text content block; `Event.ToolUse` appends an Anthropic-shaped
+  `%{type: :tool_call, ...}` content block; `Event.ToolResult` flushes
+  the in-progress assistant message, appends a `%Tau.Message.ToolResult{}`,
+  broadcasts a `%Events.ToolEnd{}`, and starts a fresh pending
+  assistant message; `Event.FileEdit` and `Event.Cost` emit telemetry
+  only (cost aggregation lands in Phase 1B Team D); `Event.Done`
+  finalizes and returns to `:awaiting_user`.
+
+The normalization step is deliberate: **coding-agent events become
+`Tau.Message` structs**, which means the existing TUI render path,
+JSONL persistence, and `/resume` apply unchanged (D-037). Adapters are
+addressed by atom on `data.coding_agent`; the FSM never switches on
+agent type (D-031).
+
 The returned Enumerable emits `Tau.CodingAgent.Event` structs:
 
 ```
@@ -166,6 +189,25 @@ The dispatcher **guarantees** every run terminates with exactly one
 - Opt-in: dispatcher's cwd via an explicit `--cwd` flag on the Delegate tool / session mode. The user-facing wording is "run in my current directory" so the trade-off is visible.
 - Adapter MUST validate the workspace exists and is a directory before spawn.
 - D-033 stands regardless: the path is **always** explicit in `task.workspace`; the dispatcher MUST NOT silently inherit tau's cwd. Worktree creation is the caller's responsibility (Phase 1B Team B); this contract just enforces the boundary.
+
+**Phase 1B Team B implementation (landed).** Worktree creation lives in
+`Tau.CodingAgent.Workspace`, a pluggable behaviour with two backends:
+
+- `Tau.CodingAgent.Workspace.Git` — default when tau is invoked inside
+  a git repository. Creates a per-session worktree at
+  `~/.tau/worktrees/<session_id>/` on branch
+  `tau/coding-agent/<session_id>`. Cleaned up on session terminate
+  (normal exit, crash, or supervisor shutdown) via
+  `git worktree remove --force`.
+- `Tau.CodingAgent.Workspace.Cwd` — passthrough fallback when tau was
+  invoked outside a git repo, and the surface tests rely on. No state
+  is allocated; cleanup is a no-op. A
+  `[:tau, :coding_agent, :workspace, :git_repo_absent]` telemetry
+  event marks the fallback so `tau doctor` can surface it.
+
+Backend resolution is automatic — the user does not have to think about
+worktree vs cwd. `:coding_agent_workspace_backend` can be passed to
+`Tau.start_session/1` to override (tests use this).
 
 ### B4 — `tau-context` MCP server
 
@@ -210,6 +252,7 @@ The dispatcher **guarantees** every run terminates with exactly one
 | **D-034** | Telemetry parity with `Tau.Provider`. Start/event/stop/exception in the documented shape. |
 | **D-035** | Adapter failures surface in-stream as `%CodingAgent.Event.Error{}` events. Adapters MUST NOT raise for transport, auth, or parse errors. Hard configuration errors (no executable on PATH, malformed argv) may return synchronous `{:error, reason}` from `start/2`. |
 | **D-036** | Auth boundary — tau MUST NOT inject or copy credentials. The subprocess inherits the host user's config dir. Tau MAY check existence and emit a user-actionable "not configured" error. |
+| **D-037** | Coding-agent runs are **first-class sessions**: dispatcher events normalize into `Tau.Message.Assistant{}` / `Tau.Message.ToolResult{}` on ingestion so the session FSM's existing `data.messages` list, JSONL persistence, `%Events.MessageEnd{}` broadcast, TUI render path, and `/resume` apply unchanged. The `:coding_agent_streaming` state lives parallel to `:provider_streaming` and is selected at `process_user_message/2` time when `data.coding_agent != nil`. The no-coding-agent path remains byte-identical to today's provider flow. |
 
 ## 7. Resolved design questions
 
@@ -281,18 +324,32 @@ test/tau/coding_agent/telemetry_test.exs         # D-034 shape
 test/tau/coding_agent/lifecycle_property_test.exs # AC-5 skeleton
 ```
 
+Phase 1B Team B (this PR — landed):
+
+```
+lib/tau/coding_agent/workspace.ex                # behaviour + dispatch
+lib/tau/coding_agent/workspace/git.ex            # per-session worktree backend
+lib/tau/coding_agent/workspace/cwd.ex            # passthrough backend
+lib/tau/cli.ex                                   # --coding-agent flag + resolver
+lib/tau/tui/app.ex                               # plumbs flag through RuntimeOpts
+lib/tau/tui/runtime_opts.ex                      # documented :coding_agent key
+lib/tau/session.ex                               # :coding_agent_streaming state + helpers
+lib/tau/settings/schema.ex                       # coding_agent.default_agent
+test/tau/cli_coding_agent_flag_test.exs          # CLI flag parse + resolver
+test/tau/coding_agent/workspace_test.exs         # worktree create/cleanup
+test/tau/session/coding_agent_streaming_test.exs # FSM drives Replay end-to-end
+```
+
 Phase 1B / Phase 2 (planned):
 
 ```
 lib/tau/coding_agents/claude_code.ex             # first real adapter (Team A)
-lib/tau/cli.ex                                   # --coding-agent flag (Team B)
-lib/tau/coding_agent/workspace.ex                # worktree creation (Team B)
 lib/tau/mcp/servers/tau_context.ex               # tau-context MCP server (Team C)
 lib/tau/cost.ex                                  # adapter-tagged line items (Team D)
 lib/tau/tools/builtin/delegate.ex                # tool surface (Phase 2)
 ```
 
-Total runtime invariants claimed by this spec: **D-031 through D-036** (6).
+Total runtime invariants claimed by this spec: **D-031 through D-037** (7).
 
 ## Appendix B — non-goals discussion
 

--- a/lib/tau.ex
+++ b/lib/tau.ex
@@ -62,6 +62,22 @@ defmodule Tau do
       `:session` pins it for the session's life so a sub-agent cannot
       dismiss its own persona. Has no effect when `:active_skill` is
       `nil`.
+    * `:coding_agent` — module implementing `Tau.CodingAgent`
+      (SPEC-CODING-AGENT). When set, user messages route through the
+      coding-agent dispatcher (FSM state `:coding_agent_streaming`)
+      instead of `provider.stream/3`. Default `nil` preserves the
+      legacy provider path byte-identically. See `--coding-agent` on
+      the CLI for the user-facing surface.
+    * `:coding_agent_ctx` — per-run map threaded into the
+      `Tau.CodingAgent` adapter's `ctx` argument. Same shape as
+      `:provider_ctx` (ADR-0002): not persisted, not propagated to
+      forks/resumes. Tests use this to thread Replay fixtures.
+    * `:coding_agent_workspace_backend` — override the workspace
+      backend (`Tau.CodingAgent.Workspace.Git` /
+      `Tau.CodingAgent.Workspace.Cwd`). Default: Git when invoked
+      inside a repo, Cwd otherwise.
+    * `:coding_agent_workspace_opts` — extra opts (e.g. `:state_dir`)
+      passed through to `Tau.CodingAgent.Workspace.prepare/1`.
   """
   @spec start_session(keyword()) :: {:ok, session_id()} | {:error, term()}
   def start_session(opts \\ []) do

--- a/lib/tau/cli.ex
+++ b/lib/tau/cli.ex
@@ -221,7 +221,19 @@ defmodule Tau.CLI do
           about: "Launch the interactive TUI",
           options: [
             provider: [short: "-p", long: "--provider", help: "Provider id"],
-            model: [short: "-m", long: "--model", help: "Model id"]
+            model: [short: "-m", long: "--model", help: "Model id"],
+            # SPEC-CODING-AGENT (#191) — session-mode coding-agent surface.
+            # When set, the TUI's "Send" routes user messages to the
+            # named coding-agent (e.g. `claude_code`, `replay`) via the
+            # `Tau.CodingAgent.Dispatcher` and the FSM's
+            # `:coding_agent_streaming` state, in place of the provider
+            # path. Default `nil` preserves the legacy `Tau.Provider`
+            # path byte-identically.
+            coding_agent: [
+              long: "--coding-agent",
+              help:
+                "Run the TUI in coding-agent session mode (claude_code|replay|<Module>); skips the provider path"
+            ]
           ]
         ]
       ]
@@ -355,12 +367,31 @@ defmodule Tau.CLI do
     []
     |> tui_put(:provider, opts[:provider], &resolve_provider/1)
     |> tui_put(:model, opts[:model], & &1)
+    |> tui_put(:coding_agent, opts[:coding_agent], &resolve_coding_agent/1)
   end
 
   defp tui_opts(_), do: []
 
   defp tui_put(opts, _key, nil, _xform), do: opts
   defp tui_put(opts, key, value, xform), do: Keyword.put(opts, key, xform.(value))
+
+  # SPEC-CODING-AGENT §4 B1 / D-031: adapters are addressed by atom in
+  # tau's runtime (the FSM's `data.coding_agent` is an atom module).
+  # Mirrors `resolve_provider/1`'s pattern: known short names map to
+  # concrete modules; anything else is treated as a `Tau.CodingAgents.<X>`
+  # module reference. Used by Optimus value -> module conversion when
+  # building `Tau.TUI.RuntimeOpts`.
+  @doc false
+  def resolve_coding_agent(nil), do: nil
+  def resolve_coding_agent("claude_code"), do: Tau.CodingAgents.ClaudeCode
+  def resolve_coding_agent("claudecode"), do: Tau.CodingAgents.ClaudeCode
+  def resolve_coding_agent("replay"), do: Tau.CodingAgents.Replay
+
+  def resolve_coding_agent(other) when is_binary(other) do
+    Module.concat(["Tau", "CodingAgents", String.capitalize(other)])
+  end
+
+  def resolve_coding_agent(mod) when is_atom(mod), do: mod
 
   defp resolve_provider(nil), do: Tau.Provider.default()
   defp resolve_provider("anthropic"), do: Tau.Providers.Anthropic

--- a/lib/tau/coding_agent.ex
+++ b/lib/tau/coding_agent.ex
@@ -10,7 +10,7 @@ defmodule Tau.CodingAgent do
   tool calls, edits, and (often) cost reporting.
 
   See `docs/spec/SPEC-CODING-AGENT.md` for the design rationale and
-  the D-031..D-036 runtime invariants.
+  the D-031..D-037 runtime invariants.
 
   ## Contract
 

--- a/lib/tau/coding_agent/workspace.ex
+++ b/lib/tau/coding_agent/workspace.ex
@@ -1,0 +1,152 @@
+defmodule Tau.CodingAgent.Workspace do
+  @moduledoc """
+  Workspace preparation and cleanup for coding-agent runs.
+
+  Phase 1B Team B (#191) introduces a **per-session git worktree** as the
+  default workspace for coding-agent runs (SPEC-CODING-AGENT §4 B3, Q3).
+  The worktree isolates the agent's edits from the user's working tree
+  and survives until the session ends.
+
+  This module is a thin **behaviour** with pluggable backends:
+
+    * `Tau.CodingAgent.Workspace.Git` — repo-detection + `git worktree add`
+      + `git worktree remove` on cleanup. The default.
+    * `Tau.CodingAgent.Workspace.Cwd` — passthrough; uses the session's
+      cwd directly. Used when there is no surrounding git repository or
+      when the caller explicitly opted out. Replay tests select this
+      backend so they don't depend on a real repo.
+
+  D-033 (SPEC-CODING-AGENT §6): the workspace path returned here is
+  **always** an explicit absolute path; the dispatcher MUST NOT inherit
+  tau's cwd silently. `prepare/2` validates the result before returning.
+
+  ## Lifecycle
+
+      {:ok, ws} = Workspace.prepare(opts)
+      # ws.path is the absolute path the dispatcher's `task.workspace`
+      # field MUST carry.
+      # ... run dispatcher against ws.path ...
+      :ok = Workspace.cleanup(ws)
+
+  The session FSM owns the lifecycle: prepares at the first
+  `:coding_agent_streaming` transition for a session, cleans up on
+  `terminate/3` (whether the session exits cleanly or crashes). The
+  cleanup is best-effort — a partially-prepared workspace (failed mid-add)
+  is also a no-op so resume / crash-recovery never wedges on a stale
+  worktree.
+
+  ## Behaviour contract
+
+  Implementations declare two callbacks:
+
+      @callback prepare(opts :: keyword()) :: {:ok, t()} | {:error, term()}
+      @callback cleanup(t()) :: :ok
+
+  `opts` is implementation-defined; the canonical keys are:
+
+    * `:session_id` — string, used to name the worktree directory.
+    * `:cwd`        — absolute path the user invoked tau from.
+    * `:state_dir`  — root under which worktrees are created
+      (default `Path.join(System.user_home!(), ".tau/worktrees")`).
+  """
+
+  @type backend :: module()
+
+  @type t :: %__MODULE__{
+          backend: backend(),
+          path: Path.t(),
+          repo_root: Path.t() | nil,
+          branch: String.t() | nil,
+          # backend-specific opaque
+          handle: term()
+        }
+
+  @enforce_keys [:backend, :path]
+  defstruct [:backend, :path, :repo_root, :branch, :handle]
+
+  @callback prepare(opts :: keyword()) :: {:ok, t()} | {:error, term()}
+  @callback cleanup(t()) :: :ok
+
+  @doc """
+  Prepare a workspace. Dispatches to the requested backend (default
+  `Tau.CodingAgent.Workspace.Git`) and validates that the returned
+  `:path` is an absolute path to an existing directory before handing
+  it back to the caller (D-033).
+  """
+  @spec prepare(keyword()) :: {:ok, t()} | {:error, term()}
+  def prepare(opts) do
+    backend = Keyword.get(opts, :backend, Tau.CodingAgent.Workspace.Git)
+
+    case backend.prepare(opts) do
+      {:ok, %__MODULE__{path: path} = ws} ->
+        cond do
+          not is_binary(path) -> {:error, {:workspace_invalid, :path_not_binary}}
+          Path.absname(path) != path -> {:error, {:workspace_invalid, :path_not_absolute}}
+          not File.dir?(path) -> {:error, {:workspace_invalid, {:not_a_directory, path}}}
+          true -> {:ok, ws}
+        end
+
+      {:ok, other} ->
+        {:error, {:workspace_invalid, {:not_a_workspace_struct, other}}}
+
+      {:error, _} = err ->
+        err
+    end
+  end
+
+  @doc """
+  Tear down a workspace. Idempotent and best-effort: a `nil` workspace
+  (preparation failed before this struct existed) is a no-op; a
+  backend-level failure is logged via telemetry but does not raise.
+  """
+  @spec cleanup(t() | nil) :: :ok
+  def cleanup(nil), do: :ok
+
+  def cleanup(%__MODULE__{backend: backend} = ws) do
+    backend.cleanup(ws)
+  rescue
+    e ->
+      :telemetry.execute(
+        [:tau, :coding_agent, :workspace, :cleanup_failed],
+        %{system_time: System.system_time()},
+        %{backend: backend, path: ws.path, reason: Exception.message(e)}
+      )
+
+      :ok
+  catch
+    kind, reason ->
+      :telemetry.execute(
+        [:tau, :coding_agent, :workspace, :cleanup_failed],
+        %{system_time: System.system_time()},
+        %{backend: backend, path: ws.path, reason: {kind, reason}}
+      )
+
+      :ok
+  end
+
+  @doc """
+  Resolve the appropriate backend for a given cwd. Returns
+  `Tau.CodingAgent.Workspace.Git` when `cwd` (or any ancestor) contains
+  a `.git` entry; falls back to `Tau.CodingAgent.Workspace.Cwd`
+  otherwise.
+
+  Used by the session FSM so the user is not forced to think about
+  worktree vs cwd — the default Just Works in a git repo and degrades
+  gracefully when invoked elsewhere. A telemetry event records the
+  fallback so the user can see the reason in `tau doctor` later.
+  """
+  @spec resolve_default_backend(Path.t()) :: backend()
+  def resolve_default_backend(cwd) when is_binary(cwd) do
+    if Tau.CodingAgent.Workspace.Git.find_repo_root(cwd) do
+      Tau.CodingAgent.Workspace.Git
+    else
+      :telemetry.execute(
+        [:tau, :coding_agent, :workspace, :git_repo_absent],
+        %{system_time: System.system_time()},
+        %{cwd: cwd}
+      )
+
+      Tau.CodingAgent.Workspace.Cwd
+    end
+  end
+end

--- a/lib/tau/coding_agent/workspace/cwd.ex
+++ b/lib/tau/coding_agent/workspace/cwd.ex
@@ -1,0 +1,49 @@
+defmodule Tau.CodingAgent.Workspace.Cwd do
+  @moduledoc """
+  Passthrough workspace — the coding agent operates directly in the
+  session's cwd (SPEC-CODING-AGENT §4 B3, opt-in surface).
+
+  Selected automatically when the user invoked tau outside a git
+  repository (so `Workspace.Git` would refuse) and explicitly when the
+  caller passes `backend: Tau.CodingAgent.Workspace.Cwd`. Replay-based
+  tests use this backend so they don't need a real git repo.
+
+  No state is allocated: `prepare/1` simply validates that `:cwd` is an
+  absolute path to an existing directory and wraps it in a
+  `%Workspace{}`. `cleanup/1` is a no-op — the user's cwd is sacred.
+  """
+
+  @behaviour Tau.CodingAgent.Workspace
+
+  alias Tau.CodingAgent.Workspace
+
+  @impl Tau.CodingAgent.Workspace
+  def prepare(opts) do
+    cwd = Keyword.fetch!(opts, :cwd)
+
+    cond do
+      not is_binary(cwd) ->
+        {:error, {:workspace_invalid, :cwd_not_binary}}
+
+      not File.dir?(cwd) ->
+        {:error, {:workspace_invalid, {:cwd_not_a_directory, cwd}}}
+
+      true ->
+        ws = %Workspace{backend: __MODULE__, path: Path.expand(cwd)}
+
+        :telemetry.execute(
+          [:tau, :coding_agent, :workspace, :prepared],
+          %{system_time: System.system_time()},
+          %{backend: __MODULE__, path: ws.path}
+        )
+
+        {:ok, ws}
+    end
+  end
+
+  @impl Tau.CodingAgent.Workspace
+  def cleanup(%Workspace{backend: __MODULE__}) do
+    # No-op: never delete the user's working tree.
+    :ok
+  end
+end

--- a/lib/tau/coding_agent/workspace/git.ex
+++ b/lib/tau/coding_agent/workspace/git.ex
@@ -1,0 +1,215 @@
+defmodule Tau.CodingAgent.Workspace.Git do
+  @moduledoc """
+  Per-session **git worktree** workspace (SPEC-CODING-AGENT §4 B3, Q3).
+
+  Each session gets a fresh worktree at
+  `~/.tau/worktrees/<session_id>/` (overridable via `:state_dir`), on a
+  branch named `tau/coding-agent/<session_id>`. The worktree is removed
+  on `cleanup/1` via `git worktree remove --force`.
+
+  ## Why a worktree
+
+  The dominant destructive interaction surface flagged in
+  SPEC-CODING-AGENT §3 ([C1-B3] / [C2-B3]) is a concurrent editor
+  session writing the same files the coding agent edits. A worktree
+  isolates the agent's writes onto a parallel branch without copying
+  the repo or interfering with the user's index. The user can review
+  the agent's changes via `git diff <ws-path>` or merge the branch
+  back when satisfied.
+
+  ## Failure modes
+
+    * The user invoked tau from a directory that is **not** inside a
+      git repo: this backend will never be selected by
+      `Workspace.resolve_default_backend/1` — the FSM falls back to
+      `Workspace.Cwd`. Calling `prepare/1` here directly in that
+      situation returns `{:error, :not_a_git_repo}`.
+    * `git` is not on PATH: `prepare/1` returns
+      `{:error, {:git_missing, _}}`. Adapters that require a worktree
+      should surface this as an `%Event.Error{}` rather than crash.
+    * The state directory cannot be created: `{:error, {:state_dir,
+      reason}}`.
+
+  All failure modes are tagged-tuple returns; no exceptions cross the
+  boundary.
+  """
+
+  @behaviour Tau.CodingAgent.Workspace
+
+  alias Tau.CodingAgent.Workspace
+
+  @branch_prefix "tau/coding-agent/"
+
+  @impl Tau.CodingAgent.Workspace
+  def prepare(opts) do
+    session_id = Keyword.fetch!(opts, :session_id)
+    cwd = Keyword.fetch!(opts, :cwd)
+    state_dir = Keyword.get(opts, :state_dir, default_state_dir())
+
+    with {:ok, git_bin} <- find_git(),
+         {:ok, repo_root} <- locate_repo(cwd),
+         :ok <- ensure_state_dir(state_dir),
+         {:ok, path} <- compute_worktree_path(state_dir, session_id),
+         branch <- @branch_prefix <> session_id,
+         :ok <- create_worktree(git_bin, repo_root, path, branch) do
+      ws = %Workspace{
+        backend: __MODULE__,
+        path: path,
+        repo_root: repo_root,
+        branch: branch,
+        handle: %{git_bin: git_bin}
+      }
+
+      :telemetry.execute(
+        [:tau, :coding_agent, :workspace, :prepared],
+        %{system_time: System.system_time()},
+        %{backend: __MODULE__, path: path, repo_root: repo_root, branch: branch}
+      )
+
+      {:ok, ws}
+    end
+  end
+
+  @impl Tau.CodingAgent.Workspace
+  def cleanup(%Workspace{backend: __MODULE__, path: path, repo_root: repo_root, handle: handle}) do
+    git_bin = Map.get(handle || %{}, :git_bin) || System.find_executable("git")
+
+    if git_bin && File.dir?(path) do
+      # `--force` because the agent's branch is almost certainly dirty
+      # at end-of-session — that's the whole point.
+      System.cmd(git_bin, ["worktree", "remove", "--force", path],
+        cd: repo_root,
+        stderr_to_stdout: true
+      )
+    end
+
+    # Best-effort directory removal in case `git worktree remove` left
+    # an orphan (it shouldn't, but worktrees can drift on a crashed
+    # session).
+    if File.dir?(path), do: File.rm_rf(path)
+
+    :telemetry.execute(
+      [:tau, :coding_agent, :workspace, :cleaned],
+      %{system_time: System.system_time()},
+      %{backend: __MODULE__, path: path, repo_root: repo_root}
+    )
+
+    :ok
+  end
+
+  @doc """
+  Locate the git repository root for a starting directory by walking
+  up the path tree looking for a `.git` entry. Returns the absolute
+  path of the repository root, or `nil` if `cwd` is not under a git
+  repo.
+
+  Public so the workspace dispatcher can pre-check before selecting
+  this backend; also exercised directly by the workspace unit tests.
+  """
+  @spec find_repo_root(Path.t()) :: Path.t() | nil
+  def find_repo_root(cwd) when is_binary(cwd) do
+    cwd = Path.expand(cwd)
+    do_find_repo_root(cwd)
+  end
+
+  defp do_find_repo_root(path) do
+    git_entry = Path.join(path, ".git")
+
+    cond do
+      File.exists?(git_entry) ->
+        path
+
+      path == "/" or Path.dirname(path) == path ->
+        nil
+
+      true ->
+        do_find_repo_root(Path.dirname(path))
+    end
+  end
+
+  # ── helpers ───────────────────────────────────────────────────
+
+  defp find_git do
+    case System.find_executable("git") do
+      nil -> {:error, {:git_missing, "git binary not on PATH"}}
+      bin -> {:ok, bin}
+    end
+  end
+
+  defp locate_repo(cwd) do
+    case find_repo_root(cwd) do
+      nil -> {:error, :not_a_git_repo}
+      root -> {:ok, root}
+    end
+  end
+
+  defp ensure_state_dir(dir) do
+    case File.mkdir_p(dir) do
+      :ok -> :ok
+      {:error, reason} -> {:error, {:state_dir, reason}}
+    end
+  end
+
+  defp compute_worktree_path(state_dir, session_id) do
+    # Sanitise session_id: only word chars and dashes survive. UUIDv7
+    # ids are already safe; this is paranoia for tests that hand in
+    # arbitrary strings.
+    safe = String.replace(session_id, ~r/[^\w\-]/, "_")
+    path = Path.join(state_dir, safe)
+
+    cond do
+      File.dir?(path) ->
+        # A stale worktree from a previous crashed session. Best-effort
+        # nuke it so we get a clean slate. `git worktree remove --force`
+        # against the *repo* would be cleaner but we don't have the repo
+        # root yet at the right level — File.rm_rf works fine because
+        # the worktree's metadata under the repo's .git/worktrees/ will
+        # be GC'd by `git worktree prune` on the next `add` call below.
+        File.rm_rf(path)
+        {:ok, path}
+
+      File.exists?(path) ->
+        {:error, {:state_dir, {:path_exists_as_file, path}}}
+
+      true ->
+        {:ok, path}
+    end
+  end
+
+  defp create_worktree(git_bin, repo_root, path, branch) do
+    # `git worktree prune` first — removes references to stale worktree
+    # paths that may match our target. Without this, a crashed previous
+    # session leaves an entry in `.git/worktrees/` and `git worktree add`
+    # refuses with "fatal: '...' already exists".
+    System.cmd(git_bin, ["worktree", "prune"], cd: repo_root, stderr_to_stdout: true)
+
+    # `-b <branch>` creates a fresh branch off HEAD. If the branch
+    # already exists (resumed session id collision) we retry without
+    # `-b` so an existing branch is reattached.
+    case System.cmd(git_bin, ["worktree", "add", "-b", branch, path],
+           cd: repo_root,
+           stderr_to_stdout: true
+         ) do
+      {_out, 0} ->
+        :ok
+
+      {out, _nonzero} ->
+        # Heuristic: branch already exists. Retry without -b.
+        if out =~ "already exists" do
+          case System.cmd(git_bin, ["worktree", "add", path, branch],
+                 cd: repo_root,
+                 stderr_to_stdout: true
+               ) do
+            {_out, 0} -> :ok
+            {out2, _} -> {:error, {:git_worktree_add_failed, String.trim(out2)}}
+          end
+        else
+          {:error, {:git_worktree_add_failed, String.trim(out)}}
+        end
+    end
+  end
+
+  defp default_state_dir do
+    Path.join(System.user_home!(), ".tau/worktrees")
+  end
+end

--- a/lib/tau/session.ex
+++ b/lib/tau/session.ex
@@ -29,6 +29,15 @@ defmodule Tau.Session do
   alias Tau.Session.Events
   alias Tau.Provider.Event, as: PEvent
   alias Tau.Settings.Cache, as: SettingsCache
+  # SPEC-CODING-AGENT (#191): coding-agent session mode. The FSM hosts
+  # a parallel `:coding_agent_streaming` state. When `data.coding_agent`
+  # is non-nil, user messages route through `Tau.CodingAgent.Dispatcher`
+  # instead of `data.provider.stream/3`; the dispatcher's normalized
+  # events fold into `data.messages` as `%Assistant{}` / `%ToolResult{}`
+  # so the existing TUI render path, persistence, and `/resume` apply
+  # unchanged (D-037).
+  alias Tau.CodingAgent.Event, as: CAEvent
+  alias Tau.CodingAgent.Workspace, as: CAWorkspace
 
   # #17: name of the synthetic FSM-internal tool the model emits to
   # activate a discovered skill. Not registered as a `Tau.Tool` module
@@ -381,6 +390,24 @@ defmodule Tau.Session do
     provider_ctx = opts[:provider_ctx] || %{}
     persistence = opts[:persistence] || Tau.Persistence.impl()
     preload = opts[:preload_events] || []
+    # SPEC-CODING-AGENT §4 B1 / D-037: coding-agent session mode. When
+    # `:coding_agent` is set the FSM routes user messages through the
+    # `:coding_agent_streaming` state. CLI flag overrides settings;
+    # settings provides the deployment-wide default.
+    coding_agent =
+      opts[:coding_agent] ||
+        coding_agent_from_settings()
+
+    coding_agent_workspace_backend =
+      opts[:coding_agent_workspace_backend] ||
+        if(coding_agent, do: CAWorkspace.resolve_default_backend(cwd), else: nil)
+
+    coding_agent_workspace_opts = opts[:coding_agent_workspace_opts] || []
+    # SPEC-CODING-AGENT §4 B1: per-run knobs for the coding-agent
+    # adapter. Mirrors `:provider_ctx` (ADR-0002) — not persisted, not
+    # propagated to forks/resumes. Tests use this to thread a Replay
+    # fixture into the adapter without touching settings or env.
+    coding_agent_ctx = opts[:coding_agent_ctx] || %{}
 
     case persistence.open(id,
            cwd: cwd,
@@ -513,7 +540,48 @@ defmodule Tau.Session do
           max_tool_iterations:
             opts[:max_tool_iterations] ||
               get_in(SettingsCache.get(), [:session, :max_tool_iterations]) ||
-              20
+              20,
+          # SPEC-CODING-AGENT (#191):
+          #
+          # `coding_agent` — adapter module or nil. When set, user
+          # messages route to `:coding_agent_streaming`.
+          #
+          # `coding_agent_workspace_backend` — pluggable backend module
+          # (`Workspace.Git` for repo-detected, `Workspace.Cwd`
+          # otherwise). Resolved at init time from `cwd`; lazily
+          # `prepare/2`'d on the first `:coding_agent_streaming`
+          # transition so a session that never runs an agent pays no
+          # worktree cost.
+          #
+          # `coding_agent_workspace_opts` — extra opts threaded through
+          # to `Workspace.prepare/1` (e.g. `:state_dir` overrides in
+          # tests).
+          #
+          # `coding_agent_workspace` — the prepared `%Workspace{}` once
+          # established; persists across turns within the same session
+          # so the agent keeps editing the same isolated branch.
+          # Cleaned up in `terminate/3`.
+          #
+          # `coding_agent_dispatcher` — pid of the currently-running
+          # dispatcher, or nil. Holds the cancel target for
+          # `:cancel` in `:coding_agent_streaming`.
+          #
+          # `coding_agent_pending` — the in-progress `%Assistant{}`
+          # being assembled from dispatcher events. Finalized on `Done`.
+          #
+          # `coding_agent_blocks` — ordered content-block accumulator
+          # for the in-progress assistant message. AssistantText events
+          # append to a single text block (per turn); ToolUse events
+          # append `%{type: :tool_call, ...}` blocks. Mirrors the
+          # provider-side `Assembler`'s `:order` semantics.
+          coding_agent: coding_agent,
+          coding_agent_ctx: coding_agent_ctx,
+          coding_agent_workspace_backend: coding_agent_workspace_backend,
+          coding_agent_workspace_opts: coding_agent_workspace_opts,
+          coding_agent_workspace: nil,
+          coding_agent_dispatcher: nil,
+          coding_agent_pending: nil,
+          coding_agent_blocks: []
         }
 
         {:ok, :awaiting_user, data}
@@ -524,8 +592,19 @@ defmodule Tau.Session do
   end
 
   @impl :gen_statem
-  def terminate(reason, _state, %{persistence: p, persist_handle: h, id: id}) do
+  def terminate(reason, _state, %{persistence: p, persist_handle: h, id: id} = data) do
     p.close(h)
+
+    # SPEC-CODING-AGENT D-032 + Workspace cleanup. Runs on every
+    # terminate path — normal exit, crash, supervisor shutdown — so
+    # the worktree never leaks across BEAM restarts. Best-effort and
+    # idempotent (no-op when workspace is nil or already cleaned).
+    if Map.get(data, :coding_agent_dispatcher) do
+      pid = data.coding_agent_dispatcher
+      if Process.alive?(pid), do: Tau.CodingAgent.Dispatcher.cancel(pid)
+    end
+
+    CAWorkspace.cleanup(Map.get(data, :coding_agent_workspace))
 
     broadcast(id, %Events.SessionEnd{session_id: id, reason: reason})
 
@@ -705,6 +784,52 @@ defmodule Tau.Session do
     end
   end
 
+  # ── coding-agent streaming (SPEC-CODING-AGENT §4 B1 / D-037) ─────
+  #
+  # Parallel to `:start_provider`. Spins up a dispatcher under
+  # `Tau.CodingAgent.Supervisor`, hands it the prepared workspace
+  # path, and consumes the normalized event stream. Each event lands
+  # in the FSM mailbox tagged `{:coding_agent_event, pid, struct}` and
+  # is dispatched in `handle_event(:info, {:coding_agent_event, ...},
+  # :coding_agent_streaming, _)`.
+  def handle_event(:internal, :start_coding_agent, :coding_agent_streaming, data) do
+    transition(data.id, data, :coding_agent_streaming)
+
+    :telemetry.execute(
+      [:tau, :session, :coding_agent_streaming, :start],
+      %{system_time: System.system_time()},
+      %{session_id: data.id, agent: data.coding_agent}
+    )
+
+    case ensure_coding_agent_workspace(data) do
+      {:ok, data, workspace_path} ->
+        start_coding_agent_dispatcher(data, workspace_path)
+
+      {:error, reason} ->
+        emit_coding_agent_sync_error(data, reason)
+    end
+  end
+
+  # Forward dispatcher events into the FSM. Stale events (from a
+  # previous run that was cancelled and superseded) are dropped by
+  # the pid mismatch — analogous to `stream_ref` for the provider
+  # path (ADR-0012).
+  def handle_event(
+        :info,
+        {:coding_agent_event, pid, event},
+        :coding_agent_streaming,
+        %{coding_agent_dispatcher: pid} = data
+      ) do
+    handle_coding_agent_event(event, data)
+  end
+
+  # Stale or out-of-order event — dispatcher mismatch. Drop silently;
+  # the dispatcher's `restart: :temporary` guarantees no zombie pid
+  # is resurrected.
+  def handle_event(:info, {:coding_agent_event, _other_pid, _event}, _state, data) do
+    {:keep_state, data}
+  end
+
   # ADR-0012: retryable mid-stream errors fall back to the next provider
   # in `data.fallback_chain_remaining`. Inserted *before* the generic
   # :provider_event clause so a non-empty chain takes over before the
@@ -882,6 +1007,14 @@ defmodule Tau.Session do
       Process.exit(data.command_task, :brutal_kill)
     end
 
+    # SPEC-CODING-AGENT D-032: subprocess lifecycle bound to session.
+    # Cancel the dispatcher cooperatively; it will emit a synthetic
+    # `%Done{exit_status: -2}` event that we ignore here (the cancel
+    # cascade has already broadcast `%Cancelled{}` for the user).
+    if data.coding_agent_dispatcher && Process.alive?(data.coding_agent_dispatcher) do
+      Tau.CodingAgent.Dispatcher.cancel(data.coding_agent_dispatcher)
+    end
+
     broadcast(data.id, %Events.Cancelled{session_id: data.id, reason: :user})
 
     persist_event(data, "cancellation", %{
@@ -907,7 +1040,12 @@ defmodule Tau.Session do
          active_skill: nil,
          # D-027: reset per-turn tool-iteration counter on every
          # return to :awaiting_user, including cancellation.
-         tool_iterations: 0
+         tool_iterations: 0,
+         # SPEC-CODING-AGENT: dispatcher state is per-turn; reset on
+         # cancel. Workspace is per-session — preserved.
+         coding_agent_dispatcher: nil,
+         coding_agent_pending: nil,
+         coding_agent_blocks: []
      }}
   end
 
@@ -1053,7 +1191,15 @@ defmodule Tau.Session do
           |> append_message(msg)
           |> persist_event("user_message", message_to_data(msg))
 
-        handle_event(:internal, :start_provider, :provider_streaming, data)
+        # SPEC-CODING-AGENT (#191) / D-037: route to the coding-agent
+        # dispatcher when one is configured; preserve the legacy
+        # provider path otherwise. The byte-identity guarantee for
+        # the no-coding-agent case lives here.
+        if data.coding_agent do
+          handle_event(:internal, :start_coding_agent, :coding_agent_streaming, data)
+        else
+          handle_event(:internal, :start_provider, :provider_streaming, data)
+        end
     end
   end
 
@@ -1593,6 +1739,24 @@ defmodule Tau.Session do
   # Both atom and string keys are accepted (Settings.Loader uses
   # `keys: :atoms`; Jason leaves *values* as strings, so the resolver
   # is the canonical str → module step).
+  # SPEC-CODING-AGENT §5 / D-037: deployment-wide default for the
+  # coding-agent surface. Read from the merged settings cascade at
+  # session init only — the CLI flag overrides; in-flight sessions
+  # are not affected by mid-session settings reloads (D-007).
+  defp coding_agent_from_settings do
+    settings = SettingsCache.get()
+
+    raw =
+      get_in(settings, [:coding_agent, :default_agent]) ||
+        get_in(settings, ["coding_agent", "default_agent"])
+
+    case raw do
+      nil -> nil
+      mod when is_atom(mod) -> mod
+      str when is_binary(str) -> Tau.CLI.resolve_coding_agent(str)
+    end
+  end
+
   defp lookup_fallback_chain(original_provider) when is_atom(original_provider) do
     settings = Tau.Settings.Cache.get()
 
@@ -1663,6 +1827,457 @@ defmodule Tau.Session do
       %{session_id: data.id, from_state: state}
     )
   end
+
+  # --- Coding-agent streaming (SPEC-CODING-AGENT §4 B1 / D-037) ------------
+  #
+  # Helpers for the `:coding_agent_streaming` FSM state. The split mirrors
+  # the provider path's helpers (Assembler + finalize_assistant +
+  # cancel_provider_task) but operates on `Tau.CodingAgent.Event` instead
+  # of `Tau.Provider.Event`. Folding into a unified message type happens
+  # here so the TUI render, persistence, and `/resume` reuse the provider
+  # path unchanged.
+
+  # Ensure a per-session workspace exists. Re-uses an already-prepared
+  # workspace for subsequent turns within the same session (the worktree
+  # / cwd survives across user turns; only torn down at session end).
+  # Returns `{:ok, data, path}` on success, `{:error, reason}` on failure.
+  defp ensure_coding_agent_workspace(%{coding_agent_workspace: %CAWorkspace{} = ws} = data) do
+    {:ok, data, ws.path}
+  end
+
+  defp ensure_coding_agent_workspace(%{coding_agent_workspace: nil} = data) do
+    backend = data.coding_agent_workspace_backend || CAWorkspace.resolve_default_backend(data.cwd)
+
+    opts =
+      Keyword.merge(
+        [
+          backend: backend,
+          session_id: data.id,
+          cwd: data.cwd
+        ],
+        data.coding_agent_workspace_opts || []
+      )
+
+    case CAWorkspace.prepare(opts) do
+      {:ok, ws} -> {:ok, %{data | coding_agent_workspace: ws}, ws.path}
+      {:error, reason} -> {:error, {:workspace_prepare_failed, reason}}
+    end
+  end
+
+  # Synchronous pre-dispatch error (workspace prepare failed, supervisor
+  # refused to start a dispatcher, …). Surfaces as an `%Assistant{}` with
+  # `stop_reason: :error` and a non-empty content block — mirrors D-009
+  # for the provider path so the existing TUI render path Just Works.
+  defp emit_coding_agent_sync_error(data, reason) do
+    reason_str = describe_coding_agent_error(reason)
+
+    msg =
+      Assistant.new(
+        stop_reason: :error,
+        error_message: reason_str,
+        content: [%{type: :text, text: "Error: " <> reason_str}]
+      )
+
+    data =
+      data
+      |> append_message(msg)
+      |> persist_event("assistant_message", message_to_data(msg))
+
+    broadcast(data.id, %Events.MessageEnd{session_id: data.id, message: msg})
+
+    :telemetry.execute(
+      [:tau, :session, :coding_agent_streaming, :exception],
+      %{system_time: System.system_time()},
+      %{session_id: data.id, agent: data.coding_agent, reason: reason}
+    )
+
+    {:next_state, :awaiting_user,
+     %{data | coding_agent_dispatcher: nil, coding_agent_pending: nil, coding_agent_blocks: []}}
+  end
+
+  # Start a fresh dispatcher under `Tau.CodingAgent.Supervisor` and
+  # broadcast `MessageStart` so the TUI's `:streaming` indicator lights
+  # up immediately (no waiting for the first AssistantText event).
+  defp start_coding_agent_dispatcher(data, workspace_path) do
+    user_text = latest_user_text(data.messages)
+
+    task = %{
+      prompt: user_text,
+      workspace: workspace_path,
+      session_id: data.id,
+      allowed_tools: :all,
+      mcp_servers: [],
+      timeout: :infinity
+    }
+
+    ctx =
+      Map.merge(
+        %{
+          session_id: data.id,
+          request_id: generate_event_id()
+        },
+        data.coding_agent_ctx || %{}
+      )
+
+    args = [
+      adapter: data.coding_agent,
+      task: task,
+      ctx: ctx,
+      subscriber: self()
+    ]
+
+    case Tau.CodingAgent.Supervisor.start_dispatcher(args) do
+      {:ok, pid} ->
+        pending =
+          Assistant.new(
+            provider: data.coding_agent,
+            model: nil,
+            api: :coding_agent,
+            content: []
+          )
+
+        broadcast(data.id, %Events.MessageStart{session_id: data.id, message: pending})
+
+        {:next_state, :coding_agent_streaming,
+         %{
+           data
+           | coding_agent_dispatcher: pid,
+             coding_agent_pending: pending,
+             coding_agent_blocks: []
+         }}
+
+      {:error, reason} ->
+        emit_coding_agent_sync_error(data, {:dispatcher_start_failed, reason})
+    end
+  end
+
+  defp latest_user_text(messages) do
+    # Walk from the end to find the most recent user-supplied text.
+    # The skill/memory injection prepends synthetic User messages with
+    # `metadata.role in [:system, :compaction_summary]`; skip those.
+    messages
+    |> Enum.reverse()
+    |> Enum.find_value("", fn
+      %User{metadata: %{role: r}} when r in [:system, :compaction_summary] ->
+        nil
+
+      %User{content: c} when is_binary(c) ->
+        c
+
+      %User{content: blocks} when is_list(blocks) ->
+        Enum.map_join(blocks, "\n", fn
+          %{type: :text, text: t} -> t
+          %{"type" => "text", "text" => t} -> t
+          _ -> ""
+        end)
+
+      _ ->
+        nil
+    end)
+  end
+
+  # ── Event-by-event handlers (D-031: pattern match on struct module).
+  #
+  # AssistantText accumulates into a single text block per turn (or
+  # restarts when a `turn` jump is observed). ToolUse and ToolResult
+  # emit their own messages so the assembled assistant message reflects
+  # the agent's actual content shape, matching the provider path. Cost
+  # and FileEdit emit telemetry; Cost is also NOT yet aggregated into
+  # session cost totals (Team D's scope). Error / Done finalize.
+
+  defp handle_coding_agent_event(%CAEvent.Start{} = ev, data) do
+    :telemetry.execute(
+      [:tau, :session, :coding_agent_streaming, :adapter_start],
+      %{system_time: System.system_time()},
+      %{session_id: data.id, agent: data.coding_agent, version: ev.version}
+    )
+
+    {:keep_state, data}
+  end
+
+  defp handle_coding_agent_event(%CAEvent.AssistantText{text: t}, data) do
+    blocks = append_assistant_text(data.coding_agent_blocks, t)
+    pending = %{data.coding_agent_pending | content: blocks}
+
+    broadcast(data.id, %Events.MessageUpdate{
+      session_id: data.id,
+      event: %CAEvent.AssistantText{text: t},
+      message: pending
+    })
+
+    {:keep_state, %{data | coding_agent_blocks: blocks, coding_agent_pending: pending}}
+  end
+
+  defp handle_coding_agent_event(%CAEvent.ToolUse{id: id, name: name, input: input}, data) do
+    # Anthropic-compatible content-block shape — same as the provider
+    # path's `%{type: :tool_call, ...}` blocks the Assembler emits.
+    block = %{type: :tool_call, id: id, name: name, arguments: input || %{}}
+    blocks = data.coding_agent_blocks ++ [block]
+    pending = %{data.coding_agent_pending | content: blocks}
+
+    broadcast(data.id, %Events.MessageUpdate{
+      session_id: data.id,
+      event: %CAEvent.ToolUse{id: id, name: name, input: input},
+      message: pending
+    })
+
+    # ToolStart broadcast mirrors the provider path so existing TUI /
+    # audit subscribers see the same tool-call surface regardless of
+    # which event source produced it (D-031).
+    broadcast(data.id, %Events.ToolStart{
+      session_id: data.id,
+      tool_call_id: id,
+      name: name,
+      arguments: input || %{}
+    })
+
+    {:keep_state, %{data | coding_agent_blocks: blocks, coding_agent_pending: pending}}
+  end
+
+  defp handle_coding_agent_event(
+         %CAEvent.ToolResult{tool_use_id: tool_id, content: content, is_error: is_err},
+         data
+       ) do
+    # ToolResult is a separate message in Anthropic's wire format. We
+    # finalise the current assistant message (so the user can see what
+    # the agent said BEFORE the tool result), append a ToolResult
+    # message, broadcast ToolEnd, then start a new pending assistant
+    # message for any subsequent AssistantText.
+    {data, _} = flush_pending_assistant(data, :tool_use)
+
+    tool_result =
+      ToolResult.new(
+        tool_call_id: tool_id,
+        # ToolUse may not have been observed (some adapters emit
+        # ToolResult standalone); we don't have the tool name here, so
+        # fall back to "tool" — matches Anthropic's permissive shape.
+        tool_name: tool_name_for(data, tool_id),
+        content: content,
+        is_error: is_err
+      )
+
+    data =
+      data
+      |> append_message(tool_result)
+      |> persist_event("tool_result", tool_result_to_data(tool_result))
+
+    broadcast(data.id, %Events.ToolEnd{
+      session_id: data.id,
+      tool_call_id: tool_id,
+      result: tool_result
+    })
+
+    # Start a fresh assistant message for any further AssistantText
+    # the agent emits before `Done`.
+    pending =
+      Assistant.new(
+        provider: data.coding_agent,
+        model: nil,
+        api: :coding_agent,
+        content: []
+      )
+
+    broadcast(data.id, %Events.MessageStart{session_id: data.id, message: pending})
+
+    {:keep_state, %{data | coding_agent_pending: pending, coding_agent_blocks: []}}
+  end
+
+  defp handle_coding_agent_event(%CAEvent.FileEdit{path: path, kind: kind}, data) do
+    :telemetry.execute(
+      [:tau, :session, :coding_agent_streaming, :file_edit],
+      %{system_time: System.system_time()},
+      %{session_id: data.id, agent: data.coding_agent, path: path, kind: kind}
+    )
+
+    {:keep_state, data}
+  end
+
+  defp handle_coding_agent_event(%CAEvent.Cost{} = cost, data) do
+    # Team D will fold this into session cost totals; for now we just
+    # surface telemetry so observers (tau doctor, future TUI panel)
+    # can see it. The hook below is the deliberate extension point.
+    :telemetry.execute(
+      [:tau, :session, :coding_agent_streaming, :cost],
+      %{
+        system_time: System.system_time(),
+        duration_ms: cost.duration_ms,
+        usd: cost.usd || 0.0
+      },
+      %{session_id: data.id, agent: data.coding_agent, tokens: cost.tokens}
+    )
+
+    {:keep_state, maybe_apply_cost_hook(data, cost)}
+  end
+
+  defp handle_coding_agent_event(%CAEvent.Error{reason: reason, recoverable: rec?}, data) do
+    reason_str = describe_coding_agent_error(reason)
+
+    if rec? do
+      # Recoverable: stash an error-content block so the user sees
+      # *something* and let the dispatcher continue.
+      blocks =
+        data.coding_agent_blocks ++ [%{type: :text, text: "[adapter error] " <> reason_str}]
+
+      pending = %{data.coding_agent_pending | content: blocks, error_message: reason_str}
+
+      broadcast(data.id, %Events.MessageUpdate{
+        session_id: data.id,
+        event: %CAEvent.Error{reason: reason, recoverable: rec?},
+        message: pending
+      })
+
+      {:keep_state, %{data | coding_agent_blocks: blocks, coding_agent_pending: pending}}
+    else
+      # Non-recoverable: the dispatcher will follow with a synthetic
+      # Done. Mark the pending message and let the Done finaliser
+      # render. We don't transition here — Done does the FSM move.
+      pending = %{
+        data.coding_agent_pending
+        | error_message: reason_str,
+          stop_reason: :error
+      }
+
+      {:keep_state, %{data | coding_agent_pending: pending}}
+    end
+  end
+
+  defp handle_coding_agent_event(%CAEvent.Done{} = done, data) do
+    finalize_coding_agent_turn(done, data)
+  end
+
+  defp handle_coding_agent_event(_other, data), do: {:keep_state, data}
+
+  # Build / extend the in-progress text block. AssistantText events
+  # within one turn concatenate into a single text content block — this
+  # mirrors how Anthropic's stream-json folds text deltas.
+  defp append_assistant_text(blocks, t) when is_binary(t) do
+    case List.last(blocks) do
+      %{type: :text, text: existing} ->
+        Enum.drop(blocks, -1) ++ [%{type: :text, text: existing <> t}]
+
+      _ ->
+        blocks ++ [%{type: :text, text: t}]
+    end
+  end
+
+  # Push the current pending assistant message into `data.messages`,
+  # persist, broadcast `MessageEnd`. Leaves the FSM state untouched
+  # (caller decides). Returns `{data, msg}`.
+  defp flush_pending_assistant(%{coding_agent_pending: nil} = data, _stop_reason),
+    do: {data, nil}
+
+  defp flush_pending_assistant(data, stop_reason) do
+    msg = %{
+      data.coding_agent_pending
+      | content:
+          ensure_visible_assistant_content(data.coding_agent_blocks, data.coding_agent_pending),
+        stop_reason: data.coding_agent_pending.stop_reason || stop_reason
+    }
+
+    data =
+      data
+      |> append_message(msg)
+      |> persist_event("assistant_message", message_to_data(msg))
+
+    broadcast(data.id, %Events.MessageEnd{session_id: data.id, message: msg})
+
+    {data, msg}
+  end
+
+  # Mirrors the Assembler's `ensure_visible_content/1` so an
+  # error-with-empty-content message still surfaces a text block to the
+  # TUI (D-009 invariant preserved on the coding-agent path).
+  defp ensure_visible_assistant_content([], %{stop_reason: :error, error_message: em})
+       when is_binary(em) and em != "" do
+    [%{type: :text, text: "Error: " <> em}]
+  end
+
+  defp ensure_visible_assistant_content([], %{stop_reason: :error}) do
+    [%{type: :text, text: "Error: coding-agent ended with no content"}]
+  end
+
+  defp ensure_visible_assistant_content([], _pending) do
+    [%{type: :text, text: "(empty response)"}]
+  end
+
+  defp ensure_visible_assistant_content(blocks, _pending), do: blocks
+
+  defp finalize_coding_agent_turn(%CAEvent.Done{exit_status: status} = done, data) do
+    stop_reason =
+      cond do
+        data.coding_agent_pending && data.coding_agent_pending.stop_reason == :error -> :error
+        # Synthetic cancel sentinel (D-032).
+        status == -2 -> :aborted
+        # Synthetic dispatcher / adapter death.
+        status == -1 -> :error
+        status == 0 -> :end_turn
+        true -> :error
+      end
+
+    # Inject the final_message as a trailing text block if the agent
+    # supplied one and we don't already have content covering it.
+    blocks =
+      case done.final_message do
+        nil -> data.coding_agent_blocks
+        "" -> data.coding_agent_blocks
+        text -> append_assistant_text(data.coding_agent_blocks, "\n" <> text)
+      end
+
+    data = %{data | coding_agent_blocks: blocks}
+
+    {data, _msg} = flush_pending_assistant(data, stop_reason)
+
+    :telemetry.execute(
+      [:tau, :session, :coding_agent_streaming, :stop],
+      %{system_time: System.system_time()},
+      %{
+        session_id: data.id,
+        agent: data.coding_agent,
+        exit_status: status,
+        stop_reason: stop_reason
+      }
+    )
+
+    {:next_state, :awaiting_user,
+     %{
+       data
+       | coding_agent_dispatcher: nil,
+         coding_agent_pending: nil,
+         coding_agent_blocks: []
+     }}
+  end
+
+  # Recover a tool name from the in-progress message's ToolUse blocks
+  # for a given `tool_use_id`. Falls back to "tool" if the ToolUse
+  # event wasn't observed (some adapters elide it for cheap tools).
+  defp tool_name_for(data, tool_use_id) do
+    blocks = (data.coding_agent_pending && data.coding_agent_pending.content) || []
+
+    Enum.find_value(blocks, "tool", fn
+      %{type: :tool_call, id: ^tool_use_id, name: n} -> n
+      _ -> nil
+    end)
+  end
+
+  # Extension point for Team D's cost-piping work. Today a no-op; the
+  # `Cost` event already produces telemetry above. When Team D's
+  # aggregator lands they can replace this body with a call into the
+  # session-cost tracker.
+  defp maybe_apply_cost_hook(data, _cost), do: data
+
+  # Translate a coding-agent error reason into a user-visible string.
+  # Mirrors `describe_provider_error/1` for the provider path.
+  defp describe_coding_agent_error({:workspace_prepare_failed, reason}),
+    do: "Workspace preparation failed: " <> inspect(reason)
+
+  defp describe_coding_agent_error({:dispatcher_start_failed, reason}),
+    do: "Coding-agent dispatcher failed to start: " <> inspect(reason)
+
+  defp describe_coding_agent_error(:cancelled), do: "cancelled"
+  defp describe_coding_agent_error(:inactivity_timeout), do: "Coding-agent inactivity timeout"
+
+  defp describe_coding_agent_error(other) when is_binary(other), do: other
+  defp describe_coding_agent_error(other), do: inspect(other)
 
   # --- Hook payload --------------------------------------------------------
   #

--- a/lib/tau/settings/schema.ex
+++ b/lib/tau/settings/schema.ex
@@ -155,6 +155,19 @@ defmodule Tau.Settings.Schema do
             "enum" => ~w(env keychain_mac keychain_linux keychain_windows auto)
           }
         }
+      },
+      # SPEC-CODING-AGENT (#191) / D-037: deployment-wide default for
+      # the coding-agent session-mode surface. `default_agent` is a
+      # short name resolved via `Tau.CLI.resolve_coding_agent/1`
+      # (e.g. `"claude_code"`, `"replay"`). The CLI flag
+      # `--coding-agent` overrides; in-flight sessions snapshot at init.
+      "coding_agent" => %{
+        "type" => "object",
+        "additionalProperties" => true,
+        "properties" => %{
+          "default_agent" => %{"type" => ["string", "null"]},
+          "expose_tau_context" => %{"type" => "boolean"}
+        }
       }
     }
   }

--- a/lib/tau/tui/app.ex
+++ b/lib/tau/tui/app.ex
@@ -42,6 +42,13 @@ if Code.ensure_loaded?(Ratatouille.Runtime) do
         |> put_if(:provider, Map.get(runtime_opts, :provider))
         |> put_if(:model, Map.get(runtime_opts, :model))
         |> put_if(:provider_ctx, Map.get(runtime_opts, :provider_ctx))
+        # SPEC-CODING-AGENT §4 B1 / D-037: when the user invoked tau
+        # with `--coding-agent <name>`, the session FSM routes user
+        # messages through the coding-agent dispatcher instead of
+        # `data.provider.stream/3`. The TUI's submit path is unchanged
+        # (`Tau.send/2` → cast → FSM); the routing decision lives in
+        # `Tau.Session.process_user_message/2`.
+        |> put_if(:coding_agent, Map.get(runtime_opts, :coding_agent))
 
       {:ok, ^session_id} = Tau.start_session(start_opts)
 
@@ -51,7 +58,8 @@ if Code.ensure_loaded?(Ratatouille.Runtime) do
         transcript: [],
         tool_output: [],
         status: :idle,
-        last_assistant: nil
+        last_assistant: nil,
+        coding_agent: Map.get(runtime_opts, :coding_agent)
       }
     end
 
@@ -242,12 +250,21 @@ if Code.ensure_loaded?(Ratatouille.Runtime) do
           content:
             "session: " <>
               model.session_id <>
+              status_bar_coding_agent(model) <>
               " | status: " <>
               to_string(model.status) <>
               " | <Enter> submit · <Esc> cancel · <Ctrl-C> quit"
         )
       end
     end
+
+    # SPEC-CODING-AGENT §4 B1: when the TUI was launched with
+    # `--coding-agent`, surface the adapter in the status bar so the
+    # user can tell at a glance that "Send" is routed through a
+    # subprocess agent rather than the configured `Tau.Provider`.
+    defp status_bar_coding_agent(%{coding_agent: nil}), do: ""
+    defp status_bar_coding_agent(%{coding_agent: mod}), do: " | agent: " <> inspect(mod)
+    defp status_bar_coding_agent(_), do: ""
 
     # D-026 ([C51-B3]): a solid block cursor (U+2588 "█") MUST be appended
     # after the current input so the user can see the insertion point.

--- a/lib/tau/tui/runtime_opts.ex
+++ b/lib/tau/tui/runtime_opts.ex
@@ -19,6 +19,10 @@ defmodule Tau.TUI.RuntimeOpts do
     * `:provider` — provider module atom (e.g. `Tau.Providers.Replay`)
     * `:model` — model id string
     * `:provider_ctx` — provider-scoped runtime context map (ADR-0002)
+    * `:coding_agent` — coding-agent adapter module atom (e.g.
+      `Tau.CodingAgents.ClaudeCode`). When set, the TUI's user-message
+      path routes through `Tau.CodingAgent.Dispatcher` instead of the
+      provider stream (SPEC-CODING-AGENT §4 B1).
   """
 
   @key {Tau.TUI, :runtime_opts}

--- a/test/tau/cli_coding_agent_flag_test.exs
+++ b/test/tau/cli_coding_agent_flag_test.exs
@@ -1,0 +1,72 @@
+defmodule Tau.CLICodingAgentFlagTest do
+  @moduledoc """
+  SPEC-CODING-AGENT §4 B1 / D-037: the `--coding-agent` flag on the
+  `tui` subcommand (and on bare `tau`, via the same Optimus spec)
+  parses cleanly and resolves the string into a concrete adapter
+  module that the session FSM and TUI route through.
+
+  This test exercises `Tau.CLI.spec/0` directly (mirroring
+  `Tau.CLI.MainDispatchTest`) so it can't accidentally invoke
+  `System.halt/1` via `main/1`.
+  """
+  use ExUnit.Case, async: true
+
+  describe "Optimus spec — --coding-agent option" do
+    test "tui subcommand accepts --coding-agent replay" do
+      assert {[:tui], parsed} =
+               Optimus.parse!(Tau.CLI.spec(), ["tui", "--coding-agent", "replay"])
+
+      assert parsed.options[:coding_agent] == "replay"
+    end
+
+    test "tui subcommand accepts --coding-agent claude_code" do
+      assert {[:tui], parsed} =
+               Optimus.parse!(Tau.CLI.spec(), ["tui", "--coding-agent", "claude_code"])
+
+      assert parsed.options[:coding_agent] == "claude_code"
+    end
+
+    test "the option is optional: absence yields nil (default-provider path unchanged)" do
+      assert {[:tui], parsed} = Optimus.parse!(Tau.CLI.spec(), ["tui"])
+      assert is_nil(parsed.options[:coding_agent])
+    end
+  end
+
+  describe "resolve_coding_agent/1 — string → module" do
+    test "claude_code resolves to Tau.CodingAgents.ClaudeCode (even when module isn't loaded)" do
+      assert Tau.CLI.resolve_coding_agent("claude_code") == Tau.CodingAgents.ClaudeCode
+      assert Tau.CLI.resolve_coding_agent("claudecode") == Tau.CodingAgents.ClaudeCode
+    end
+
+    test "replay resolves to Tau.CodingAgents.Replay" do
+      assert Tau.CLI.resolve_coding_agent("replay") == Tau.CodingAgents.Replay
+    end
+
+    test "nil passes through (no-flag path)" do
+      assert is_nil(Tau.CLI.resolve_coding_agent(nil))
+    end
+
+    test "atom passes through (programmatic callers)" do
+      assert Tau.CLI.resolve_coding_agent(Tau.CodingAgents.Replay) == Tau.CodingAgents.Replay
+    end
+
+    test "unknown short name falls back to Tau.CodingAgents.<X> shape" do
+      # Mirrors `resolve_provider/1`'s last-resort path; "foo" → Tau.CodingAgents.Foo.
+      assert Tau.CLI.resolve_coding_agent("foo") == Tau.CodingAgents.Foo
+    end
+  end
+
+  describe "tui_opts/1 — runtime opts plumbing" do
+    test "produces :coding_agent module in keyword list when flag set" do
+      # Use the spec to build a ParseResult so we test the same path
+      # main/1 uses. tui_opts/1 is private; we exercise it via
+      # `Tau.CLI.spec()` + Optimus + the public `tui_opts/1` wrapper if
+      # exposed. Since it's private, the integration is covered by the
+      # spec parse above plus the session-mode FSM test (route exists).
+      assert {[:tui], parsed} =
+               Optimus.parse!(Tau.CLI.spec(), ["tui", "--coding-agent", "replay"])
+
+      assert parsed.options[:coding_agent] == "replay"
+    end
+  end
+end

--- a/test/tau/coding_agent/workspace_test.exs
+++ b/test/tau/coding_agent/workspace_test.exs
@@ -1,0 +1,222 @@
+defmodule Tau.CodingAgent.WorkspaceTest do
+  @moduledoc """
+  SPEC-CODING-AGENT §4 B3 / D-033: workspace preparation/cleanup.
+
+  Covers both backends:
+
+    * `Tau.CodingAgent.Workspace.Git` — repo detection, worktree
+      creation under a per-session state dir, branch naming, cleanup
+      via `git worktree remove --force`.
+    * `Tau.CodingAgent.Workspace.Cwd` — passthrough; no state
+      created; cleanup is a no-op.
+
+  And the dispatcher:
+
+    * `Workspace.resolve_default_backend/1` picks Git when invoked
+      inside a repo, Cwd when not.
+    * `Workspace.prepare/1` validates the returned path is absolute
+      and exists (D-033).
+  """
+  use ExUnit.Case, async: true
+
+  alias Tau.CodingAgent.Workspace
+  alias Tau.CodingAgent.Workspace.{Cwd, Git}
+
+  defp unique_tmpdir(prefix) do
+    base =
+      Path.join(
+        System.tmp_dir!(),
+        "#{prefix}-#{System.unique_integer([:positive])}"
+      )
+
+    File.mkdir_p!(base)
+    on_exit(fn -> File.rm_rf(base) end)
+    base
+  end
+
+  defp init_repo(dir) do
+    git = System.find_executable("git") || flunk("git not on PATH")
+
+    {_, 0} =
+      System.cmd(git, ["init", "--initial-branch=main", "--quiet"],
+        cd: dir,
+        stderr_to_stdout: true
+      )
+
+    {_, 0} =
+      System.cmd(git, ["-c", "user.email=t@t", "-c", "user.name=t", "config", "user.email", "t@t"],
+        cd: dir,
+        stderr_to_stdout: true
+      )
+
+    {_, 0} =
+      System.cmd(git, ["config", "user.name", "t"], cd: dir, stderr_to_stdout: true)
+
+    File.write!(Path.join(dir, "README.md"), "seed\n")
+
+    {_, 0} =
+      System.cmd(git, ["add", "README.md"], cd: dir, stderr_to_stdout: true)
+
+    {_, 0} =
+      System.cmd(git, ["commit", "-q", "-m", "seed"], cd: dir, stderr_to_stdout: true)
+
+    :ok
+  end
+
+  describe "resolve_default_backend/1" do
+    test "returns Git when cwd is inside a repo" do
+      dir = unique_tmpdir("tau-ws-resolve-repo")
+      init_repo(dir)
+
+      assert Workspace.resolve_default_backend(dir) == Tau.CodingAgent.Workspace.Git
+    end
+
+    test "returns Cwd when cwd is not inside a repo" do
+      dir = unique_tmpdir("tau-ws-resolve-norepo")
+
+      assert Workspace.resolve_default_backend(dir) == Tau.CodingAgent.Workspace.Cwd
+    end
+
+    test "walks up parent dirs to find .git" do
+      root = unique_tmpdir("tau-ws-resolve-nested")
+      init_repo(root)
+
+      nested = Path.join([root, "a", "b", "c"])
+      File.mkdir_p!(nested)
+
+      assert Workspace.resolve_default_backend(nested) == Tau.CodingAgent.Workspace.Git
+    end
+  end
+
+  describe "Workspace.Git.find_repo_root/1" do
+    test "returns the repo root when called from a subdir" do
+      root = unique_tmpdir("tau-ws-find")
+      init_repo(root)
+
+      nested = Path.join(root, "subdir")
+      File.mkdir_p!(nested)
+
+      assert Git.find_repo_root(nested) == root
+    end
+
+    test "returns nil outside a repo" do
+      dir = unique_tmpdir("tau-ws-find-none")
+      assert is_nil(Git.find_repo_root(dir))
+    end
+  end
+
+  describe "Workspace.Git — prepare + cleanup" do
+    test "creates a worktree under the configured state_dir and cleans up" do
+      repo = unique_tmpdir("tau-ws-git-repo")
+      state_dir = unique_tmpdir("tau-ws-git-state")
+      init_repo(repo)
+
+      sid = "sess-#{System.unique_integer([:positive])}"
+
+      {:ok, ws} =
+        Workspace.prepare(
+          backend: Git,
+          session_id: sid,
+          cwd: repo,
+          state_dir: state_dir
+        )
+
+      # D-033: absolute path that exists as a directory.
+      assert is_binary(ws.path)
+      assert Path.absname(ws.path) == ws.path
+      assert File.dir?(ws.path)
+
+      # The worktree must be a real git worktree of the source repo.
+      assert ws.repo_root == repo
+      assert ws.branch == "tau/coding-agent/" <> sid
+      assert ws.backend == Git
+
+      # `git worktree list` should mention the new path.
+      git = System.find_executable("git")
+      {out, 0} = System.cmd(git, ["worktree", "list"], cd: repo, stderr_to_stdout: true)
+      assert out =~ ws.path
+
+      # Cleanup removes the directory.
+      assert :ok = Workspace.cleanup(ws)
+      refute File.dir?(ws.path)
+    end
+
+    test "prepare fails closed when invoked outside a repo" do
+      dir = unique_tmpdir("tau-ws-git-norepo")
+
+      assert {:error, :not_a_git_repo} =
+               Git.prepare(session_id: "sess-x", cwd: dir, state_dir: dir)
+    end
+
+    test "stale worktree path is cleaned and rebuilt" do
+      repo = unique_tmpdir("tau-ws-git-stale")
+      state_dir = unique_tmpdir("tau-ws-git-stale-state")
+      init_repo(repo)
+
+      sid = "sess-stale-#{System.unique_integer([:positive])}"
+
+      # First prepare succeeds.
+      {:ok, ws1} =
+        Workspace.prepare(
+          backend: Git,
+          session_id: sid,
+          cwd: repo,
+          state_dir: state_dir
+        )
+
+      # Pretend the process crashed: do NOT clean up. A subsequent
+      # prepare under the same session_id (e.g. a restarted session)
+      # must succeed by reclaiming the path.
+      {:ok, ws2} =
+        Workspace.prepare(
+          backend: Git,
+          session_id: sid,
+          cwd: repo,
+          state_dir: state_dir
+        )
+
+      assert ws2.path == ws1.path
+      assert File.dir?(ws2.path)
+
+      assert :ok = Workspace.cleanup(ws2)
+    end
+  end
+
+  describe "Workspace.Cwd — passthrough" do
+    test "prepare returns the cwd unchanged; cleanup is a no-op" do
+      dir = unique_tmpdir("tau-ws-cwd")
+
+      {:ok, ws} =
+        Workspace.prepare(
+          backend: Cwd,
+          session_id: "sess-cwd",
+          cwd: dir
+        )
+
+      assert ws.backend == Cwd
+      assert ws.path == Path.expand(dir)
+      assert File.dir?(ws.path)
+
+      assert :ok = Workspace.cleanup(ws)
+      # cwd preserved: the user's working tree is sacred.
+      assert File.dir?(ws.path)
+    end
+
+    test "prepare rejects a non-directory cwd" do
+      file =
+        Path.join(System.tmp_dir!(), "tau-ws-cwd-not-dir-#{System.unique_integer([:positive])}")
+
+      File.write!(file, "x")
+      on_exit(fn -> File.rm(file) end)
+
+      assert {:error, {:workspace_invalid, {:cwd_not_a_directory, ^file}}} =
+               Cwd.prepare(session_id: "sess-x", cwd: file)
+    end
+  end
+
+  describe "Workspace.cleanup/1 — nil and error tolerance" do
+    test "nil is a clean no-op (covers prepare-failed-before-struct path)" do
+      assert :ok = Workspace.cleanup(nil)
+    end
+  end
+end

--- a/test/tau/session/coding_agent_streaming_test.exs
+++ b/test/tau/session/coding_agent_streaming_test.exs
@@ -1,0 +1,225 @@
+defmodule Tau.Session.CodingAgentStreamingTest do
+  @moduledoc """
+  SPEC-CODING-AGENT §4 B1 / D-037: when a session is started with a
+  `:coding_agent` configured, user messages route to the
+  `:coding_agent_streaming` FSM state. The dispatcher's normalized
+  `Tau.CodingAgent.Event` stream folds into `data.messages` as
+  `%Tau.Message.Assistant{}` / `%Tau.Message.ToolResult{}` so the
+  existing TUI render path (`Session.Events.MessageEnd`) and
+  persistence apply unchanged.
+
+  Drives the FSM through the `Tau.CodingAgents.Replay` adapter so the
+  test never spawns a real `claude` subprocess and the assertions are
+  deterministic.
+  """
+  use ExUnit.Case, async: false
+
+  import Tau.Test.SessionHelper, only: [start_session_for_test: 1]
+
+  alias Tau.Session.Events, as: SE
+  alias Tau.CodingAgent.Event, as: CAE
+
+  setup do
+    tmp = Path.join(System.tmp_dir!(), "tau-ca-stream-#{System.unique_integer([:positive])}")
+    File.mkdir_p!(tmp)
+    Application.put_env(:tau, :data_dir, tmp)
+
+    on_exit(fn ->
+      File.rm_rf!(tmp)
+      Application.delete_env(:tau, :data_dir)
+    end)
+
+    %{data_dir: tmp}
+  end
+
+  # The Replay fixture: a basic happy-path run that lets us assert
+  # text content, telemetry, and FSM transition without needing git.
+  defp happy_fixture do
+    [
+      %CAE.Start{agent: :replay, version: "test"},
+      %CAE.AssistantText{text: "Hello", turn: 0},
+      %CAE.AssistantText{text: ", world", turn: 0},
+      %CAE.Cost{tokens: %{}, usd: 0.0, duration_ms: 1},
+      %CAE.Done{exit_status: 0, final_message: nil}
+    ]
+  end
+
+  defp tool_fixture do
+    [
+      %CAE.Start{agent: :replay, version: "test"},
+      %CAE.AssistantText{text: "Looking at it.", turn: 0},
+      %CAE.ToolUse{id: "t1", name: "Read", input: %{"path" => "README.md"}},
+      %CAE.ToolResult{tool_use_id: "t1", content: "file body", is_error: false},
+      %CAE.AssistantText{text: "Done.", turn: 1},
+      %CAE.Done{exit_status: 0, final_message: nil}
+    ]
+  end
+
+  defp start_with_fixture(fixture) do
+    sid = "ca-stream-#{System.unique_integer([:positive])}"
+    Phoenix.PubSub.subscribe(Tau.PubSub, "session:#{sid}")
+
+    # Workspace.Cwd backend so the test doesn't need a git repo; the
+    # Replay fixture's `replay_fixture` slot is threaded via
+    # provider_ctx → ctx.
+    {:ok, ^sid} =
+      start_session_for_test(
+        session_id: sid,
+        coding_agent: Tau.CodingAgents.Replay,
+        coding_agent_workspace_backend: Tau.CodingAgent.Workspace.Cwd,
+        coding_agent_ctx: %{replay_fixture: fixture}
+      )
+
+    sid
+  end
+
+  describe "happy path — AssistantText events normalize to %Assistant{}" do
+    test "MessageEnd carries a non-empty content block with the concatenated text" do
+      sid = start_with_fixture(happy_fixture())
+
+      Tau.send(sid, "say hello")
+
+      assert_receive %SE.MessageStart{}, 2_000
+      assert_receive %SE.MessageEnd{message: msg}, 2_000
+
+      assert %Tau.Message.Assistant{} = msg
+      assert is_list(msg.content) and msg.content != []
+
+      text =
+        msg.content
+        |> Enum.filter(&match?(%{type: :text}, &1))
+        |> Enum.map_join("", & &1.text)
+
+      assert text =~ "Hello"
+      assert text =~ "world"
+      assert msg.stop_reason == :end_turn
+    end
+
+    test "FSM returns to :awaiting_user after Done" do
+      sid = start_with_fixture(happy_fixture())
+      Tau.send(sid, "say hello")
+
+      assert_receive %SE.MessageEnd{}, 2_000
+      Process.sleep(50)
+
+      {:ok, snap} = Tau.snapshot(sid)
+      assert snap.state == :awaiting_user
+    end
+
+    test "[:tau, :session, :coding_agent_streaming, :start] telemetry fires" do
+      parent = self()
+      handler_id = "tau-ca-stream-start-#{System.unique_integer([:positive])}"
+
+      :telemetry.attach(
+        handler_id,
+        [:tau, :session, :coding_agent_streaming, :start],
+        fn _e, _m, meta, _ -> send(parent, {:tel_start, meta}) end,
+        nil
+      )
+
+      on_exit(fn -> :telemetry.detach(handler_id) end)
+
+      sid = start_with_fixture(happy_fixture())
+      Tau.send(sid, "go")
+
+      assert_receive {:tel_start, %{agent: Tau.CodingAgents.Replay}}, 2_000
+    end
+
+    test "[:tau, :session, :coding_agent_streaming, :stop] telemetry fires on Done" do
+      parent = self()
+      handler_id = "tau-ca-stream-stop-#{System.unique_integer([:positive])}"
+
+      :telemetry.attach(
+        handler_id,
+        [:tau, :session, :coding_agent_streaming, :stop],
+        fn _e, _m, meta, _ -> send(parent, {:tel_stop, meta}) end,
+        nil
+      )
+
+      on_exit(fn -> :telemetry.detach(handler_id) end)
+
+      sid = start_with_fixture(happy_fixture())
+      Tau.send(sid, "go")
+
+      assert_receive {:tel_stop,
+                      %{agent: Tau.CodingAgents.Replay, exit_status: 0, stop_reason: :end_turn}},
+                     2_000
+    end
+  end
+
+  describe "ToolUse / ToolResult round-trip" do
+    test "ToolUse appends a :tool_call content block; ToolResult becomes a ToolResult message" do
+      sid = start_with_fixture(tool_fixture())
+
+      Tau.send(sid, "do it")
+
+      # First assistant message ends when the ToolUse is followed by a
+      # ToolResult — the FSM flushes the pending message so the user
+      # sees the tool result framed correctly. Then a final
+      # MessageEnd carries the post-tool AssistantText.
+      assert_receive %SE.MessageStart{}, 2_000
+      assert_receive %SE.MessageEnd{message: pre_tool_msg}, 2_000
+
+      assert Enum.any?(pre_tool_msg.content, &match?(%{type: :tool_call, name: "Read"}, &1))
+
+      assert_receive %SE.ToolEnd{tool_call_id: "t1", result: tool_result}, 2_000
+      assert %Tau.Message.ToolResult{tool_name: "Read", content: "file body"} = tool_result
+
+      assert_receive %SE.MessageStart{}, 2_000
+      assert_receive %SE.MessageEnd{message: post_tool_msg}, 2_000
+      assert post_tool_msg.stop_reason == :end_turn
+
+      assert Enum.any?(post_tool_msg.content, fn
+               %{type: :text, text: t} -> String.contains?(t, "Done.")
+               _ -> false
+             end)
+
+      Process.sleep(50)
+      {:ok, snap} = Tau.snapshot(sid)
+      assert snap.state == :awaiting_user
+    end
+  end
+
+  describe "regression — no coding_agent leaves provider path byte-identical" do
+    test "without :coding_agent the FSM still routes through :provider_streaming" do
+      sid = "ca-stream-noflag-#{System.unique_integer([:positive])}"
+
+      {:ok, ^sid} =
+        start_session_for_test(
+          session_id: sid,
+          provider: Tau.Providers.Replay,
+          model: "replay"
+        )
+
+      Tau.send(sid, "hello")
+      Process.sleep(150)
+
+      {:ok, snap} = Tau.snapshot(sid)
+      # Either it streamed and returned to awaiting_user, or it's
+      # still mid-stream — neither is `:coding_agent_streaming`. The
+      # negative assertion is the regression guard.
+      refute snap.state == :coding_agent_streaming
+    end
+  end
+
+  describe "non-recoverable Error event surfaces a visible assistant message" do
+    test "Error{recoverable: false} → assistant with stop_reason: :error and non-empty content" do
+      fixture = [
+        %CAE.Start{agent: :replay},
+        %CAE.Error{reason: :auth_failed, recoverable: false},
+        # Adapter's dispatcher will follow with a synthetic Done.
+        %CAE.Done{exit_status: -1}
+      ]
+
+      sid = start_with_fixture(fixture)
+      Tau.send(sid, "anything")
+
+      assert_receive %SE.MessageEnd{message: msg}, 2_000
+      assert msg.stop_reason == :error
+      assert is_binary(msg.error_message) and msg.error_message != ""
+
+      assert msg.content != [],
+             "D-009 must hold on the coding-agent path: error content MUST be non-empty"
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Phase 1B Team B of #191 (SPEC-CODING-AGENT). Wires `tau --coding-agent <name>` end-to-end through CLI → TUI → Session FSM → CodingAgent dispatcher, with a per-session git worktree as the workspace.

**Architectural decision (resolved 2026-05-15 toward FSM-extended):** `session.ex` hosts a new `:coding_agent_streaming` state parallel to `:provider_streaming`. Coding-agent events normalize into `%Tau.Message.Assistant{}` / `%Tau.Message.ToolResult{}` on ingestion (D-037 — new) so the existing TUI render path, JSONL persistence, and `/resume` apply unchanged. The no-coding-agent path stays **byte-identical** to today's provider flow.

This is the largest PR in Phase 1B — session.ex gains a new state, TUI verified, CLI flag added.

## Deliverables

- **CLI:** `--coding-agent` option on `tui` subcommand + bare invocation; `Tau.CLI.resolve_coding_agent/1` resolves `claude_code` / `replay` / arbitrary module strings.
- **FSM:** new `:coding_agent_streaming` state with event-by-event handlers (AssistantText → text content; ToolUse → tool_call block; ToolResult → flush + ToolResult message; FileEdit/Cost → telemetry only; Error/Done → finalize).
- **Workspace:** new `Tau.CodingAgent.Workspace` behaviour + two backends — `Workspace.Git` (per-session worktree under `~/.tau/worktrees/`, branch `tau/coding-agent/<sid>`) and `Workspace.Cwd` (passthrough fallback). Auto-resolved at session init. Cleaned up on `terminate/3` (normal, crash, supervisor shutdown).
- **Settings:** `coding_agent.default_agent` cascade key.
- **Telemetry:** `[:tau, :session, :coding_agent_streaming, {start, stop, exception, adapter_start, file_edit, cost}]`.

## Invariants enforced

D-031 (normalized event union), D-032 (cancel + terminate cleanup), D-033 (explicit workspace path), D-034 (telemetry parity), D-035 (workspace prepare error → in-stream Error → Done), **D-037 (new — first-class sessions)**.

## SPEC amendments in this PR

- §4 B1 — FSM-extended approach documented (parallel state, normalization).
- §4 B3 — Phase 1B Team B implementation section.
- §6 — D-037 added.
- Appendix A — source map updated.

## Out of scope (other teams)

- Team A: `Tau.CodingAgents.ClaudeCode` adapter — concurrent.
- Team C: `tau-context` MCP server (modifies `dispatcher.ex` — no overlap with this PR's surface).
- Team D: cost piping into session totals; `--resume <id>` persistence — sequenced after this merges. Extension point left at `maybe_apply_cost_hook/2` in session.ex.

## AC progress

- **AC-2 against Replay**: substantially achieved — `test/tau/session/coding_agent_streaming_test.exs` drives the FSM through a Replay-backed coding-agent run and asserts the assistant response renders.
- **AC-2 against real ClaudeCode**: pending Team A's merge.

## Test plan

- [x] `mix test` — 446 tests, 0 failures (38 properties), 27 new tests.
- [x] `mix compile --warnings-as-errors` — clean.
- [x] `mix format --check-formatted` — clean for all changed files.
- [x] `mix credo --strict` — no new errors introduced; only pre-existing suggestions remain.
- [x] `mix dialyzer` — no new warnings introduced (warning count identical to main).
- [x] No-coding-agent regression guard test ensures `:provider_streaming` path is untouched.

Closes part of #191 (Phase 1B Team B).

🤖 Generated with [Claude Code](https://claude.com/claude-code)