### PR TITLE
feat(circuit-breaker): SPEC + pure state core (PR1 of #65)

### DIFF
--- a/.claude/rules/spec-before-code.md
+++ b/.claude/rules/spec-before-code.md
@@ -29,6 +29,15 @@ The current spec catalog:
   `lib/tau/tools/builtin/delegate.ex` (Phase 2; D-039). Triage score
   4/5; D-031..D-039 live here.
 
+- `docs/spec/SPEC-CIRCUIT-BREAKER.md` — the per-provider circuit breaker:
+  `:closed/:open/:half_open` state machine, ETS-owner lifecycle anchor
+  (`Tau.CircuitBreaker.Store`), and `Tau.CircuitBreaker` façade.
+  Mandatory for any PR touching `lib/tau/circuit_breaker.ex`,
+  `lib/tau/circuit_breaker/state.ex`, `lib/tau/circuit_breaker/store.ex`,
+  `test/tau/circuit_breaker/`, or the supervision-tree entry for `Store`
+  in `lib/tau/application.ex`. Triage score 5/5; D-029, D-030, D-043,
+  D-044 live here.
+
 Future SPECs land here as new components reach triage threshold.
 
 ## What this rule requires

--- a/docs/adr/0019-circuit-breaker-is-ets-state-with-lifecycle-anchor.md
+++ b/docs/adr/0019-circuit-breaker-is-ets-state-with-lifecycle-anchor.md
@@ -1,0 +1,162 @@
+# ADR-0019: Circuit breaker uses an ETS-owner shape, not a GenServer-per-resource
+
+- **Status:** Accepted
+- **Date:** 2026-05-18
+- **Deciders:** the agent loop, with no objection from @smug-haus
+- **Related:**
+  - Issue: #65 (M2)
+  - Spec: `docs/spec/SPEC-CIRCUIT-BREAKER.md`
+  - Prior: ADR-0010 (cost tracker owns ETS — the ETS-owner precedent),
+    ADR-0011 (per-provider rate limiter is a stateful GenServer — the
+    contrasting pattern), ADR-0012 (provider fallback is FSM-internal retry)
+
+## Context
+
+The circuit breaker must gate outgoing provider calls in `:closed`,
+`:open`, and `:half_open` states. Every concurrent session-turn task
+reads the breaker state on each provider call; failures and successes
+update it. The question is whether this is better served by the
+GenServer-per-resource shape (ADR-0011) or the ETS-owner shape
+(ADR-0010).
+
+### Why ADR-0011's GenServer shape does not fit here
+
+ADR-0011 chose a GenServer for the rate limiter because:
+
+1. Token-bucket arithmetic is intrinsically serial — `take(bucket, n)`
+   depends on the result of every prior `take` since the last refill.
+   The counter update cannot be expressed as a CRDT-style merge.
+2. Wait queues are intrinsically serial — when the bucket is empty,
+   callers block on `GenServer.call/3`. The GenServer mailbox *is* the
+   wait queue.
+3. Reads and writes are 1:1 — every provider call is exactly one
+   `acquire` call.
+
+The circuit breaker does not share these properties:
+
+1. **Counter writes commute.** Failure-count increments are independent;
+   no increment depends on the previous increment's result. Two tasks
+   that both observe failure and both increment `failure_count` produce
+   the same result in either order. `:ets.update_counter/3` is atomic
+   and handles this correctly without mailbox serialisation.
+2. **No wait queue.** A circuit breaker never blocks callers. It either
+   admits the call (`:closed` or admitted probe in `:half_open`) or
+   rejects it immediately (`{:error, :circuit_open}`). There is no
+   "wait until the breaker closes" semantic — callers receive the
+   rejection and surface it to the user.
+3. **Read fan-out is high.** Every concurrent session turn reads the
+   breaker state before invoking the provider. With N active sessions,
+   a GenServer mailbox would serialise N concurrent reads on every
+   turn — the exact bottleneck ADR-0010 identified for the cost tracker.
+
+### Why state transitions still require atomic operations
+
+Although counter writes commute, full state transitions
+(`:closed → :open`, `:open → :half_open`, etc.) must not race. Two
+concurrent failure-count increments that both simultaneously compute
+"we just crossed the threshold" must not both initiate an open
+transition. This is handled by `:ets.select_replace/2` with a guard on
+the current state field — a full-row CAS that only one process wins.
+The loser treats the `0` match count as a no-op; its transition already
+happened via the winner.
+
+The half-open probe admission case requires the same treatment: exactly
+one concurrent caller is admitted. `:ets.select_replace/2` on the
+`probe_slot` field (`0 → 1`) provides the atomic swap; a match count of
+`1` means admitted, `0` means rejected.
+
+No state transition requires two separate ETS writes. The row layout
+in SPEC §4 B2 is designed so that every transition is either a single
+`update_counter` (counter bump) or a single `select_replace` (full-row
+CAS). This is a binding constraint enforced by D-044.
+
+### Why not a Manager GenServer
+
+A single `Tau.CircuitBreaker.Manager` GenServer holding state for all
+providers is forbidden by OTP non-negotiable #1 ("MUST NOT introduce a
+Manager / Service GenServer for shared state"). Even a per-provider
+GenServer is contraindicated by the absence of a wait-queue requirement
+and the commutative-write property — it would serialise reads for no
+benefit.
+
+## Decision
+
+`Tau.CircuitBreaker.Store` is a `GenServer` whose **only** job is to
+own the ETS table named `:tau_circuit_breakers` and serve as its
+lifecycle anchor. It exposes `probe_admitted?/1` (a synchronous call
+that performs a `select_replace` on the `probe_slot` field) and
+`transition/2` (for full-row state transitions via `select_replace`).
+All reads and counter increments go directly to ETS from the caller
+process — no `GenServer.call/3` serialisation.
+
+Specifically:
+
+- **Table options:**
+  `:named_table, :public, :set, read_concurrency: true, write_concurrency: true`
+- **Row layout (positional, fixed):**
+  `{provider_key, state_atom, failure_count, success_count, opened_at_ms, probe_slot}`
+- **Counter writes:** `:ets.update_counter/3` directly from the caller
+  process. No mailbox hop.
+- **State transitions:** `:ets.select_replace/2` via `Store` (GenServer
+  call), which serialises only the CAS — not the reads or counter bumps.
+- **Probe admission:** `:ets.select_replace/2` on `probe_slot` (0 → 1)
+  via `Store` call. Returns `true` (admitted) or `false` (rejected).
+- **Lifecycle:** `Store.init/1` creates the table; `Store.terminate/2`
+  deletes it. A crash restarts the process and recreates the table
+  empty — all breakers reset to `:closed`. Counter loss on crash is
+  acceptable; breaker state is derived signal, not user data.
+
+The pure state-machine logic lives in `Tau.CircuitBreaker.State`
+(PR1): a struct and pure functions with no process or ETS dependency.
+The public façade `Tau.CircuitBreaker` (PR3) composes `State` and
+`Store` into the `call/3` entry point.
+
+## Consequences
+
+- Concurrent session turns read breaker state from ETS without touching
+  the `Store` mailbox — read fan-out scales with scheduler count.
+- Failure and success counter bumps are lock-free atomic operations.
+- Full state transitions and probe admissions go through one `Store.call/3`
+  per transition — a low-frequency operation (transitions happen at the
+  failure-threshold boundary, not per call).
+- Crashing `Store` resets all breaker state. Sessions experience a
+  brief `:noproc` on any in-flight `probe_admitted?` or `transition`
+  call; the supervisor restarts `Store` immediately. The cost is
+  re-opening breakers that were already open — a safe conservative
+  fallback (providers get another chance).
+- `:tau_circuit_breakers` is `:public`; tests can seed rows directly.
+  The table is named so tests can reset it via `:ets.delete_all_objects/1`.
+- The row layout in §4 B2 of the SPEC is immutable within a schema
+  version (D-044). Field additions require a schema-version bump.
+
+## Alternatives considered
+
+- **GenServer-per-provider (ADR-0011 shape).** Rejected: counter
+  writes commute, no wait-queue requirement, read fan-out would be
+  serialised through the mailbox unnecessarily.
+- **Manager GenServer for all providers.** Rejected by OTP
+  non-negotiable #1.
+- **`:counters` BIF module.** Faster than ETS for raw counter bumps
+  but provides no key-based lookup (each provider would need a separate
+  ref stored elsewhere) and no conditional replace for CAS operations.
+  ETS `select_replace` is the only atomic conditional write primitive
+  available for keyed state.
+- **`persistent_term`.** Write-once / read-many semantics; each write
+  triggers a global GC scan. Circuit-breaker counters update on every
+  provider call — `persistent_term` is inappropriate for high-frequency
+  writes.
+- **Exposing all writes through `Store` calls.** Rejected: serialising
+  every failure-count increment through the GenServer mailbox
+  re-introduces the bottleneck we are avoiding. Only the CAS operations
+  (state transition, probe admission) need serialisation; commutative
+  counter bumps do not.
+
+## Notes
+
+This decision deliberately differs from ADR-0011 because the circuit
+breaker's write pattern (commutative counters, no wait queue) matches
+ADR-0010's topology (fan-in writers, fan-out readers, lock-free ETS
+writes) rather than ADR-0011's topology (serial arithmetic, wait
+queue). The decision boundary is the write-commutativity question: if
+writes commute, use ETS; if they do not (or if a wait queue is needed),
+use a GenServer.

