### PR TITLE
feat(memory): FTS5 full-text search (PR2 of #67)

### DIFF
--- a/lib/tau/memory/migrations.ex
+++ b/lib/tau/memory/migrations.ex
@@ -18,7 +18,7 @@ defmodule Tau.Memory.Migrations do
   after all existing versions; ISO-8601 prefix (e.g. `"20260518_001"`) is
   recommended.
 
-  PR2 adds the `memory_fts` FTS5 virtual table migration here.
+  PR2 adds `memory_fts` (FTS5 virtual table) and three sync triggers here.
   PR3 adds the `memory_vec` sqlite-vec virtual table migration here.
   """
 
@@ -43,6 +43,38 @@ defmodule Tau.Memory.Migrations do
        created_at       TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
        updated_at       TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
      )
+     """},
+    {"20260518_003_memory_fts",
+     """
+     CREATE VIRTUAL TABLE IF NOT EXISTS memory_fts
+       USING fts5(id UNINDEXED, kind, scope, content,
+                  content='memory_entries', content_rowid='rowid')
+     """},
+    {"20260518_004_memory_fts_triggers",
+     """
+     CREATE TRIGGER IF NOT EXISTS memory_entries_ai
+       AFTER INSERT ON memory_entries BEGIN
+         INSERT INTO memory_fts(rowid, id, kind, scope, content)
+           VALUES (new.rowid, new.id, new.kind, new.scope, new.content);
+       END
+     """},
+    {"20260518_005_memory_fts_delete_trigger",
+     """
+     CREATE TRIGGER IF NOT EXISTS memory_entries_ad
+       AFTER DELETE ON memory_entries BEGIN
+         INSERT INTO memory_fts(memory_fts, rowid, id, kind, scope, content)
+           VALUES ('delete', old.rowid, old.id, old.kind, old.scope, old.content);
+       END
+     """},
+    {"20260518_006_memory_fts_update_trigger",
+     """
+     CREATE TRIGGER IF NOT EXISTS memory_entries_au
+       AFTER UPDATE ON memory_entries BEGIN
+         INSERT INTO memory_fts(memory_fts, rowid, id, kind, scope, content)
+           VALUES ('delete', old.rowid, old.id, old.kind, old.scope, old.content);
+         INSERT INTO memory_fts(rowid, id, kind, scope, content)
+           VALUES (new.rowid, new.id, new.kind, new.scope, new.content);
+       END
      """}
   ]
 

--- a/lib/tau/memory/store.ex
+++ b/lib/tau/memory/store.ex
@@ -12,7 +12,8 @@ defmodule Tau.Memory.Store do
   - D-045: Exactly one process holds the write connection. No handle escapes
     the owning process's heap.
   - D-046: `embedding_status` ∈ `"pending" | "ready" | "failed"`. The `"failed"`
-    state carries a `"transient"` / `"terminal"` kind in metadata.
+    state carries a `"transient"` / `"terminal"` kind in metadata. Pending rows
+    are included in FTS results (search/2); excluded from semantic_search/2.
   - D-047: Migrations run to completion before the owner reports `:ok`.
   """
 
@@ -21,6 +22,8 @@ defmodule Tau.Memory.Store do
         }
 
   @type id :: String.t()
+
+  @type search_opts :: [limit: pos_integer(), scope: String.t()]
 
   @doc """
   Persist a memory entry.
