### PR TITLE
refactor(session): unify event-folding into Message.Assembler.finalize/3

### DIFF
--- a/docs/spec/SPEC-CODING-AGENT.md
+++ b/docs/spec/SPEC-CODING-AGENT.md
@@ -69,6 +69,7 @@ Format: `[Cn-Bm]` = constraint number + boundary. **★** marks non-obvious.
 - **★ [C6-B2]** Subprocess writes garbage to stdout (e.g. mixed stream-json with rogue prints). Normalizer MUST emit `%Event.Error{}` on parse failure and continue draining; MUST NOT crash the dispatcher.
 - **[C7-B2]** Subprocess hangs (no output, no exit). Dispatcher MUST enforce an inactivity timeout (configurable, default 120s) and SIGTERM the subprocess on timeout.
 - **★ [C8-B6]** Host config dir absent / corrupted (e.g. expired Claude Code OAuth). Subprocess fails immediately with auth error. Adapter MUST surface a user-actionable message ("run `claude /login`") in the `%Event.Error{}` reason.
+- **[C14-B1]** Before WI-C the coding-agent finalize path carried its own mirror of the Assembler's D-009 guarantee; two copies of one invariant drift silently. Mitigation: the terminal fold is unified in `Tau.Message.Assembler.finalize/3`; no path holds independent visible-content logic.
 
 ### Q4: What invariants must hold across restarts?
 
@@ -143,7 +144,8 @@ to** the existing `:provider_streaming` state. The transition rules:
   broadcasts a `%Events.ToolEnd{}`, and starts a fresh pending
   assistant message; `Event.FileEdit` and `Event.Cost` emit telemetry
   only (cost aggregation lands in Phase 1B Team D); `Event.Done`
-  finalizes and returns to `:awaiting_user`.
+  finalizes — through the shared source-agnostic fold
+  `Tau.Message.Assembler.finalize/3` — and returns to `:awaiting_user`.
 
 The normalization step is deliberate: **coding-agent events become
 `Tau.Message` structs**, which means the existing TUI render path,
@@ -252,7 +254,7 @@ worktree vs cwd. `:coding_agent_workspace_backend` can be passed to
 | **D-034** | Telemetry parity with `Tau.Provider`. Start/event/stop/exception in the documented shape. |
 | **D-035** | Adapter failures surface in-stream as `%CodingAgent.Event.Error{}` events. Adapters MUST NOT raise for transport, auth, or parse errors. Hard configuration errors (no executable on PATH, malformed argv) may return synchronous `{:error, reason}` from `start/2`. |
 | **D-036** | Auth boundary — tau MUST NOT inject or copy credentials. The subprocess inherits the host user's config dir. Tau MAY check existence and emit a user-actionable "not configured" error. |