--- a/docs/spec/SPEC-CIRCUIT-BREAKER.md
+++ b/docs/spec/SPEC-CIRCUIT-BREAKER.md
@@ -1,0 +1,341 @@
+# SPEC: Circuit Breaker
+
+| | |
+|---|---|
+| **Status** | Draft |
+| **Date** | 2026-05-18 |
+| **Scope** | Per-provider circuit breaker: `:closed/:open/:half_open` state machine, ETS-owner lifecycle anchor, façade. |
+| **Method** | PSDH (`.claude/skills/design-reasoning`); L0 + boundary contracts. |
+| **Issue** | #65 (M2) |
+
+**Changelog:** Initial draft — §0–§7 + Appendix B. D-029, D-030, D-043, D-044 introduced.
+
+## 0. Why this spec exists
+
+The provider layer (ADR-0011, ADR-0012) already handles back-pressure from rate
+limiters and provider errors, but has no mechanism to stop hammering a provider
+that is returning consistent hard errors. Without a circuit breaker, a
+session experiencing a sustained 5xx storm loops at the provider indefinitely:
+each turn spawns a provider task, which fails immediately, which triggers
+fallback logic, which retries — consuming quota, billing tokens that yield no
+useful output, and delaying the user's error feedback.
+
+A circuit breaker wraps this at the provider-call level. After N consecutive
+failures it opens a gate that short-circuits calls immediately (`:open`), waits
+a configurable cooldown (`cooldown_ms`), then admits a single probe call
+(`:half_open`). Success closes the breaker; failure re-opens it.
+
+The component is coordination-heavy (triage score 5/5; see §1) and therefore
+requires this spec before any implementation PR modifies the breaker boundary.
+
+## 1. Triage
+
+| # | Property | Score | Evidence |
+|---|----------|-------|----------|
+| 1 | Shared mutable state | 1 | Breaker state per provider is read by every concurrent session turn and written on every provider-call outcome; the ETS table is the shared structure. |
+| 2 | Temporal coupling | 1 | `opened_at_ms` determines when `:open → :half_open` fires; wall-clock progression is load-bearing; `check/2` must be called with a consistent `now_ms` relative to `opened_at_ms`. |
+| 3 | Cross-process coordination | 1 | `Tau.CircuitBreaker.Store` (GenServer, PR2) owns the ETS table; concurrent session-turn tasks read and write probe slots via ETS atomics — no mailbox serialisation. |
+| 4 | Feedback loops | 1 | Provider failure → breaker opens → sessions see `:open` → error surfaced to user → user retries → breaker admits probe → success closes → normal flow resumes. |
+| 5 | State accumulation | 1 | `failure_count` and `success_count` accumulate across turns until a threshold triggers a transition; `opened_at_ms` persists until the cooldown expires. |
+
+**Triage score: 5/5. L0 + boundary contracts indicated.**
+
+## 2. Component decomposition
+
+Three layers. Naming is precise so that contracts in §4 attach to specific
+operations.
+
+| # | Component | Role |
+|---|-----------|------|
+| C1 | `Tau.CircuitBreaker.State` | Pure state-machine module. `%State{}` struct + `record_failure/2`, `record_success/2`, `check/2`. No process, no ETS. |
+| C2 | `Tau.CircuitBreaker.Store` | GenServer lifecycle anchor. Owns the ETS table `:tau_circuit_breakers`. Exposes `transition/2` (atomically CAS a full row) and `probe_admitted?/1` (atomic half-open single-probe gate). |
+| C3 | `Tau.CircuitBreaker` | Public façade. `call/3 :: (provider, opts, thunk) → result`. Checks state, admits or short-circuits, records outcome, drives transitions. |
+
+Boundaries between layers:
+
+| # | Boundary | Operation |
+|---|----------|-----------|
+| B1 | `Tau.CircuitBreaker` (C3) ↔ `Tau.CircuitBreaker.Store` (C2) | ETS read for `check`; atomic write for `transition` and probe-slot bump. |
+| B2 | `Tau.CircuitBreaker.Store` (C2) ↔ ETS (`:tau_circuit_breakers`) | Table create/destroy in `init/1` / `terminate/2`; all reads and writes via ETS primitives. |
+| B3 | `Tau.Session` / provider task ↔ `Tau.CircuitBreaker` (C3) | `call/3` wraps the provider `stream/3` thunk; returns `{:error, :circuit_open}` when the breaker is open. |
+| B4 | `Tau.CircuitBreaker.State` (C1) ↔ callers | Pure function calls; no side effects. |
+
+## 3. L0 constraints
+
+Format: `[Cn-Bm]` = constraint number + boundary. **★** marks non-obvious.
+
+### Q1: What can be written by more than one actor?
+
+- **★ [C56-B1]** The ETS row for a provider can be updated by N concurrent
+  session-turn tasks simultaneously — each records a success or failure
+  independently. Counter fields (`failure_count`, `success_count`) MUST be
+  updated with `:ets.update_counter/3` (atomic); full-row state transitions
+  MUST use `:ets.select_replace/2` with a guard so no two processes race a
+  non-atomic multi-field write.
+- **★ [C57-B1]** The half-open probe slot is a single counter field
+  `probe_slot` (position in the ETS row). Admission is an `:ets.update_counter/3`
+  bump with a threshold guard: the call that increments `probe_slot` from 0 to 1
+  is the admitted probe; any call that finds `probe_slot >= 1` MUST be rejected
+  as `:circuit_open`. This is the only correct way to admit exactly one probe
+  under concurrent access — no lock, no GenServer serialisation.
+- **[C58-B2]** The `Store` GenServer creates the table in `init/1` and is the
+  only process that calls `:ets.new/2` or `:ets.delete/1` on it. Any process
+  may read or update counters directly via ETS.
+
+### Q2: What ordering assumptions are implicit?
+
+- **★ [C59-B3]** `check/2` (via `Store` ETS read) MUST be called before the
+  provider thunk is invoked. The result of `check/2` at the instant of the
+  call is authoritative — the breaker state may transition between `check` and
+  the thunk returning, but that is handled by the next call, not this one.
+- **★ [C60-B1]** State transitions MUST be confined to a single atomic
+  operation: either a single counter field update (`update_counter`) or a
+  full-row CAS (`select_replace`). No transition may require two separate ETS
+  writes to be atomic — there is no ETS transaction API.
+- **[C61-B2]** `Store` `init/1` MUST create the ETS table before returning
+  `{:ok, state}`, so any caller of `Tau.CircuitBreaker.call/3` can rely on the
+  table existing if `Store` is running.
+
+### Q3: What happens if a component fails silently?
+
+- **★ [C62-B3]** If the breaker is `:open` and the caller does not check the
+  return value of `call/3`, the short-circuit error `{:error, :circuit_open}`
+  is swallowed. The façade MUST log a telemetry event
+  `[:tau, :circuit_breaker, :open]` so the TUI and session FSM have an
+  observable signal.
+- **★ [C63-B2]** If `Store` crashes, the ETS table is destroyed (it is
+  `:private` to the owner process — see §4). All concurrent reads and writes
+  fail. The supervisor MUST restart `Store` and the table is recreated empty —
+  all breakers reset to `:closed`. This is acceptable: a restart means the
+  crash cost is a momentary reset of error counters, not data loss of
+  user-visible state.
+- **[C64-B1]** If the ETS row for a provider does not exist (first call ever),
+  `check/2` MUST default to `:closed` — absence of state means the breaker is
+  healthy. Row creation MUST be idempotent (`:ets.insert_new/2` or equivalent).
+
+### Q4: What information crosses a boundary, and what is lost?
+
+- **★ [C65-B3]** `call/3` wraps the thunk result. The full error term from the
+  provider is preserved and returned to the caller; only the outcome tag
+  (`:ok` or `:error`) is used to drive the breaker transition. No information
+  is stripped.
+- **[C66-B1]** The ETS row carries `opened_at_ms` (wall clock, milliseconds).
+  Time is not shared across nodes — this spec is BEAM-local only. Distributed
+  circuit breaking is out of scope.
+
+## 4. Boundary contracts
+
+### B1: `Tau.CircuitBreaker` (C3) ↔ `Tau.CircuitBreaker.Store` (C2)
+
+**Read contract** (`check/2`):
+
+- Input: `provider :: module()`, `now_ms :: non_neg_integer()`
+- Output: `:closed | :open | :half_open`
+- Pre: `Store` is running; ETS table exists.
+- Post: returns `:closed` if no row exists for `provider`.
+- Invariant: `:half_open` is returned only if `now_ms >= opened_at_ms + cooldown_ms`.
+
+**Write contract** (`transition/2` — full-row CAS):
+
+- Input: `provider :: module()`, `new_state :: %State{}`
+- Operation: `:ets.select_replace/2` with a guard on the current row's state
+  field. Returns `0` (no match — concurrent transition won) or `1` (replaced).
+- Invariant: the caller that returns `1` is the sole writer of the new row;
+  callers that return `0` treat it as a no-op (their transition lost the race).
+
+**Probe-admission contract** (`probe_admitted?/1`):
+
+- Input: `provider :: module()`
+- Operation: `:ets.update_counter(:tau_circuit_breakers, provider, {probe_slot_pos, 1, 1, 1})`
+  where the threshold is `1` — the operation increments the field, caps it at 1,
+  and returns the new value. Return `1` → admitted; return value already `1`
+  before increment cannot occur because `update_counter` with threshold
+  `{pos, incr, threshold, default}` semantics clamp to `threshold`. Concretely:
+  the ETS call form is `{probe_slot_pos, +1, 1, 1}` meaning "increment by 1,
+  clamp at 1, default row counter to 1 if key missing" — so the first caller
+  gets `1` (admitted) and all subsequent callers also get `1` (clamped, but
+  the row already existed, so the default is not used). This approach requires
+  a separate `:ets.lookup/2` to distinguish "first to arrive" from "subsequent":
+  **the correct primitive is `update_counter` with a `{pos, 1, 1, 1}` spec;
+  the caller that finds the pre-increment value was `0` is admitted; all others
+  are rejected.** The pre-increment value is recoverable because
+  `update_counter` returns the post-increment value; a post-increment value of
+  `1` means pre-increment was `0` → admitted. Post-increment `1` from a
+  non-zero pre-increment is impossible given the clamp at `1`. Therefore:
+  **`update_counter` returns `1` → admitted; would not return other than `1` due
+  to clamp**. Clarification: the threshold form `{pos, increment, threshold, reset_value}`
+  in `:ets.update_counter/3` means the counter is set to `reset_value` when it
+  would exceed `threshold`. We use `{probe_slot_pos, 1, 0, 1}` — increment by 1,
+  if result would exceed 0... that is wrong. The correct form:
+
+  **Binding primitive (CRITIC-MANDATED):**
+  ```
+  :ets.update_counter(:tau_circuit_breakers, provider_key,
+    [{probe_slot_pos, 1, 1, 1}])
+  ```
+  Semantics: increment `probe_slot` by 1; if `probe_slot >= 1` after increment,
+  set it to 1 (clamp). The call returns the post-update value. Because the
+  counter starts at `0` on a fresh `:half_open` transition (reset by
+  `select_replace`), the first caller receives `1` and all subsequent callers
+  also receive `1` (clamped). To distinguish admission, use
+  `:ets.update_counter/4` with a default tuple: `{provider_key, 0}` as the
+  default row, and the update spec `[{probe_slot_pos, 1, 1, 1}]`. **The caller
+  is admitted if and only if it observed a pre-increment value of `0`.** Since
+  `update_counter` only returns the post-increment value, the Store MUST expose
+  `probe_admitted?/1` as a GenServer call that performs a `select_replace`
+  atomic swap on the `probe_slot` field from `0` to `1`, returning `true` iff
+  the match count was `1` (it was 0 before, now set to 1). This is the correct
+  single-probe admission primitive.
+
+  **Final binding form:** `probe_admitted?/1` in `Store` uses
+  `:ets.select_replace/2` with a match spec that matches the row when
+  `probe_slot == 0` and replaces it with the same row with `probe_slot = 1`.
+  Return value `1` → admitted; `0` → rejected. This is a full-row CAS on the
+  `probe_slot` field only, expressed as `select_replace` so no two probes are
+  simultaneously admitted. No other ETS primitive guarantees this — not
+  `update_counter` (which returns post-increment and cannot distinguish first
+  from nth caller when clamped), not `insert` (which is not conditional on
+  current value).
+
+### B2: `Tau.CircuitBreaker.Store` (C2) ↔ ETS
+
+**Table options (binding):**
+```
+:ets.new(:tau_circuit_breakers, [
+  :named_table, :public, :set,
+  read_concurrency: true,
+  write_concurrency: true
+])
+```
+
+**Row layout (binding — every field position is fixed):**
+
+```
+{provider_key, state_atom, failure_count, success_count, opened_at_ms, probe_slot}
+```
+
+- Position 1: `provider_key :: module()` — the ETS key.
+- Position 2: `state_atom :: :closed | :open | :half_open`
+- Position 3: `failure_count :: non_neg_integer()` — consecutive failure count.
+- Position 4: `success_count :: non_neg_integer()` — consecutive success count in `:half_open`.
+- Position 5: `opened_at_ms :: non_neg_integer()` — monotonic ms at which breaker opened; `0` when `:closed`.
+- Position 6: `probe_slot :: 0 | 1` — `0` = probe available; `1` = probe in flight or completed.
+
+**Why fixed positions:** `:ets.update_counter/3` and `:ets.select_replace/2`
+operate on positional fields. A future schema change that moves a field breaks
+all active `:update_counter` calls silently. Positions MUST NOT be renumbered
+without a data-migration step.
+
+**State transition atomicity (binding):**
+
+- `failure_count` increments: `:ets.update_counter(:tau_circuit_breakers, key, {3, 1})`
+- `success_count` increments: `:ets.update_counter(:tau_circuit_breakers, key, {4, 1})`
+- Full state transition (`:closed → :open`, `:open → :half_open`, `:half_open → :closed`, `:half_open → :open`): `:ets.select_replace/2` with a guard on position 2 (current `state_atom`). A match count of `0` means a concurrent process already transitioned; treat as no-op.
+- Probe-slot admission: `:ets.select_replace/2` matching `probe_slot == 0`, replacing with `probe_slot = 1`. Match count `1` → admitted; `0` → rejected.
+
+**No transition requires two separate ETS writes** — each is either a single
+`update_counter` (counter bump) or a single `select_replace` (full-row CAS).
+
+### B3: `Tau.Session` / provider task ↔ `Tau.CircuitBreaker` (C3)
+
+- `call/3 :: (provider :: module(), opts :: keyword(), thunk :: (-> result)) -> result | {:error, :circuit_open}`
+- Pre: `Store` is running.
+- Post: if `:open`, returns `{:error, :circuit_open}` without invoking `thunk`.
+- Post: if `:closed` or `:half_open` (and admitted), invokes `thunk`, records outcome.
+- Telemetry events: `[:tau, :circuit_breaker, :check]`, `[:tau, :circuit_breaker, :open]` (when short-circuited), `[:tau, :circuit_breaker, :transition]` (on state change).
+
+### B4: `Tau.CircuitBreaker.State` (C1) ↔ callers
+
+- Pure functions, no side effects.
+- `record_failure/2 :: (%State{}, opts) -> %State{}`
+- `record_success/2 :: (%State{}, opts) -> %State{}`
+- `check/2 :: (%State{}, now_ms :: non_neg_integer()) -> :closed | :open | :half_open`
+- All functions are total — no raises on valid inputs.
+
+## 5. State enumeration
+
+| State | Meaning | Entry condition | Exit condition |
+|-------|---------|-----------------|----------------|
+| `:closed` | Normal operation | Initial; or success in `:half_open` | `failure_count >= failure_threshold` |
+| `:open` | Short-circuiting all calls | `failure_count >= failure_threshold`; or failure in `:half_open` | `now_ms >= opened_at_ms + cooldown_ms` |
+| `:half_open` | Admitting exactly one probe | `cooldown_ms` elapsed since opening | Probe succeeds → `:closed`; probe fails → `:open` |
+
+**Transition table:**
+
+```
+:closed  + record_failure → failure_count < threshold  → :closed (count bumped)
+:closed  + record_failure → failure_count >= threshold → :open   (reset success_count; set opened_at_ms)
+:closed  + record_success → any                        → :closed (reset failure_count)
+:open    + check(now_ms)  → now_ms < opened_at_ms + cooldown_ms → :open
+:open    + check(now_ms)  → now_ms >= opened_at_ms + cooldown_ms → :half_open (reset probe_slot = 0)
+:half_open + probe_admitted? → true  → call thunk
+:half_open + probe_admitted? → false → :open (reject, no thunk call)
+:half_open + record_success → → :closed (reset failure_count, success_count, probe_slot)
+:half_open + record_failure → → :open  (reset probe_slot; set new opened_at_ms)
+```
+
+**Defaults** (overridable via opts in PR2):
+
+- `failure_threshold`: `5` consecutive failures.
+- `cooldown_ms`: `30_000` ms (30 seconds).
+- `success_threshold`: `1` success in `:half_open` to close.
+
+## 6. D-NNN invariants
+
+**D-029 — Circuit breaker state machine is total and deterministic:**
+For any `%State{}` and any `now_ms`, `check/2` returns exactly one of
+`:closed`, `:open`, `:half_open`. `record_failure/2` and `record_success/2`
+return a valid `%State{}`. No combination of inputs reaches an undefined or
+intermediate state. This invariant is enforced by the property suite in PR1
+(`state_property_test.exs`) and by the ETS-level constraint that `state_atom`
+is always one of the three atoms.
+
+**D-030 — Probe admission is exclusive under concurrency:**
+In `:half_open` state, at most one concurrent caller is admitted as a probe.
+Enforced by the `probe_admitted?/1` implementation in `Store` (PR2) using
+`:ets.select_replace/2` on `probe_slot` (0 → 1). The property suite in PR2
+MUST include a concurrent-probe race property: N processes race a half-open
+breaker simultaneously; exactly one receives `{:ok, admitted}`, the rest
+receive `{:error, :circuit_open}`. This property MUST be tagged `:property`
+and run under `async: false`.
+
+**D-043 — All-open chain terminates:**
+A chain of N providers where all breakers are `:open` terminates in at most N
+`call/3` invocations, each returning `{:error, :circuit_open}`. The chain
+MUST NOT loop. Enforced by the fallback logic in PR3: a fallback sequence that
+encounters `:circuit_open` on every member reports the error immediately rather
+than retrying indefinitely. The property suite in PR2 MUST include an
+all-breakers-open fallback-termination property: given a list of providers all
+in `:open` state, `call/3` over each returns `{:error, :circuit_open}` and the
+total invocation count equals the length of the list (never exceeds it).
+
+**D-044 — ETS row layout is immutable within a schema version:**
+The positional field layout defined in §4 B2 MUST NOT be changed without a
+schema-version bump and data migration. `update_counter` and `select_replace`
+calls hardcode field positions; a silent reorder silently corrupts counters.
+Any PR that changes the row layout MUST bump a `@schema_version` module
+attribute in `Tau.CircuitBreaker.Store` and document the migration in the PR
+description.
+
+## 7. Acceptance criteria
+
+- **AC-1 (PR1):** `mix compile --warnings-as-errors` passes with `lib/tau/circuit_breaker/state.ex` present.
+- **AC-2 (PR1):** `mix test test/tau/circuit_breaker/state_property_test.exs` passes; all properties tagged `:property` exercise the D-029 invariant.
+- **AC-3 (PR2):** `mix test --only property` passes including the concurrent-probe race property (D-030) and the all-open termination property (D-043).
+- **AC-4 (PR2):** `Tau.CircuitBreaker.Store` starts under `Tau.Application` supervision; `mix test` passes.
+- **AC-5 (PR3):** `Tau.CircuitBreaker.call/3` wraps a synthetic always-failing thunk; after `failure_threshold` failures, subsequent calls return `{:error, :circuit_open}` without invoking the thunk.
+- **AC-6 (PR3):** After `cooldown_ms`, `call/3` admits exactly one probe; if the probe fails, all subsequent calls are again `:circuit_open` until the next cooldown.
+- **AC-7 (PR4):** Integration with `Tau.Session` provider dispatch; a session turn against an open breaker surfaces a visible error event to the TUI (not a silent drop).
+
+## Appendix B — Source map
+
+Files that bring a PR into scope of this SPEC:
+
+- `lib/tau/circuit_breaker.ex` (façade, C3) — PR3+
+- `lib/tau/circuit_breaker/state.ex` (pure core, C1) — PR1
+- `lib/tau/circuit_breaker/store.ex` (ETS owner, C2) — PR2
+- `test/tau/circuit_breaker/state_property_test.exs` — PR1
+- `test/tau/circuit_breaker/store_property_test.exs` — PR2
+- `test/tau/circuit_breaker/circuit_breaker_test.exs` — PR3
+- `lib/tau/application.ex` (supervision tree) — PR2
+- `lib/tau/session.ex` or provider dispatch path — PR4

