### PR TITLE
feat(circuit-breaker): ETS-owner Store + supervision wiring (PR2 of #65)

### DIFF
--- a/lib/tau/application.ex
+++ b/lib/tau/application.ex
@@ -24,7 +24,13 @@ defmodule Tau.Application do
     7. **Finch** — HTTP client, used by providers.
     8. **Providers.RateLimiter.Supervisor** — per-provider token-bucket
        limiters (ADR-0011). Boots after Finch (limiters wrap Finch
-       sends) and before the task supervisors.
+       sends) and before the circuit breaker.
+    9. **CircuitBreaker.Store** — ETS-owner lifecycle anchor for
+       `:tau_circuit_breakers` (SPEC-CIRCUIT-BREAKER §4 B2, ADR-0019).
+       Placed after rate limiters (circuit breakers wrap provider calls
+       at a higher level than rate limiting) and before task supervisors
+       so the table exists when any session-turn task first calls a
+       provider.
     9. **Task supervisors** — for tool dispatch.
     10. **Extensions.Loader** — registers tools/hooks/commands
         defined by extensions.
@@ -66,6 +72,7 @@ defmodule Tau.Application do
       Tau.Permissions.RuleSet,
       {Finch, name: Tau.Providers.Finch},
       Tau.Providers.RateLimiter.Supervisor,
+      Tau.CircuitBreaker.Store,
       {Task.Supervisor, name: Tau.Tools.TaskSupervisor},
       Tau.Extensions.Loader,
       Tau.MCP.Supervisor,

