### PR TITLE
feat(providers): Groq provider (PR3 of #181)

### DIFF
--- a/docs/providers/groq.md
+++ b/docs/providers/groq.md
@@ -1,0 +1,54 @@
+# Groq Provider
+
+`Tau.Providers.Groq` — OpenAI-compatible Chat Completions endpoint at
+`https://api.groq.com/openai/v1`. Default model: `llama-3.3-70b-versatile`.
+
+## Authentication
+
+Set `GROQ_API_KEY` to your Groq API key. Three resolution paths,
+evaluated in priority order:
+
+1. Application env: `config :tau, Tau.Providers.Groq, api_key: "gsk_..."`
+2. Vault: `Tau.Settings.Vault.resolve({:vault, "GROQ_API_KEY"})`
+3. Environment variable: `GROQ_API_KEY`
+
+Missing key → `stream/3` returns `{:error, :missing_api_key}` synchronously.
+
+## Base URL Override
+
+To route requests through a proxy or a local Groq-compatible endpoint:
+
+1. Application env: `config :tau, Tau.Providers.Groq, base_url: "https://..."`
+2. Environment variable: `GROQ_BASE_URL`
+3. Default: `https://api.groq.com/openai/v1`
+
+## Usage
+
+```
+tau tui -p groq
+```
+
+Or set as the default provider:
+
+```
+config :tau, :default_provider, Tau.Providers.Groq
+```
+
+## Capabilities
+
+| Capability      | Supported |
+|-----------------|-----------|
+| Thinking        | false     |
+| Tools           | true      |
+| Vision          | false     |
+| Prompt caching  | false     |
+| Parallel tools  | true      |
+
+## Diagnostics
+
+```
+tau doctor
+```
+
+Reports `provider Tau.Providers.Groq: groq configured` if a key
+is present, `not configured` otherwise.

--- a/lib/tau/cli.ex
+++ b/lib/tau/cli.ex
@@ -336,6 +336,13 @@ defmodule Tau.CLI do
     deepseek_status = if deepseek_key, do: "configured", else: "not configured"
     IO.puts("provider Tau.Providers.DeepSeek: deepseek #{deepseek_status}")
 
+    groq_key =
+      Application.get_env(:tau, Tau.Providers.Groq, [])[:api_key] ||
+        System.get_env("GROQ_API_KEY")
+
+    groq_status = if groq_key, do: "configured", else: "not configured"
+    IO.puts("provider Tau.Providers.Groq: groq #{groq_status}")
+
     0
   end
 
@@ -408,6 +415,7 @@ defmodule Tau.CLI do
   defp resolve_provider("bedrock"), do: Tau.Providers.Bedrock
   defp resolve_provider("gemini"), do: Tau.Providers.Gemini
   defp resolve_provider("deepseek"), do: Tau.Providers.DeepSeek
+  defp resolve_provider("groq"), do: Tau.Providers.Groq
   defp resolve_provider("replay"), do: Tau.Providers.Replay
 
   # Last-resort fallback for "Foo" → Tau.Providers.Foo style atoms.

--- a/lib/tau/providers/groq.ex
+++ b/lib/tau/providers/groq.ex
@@ -1,0 +1,102 @@
+defmodule Tau.Providers.Groq do
+  @moduledoc """
+  Groq Chat Completions API (`https://api.groq.com/openai/v1/chat/completions`).
+
+  Uses the same OpenAI-compatible wire format as `Tau.Providers.OpenAI.Chat`.
+  Wire-level helpers live in `Tau.Providers.Shared.OpenAIChatWire`.
+
+  ## Configuration
+
+  Priority order for API key resolution:
+
+  1. `config :tau, Tau.Providers.Groq, api_key: "gsk_..."` (application env)
+  2. `Tau.Settings.Vault.resolve({:vault, "GROQ_API_KEY"})`
+  3. `System.get_env("GROQ_API_KEY")`
+
+  Base URL override (for proxies or local forks):
+
+  1. `config :tau, Tau.Providers.Groq, base_url: "https://..."`
+  2. `System.get_env("GROQ_BASE_URL")`
+  3. `https://api.groq.com/openai/v1` (upstream default)
+  """
+
+  @behaviour Tau.Provider
+
+  alias Tau.Providers.RateLimiter
+  alias Tau.Providers.Shared.{FinchStream, OpenAIChatWire, TokenEstimate}
+
+  @api_url "https://api.groq.com/openai/v1"
+  @default_model "llama-3.3-70b-versatile"
+
+  @impl Tau.Provider
+  def default_model, do: @default_model
+
+  @impl Tau.Provider
+  def capabilities do
+    %{
+      thinking: false,
+      tools: true,
+      vision: false,
+      prompt_caching: false,
+      parallel_tools: true
+    }
+  end
+
+  @impl Tau.Provider
+  def stream(messages, opts \\ %{}, ctx \\ %{}) do
+    case api_key() do
+      nil ->
+        {:error, :missing_api_key}
+
+      key ->
+        est = TokenEstimate.estimate(messages)
+
+        case RateLimiter.acquire(__MODULE__, est) do
+          {:error, :rate_limit_timeout} ->
+            {:error, :rate_limited}
+
+          :ok ->
+            body = OpenAIChatWire.build_body(messages, opts, __MODULE__, @default_model)
+
+            request =
+              Finch.build(
+                :post,
+                base_url() <> "/chat/completions",
+                OpenAIChatWire.headers(key),
+                Jason.encode!(body)
+              )
+
+            {:ok,
+             FinchStream.run(
+               request,
+               &OpenAIChatWire.decode/2,
+               %{
+                 tool_calls: %{},
+                 model: nil,
+                 provider: __MODULE__,
+                 # ADR-0017: cooperative cancellation flag.
+                 cancel_flag: ctx[:cancel_flag]
+               }
+             )}
+        end
+    end
+  end
+
+  defp api_key do
+    Application.get_env(:tau, __MODULE__, [])[:api_key] ||
+      vault_key() ||
+      System.get_env("GROQ_API_KEY")
+  end
+
+  defp vault_key do
+    if Code.ensure_loaded?(Tau.Settings.Vault) do
+      Tau.Settings.Vault.resolve({:vault, "GROQ_API_KEY"})
+    end
+  end
+
+  defp base_url do
+    Application.get_env(:tau, __MODULE__, [])[:base_url] ||
+      System.get_env("GROQ_BASE_URL") ||
+      @api_url
+  end
+end

--- a/lib/tau/providers/shared/tool_spec.ex
+++ b/lib/tau/providers/shared/tool_spec.ex
@@ -93,6 +93,10 @@ defmodule Tau.Providers.Shared.ToolSpec do
     %{type: "function", function: %{name: n, description: d, parameters: p}}
   end
 
+  defp shape(%{name: n, description: d, parameters: p}, Tau.Providers.Groq) do
+    %{type: "function", function: %{name: n, description: d, parameters: p}}
+  end
+
   defp shape(%{name: n, description: d, parameters: p}, Tau.Providers.Gemini) do
     %{name: n, description: d, parameters: GeminiSubset.downshift(p)}
   end

--- a/test/tau/providers/groq_test.exs
+++ b/test/tau/providers/groq_test.exs
@@ -1,0 +1,170 @@
+defmodule Tau.Providers.GroqTest do
+  @moduledoc """
+  Enforces the OTP non-negotiable (B5, SPEC-USER-TURN §4): non-2xx HTTP
+  responses from the Groq API MUST yield `%Tau.Provider.Event.Error{}`
+  stream items — never raise. Missing API key MUST yield a synchronous
+  `{:error, :missing_api_key}` without a network call.
+
+  Uses Bypass to stub the Groq endpoint; no real network call is made.
+  """
+  use ExUnit.Case, async: false
+
+  alias Tau.Message.User
+  alias Tau.Provider.Event
+  alias Tau.Providers.Groq
+
+  @sse_text_chunk Jason.encode!(%{
+                    "id" => "chatcmpl-groq1",
+                    "model" => "llama-3.3-70b-versatile",
+                    "choices" => [
+                      %{
+                        "delta" => %{"role" => "assistant", "content" => "Hello"},
+                        "finish_reason" => nil,
+                        "index" => 0
+                      }
+                    ]
+                  })
+
+  @sse_done_chunk Jason.encode!(%{
+                    "id" => "chatcmpl-groq1",
+                    "model" => "llama-3.3-70b-versatile",
+                    "choices" => [
+                      %{
+                        "delta" => %{},
+                        "finish_reason" => "stop",
+                        "index" => 0
+                      }
+                    ]
+                  })
+
+  defp sse_body(chunks) do
+    data_lines = Enum.map(chunks, fn c -> "data: #{c}\n\n" end)
+    Enum.join(data_lines) <> "data: [DONE]\n\n"
+  end
+
+  setup do
+    bypass = Bypass.open()
+    base_url = "http://localhost:#{bypass.port}/openai/v1"
+
+    Application.put_env(:tau, Tau.Providers.Groq,
+      api_key: "gsk-test-key",
+      base_url: base_url
+    )
+
+    on_exit(fn ->
+      Application.delete_env(:tau, Tau.Providers.Groq)
+    end)
+
+    %{bypass: bypass}
+  end
+
+  describe "api_key/0 missing → synchronous error" do
+    test "stream/3 returns {:error, :missing_api_key} when no key configured" do
+      Application.put_env(:tau, Tau.Providers.Groq,
+        api_key: nil,
+        base_url: "http://localhost:9999/openai/v1"
+      )
+
+      result = Groq.stream([User.new("hi")], %{}, %{})
+      assert {:error, :missing_api_key} = result
+    end
+  end
+
+  describe "happy-path stream" do
+    test "text delta emits Event.Start, TextStart, TextDelta, TextEnd, Done", %{bypass: bypass} do
+      Bypass.expect_once(bypass, "POST", "/openai/v1/chat/completions", fn conn ->
+        conn
+        |> Plug.Conn.put_resp_header("content-type", "text/event-stream")
+        |> Plug.Conn.send_resp(200, sse_body([@sse_text_chunk, @sse_done_chunk]))
+      end)
+
+      assert {:ok, stream} = Groq.stream([User.new("hello")], %{}, %{})
+      events = Enum.to_list(stream)
+
+      assert Enum.any?(events, &match?(%Event.Start{}, &1)),
+             "Expected Event.Start; got: #{inspect(events)}"
+
+      assert Enum.any?(events, &match?(%Event.TextStart{block_id: "text"}, &1)),
+             "Expected Event.TextStart; got: #{inspect(events)}"
+
+      assert Enum.any?(events, &match?(%Event.TextDelta{block_id: "text", text: "Hello"}, &1)),
+             "Expected Event.TextDelta with 'Hello'; got: #{inspect(events)}"
+
+      assert Enum.any?(events, &match?(%Event.Done{stop_reason: :stop}, &1)),
+             "Expected Event.Done{stop_reason: :stop}; got: #{inspect(events)}"
+    end
+  end
+
+  describe "HTTP error responses yield in-stream Event.Error, no raise" do
+    test "HTTP 401 → %Event.Error{reason: {:http_status, 401, _}, retryable?: false}",
+         %{bypass: bypass} do
+      Bypass.expect_once(bypass, "POST", "/openai/v1/chat/completions", fn conn ->
+        conn
+        |> Plug.Conn.put_resp_header("content-type", "application/json")
+        |> Plug.Conn.send_resp(
+          401,
+          Jason.encode!(%{
+            "error" => %{
+              "type" => "authentication_error",
+              "message" => "Invalid API key"
+            }
+          })
+        )
+      end)
+
+      assert {:ok, stream} = Groq.stream([User.new("hello")], %{}, %{})
+      events = Enum.to_list(stream)
+
+      assert Enum.any?(events, fn
+               %Event.Error{reason: {:http_status, 401, _}, retryable?: false} -> true
+               _ -> false
+             end),
+             "Expected non-retryable Event.Error for 401; got: #{inspect(events)}"
+    end
+
+    test "HTTP 429 → %Event.Error{reason: {:http_status, 429, _}, retryable?: true}",
+         %{bypass: bypass} do
+      Bypass.expect_once(bypass, "POST", "/openai/v1/chat/completions", fn conn ->
+        conn
+        |> Plug.Conn.put_resp_header("content-type", "application/json")
+        |> Plug.Conn.send_resp(
+          429,
+          Jason.encode!(%{
+            "error" => %{
+              "type" => "rate_limit_error",
+              "message" => "Rate limit exceeded"
+            }
+          })
+        )
+      end)
+
+      assert {:ok, stream} = Groq.stream([User.new("hello")], %{}, %{})
+      events = Enum.to_list(stream)
+
+      assert Enum.any?(events, fn
+               %Event.Error{reason: {:http_status, 429, _}, retryable?: true} -> true
+               _ -> false
+             end),
+             "Expected retryable Event.Error for 429; got: #{inspect(events)}"
+    end
+
+    test "stream does not raise on 401 or 429", %{bypass: bypass} do
+      for status <- [401, 429] do
+        Bypass.expect_once(bypass, "POST", "/openai/v1/chat/completions", fn conn ->
+          conn
+          |> Plug.Conn.put_resp_header("content-type", "application/json")
+          |> Plug.Conn.send_resp(
+            status,
+            Jason.encode!(%{"error" => %{"type" => "error", "message" => "error"}})
+          )
+        end)
+
+        assert {:ok, stream} = Groq.stream([User.new("hello")], %{}, %{})
+        events = Enum.to_list(stream)
+
+        assert Enum.any?(events, &match?(%Event.Error{}, &1)),
+               "Expected Event.Error for #{status}; got: #{inspect(events)}"
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- `Tau.Providers.Groq` — OpenAI-Chat-compatible provider delegating wire logic to `OpenAIChatWire`; modelled on the merged DeepSeek provider.
- One `ToolSpec.shape/2` clause for `Tau.Providers.Groq`; `cli.ex` `resolve_provider("groq")` + `doctor_cmd` entry; `docs/providers/groq.md`.

Advances C68 (OpenAI-compatible-wire failure surface; established by #181 PR2). Refs #181

## Test plan
- [x] `mix test` — 799 tests, 0 failures; 5 Bypass tests (happy-path SSE, missing-key, HTTP 401/429)
- [x] `mix format`, `mix credo --strict`, `mix compile --warnings-as-errors` clean on PR files

🤖 Generated with [Claude Code](https://claude.com/claude-code)