-| **D-037** | Coding-agent runs are **first-class sessions**: dispatcher events normalize into `Tau.Message.Assistant{}` / `Tau.Message.ToolResult{}` on ingestion so the session FSM's existing `data.messages` list, JSONL persistence, `%Events.MessageEnd{}` broadcast, TUI render path, and `/resume` apply unchanged. The `:coding_agent_streaming` state lives parallel to `:provider_streaming` and is selected at `process_user_message/2` time when `data.coding_agent != nil`. The no-coding-agent path remains byte-identical to today's provider flow. |
+| **D-037** | Coding-agent runs are **first-class sessions**: dispatcher events normalize into `Tau.Message.Assistant{}` / `Tau.Message.ToolResult{}` on ingestion so the session FSM's existing `data.messages` list, JSONL persistence, `%Events.MessageEnd{}` broadcast, TUI render path, and `/resume` apply unchanged. The `:coding_agent_streaming` state lives parallel to `:provider_streaming` and is selected at `process_user_message/2` time when `data.coding_agent != nil`. The no-coding-agent path remains byte-identical to today's provider flow. The terminal fold producing the final `%Tau.Message.Assistant{}`, including the D-009 visible-content guarantee, is source-agnostic: both the provider and coding-agent finalize paths route through `Tau.Message.Assembler.finalize/3`. No path may carry a parallel `ensure_visible_content` implementation. |
 | **D-038** | Cost line items MUST be tagged by source so the user sees the split. Each `%Tau.CodingAgent.Event.Cost{}` folds into the session-cost aggregator as a `%Tau.CodingAgent.Cost{}` record carrying the adapter atom (`source/1` yields `"coding_agent.<agent>"`); provider-direct cost continues to land tagged `"provider.<provider>"` via the existing `[:tau, :provider, :request, :stop]` event. The session FSM emits `[:tau, :coding_agent, :cost]` per fold (D-034 parity) and persists a `coding_agent_cost` JSONL event so `/resume` recomputes totals from disk. Cost-folding failures MUST degrade gracefully (D-035): `[:tau, :coding_agent, :cost, :failed]` surfaces the reason but does not crash the session. |
 | **D-039** | Delegate-tool recursion MUST bottom out. `Tau.Tools.Builtin.Delegate` carries a `depth` parameter (default 0) and refuses calls at `depth >= 2`, returning a `ToolResult{is_error: true, details.kind: :depth_exceeded}` synchronously before any dispatcher starts. The same ceiling propagates through the per-run tau-context MCP server's `tau_delegate` tool (`tau_context_max_depth` in `Tau.CodingAgent.Dispatcher.ctx`), so coding-agent-driven re-entry hits the same limit. Each Delegate invocation is **stateless** (no resume id is persisted across calls — SPEC §7 Q5). |
 
@@ -337,7 +339,7 @@ lib/tau/coding_agent/workspace/cwd.ex            # passthrough backend
 lib/tau/cli.ex                                   # --coding-agent flag + resolver
 lib/tau/tui/app.ex                               # plumbs flag through RuntimeOpts
 lib/tau/tui/runtime_opts.ex                      # documented :coding_agent key
-lib/tau/session.ex                               # :coding_agent_streaming state + helpers
+lib/tau/session.ex                               # :coding_agent_streaming state + helpers; finalize via Assembler.finalize/3
 lib/tau/settings/schema.ex                       # coding_agent.default_agent
 test/tau/cli_coding_agent_flag_test.exs          # CLI flag parse + resolver
 test/tau/coding_agent/workspace_test.exs         # worktree create/cleanup

--- a/docs/spec/SPEC-USER-TURN.md
+++ b/docs/spec/SPEC-USER-TURN.md
@@ -8,6 +8,8 @@
 | **Method** | PSDH (`.claude/skills/design-reasoning`); L0 + L1 + boundary contracts. L2 deferred. |
 | **Self-hosting target** | Working TUI is the prerequisite for Tau replacing the vendored claude-harness as the dev tool for Tau itself (see memory: `project_1_0_self_hosting.md`). |
 
+**Changelog:** WI-C / #202: D-009 reworded — visible-content guarantee unified into `Assembler.finalize/3`.
+
 ## 0. Why this spec exists
 
 Three days of activity (May 1–3 2026) produced 110 commits and a binary that
@@ -359,7 +361,7 @@ Each entry: id, statement, severity, detection_method, source_constraint.
 | D-006 | When `Tau.send/2` returns non-:ok, TUI MUST surface to user | medium | review criterion + property test on submit/1 | [C15] |
 | D-007 | `Settings.Cache` values consumed in a turn are snapshotted at `:start_provider` | medium | property test: mutate settings during a Replay turn; assert in-flight uses old | [C5] |
 | D-008 | Watcher degraded mode emits `[:tau, :settings, :watcher_degraded]` telemetry | low | unit test: start watcher without inotify; assert telemetry | [C8] |