--- a/lib/tau/circuit_breaker/store.ex
+++ b/lib/tau/circuit_breaker/store.ex
@@ -1,0 +1,236 @@
+defmodule Tau.CircuitBreaker.Store do
+  @moduledoc """
+  ETS-owner lifecycle anchor for the circuit-breaker table (SPEC-CIRCUIT-BREAKER §4 B2, C2).
+
+  This GenServer's only job is to own the `:tau_circuit_breakers` ETS table
+  and expose two atomic CAS operations:
+
+  - `transition/2` — full-row state transition via `:ets.select_replace/2` with
+    a guard on the current `state_atom` field. Serialises only the CAS, not reads
+    or counter bumps.
+  - `probe_admitted?/1` — half-open single-probe admission via `:ets.select_replace/2`
+    on `probe_slot` (0 → 1). Returns `true` (admitted) or `false` (rejected).
+
+  All direct reads and `failure_count` / `success_count` counter bumps go
+  straight to ETS from the caller process — no GenServer mailbox hop.
+
+  ## ETS table
+
+  Name:    `:tau_circuit_breakers`
+  Options: `:named_table, :public, :set, read_concurrency: true, write_concurrency: true`
+
+  ## Row layout (D-044 — positional, fixed)
+
+  ```
+  {provider_key, state_atom, failure_count, success_count, opened_at_ms, probe_slot}
+  ```
+
+  - Position 1: `provider_key :: module()` — ETS key
+  - Position 2: `state_atom :: :closed | :open | :half_open`
+  - Position 3: `failure_count :: non_neg_integer()`
+  - Position 4: `success_count :: non_neg_integer()`
+  - Position 5: `opened_at_ms :: non_neg_integer()`
+  - Position 6: `probe_slot :: 0 | 1`
+
+  Field positions MUST NOT be renumbered without bumping `@schema_version`
+  and adding a data-migration step in the PR description (D-044).
+
+  ## Schema version
+
+  Bumped whenever the row layout changes. See D-044.
+  """
+
+  use GenServer
+
+  @table :tau_circuit_breakers
+  @schema_version 1
+
+  @doc "Returns the current schema version."
+  @spec schema_version() :: pos_integer()
+  def schema_version, do: @schema_version
+
+  @doc "Returns the ETS table name."
+  @spec table() :: atom()
+  def table, do: @table
+
+  # ---------------------------------------------------------------------------
+  # Public API
+  # ---------------------------------------------------------------------------
+
+  @doc """
+  Starts the Store as a named process.
+  """
+  def start_link(opts \\ []) do
+    GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+  end
+
+  @doc """
+  Reads the raw ETS row for `provider`, returning the tuple or `nil`.
+
+  Called directly by `Tau.CircuitBreaker` — no GenServer hop.
+  """
+  @spec get(module()) :: tuple() | nil
+  def get(provider) do
+    case :ets.lookup(@table, provider) do
+      [row] -> row
+      [] -> nil
+    end
+  end
+
+  @doc """
+  Returns the current state atom for `provider`.
+
+  Defaults to `:closed` when no row exists (C64-B1).
+  """
+  @spec state_for(module()) :: :closed | :open | :half_open
+  def state_for(provider) do
+    case :ets.lookup(@table, provider) do
+      [{_key, state_atom, _fc, _sc, _oat, _ps}] -> state_atom
+      [] -> :closed
+    end
+  end
+
+  @doc """
+  Ensures a row exists for `provider`; inserts a default `:closed` row if absent.
+
+  Idempotent (`:ets.insert_new/2`). Called directly by `Tau.CircuitBreaker`.
+  """
+  @spec ensure_row(module()) :: :ok
+  def ensure_row(provider) do
+    :ets.insert_new(@table, {provider, :closed, 0, 0, 0, 0})
+    :ok
+  end
+
+  @doc """
+  Performs a full-row CAS state transition via `:ets.select_replace/2`.
+
+  The match spec guards on `current_state` (position 2) so the replace
+  only fires if the row still holds the state the caller observed. Returns
+  `1` if the transition succeeded (this caller wins), `0` if a concurrent
+  process already transitioned (treat as no-op).
+
+  The new row is built from `new_state :: Tau.CircuitBreaker.State.t()`.
+  """
+  @spec transition(module(), :closed | :open | :half_open, Tau.CircuitBreaker.State.t()) ::
+          0 | 1
+  def transition(provider, current_state_atom, new_state) do
+    GenServer.call(__MODULE__, {:transition, provider, current_state_atom, new_state})
+  end
+
+  @doc """
+  Atomic half-open probe admission via `:ets.select_replace/2` on `probe_slot`.
+
+  Returns `true` if admitted (probe_slot 0 → 1), `false` if rejected
+  (probe_slot was already 1). Only one concurrent caller can receive `true`
+  — this enforces D-030.
+  """
+  @spec probe_admitted?(module()) :: boolean()
+  def probe_admitted?(provider) do
+    GenServer.call(__MODULE__, {:probe_admitted, provider})
+  end
+
+  # ---------------------------------------------------------------------------
+  # GenServer callbacks
+  # ---------------------------------------------------------------------------
+
+  @impl true
+  def init(_opts) do
+    table =
+      :ets.new(@table, [
+        :named_table,
+        :public,
+        :set,
+        {:read_concurrency, true},
+        {:write_concurrency, true}
+      ])
+
+    :telemetry.execute(
+      [:tau, :circuit_breaker, :store, :init],
+      %{system_time: System.system_time()},
+      %{table: table, schema_version: @schema_version}
+    )
+
+    {:ok, %{table: table}}
+  end
+
+  @impl true
+  def terminate(_reason, _state) do
+    :ets.delete(@table)
+    :ok
+  end
+
+  @impl true
+  def handle_call({:transition, provider, current_state_atom, new_state}, _from, state) do
+    match_count = do_transition(provider, current_state_atom, new_state)
+    {:reply, match_count, state}
+  end
+
+  def handle_call({:probe_admitted, provider}, _from, state) do
+    admitted = do_probe_admission(provider)
+    {:reply, admitted, state}
+  end
+
+  # ---------------------------------------------------------------------------
+  # Private helpers
+  # ---------------------------------------------------------------------------
+
+  # Builds a select_replace match spec for a full-row CAS state transition.
+  #
+  # ETS match spec body language (from :ets.fun2ms output):
+  #   - The body list contains ONE element for select_replace.
+  #   - That element is the replacement TUPLE, wrapped in an outer tuple:
+  #     `[{{field1, field2, ...}}]`. The outer `{}` wrapping signals "this is the
+  #     replacement object", not a BIF call.
+  #   - `:"$N"` variables reference fields captured in the head.
+  #   - Atoms captured as `:"$1"` avoid issues with special match-spec atoms like
+  #     `:_` or `:'$N'` appearing as literal keys in the head.
+  #
+  # The guard `{:==, :"$1", {:const, provider}}` pins the match to the exact
+  # provider key, so `:_` and other special atoms generated in tests match only
+  # their literal row.
+  defp do_transition(provider, current_state_atom, new_state) do
+    # Head: capture key as $1; match current_state_atom literally in pos 2;
+    # capture remaining fields for passthrough (not needed in body, but :_ is fine).
+    match_head = {:"$1", current_state_atom, :_, :_, :_, :_}
+
+    # Guard: pin to the exact provider key.
+    guards = [{:==, :"$1", {:const, provider}}]
+
+    # Body: replacement tuple wrapped in outer tuple (ETS match spec convention).
+    body = [
+      {{
+         :"$1",
+         new_state.state,
+         new_state.failure_count,
+         new_state.success_count,
+         new_state.opened_at_ms,
+         new_state.probe_slot
+       }}
+    ]
+
+    :ets.select_replace(@table, [{match_head, guards, body}])
+  end
+
+  # Builds a select_replace match spec for atomic probe-slot admission.
+  #
+  # Matches rows where probe_slot == 0 (probe available) for the exact provider
+  # key. Captures all other fields so they are preserved in the replacement.
+  # Replaces the row with probe_slot = 1 (probe in flight). Returns true if
+  # this process won the race (match count 1), false if another already
+  # claimed the slot (match count 0).
+  defp do_probe_admission(provider) do
+    # Head: capture all fields; match probe_slot == 0 literally.
+    match_head = {:"$1", :"$2", :"$3", :"$4", :"$5", 0}
+
+    # Guard: pin to the exact provider key.
+    guards = [{:==, :"$1", {:const, provider}}]
+
+    # Body: same row with probe_slot = 1.
+    body = [
+      {{:"$1", :"$2", :"$3", :"$4", :"$5", 1}}
+    ]
+
+    match_count = :ets.select_replace(@table, [{match_head, guards, body}])
+    match_count == 1
+  end
+end

