### PR TITLE
chore(coordinator): close the spawn-brief-drift gap

### DIFF
--- a/.claude/agents/implementer.md
+++ b/.claude/agents/implementer.md
@@ -12,10 +12,20 @@ You are an implementation agent. Complete the assigned task and report
 results. Your work happens in an isolated worktree.
 
 ## Process
-1. Read the task specification carefully.
-2. Plan your approach before writing code.
-3. Implement incrementally. Run tests after each change.
-4. When all tests pass and the task is complete, summarize what you did
+1. **Verify your position before any other work.** Run `pwd`,
+   `git rev-parse HEAD`, and `git branch --show-current`. Do NOT trust
+   the spawn brief's claims about your location or fork-point —
+   `isolation: worktree` always forks from `main`, so a brief asserting
+   "you are forked from `feat/X`" or "you are at commit `<sha>`" is
+   unreliable. If `pwd` is the parent repo root (not an isolated
+   worktree under `.claude/worktrees/`), abort and report rather than
+   operate on the parent. If the task requires building on a specific
+   branch, fetch and check it out explicitly inside the worktree before
+   proceeding.
+2. Read the task specification carefully.
+3. Plan your approach before writing code.
+4. Implement incrementally. Run tests after each change.
+5. When all tests pass and the task is complete, summarize what you did
    and what files you modified.
 
 ## Constraints

--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -28,12 +28,21 @@ edit, write, or delete any files. Report findings only.
 
 ## Evaluation Process
 
-1. Read the original task specification.
-2. Run the test suite: `mix test`. Record pass/fail counts.
-3. Run the formatter: `mix format --check-formatted`. Record any unformatted files.
-4. Run the linter: `mix credo --strict`. Record issues by category.
-5. Inspect modified files against the spec.
-6. Report findings in structured format.
+1. **Verify your position before any other work.** Run `pwd`,
+   `git rev-parse HEAD`, and `git branch --show-current`. Do NOT trust
+   the spawn brief's claims about your location or fork-point —
+   `isolation: worktree` always forks from `main`, so a brief asserting
+   "you are reviewing `feat/X`" or "you are at commit `<sha>`" is
+   unreliable. If `pwd` is the parent repo root (not an isolated
+   worktree under `.claude/worktrees/`), abort and report rather than
+   operate on the parent. To review a specific branch, fetch and check
+   it out explicitly inside the worktree before evaluating.
+2. Read the original task specification.
+3. Run the test suite: `mix test`. Record pass/fail counts.
+4. Run the formatter: `mix format --check-formatted`. Record any unformatted files.
+5. Run the linter: `mix credo --strict`. Record issues by category.
+6. Inspect modified files against the spec.
+7. Report findings in structured format.
 
 ## What to Check
 

--- a/.claude/commands/pr.md
+++ b/.claude/commands/pr.md
@@ -13,7 +13,23 @@ task lifecycle.
 
 Steps in order — **do not skip**.
 
-## Step 1 — Compute the diff
+## Step 1 — Verify the branch is rebased onto `origin/main`
+
+Before the gate runs, the PR branch MUST sit on top of current
+`origin/main` so that `git diff main...HEAD` reflects only this PR's own
+changes — not unrelated work merged to `main` since the branch forked.
+
+```sh
+git fetch origin
+git merge-base --is-ancestor origin/main HEAD
+```
+
+If `git merge-base --is-ancestor` exits non-zero, the branch is behind
+or diverged. Rebase it (`git rebase origin/main`) and re-run the check;
+if the rebase cannot complete cleanly, **abort** with a clear message
+naming the conflict — do not proceed to the gate on a stale branch.
+
+## Step 2 — Compute the diff
 
 Determine the base branch (default `main`):
 
@@ -24,14 +40,14 @@ git log main..HEAD --oneline
 
 Fail loudly if `HEAD` has no commits ahead of `main`.
 
-## Step 2 — Identify the linked issue
+## Step 3 — Identify the linked issue
 
 Scan commit messages for `Closes #N` / `Refs #N`. Read the issue body via
 `gh issue view <N>` to recover the original spec. If no issue is linked,
 **abort** — the `tau-github-workflow` rule requires every non-trivial
 change to be issue-driven.
 
-## Step 3 — Spawn `critic` (design veto)
+## Step 4 — Spawn `critic` (design veto)
 
 NOTE: `.claude/agents/critic.md` cannot be auto-registered by Claude Code from
 a project-local path. Invoke via the Task tool **without** `subagent_type`.
@@ -56,7 +72,7 @@ Parse `ok` from the JSON object on the agent's **last line** (`{"ok": true}` or
 `{"ok": false, "reason": "..."}`). The critic does not emit a `verdict` field —
 use `ok` only.
 
