### PR TITLE
fix(tools): make Tau.Tools.Registry :duplicate so tools survive session churn

### DIFF
--- a/lib/tau/registries.ex
+++ b/lib/tau/registries.ex
@@ -7,11 +7,25 @@ defmodule Tau.Registries do
   process death. We use them everywhere a "lookup table" might be tempting
   in an OO codebase.
 
-    * `Tau.Tools.Registry` — `:unique`, partitioned by scheduler count.
+    * `Tau.Tools.Registry` — `:duplicate`, partitioned by scheduler count.
       Built-in tools, MCP-derived tools, and extension tools all register
       here under their public name. MCP-derived tools register under
       `mcp__<server_name>__<tool_name>` (double-underscore separator;
       both segments are dynamic — see `Tau.MCP.Server`).
+
+      The registry is `:duplicate` (not `:unique`) because built-in tools
+      are registered *per session* by `Tau.Session.init/1`
+      (`register_builtins/0`): `Registry.register/3` makes the *calling*
+      process the entry owner. Under a `:unique` registry only the first
+      session to boot owned a tool; every later session's registration was
+      silently rejected as `{:already_registered, _}`. When that first
+      session terminated, the tool was deregistered out from under every
+      other still-live session, so concurrent sessions lost tool access
+      (issue #250). Under a `:duplicate` registry each session holds its
+      own claim, so a tool stays registered as long as *any* session that
+      registered it is alive. All registrants for a given tool name carry
+      the same module value, so `Tau.Tool.lookup/1` resolves against the
+      first entry.
 
     * `Tau.Hooks.Registry` — `:duplicate`, keyed by event atom. Multiple
       hooks may listen on the same event; dispatch is deterministic by
@@ -39,7 +53,8 @@ defmodule Tau.Registries do
   @impl true
   def init(_opts) do
     children = [
-      {Registry, keys: :unique, name: Tau.Tools.Registry, partitions: System.schedulers_online()},
+      {Registry,
+       keys: :duplicate, name: Tau.Tools.Registry, partitions: System.schedulers_online()},
       {Registry, keys: :duplicate, name: Tau.Hooks.Registry},
       {Registry, keys: :unique, name: Tau.Commands.Registry},
       {Registry, keys: :unique, name: Tau.Skills.Registry},

--- a/lib/tau/tool.ex
+++ b/lib/tau/tool.ex
@@ -35,12 +35,19 @@ defmodule Tau.Tool do
 
   @optional_callbacks [execution_mode: 0, streams_updates?: 0]
 
-  @doc "Look up a registered tool by its public name."
+  @doc """
+  Look up a registered tool by its public name.
+
+  `Tau.Tools.Registry` is a `:duplicate` registry (see `Tau.Registries`):
+  built-in tools are registered once per live session, so a name may carry
+  several entries. Every registrant for a name holds the same module value,
+  so the first entry is authoritative.
+  """
   @spec lookup(String.t()) :: {:ok, module()} | :error
   def lookup(name) do
     case Registry.lookup(Tau.Tools.Registry, name) do
-      [{_pid, mod}] -> {:ok, mod}
-      _ -> :error
+      [{_pid, mod} | _] -> {:ok, mod}
+      [] -> :error
     end
   end
 
@@ -50,9 +57,16 @@ defmodule Tau.Tool do
     Registry.register(Tau.Tools.Registry, mod.name(), mod)
   end
 
-  @doc "All tool names currently registered."
+  @doc """
+  All tool names currently registered.
+
+  De-duplicated: under the `:duplicate` `Tau.Tools.Registry` a name appears
+  once per registrant process.
+  """
   @spec list() :: [String.t()]
   def list do
-    Registry.select(Tau.Tools.Registry, [{{:"$1", :_, :_}, [], [:"$1"]}])
+    Tau.Tools.Registry
+    |> Registry.select([{{:"$1", :_, :_}, [], [:"$1"]}])
+    |> Enum.uniq()
   end
 end


### PR DESCRIPTION
## Summary

`Tau.Tools.Registry` was a `:unique` registry. Built-in tools are registered
*per session* by `Tau.Session.init/1` (`register_builtins/0`), and
`Registry.register/3` makes the **calling process** the entry owner — so under
`:unique` only the *first* session to boot owned each tool name; every later
session's registration was silently dropped. When that first session
terminated, the tool was deregistered out from under every still-live session,
which lost tool access.

This is a genuine runtime bug, not test-only pollution — `agent_test.exs`
(`async: false`) churns sessions, so a prior test's parent FSM is torn down as
the next boots, opening a window where no live FSM owns `"Agent"`. The full
suite masked it (hundreds of interleaved sessions almost always kept *some* FSM
holding the tool).

Fix: `Tau.Tools.Registry` → `:duplicate`. Each session holds its own
ref-counting claim; a tool stays registered as long as any registrant lives.
`Tau.Tool.lookup/1` takes the first of possibly-many (identical-valued) entries;
`Tau.Tool.list/0` de-dupes.

## Linked issues

Closes #250

## Gate verdicts

- critic: PASS (`ok: true`) — `:unique`→`:duplicate` verified safe for all
  consumers (`lookup/1`, `list/0`, `Tau.MCP.Server`, `Tau.Extensions.Loader`).
  3 non-blocking SUGGESTIONs raised (see below).
- reviewer: PASS (`verdict: PASS`) — 887 tests, 0 failures; `agent_test.exs`
  alone green 12/12 random seeds; `agent_test.exs + mode_test.exs` (the
  previously-failing combination) green 8/8 random seeds; `mix format` and
  `mix credo --strict` clean (no new issues).

### Non-blocking follow-ups (critic SUGGESTIONs)

1. Per-session built-in registration now creates `N × live_sessions` duplicate
   entries (reaped on session death — not an unbounded leak). Cleaner long-term:
   register built-ins once under a long-lived supervised owner.
2. `:duplicate` removes the `{:already_registered, _}` collision guard;
   `lookup/1` silently returns the first-registered module if a name ever
   carries divergent modules. No current code triggers this.
3. `register_builtins/0` still handles `{:error, {:already_registered, _}}` —
   now dead code under `:duplicate`.

## Test plan

- [x] `mix test test/tau/tools/builtin/agent_test.exs` — green across 12 random seeds
- [x] `mix test test/tau/tools/builtin/agent_test.exs test/tau/permissions/mode_test.exs` — green across 8 random seeds
- [x] full `mix test` — 887 tests, 0 failures
- [x] `mix format --check-formatted`, `mix credo --strict` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)