--- a/lib/tau/circuit_breaker/store.ex
+++ b/lib/tau/circuit_breaker/store.ex
@@ -2,16 +2,17 @@ defmodule Tau.CircuitBreaker.Store do
   @moduledoc """
   ETS-owner lifecycle anchor for the circuit-breaker table (SPEC-CIRCUIT-BREAKER §4 B2, C2).
 
-  This GenServer's only job is to own the `:tau_circuit_breakers` ETS table
-  and expose two atomic CAS operations:
+  This GenServer's ONLY job is to own the `:tau_circuit_breakers` ETS table —
+  it creates the table in `init/1` and holds it alive. All reads and writes,
+  including the two atomic CAS operations, execute directly in the CALLER'S
+  process against the `:public` ETS table — no GenServer mailbox hop (§3 [C57-B1]).
 
-  - `transition/2` — full-row state transition via `:ets.select_replace/2` with
-    a guard on the current `state_atom` field. Serialises only the CAS, not reads
-    or counter bumps.
+  - `transition/3` — full-row CAS state transition via `:ets.select_replace/2`
+    with a guard on `state_atom`. Called directly by the caller process.
   - `probe_admitted?/1` — half-open single-probe admission via `:ets.select_replace/2`
-    on `probe_slot` (0 → 1). Returns `true` (admitted) or `false` (rejected).
+    on `probe_slot` (0 → 1). Called directly by the caller process.
 
-  All direct reads and `failure_count` / `success_count` counter bumps go
+  All direct reads and `failure_count` / `success_count` counter bumps also go
   straight to ETS from the caller process — no GenServer mailbox hop.
 
   ## ETS table
@@ -104,6 +105,9 @@ defmodule Tau.CircuitBreaker.Store do
   @doc """
   Performs a full-row CAS state transition via `:ets.select_replace/2`.
 