-| D-009 | Provider sync error path produces a non-empty `content` block (text: "Error: ...") | high | unit test on Session.start_provider error branch | [C12] structural fix |
+| D-009 | The visible-content guarantee — every finalized `%Assistant{}` carries a non-empty `content` block so no render path drops it silently — is implemented exactly once, in `Tau.Message.Assembler.ensure_visible_content/1`, and reached by every finalize path (provider and coding-agent) via `Tau.Message.Assembler.finalize/3`. No consumer-side or path-specific mirror is permitted. | high | unit + property test on `Assembler.finalize/3`; coding-agent finalize test | [C12] structural fix |
 | D-010 | TUI MUST monitor the Session FSM pid; on `:DOWN`, surface "session crashed" line | medium | unit test simulating FSM crash | [L1-C45] |
 | D-011 | Stopped FSM MUST terminate `data.provider_task` before exiting | high | unit test: stop session during streaming; assert task pid !alive after stop | [L1-C43] |
 | D-012 | `Settings.Watcher` reconciles disk state on (re)boot | medium | unit test: edit settings while watcher down; restart; assert cache reflects edit | [L1-C44] |
@@ -475,6 +477,7 @@ For each constraint, the file:line where it lives in the current codebase:
 | C7 | `lib/tau/tui/app.ex:76` (`quit_events`) |
 | C8 | `lib/tau/settings/watcher.ex` (on file_system absence) |
 | C12, C19 | `lib/tau/session.ex:650-654` (sync error branch) + `lib/tau/tui/app.ex:183-200` (on_message_end) |
+| D-009 | `lib/tau/message/assembler.ex` (`ensure_visible_content/1` + `finalize/3` — the single source-agnostic terminal fold) |
 | C15 | `lib/tau/tui/app.ex:156-165` (submit ignores Tau.send return) |
 | C24 | `lib/tau/session.ex:1056-1066` (no iteration cap) |
 | C29 | `lib/tau/session.ex:362-363` (model: opts[:model], no default) |

--- a/lib/tau/message/assembler.ex
+++ b/lib/tau/message/assembler.ex
@@ -144,29 +144,50 @@ defmodule Tau.Message.Assembler do
 
   # SPEC-USER-TURN [C12]/[C19] / D-009: render paths that iterate
   # `msg.content` (Tau.TUI.App.on_message_end/2) silently drop a
-  # message with empty content. When the provider stream errors before
-  # emitting any TextDelta — e.g. Anthropic auth failure, network
-  # error, OAuth expiry — `build_content/1` returns []. This guard
-  # synthesizes a single text block carrying the error so the TUI,
-  # CLI streamer, and any other consumer surface SOMETHING instead of
-  # going silent. Mirrors the shape used by the synchronous-error
-  # branch at lib/tau/session.ex:677-681.
-  defp ensure_visible_content(%{content: [_ | _]} = msg), do: msg
+  # message with empty content. When a stream errors before emitting
+  # any TextDelta — e.g. Anthropic auth failure, network error, OAuth
+  # expiry — `build_content/1` returns []. This guard synthesizes a
+  # single text block carrying the error so the TUI, CLI streamer, and
+  # any other consumer surface SOMETHING instead of going silent.
+  #
+  # This is the single source-agnostic D-009 implementation: both the
+  # provider and coding-agent finalize paths route through it via
+  # `finalize/3`. No path may carry a parallel copy.
+  @doc """
+  D-009 guarantee: ensure a finalized `%Assistant{}` has non-empty
+  `content` so no render path drops it silently. Source-agnostic.
+  """
+  @spec ensure_visible_content(Assistant.t()) :: Assistant.t()
+  def ensure_visible_content(%{content: [_ | _]} = msg), do: msg
 
-  defp ensure_visible_content(%{content: [], stop_reason: :error, error_message: em} = msg)
-       when is_binary(em) and em != "" do
+  def ensure_visible_content(%{content: [], stop_reason: :error, error_message: em} = msg)
+      when is_binary(em) and em != "" do
     %{msg | content: [%{type: :text, text: "Error: " <> em}]}
   end
 
-  defp ensure_visible_content(%{content: [], stop_reason: :error} = msg) do
-    %{msg | content: [%{type: :text, text: "Error: provider stream ended with no content"}]}
+  def ensure_visible_content(%{content: [], stop_reason: :error} = msg) do
+    %{msg | content: [%{type: :text, text: "Error: stream ended with no content"}]}
   end
 