--- a/docs/spec/SPEC-CIRCUIT-BREAKER.md
+++ b/docs/spec/SPEC-CIRCUIT-BREAKER.md
@@ -146,56 +146,16 @@ Format: `[Cn-Bm]` = constraint number + boundary. **★** marks non-obvious.
 **Probe-admission contract** (`probe_admitted?/1`):
 
 - Input: `provider :: module()`
-- Operation: `:ets.update_counter(:tau_circuit_breakers, provider, {probe_slot_pos, 1, 1, 1})`
-  where the threshold is `1` — the operation increments the field, caps it at 1,
-  and returns the new value. Return `1` → admitted; return value already `1`
-  before increment cannot occur because `update_counter` with threshold
-  `{pos, incr, threshold, default}` semantics clamp to `threshold`. Concretely:
-  the ETS call form is `{probe_slot_pos, +1, 1, 1}` meaning "increment by 1,
-  clamp at 1, default row counter to 1 if key missing" — so the first caller
-  gets `1` (admitted) and all subsequent callers also get `1` (clamped, but
-  the row already existed, so the default is not used). This approach requires
-  a separate `:ets.lookup/2` to distinguish "first to arrive" from "subsequent":
-  **the correct primitive is `update_counter` with a `{pos, 1, 1, 1}` spec;
-  the caller that finds the pre-increment value was `0` is admitted; all others
-  are rejected.** The pre-increment value is recoverable because
-  `update_counter` returns the post-increment value; a post-increment value of
-  `1` means pre-increment was `0` → admitted. Post-increment `1` from a
-  non-zero pre-increment is impossible given the clamp at `1`. Therefore:
-  **`update_counter` returns `1` → admitted; would not return other than `1` due
-  to clamp**. Clarification: the threshold form `{pos, increment, threshold, reset_value}`
-  in `:ets.update_counter/3` means the counter is set to `reset_value` when it
-  would exceed `threshold`. We use `{probe_slot_pos, 1, 0, 1}` — increment by 1,
-  if result would exceed 0... that is wrong. The correct form:
-
-  **Binding primitive (CRITIC-MANDATED):**
-  ```
-  :ets.update_counter(:tau_circuit_breakers, provider_key,
-    [{probe_slot_pos, 1, 1, 1}])
-  ```
-  Semantics: increment `probe_slot` by 1; if `probe_slot >= 1` after increment,
-  set it to 1 (clamp). The call returns the post-update value. Because the
-  counter starts at `0` on a fresh `:half_open` transition (reset by
-  `select_replace`), the first caller receives `1` and all subsequent callers
-  also receive `1` (clamped). To distinguish admission, use
-  `:ets.update_counter/4` with a default tuple: `{provider_key, 0}` as the
-  default row, and the update spec `[{probe_slot_pos, 1, 1, 1}]`. **The caller
-  is admitted if and only if it observed a pre-increment value of `0`.** Since
-  `update_counter` only returns the post-increment value, the Store MUST expose
-  `probe_admitted?/1` as a GenServer call that performs a `select_replace`
-  atomic swap on the `probe_slot` field from `0` to `1`, returning `true` iff
-  the match count was `1` (it was 0 before, now set to 1). This is the correct
-  single-probe admission primitive.
-
-  **Final binding form:** `probe_admitted?/1` in `Store` uses
-  `:ets.select_replace/2` with a match spec that matches the row when
-  `probe_slot == 0` and replaces it with the same row with `probe_slot = 1`.
-  Return value `1` → admitted; `0` → rejected. This is a full-row CAS on the
-  `probe_slot` field only, expressed as `select_replace` so no two probes are
-  simultaneously admitted. No other ETS primitive guarantees this — not
-  `update_counter` (which returns post-increment and cannot distinguish first
-  from nth caller when clamped), not `insert` (which is not conditional on
-  current value).
+- Operation: `:ets.select_replace/2` with a match spec that matches the row
+  when `probe_slot == 0` and replaces it with the same row with `probe_slot = 1`.
+  Return value `1` → admitted (this process is the sole probe); `0` → rejected
+  (another process already claimed the slot).
+- Why not `update_counter`: `:ets.update_counter/3` returns only the
+  post-increment value. With a clamp-at-1 spec, both the first and all
+  subsequent callers receive `1` — there is no way to distinguish the first
+  caller from the nth using the return value alone. `select_replace` performs a
+  conditional full-row CAS (match only when `probe_slot == 0`), so exactly one
+  caller receives match count `1`; all others receive `0`.
 
 ### B2: `Tau.CircuitBreaker.Store` (C2) ↔ ETS
 
