### PR TITLE
feat(build): stamp git short-hash into version string

### DIFF
--- a/lib/tau/build.ex
+++ b/lib/tau/build.ex
@@ -1,0 +1,71 @@
+defmodule Tau.Build do
+  @moduledoc """
+  Build provenance — version string stamped with git short-hash at compile time.
+
+  The release version drives Burrito's runtime extraction-cache path
+  (`<app>_erts-<erts>_<release-version>`). Stamping the git short-hash
+  makes that path unique per commit, so a fresh build is never served from
+  a stale extraction (issue #200).
+  """
+
+  # Recompile this module when HEAD moves or the index changes, so the
+  # stamped descriptor stays current. Guarded on existence: a Hex package
+  # build has no `.git`.
+  for path <- [".git/HEAD", ".git/index"], File.exists?(path) do
+    @external_resource path
+  end
+
+  @doc """
+  Pure descriptor builder: maps a `{sha_or_nil, dirty?}` pair to the
+  version suffix.
+
+  Clean → `"+<sha>"`, dirty → `"+<sha>.dirty"`, no git → `""`.
+  """
+  @spec descriptor(String.t() | nil, boolean()) :: String.t()
+  def descriptor(nil, _dirty?), do: ""
+  def descriptor(sha, true) when is_binary(sha), do: "+" <> sha <> ".dirty"
+  def descriptor(sha, false) when is_binary(sha), do: "+" <> sha
+
+  # Compile-time git descriptor. The module body cannot call this module's
+  # own functions (they are not compiled yet), so the probe and the
+  # descriptor mapping are inlined here — the same compile-ordering
+  # constraint `mix.exs` documents for its own `git_descriptor/0`. The
+  # `rescue` guarantees the build never fails on a git error; absent git
+  # (e.g. a Hex package build) degrades to `""`.
+  @git_descriptor (try do
+                     if System.find_executable("git") do
+                       case System.cmd("git", ["rev-parse", "--short", "HEAD"],
+                              stderr_to_stdout: true
+                            ) do
+                         {sha, 0} ->
+                           dirty? =
+                             case System.cmd("git", ["status", "--porcelain"],
+                                    stderr_to_stdout: true
+                                  ) do
+                               {out, 0} -> String.trim(out) != ""
+                               _ -> false
+                             end
+
+                           "+" <> String.trim(sha) <> if(dirty?, do: ".dirty", else: "")
+
+                         _ ->
+                           ""
+                       end
+                     else
+                       ""
+                     end
+                   rescue
+                     _ -> ""
+                   end)
+
+  @version Mix.Project.config()[:version]
+
+  @doc """
+  The full build version: app version plus git descriptor.
+
+  Examples: `"0.2.0+d4d35ee"`, `"0.2.0+d4d35ee.dirty"`, or bare `"0.2.0"`
+  when built without git.
+  """
+  @spec version() :: String.t()
+  def version, do: @version <> @git_descriptor
+end