-  defp ensure_visible_content(%{content: []} = msg) do
+  def ensure_visible_content(%{content: []} = msg) do
     %{msg | content: [%{type: :text, text: "(empty response)"}]}
   end
 
-  defp ensure_visible_content(msg), do: msg
+  def ensure_visible_content(msg), do: msg
+
+  @doc """
+  Source-agnostic terminal fold: build the final `%Assistant{}` from a
+  base message and a list of content blocks, applying the D-009
+  visible-content guarantee. Both the provider and coding-agent
+  finalize paths route through this.
+  """
+  @spec finalize(Assistant.t(), [map()], keyword()) :: Assistant.t()
+  def finalize(%Assistant{} = base, blocks, opts \\ []) when is_list(blocks) do
+    stop_reason = opts[:stop_reason] || base.stop_reason
+
+    %{base | content: blocks, stop_reason: stop_reason}
+    |> ensure_visible_content()
+  end
 
   @doc "Has the stream finished (cleanly or with an error)?"
   @spec done?(t()) :: boolean()
@@ -174,13 +195,6 @@ defmodule Tau.Message.Assembler do
 
   @doc "Get the assembled `%Assistant{}` (only meaningful after `done?/1`)."
   @spec assistant(t()) :: Assistant.t()
-  def assistant(%__MODULE__{message: msg, error: nil} = s) do
-    %{msg | content: build_content(s)}
-    |> ensure_visible_content()
-  end
-
-  def assistant(%__MODULE__{message: msg} = s) do
-    %{msg | content: build_content(s)}
-    |> ensure_visible_content()
-  end
+  def assistant(%__MODULE__{message: msg} = s),
+    do: finalize(msg, build_content(s), stop_reason: msg.stop_reason)
 end

--- a/lib/tau/session.ex
+++ b/lib/tau/session.ex
@@ -837,16 +837,19 @@ defmodule Tau.Session do
   end
 
   # Forward dispatcher events into the FSM. Stale events (from a
-  # previous run that was cancelled and superseded) are dropped by
-  # the pid mismatch — analogous to `stream_ref` for the provider
-  # path (ADR-0012).
+  # previous run that was cancelled and superseded) are dropped by the
+  # `current_run?/2` pid check — analogous to `stream_ref` for the
+  # provider path (ADR-0012). This clause MUST stay before the
+  # state-agnostic catch-all below.
   def handle_event(
         :info,
         {:coding_agent_event, pid, event},
         :coding_agent_streaming,
-        %{coding_agent_dispatcher: pid} = data
+        data
       ) do
-    handle_coding_agent_event(event, data)
+    if current_run?(data, {:coding_agent, pid}),
+      do: handle_coding_agent_event(event, data),
+      else: {:keep_state, data}
   end
 
   # Stale or out-of-order event — dispatcher mismatch. Drop silently;
@@ -861,6 +864,13 @@ defmodule Tau.Session do
   # :provider_event clause so a non-empty chain takes over before the
   # error reaches the assembler. Empty chain → fall through to the
   # generic clause, which records the error and finalises the message.
+  #
+  # CLAUSE ORDERING IS LOAD-BEARING: the generic :provider_event clause
+  # below no longer head-discriminates on `stream_ref` (it uses
+  # `current_run?/2` in its body), so only source order keeps this
+  # fallback clause winning. If reordered, retryable mid-stream errors
+  # would silently skip the ADR-0012 fallback and finalize as terminal
+  # errors. This fallback clause MUST stay first.
   def handle_event(
         :info,
         {:provider_event, ref, %PEvent.Error{retryable?: true} = ev},
@@ -926,20 +936,24 @@ defmodule Tau.Session do
         :info,
         {:provider_event, ref, ev},
         :provider_streaming,
-        %{stream_ref: ref} = data
+        data
       ) do