@@ -247,10 +207,20 @@ without a data-migration step.
 ### B4: `Tau.CircuitBreaker.State` (C1) ↔ callers
 
 - Pure functions, no side effects.
-- `record_failure/2 :: (%State{}, opts) -> %State{}`
-- `record_success/2 :: (%State{}, opts) -> %State{}`
+- `record_failure/2 :: (%State{}, opts :: keyword()) -> %State{}`
+- `record_success/2 :: (%State{}, opts :: keyword()) -> %State{}`
 - `check/2 :: (%State{}, now_ms :: non_neg_integer()) -> :closed | :open | :half_open`
 - All functions are total — no raises on valid inputs.
+
+**`opts` keys for `record_failure/2` and `record_success/2`:**
+
+| Key | Type | Required? | Default | Purpose |
+|-----|------|-----------|---------|---------|
+| `:now_ms` | `non_neg_integer()` | **REQUIRED** when call can trigger `:open` transition (i.e. in `:closed` or `:half_open` state) | — | Wall-clock milliseconds at time of call; stored as `opened_at_ms` on `:open` transition. Omitting it raises `KeyError`. |
+| `:failure_threshold` | `pos_integer()` | optional | `5` | Consecutive failures before opening. |
+| `:success_threshold` | `pos_integer()` | optional | `1` | Successes in `:half_open` before closing. |
+
+`:now_ms` is a required key for any state that can transition to `:open`. Callers must supply a monotonic millisecond timestamp. Omitting `:now_ms` where it is required raises a `KeyError` (fail loud — silent `0` defaults cause the cooldown to appear already elapsed on any subsequent `check/2`).
 
 ## 5. State enumeration
 
