### PR TITLE
feat(circuit-breaker): Tau.CircuitBreaker call/3 façade (PR3 of #65)

### DIFF
--- a/docs/spec/SPEC-CIRCUIT-BREAKER.md
+++ b/docs/spec/SPEC-CIRCUIT-BREAKER.md
@@ -48,7 +48,7 @@ operations.
 | # | Component | Role |
 |---|-----------|------|
 | C1 | `Tau.CircuitBreaker.State` | Pure state-machine module. `%State{}` struct + `record_failure/2`, `record_success/2`, `check/2`. No process, no ETS. |
-| C2 | `Tau.CircuitBreaker.Store` | GenServer lifecycle anchor. Owns the ETS table `:tau_circuit_breakers`. Exposes `transition/2` (atomically CAS a full row) and `probe_admitted?/1` (atomic half-open single-probe gate). |
+| C2 | `Tau.CircuitBreaker.Store` | GenServer lifecycle anchor. Owns the ETS table `:tau_circuit_breakers`. Exposes `transition/3` (atomically CAS a full row, guarded on current state) and `probe_admitted?/1` (atomic half-open single-probe gate). |
 | C3 | `Tau.CircuitBreaker` | Public façade. `call/3 :: (provider, opts, thunk) → result`. Checks state, admits or short-circuits, records outcome, drives transitions. |
 
 Boundaries between layers:
@@ -73,11 +73,14 @@ Format: `[Cn-Bm]` = constraint number + boundary. **★** marks non-obvious.
   MUST use `:ets.select_replace/2` with a guard so no two processes race a
   non-atomic multi-field write.
 - **★ [C57-B1]** The half-open probe slot is a single counter field
-  `probe_slot` (position in the ETS row). Admission is an `:ets.update_counter/3`
-  bump with a threshold guard: the call that increments `probe_slot` from 0 to 1
-  is the admitted probe; any call that finds `probe_slot >= 1` MUST be rejected
-  as `:circuit_open`. This is the only correct way to admit exactly one probe
-  under concurrent access — no lock, no GenServer serialisation.
+  `probe_slot` (position in the ETS row). Admission uses `:ets.select_replace/2`
+  with a match spec that matches the row when `probe_slot == 0` and replaces it
+  with the same row with `probe_slot = 1`. The call that receives match count `1`
+  is the admitted probe; any call that receives `0` MUST be rejected as
+  `:circuit_open`. This is the only correct way to admit exactly one probe under
+  concurrent access — `update_counter` cannot distinguish the first caller from
+  the nth (see §4 B1 probe-admission contract for the rebuttal). No lock, no
+  GenServer serialisation.
 - **[C58-B2]** The `Store` GenServer creates the table in `init/1` and is the
   only process that calls `:ets.new/2` or `:ets.delete/1` on it. Any process
   may read or update counters directly via ETS.
@@ -135,13 +138,22 @@ Format: `[Cn-Bm]` = constraint number + boundary. **★** marks non-obvious.
 - Post: returns `:closed` if no row exists for `provider`.
 - Invariant: `:half_open` is returned only if `now_ms >= opened_at_ms + cooldown_ms`.
 
-**Write contract** (`transition/2` — full-row CAS):
+**Write contract** (`transition/3` — state-column CAS):
 
-- Input: `provider :: module()`, `new_state :: %State{}`
+- Input: `provider :: module()`, `current_state :: :closed | :open | :half_open`, `new_state :: %State{}`
 - Operation: `:ets.select_replace/2` with a guard on the current row's state
   field. Returns `0` (no match — concurrent transition won) or `1` (replaced).
 - Invariant: the caller that returns `1` is the sole writer of the new row;
   callers that return `0` treat it as a no-op (their transition lost the race).
+- **Counter preservation invariant ([C56-B1]):** `transition/3` MUST NOT
+  overwrite `failure_count` (position 3) or `success_count` (position 4). These
+  columns are owned exclusively by `bump_failure_count/1` and
+  `bump_success_count/1` (`:ets.update_counter/3`). The match spec body MUST
+  bind counter fields as `:"$N"` variables and write them back unchanged. A
+  `select_replace` that overwrites counter columns loses concurrent increments
+  that land between the `Store.get` read and the `select_replace` write — the
+  exact lost-update class `update_counter` was introduced to prevent. Only
+  `state`, `opened_at_ms`, and `probe_slot` are mutated by a transition write.
 
 **Probe-admission contract** (`probe_admitted?/1`):
 

--- a/lib/tau/circuit_breaker.ex
+++ b/lib/tau/circuit_breaker.ex
@@ -1,0 +1,201 @@
+defmodule Tau.CircuitBreaker do
+  @moduledoc """
+  Public façade for the per-provider circuit breaker (SPEC-CIRCUIT-BREAKER §4 B3, C3).
+
+  Wraps a provider-call thunk with the circuit-breaker lifecycle:
+
+  1. Ensures a row exists for `provider` (idempotent).
+  2. Reads the current state from ETS via `Store`.
+  3. Short-circuits with `{:error, :circuit_open}` when the breaker is `:open`.
+  4. When `:half_open`, admits exactly one probe via `Store.probe_admitted?/1`
+     (exclusive CAS — D-030); rejects concurrent callers as `:circuit_open`.
+  5. Invokes the thunk; records the outcome; drives state transitions via
+     `Store.transition/3` (select_replace CAS — D-044).
+
+  The façade is a **stateless module** — no process, no GenServer. All
+  concurrency safety is handled by ETS atomics in `Tau.CircuitBreaker.Store`.
+
+  ## Telemetry
+
+  - `[:tau, :circuit_breaker, :check]` — emitted before every thunk call,
+    with `%{system_time: integer()}` in measurements and
+    `%{provider: provider, state: state_atom}` in metadata.
+  - `[:tau, :circuit_breaker, :open]` — emitted when a call is short-circuited
+    because the breaker is `:open` or the probe slot is taken (C62-B3).
+  - `[:tau, :circuit_breaker, :transition]` — emitted when a state transition
+    occurs, with `%{from: old_state, to: new_state}` in metadata.
+
+  ## D-043
+
+  A chain of providers where all breakers are `:open` terminates in exactly N
+  `call/3` invocations — each returns `{:error, :circuit_open}` without
+  invoking the thunk. The fallback sequence MUST NOT retry on `:circuit_open`.
+  """
+
+  alias Tau.CircuitBreaker.State
+  alias Tau.CircuitBreaker.Store
+
+  @default_failure_threshold 5
+  @default_success_threshold 1
+
+  @doc """
+  Wraps a provider call with circuit-breaker logic.
+
+  ## Arguments
+
+  - `provider` — the provider module atom (ETS key).
+  - `opts` — keyword list:
+    - `:failure_threshold` (default `5`) — consecutive failures before opening.
+    - `:success_threshold` (default `1`) — successes in `:half_open` to close.
+  - `thunk` — a zero-arity function that performs the actual provider call.
+
+  ## Thunk contract
+
+  The thunk MUST return `{:ok, result}` or `{:error, reason}`. The thunk MUST
+  NOT raise — an exception propagates to the caller and is NOT recorded as a
+  breaker failure. Only the `:ok` / `:error` tag drives the breaker transition
+  (C65-B3); the full return value is forwarded unchanged.
+
+  ## Returns
+
+  - `{:error, :circuit_open}` — breaker is `:open`, or probe slot taken.
+  - The thunk's own return value otherwise (success or error).
+
+  The full error term from a failing thunk is preserved and returned to the
+  caller; only the `:ok` / `:error` tag drives the breaker transition (C65-B3).
+  """
+  @spec call(module(), keyword(), (-> {:ok, term()} | {:error, term()})) ::
+          {:ok, term()} | {:error, term()}
+  def call(provider, opts \\ [], thunk) do
+    Store.ensure_row(provider)
+    now_ms = System.monotonic_time(:millisecond)
+    state_atom = Store.state_for(provider)
+
+    :telemetry.execute(
+      [:tau, :circuit_breaker, :check],
+      %{system_time: System.system_time()},
+      %{provider: provider, state: state_atom}
+    )
+
+    dispatch(provider, state_atom, now_ms, opts, thunk)
+  end
+
+  # ---------------------------------------------------------------------------
+  # Private helpers
+  # ---------------------------------------------------------------------------
+
+  # Dispatch based on the observed state at call time.
+  defp dispatch(provider, :closed, now_ms, opts, thunk) do
+    result = thunk.()
+    record_outcome(provider, :closed, result, now_ms, opts)
+    result
+  end
+
+  defp dispatch(provider, :open, _now_ms, _opts, _thunk) do
+    emit_open(provider, :open)
+    {:error, :circuit_open}
+  end
+
+  defp dispatch(provider, :half_open, now_ms, opts, thunk) do
+    if Store.probe_admitted?(provider) do
+      result = thunk.()
+      record_outcome(provider, :half_open, result, now_ms, opts)
+      result
+    else
+      emit_open(provider, :half_open)
+      {:error, :circuit_open}
+    end
+  end
+
+  # Record the thunk outcome and drive transitions.
+  #
+  # Counter increments (failure_count / success_count) go through the atomic
+  # Store.bump_* primitives ([C56-B1] / [C60-B1]). The returned post-increment
+  # count is then fed into the pure State functions to decide whether a
+  # state-machine transition is required. The transition itself is a CAS
+  # select_replace guarded on the current state atom — correct and unchanged.
+  #
+  # The bump returns the NEW count (post-increment). To keep State's pure
+  # functions unmodified (they each do `count + 1` internally), we pass
+  # `new_count - 1` as the pre-bump value so the pure function computes the
+  # same `new_count`. This is safe: `new_count - 1` is the value THIS process
+  # incremented from — no other process produced this specific (new_count - 1)
+  # value for the same bump operation.
+  defp record_outcome(provider, current_state, {:ok, _}, now_ms, opts) do
+    new_count = Store.bump_success_count(provider)
+    row = current_struct(provider)
+    struct_pre_bump = %State{row | success_count: new_count - 1}
+    new_state = State.record_success(struct_pre_bump, Keyword.put(opts, :now_ms, now_ms))
+    maybe_transition(provider, current_state, new_state)
+  end
+
+  defp record_outcome(provider, current_state, {:error, _}, now_ms, opts) do
+    new_count = Store.bump_failure_count(provider)
+    row = current_struct(provider)
+    struct_pre_bump = %State{row | failure_count: new_count - 1}
+
+    new_state =
+      State.record_failure(
+        struct_pre_bump,
+        opts |> Keyword.put(:now_ms, now_ms)
+      )
+
+    maybe_transition(provider, current_state, new_state)
+  end
+
+  # Build a %State{} from the current ETS row so State pure functions can compute
+  # the next value. Defaults to a fresh :closed struct if no row exists.
+  defp current_struct(provider) do
+    case Store.get(provider) do
+      nil ->
+        %State{}
+
+      {_key, state_atom, failure_count, success_count, opened_at_ms, probe_slot} ->
+        %State{
+          state: state_atom,
+          failure_count: failure_count,
+          success_count: success_count,
+          opened_at_ms: opened_at_ms,
+          probe_slot: probe_slot
+        }
+    end
+  end
+
+  # Attempt the CAS state-machine transition. Only called when `new_state.state`
+  # differs from `current_state` — i.e. a real state-machine change is required.
+  # When there is no state change (counter bumped but state unchanged), this
+  # function is NOT called: the atomic bump via Store.bump_*/1 is sufficient
+  # and a full-row select_replace would clobber concurrent counter updates.
+  #
+  # When a state change IS required, the full-row CAS is necessary. If the CAS
+  # loses the race (returns 0), a concurrent caller already transitioned — no-op.
+  defp maybe_transition(provider, current_state, new_state) do
+    if new_state.state != current_state do
+      count = Store.transition(provider, current_state, new_state)
+
+      if count == 1 do
+        :telemetry.execute(
+          [:tau, :circuit_breaker, :transition],
+          %{system_time: System.system_time()},
+          %{provider: provider, from: current_state, to: new_state.state}
+        )
+      end
+    end
+
+    :ok
+  end
+
+  defp emit_open(provider, observed_state) do
+    :telemetry.execute(
+      [:tau, :circuit_breaker, :open],
+      %{system_time: System.system_time()},
+      %{provider: provider, observed_state: observed_state}
+    )
+  end
+
+  # Expose defaults for test helpers.
+  @doc false
+  def default_failure_threshold, do: @default_failure_threshold
+  @doc false
+  def default_success_threshold, do: @default_success_threshold
+end

--- a/lib/tau/circuit_breaker/store.ex
+++ b/lib/tau/circuit_breaker/store.ex
@@ -103,7 +103,39 @@ defmodule Tau.CircuitBreaker.Store do
   end
 
   @doc """
-  Performs a full-row CAS state transition via `:ets.select_replace/2`.
+  Atomically increments `failure_count` (position 3) for `provider` and returns
+  the new value.
+
+  Uses `:ets.update_counter/3` — the SPEC-pinned primitive for counter fields
+  ([C56-B1] / [C60-B1]). Executes directly in the CALLER'S process; no GenServer
+  mailbox hop.
+
+  Assumes a row already exists (call `ensure_row/1` first).
+  """
+  @spec bump_failure_count(module()) :: non_neg_integer()
+  def bump_failure_count(provider) do
+    # Position 3 is failure_count; increment by 1.
+    :ets.update_counter(@table, provider, {3, 1})
+  end
+
+  @doc """
+  Atomically increments `success_count` (position 4) for `provider` and returns
+  the new value.
+
+  Uses `:ets.update_counter/3` — the SPEC-pinned primitive for counter fields
+  ([C56-B1] / [C60-B1]). Executes directly in the CALLER'S process; no GenServer
+  mailbox hop.
+
+  Assumes a row already exists (call `ensure_row/1` first).
+  """
+  @spec bump_success_count(module()) :: non_neg_integer()
+  def bump_success_count(provider) do
+    # Position 4 is success_count; increment by 1.
+    :ets.update_counter(@table, provider, {4, 1})
+  end
+
+  @doc """
+  Performs a state-column CAS transition via `:ets.select_replace/2`.
 
   Executes directly in the CALLER'S process against the `:public` ETS table
   — no GenServer mailbox hop (§3 [C57-B1]).
@@ -113,7 +145,16 @@ defmodule Tau.CircuitBreaker.Store do
   `1` if the transition succeeded (this caller wins), `0` if a concurrent
   process already transitioned (treat as no-op).
 
-  The new row is built from `new_state :: Tau.CircuitBreaker.State.t()`.
+  **Counter columns (`failure_count`, `success_count`) are NOT overwritten.**
+  They are owned exclusively by the atomic `bump_failure_count/1` and
+  `bump_success_count/1` primitives (`update_counter`). The match spec body
+  binds these columns as `:"$N"` variables and writes them back unchanged,
+  so a concurrent `bump_*` that races with this transition is never clobbered
+  ([C56-B1] / SPEC-CIRCUIT-BREAKER §4 B1/B2).
+
+  Only the columns that actually change at a state transition are mutated:
+  `state`, `opened_at_ms`, and `probe_slot`. The `new_state` argument
+  supplies those values; its counter fields are ignored.
   """
   @spec transition(module(), :closed | :open | :half_open, Tau.CircuitBreaker.State.t()) ::
           0 | 1
@@ -164,7 +205,7 @@ defmodule Tau.CircuitBreaker.Store do
   # Private helpers
   # ---------------------------------------------------------------------------
 
-  # Builds a select_replace match spec for a full-row CAS state transition.
+  # Builds a select_replace match spec for a state-column CAS transition.
   #
   # ETS match spec body language (from :ets.fun2ms output):
   #   - The body list contains ONE element for select_replace.
@@ -178,21 +219,27 @@ defmodule Tau.CircuitBreaker.Store do
   # The guard `{:==, :"$1", {:const, provider}}` pins the match to the exact
   # provider key, so `:_` and other special atoms generated in tests match only
   # their literal row.
+  #
+  # Counter columns ($3 = failure_count, $4 = success_count) are captured as
+  # bound variables and written back unchanged. This is the critical invariant
+  # ([C56-B1]): only `update_counter` bumps may mutate counter fields. A
+  # `select_replace` that overwrites them would lose concurrent increments.
   defp do_transition(provider, current_state_atom, new_state) do
     # Head: capture key as $1; match current_state_atom literally in pos 2;
-    # capture remaining fields for passthrough (not needed in body, but :_ is fine).
-    match_head = {:"$1", current_state_atom, :_, :_, :_, :_}
+    # capture failure_count as $3 and success_count as $4 so they are preserved;
+    # remaining fields ($5, $6) are not needed.
+    match_head = {:"$1", current_state_atom, :"$3", :"$4", :_, :_}
 
     # Guard: pin to the exact provider key.
     guards = [{:==, :"$1", {:const, provider}}]
 
-    # Body: replacement tuple wrapped in outer tuple (ETS match spec convention).
+    # Body: write back $3/$4 (counters) unchanged; update only state columns.
     body = [
       {{
          :"$1",
          new_state.state,
-         new_state.failure_count,
-         new_state.success_count,
+         :"$3",
+         :"$4",
          new_state.opened_at_ms,
          new_state.probe_slot
        }}

--- a/test/tau/circuit_breaker/circuit_breaker_test.exs
+++ b/test/tau/circuit_breaker/circuit_breaker_test.exs
@@ -1,0 +1,439 @@
+defmodule Tau.CircuitBreakerTest do
+  @moduledoc """
+  Tests for `Tau.CircuitBreaker` façade (SPEC-CIRCUIT-BREAKER PR3).
+
+  Covers:
+  - AC-5: After `failure_threshold` failures, subsequent calls return
+    `{:error, :circuit_open}` without invoking the thunk.
+  - AC-6: After `cooldown_ms`, `call/3` admits exactly one probe; if the probe
+    fails, subsequent calls are again `:circuit_open`.
+  - AC-3b / D-043: All-breakers-open chain terminates in exactly N invocations.
+  - Telemetry: `:check`, `:open`, and `:transition` events are emitted.
+  """
+
+  use ExUnit.Case, async: false
+  use ExUnitProperties
+
+  alias Tau.CircuitBreaker
+  alias Tau.CircuitBreaker.State
+  alias Tau.CircuitBreaker.Store
+
+  @table Store.table()
+
+  # ---------------------------------------------------------------------------
+  # Setup
+  # ---------------------------------------------------------------------------
+
+  setup do
+    case Process.whereis(Store) do
+      nil -> {:ok, _pid} = start_supervised(Store)
+      _pid -> :ok
+    end
+
+    :ets.delete_all_objects(@table)
+    :ok
+  end
+
+  # ---------------------------------------------------------------------------
+  # Helpers
+  # ---------------------------------------------------------------------------
+
+  defp failing_thunk, do: fn -> {:error, :provider_down} end
+  defp ok_thunk, do: fn -> {:ok, :response} end
+
+  defp thunk_counter do
+    counter = :counters.new(1, [])
+
+    thunk = fn ->
+      :counters.add(counter, 1, 1)
+      {:error, :provider_down}
+    end
+
+    {counter, thunk}
+  end
+
+  defp count_calls(counter), do: :counters.get(counter, 1)
+
+  # Force `failure_threshold` failures to open the breaker.
+  defp open_breaker(provider, threshold) do
+    for _ <- 1..threshold do
+      CircuitBreaker.call(provider, [failure_threshold: threshold], failing_thunk())
+    end
+  end
+
+  # Force the ETS row into :half_open state by directly writing it, using the
+  # opened_at_ms = 0 so that State.check sees cooldown elapsed. Then call
+  # Store.transition to simulate the check+transition the façade would do.
+  defp seed_half_open(provider) do
+    # Insert an :open row with opened_at_ms = 0 (well in the past).
+    :ets.insert(@table, {provider, :open, 5, 0, 0, 0})
+
+    # Transition to :half_open explicitly (simulating cooldown elapsed).
+    half_open = %State{
+      state: :half_open,
+      failure_count: 5,
+      success_count: 0,
+      opened_at_ms: 0,
+      probe_slot: 0
+    }
+
+    1 = Store.transition(provider, :open, half_open)
+  end
+
+  # ---------------------------------------------------------------------------
+  # AC-5: Thunk not called when breaker is :open
+  # ---------------------------------------------------------------------------
+
+  test "AC-5 — after failure_threshold failures, subsequent calls return {:error, :circuit_open} without calling thunk" do
+    provider = :ac5_provider
+
+    {counter, counting_thunk} = thunk_counter()
+
+    threshold = 3
+
+    for _ <- 1..threshold do
+      result = CircuitBreaker.call(provider, [failure_threshold: threshold], counting_thunk)
+      assert result == {:error, :provider_down}
+    end
+
+    assert count_calls(counter) == threshold,
+           "thunk should have been called exactly threshold times"
+
+    # Now the breaker should be :open
+    assert Store.state_for(provider) == :open
+
+    # Subsequent calls must not invoke the thunk
+    result1 = CircuitBreaker.call(provider, [failure_threshold: threshold], counting_thunk)
+    result2 = CircuitBreaker.call(provider, [failure_threshold: threshold], counting_thunk)
+
+    assert result1 == {:error, :circuit_open}
+    assert result2 == {:error, :circuit_open}
+    assert count_calls(counter) == threshold, "thunk must not be called when breaker is :open"
+  end
+
+  # ---------------------------------------------------------------------------
+  # AC-6: Half-open probe admission and re-open on probe failure
+  # ---------------------------------------------------------------------------
+
+  test "AC-6 — after cooldown, exactly one probe is admitted; probe failure re-opens the breaker" do
+    provider = :ac6_provider
+    {counter, counting_thunk} = thunk_counter()
+
+    # Seed directly into :half_open with probe_slot = 0
+    Store.ensure_row(provider)
+    seed_half_open(provider)
+
+    # First call: probe admitted, thunk runs, fails → re-opens
+    result = CircuitBreaker.call(provider, [], counting_thunk)
+    assert result == {:error, :provider_down}
+    assert count_calls(counter) == 1
+
+    # Breaker should be :open again
+    assert Store.state_for(provider) == :open
+
+    # Further calls: circuit is open, thunk not called
+    result2 = CircuitBreaker.call(provider, [], counting_thunk)
+    assert result2 == {:error, :circuit_open}
+    assert count_calls(counter) == 1, "thunk must not be called after re-open"
+  end
+
+  test "AC-6 — probe success closes the breaker" do
+    provider = :ac6_success_provider
+    Store.ensure_row(provider)
+    seed_half_open(provider)
+
+    result = CircuitBreaker.call(provider, [], ok_thunk())
+    assert result == {:ok, :response}
+
+    assert Store.state_for(provider) == :closed
+  end
+
+  # ---------------------------------------------------------------------------
+  # AC-6 — second concurrent probe is rejected (D-030 enforcement at façade level)
+  # ---------------------------------------------------------------------------
+
+  test "AC-6 — second probe_admitted? call is rejected → {:error, :circuit_open}" do
+    provider = :ac6_concurrent_provider
+    Store.ensure_row(provider)
+    seed_half_open(provider)
+
+    # Manually claim the probe slot
+    assert Store.probe_admitted?(provider) == true
+    # Now the slot is taken; a second call through the façade must be rejected
+    # We simulate by directly calling probe_admitted? again
+    assert Store.probe_admitted?(provider) == false
+
+    # And a call through the façade with probe_slot already taken returns :circuit_open
+    # Seed a fresh half_open row for the façade call
+    provider2 = :ac6_concurrent_provider2
+    Store.ensure_row(provider2)
+    seed_half_open(provider2)
+
+    # Claim the slot before the façade call
+    assert Store.probe_admitted?(provider2) == true
+
+    # Now façade sees :half_open but probe_admitted? returns false
+    result = CircuitBreaker.call(provider2, [], ok_thunk())
+    assert result == {:error, :circuit_open}
+  end
+
+  # ---------------------------------------------------------------------------
+  # D-043: All-open chain terminates in exactly N invocations
+  # ---------------------------------------------------------------------------
+
+  @tag :property
+  property "D-043 — all-open chain terminates in exactly N call/3 invocations" do
+    check all(
+            providers <- list_of(atom(:alphanumeric), min_length: 1, max_length: 10),
+            max_runs: 50
+          ) do
+      :ets.delete_all_objects(@table)
+
+      # Deduplicate providers (list_of may produce duplicates)
+      providers = Enum.uniq(providers)
+      n = length(providers)
+
+      # Seed all providers as :open
+      for p <- providers do
+        :ets.insert(@table, {p, :open, 5, 0, System.monotonic_time(:millisecond), 0})
+      end
+
+      counter = :counters.new(1, [])
+
+      tracking_thunk = fn ->
+        :counters.add(counter, 1, 1)
+        {:error, :provider_down}
+      end
+
+      results =
+        Enum.map(providers, fn p ->
+          CircuitBreaker.call(p, [], tracking_thunk)
+        end)
+
+      # Every result must be :circuit_open
+      assert Enum.all?(results, &(&1 == {:error, :circuit_open})),
+             "All results must be {:error, :circuit_open}"
+
+      # The thunk must never have been called
+      assert :counters.get(counter, 1) == 0,
+             "Thunk must not be invoked when all breakers are :open (D-043)"
+
+      # Invocation count equals list length — no retries or loops
+      assert length(results) == n
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Telemetry: :check event is emitted
+  # ---------------------------------------------------------------------------
+
+  test "telemetry :check event is emitted on each call" do
+    provider = :telemetry_check_provider
+    test_pid = self()
+    handler_id = {__MODULE__, :check, make_ref()}
+
+    :telemetry.attach(
+      handler_id,
+      [:tau, :circuit_breaker, :check],
+      fn [:tau, :circuit_breaker, :check], _meas, meta, _cfg ->
+        send(test_pid, {:telemetry, :check, meta})
+      end,
+      nil
+    )
+
+    CircuitBreaker.call(provider, [], ok_thunk())
+
+    :telemetry.detach(handler_id)
+
+    assert_receive {:telemetry, :check, %{provider: ^provider}}, 500
+  end
+
+  # ---------------------------------------------------------------------------
+  # Telemetry: :open event is emitted on short-circuit
+  # ---------------------------------------------------------------------------
+
+  test "telemetry :open event is emitted when call is short-circuited" do
+    provider = :telemetry_open_provider
+    open_breaker(provider, 5)
+
+    test_pid = self()
+    handler_id = {__MODULE__, :open, make_ref()}
+
+    :telemetry.attach(
+      handler_id,
+      [:tau, :circuit_breaker, :open],
+      fn [:tau, :circuit_breaker, :open], _meas, meta, _cfg ->
+        send(test_pid, {:telemetry, :open, meta})
+      end,
+      nil
+    )
+
+    CircuitBreaker.call(provider, [], ok_thunk())
+
+    :telemetry.detach(handler_id)
+
+    assert_receive {:telemetry, :open, %{provider: ^provider}}, 500
+  end
+
+  # ---------------------------------------------------------------------------
+  # Telemetry: :transition event is emitted on state change
+  # ---------------------------------------------------------------------------
+
+  test "telemetry :transition event is emitted when breaker opens" do
+    provider = :telemetry_transition_provider
+    test_pid = self()
+    handler_id = {__MODULE__, :transition, make_ref()}
+
+    :telemetry.attach(
+      handler_id,
+      [:tau, :circuit_breaker, :transition],
+      fn [:tau, :circuit_breaker, :transition], _meas, meta, _cfg ->
+        send(test_pid, {:telemetry, :transition, meta})
+      end,
+      nil
+    )
+
+    open_breaker(provider, 5)
+
+    :telemetry.detach(handler_id)
+
+    assert_receive {:telemetry, :transition, %{from: :closed, to: :open, provider: ^provider}}, 500
+  end
+
+  # ---------------------------------------------------------------------------
+  # C56-B1 / C60-B1: atomic counter increments — no lost updates under concurrency
+  # ---------------------------------------------------------------------------
+
+  @tag :property
+  property "C56-B1 — concurrent failures on :closed breaker produce exact failure_count" do
+    check all(n <- integer(2..20), max_runs: 20) do
+      provider = :"concurrent_failure_#{n}_#{System.unique_integer([:positive])}"
+      :ets.delete_all_objects(@table)
+      Store.ensure_row(provider)
+
+      # Use a threshold high enough that the breaker stays :closed throughout
+      # (we want to count increments, not transitions).
+      threshold = n + 1
+      opts = [failure_threshold: threshold]
+
+      # Real barrier: spawn N processes; each blocks on :go before executing.
+      # Once all N are ready (each sends :ready), coordinator broadcasts :go
+      # so all N race to CircuitBreaker.call/3 simultaneously.
+      parent = self()
+
+      pids =
+        for _ <- 1..n do
+          spawn(fn ->
+            send(parent, {:ready, self()})
+
+            receive do
+              :go -> :ok
+            end
+
+            CircuitBreaker.call(provider, opts, fn -> {:error, :concurrent_failure} end)
+            send(parent, :done)
+          end)
+        end
+
+      # Wait until all N processes are ready at the barrier.
+      for _ <- 1..n, do: assert_receive({:ready, _pid}, 5_000)
+
+      # Release all N simultaneously.
+      for pid <- pids, do: send(pid, :go)
+
+      # Wait for all to complete.
+      for _ <- pids, do: assert_receive(:done, 5_000)
+
+      # Each of the N calls must have bumped failure_count exactly once.
+      # The row stays :closed (threshold = n+1) so no transition clobbers counters.
+      [{_key, _state, final_count, _sc, _oat, _ps}] = :ets.lookup(@table, provider)
+
+      assert final_count == n,
+             "Expected failure_count == #{n}, got #{final_count} — lost update detected"
+    end
+  end
+
+  @tag :property
+  property "F1 fix — concurrent failures crossing :open threshold preserve exact failure_count" do
+    check all(n <- integer(2..10), max_runs: 20) do
+      provider = :"concurrent_open_#{n}_#{System.unique_integer([:positive])}"
+      :ets.delete_all_objects(@table)
+      Store.ensure_row(provider)
+
+      # Set threshold == n so the nth failure triggers the :closed → :open transition.
+      # If select_replace overwrites counter columns, the transition write races
+      # with concurrent update_counter bumps and loses increments.
+      threshold = n
+      opts = [failure_threshold: threshold]
+
+      parent = self()
+
+      pids =
+        for _ <- 1..n do
+          spawn(fn ->
+            send(parent, {:ready, self()})
+
+            receive do
+              :go -> :ok
+            end
+
+            CircuitBreaker.call(provider, opts, fn -> {:error, :concurrent_failure} end)
+            send(parent, :done)
+          end)
+        end
+
+      for _ <- 1..n, do: assert_receive({:ready, _pid}, 5_000)
+      for pid <- pids, do: send(pid, :go)
+      for _ <- pids, do: assert_receive(:done, 5_000)
+
+      [{_key, final_state, final_count, _sc, _oat, _ps}] = :ets.lookup(@table, provider)
+
+      # Breaker must have opened (threshold reached).
+      assert final_state == :open,
+             "Expected breaker to be :open, got #{final_state}"
+
+      # failure_count must be >= threshold — no bump was lost at the transition.
+      assert final_count >= threshold,
+             "Expected failure_count >= #{threshold}, got #{final_count} — lost update at transition"
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # :closed + success resets failure_count
+  # ---------------------------------------------------------------------------
+
+  test "success in :closed state resets failure_count" do
+    provider = :closed_success_provider
+    Store.ensure_row(provider)
+
+    # Accumulate some failures (below threshold)
+    CircuitBreaker.call(provider, [failure_threshold: 5], failing_thunk())
+    CircuitBreaker.call(provider, [failure_threshold: 5], failing_thunk())
+
+    assert Store.state_for(provider) == :closed
+
+    # A success should reset failure_count
+    CircuitBreaker.call(provider, [], ok_thunk())
+
+    # Breaker remains closed
+    assert Store.state_for(provider) == :closed
+
+    # Now needs threshold failures to open again
+    for _ <- 1..5 do
+      CircuitBreaker.call(provider, [failure_threshold: 5], failing_thunk())
+    end
+
+    assert Store.state_for(provider) == :open
+  end
+
+  # ---------------------------------------------------------------------------
+  # Full error term is preserved (C65-B3)
+  # ---------------------------------------------------------------------------
+
+  test "C65-B3 — full error term from thunk is returned unchanged" do
+    provider = :c65_provider
+    rich_error = {:error, %{code: 503, body: "service unavailable"}}
+    result = CircuitBreaker.call(provider, [], fn -> rich_error end)
+    assert result == rich_error
+  end
+end

--- a/test/tau/circuit_breaker/store_property_test.exs
+++ b/test/tau/circuit_breaker/store_property_test.exs
@@ -193,35 +193,41 @@ defmodule Tau.CircuitBreaker.StorePropertyTest do
   # D-044: Field positions are stable across transitions
   # ---------------------------------------------------------------------------
 
-  property "D-044 — transition preserves all row fields at correct positions" do
+  property "D-044 — transition writes state columns; counter columns preserved from ETS" do
     check all(
             provider <- atom(:alphanumeric),
-            fc <- integer(0..20),
-            sc <- integer(0..5),
+            pre_fc <- integer(0..20),
+            pre_sc <- integer(0..5),
             oat <- integer(0..1_000_000),
             max_runs: 50
           ) do
       :ets.delete_all_objects(@table)
       Store.ensure_row(provider)
 
+      # Seed counters via atomic bumps so ETS holds known values.
+      for _ <- 1..pre_fc//1, do: Store.bump_failure_count(provider)
+      for _ <- 1..pre_sc//1, do: Store.bump_success_count(provider)
+
       new_state = %State{
         state: :open,
-        failure_count: fc,
-        success_count: sc,
+        # counter fields in new_state are intentionally different — must be ignored
+        failure_count: 999,
+        success_count: 999,
         opened_at_ms: oat,
         probe_slot: 0
       }
 
       assert Store.transition(provider, :closed, new_state) == 1
 
-      # Read raw row and assert field positions match D-044
+      # Read raw row and assert field positions match D-044.
       [{row_key, row_state, row_fc, row_sc, row_oat, row_probe_slot}] =
         :ets.lookup(@table, provider)
 
       assert row_key == provider
       assert row_state == :open
-      assert row_fc == fc
-      assert row_sc == sc
+      # Counter columns are PRESERVED from ETS, not taken from new_state.
+      assert row_fc == pre_fc, "failure_count must be preserved from ETS, not overwritten"
+      assert row_sc == pre_sc, "success_count must be preserved from ETS, not overwritten"
       assert row_oat == oat
       assert row_probe_slot == 0
     end


### PR DESCRIPTION
## Summary
- `lib/tau/circuit_breaker.ex` — the stateless `Tau.CircuitBreaker` façade (`call/3`): checks ETS state, short-circuits on `:open`, admits a single half-open probe, records the outcome.
- Counter columns (`failure_count`/`success_count`) are owned solely by atomic `:ets.update_counter/3` bumps; the state-transition `select_replace` preserves them and mutates only `state`/`opened_at_ms`/`probe_slot`.
- Telemetry `[:tau, :circuit_breaker, :check|:open|:transition]`.
- SPEC reconciliations: §3 `[C57-B1]` `update_counter`→`select_replace`, §4 `transition/2`→`transition/3`.

## Spec
Advances AC-5, AC-6, AC-3b; D-030/D-043/D-044. Per `SPEC-CIRCUIT-BREAKER.md`. PR4 (session integration / AC-7) remains.

Refs #65

## Test plan
- [x] `mix test` — 22 properties + 9 examples; concurrency property with a real start-barrier asserts no lost counter increments; threshold-crossing property under contention
- [x] `mix format`, `mix credo --strict`, `mix compile --warnings-as-errors` clean on PR files

🤖 Generated with [Claude Code](https://claude.com/claude-code)