### PR TITLE
feat(session): mid-session model swap via /model

### DIFF
--- a/docs/spec/SPEC-USER-TURN.md
+++ b/docs/spec/SPEC-USER-TURN.md
@@ -8,7 +8,7 @@
 | **Method** | PSDH (`.claude/skills/design-reasoning`); L0 + L1 + boundary contracts. L2 deferred. |
 | **Self-hosting target** | Working TUI is the prerequisite for Tau replacing the vendored claude-harness as the dev tool for Tau itself (see memory: `project_1_0_self_hosting.md`). |
 
-**Changelog:** WI-C / #202: D-009 reworded — visible-content guarantee unified into `Assembler.finalize/3`. #211: C53, D-040 — plain-release CLI dispatch via `TAU_CLI_ARGV`; B2 contract amended with three argv sources.
+**Changelog:** WI-C / #202: D-009 reworded — visible-content guarantee unified into `Assembler.finalize/3`. #211: C53, D-040 — plain-release CLI dispatch via `TAU_CLI_ARGV`; B2 contract amended with three argv sources. #179: C54, D-041 — mid-session model swap via `/model`; AC-8 added; D-002 amended to name the sanctioned swap path; B4 boundary contract note added.
 
 ## 0. Why this spec exists
 
@@ -90,6 +90,7 @@ Each question lists raw constraints. Format: `[Cn-Bm]` = constraint number + bou
 - **[C49-B8]** OAuth `scopes` must include `user:inference` for the Messages API. Tau should validate this at config-load time and surface a clear error if missing.
 - **★ [C51-B3]** The TUI prompt MUST render a visible cursor glyph at the end of `model.input`. Without it, an empty input field is indistinguishable from a frozen or blank render — the user cannot tell whether the TUI is waiting for input or has hung. Silent-failure category: the render path produces output, but the output is ambiguous to the human observer. Detection: tmux `capture-pane` must contain the cursor glyph character after a render-settle delay.
 - **★ [C53-B2]** The CLI argv for a plain `mix release` MUST come from the explicit `TAU_CLI_ARGV` env marker (US-separated tokens), never inferred from positional VM arguments. The marker MUST NOT be inherited by `tau`-spawned subprocesses: `cli_argv/0` deletes it (via `System.delete_env/1`) immediately after reading, before returning the decoded argv. A plain-release boot with no marker resolves to `:no_cli`; the OTP app stays up with no `System.halt`. Positional VM args passed to the release launcher (`bin/tau start`) MUST NOT influence dispatch. (Closes D-040.)
+- **★ [C54-B4]** `data.model` in `Tau.Session` FSM data MUST have a single mutation site: `do_swap_model/2` (a pure function). All paths that update `data.model` — the `{:swap_model}` synchronous call handler, the `/model` slash-command path, and the `{:reconfigure}` cast — MUST route through `do_swap_model/2`. Direct `Map.put(data, :model, ...)` outside of `do_swap_model/2` is forbidden. `Tau.Session.swap_model/2` is the only public surface; `update_provider/2`'s `:reconfigure` path routes model through `do_swap_model/2` but MUST NOT emit a `model_swap` event — it emits a single `reconfigure` event preserving today's contract. (Closes D-041.)
 
 ### Q4: What information crosses a boundary, and what is lost?
 
@@ -367,7 +368,7 @@ Each entry: id, statement, severity, detection_method, source_constraint.
 | ID | Statement | Severity | Detection | Source |
 |---|---|---|---|---|
 | D-001 | TUI MUST render `Assistant.error_message` for `stop_reason: :error` messages | high | property test: feed Replay error → TUI render fixture; assert non-empty render | [C12], [C19] |
-| D-002 | `Tau.start_session/1` MUST resolve a non-nil model before reaching `:start_provider` | high | property test: start_session([]) ; assert data.model != nil | [C29] |
+| D-002 | `Tau.start_session/1` MUST resolve a non-nil model before reaching `:start_provider`. `data.model` is resolved at session init (from `opts[:model]` → last persisted `model_swap` → `provider.default_model()`). The ONLY sanctioned between-turn mutation is `Tau.Session.swap_model/2`, gated to `:awaiting_user` state (D-041). | high | property test: start_session([]) ; assert data.model != nil | [C29], [C54] |
 | D-003 | `Ratatouille.run` quit_events MUST NOT include bare `{:ch, ?q}` — quit must be context-aware | medium | source-level: refute regex match; manual-test gate | [C7] |
 | D-004 | TUI MUST `Phoenix.PubSub.subscribe/2` BEFORE `Tau.start_session/1` returns | high | property test: capture SessionStart event from TUI side | [C6] |
 | D-005 | _Superseded by D-027 (same invariant, fully specified there). Retained as placeholder; references to D-005 in code comments and commit history point here._ | — | _see D-027_ | [C24] |