-## Step 4 — On `critic` veto
+## Step 5 — On `critic` veto
 
 If `critic` returned `{"ok": false, ...}`:
 
@@ -72,9 +88,9 @@ If `critic` returned `{"ok": false, ...}`:
    ```
    Initialise the file with `{"task_id": "<branch-name>", "attempts": []}` if it does not exist.
 2. Print the full reason to the user.
-3. **Abort.** Do not proceed to step 5; do not run `gh pr create`.
+3. **Abort.** Do not proceed to step 6; do not run `gh pr create`.
 
-## Step 5 — Spawn `reviewer` (quality veto)
+## Step 6 — Spawn `reviewer` (quality veto)
 
 NOTE: `.claude/agents/reviewer.md` cannot be auto-registered by Claude Code from
 a project-local path. Invoke via the Task tool **without** `subagent_type`.
@@ -100,11 +116,11 @@ Parse `ok` from the JSON object on the agent's **last line** (`{"ok": true}` or
 immediately before the final line containing a `"verdict": "PASS|FAIL|PARTIAL"`
 field — extract that for the solution tree and PR body.
 
-## Step 6 — On `reviewer` veto
+## Step 7 — On `reviewer` veto
 
-Same as step 4, but with `kill_reason: "reviewer_blocked: <reason>"`.
+Same as step 5, but with `kill_reason: "reviewer_blocked: <reason>"`.
 
-## Step 7 — Both passed
+## Step 8 — Both passed
 
 Append to the solution tree with `outcome: "pr_gates_passed"` and the
 two verdicts. Compose the PR body:

--- a/.claude/rules/worktree-discipline.md
+++ b/.claude/rules/worktree-discipline.md
@@ -49,6 +49,15 @@ When the invariants have already been violated (untracked file leak, parent on a
 6. `git branch | grep -v 'main\|<active-agent-branches>' | xargs -n1 git branch -D` to clear orphan local branches.
 7. Verify final state: parent on main at origin/main; no untracked files; only currently-running agents' worktrees registered.
 
+## Spawn-brief integrity
+
+A spawn brief is an instruction set, not a trustworthy report of the worktree's git state. `isolation: worktree` always forks the new worktree from `main` — never from the spawning agent's current branch. A brief that asserts "you are forked from `feat/X`" or "you are at commit `<sha>`" is therefore unreliable and MUST NOT be relied upon.
+
+- A spawn brief MUST NOT assert a fork-point or a "you are at commit/branch X" claim as fact. State the *task* (e.g. "review the changes on `feat/X`"); do not state the *position*.
+- Every agent verifies its own position before doing any work — `pwd`, `git rev-parse HEAD`, `git branch --show-current` — and aborts if it finds itself in the parent repo root rather than an isolated worktree. The `implementer` and `reviewer` personas encode this as their first process step.
+- An agent that must operate on a specific branch fetches and checks it out explicitly inside its worktree; it does not assume the spawn placed it there.
+- PR branches are rebased onto current `origin/main` before the critic/reviewer gate runs, so `git diff main...HEAD` reflects only the PR's own changes. The `/pr` flow enforces this as a precondition.
+
 ## When to update this rule
 
 When a new collision pattern surfaces that this rule does not cover, add an invariant. When `isolation: worktree` semantics change (e.g. Claude Code starts auto-syncing fork-points to origin/main), revise the parent-on-main invariant. When the spawn protocol changes such that one of these invariants becomes vacuous, document the change rather than silently dropping the invariant.


### PR DESCRIPTION
## Summary

Closes the spawn-brief-drift gap surfaced this session — agents trusting hand-authored spawn briefs about their git position instead of verifying it (one reviewer reviewed the wrong base; one implementer wrote to the parent working tree instead of its isolated worktree).

- `.claude/agents/reviewer.md` + `.claude/agents/implementer.md` — new step 1: a fork-point / CWD self-check (`pwd`, `git rev-parse HEAD`, `git branch --show-current`). The agent does not trust the brief's fork-point claims, aborts if its CWD is the parent repo root, and fetches + checks out a target branch explicitly.
- `.claude/commands/pr.md` — new first step: verify the PR branch is rebased onto `origin/main` before the critic/reviewer gate runs, so `git diff main...HEAD` reflects only the PR's own changes.
- `.claude/rules/worktree-discipline.md` — a "Spawn-brief integrity" subsection.

Closes #206.

## Notes

- Persona/command frontmatter and `hooks:` blocks left untouched (per `.claude/rules/hooks-and-scripts.md`).
- Markdown/config only — no compile/test gate applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)