### PR TITLE
feat(commands): /tree /copy /export informational slash commands (PR1 of #178)

### DIFF
--- a/lib/tau/commands/builtin.ex
+++ b/lib/tau/commands/builtin.ex
@@ -52,7 +52,10 @@ defmodule Tau.Commands.Builtin do
   @spec table() :: %{String.t() => module()}
   def table do
     %{
-      "/ping" => Tau.Commands.Builtin.Ping
+      "/ping" => Tau.Commands.Builtin.Ping,
+      "/tree" => Tau.Commands.Builtin.Tree,
+      "/copy" => Tau.Commands.Builtin.Copy,
+      "/export" => Tau.Commands.Builtin.Export
     }
   end
 end

--- a/lib/tau/commands/builtin/copy.ex
+++ b/lib/tau/commands/builtin/copy.ex
@@ -1,0 +1,102 @@
+defmodule Tau.Commands.Builtin.Copy do
+  @moduledoc """
+  Built-in `/copy` command.
+
+  Copies the last assistant message's text to the system clipboard.
+  Finds the last `%Tau.Message.Assistant{}` in `data.messages`, concatenates
+  its `:text`-typed content blocks, and writes the result to the platform
+  clipboard tool (`pbcopy` on macOS, `xclip -selection clipboard` on Linux,
+  `clip.exe` on WSL/Windows).
+
+  The clipboard write is fire-and-forget under `Tau.Tools.TaskSupervisor` —
+  it never blocks the FSM.  The immediate return is `{:notice, …}` or
+  `{:error, …}`; no provider turn is started (D-042).
+
+  ## Headless decision
+
+  When no clipboard tool is found on PATH, the command returns
+  `{:error, "Clipboard unavailable in this environment."}` rather than
+  crashing or printing to stdout.  This is the safest default for headless
+  / SSH / CI contexts.  A future command-option (e.g. `/copy --stdout`)
+  could add a plain-text fallback if needed.
+  """
+
+  @behaviour Tau.Commands.Builtin
+
+  alias Tau.Message.Assistant
+
+  @clipboard_tools [
+    {"pbcopy", ["pbcopy"]},
+    {"xclip", ["xclip", "-selection", "clipboard"]},
+    {"xsel", ["xsel", "--clipboard", "--input"]},
+    {"clip.exe", ["clip.exe"]}
+  ]
+
+  @impl Tau.Commands.Builtin
+  def name, do: "/copy"
+
+  @impl Tau.Commands.Builtin
+  def run(_args, data) do
+    case last_assistant_text(data) do
+      nil ->
+        {:error, "No assistant message to copy."}
+
+      "" ->
+        {:error, "No assistant message to copy."}
+
+      text ->
+        case find_clipboard_tool() do
+          nil ->
+            {:error, "Clipboard unavailable in this environment."}
+
+          argv ->
+            session_id = data.id
+            _pid = fire_clipboard_write(text, argv, session_id)
+            {:notice, "Copied last assistant message to clipboard."}
+        end
+    end
+  end
+
+  # Returns the concatenated text of all :text blocks in the last
+  # Assistant message, or nil if no Assistant message exists.
+  defp last_assistant_text(%{messages: messages}) when is_list(messages) do
+    messages
+    |> Enum.filter(&match?(%Assistant{}, &1))
+    |> List.last()
+    |> case do
+      nil -> nil
+      %Assistant{content: content} -> extract_text(content)
+    end
+  end
+
+  defp last_assistant_text(_), do: nil
+
+  defp extract_text(content) when is_list(content) do
+    content
+    |> Enum.filter(&match?(%{type: :text}, &1))
+    |> Enum.map_join("", & &1.text)
+  end
+
+  defp extract_text(_), do: ""
+
+  defp find_clipboard_tool do
+    Enum.find_value(@clipboard_tools, fn {bin, argv} ->
+      case System.find_executable(bin) do
+        nil -> nil
+        _ -> argv
+      end
+    end)
+  end
+
+  defp fire_clipboard_write(text, argv, _session_id) do
+    [cmd | args] = argv
+
+    Task.Supervisor.start_child(Tau.Tools.TaskSupervisor, fn ->
+      try do
+        System.cmd(cmd, args, input: text, stderr_to_stdout: true)
+      rescue
+        _ -> :error
+      end
+    end)
+  end
+end

--- a/lib/tau/commands/builtin/export.ex
+++ b/lib/tau/commands/builtin/export.ex
@@ -1,0 +1,158 @@
+defmodule Tau.Commands.Builtin.Export do
+  @moduledoc """
+  Built-in `/export [format]` command.
+
+  Writes the session transcript to `$TAU_DATA_DIR/exports/<session_id>.<ext>`.
+  Supported formats: `jsonl` (default), `html`.
+
+  The file write is fire-and-forget under `Tau.Tools.TaskSupervisor`; the FSM
+  is never blocked.  The spawned task broadcasts a follow-up
+  `%Tau.Session.Events.SystemNotice{}` with the output path once the write
+  completes.
+
+  Immediate return values:
+  - `{:notice, "Exporting..."}` — write dispatched.
+  - `{:error, "Unknown export format: <fmt>"}` — unrecognised format; no write.
+
+  No provider turn is started (D-042).
+
+  ## Format details
+
+  - **jsonl**: one JSON object per message, schema `{role, content, timestamp}`.
+    Each `content` entry preserves the block map as-is.
+  - **html**: a minimal self-contained HTML document with pre-formatted turns.
+    Intended for reading in a browser; not a styled transcript viewer.
+  """
+
+  @behaviour Tau.Commands.Builtin
+
+  alias Tau.Message.{Assistant, ToolResult, User}
+  alias Tau.Session.Events
+
+  @supported_formats ~w[jsonl html]
+
+  @impl Tau.Commands.Builtin
+  def name, do: "/export"
+
+  @impl Tau.Commands.Builtin
+  def run(args, data) do
+    format = args |> String.trim() |> normalise_format()
+
+    if format in @supported_formats do
+      dispatch_export(format, data)
+      {:notice, "Exporting..."}
+    else
+      {:error, "Unknown export format: #{format}"}
+    end
+  end
+
+  defp normalise_format(""), do: "jsonl"
+  defp normalise_format(f), do: String.downcase(f)
+
+  defp dispatch_export(format, data) do
+    session_id = data.id
+    messages = data.messages || []
+    ext = format
+
+    Task.Supervisor.start_child(Tau.Tools.TaskSupervisor, fn ->
+      export_dir = Path.join(Tau.Settings.data_dir(), "exports")
+      File.mkdir_p!(export_dir)
+
+      filename = "#{session_id}.#{ext}"
+      path = Path.join(export_dir, filename)
+
+      body = render(format, session_id, messages)
+      File.write!(path, body)
+
+      Phoenix.PubSub.broadcast(
+        Tau.PubSub,
+        "session:#{session_id}",
+        %Events.SystemNotice{session_id: session_id, text: "Export written to: #{path}"}
+      )
+    end)
+  end
+
+  # --- Renderers (grouped together) ---
+
+  defp render("jsonl", _session_id, messages) do
+    messages
+    |> Enum.map(&message_to_jsonl_map/1)
+    |> Enum.map_join("\n", &Jason.encode!/1)
+  end
+
+  defp render("html", session_id, messages) do
+    turns = Enum.map_join(messages, "\n", &message_to_html/1)
+
+    """
+    <!DOCTYPE html>
+    <html lang="en">
+    <head>
+      <meta charset="UTF-8">
+      <title>Tau session #{session_id}</title>
+      <style>
+        body { font-family: monospace; max-width: 900px; margin: 2rem auto; padding: 0 1rem; }
+        .turn { margin: 1.5rem 0; padding: 1rem; border-left: 4px solid #ccc; white-space: pre-wrap; }
+        .turn.user { border-color: #4a90e2; }
+        .turn.assistant { border-color: #7ed321; }
+        .turn.tool_result { border-color: #f5a623; }
+        .role { font-weight: bold; margin-bottom: 0.5rem; font-size: 0.85em; text-transform: uppercase; color: #666; }
+      </style>
+    </head>
+    <body>
+      <h1>Session: #{session_id}</h1>
+    #{turns}
+    </body>
+    </html>
+    """
+  end
+
+  # --- JSONL helpers ---
+
+  defp message_to_jsonl_map(%User{content: content, timestamp: ts}) do
+    %{role: "user", content: content, timestamp: DateTime.to_iso8601(ts)}
+  end
+
+  defp message_to_jsonl_map(%Assistant{content: content, timestamp: ts}) do
+    %{role: "assistant", content: content, timestamp: DateTime.to_iso8601(ts)}
+  end
+
+  defp message_to_jsonl_map(%ToolResult{tool_name: name, content: content, timestamp: ts}) do
+    %{role: "tool_result", tool_name: name, content: content, timestamp: DateTime.to_iso8601(ts)}
+  end
+
+  # --- HTML helpers ---
+
+  defp message_to_html(%User{content: content}) do
+    text = extract_html_text(content)
+    "<div class=\"turn user\"><div class=\"role\">User</div>#{html_escape(text)}</div>"
+  end
+
+  defp message_to_html(%Assistant{content: content}) do
+    text = extract_html_text(content)
+    "<div class=\"turn assistant\"><div class=\"role\">Assistant</div>#{html_escape(text)}</div>"
+  end
+
+  defp message_to_html(%ToolResult{tool_name: name, content: content}) do
+    text = extract_html_text(content)
+
+    "<div class=\"turn tool_result\"><div class=\"role\">Tool result: #{html_escape(name)}</div>#{html_escape(text)}</div>"
+  end
+
+  defp extract_html_text(content) when is_binary(content), do: content
+
+  defp extract_html_text(content) when is_list(content) do
+    content
+    |> Enum.filter(&match?(%{type: :text}, &1))
+    |> Enum.map_join("\n", & &1.text)
+  end
+
+  defp extract_html_text(_), do: ""
+
+  defp html_escape(text) do
+    text
+    |> String.replace("&", "&amp;")
+    |> String.replace("<", "&lt;")
+    |> String.replace(">", "&gt;")
+    |> String.replace("\"", "&quot;")
+  end
+end

--- a/lib/tau/commands/builtin/tree.ex
+++ b/lib/tau/commands/builtin/tree.ex
@@ -1,0 +1,121 @@
+defmodule Tau.Commands.Builtin.Tree do
+  @moduledoc """
+  Built-in `/tree` command.
+
+  Renders the current session's parent/fork chain as a bounded ASCII tree.
+  Reads `data.metadata[:forked_from]` (a `%{session: id, event: id}` map
+  set by `Tau.Session.fork/2`).  Walks up to `@max_depth` ancestors via
+  `Tau.Persistence`, collecting each ancestor's session id from its JSONL
+  header.  Returns `{:notice, [lines]}` — never mutates session state and
+  never drives a provider turn (D-042).
+
+  If no fork ancestry exists, returns a single-line notice stating the
+  session is a root.
+
+  ## Depth cap
+
+  Walking arbitrary chains in the session FSM could block the FSM for an
+  unbounded time.  This implementation caps the walk at `@max_depth = 10`
+  ancestors and emits a truncation notice if the cap is hit.
+  """
+
+  @behaviour Tau.Commands.Builtin
+
+  @max_depth 10
+
+  @impl Tau.Commands.Builtin
+  def name, do: "/tree"
+
+  @impl Tau.Commands.Builtin
+  def run(_args, data) do
+    session_id = data.id
+    forked_from = Map.get(data.metadata || %{}, :forked_from)
+
+    case build_chain(session_id, forked_from, 0) do
+      {ancestors, truncated?} ->
+        lines = render(ancestors, session_id, truncated?)
+        {:notice, lines}
+    end
+  end
+
+  # Returns `{[{depth, session_id}], truncated?}` — the chain from deepest
+  # ancestor to current, each tagged with depth (0 = current).
+  defp build_chain(current_id, nil, _depth) do
+    # No parent — current is a root.
+    {[{0, current_id, nil}], false}
+  end
+
+  defp build_chain(current_id, forked_from, depth) when depth >= @max_depth do
+    parent_id = forked_from[:session] || forked_from["session"]
+    {[{depth + 1, parent_id, :truncated}, {depth, current_id, forked_from}], true}
+  end
+
+  defp build_chain(current_id, forked_from, depth) do
+    parent_id = forked_from[:session] || forked_from["session"]
+
+    case read_header(parent_id) do
+      nil ->
+        # Parent session not found; stop here.
+        {[{depth + 1, parent_id, :missing}, {depth, current_id, forked_from}], false}
+
+      parent_header ->
+        grandparent_forked =
+          case parent_header["metadata"] do
+            %{"forked_from" => gp} -> atomise_forked_from(gp)
+            _ -> nil
+          end
+
+        {upper_chain, truncated?} = build_chain(parent_id, grandparent_forked, depth + 1)
+        {upper_chain ++ [{depth, current_id, forked_from}], truncated?}
+    end
+  end
+
+  defp read_header(session_id) do
+    persistence = Tau.Persistence.impl()
+
+    case persistence.stream(session_id) |> Enum.take(1) do
+      [%{"kind" => "session_header", "data" => header}] -> header
+      _ -> nil
+    end
+  rescue
+    _ -> nil
+  end
+
+  # The persisted header stores :forked_from as string-keyed (JSON round-trip).
+  defp atomise_forked_from(%{"session" => s, "event" => e}), do: %{session: s, event: e}
+  defp atomise_forked_from(%{session: _} = m), do: m
+  defp atomise_forked_from(_), do: nil
+
+  defp render(chain, _current_id, truncated?) do
+    sorted = Enum.sort_by(chain, fn {depth, _, _} -> -depth end)
+
+    header = ["Session fork tree:"]
+
+    node_lines =
+      sorted
+      |> Enum.with_index()
+      |> Enum.flat_map(fn {{depth, sid, info}, idx} ->
+        is_last = idx == length(sorted) - 1
+        prefix = if is_last, do: "└── ", else: "├── "
+        indent = String.duplicate("    ", length(sorted) - 1 - depth)
+
+        label =
+          cond do
+            info == nil -> "#{sid} (root)"
+            info == :truncated -> "#{sid} (chain truncated at depth #{@max_depth})"
+            info == :missing -> "#{sid} (not found in persistence)"
+            is_last -> "#{sid} (current)"
+            true -> "#{sid}"
+          end
+
+        ["#{indent}#{prefix}#{label}"]
+      end)
+
+    footer =
+      if truncated?,
+        do: ["(chain deeper than #{@max_depth} — only last #{@max_depth} ancestors shown)"],
+        else: []
+
+    header ++ node_lines ++ footer
+  end
+end

--- a/test/tau/commands/builtin/copy_test.exs
+++ b/test/tau/commands/builtin/copy_test.exs
@@ -1,0 +1,90 @@
+defmodule Tau.Commands.Builtin.CopyTest do
+  @moduledoc """
+  Unit tests for `Tau.Commands.Builtin.Copy`.
+
+  The actual clipboard write is fire-and-forget and cannot be verified in a
+  unit test without platform clipboard tooling.  We verify:
+  - No assistant message → `{:error, ...}`.
+  - An assistant message present → `{:notice, ...}` when a clipboard tool is
+    available, or `{:error, "Clipboard unavailable..."}` when none is on PATH.
+  """
+  use ExUnit.Case, async: true
+
+  alias Tau.Commands.Builtin.Copy
+  alias Tau.Message.Assistant
+
+  describe "name/0" do
+    test "returns \"/copy\"" do
+      assert Copy.name() == "/copy"
+    end
+  end
+
+  describe "run/2 — no assistant messages" do
+    test "returns error when messages list is empty" do
+      data = %{id: "s1", metadata: %{}, messages: []}
+      assert {:error, msg} = Copy.run("", data)
+      assert String.contains?(msg, "No assistant message")
+    end
+
+    test "returns error when messages contains only user messages" do
+      user_msg = %Tau.Message.User{content: "hello", timestamp: DateTime.utc_now()}
+      data = %{id: "s2", metadata: %{}, messages: [user_msg]}
+      assert {:error, msg} = Copy.run("", data)
+      assert String.contains?(msg, "No assistant message")
+    end
+
+    test "returns error when data has no messages key" do
+      data = %{id: "s3", metadata: %{}}
+      assert {:error, msg} = Copy.run("", data)
+      assert String.contains?(msg, "No assistant message")
+    end
+  end
+
+  describe "run/2 — with assistant message" do
+    test "returns :notice or :error (clipboard unavailable) when assistant message exists" do
+      assistant_msg =
+        Assistant.new(
+          content: [%{type: :text, text: "Hello world"}],
+          timestamp: DateTime.utc_now()
+        )
+
+      data = %{id: "s4", metadata: %{}, messages: [assistant_msg]}
+
+      result = Copy.run("", data)
+      # In a headless CI environment, clipboard tools may be absent.
+      assert match?({:notice, _}, result) or match?({:error, "Clipboard unavailable" <> _}, result)
+    end
+
+    test "args are ignored" do
+      assistant_msg =
+        Assistant.new(
+          content: [%{type: :text, text: "Some text"}],
+          timestamp: DateTime.utc_now()
+        )
+
+      data = %{id: "s5", metadata: %{}, messages: [assistant_msg]}
+
+      result = Copy.run("some random args", data)
+      assert match?({:notice, _}, result) or match?({:error, _}, result)
+    end
+
+    test "uses the LAST assistant message when multiple exist" do
+      # We can't inspect what was copied, but we can verify no crash and a
+      # well-formed return when multiple assistant messages exist.
+      msg1 = Assistant.new(content: [%{type: :text, text: "First"}], timestamp: DateTime.utc_now())
+      msg2 = Assistant.new(content: [%{type: :text, text: "Last"}], timestamp: DateTime.utc_now())
+      data = %{id: "s6", metadata: %{}, messages: [msg1, msg2]}
+
+      result = Copy.run("", data)
+      assert match?({:notice, _}, result) or match?({:error, _}, result)
+    end
+  end
+
+  describe "behaviour compliance" do
+    test "implements Tau.Commands.Builtin" do
+      Code.ensure_loaded!(Copy)
+      assert function_exported?(Copy, :name, 0)
+      assert function_exported?(Copy, :run, 2)
+    end
+  end
+end

--- a/test/tau/commands/builtin/export_test.exs
+++ b/test/tau/commands/builtin/export_test.exs
@@ -1,0 +1,83 @@
+defmodule Tau.Commands.Builtin.ExportTest do
+  @moduledoc """
+  Unit tests for `Tau.Commands.Builtin.Export`.
+  """
+  use ExUnit.Case, async: false
+
+  alias Tau.Commands.Builtin.Export
+
+  setup do
+    tmp = Path.join(System.tmp_dir!(), "tau-export-test-#{System.unique_integer([:positive])}")
+    File.mkdir_p!(tmp)
+    Application.put_env(:tau, :data_dir, tmp)
+
+    on_exit(fn ->
+      # Use soft rm_rf — spawned export tasks may still hold the dir open
+      # on WSL/Windows when on_exit fires.
+      File.rm_rf(tmp)
+      Application.delete_env(:tau, :data_dir)
+    end)
+
+    {:ok, tmp_dir: tmp}
+  end
+
+  describe "name/0" do
+    test "returns \"/export\"" do
+      assert Export.name() == "/export"
+    end
+  end
+
+  describe "run/2 — format validation" do
+    test "unknown format returns error" do
+      data = %{id: "s1", metadata: %{}, messages: []}
+      assert {:error, msg} = Export.run("pdf", data)
+      assert String.contains?(msg, "Unknown export format: pdf")
+    end
+
+    test "empty format defaults to jsonl (returns notice)" do
+      data = %{id: "s2", metadata: %{}, messages: []}
+      assert {:notice, _} = Export.run("", data)
+    end
+
+    test "explicit jsonl format returns notice" do
+      data = %{id: "s3", metadata: %{}, messages: []}
+      assert {:notice, _} = Export.run("jsonl", data)
+    end
+
+    test "explicit html format returns notice" do
+      data = %{id: "s4", metadata: %{}, messages: []}
+      assert {:notice, _} = Export.run("html", data)
+    end
+
+    test "format is case-insensitive" do
+      data = %{id: "s5", metadata: %{}, messages: []}
+      assert {:notice, _} = Export.run("JSONL", data)
+      assert {:notice, _} = Export.run("HTML", data)
+    end
+
+    test "unknown format includes the format name in error" do
+      data = %{id: "s6", metadata: %{}, messages: []}
+      {:error, msg} = Export.run("xml", data)
+      assert String.contains?(msg, "xml")
+    end
+  end
+
+  describe "run/2 — immediate return does not block" do
+    test "returns immediately (fire-and-forget dispatch)" do
+      data = %{id: "s7", metadata: %{}, messages: []}
+      # Should return fast — no blocking write on the calling process.
+      {time_us, result} = :timer.tc(fn -> Export.run("jsonl", data) end)
+      assert {:notice, _} = result
+      # Should be well under 500ms (generous budget for a fire-and-forget)
+      assert time_us < 500_000
+    end
+  end
+
+  describe "behaviour compliance" do
+    test "implements Tau.Commands.Builtin" do
+      Code.ensure_loaded!(Export)
+      assert function_exported?(Export, :name, 0)
+      assert function_exported?(Export, :run, 2)
+    end
+  end
+end

--- a/test/tau/commands/builtin/tree_test.exs
+++ b/test/tau/commands/builtin/tree_test.exs
@@ -1,0 +1,76 @@
+defmodule Tau.Commands.Builtin.TreeTest do
+  @moduledoc """
+  Unit tests for `Tau.Commands.Builtin.Tree`.
+  """
+  use ExUnit.Case, async: true
+
+  alias Tau.Commands.Builtin.Tree
+
+  describe "name/0" do
+    test "returns \"/tree\"" do
+      assert Tree.name() == "/tree"
+    end
+  end
+
+  describe "run/2 — root session (no fork ancestry)" do
+    test "returns {:notice, lines} for a root session" do
+      data = %{id: "root-session-1", metadata: %{}, messages: []}
+      assert {:notice, lines} = Tree.run("", data)
+      assert is_list(lines)
+      assert lines != []
+    end
+
+    test "includes the session id in the output" do
+      sid = "my-root-session"
+      data = %{id: sid, metadata: %{}, messages: []}
+      {:notice, lines} = Tree.run("", data)
+      assert Enum.any?(lines, &String.contains?(&1, sid))
+    end
+
+    test "includes 'root' label for a session with no forked_from" do
+      data = %{id: "root-sess", metadata: %{}, messages: []}
+      {:notice, lines} = Tree.run("", data)
+      assert Enum.any?(lines, &String.contains?(&1, "root"))
+    end
+
+    test "args are ignored" do
+      data = %{id: "root-sess-2", metadata: %{}, messages: []}
+      assert {:notice, _} = Tree.run("anything", data)
+    end
+  end
+
+  describe "run/2 — metadata with forked_from (no live persistence)" do
+    test "returns {:notice, lines} when forked_from is present but parent not in persistence" do
+      # Persistence will return an empty stream for an unknown session.
+      data = %{
+        id: "child-session",
+        metadata: %{forked_from: %{session: "parent-session-id", event: "evt-1"}},
+        messages: []
+      }
+
+      assert {:notice, lines} = Tree.run("", data)
+      assert is_list(lines)
+      # Should mention both sessions
+      assert Enum.any?(lines, &String.contains?(&1, "child-session"))
+    end
+
+    test "handles string-keyed forked_from (JSON round-trip form)" do
+      data = %{
+        id: "child-str-keys",
+        metadata: %{forked_from: %{"session" => "parent-str", "event" => "e1"}},
+        messages: []
+      }
+
+      assert {:notice, lines} = Tree.run("", data)
+      assert is_list(lines)
+    end
+  end
+
+  describe "behaviour compliance" do
+    test "implements Tau.Commands.Builtin" do
+      Code.ensure_loaded!(Tree)
+      assert function_exported?(Tree, :name, 0)
+      assert function_exported?(Tree, :run, 2)
+    end
+  end
+end

--- a/test/tau/commands/builtin_test.exs
+++ b/test/tau/commands/builtin_test.exs
@@ -22,6 +22,18 @@ defmodule Tau.Commands.BuiltinTest do
       assert Builtin.table()["/ping"] == Tau.Commands.Builtin.Ping
     end
 
+    test "contains /tree => Tau.Commands.Builtin.Tree" do
+      assert Builtin.table()["/tree"] == Tau.Commands.Builtin.Tree
+    end
+
+    test "contains /copy => Tau.Commands.Builtin.Copy" do
+      assert Builtin.table()["/copy"] == Tau.Commands.Builtin.Copy
+    end
+
+    test "contains /export => Tau.Commands.Builtin.Export" do
+      assert Builtin.table()["/export"] == Tau.Commands.Builtin.Export
+    end
+
     test "all values are modules (atoms)" do
       Builtin.table()
       |> Map.values()
@@ -51,6 +63,7 @@ defmodule Tau.Commands.BuiltinTest do
     end
 
     test "implements the Tau.Commands.Builtin behaviour" do
+      Code.ensure_loaded!(Ping)
       assert function_exported?(Ping, :name, 0)
       assert function_exported?(Ping, :run, 2)
     end

--- a/test/tau/session/informational_builtin_dispatch_test.exs
+++ b/test/tau/session/informational_builtin_dispatch_test.exs
@@ -1,0 +1,173 @@
+defmodule Tau.Session.InformationalBuiltinDispatchTest do
+  @moduledoc """
+  D-042 dispatch tests for the three informational built-ins:
+  `/tree`, `/copy`, `/export`.
+
+  Each test asserts:
+  - The command dispatches via `handle_builtin_command/4`.
+  - The FSM produces a SystemNotice (or error-notice) without starting a
+    provider turn (no MessageStart, no `stream/3` call).
+  - The FSM stays alive in `:awaiting_user` (snapshot/1 succeeds after).
+  """
+  use ExUnit.Case, async: false
+
+  import Tau.Test.SessionHelper, only: [start_session_for_test: 1]
+  alias Tau.Session.Events, as: SE
+
+  setup do
+    tmp = Path.join(System.tmp_dir!(), "tau-info-cmds-#{System.unique_integer([:positive])}")
+    File.mkdir_p!(tmp)
+    Application.put_env(:tau, :data_dir, tmp)
+
+    on_exit(fn ->
+      File.rm_rf!(tmp)
+      Application.delete_env(:tau, :data_dir)
+    end)
+
+    :ok
+  end
+
+  # Minimal recording provider — identical to builtin_command_dispatch_test.exs.
+  defmodule RecordingProvider do
+    @behaviour Tau.Provider
+
+    @impl Tau.Provider
+    def default_model, do: "recording-model"
+
+    @impl Tau.Provider
+    def capabilities,
+      do: %{
+        thinking: false,
+        tools: false,
+        vision: false,
+        prompt_caching: false,
+        parallel_tools: false
+      }
+
+    @impl Tau.Provider
+    def configure(opts), do: {:ok, opts}
+
+    @impl Tau.Provider
+    def stream(_messages, _opts, ctx) do
+      owner = ctx[:stream_owner]
+      if owner, do: send(owner, {:stream_called, self()})
+
+      stream =
+        Stream.map(
+          [
+            %Tau.Provider.Event.Start{request_id: "r", model: "recording-model"},
+            %Tau.Provider.Event.TextStart{block_id: "b"},
+            %Tau.Provider.Event.TextDelta{block_id: "b", text: "recording"},
+            %Tau.Provider.Event.TextEnd{block_id: "b"},
+            %Tau.Provider.Event.Done{stop_reason: :stop, usage: %{}}
+          ],
+          & &1
+        )
+
+      {:ok, stream}
+    end
+  end
+
+  defp start_session(sid, owner) do
+    Phoenix.PubSub.subscribe(Tau.PubSub, "session:#{sid}")
+
+    {:ok, ^sid} =
+      start_session_for_test(
+        provider: RecordingProvider,
+        model: "recording-model",
+        session_id: sid,
+        provider_ctx: %{stream_owner: owner}
+      )
+  end
+
+  # ── /tree ──────────────────────────────────────────────────────────────────
+
+  test "D-042: /tree produces SystemNotice, zero provider stream calls, FSM alive" do
+    sid = "builtin-tree-d042-#{System.unique_integer([:positive])}"
+    owner = self()
+    start_session(sid, owner)
+
+    Tau.send(sid, "/tree")
+
+    # Must receive at least one SystemNotice
+    assert_receive %SE.SystemNotice{session_id: ^sid}, 2_000
+
+    # Must NOT drive a provider turn
+    refute_receive %SE.MessageStart{}, 300
+    refute_receive {:stream_called, _}, 300
+
+    # Session alive in :awaiting_user
+    assert {:ok, snap} = Tau.snapshot(sid)
+    assert snap.id == sid
+  end
+
+  # ── /copy ──────────────────────────────────────────────────────────────────
+
+  test "D-042: /copy with no assistant messages produces error SystemNotice, no provider turn" do
+    sid = "builtin-copy-noassist-#{System.unique_integer([:positive])}"
+    owner = self()
+    start_session(sid, owner)
+
+    Tau.send(sid, "/copy")
+
+    # Should be an error notice (no assistant messages yet)
+    assert_receive %SE.SystemNotice{session_id: ^sid, text: text}, 2_000
+    assert String.contains?(text, "Error: No assistant message")
+
+    refute_receive %SE.MessageStart{}, 300
+    refute_receive {:stream_called, _}, 300
+
+    assert {:ok, snap} = Tau.snapshot(sid)
+    assert snap.id == sid
+  end
+
+  # ── /export ────────────────────────────────────────────────────────────────
+
+  test "D-042: /export jsonl produces notice, zero provider stream calls, FSM alive" do
+    sid = "builtin-export-jsonl-#{System.unique_integer([:positive])}"
+    owner = self()
+    start_session(sid, owner)
+
+    Tau.send(sid, "/export jsonl")
+
+    # Immediate notice ("Exporting...")
+    assert_receive %SE.SystemNotice{session_id: ^sid, text: text}, 2_000
+    assert String.contains?(text, "Exporting")
+
+    refute_receive %SE.MessageStart{}, 300
+    refute_receive {:stream_called, _}, 300
+
+    assert {:ok, snap} = Tau.snapshot(sid)
+    assert snap.id == sid
+  end
+
+  test "D-042: /export html produces notice, no provider turn" do
+    sid = "builtin-export-html-#{System.unique_integer([:positive])}"
+    owner = self()
+    start_session(sid, owner)
+
+    Tau.send(sid, "/export html")
+
+    assert_receive %SE.SystemNotice{session_id: ^sid}, 2_000
+    refute_receive %SE.MessageStart{}, 300
+    refute_receive {:stream_called, _}, 300
+
+    assert {:ok, _snap} = Tau.snapshot(sid)
+  end
+
+  test "D-042: /export <unknown> produces error SystemNotice, no provider turn" do
+    sid = "builtin-export-bad-#{System.unique_integer([:positive])}"
+    owner = self()
+    start_session(sid, owner)
+
+    Tau.send(sid, "/export pdf")
+
+    assert_receive %SE.SystemNotice{session_id: ^sid, text: text}, 2_000
+    assert String.contains?(text, "Error: Unknown export format: pdf")
+
+    refute_receive %SE.MessageStart{}, 300
+    refute_receive {:stream_called, _}, 300
+
+    assert {:ok, _snap} = Tau.snapshot(sid)
+  end
+end


### PR DESCRIPTION
## Summary
PR 1 of 4 of the #178 slash-command parity program — the informational/read-only batch. All three are `Tau.Commands.Builtin` modules: read-only, return `{:notice,_}` / `{:error,_}`, never mutate session state, never drive a provider turn (D-042).
- `/tree` — ASCII parent/fork chain from `data.metadata[:forked_from]` (depth-capped 10).
- `/copy` — last assistant message to system clipboard; fire-and-forget write under `Tau.Tools.TaskSupervisor`. Headless: `{:error, "Clipboard unavailable…"}` when no clipboard tool on PATH.
- `/export [jsonl|html]` — transcript to `$TAU_DATA_DIR/exports/`; fire-and-forget, broadcasts the path on completion.

Refs #178 (PR 1 of 4 — does not close the umbrella).

## Verification
658 tests + 39 properties, 0 failures; compile/format/credo clean. New: per-command unit tests + a D-042 dispatch test (zero provider calls).