@@ -389,8 +390,9 @@ Each entry: id, statement, severity, detection_method, source_constraint.
 | D-027 | Session FSM MUST cap tool-call iterations per turn at `max_tool_iterations` (default 20, readable from `opts[:max_tool_iterations]` or `Settings.Cache.get()[:session][:max_tool_iterations]`). When the cap is exceeded, the FSM MUST emit `[:tau, :session, :tool_iteration_cap]` telemetry with measurements `%{iterations: N, cap: K}` — where `N` is the count of completed dispatches in the aborted turn (equals `K` at the abort boundary; resets to 0 at the start of the next turn) — and metadata `%{session_id: id}`, then abort the turn with `stop_reason: :tool_loop_aborted`. The per-turn counter resets to 0 on every return to `:awaiting_user`. | high | property test `test/tau/session/tool_iteration_cap_property_test.exs`: drives a session backed by bespoke `AlwaysToolCallProvider` (a `Tau.Provider` behaviour implementation that always emits a `tool_call` event stream, independent of Replay); asserts turn terminates within `max_tool_iterations` with `stop_reason: :tool_loop_aborted` and that the telemetry event fires with `iterations == cap` | [C24], [C50] |
 | D-028 | Assistant text content rendered to the TUI transcript MUST be parsed as CommonMark with GFM tables (`Tau.Markdown.render/1`) before display. Raw markdown source MUST NOT appear in the rendered pane for valid CommonMark input. Output MUST be ASCII-only: tables use `\|` / `-` / `+` (NOT Unicode box-drawing — Ratatouille 0.5.1's `Renderer.Cells.to_char/1` crashes on multi-byte UTF-8 in label content; see Ratatouille tracking issue). Bold and italic markers are STRIPPED (Ratatouille labels render flat text with no inline attributes); inline-code backticks preserved as visual cue. On parse error, a `[markdown-parse-error]` prefix surfaces the failure rather than silently dropping the content. | medium | unit test on `Tau.Markdown.render/1` over a markdown fixture containing a table + bold + inline code + fenced code; assert the output list contains ASCII pipe-and-plus tables and no Unicode box-drawing chars | [C52-B5] |
 | D-040 | A plain (non-Burrito) `mix release` boot with no explicit CLI-dispatch marker (`TAU_CLI_ARGV`) MUST NOT dispatch the Tau CLI and MUST NOT call `System.halt`. Positional VM arguments passed to the release launcher (`bin/tau start`) MUST NOT be consulted for dispatch. The `TAU_CLI_ARGV` marker is consumed-and-deleted (`System.delete_env/1`) by `Tau.Application.cli_argv/0` immediately after reading so it is NOT inherited by tau-spawned subprocesses. Encoding: tokens are joined by ASCII Unit Separator (`\x1f`); `Tau.Application.encode_cli_argv/1` is the single source of truth — no other code path may duplicate the separator literal. | high | `test/tau/application/cli_argv_test.exs` (all six tests); `test/tau/cli/tui_smoke_test.exs` AC-H1 and AC-H2 against `_build/prod/rel/tau/bin/tau` | [C53-B2] |
+| D-041 | `data.model` in the session FSM MUST be treated as immutable within a provider turn. `Tau.Session.swap_model/2` is the sole sanctioned mid-session mutation of `data.model`, gated to `:awaiting_user` state with `command_task == nil`; any other state MUST return `{:error, :busy}`. `do_swap_model/2` is the single `data.model` mutation site ([C54-B4]). On success the FSM MUST emit `[:tau, :session, :model_swapped]` telemetry and persist a `model_swap` JSONL event. The persisted event is folded back into `data.model` on resume/fork via `model_from_preload/1` in `init/1`. | high | `test/tau/session/swap_model_test.exs` — 7 cases covering success, busy, JSONL persistence, not_found, idempotent, invalid_model (empty + whitespace) | [C54-B4], [C29] |
 
-23 D-xxx entries. Each is enforceable. None require speculation.
+25 D-xxx entries. Each is enforceable. None require speculation.
 
 ## 7. Acceptance criteria — "working TUI"
 
@@ -432,6 +434,11 @@ These are the bar for closing the umbrella issue (#153/#149) and unblocking the 
 
 ### AC-7: Resume sanity
 - After AC-2, `tau sessions list` shows the session. `tau sessions show <id>` prints the JSONL events. `tau resume <id>` opens a TUI for the resumed session whose transcript pane includes the prior turn.
+
+### AC-8: Mid-session model swap
+- `/model` with no argument broadcasts a `SystemNotice` showing the current model; no provider turn starts.
+- `/model <id>` mutates `data.model`, broadcasts a `SystemNotice` confirming the change, and the immediately following turn uses the new model string. The FSM MUST return `{:error, :busy}` if the swap is attempted while streaming or running a command task. The swap is persisted as a `model_swap` JSONL event and survives `Tau.resume/1`. Empty or whitespace-only model ids return `{:error, :invalid_model}`.
+- Tests: `test/tau/session/swap_model_test.exs` (7 cases) and `test/tau/session/slash_model_command_test.exs` (2 cases).
 
 ## 8. Out-of-scope hazards (explicitly deferred)
 
@@ -502,5 +509,6 @@ For each constraint, the file:line where it lives in the current codebase:
 
 | C50 | `lib/tau/session.ex` init/1 — `max_tool_iterations` resolution (opts → Settings.Cache → 20) |
 | C53 | `lib/tau/application.ex` — `cli_argv/0` (env-marker read → delete → decode); `test/support/tui_pty_helper.ex` — `start/2` plain-release branch; `test/tau/application/cli_argv_test.exs` |
+| C54 | `lib/tau/session.ex` — `do_swap_model/2` (pure mutation core), `apply_model_swap/2` (shared helper with telemetry+persist), `handle_event({:call, from}, {:swap_model, _}, ...)` (gated call handler), `handle_slash_model_swap/2` (/model slash path), `reconfigure_model/2` ({:reconfigure} cast routing); `lib/tau/session/events.ex` — `%SystemNotice{}`; `lib/tau/tui/app.ex` — `%SystemNotice{}` dispatch clause; `test/tau/session/swap_model_test.exs`; `test/tau/session/slash_model_command_test.exs` |
 
 Other constraints map to sites named in their text.

--- a/lib/tau.ex
+++ b/lib/tau.ex
@@ -145,6 +145,20 @@ defmodule Tau do
   defdelegate update_provider(session_id, opts), to: Session
 
   @doc """
+  Swap the active model for a running session. Gated on the session being
+  in `:awaiting_user` with no command task in flight (D-041 / [C54-B4]).
+
+  Returns `{:ok, %{from: old_model, to: new_model}}` on success.
+  Returns `{:error, :busy}` if streaming or running a command.
+  Returns `{:error, :not_found}` if the session id is unknown.
+  Returns `{:error, :invalid_model}` if `model` is blank or whitespace.
+  """
+  @spec swap_model(session_id(), String.t()) ::
+          {:ok, %{from: String.t(), to: String.t()}}
+          | {:error, :busy | :not_found | :invalid_model}
+  defdelegate swap_model(session_id, model), to: Session
+
+  @doc """
   Stop a session entirely. Runs `:stop` hooks (which may veto), flushes
   persistence, and removes the session process.
   """

--- a/lib/tau/session.ex
+++ b/lib/tau/session.ex
@@ -271,6 +271,25 @@ defmodule Tau.Session do
     end
   end
 
+  @doc """
+  Swap the active model for a session mid-session. Gated: only allowed
+  while the FSM is in `:awaiting_user` with no command task in flight.
+
+  Returns `{:ok, %{from: old_model, to: new_model}}` on success.
+  Returns `{:error, :busy}` if the session is streaming or running a command.
+  Returns `{:error, :not_found}` if the session id is unknown.
+  Returns `{:error, :invalid_model}` if `model` is blank or whitespace.
+  """
+  @spec swap_model(id(), String.t()) ::
+          {:ok, %{from: String.t(), to: String.t()}}
+          | {:error, :busy | :not_found | :invalid_model}
+  def swap_model(id, model) do
+    case whereis(id) do
+      {:ok, pid} -> :gen_statem.call(pid, {:swap_model, model})
+      err -> err
+    end
+  end
+
   @spec list_sessions(map()) :: [Meta.t()]
   def list_sessions(filters \\ %{}), do: Tau.Persistence.impl().list(filters)
 
@@ -395,7 +414,13 @@ defmodule Tau.Session do
     # default at session init, NOT at stream-call time. Without this,
     # `data.model` stays nil through telemetry, persistence header, and
     # the assembler — all of which expect a real model id.
-    model = opts[:model] || provider.default_model()
+    #
+    # D-041 / [C54-B4]: fold the last persisted `model_swap` event from
+    # preload so resume and fork both converge on the swapped model.
+    # Mirrors `coding_agent_state_from_preload/1`.
+    model =
+      model_from_preload(opts[:preload_events] || []) || opts[:model] || provider.default_model()
+
     metadata = opts[:metadata] || %{}
     provider_ctx = opts[:provider_ctx] || %{}
     persistence = opts[:persistence] || Tau.Persistence.impl()
@@ -675,6 +700,16 @@ defmodule Tau.Session do
       {:skill_activation, skill, rewritten_msg} ->
         data = activate_skill_via_slash(data, skill)
         process_user_message(rewritten_msg, data)
+
+      {:model_command, "", _msg} ->
+        # /model with no args: show current model
+        notice = "Current model: #{data.model}"
+        broadcast(data.id, %Events.SystemNotice{session_id: data.id, text: notice})
+        {:keep_state, data}
+
+      {:model_command, new_model, _msg} ->
+        # /model <id>: attempt swap
+        handle_slash_model_swap(data, new_model)
 
       {:sync, msg} ->
         process_user_message(msg, data)
@@ -1108,6 +1143,10 @@ defmodule Tau.Session do
   # #38: in-place provider/model/provider_ctx update. The change applies
   # to the next provider call — an in-flight :provider_streaming keeps
   # using the previous provider until it completes.
+  # [C54-B4]: when opts[:model] is present and non-nil, route it through
+  # do_swap_model/2 (the single data.model mutation site). A nil opts[:model]
+  # (provider-only reconfigure) MUST NOT touch data.model. No model_swap
+  # event is emitted here — only the single "reconfigure" event below.
   def handle_event(:cast, {:reconfigure, opts}, _state, data) do
     data =
       data
@@ -1116,7 +1155,7 @@ defmodule Tau.Session do
       # configured provider. Reconfigure replaces both — fallback chains
       # are looked up keyed by the *new* primary on the next turn.
       |> maybe_replace(:original_provider, opts[:provider])
-      |> maybe_replace(:model, opts[:model])
+      |> reconfigure_model(opts[:model])
       |> merge_provider_ctx(opts[:provider_ctx])
       # SPEC-CODING-AGENT (#191): reconfigure may also adjust the
       # coding-agent per-run ctx. Used by tests to thread a different
@@ -1163,6 +1202,24 @@ defmodule Tau.Session do
     else
       {:keep_state, %{data | tools_in_flight: tools}}
     end
+  end
+
+  # D-041 / [C54-B4]: synchronous, state-gated model swap. Allowed only in
+  # :awaiting_user with no in-flight command task. Any other state is :busy.
+  # do_swap_model/2 is the single data.model mutation site ([C54-B4]).
+  def handle_event({:call, from}, {:swap_model, model}, :awaiting_user, %{command_task: nil} = data) do
+    case apply_model_swap(data, model) do
+      {:error, :invalid_model} ->
+        {:keep_state_and_data, [{:reply, from, {:error, :invalid_model}}]}
+
+      {:ok, data2, result} ->
+        {:keep_state, data2, [{:reply, from, {:ok, result}}]}
+    end
+  end
+
+  # Busy: state is not :awaiting_user, or command_task is in flight.
+  def handle_event({:call, from}, {:swap_model, _model}, _state, _data) do
+    {:keep_state_and_data, [{:reply, from, {:error, :busy}}]}
   end
 
   def handle_event(_type, _event, _state, data), do: {:keep_state, data}
@@ -1763,6 +1820,50 @@ defmodule Tau.Session do
   end
 
   defp append_message(data, msg), do: %{data | messages: data.messages ++ [msg]}
+
+  # [C54-B4]: single data.model mutation site. Pure function — no side effects.
+  # Returns {:ok, updated_data, from_model} | {:error, :invalid_model}.
+  # "invalid" means nil, empty string, or whitespace-only.
+  defp do_swap_model(data, model) do
+    if is_binary(model) and String.trim(model) != "" do
+      {:ok, %{data | model: model}, data.model}
+    else
+      {:error, :invalid_model}
+    end
+  end
+
+  # D-041: shared helper for swap_model telemetry + persist, used by both the
+  # {:call, from} {:swap_model} FSM clause and the /model slash-command path.
+  defp apply_model_swap(data, model) do
+    case do_swap_model(data, model) do
+      {:error, :invalid_model} ->
+        {:error, :invalid_model}
+
+      {:ok, data2, from_model} ->
+        :telemetry.execute(
+          [:tau, :session, :model_swapped],
+          %{system_time: System.system_time()},
+          %{session_id: data2.id, from: from_model, to: model, provider: data2.provider}
+        )
+
+        data2 = persist_event(data2, "model_swap", %{"from" => from_model, "to" => model})
+        {:ok, data2, %{from: from_model, to: model}}
+    end
+  end
+
+  # [C54-B4]: route reconfigure's model opt through do_swap_model/2 so
+  # data.model has a single mutation site. nil means "no change" — a
+  # provider-only reconfigure must NOT touch data.model (preserves the
+  # update_provider_test.exs assertion that a model-only reconfigure
+  # persists one "reconfigure" event carrying data.model).
+  defp reconfigure_model(data, nil), do: data
+
+  defp reconfigure_model(data, model) do
+    case do_swap_model(data, model) do
+      {:ok, data2, _from} -> data2
+      {:error, :invalid_model} -> data
+    end
+  end
 
   # #38 helpers — in-place data updates for {:reconfigure, opts}.
   defp maybe_replace(data, _key, nil), do: data
@@ -2836,6 +2937,19 @@ defmodule Tau.Session do
 
   defp event_to_message(_), do: nil
 
+  # D-041 / [C54-B4]: fold the last persisted model_swap event from a
+  # preload list so resume and fork both converge on the swapped model.
+  # Returns the most recent "to" value, or nil when no swap is recorded.
+  # Mirrors coding_agent_state_from_preload/1.
+  defp model_from_preload(preload) when is_list(preload) do
+    Enum.reduce(preload, nil, fn
+      %{"kind" => "model_swap", "data" => %{"to" => to}}, _acc when is_binary(to) -> to
+      _, acc -> acc
+    end)
+  end
+
+  defp model_from_preload(_), do: nil
+
   # SPEC-CODING-AGENT §7 Q5: recover the most recent
   # adapter-side session_id from a preload event log so a resumed
   # session can pass it back as `task.resume_id`. Walks events in
@@ -2928,6 +3042,9 @@ defmodule Tau.Session do
   defp classify_slash_command(%Tau.Message.User{content: c} = msg, skills)
        when is_binary(c) do
     case Tau.Commands.Parser.parse(c) do
+      {:command, "/model", args} ->
+        {:model_command, String.trim(args), msg}
+
       {:command, "/" <> bare_name = name, args} ->
         case Tau.Commands.Parser.lookup(name) do
           {:ok, mod} when is_atom(mod) ->
@@ -3046,6 +3163,24 @@ defmodule Tau.Session do
   end
 
   defp prepare_command_args(_mod, args), do: {:ok, args}
+
+  # D-041: /model <id> slash-command handler. Runs the same validate +
+  # mutate + telemetry + persist logic as the {:swap_model} call handler
+  # via the shared apply_model_swap/2 helper. Does NOT start a provider
+  # turn — broadcasts a SystemNotice instead.
+  defp handle_slash_model_swap(data, new_model) do
+    case apply_model_swap(data, new_model) do
+      {:ok, data2, %{from: from, to: to}} ->
+        notice = "Model changed: #{from} → #{to}"
+        broadcast(data2.id, %Events.SystemNotice{session_id: data2.id, text: notice})
+        {:keep_state, data2}
+
+      {:error, :invalid_model} ->
+        notice = "Error: '#{new_model}' is not a valid model id (empty or whitespace)."
+        broadcast(data.id, %Events.SystemNotice{session_id: data.id, text: notice})
+        {:keep_state, data}
+    end
+  end
 
   defp invoke_file_command(path, args, msg) do
     case File.read(path) do

--- a/lib/tau/session/events.ex
+++ b/lib/tau/session/events.ex
@@ -69,6 +69,18 @@ defmodule Tau.Session.Events do
     @type t :: %__MODULE__{}
   end
 
+  defmodule SystemNotice do
+    @moduledoc """
+    Broadcast when a built-in FSM slash command (e.g. `/model`) needs
+    to surface a message to the user without starting a provider turn.
+    The `text` field contains a human-readable notice line appended to
+    the TUI transcript.
+    """
+    @enforce_keys [:session_id, :text]
+    defstruct [:session_id, :text]
+    @type t :: %__MODULE__{}
+  end
+
   defmodule SessionEnd do
     @enforce_keys [:session_id]
     defstruct [:session_id, :reason]

--- a/lib/tau/tui/app.ex
+++ b/lib/tau/tui/app.ex
@@ -87,6 +87,7 @@ if Code.ensure_loaded?(Ratatouille.Runtime) do
         %Tau.Session.Events.ToolEnd{} = e -> on_tool_end(model, e)
         %Tau.Session.Events.Cancelled{} = e -> on_cancelled(model, e)
         %Tau.Session.Events.SessionEnd{} = e -> on_session_end(model, e)
+        %Tau.Session.Events.SystemNotice{text: t} -> %{model | transcript: model.transcript ++ [t]}
         _ -> model
       end
     end

--- a/test/tau/session/slash_model_command_test.exs
+++ b/test/tau/session/slash_model_command_test.exs
@@ -1,0 +1,93 @@
+defmodule Tau.Session.SlashModelCommandTest do
+  @moduledoc """
+  D-041: `/model` slash-command behaviour.
+
+    - `/model` with no arg broadcasts a SystemNotice showing the current
+      model; no provider turn is started.
+    - `/model <id>` swaps the model and the next turn uses it.
+  """
+  use ExUnit.Case, async: false
+
+  import Tau.Test.SessionHelper, only: [start_session_for_test: 1]
+  alias Tau.Provider.Event
+  alias Tau.Session.Events, as: SE
+
+  setup do
+    tmp = Path.join(System.tmp_dir!(), "tau-slash-model-#{System.unique_integer([:positive])}")
+    File.mkdir_p!(tmp)
+    Application.put_env(:tau, :data_dir, tmp)
+
+    on_exit(fn ->
+      File.rm_rf!(tmp)
+      Application.delete_env(:tau, :data_dir)
+    end)
+
+    :ok
+  end
+
+  defp replay_fixture do
+    [
+      %Event.Start{request_id: "r", model: "replay"},
+      %Event.TextStart{block_id: "b"},
+      %Event.TextDelta{block_id: "b", text: "response"},
+      %Event.TextEnd{block_id: "b"},
+      %Event.Done{stop_reason: :stop, usage: %{}}
+    ]
+  end
+
+  test "/model with no args shows current model via SystemNotice, no turn starts" do
+    sid = "slash-model-noarg-#{System.unique_integer([:positive])}"
+    Phoenix.PubSub.subscribe(Tau.PubSub, "session:#{sid}")
+
+    {:ok, ^sid} =
+      start_session_for_test(
+        provider: Tau.Providers.Replay,
+        model: "my-model",
+        session_id: sid,
+        provider_ctx: %{replay_fixture: replay_fixture()}
+      )
+
+    Tau.send(sid, "/model")
+
+    # Expect a SystemNotice containing the model name
+    assert_receive %SE.SystemNotice{session_id: ^sid, text: text}, 2_000
+    assert String.contains?(text, "my-model")
+
+    # No MessageStart should arrive (no provider turn)
+    refute_receive %SE.MessageStart{}, 200
+  end
+
+  test "/model <id> swaps model and the next turn uses it" do
+    sid = "slash-model-swap-#{System.unique_integer([:positive])}"
+    Phoenix.PubSub.subscribe(Tau.PubSub, "session:#{sid}")
+
+    {:ok, ^sid} =
+      start_session_for_test(
+        provider: Tau.Providers.Replay,
+        model: "original-model",
+        session_id: sid,
+        provider_ctx: %{replay_fixture: replay_fixture()}
+      )
+
+    # Swap the model via /model slash command
+    Tau.send(sid, "/model new-model")
+
+    # Expect a SystemNotice about the swap
+    assert_receive %SE.SystemNotice{session_id: ^sid, text: text}, 2_000
+    assert String.contains?(text, "new-model")
+
+    # No provider turn should start from the slash command itself
+    refute_receive %SE.MessageStart{}, 200
+
+    # Snapshot should reflect the new model
+    {:ok, snap} = Tau.snapshot(sid)
+    assert snap.model == "new-model"
+
+    # Send a real message — should use the new model
+    Tau.send(sid, "hello")
+    assert_receive %SE.MessageEnd{}, 5_000
+
+    {:ok, snap2} = Tau.snapshot(sid)
+    assert snap2.model == "new-model"
+  end
+end

--- a/test/tau/session/swap_model_test.exs
+++ b/test/tau/session/swap_model_test.exs
@@ -1,0 +1,192 @@
+defmodule Tau.Session.SwapModelTest do
+  @moduledoc """
+  D-041 / [C54-B4]: `Tau.swap_model/2` — the synchronous, state-gated
+  mid-session model swap API. Covers:
+
+    - Swap succeeds in :awaiting_user + telemetry fires + snapshot reflects it.
+    - Swap rejected {:error, :busy} when state != :awaiting_user (mid-stream).
+    - model_swap event persisted to JSONL.
+    - {:error, :not_found} for unknown session id.
+    - Idempotent same-model swap (succeeds, from == to).
+    - {:error, :invalid_model} for empty / whitespace-only strings.
+  """
+  use ExUnit.Case, async: false
+
+  import Tau.Test.SessionHelper, only: [start_session_for_test: 1]
+  alias Tau.Provider.Event
+  alias Tau.Session.Events, as: SE
+
+  setup do
+    tmp = Path.join(System.tmp_dir!(), "tau-swap-#{System.unique_integer([:positive])}")
+    File.mkdir_p!(tmp)
+    Application.put_env(:tau, :data_dir, tmp)
+
+    on_exit(fn ->
+      File.rm_rf!(tmp)
+      Application.delete_env(:tau, :data_dir)
+    end)
+
+    %{data_dir: tmp}
+  end
+
+  defp base_fixture do
+    [
+      %Event.Start{request_id: "r", model: "replay"},
+      %Event.TextStart{block_id: "b"},
+      %Event.TextDelta{block_id: "b", text: "hello"},
+      %Event.TextEnd{block_id: "b"},
+      %Event.Done{stop_reason: :stop, usage: %{}}
+    ]
+  end
+
+  # A slow replay fixture that pauses between events so we can catch the FSM
+  # mid-stream.
+  defp slow_fixture do
+    [
+      %Event.Start{request_id: "r", model: "replay"},
+      %Event.TextStart{block_id: "b"},
+      %Event.TextDelta{block_id: "b", text: "part1"},
+      %Event.TextDelta{block_id: "b", text: "part2"},
+      %Event.TextDelta{block_id: "b", text: "part3"},
+      %Event.TextEnd{block_id: "b"},
+      %Event.Done{stop_reason: :stop, usage: %{}}
+    ]
+  end
+
+  test "swap in :awaiting_user succeeds, telemetry fires, snapshot reflects new model" do
+    handler_id = "tau-swap-ok-#{System.unique_integer([:positive])}"
+    test_pid = self()
+
+    :telemetry.attach(
+      handler_id,
+      [:tau, :session, :model_swapped],
+      fn _event, measurements, metadata, _config ->
+        send(test_pid, {:telemetry, measurements, metadata})
+      end,
+      nil
+    )
+
+    on_exit(fn -> :telemetry.detach(handler_id) end)
+
+    sid = "swap-ok-#{System.unique_integer([:positive])}"
+
+    {:ok, ^sid} =
+      start_session_for_test(
+        provider: Tau.Providers.Replay,
+        model: "old-model",
+        session_id: sid,
+        provider_ctx: %{replay_fixture: base_fixture()}
+      )
+
+    assert {:ok, %{from: "old-model", to: "new-model"}} = Tau.swap_model(sid, "new-model")
+
+    {:ok, snap} = Tau.snapshot(sid)
+    assert snap.model == "new-model"
+
+    assert_receive {:telemetry, _measurements,
+                    %{from: "old-model", to: "new-model", session_id: ^sid}},
+                   1_000
+  end
+
+  test "swap rejected {:error, :busy} mid-stream" do
+    sid = "swap-busy-#{System.unique_integer([:positive])}"
+    Phoenix.PubSub.subscribe(Tau.PubSub, "session:#{sid}")
+
+    {:ok, ^sid} =
+      start_session_for_test(
+        provider: Tau.Providers.Replay,
+        model: "slow",
+        session_id: sid,
+        # A long delay keeps the stream in :provider_streaming long enough for
+        # the call to land while the FSM is still busy.
+        provider_ctx: %{replay_fixture: slow_fixture(), replay_delay_ms: 100}
+      )
+
+    Tau.send(sid, "go")
+    assert_receive %SE.MessageStart{}, 2_000
+
+    # FSM is in :provider_streaming — swap MUST be rejected
+    assert {:error, :busy} = Tau.swap_model(sid, "other")
+
+    assert_receive %SE.MessageEnd{}, 5_000
+  end
+
+  test "model_swap event persisted to JSONL" do
+    sid = "swap-jsonl-#{System.unique_integer([:positive])}"
+
+    {:ok, ^sid} =
+      start_session_for_test(
+        provider: Tau.Providers.Replay,
+        model: "orig",
+        session_id: sid,
+        provider_ctx: %{replay_fixture: base_fixture()}
+      )
+
+    {:ok, _} = Tau.swap_model(sid, "swapped")
+
+    Process.sleep(50)
+
+    [path] = Path.wildcard(Path.join(Tau.Settings.data_dir(), "sessions/*/#{sid}.jsonl"))
+
+    events =
+      File.read!(path)
+      |> String.split("\n", trim: true)
+      |> Enum.map(&Jason.decode!/1)
+
+    kinds = Enum.map(events, & &1["kind"])
+    assert "model_swap" in kinds
+
+    swap_event = Enum.find(events, &(&1["kind"] == "model_swap"))
+    assert swap_event["data"]["from"] == "orig"
+    assert swap_event["data"]["to"] == "swapped"
+  end
+
+  test "{:error, :not_found} for unknown session id" do
+    assert {:error, :not_found} = Tau.swap_model("no-such-session-id", "any-model")
+  end
+
+  test "idempotent same-model swap succeeds" do
+    sid = "swap-idem-#{System.unique_integer([:positive])}"
+
+    {:ok, ^sid} =
+      start_session_for_test(
+        provider: Tau.Providers.Replay,
+        model: "same",
+        session_id: sid,
+        provider_ctx: %{replay_fixture: base_fixture()}
+      )
+
+    assert {:ok, %{from: "same", to: "same"}} = Tau.swap_model(sid, "same")
+
+    {:ok, snap} = Tau.snapshot(sid)
+    assert snap.model == "same"
+  end
+
+  test "{:error, :invalid_model} for empty string" do
+    sid = "swap-blank-#{System.unique_integer([:positive])}"
+
+    {:ok, ^sid} =
+      start_session_for_test(
+        provider: Tau.Providers.Replay,
+        model: "orig",
+        session_id: sid,
+        provider_ctx: %{replay_fixture: base_fixture()}
+      )
+
+    assert {:error, :invalid_model} = Tau.swap_model(sid, "")
+  end
+
+  test "{:error, :invalid_model} for whitespace-only string" do
+    sid = "swap-ws-#{System.unique_integer([:positive])}"
+
+    {:ok, ^sid} =
+      start_session_for_test(
+        provider: Tau.Providers.Replay,
+        model: "orig",
+        session_id: sid,
+        provider_ctx: %{replay_fixture: base_fixture()}
+      )
+
+    assert {:error, :invalid_model} = Tau.swap_model(sid, "   ")
+  end
+end


### PR DESCRIPTION
## Summary
Adds `/model` — swap the model mid-session, between turns.
- `Tau.Session.swap_model/2` — synchronous `:gen_statem.call`, state-gated to `:awaiting_user` (else `{:error, :busy}`); `lib/tau.ex` delegate.
- `do_swap_model/2` — pure single `data.model` mutation site [C54-B4]; `apply_model_swap/2` shared helper (telemetry + persist) for the call handler and the `/model` slash path.
- `{:reconfigure}` routes its model opt through the pure core without emitting `model_swap` — `update_provider_test.exs` unchanged.
- `model_from_preload/1` folds the last `model_swap` JSONL event at `init/1` (resume + fork).
- `%Events.SystemNotice{}` rendered in the TUI transcript.

Closes #179.

## Spec amendments (in this PR)
SPEC-USER-TURN: new AC-8, invariant D-041, constraint [C54-B4], D-002 reword, Appendix B + changelog. Advances D-041.

## Verification
607 tests, 0 failures. New: `swap_model_test.exs` (7), `slash_model_command_test.exs` (2).