--- a/lib/tau/cli.ex
+++ b/lib/tau/cli.ex
@@ -117,7 +117,7 @@ defmodule Tau.CLI do
     Optimus.new!(
       name: "tau",
       description: "Tau — an OTP/BEAM agentic coding harness.",
-      version: version(),
+      version: Tau.Build.version(),
       subcommands: [
         run: [
           name: "run",
@@ -301,7 +301,7 @@ defmodule Tau.CLI do
   end
 
   defp version_cmd do
-    IO.puts("tau #{version()}")
+    IO.puts("tau #{Tau.Build.version()}")
     0
   end
 
@@ -409,13 +409,6 @@ defmodule Tau.CLI do
   # custom provider modules a caller registers themselves.
   defp resolve_provider(other) when is_binary(other) do
     Module.concat(["Tau", "Providers", String.capitalize(other)])
-  end
-
-  defp version do
-    case Application.spec(:tau, :vsn) do
-      nil -> "0.0.0-dev"
-      v -> to_string(v)
-    end
   end
 
   defp halt(code) when is_integer(code), do: System.halt(code)

--- a/mix.exs
+++ b/mix.exs
@@ -121,11 +121,44 @@ defmodule Tau.MixProject do
   defp releases do
     [
       tau: [
+        # Release version is stamped with the git short-hash so Burrito's
+        # extraction-cache path (`<app>_erts-<erts>_<release-version>`) is
+        # unique per commit — a fresh build is never served from a stale
+        # extraction (issue #200). The `+<sha>` form is SemVer build
+        # metadata; `@version` (the Hex package version) stays unchanged.
+        version: @version <> git_descriptor(),
         include_executables_for: [:unix],
         applications: [tau: :permanent],
         steps: [:assemble, &maybe_burrito/1]
       ]
     ]
+  end
+
+  # Compile-time git descriptor for the release version. Mirrors
+  # `Tau.Build.descriptor/2`; the duplication is intentional — `mix.exs` is
+  # compiled before `lib/` and cannot reference `Tau.Build`.
+  # Clean → `"+<sha>"`, dirty → `"+<sha>.dirty"`, no git → `""`.
+  defp git_descriptor do
+    if System.find_executable("git") do
+      case System.cmd("git", ["rev-parse", "--short", "HEAD"], stderr_to_stdout: true) do
+        {sha, 0} ->
+          dirty? =
+            case System.cmd("git", ["status", "--porcelain"], stderr_to_stdout: true) do
+              {out, 0} -> String.trim(out) != ""
+              _ -> false
+            end
+
+          suffix = if dirty?, do: ".dirty", else: ""
+          "+" <> String.trim(sha) <> suffix
+
+        _ ->
+          ""
+      end
+    else
+      ""
+    end
+  rescue
+    _ -> ""
   end
 
   defp maybe_burrito(release) do

--- a/test/tau/build_test.exs
+++ b/test/tau/build_test.exs
@@ -1,0 +1,41 @@
+defmodule Tau.BuildTest do
+  use ExUnit.Case, async: true
+
+  alias Tau.Build
+
+  describe "version/0" do
+    test "returns a binary starting with the app version" do
+      app_version = to_string(Application.spec(:tau, :vsn))
+      assert is_binary(Build.version())
+      assert String.starts_with?(Build.version(), app_version)
+    end
+
+    test "matches the semver + optional git-descriptor shape" do
+      assert Build.version() =~ ~r/^\d+\.\d+\.\d+(\+[0-9a-f]+(\.dirty)?)?$/
+    end
+
+    test "is parseable by Version.parse/1" do
+      assert {:ok, %Version{}} = Version.parse(Build.version())
+    end
+  end
+
+  describe "descriptor/2 (pure)" do
+    test "no git → empty suffix" do
+      assert Build.descriptor(nil, false) == ""
+      assert Build.descriptor(nil, true) == ""
+    end
+
+    test "clean tree → +sha" do
+      assert Build.descriptor("d4d35ee", false) == "+d4d35ee"
+    end
+
+    test "dirty tree → +sha.dirty" do
+      assert Build.descriptor("d4d35ee", true) == "+d4d35ee.dirty"
+    end
+
+    test "produced suffixes form valid SemVer build metadata" do
+      assert {:ok, %Version{}} = Version.parse("0.2.0" <> Build.descriptor("d4d35ee", false))
+      assert {:ok, %Version{}} = Version.parse("0.2.0" <> Build.descriptor("d4d35ee", true))
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Adds `Tau.Build`: a compile-time git probe that stamps the short-hash (+ `.dirty` marker) onto the version string.
- `mix.exs` release version and `Tau.Build.version/0` both carry the descriptor, so Burrito's extraction-cache path is unique per commit — a fresh build is never served from a stale extraction.
- `tau version` and `tau --version` now report the same git-stamped version.

Closes #200.

## Notes

- The compile-time descriptor is inlined in `Tau.Build`'s module body: a module cannot call its own functions during body evaluation. The prior unmerged WIP called a `defp` from the body, so `mix compile` failed with `undefined function git_state/0`; this PR fixes that.
- Touches `lib/tau/cli.ex` (SPEC-USER-TURN Appendix B). The change is confined to version-string reporting; it advances no AC-N, enforces no D-xxx, changes no §4 boundary contract, and adds no boundary state. No spec amendment required.

## Test plan

- [ ] `mix compile --warnings-as-errors`
- [ ] `mix test test/tau/build_test.exs` (7 tests)
- [ ] `mix format --check-formatted`
- [ ] `tau version` / `tau --version` show `<semver>+<sha>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)