+  Executes directly in the CALLER'S process against the `:public` ETS table
+  — no GenServer mailbox hop (§3 [C57-B1]).
+
   The match spec guards on `current_state` (position 2) so the replace
   only fires if the row still holds the state the caller observed. Returns
   `1` if the transition succeeded (this caller wins), `0` if a concurrent
@@ -114,11 +118,14 @@ defmodule Tau.CircuitBreaker.Store do
   @spec transition(module(), :closed | :open | :half_open, Tau.CircuitBreaker.State.t()) ::
           0 | 1
   def transition(provider, current_state_atom, new_state) do
-    GenServer.call(__MODULE__, {:transition, provider, current_state_atom, new_state})
+    do_transition(provider, current_state_atom, new_state)
   end
 
   @doc """
   Atomic half-open probe admission via `:ets.select_replace/2` on `probe_slot`.
+
+  Executes directly in the CALLER'S process against the `:public` ETS table
+  — no GenServer mailbox hop (§3 [C57-B1]).
 
   Returns `true` if admitted (probe_slot 0 → 1), `false` if rejected
   (probe_slot was already 1). Only one concurrent caller can receive `true`
@@ -126,7 +133,7 @@ defmodule Tau.CircuitBreaker.Store do
   """
   @spec probe_admitted?(module()) :: boolean()
   def probe_admitted?(provider) do
-    GenServer.call(__MODULE__, {:probe_admitted, provider})
+    do_probe_admission(provider)
   end
 
   # ---------------------------------------------------------------------------
@@ -151,23 +158,6 @@ defmodule Tau.CircuitBreaker.Store do
     )
 
     {:ok, %{table: table}}
-  end
-
-  @impl true
-  def terminate(_reason, _state) do
-    :ets.delete(@table)
-    :ok
-  end
-
-  @impl true
-  def handle_call({:transition, provider, current_state_atom, new_state}, _from, state) do
-    match_count = do_transition(provider, current_state_atom, new_state)
-    {:reply, match_count, state}
-  end
-
-  def handle_call({:probe_admitted, provider}, _from, state) do
-    admitted = do_probe_admission(provider)
-    {:reply, admitted, state}
   end
 
   # ---------------------------------------------------------------------------

