### PR TITLE
fix: move PATH-mutating test out of the async test module

### DIFF
--- a/test/tau/coding_agents/claude_code_sync_test.exs
+++ b/test/tau/coding_agents/claude_code_sync_test.exs
@@ -1,0 +1,36 @@
+defmodule Tau.CodingAgents.ClaudeCodeSyncTest do
+  @moduledoc """
+  Non-async tests for Tau.CodingAgents.ClaudeCode that mutate node-global
+  state (PATH). async: false to avoid racing concurrent System.find_executable/1.
+  """
+  use ExUnit.Case, async: false
+  alias Tau.CodingAgents.ClaudeCode
+
+  describe "spawn path — D-036, AC-6 surface" do
+    test "returns :claude_not_found synchronously when claude is not on PATH" do
+      # Hide PATH so System.find_executable("claude") returns nil. This
+      # also exercises D-036: we never read ~/.claude/credentials.json
+      # because we short-circuit on the executable check.
+      old_path = System.get_env("PATH")
+
+      on_exit(fn ->
+        if old_path,
+          do: System.put_env("PATH", old_path),
+          else: System.delete_env("PATH")
+      end)
+
+      System.put_env("PATH", "/no/such/dir")
+      result = ClaudeCode.start(default_task(), %{})
+      assert result == {:error, :claude_not_found}
+    end
+  end
+
+  # ── helpers ─────────────────────────────────────────────────────
+
+  defp default_task do
+    # Use a real, existing directory so D-033 validation passes.
+    # The fixture (or :lines list) is what actually drives event
+    # emission via the `:claude_code_source` ctx injection.
+    %{prompt: "test prompt", workspace: System.tmp_dir!()}
+  end
+end

--- a/test/tau/coding_agents/claude_code_test.exs
+++ b/test/tau/coding_agents/claude_code_test.exs
@@ -246,23 +246,6 @@ defmodule Tau.CodingAgents.ClaudeCodeTest do
     end
   end
 
-  describe "spawn path — D-036, AC-6 surface" do
-    test "returns :claude_not_found synchronously when claude is not on PATH" do
-      # Hide PATH so System.find_executable("claude") returns nil. This
-      # also exercises D-036: we never read ~/.claude/credentials.json
-      # because we short-circuit on the executable check.
-      old_path = System.get_env("PATH")
-
-      try do
-        System.put_env("PATH", "/no/such/dir")
-        result = ClaudeCode.start(default_task(), %{})
-        assert result == {:error, :claude_not_found}
-      after
-        if old_path, do: System.put_env("PATH", old_path), else: System.delete_env("PATH")
-      end
-    end
-  end
-
   describe "external integration (opt-in via INTEGRATION=1)" do
     # Skipped by default via `test_helper.exs` exclude list. Run with:
     #   INTEGRATION=1 mix test --only external


### PR DESCRIPTION
## Summary
`claude_code_test.exs` (`async: true`) mutated node-global `PATH`, racing concurrent `async` tests calling `System.find_executable/1`. The `describe "spawn path — D-036, AC-6 surface"` block is relocated to a new `async: false` file `test/tau/coding_agents/claude_code_sync_test.exs` with `on_exit` PATH restoration.

Closes #208.

## Note
A *separate*, pre-existing flake surfaced during this work — `dispatcher_test.exs:73` `assert_receive` racing under full-suite load (not PATH-related). Filed as #221; out of scope here.

## Verification
`mix test --seed 0` → 0 failures. (Seeds 33/99999/424242 show only the unrelated #221 dispatcher timing flake.)