-    new_assembler = Assembler.step(data.assembler, ev)
+    if current_run?(data, {:provider, ref}) do
+      new_assembler = Assembler.step(data.assembler, ev)
 
-    broadcast(data.id, %Events.MessageUpdate{
-      session_id: data.id,
-      event: ev,
-      message: new_assembler.message
-    })
+      broadcast(data.id, %Events.MessageUpdate{
+        session_id: data.id,
+        event: ev,
+        message: new_assembler.message
+      })
 
-    if Assembler.done?(new_assembler) do
-      finalize_assistant(new_assembler, data)
+      if Assembler.done?(new_assembler) do
+        finalize_assistant(new_assembler, data)
+      else
+        {:keep_state, %{data | assembler: new_assembler}}
+      end
     else
-      {:keep_state, %{data | assembler: new_assembler}}
+      {:keep_state, data}
     end
   end
 
@@ -947,16 +961,20 @@ defmodule Tau.Session do
         :info,
         {:provider_done, ref},
         :provider_streaming,
-        %{stream_ref: ref} = data
+        data
       ) do
-    if data.assembler && Assembler.done?(data.assembler) do
-      {:keep_state, data}
-    else
-      # Stream ended without a Done event — synthesise one.
-      assembler =
-        Assembler.step(data.assembler || Assembler.new(), %PEvent.Done{stop_reason: :stop})
+    if current_run?(data, {:provider, ref}) do
+      if data.assembler && Assembler.done?(data.assembler) do
+        {:keep_state, data}
+      else
+        # Stream ended without a Done event — synthesise one.
+        assembler =
+          Assembler.step(data.assembler || Assembler.new(), %PEvent.Done{stop_reason: :stop})
 
-      finalize_assistant(assembler, data)
+        finalize_assistant(assembler, data)
+      end
+    else
+      {:keep_state, data}
     end
   end
 
@@ -964,15 +982,19 @@ defmodule Tau.Session do
         :info,
         {:provider_failed, ref, msg},
         :provider_streaming,
-        %{stream_ref: ref} = data
+        data
       ) do
-    assembler =
-      Assembler.step(data.assembler || Assembler.new(), %PEvent.Error{
-        reason: msg,
-        retryable?: false
-      })
+    if current_run?(data, {:provider, ref}) do
+      assembler =
+        Assembler.step(data.assembler || Assembler.new(), %PEvent.Error{
+          reason: msg,
+          retryable?: false
+        })
 
-    finalize_assistant(assembler, data)
+      finalize_assistant(assembler, data)
+    else
+      {:keep_state, data}
+    end
   end
 
   # ADR-0014 (#92): bookkeeping casts from the (future) `Agent` tool task.
@@ -1144,6 +1166,18 @@ defmodule Tau.Session do
   end
 
   def handle_event(_type, _event, _state, data), do: {:keep_state, data}
+
+  # Is the inbound event tagged with the currently-live run token?
+  # Provider events carry a `stream_ref`; coding-agent events carry a
+  # dispatcher pid. Stale events from superseded runs return false and
+  # are dropped by the caller (ADR-0012).
+  @spec current_run?(map(), {:provider, reference()} | {:coding_agent, pid()}) :: boolean()
+  defp current_run?(%{stream_ref: ref}, {:provider, ref}) when is_reference(ref), do: true
+
+  defp current_run?(%{coding_agent_dispatcher: pid}, {:coding_agent, pid}) when is_pid(pid),
+    do: true
+
+  defp current_run?(_data, _token), do: false
 
   # --- Helpers --------------------------------------------------------------
 
@@ -2227,12 +2261,12 @@ defmodule Tau.Session do
     do: {data, nil}
 
   defp flush_pending_assistant(data, stop_reason) do
-    msg = %{
-      data.coding_agent_pending
-      | content:
-          ensure_visible_assistant_content(data.coding_agent_blocks, data.coding_agent_pending),
-        stop_reason: data.coding_agent_pending.stop_reason || stop_reason
-    }
+    effective_stop = data.coding_agent_pending.stop_reason || stop_reason
+
+    msg =
+      Assembler.finalize(data.coding_agent_pending, data.coding_agent_blocks,
+        stop_reason: effective_stop
+      )
 
     data =
       data
