### PR TITLE
chore: fix mix format drift (#225)

### DIFF
--- a/lib/tau/providers/shared/finch_stream.ex
+++ b/lib/tau/providers/shared/finch_stream.ex
@@ -188,7 +188,8 @@ defmodule Tau.Providers.Shared.FinchStream do
     %{s | partial: partial, pending: s.pending ++ events}
   end
 
-  defp handle({:data, chunk}, %{status: n} = s, _decoder) when is_integer(n) and n not in 200..299 do
+  defp handle({:data, chunk}, %{status: n} = s, _decoder)
+       when is_integer(n) and n not in 200..299 do
     %{s | error_body: (s.error_body || "") <> chunk}
   end
 

--- a/test/tau/markdown_test.exs
+++ b/test/tau/markdown_test.exs
@@ -98,6 +98,7 @@ defmodule Tau.MarkdownTest do
       """
 
       lines = Markdown.render(md)
+
       assert Enum.any?(lines, &String.contains?(&1, "| def hello")),
              "code block not delimited: #{inspect(lines)}"
 


### PR DESCRIPTION
## Summary
Runs `mix format` on the two pre-existing unformatted files — `lib/tau/providers/shared/finch_stream.ex` and `test/tau/markdown_test.exs`. Whitespace/formatting only, no logic changes. `mix format --check-formatted` now passes repo-wide.
Closes #225.