@@ -304,7 +274,7 @@ A chain of N providers where all breakers are `:open` terminates in at most N
 `call/3` invocations, each returning `{:error, :circuit_open}`. The chain
 MUST NOT loop. Enforced by the fallback logic in PR3: a fallback sequence that
 encounters `:circuit_open` on every member reports the error immediately rather
-than retrying indefinitely. The property suite in PR2 MUST include an
+than retrying indefinitely. The property suite in PR3 MUST include an
 all-breakers-open fallback-termination property: given a list of providers all
 in `:open` state, `call/3` over each returns `{:error, :circuit_open}` and the
 total invocation count equals the length of the list (never exceeds it).
@@ -321,7 +291,8 @@ description.
 
 - **AC-1 (PR1):** `mix compile --warnings-as-errors` passes with `lib/tau/circuit_breaker/state.ex` present.
 - **AC-2 (PR1):** `mix test test/tau/circuit_breaker/state_property_test.exs` passes; all properties tagged `:property` exercise the D-029 invariant.
-- **AC-3 (PR2):** `mix test --only property` passes including the concurrent-probe race property (D-030) and the all-open termination property (D-043).
+- **AC-3 (PR2):** `mix test --only property` passes including the concurrent-probe race property (D-030).
+- **AC-3b (PR3):** `mix test --only property` passes including the all-open termination property (D-043).
 - **AC-4 (PR2):** `Tau.CircuitBreaker.Store` starts under `Tau.Application` supervision; `mix test` passes.
 - **AC-5 (PR3):** `Tau.CircuitBreaker.call/3` wraps a synthetic always-failing thunk; after `failure_threshold` failures, subsequent calls return `{:error, :circuit_open}` without invoking the thunk.
 - **AC-6 (PR3):** After `cooldown_ms`, `call/3` admits exactly one probe; if the probe fails, all subsequent calls are again `:circuit_open` until the next cooldown.