@@ -38,6 +41,19 @@ defmodule Tau.Memory.Store do
   `{:error, reason}` only on a DB error.
   """
   @callback delete(id()) :: :ok | {:error, term()}
+
+  @doc """
+  Full-text search over memory entries (FTS5).
+
+  Returns `{:ok, [map()]}` ordered by FTS rank descending. Rows with any
+  `embedding_status` (`"pending"`, `"ready"`, `"failed"`) are included (D-046).
+
+  Options:
+  - `:limit` — maximum number of results (default 10).
+  - `:scope` — filter results to this scope value.
+  """
+  @callback search(query :: String.t(), opts :: search_opts()) ::
+              {:ok, [map()]} | {:error, term()}
 
   @doc "Look up the configured store implementation."
   @spec impl() :: module()

--- a/lib/tau/memory/store/sqlite.ex
+++ b/lib/tau/memory/store/sqlite.ex
@@ -4,8 +4,10 @@ defmodule Tau.Memory.Store.SQLite do
 
   A `GenServer` that owns a single `Exqlite.Sqlite3` write connection (a NIF
   reference). The connection never escapes this process's heap (D-045). All
-  writes are serialised through the mailbox (D-045, ADR-0020): SQLite has a
-  single-writer constraint that the mailbox enforces without external locking.
+  writes and searches are serialised through the mailbox (D-045, ADR-0020):
+  SQLite has a single-writer constraint that the mailbox enforces without
+  external locking. Read operations (search/2) also route through the mailbox
+  to avoid exposing the db reference.
 
   Schema migrations run to completion in `init/1` before the process reports
   `{:ok, state}`. A DB-open failure causes `init/1` to return
@@ -15,16 +17,20 @@ defmodule Tau.Memory.Store.SQLite do
   Database location: `Path.join(Tau.Settings.data_dir(), "memory.db")`.
   WAL mode is enabled immediately after `open`.
 
+  PR2 adds `search/2` (FTS5 full-text search). The FTS index is maintained by
+  three triggers added in migrations 004–006 (insert, delete, update). Pending
+  and failed rows are included in FTS results per D-046.
+
   ## Telemetry
 
-  Every `write/1` and `delete/1` call emits:
+  Every `write/1`, `delete/1`, and `search/2` call emits:
 
-    - `[:tau, :memory, :write | :delete, :start]` — before the operation.
-    - `[:tau, :memory, :write | :delete, :stop]` — after a successful operation.
-    - `[:tau, :memory, :write | :delete, :exception]` — on error or exception.
+    - `[:tau, :memory, :write | :delete | :search, :start]` — before the operation.
+    - `[:tau, :memory, :write | :delete | :search, :stop]` — after a successful operation.
+    - `[:tau, :memory, :write | :delete | :search, :exception]` — on error or exception.
 
   Measurements on `:stop`: `%{duration: non_neg_integer()}` (nanoseconds).
-  Metadata on `:stop`: `%{id: binary()}` (write only).
+  Metadata on `:stop`: `%{id: binary()}` (write only); `%{count: non_neg_integer()}` (search).
 
   Events are emitted via `:telemetry.span/3` which guarantees pairing of
   `:start` with `:stop` or `:exception` on every code path.
@@ -92,6 +98,23 @@ defmodule Tau.Memory.Store.SQLite do
     GenServer.call(server, {:delete, id})
   end
 
+  @impl Tau.Memory.Store
+  @doc """
+  Full-text search via FTS5.
+
+  Returns `{:ok, [map()]}` ordered by FTS rank descending. Rows with any
+  `embedding_status` are included per D-046. Options: `:limit` (default 10),
+  `:scope` (filter by scope value).
+  """
+  @spec search(String.t(), keyword()) :: {:ok, [map()]} | {:error, term()}
+  def search(query, opts \\ []), do: search(__MODULE__, query, opts)
+
+  @doc "Search via a named or pid server. Useful in tests."
+  @spec search(GenServer.server(), String.t(), keyword()) :: {:ok, [map()]} | {:error, term()}
+  def search(server, query, opts) do
+    GenServer.call(server, {:search, query, opts})
+  end
+
   # ---------------------------------------------------------------------------
   # GenServer callbacks
   # ---------------------------------------------------------------------------
@@ -142,6 +165,27 @@ defmodule Tau.Memory.Store.SQLite do
         fn ->
           r = do_delete(db, id)
           {r, %{id: id}}
+        end
+      )
+
+    {:reply, result, state}
+  end
+
+  def handle_call({:search, query, opts}, _from, %{db: db} = state) do
+    result =
+      :telemetry.span(
+        [:tau, :memory, :search],
+        %{},
+        fn ->
+          r = do_search(db, query, opts)
+
+          meta =
+            case r do
+              {:ok, rows} -> %{count: length(rows)}
+              _ -> %{}
+            end
+
+          {r, meta}
         end
       )
 
@@ -220,6 +264,76 @@ defmodule Tau.Memory.Store.SQLite do
   end
 
   defp do_delete(_db, id), do: {:error, {:invalid_id, id}}
+
+  defp do_search(db, query, opts) when is_binary(query) do
+    limit = Keyword.get(opts, :limit, 10)
+    scope = Keyword.get(opts, :scope)
+
+    {sql, params} = build_search_sql(query, scope, limit)
+
+    with {:ok, stmt} <- Exqlite.Sqlite3.prepare(db, sql),
+         :ok <- Exqlite.Sqlite3.bind(stmt, params),
+         {:ok, rows} <- Exqlite.Sqlite3.fetch_all(db, stmt),
+         :ok <- Exqlite.Sqlite3.release(db, stmt) do
+      {:ok, Enum.map(rows, &row_to_map/1)}
+    end
+  end
+
+  defp do_search(_db, query, _opts), do: {:error, {:invalid_query, query}}
+
+  # Build FTS5 search SQL. When scope is provided, filter on it.
+  # The FTS table is joined to memory_entries via rowid to retrieve all columns.
+  # Pending and failed rows are included (D-046).
+  defp build_search_sql(query, nil, limit) do
+    sql = """
+    SELECT e.id, e.kind, e.scope, e.content, e.metadata, e.embedding_status,
+           e.created_at, e.updated_at
+    FROM memory_fts AS f
+    JOIN memory_entries AS e ON e.rowid = f.rowid
+    WHERE memory_fts MATCH ?1
+    ORDER BY rank
+    LIMIT ?2
+    """
+
+    {String.trim(sql), [query, limit]}
+  end
+
+  defp build_search_sql(query, scope, limit) do
+    sql = """
+    SELECT e.id, e.kind, e.scope, e.content, e.metadata, e.embedding_status,
+           e.created_at, e.updated_at
+    FROM memory_fts AS f
+    JOIN memory_entries AS e ON e.rowid = f.rowid
+    WHERE memory_fts MATCH ?1
+      AND e.scope = ?2
+    ORDER BY rank
+    LIMIT ?3
+    """
+
+    {String.trim(sql), [query, scope, limit]}
+  end
+
+  defp row_to_map([
+         id,
+         kind,
+         scope,
+         content,
+         metadata_json,
+         embedding_status,
+         created_at,
+         updated_at
+       ]) do
+    %{
+      "id" => id,
+      "kind" => kind,
+      "scope" => scope,
+      "content" => content,
+      "metadata" => Jason.decode!(metadata_json),
+      "embedding_status" => embedding_status,
+      "created_at" => created_at,
+      "updated_at" => updated_at
+    }
+  end
 
   defp required_string(map, key) do
     case Map.get(map, key) do

--- a/test/tau/memory/migrations_test.exs
+++ b/test/tau/memory/migrations_test.exs
@@ -46,6 +46,39 @@ defmodule Tau.Memory.MigrationsTest do
       assert actual_versions == expected_versions
     end
 
+    test "memory_fts virtual table exists after migration (PR2)" do
+      {:ok, db} = Exqlite.Sqlite3.open(":memory:")
+      :ok = Migrations.run(db)
+
+      # FTS5 virtual tables appear in sqlite_master with type='table'.
+      {:ok, stmt} =
+        Exqlite.Sqlite3.prepare(db, "SELECT name FROM sqlite_master WHERE name = 'memory_fts'")
+
+      {:ok, rows} = Exqlite.Sqlite3.fetch_all(db, stmt)
+      :ok = Exqlite.Sqlite3.release(db, stmt)
+
+      assert [["memory_fts"]] = rows
+    end
+
+    test "sync triggers exist after migration (PR2)" do
+      {:ok, db} = Exqlite.Sqlite3.open(":memory:")
+      :ok = Migrations.run(db)
+
+      {:ok, stmt} =
+        Exqlite.Sqlite3.prepare(
+          db,
+          "SELECT name FROM sqlite_master WHERE type='trigger' ORDER BY name"
+        )
+
+      {:ok, rows} = Exqlite.Sqlite3.fetch_all(db, stmt)
+      :ok = Exqlite.Sqlite3.release(db, stmt)
+
+      trigger_names = Enum.map(rows, fn [n] -> n end)
+      assert "memory_entries_ai" in trigger_names
+      assert "memory_entries_ad" in trigger_names
+      assert "memory_entries_au" in trigger_names
+    end
+
     test "memory_entries table exists and has correct columns after migration" do
       {:ok, db} = Exqlite.Sqlite3.open(":memory:")
       :ok = Migrations.run(db)

--- a/test/tau/memory/store_sqlite_test.exs
+++ b/test/tau/memory/store_sqlite_test.exs
@@ -1,9 +1,9 @@
 defmodule Tau.Memory.Store.SQLiteTest do
   @moduledoc """