@@ -2243,24 +2277,6 @@ defmodule Tau.Session do
 
     {data, msg}
   end
-
-  # Mirrors the Assembler's `ensure_visible_content/1` so an
-  # error-with-empty-content message still surfaces a text block to the
-  # TUI (D-009 invariant preserved on the coding-agent path).
-  defp ensure_visible_assistant_content([], %{stop_reason: :error, error_message: em})
-       when is_binary(em) and em != "" do
-    [%{type: :text, text: "Error: " <> em}]
-  end
-
-  defp ensure_visible_assistant_content([], %{stop_reason: :error}) do
-    [%{type: :text, text: "Error: coding-agent ended with no content"}]
-  end
-
-  defp ensure_visible_assistant_content([], _pending) do
-    [%{type: :text, text: "(empty response)"}]
-  end
-
-  defp ensure_visible_assistant_content(blocks, _pending), do: blocks
 
   defp finalize_coding_agent_turn(%CAEvent.Done{exit_status: status} = done, data) do
     stop_reason =

--- a/test/tau/message/assembler_test.exs
+++ b/test/tau/message/assembler_test.exs
@@ -1,7 +1,9 @@
 defmodule Tau.Message.AssemblerTest do
   use ExUnit.Case, async: true
+  use ExUnitProperties
 
   alias Tau.Message.Assembler
+  alias Tau.Message.Assistant
   alias Tau.Provider.Event
 
   describe "step/2 — text blocks" do
@@ -72,6 +74,77 @@ defmodule Tau.Message.AssemblerTest do
       assert msg.stop_reason == :error
       assert msg.error_message =~ "503"
       assert [%{type: :text, text: "partial"}] = msg.content
+    end
+  end
+
+  describe "finalize/3 — source-agnostic terminal fold (D-009)" do
+    test "non-empty blocks pass through with stop_reason applied" do
+      base = Assistant.new(content: [])
+      blocks = [%{type: :text, text: "hello"}]
+
+      msg = Assembler.finalize(base, blocks, stop_reason: :end_turn)
+
+      assert msg.content == blocks
+      assert msg.stop_reason == :end_turn
+    end
+
+    test "empty blocks + :error + error_message → \"Error: \" <> em block" do
+      base = Assistant.new(content: [], stop_reason: :error, error_message: "auth failed")
+
+      msg = Assembler.finalize(base, [])
+
+      assert msg.content == [%{type: :text, text: "Error: auth failed"}]
+      assert msg.stop_reason == :error
+    end
+
+    test "empty blocks + :error without error_message → source-agnostic fallback text" do
+      base = Assistant.new(content: [])
+
+      msg = Assembler.finalize(base, [], stop_reason: :error)
+
+      assert msg.content == [%{type: :text, text: "Error: stream ended with no content"}]
+    end
+
+    test "empty blocks + non-error → \"(empty response)\"" do
+      base = Assistant.new(content: [])
+
+      msg = Assembler.finalize(base, [], stop_reason: :end_turn)
+
+      assert msg.content == [%{type: :text, text: "(empty response)"}]
+    end
+
+    test "base.stop_reason is used when opts[:stop_reason] is absent" do
+      base = Assistant.new(content: [], stop_reason: :tool_use)
+
+      msg = Assembler.finalize(base, [%{type: :text, text: "x"}])
+
+      assert msg.stop_reason == :tool_use
+    end
+  end
+
+  describe "finalize/3 — property" do
+    @describetag :property
+
+    property "finalize/3 content is never [] for any blocks list and base" do
+      block_gen =
+        StreamData.bind(
+          StreamData.string(:alphanumeric, min_length: 0, max_length: 16),
+          fn t -> StreamData.constant(%{type: :text, text: t}) end
+        )
+
+      stop_gen =
+        StreamData.member_of([nil, :stop, :end_turn, :error, :aborted, :tool_use])
+
+      check all(
+              blocks <- StreamData.list_of(block_gen, min_length: 0, max_length: 5),
+              stop <- stop_gen,
+              opts_stop <- stop_gen
+            ) do
+        base = Assistant.new(content: [], stop_reason: stop)
+        msg = Assembler.finalize(base, blocks, stop_reason: opts_stop)
+
+        refute msg.content == [], "finalize/3 must never yield empty content"
+      end
     end
   end
 