--- a/lib/tau/circuit_breaker/state.ex
+++ b/lib/tau/circuit_breaker/state.ex
@@ -1,0 +1,157 @@
+defmodule Tau.CircuitBreaker.State do
+  @moduledoc """
+  Pure state-machine core for the circuit breaker (SPEC-CIRCUIT-BREAKER §4 B4).
+
+  Holds the breaker's current status and counters. All functions are pure —
+  no process, no ETS, no side effects. `Tau.CircuitBreaker.Store` (PR2)
+  persists instances of this struct in ETS and drives transitions via
+  `Tau.CircuitBreaker` (the façade, PR3).
+
+  ## States
+
+  - `:closed`    — normal operation; provider calls are admitted.
+  - `:open`      — short-circuiting; all calls return `{:error, :circuit_open}`.
+  - `:half_open` — cooldown elapsed; exactly one probe is admitted.
+
+  ## Defaults
+
+  - `failure_threshold`: `5` — consecutive failures before opening.
+  - `cooldown_ms`:       `30_000` — milliseconds to wait before probing.
+  - `success_threshold`: `1` — successes in `:half_open` to close.
+
+  ## D-029
+
+  For any `%State{}` and any `now_ms`, `check/2` returns exactly one of
+  `:closed`, `:open`, `:half_open`. All functions are total.
+  """
+
+  @type state_atom :: :closed | :open | :half_open
+
+  @type t :: %__MODULE__{
+          state: state_atom(),
+          failure_count: non_neg_integer(),
+          success_count: non_neg_integer(),
+          opened_at_ms: non_neg_integer(),
+          half_open_probe?: boolean()
+        }
+
+  defstruct state: :closed,
+            failure_count: 0,
+            success_count: 0,
+            opened_at_ms: 0,
+            half_open_probe?: false
+
+  @default_failure_threshold 5
+  @default_cooldown_ms 30_000
+  @default_success_threshold 1
+
+  @doc """
+  Returns the observable state of the breaker at `now_ms`.
+
+  Concretely:
+
+  - `:closed` — breaker is healthy or success reset it.
+  - `:open`   — cooldown has not yet elapsed since `opened_at_ms`.
+  - `:half_open` — cooldown has elapsed; a probe may be admitted.
+
+  `check/2` does not mutate state; the caller is responsible for
+  transitioning to `:half_open` if needed (done by `Tau.CircuitBreaker.Store`).
+  """
+  @spec check(t(), non_neg_integer()) :: state_atom()
+  def check(%__MODULE__{state: :closed}, _now_ms), do: :closed
+
+  def check(%__MODULE__{state: :open, opened_at_ms: opened_at_ms}, now_ms) do
+    if now_ms >= opened_at_ms + @default_cooldown_ms do
+      :half_open
+    else
+      :open
+    end
+  end
+
+  def check(%__MODULE__{state: :half_open}, _now_ms), do: :half_open
+
+  @doc """
+  Records a provider-call failure and returns the updated state.
+
+  In `:closed` state, bumps `failure_count`. When `failure_count` reaches
+  `failure_threshold`, transitions to `:open` and records `opened_at_ms`.
+
+  In `:half_open` state, the probe failed — transitions back to `:open`.
+
+  In `:open` state, the failure is a no-op (the breaker is already open).
+  """
+  @spec record_failure(t(), keyword()) :: t()
+  def record_failure(state, opts \\ [])
+
+  def record_failure(%__MODULE__{state: :closed} = s, opts) do
+    threshold = Keyword.get(opts, :failure_threshold, @default_failure_threshold)
+    now_ms = Keyword.get(opts, :now_ms, 0)
+    new_count = s.failure_count + 1
+
+    if new_count >= threshold do
+      %__MODULE__{
+        s
+        | state: :open,
+          failure_count: new_count,
+          success_count: 0,
+          opened_at_ms: now_ms
+      }
+    else
+      %__MODULE__{s | failure_count: new_count}
+    end
+  end
+
+  def record_failure(%__MODULE__{state: :half_open} = s, opts) do
+    now_ms = Keyword.get(opts, :now_ms, 0)
+
+    %__MODULE__{
+      s
+      | state: :open,
+        failure_count: s.failure_count + 1,
+        success_count: 0,
+        opened_at_ms: now_ms,
+        half_open_probe?: false
+    }
+  end
+
+  def record_failure(%__MODULE__{state: :open} = s, _opts), do: s
+
+  @doc """
+  Records a provider-call success and returns the updated state.
+
+  In `:closed` state, resets `failure_count` to `0` (consecutive-failure
+  counting — a single success clears accumulated partial failures).
+
+  In `:half_open` state, bumps `success_count`. When `success_count` reaches
+  `success_threshold`, closes the breaker.
+
+  In `:open` state, a success is a no-op (the probe has not been admitted yet;
+  this path should not occur in normal façade usage).
+  """
+  @spec record_success(t(), keyword()) :: t()
+  def record_success(state, opts \\ [])
+
+  def record_success(%__MODULE__{state: :closed} = s, _opts) do
+    %__MODULE__{s | failure_count: 0}
+  end
+
+  def record_success(%__MODULE__{state: :half_open} = s, opts) do
+    threshold = Keyword.get(opts, :success_threshold, @default_success_threshold)
+    new_count = s.success_count + 1
+
+    if new_count >= threshold do
+      %__MODULE__{
+        s
+        | state: :closed,
+          failure_count: 0,
+          success_count: 0,
+          opened_at_ms: 0,
+          half_open_probe?: false
+      }
+    else
+      %__MODULE__{s | success_count: new_count}
+    end
+  end
+
+  def record_success(%__MODULE__{state: :open} = s, _opts), do: s
+end