-  Tests for `Tau.Memory.Store.SQLite` — write/delete + telemetry.
+  Tests for `Tau.Memory.Store.SQLite` — write/delete + FTS5 search + telemetry.
 
-  Advances AC-1, AC-2, AC-5 from SPEC-MEMORY-STORE.md.
-  Enforces D-045, D-046, D-047.
+  PR1: AC-1, AC-2, AC-5 from SPEC-MEMORY-STORE.md. D-045, D-046, D-047.
+  PR2: search/2 (FTS5). D-046 (pending/failed rows included in FTS results).
   """
 
   use ExUnit.Case, async: false
@@ -238,6 +238,166 @@ defmodule Tau.Memory.Store.SQLiteTest do
         {:ok, id} = SQLite.write(pid, entry)
         assert :ok = SQLite.delete(pid, id)
         assert read_rows(pid, id) == []
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # AC-6 / D-046: search/2 (FTS5 full-text search — PR2)
+  # ---------------------------------------------------------------------------
+
+  describe "search/2 — FTS5 full-text search (D-046)" do
+    test "returns matching rows by content", %{pid: pid} do
+      SQLite.write(pid, %{"kind" => "note", "scope" => "global", "content" => "the quick brown fox"})
+
+      SQLite.write(pid, %{
+        "kind" => "note",
+        "scope" => "global",
+        "content" => "completely unrelated entry"
+      })
+
+      assert {:ok, results} = SQLite.search(pid, "fox", [])
+      assert length(results) == 1
+      [result] = results
+      assert result["content"] == "the quick brown fox"
+    end
+
+    test "includes pending rows (D-046)", %{pid: pid} do
+      # write creates rows with embedding_status = 'pending'
+      SQLite.write(pid, %{"kind" => "fact", "scope" => "s1", "content" => "pending content here"})
+
+      assert {:ok, results} = SQLite.search(pid, "pending", [])
+      assert length(results) == 1
+      assert hd(results)["embedding_status"] == "pending"
+    end
+
+    test "includes failed rows (D-046)", %{pid: pid} do
+      {:ok, id} =
+        SQLite.write(pid, %{"kind" => "fact", "scope" => "s1", "content" => "failed entry content"})
+
+      # Manually flip the embedding_status to 'failed' via a direct SQL update.
+      %{db: db} = :sys.get_state(pid)
+
+      {:ok, stmt} =
+        Exqlite.Sqlite3.prepare(
+          db,
+          "UPDATE memory_entries SET embedding_status='failed' WHERE id=?1"
+        )
+
+      :ok = Exqlite.Sqlite3.bind(stmt, [id])
+      :done = Exqlite.Sqlite3.step(db, stmt)
+      :ok = Exqlite.Sqlite3.release(db, stmt)
+
+      assert {:ok, results} = SQLite.search(pid, "failed entry", [])
+      assert Enum.any?(results, fn r -> r["id"] == id end)
+    end
+
+    test "filters by scope when :scope opt is provided", %{pid: pid} do
+      SQLite.write(pid, %{"kind" => "note", "scope" => "ns1", "content" => "scoped result"})
+      SQLite.write(pid, %{"kind" => "note", "scope" => "ns2", "content" => "scoped result"})
+
+      assert {:ok, results} = SQLite.search(pid, "scoped", scope: "ns1")
+      assert length(results) == 1
+      assert hd(results)["scope"] == "ns1"
+    end
+
+    test "respects :limit option", %{pid: pid} do
+      for i <- 1..5 do
+        SQLite.write(pid, %{
+          "kind" => "note",
+          "scope" => "global",
+          "content" => "limit test entry #{i}"
+        })
+      end
+
+      assert {:ok, results} = SQLite.search(pid, "limit test", limit: 3)
+      assert length(results) <= 3
+    end
+
+    test "returns {:ok, []} when no rows match", %{pid: pid} do
+      assert {:ok, []} = SQLite.search(pid, "xyzzy_no_match_ever", [])
+    end
+
+    test "returns {:error, _} for non-binary query", %{pid: pid} do
+      assert {:error, {:invalid_query, 42}} = SQLite.search(pid, 42, [])
+    end
+
+    test "result maps include all expected keys", %{pid: pid} do
+      SQLite.write(pid, %{"kind" => "note", "scope" => "global", "content" => "key check entry"})
+
+      assert {:ok, [result]} = SQLite.search(pid, "key check", [])
+
+      expected_keys = ~w[id kind scope content metadata embedding_status created_at updated_at]
+      assert Enum.all?(expected_keys, &Map.has_key?(result, &1))
+    end
+
+    test "search emits :start and :stop telemetry events", %{pid: pid} do
+      SQLite.write(pid, %{"kind" => "k", "scope" => "s", "content" => "telemetry check"})
+
+      events =
+        capture_telemetry(
+          [:tau, :memory, :search, :start],
+          [:tau, :memory, :search, :stop],
+          fn -> SQLite.search(pid, "telemetry", []) end
+        )
+
+      assert Enum.any?(events, fn {name, _, _} -> name == [:tau, :memory, :search, :start] end)
+      assert Enum.any?(events, fn {name, _, _} -> name == [:tau, :memory, :search, :stop] end)
+    end
+
+    test "search :stop event includes duration measurement", %{pid: pid} do
+      SQLite.write(pid, %{"kind" => "k", "scope" => "s", "content" => "duration check"})
+
+      events =
+        capture_telemetry([:tau, :memory, :search, :stop], fn ->
+          SQLite.search(pid, "duration", [])
+        end)
+
+      [{_name, measurements, _meta}] =
+        Enum.filter(events, fn {name, _, _} -> name == [:tau, :memory, :search, :stop] end)
+
+      assert is_integer(measurements.duration)
+      assert measurements.duration >= 0
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Properties — search/2 (D-046)
+  # ---------------------------------------------------------------------------
+
+  describe "search/2 properties (D-046)" do
+    @tag :property
+    property "all written rows with matching content are returned by search", %{pid: pid} do
+      check all(
+              kind <- string(:alphanumeric, min_length: 1),
+              scope <- string(:alphanumeric, min_length: 1),
+              # Use a unique token to avoid cross-test collisions
+              token <- string(:alphanumeric, min_length: 6)
+            ) do
+        content = "searchable_#{token}"
+        {:ok, id} = SQLite.write(pid, %{"kind" => kind, "scope" => scope, "content" => content})
+
+        {:ok, results} = SQLite.search(pid, content, [])
+        ids = Enum.map(results, & &1["id"])
+        assert id in ids
+      end
+    end
+
+    @tag :property
+    property "search results always have embedding_status in pending|ready|failed", %{pid: pid} do
+      check all(
+              kind <- string(:alphanumeric, min_length: 1),
+              scope <- string(:alphanumeric, min_length: 1),
+              token <- string(:alphanumeric, min_length: 6)
+            ) do
+        content = "status_check_#{token}"
+        SQLite.write(pid, %{"kind" => kind, "scope" => scope, "content" => content})
+
+        {:ok, results} = SQLite.search(pid, content, [])
+
+        Enum.each(results, fn r ->
+          assert r["embedding_status"] in ["pending", "ready", "failed"]
+        end)
       end
     end
   end


### PR DESCRIPTION
## Summary
- `memory_fts` FTS5 virtual table + AFTER INSERT/DELETE/UPDATE sync triggers keeping the index consistent with `memory_entries`.
- `Tau.Memory.Store.search/2` behaviour callback + `Store.SQLite` full-text-search implementation (`memory_fts MATCH`), with `:telemetry.span/3`.
- Pending/failed-embedding rows are included in search results (D-046).

## Spec
Per `SPEC-MEMORY-STORE.md §2`. Advances D-046; D-045/D-047 continue to hold.

Refs #67

## Test plan
- [x] `mix test` — 780 tests, 65 properties, 0 failures
- [x] FTS match / scope filter / limit / pending-inclusion / trigger-sync / telemetry tests + StreamData properties
- [x] `mix format`, `mix credo --strict`, `mix compile --warnings-as-errors` clean on PR files

🤖 Generated with [Claude Code](https://claude.com/claude-code)