--- a/test/tau/session/coding_agent_streaming_test.exs
+++ b/test/tau/session/coding_agent_streaming_test.exs
@@ -202,6 +202,23 @@ defmodule Tau.Session.CodingAgentStreamingTest do
     end
   end
 
+  describe "empty turn surfaces a visible assistant message (D-009)" do
+    test "Done{exit_status: 0} with no AssistantText / no final_message → \"(empty response)\"" do
+      fixture = [
+        %CAE.Start{agent: :replay, version: "test"},
+        %CAE.Done{exit_status: 0, final_message: nil}
+      ]
+
+      sid = start_with_fixture(fixture)
+      Tau.send(sid, "anything")
+
+      assert_receive %SE.MessageEnd{message: msg}, 2_000
+
+      assert msg.content == [%{type: :text, text: "(empty response)"}],
+             "D-009: an empty coding-agent turn MUST finalize with visible content, not []"
+    end
+  end
+
   describe "non-recoverable Error event surfaces a visible assistant message" do
     test "Error{recoverable: false} → assistant with stop_reason: :error and non-empty content" do
       fixture = [

--- a/test/tau/session/provider_fallback_test.exs
+++ b/test/tau/session/provider_fallback_test.exs
@@ -140,6 +140,9 @@ defmodule Tau.Session.ProviderFallbackTest do
     assert msg.stop_reason == :stop
     assert [%{type: :text, text: "from-secondary"}] = msg.content
 
+    assert msg.stop_reason != :error,
+           "retryable mid-stream error MUST trigger fallback, not terminal finalize (clause-order guard)"
+
     # Fallback PubSub event reached the subscriber.
     assert_receive %SE.ProviderFallback{
                      from_provider: @primary,


### PR DESCRIPTION
## Summary

Unifies the provider and coding-agent event-folding into one source-agnostic terminal fold.

- Adds `Tau.Message.Assembler.finalize/3` — the single source-agnostic blocks→`%Assistant{}` fold, applying the D-009 visible-content guarantee. Both `finalize_assistant/2` (provider) and `flush_pending_assistant/2` (coding-agent) route through it.
- Deletes the hand-rolled `ensure_visible_assistant_content/2` mirror in `session.ex`.
- Adds a shared `current_run?/2` epoch predicate; the provider and coding-agent `:gen_statem` streaming clause heads are loosened so the predicate genuinely dispatches the stale-event drop.

Closes #202.

## Spec amendments (per `.claude/rules/spec-before-code.md` — in this PR)

- **SPEC-CODING-AGENT D-037** — pins the terminal fold to `Assembler.finalize/3`; adds a §3 silent-failure constraint forbidding duplicate D-009 implementations.
- **SPEC-USER-TURN D-009** — reworded: the visible-content guarantee is implemented once, in `Assembler.ensure_visible_content/1`, reached via `finalize/3`.

Advances D-037 (single fold site) and D-009 (single visible-content implementation).

## Notes

- Clause ordering in `session.ex` is load-bearing: the retryable-fallback `:provider_event` clause must stay before the loosened generic clause (an in-source comment states this). Guard: `provider_fallback_test.exs`.
- Out of scope (debate-confirmed): collapsing the FSM states; merging the two `Event` families.

## Test plan

- [ ] `mix compile --warnings-as-errors`
- [ ] `mix test` + new `finalize/3` tests
- [ ] `mix format --check-formatted` / `mix credo --strict`
- [ ] Verify the new empty-turn coding-agent test does not leak a dispatcher across tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)