--- a/lib/tau/circuit_breaker/state.ex
+++ b/lib/tau/circuit_breaker/state.ex
@@ -32,14 +32,14 @@ defmodule Tau.CircuitBreaker.State do
           failure_count: non_neg_integer(),
           success_count: non_neg_integer(),
           opened_at_ms: non_neg_integer(),
-          half_open_probe?: boolean()
+          probe_slot: 0 | 1
         }
 
   defstruct state: :closed,
             failure_count: 0,
             success_count: 0,
             opened_at_ms: 0,
-            half_open_probe?: false
+            probe_slot: 0
 
   @default_failure_threshold 5
   @default_cooldown_ms 30_000
@@ -85,10 +85,11 @@ defmodule Tau.CircuitBreaker.State do
 
   def record_failure(%__MODULE__{state: :closed} = s, opts) do
     threshold = Keyword.get(opts, :failure_threshold, @default_failure_threshold)
-    now_ms = Keyword.get(opts, :now_ms, 0)
     new_count = s.failure_count + 1
 
     if new_count >= threshold do
+      now_ms = Keyword.fetch!(opts, :now_ms)
+
       %__MODULE__{
         s
         | state: :open,
@@ -102,7 +103,7 @@ defmodule Tau.CircuitBreaker.State do
   end
 
   def record_failure(%__MODULE__{state: :half_open} = s, opts) do
-    now_ms = Keyword.get(opts, :now_ms, 0)
+    now_ms = Keyword.fetch!(opts, :now_ms)
 
     %__MODULE__{
       s
@@ -110,7 +111,7 @@ defmodule Tau.CircuitBreaker.State do
         failure_count: s.failure_count + 1,
         success_count: 0,
         opened_at_ms: now_ms,
-        half_open_probe?: false
+        probe_slot: 0
     }
   end
 
@@ -146,7 +147,7 @@ defmodule Tau.CircuitBreaker.State do
           failure_count: 0,
           success_count: 0,
           opened_at_ms: 0,
-          half_open_probe?: false
+          probe_slot: 0
       }
     else
       %__MODULE__{s | success_count: new_count}

--- a/test/tau/circuit_breaker/state_property_test.exs
+++ b/test/tau/circuit_breaker/state_property_test.exs
@@ -186,4 +186,19 @@ defmodule Tau.CircuitBreaker.StatePropertyTest do
       assert result == :half_open
     end
   end
+
+  property "N failures in :closed sets opened_at_ms == now_ms on :open transition" do
+    check all(
+            threshold <- threshold_gen(),
+            now_ms <- now_ms_gen()
+          ) do
+      opts = [failure_threshold: threshold, now_ms: now_ms]
+
+      final_state =
+        Enum.reduce(1..threshold, %State{}, fn _, acc -> State.record_failure(acc, opts) end)
+
+      assert final_state.state == :open
+      assert final_state.opened_at_ms == now_ms
+    end
+  end
 end