--- a/test/tau/circuit_breaker/store_property_test.exs
+++ b/test/tau/circuit_breaker/store_property_test.exs
@@ -1,0 +1,270 @@
+defmodule Tau.CircuitBreaker.StorePropertyTest do
+  @moduledoc """
+  Property tests for `Tau.CircuitBreaker.Store` (SPEC-CIRCUIT-BREAKER PR2).
+
+  Covers:
+  - D-030: Probe admission is exclusive under concurrency — exactly one of N
+    concurrent callers is admitted for a `:half_open` breaker.
+  - D-044: Row layout is positional and fixed; transitions preserve all fields.
+  - Transition CAS semantics: a stale `current_state` guard returns 0 (no-op);
+    a matching guard returns 1.
+  - `ensure_row/1` is idempotent; `state_for/1` defaults to `:closed` (C64-B1).
+  """
+
+  use ExUnit.Case, async: false
+  use ExUnitProperties
+
+  alias Tau.CircuitBreaker.State
+  alias Tau.CircuitBreaker.Store
+
+  @table Store.table()
+
+  @moduletag :property
+
+  # ---------------------------------------------------------------------------
+  # Setup: start Store if not already running; reset table between tests.
+  # ---------------------------------------------------------------------------
+
+  setup do
+    case Process.whereis(Store) do
+      nil ->
+        {:ok, _pid} = start_supervised(Store)
+
+      _pid ->
+        :ok
+    end
+
+    :ets.delete_all_objects(@table)
+    :ok
+  end
+
+  # ---------------------------------------------------------------------------
+  # D-030: Probe admission exclusivity under concurrency
+  # ---------------------------------------------------------------------------
+
+  property "D-030 — exactly one of N concurrent probe_admitted? calls succeeds" do
+    check all(
+            n <- integer(2..20),
+            provider <- atom(:alphanumeric),
+            max_runs: 50
+          ) do
+      :ets.delete_all_objects(@table)
+
+      # Seed a half_open row with probe_slot = 0
+      :ets.insert(@table, {provider, :half_open, 3, 0, 0, 0})
+
+      parent = self()
+
+      # Spawn N processes that all race probe_admitted?/1 simultaneously
+      pids =
+        for _ <- 1..n do
+          spawn(fn ->
+            # Synchronise: wait for :go signal
+            receive do
+              :go ->
+                result = Store.probe_admitted?(provider)
+                send(parent, {:result, result})
+            end
+          end)
+        end
+
+      # Fire them all at once
+      Enum.each(pids, &send(&1, :go))
+
+      results =
+        for _ <- 1..n do
+          receive do
+            {:result, r} -> r
+          after
+            5_000 -> flunk("timed out waiting for probe result")
+          end
+        end
+
+      admitted_count = Enum.count(results, & &1)
+      rejected_count = Enum.count(results, &(!&1))
+
+      assert admitted_count == 1,
+             "Expected exactly 1 admitted probe, got #{admitted_count} (n=#{n})"
+
+      assert rejected_count == n - 1,
+             "Expected #{n - 1} rejected probes, got #{rejected_count}"
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Transition CAS semantics
+  # ---------------------------------------------------------------------------
+
+  property "transition/3 with matching current_state returns 1 and updates row" do
+    check all(
+            provider <- atom(:alphanumeric),
+            max_runs: 50
+          ) do
+      :ets.delete_all_objects(@table)
+      Store.ensure_row(provider)
+
+      assert Store.state_for(provider) == :closed
+
+      new_state = %State{
+        state: :open,
+        failure_count: 5,
+        success_count: 0,
+        opened_at_ms: 1_000_000,
+        probe_slot: 0
+      }
+
+      result = Store.transition(provider, :closed, new_state)
+      assert result == 1, "Expected CAS to succeed (return 1)"
+      assert Store.state_for(provider) == :open
+    end
+  end
+
+  property "transition/3 with stale current_state returns 0 (no-op)" do
+    check all(
+            provider <- atom(:alphanumeric),
+            max_runs: 50
+          ) do
+      :ets.delete_all_objects(@table)
+      Store.ensure_row(provider)
+
+      # Row is :closed; pass :open as the "current" state — a stale guard
+      new_state = %State{
+        state: :half_open,
+        failure_count: 0,
+        success_count: 0,
+        opened_at_ms: 0,
+        probe_slot: 0
+      }
+
+      result = Store.transition(provider, :open, new_state)
+      assert result == 0, "Expected stale CAS to fail (return 0)"
+      # Row must be unchanged
+      assert Store.state_for(provider) == :closed
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # ensure_row/1 idempotency
+  # ---------------------------------------------------------------------------
+
+  property "ensure_row/1 is idempotent — repeated calls do not reset existing state" do
+    check all(
+            provider <- atom(:alphanumeric),
+            max_runs: 50
+          ) do
+      :ets.delete_all_objects(@table)
+
+      # First call: inserts default row
+      Store.ensure_row(provider)
+      assert Store.state_for(provider) == :closed
+
+      # Transition to :open
+      new_state = %State{
+        state: :open,
+        failure_count: 5,
+        success_count: 0,
+        opened_at_ms: 1_000,
+        probe_slot: 0
+      }
+
+      assert Store.transition(provider, :closed, new_state) == 1
+
+      # Second ensure_row call must not overwrite the :open row
+      Store.ensure_row(provider)
+      assert Store.state_for(provider) == :open
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # state_for/1 defaults to :closed for unknown providers (C64-B1)
+  # ---------------------------------------------------------------------------
+
+  property "state_for/1 returns :closed for providers with no row (C64-B1)" do
+    check all(
+            provider <- atom(:alphanumeric),
+            max_runs: 50
+          ) do
+      :ets.delete_all_objects(@table)
+      assert Store.state_for(provider) == :closed
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # D-044: Field positions are stable across transitions
+  # ---------------------------------------------------------------------------
+
+  property "D-044 — transition preserves all row fields at correct positions" do
+    check all(
+            provider <- atom(:alphanumeric),
+            fc <- integer(0..20),
+            sc <- integer(0..5),
+            oat <- integer(0..1_000_000),
+            max_runs: 50
+          ) do
+      :ets.delete_all_objects(@table)
+      Store.ensure_row(provider)
+
+      new_state = %State{
+        state: :open,
+        failure_count: fc,
+        success_count: sc,
+        opened_at_ms: oat,
+        probe_slot: 0
+      }
+
+      assert Store.transition(provider, :closed, new_state) == 1
+
+      # Read raw row and assert field positions match D-044
+      [{row_key, row_state, row_fc, row_sc, row_oat, row_probe_slot}] =
+        :ets.lookup(@table, provider)
+
+      assert row_key == provider
+      assert row_state == :open
+      assert row_fc == fc
+      assert row_sc == sc
+      assert row_oat == oat
+      assert row_probe_slot == 0
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # probe_slot resets correctly after transition to :half_open
+  # ---------------------------------------------------------------------------
+
+  property "probe_slot is 0 after transition to :half_open; first admission wins, second rejected" do
+    check all(
+            provider <- atom(:alphanumeric),
+            max_runs: 30
+          ) do
+      :ets.delete_all_objects(@table)
+      Store.ensure_row(provider)
+
+      # Transition to :open
+      open_state = %State{
+        state: :open,
+        failure_count: 5,
+        success_count: 0,
+        opened_at_ms: 0,
+        probe_slot: 0
+      }
+
+      assert Store.transition(provider, :closed, open_state) == 1
+
+      # Transition to :half_open (simulating cooldown elapsed)
+      half_open_state = %State{
+        state: :half_open,
+        failure_count: 5,
+        success_count: 0,
+        opened_at_ms: 0,
+        probe_slot: 0
+      }
+
+      assert Store.transition(provider, :open, half_open_state) == 1
+
+      # probe_slot should be 0; first admission wins
+      assert Store.probe_admitted?(provider) == true
+      # Second call should be rejected
+      assert Store.probe_admitted?(provider) == false
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- `lib/tau/circuit_breaker/store.ex` — ETS-owner GenServer (`@schema_version 1`). `transition/3` and `probe_admitted?/1` run `:ets.select_replace/2` directly in the caller process (no mailbox serialisation, per SPEC §1 triage / §4 B1); the GenServer owns only the `:named_table, :public` table lifecycle.
- `test/tau/circuit_breaker/store_property_test.exs` — 7 StreamData properties incl. the D-030 genuine concurrent-probe race.
- `lib/tau/application.ex` — `Tau.CircuitBreaker.Store` wired into the supervision tree.

## Spec / invariants
Advances AC-3 (D-030 probe exclusivity), AC-4 (supervised Store), D-044 (row layout). Per `SPEC-CIRCUIT-BREAKER.md`.

Refs #65

## Test plan
- [x] `mix test` — 742 tests + 63 properties, 0 failures
- [x] D-030 property spawns N concurrent processes racing the CAS; exactly one admitted
- [x] `mix format`, `mix credo --strict`, `mix compile --warnings-as-errors` clean on PR files

🤖 Generated with [Claude Code](https://claude.com/claude-code)