--- a/test/tau/circuit_breaker/state_property_test.exs
+++ b/test/tau/circuit_breaker/state_property_test.exs
@@ -1,0 +1,189 @@
+defmodule Tau.CircuitBreaker.StatePropertyTest do
+  @moduledoc """
+  Properties that pin `Tau.CircuitBreaker.State` (SPEC-CIRCUIT-BREAKER §4 B4).
+
+  Enforces D-029: for any `%State{}` and any `now_ms`, `check/2` returns
+  exactly one of `:closed`, `:open`, `:half_open`; all functions are total.
+
+  Invariants tested:
+
+  * `check/2` always returns one of the three valid state atoms.
+  * N consecutive failures in `:closed` state cause transition to `:open`
+    once the failure count reaches `failure_threshold`.
+  * A success in `:closed` state resets `failure_count` to 0.
+  * `record_failure/2` on an `:open` breaker is a no-op.
+  * `record_success/2` on an `:half_open` breaker with `success_threshold = 1`
+    immediately closes it.
+  * `record_failure/2` on a `:half_open` breaker transitions to `:open`.
+  * `check/2` never returns `:half_open` before `cooldown_ms` has elapsed.
+  * State is always one of `:closed`, `:open`, `:half_open`.
+  """
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  alias Tau.CircuitBreaker.State
+
+  @moduletag :property
+
+  @valid_states [:closed, :open, :half_open]
+
+  # Default cooldown used by State.check/2
+  @default_cooldown_ms 30_000
+
+  defp now_ms_gen, do: StreamData.integer(0..10_000_000)
+  defp threshold_gen, do: StreamData.integer(1..20)
+  defp count_gen, do: StreamData.integer(0..50)
+
+  defp closed_state_gen do
+    StreamData.bind(count_gen(), fn fc ->
+      StreamData.constant(%State{state: :closed, failure_count: fc, success_count: 0})
+    end)
+  end
+
+  defp open_state_gen do
+    StreamData.bind(
+      StreamData.tuple({now_ms_gen(), count_gen()}),
+      fn {opened_at, fc} ->
+        StreamData.constant(%State{
+          state: :open,
+          failure_count: fc,
+          success_count: 0,
+          opened_at_ms: opened_at
+        })
+      end
+    )
+  end
+
+  defp half_open_state_gen do
+    StreamData.bind(count_gen(), fn sc ->
+      StreamData.constant(%State{state: :half_open, success_count: sc, failure_count: 0})
+    end)
+  end
+
+  defp any_state_gen do
+    StreamData.one_of([closed_state_gen(), open_state_gen(), half_open_state_gen()])
+  end
+
+  property "check/2 always returns a valid state atom (D-029)" do
+    check all(
+            s <- any_state_gen(),
+            now_ms <- now_ms_gen()
+          ) do
+      result = State.check(s, now_ms)
+      assert result in @valid_states
+    end
+  end
+
+  property "state field is always one of the three valid atoms after record_failure/2" do
+    check all(
+            s <- any_state_gen(),
+            now_ms <- now_ms_gen(),
+            threshold <- threshold_gen()
+          ) do
+      s2 = State.record_failure(s, failure_threshold: threshold, now_ms: now_ms)
+      assert s2.state in @valid_states
+    end
+  end
+
+  property "state field is always one of the three valid atoms after record_success/2" do
+    check all(
+            s <- any_state_gen(),
+            threshold <- threshold_gen()
+          ) do
+      s2 = State.record_success(s, success_threshold: threshold)
+      assert s2.state in @valid_states
+    end
+  end
+
+  property "N consecutive failures in :closed cause transition to :open at threshold" do
+    check all(
+            threshold <- threshold_gen(),
+            now_ms <- now_ms_gen()
+          ) do
+      opts = [failure_threshold: threshold, now_ms: now_ms]
+
+      final_state =
+        Enum.reduce(1..threshold, %State{}, fn _, acc -> State.record_failure(acc, opts) end)
+
+      assert final_state.state == :open
+    end
+  end
+
+  property "fewer than threshold failures leave breaker :closed" do
+    check all(
+            threshold <- StreamData.integer(2..20),
+            n <- StreamData.integer(1..(threshold - 1)),
+            now_ms <- now_ms_gen()
+          ) do
+      opts = [failure_threshold: threshold, now_ms: now_ms]
+      final_state = Enum.reduce(1..n, %State{}, fn _, acc -> State.record_failure(acc, opts) end)
+      assert final_state.state == :closed
+      assert final_state.failure_count == n
+    end
+  end
+
+  property "record_success/2 in :closed resets failure_count to 0" do
+    check all(s <- closed_state_gen()) do
+      s2 = State.record_success(s)
+      assert s2.state == :closed
+      assert s2.failure_count == 0
+    end
+  end
+
+  property "record_failure/2 on :open state is a no-op" do
+    check all(
+            s <- open_state_gen(),
+            now_ms <- now_ms_gen(),
+            threshold <- threshold_gen()
+          ) do
+      s2 = State.record_failure(s, failure_threshold: threshold, now_ms: now_ms)
+      assert s2 == s
+    end
+  end
+
+  property "record_success/2 on :half_open with success_threshold=1 closes the breaker" do
+    check all(s <- half_open_state_gen()) do
+      s2 = State.record_success(s, success_threshold: 1)
+      assert s2.state == :closed
+      assert s2.failure_count == 0
+      assert s2.success_count == 0
+    end
+  end
+
+  property "record_failure/2 on :half_open transitions back to :open" do
+    check all(
+            s <- half_open_state_gen(),
+            now_ms <- now_ms_gen()
+          ) do
+      s2 = State.record_failure(s, now_ms: now_ms)
+      assert s2.state == :open
+      assert s2.opened_at_ms == now_ms
+    end
+  end
+
+  property "check/2 never returns :half_open before cooldown_ms has elapsed" do
+    check all(
+            opened_at_ms <- now_ms_gen(),
+            # delta strictly less than the default cooldown threshold
+            delta <- StreamData.integer(0..(@default_cooldown_ms - 1))
+          ) do
+      now_ms = opened_at_ms + delta
+      s = %State{state: :open, opened_at_ms: opened_at_ms}
+      result = State.check(s, now_ms)
+      # Should still be :open (default cooldown not elapsed)
+      assert result == :open
+    end
+  end
+
+  property "check/2 returns :half_open once default cooldown_ms has elapsed" do
+    check all(
+            opened_at_ms <- StreamData.integer(0..5_000_000),
+            extra <- StreamData.integer(0..10_000)
+          ) do
+      now_ms = opened_at_ms + @default_cooldown_ms + extra
+      s = %State{state: :open, opened_at_ms: opened_at_ms}
+      result = State.check(s, now_ms)
+      assert result == :half_open
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- `docs/spec/SPEC-CIRCUIT-BREAKER.md` — PSDH L0 spec; pins `:ets.select_replace/2` as the half-open single-probe-admission primitive.
- `docs/adr/0019-circuit-breaker-is-ets-state-with-lifecycle-anchor.md` — ETS-state-vs-GenServer decision.
- `lib/tau/circuit_breaker/state.ex` — pure state machine: `%State{}`, `check/2`, `record_failure/2`, `record_success/2`.
- `test/tau/circuit_breaker/state_property_test.exs` — 12 StreamData properties.
- `.claude/rules/spec-before-code.md` — catalog entry.

PR1 scope: SPEC + pure core only. ETS owner process is PR2.

## Spec / invariants
Advances D-029 (totality), D-030 (probe exclusivity, PR2), D-043 (all-open termination, PR3), D-044 (row layout). New spec; entered in the catalog.

Refs #65

## Test plan
- [x] `mix test` — 690 tests, 51 properties, 0 failures
- [x] `mix compile --warnings-as-errors`, `mix format`, `mix credo --strict` clean on PR files

🤖 Generated with [Claude Code](https://claude.com/claude-code)