### PR TITLE
feat(cli): FSM-backed headless tau run — M1 self-hosting entry point

### DIFF
--- a/docs/spec/SPEC-USER-TURN.md
+++ b/docs/spec/SPEC-USER-TURN.md
@@ -8,7 +8,7 @@
 | **Method** | PSDH (`.claude/skills/design-reasoning`); L0 + L1 + boundary contracts. L2 deferred. |
 | **Self-hosting target** | Working TUI is the prerequisite for Tau replacing the vendored claude-harness as the dev tool for Tau itself (see memory: `project_1_0_self_hosting.md`). |
 
-**Changelog:** WI-C / #202: D-009 reworded — visible-content guarantee unified into `Assembler.finalize/3`. #211: C53, D-040 — plain-release CLI dispatch via `TAU_CLI_ARGV`; B2 contract amended with three argv sources. #179: C54, D-041 — mid-session model swap via `/model`; AC-8 added; D-002 amended to name the sanctioned swap path; B4 boundary contract note added. #227: C55, D-042 — built-in slash-command registry + inline dispatch; B4 amended with built-in outcome INV; D-042 added. #178 PR2b: C67, D-016 (implemented), D-048, D-049, AC-9 — async `/compact` built-in; `:compacting` FSM state; B4 amended with `{:async_compact, binary}` outcome; [C26] partially resolved; Appendix B updated. #181 PR2: C68 — OpenAI-compatible provider failure surface (synchronous missing-key vs. in-stream HTTP error); Appendix B updated. #181 PR5: C80 — Azure OpenAI auth/URL shape constraint (api-key header, deployment-based URL); Appendix B updated. #181 PR6: C81 — Custom configure-by-URL provider; nil api_key valid (omits Authorization header); synchronous error only on missing_base_url; Appendix B updated. #182 PR-A: C82, D-056 — Copilot OAuth auth subsystem + API token refresh contract; Appendix B updated. #252: C83, D-058, AC-10 — headless FSM-backed `tau run`; B2 contract amended with headless run path INV; D-058 added; AC-10 added; Appendix B updated. Closes #213 (tau run bypassed the Session FSM).
+**Changelog:** WI-C / #202: D-009 reworded — visible-content guarantee unified into `Assembler.finalize/3`. #211: C53, D-040 — plain-release CLI dispatch via `TAU_CLI_ARGV`; B2 contract amended with three argv sources. #179: C54, D-041 — mid-session model swap via `/model`; AC-8 added; D-002 amended to name the sanctioned swap path; B4 boundary contract note added. #227: C55, D-042 — built-in slash-command registry + inline dispatch; B4 amended with built-in outcome INV; D-042 added. #178 PR2b: C67, D-016 (implemented), D-048, D-049, AC-9 — async `/compact` built-in; `:compacting` FSM state; B4 amended with `{:async_compact, binary}` outcome; [C26] partially resolved; Appendix B updated. #181 PR2: C68 — OpenAI-compatible provider failure surface (synchronous missing-key vs. in-stream HTTP error); Appendix B updated. #181 PR5: C80 — Azure OpenAI auth/URL shape constraint (api-key header, deployment-based URL); Appendix B updated. #181 PR6: C81 — Custom configure-by-URL provider; nil api_key valid (omits Authorization header); synchronous error only on missing_base_url; Appendix B updated. #182 PR-A: C82, D-056 — Copilot OAuth auth subsystem + API token refresh contract; Appendix B updated. #252: C83, D-058, AC-10 — headless FSM-backed `tau run`; B2 contract amended with headless run path INV; D-058 added; AC-10 added; Appendix B updated. Closes #213 (tau run bypassed the Session FSM). #252 (f-1 fix): D-058, B2 headless INV, AC-10 amended — drain loop now enumerates failure stop_reasons (exit 1 for `:error/:tool_loop_aborted/:aborted/:compaction_failed`); all other terminal atoms → exit 0; `:tool_use` continuation and `:stop_sequence` regression tests added.
 
 ## 0. Why this spec exists
 
@@ -201,22 +201,22 @@ INV (headless run — D-058 / #252 / Closes #213)
   - The headless run loop MUST subscribe to "session:<id>" PubSub BEFORE calling
     Tau.start_session/1 (D-004 compliance — SessionStart is broadcast
     synchronously inside FSM init and would be lost if subscription comes after).
-  - Terminal stop_reason atoms are those providers actually emit after
-    normalisation by their wire decoders:
-      :stop   — Anthropic end_turn, OpenAI stop, Replay done (all normalised
-                 to :stop by anthropic.ex:234 / openai_chat_wire.ex:193).
-      :length — Anthropic/OpenAI max_tokens / length (normalised by
-                 anthropic.ex:235 and openai_chat_wire.ex:194). Context-window
-                 exhausted; still a usable response.
-    Note: the wire strings "end_turn" and "max_tokens" are NOT atoms emitted
-    by providers. Using :end_turn or :max_tokens in the terminal set would cause
-    context-window stops (:length) to fall through to the error branch.
-  - On MessageEnd with stop_reason in [:stop, :length]: print assistant text to
-    stdout, call Tau.stop/1 to flush JSONL, await SessionEnd. Exit code 0.
+  - The drain loop MUST enumerate failure stop_reasons (exit 1), not success
+    ones. The explicit failure set is:
+      :error            — session-level error
+      :tool_loop_aborted — tool iteration cap reached
+      :aborted          — coding-agent subprocess exited with status -2
+      :compaction_failed — 3 consecutive compaction failures
+    Every other terminal stop_reason (:stop, :length, :stop_sequence,
+    :end_turn, :content_filter, and any future provider atom) MUST be treated
+    as a completed turn → exit 0. This inversion ensures new provider atoms
+    default to success rather than misreporting as crashes.
+  - On MessageEnd with stop_reason in the failure set: print to stderr,
+    call Tau.stop/1, await SessionEnd. Exit code 1.
   - On MessageEnd with stop_reason :tool_use: continue waiting (tool iteration
     in progress). Do NOT exit.
-  - On MessageEnd with stop_reason :tool_loop_aborted or :error: print to stderr,
-    call Tau.stop/1, await SessionEnd. Exit code 1.
+  - On MessageEnd with any other stop_reason: print assistant text to stdout,
+    call Tau.stop/1 to flush JSONL, await SessionEnd. Exit code 0.
   - Tau.stop/1 MUST be called on every exit path INCLUDING the timeout branch so
     JSONL is flushed. After calling Tau.stop/1, drain_session_end/2 MUST be
     awaited (bounded 10 s) before returning — the timeout branch is NOT exempt.
@@ -449,7 +449,7 @@ Each entry: id, statement, severity, detection_method, source_constraint.
 | D-048 | **:compacting-state exit invariant (C67-B4).** Every exit edge from the `:compacting` gen_statem state MUST land in `:awaiting_user` with both `data.compaction_task` and `data.compaction_monitor` set to `nil`. Five terminal clauses cover all exit paths: (1) worker success `{ref, result}`; (2a) benign `{:DOWN, :normal}` (keep-state, result pending); (2b) crash `{:DOWN, reason}`; (3) live timeout; (4) stale timeout (no-op). `{:next_state, :awaiting_user, data}` is the return form for clauses 1, 2b, 3; clause 2a uses `{:keep_state, data}` because the result message is still pending. | high | `test/tau/session/compaction_test.exs`: happy path; postpone-and-flush; stale-result-drop after cancel; `:swap_model` busy during `:compacting` | [C67-B4] |
 | D-049 | **Compaction worker crash/timeout/cancel recovery (C67-B4).** The session FSM MUST NOT wedge when the compaction worker crashes, times out, or is cancelled — it MUST return to `:awaiting_user`. It MUST NOT trigger a spurious crash-recovery notice when `{ref,result}` and `{:DOWN, :normal}` arrive back-to-back (the double-message race). Achieved by: Clause 2a (`{:DOWN, :normal}`) is a `{:keep_state}` that preserves the pending result, so Clause 1 still processes it; all five typed clauses clear worker fields, so stale messages fail guards and reach the catch-all no-op. | high | `test/tau/session/compaction_test.exs`: worker-crash recovery (session not wedged); race test `{ref,result}` + `{:DOWN}` × 50 (NO spurious crash recovery); late-timeout-after-success (no FSM crash); `/cancel` outside `:compacting` (no FSM crash) | [C67-B4] |
 | D-056 | **Copilot API token refresh contract (C82-B8).** `Tau.Providers.Copilot.Auth.token/1` MUST refresh the short-lived API token when `expires_at - now < 5 min` (300,000 ms). The refresh path is: (1) call `resolve_oauth/1` to obtain the long-lived OAuth token; (2) `POST https://api.github.com/copilot_internal/v2/token` with `Authorization: token <oauth_token>`; (3) parse `{"token": "...", "expires_at": "ISO8601"}` from the 200 response; (4) store the result in `Tau.Providers.Copilot.TokenStore` (supervised GenServer, NOT module-level state). Any non-200 response or network error MUST return `{:error, :oauth_refresh_failed}` and emit `[:tau, :copilot, :auth, :refresh_failed]` telemetry. Missing OAuth token MUST return `{:error, :no_auth}`. All errors MUST surface a user-actionable message via `Auth.describe_error/1` naming the `gh auth login --scopes copilot` renewal path. | high | `test/tau/providers/copilot/auth_test.exs`: hosts.json parsing; apps.json fallback; env-var override; refresh/1 success (Bypass stub); refresh/1 non-200 → `:oauth_refresh_failed`; token/1 proactive-refresh when nearing expiry; token/1 skips refresh when token is fresh; missing file → `:no_auth`; malformed JSON → `:oauth_malformed` | [C82-B8] |
-| D-058 | **Headless FSM-backed `tau run` (C83-B2).** `tau run <prompt>` MUST start a full `Tau.Session` FSM via `Tau.start_session/1`, send the prompt via `Tau.send/2`, and consume the PubSub event stream until `%SessionEnd{}`. It MUST NOT call `provider.stream/3` directly (which bypasses tools, JSONL persistence, and permissions). The PubSub subscription MUST be established BEFORE `Tau.start_session/1` returns (D-004). `Tau.stop/1` MUST be called on every exit path (`:stop`, `:length`, `:tool_loop_aborted`, error, timeout) to flush JSONL before the process exits; the timeout path MUST also await `drain_session_end/2` (bounded 10 s) before returning. Exit code: 0 on clean stop (`stop_reason in [:stop, :length]`); 1 otherwise. Note: provider wire decoders normalise `"end_turn"`/`"max_tokens"` to `:stop`/`:length` — the atoms `:end_turn` and `:max_tokens` are NOT emitted by any provider. `--system-prompt <text>` and `--system-prompt-file <path>` inject the text as `%Tau.Skill{}` with `:persona_lifetime :session`; the skill is prepended to `data.skills` in `Session.init/1` BEFORE `prepend_skill_messages/2` runs so it reaches the model-visible system blob — setting only `active_skill` is NOT sufficient. | high | `test/tau/cli/headless_run_test.exs` (AC-10): replay run exits 0; JSONL persisted; :length → exit 0; :tool_loop_aborted → exit 1; :error → exit 1; --system-prompt body in session messages; CLI option parser | [C83-B2] |
+| D-058 | **Headless FSM-backed `tau run` (C83-B2).** `tau run <prompt>` MUST start a full `Tau.Session` FSM via `Tau.start_session/1`, send the prompt via `Tau.send/2`, and consume the PubSub event stream until `%SessionEnd{}`. It MUST NOT call `provider.stream/3` directly (which bypasses tools, JSONL persistence, and permissions). The PubSub subscription MUST be established BEFORE `Tau.start_session/1` returns (D-004). `Tau.stop/1` MUST be called on every exit path (failure, success, timeout) to flush JSONL before the process exits; the timeout path MUST also await `drain_session_end/2` (bounded 10 s) before returning. Exit code: 1 iff the stop_reason is in the explicit failure set `[:error, :tool_loop_aborted, :aborted, :compaction_failed]` or `%SessionEnd{reason: :error}` arrives; 0 for every other completed turn (`:stop`, `:length`, `:stop_sequence`, `:content_filter`, and any future provider atom). This inversion ensures new provider atoms default to success rather than misreporting as crashes. `--system-prompt <text>` and `--system-prompt-file <path>` inject the text as `%Tau.Skill{}` with `:persona_lifetime :session`; the skill is prepended to `data.skills` in `Session.init/1` BEFORE `prepend_skill_messages/2` runs so it reaches the model-visible system blob — setting only `active_skill` is NOT sufficient. | high | `test/tau/cli/headless_run_test.exs` (AC-10): replay run exits 0; JSONL persisted; :length → exit 0; :tool_loop_aborted → exit 1; :error → exit 1; :stop_sequence → exit 0; :tool_use continuation; --system-prompt body in session messages; CLI option parser | [C83-B2] |
 
 30 D-xxx entries. Each is enforceable. None require speculation.
 
@@ -515,10 +515,13 @@ These are the bar for closing the umbrella issue (#153/#149) and unblocking the 
 - `tau run "prompt" --provider replay --model replay` MUST:
   - Start a full `Tau.Session` FSM (not a bare provider.stream/3 call).
   - Print the assistant text response to stdout.
-  - Exit with code 0 on a clean stop (`stop_reason in [:stop, :length]`).
-    Note: `:end_turn` and `:max_tokens` are NOT emitted by providers (they are
-    wire strings normalised to `:stop`/`:length` by provider decoders).
-  - Exit with code 1 on `:tool_loop_aborted`, `:error`, or unknown stop_reason.
+  - Exit with code 1 iff stop_reason is in the explicit failure set
+    `[:error, :tool_loop_aborted, :aborted, :compaction_failed]`.
+  - Exit with code 0 for every other completed turn (`:stop`, `:length`,
+    `:stop_sequence`, `:content_filter`, and any future provider atom).
+    This inversion ensures new provider atoms default to success rather than
+    misreporting as crashes.
+  - Continue looping (not exit) on `:tool_use` — more tool iterations follow.
   - Persist the session to JSONL; `tau sessions list` shows the session after the run.
 - `tau run "prompt" --system-prompt "text"` injects the text into the model-visible
   system blob; the skill body MUST appear in `data.messages` as a system-role
@@ -526,10 +529,10 @@ These are the bar for closing the umbrella issue (#153/#149) and unblocking the 
 - `tau run "prompt" --system-prompt-file <path>` reads the file and applies it the same way.
 - The timeout exit path MUST also call `Tau.stop/1` and await `drain_session_end/2`
   (bounded 10 s) before returning exit code 1 (B3 fix).
-- Tests: `test/tau/cli/headless_run_test.exs` (22 cases) — replay run, JSONL persistence,
-  stop_reason matrix (:stop/:length/:tool_loop_aborted/:error), system-prompt body in
-  messages, helper unit tests, CLI option parser. Tests exercise `Tau.CLI`'s real
-  public/@doc-false functions, not private duplicates.
+- Tests: `test/tau/cli/headless_run_test.exs` — replay run, JSONL persistence,
+  stop_reason matrix (:stop/:length/:tool_loop_aborted/:error/:tool_use continuation/
+  :stop_sequence), system-prompt body in messages, helper unit tests, CLI option parser.
+  Tests exercise `Tau.CLI`'s real public/@doc-false functions, not private duplicates.
 - This test runs in CI on every PR and is a blocking gate.
 
 ## 8. Out-of-scope hazards (explicitly deferred)

--- a/docs/spec/SPEC-USER-TURN.md
+++ b/docs/spec/SPEC-USER-TURN.md
@@ -8,7 +8,7 @@
 | **Method** | PSDH (`.claude/skills/design-reasoning`); L0 + L1 + boundary contracts. L2 deferred. |
 | **Self-hosting target** | Working TUI is the prerequisite for Tau replacing the vendored claude-harness as the dev tool for Tau itself (see memory: `project_1_0_self_hosting.md`). |
 
-**Changelog:** WI-C / #202: D-009 reworded — visible-content guarantee unified into `Assembler.finalize/3`. #211: C53, D-040 — plain-release CLI dispatch via `TAU_CLI_ARGV`; B2 contract amended with three argv sources. #179: C54, D-041 — mid-session model swap via `/model`; AC-8 added; D-002 amended to name the sanctioned swap path; B4 boundary contract note added. #227: C55, D-042 — built-in slash-command registry + inline dispatch; B4 amended with built-in outcome INV; D-042 added. #178 PR2b: C67, D-016 (implemented), D-048, D-049, AC-9 — async `/compact` built-in; `:compacting` FSM state; B4 amended with `{:async_compact, binary}` outcome; [C26] partially resolved; Appendix B updated. #181 PR2: C68 — OpenAI-compatible provider failure surface (synchronous missing-key vs. in-stream HTTP error); Appendix B updated. #181 PR5: C80 — Azure OpenAI auth/URL shape constraint (api-key header, deployment-based URL); Appendix B updated. #181 PR6: C81 — Custom configure-by-URL provider; nil api_key valid (omits Authorization header); synchronous error only on missing_base_url; Appendix B updated. #182 PR-A: C82, D-056 — Copilot OAuth auth subsystem + API token refresh contract; Appendix B updated. #252: C83, D-058, AC-10 — headless FSM-backed `tau run`; B2 contract amended with headless run path INV; D-058 added; AC-10 added; Appendix B updated. Closes #213 (tau run bypassed the Session FSM). #252 (f-1 fix): D-058, B2 headless INV, AC-10 amended — drain loop now enumerates failure stop_reasons (exit 1 for `:error/:tool_loop_aborted/:aborted/:compaction_failed`); all other terminal atoms → exit 0; `:tool_use` continuation and `:stop_sequence` regression tests added.
+**Changelog:** WI-C / #202: D-009 reworded — visible-content guarantee unified into `Assembler.finalize/3`. #211: C53, D-040 — plain-release CLI dispatch via `TAU_CLI_ARGV`; B2 contract amended with three argv sources. #179: C54, D-041 — mid-session model swap via `/model`; AC-8 added; D-002 amended to name the sanctioned swap path; B4 boundary contract note added. #227: C55, D-042 — built-in slash-command registry + inline dispatch; B4 amended with built-in outcome INV; D-042 added. #178 PR2b: C67, D-016 (implemented), D-048, D-049, AC-9 — async `/compact` built-in; `:compacting` FSM state; B4 amended with `{:async_compact, binary}` outcome; [C26] partially resolved; Appendix B updated. #181 PR2: C68 — OpenAI-compatible provider failure surface (synchronous missing-key vs. in-stream HTTP error); Appendix B updated. #181 PR5: C80 — Azure OpenAI auth/URL shape constraint (api-key header, deployment-based URL); Appendix B updated. #181 PR6: C81 — Custom configure-by-URL provider; nil api_key valid (omits Authorization header); synchronous error only on missing_base_url; Appendix B updated. #182 PR-A: C82, D-056 — Copilot OAuth auth subsystem + API token refresh contract; Appendix B updated. #252: C83, D-058, AC-10 — headless FSM-backed `tau run`; B2 contract amended with headless run path INV; D-058 added; AC-10 added; Appendix B updated. Closes #213 (tau run bypassed the Session FSM). #252 (f-1 fix): D-058, B2 headless INV, AC-10 amended — drain loop now enumerates failure stop_reasons (exit 1 for `:error/:tool_loop_aborted/:aborted/:compaction_failed`); all other terminal atoms → exit 0; `:tool_use` continuation and `:stop_sequence` regression tests added. #252 (f-2 fix): D-058, B2 headless INV, AC-10 amended — content-first rule: a MessageEnd whose content carries `%{type: :tool_call}` blocks is a continuation regardless of `stop_reason`; this fixes Gemini/Bedrock which emit `stop_reason: :stop` even on tool-call turns. `run_cmd/1` made `@doc false` public; f-4 end-to-end tests added via `run_cmd/1`.
 
 ## 0. Why this spec exists
 
@@ -201,22 +201,33 @@ INV (headless run — D-058 / #252 / Closes #213)
   - The headless run loop MUST subscribe to "session:<id>" PubSub BEFORE calling
     Tau.start_session/1 (D-004 compliance — SessionStart is broadcast
     synchronously inside FSM init and would be lost if subscription comes after).
-  - The drain loop MUST enumerate failure stop_reasons (exit 1), not success
-    ones. The explicit failure set is:
-      :error            — session-level error
-      :tool_loop_aborted — tool iteration cap reached
-      :aborted          — coding-agent subprocess exited with status -2
-      :compaction_failed — 3 consecutive compaction failures
-    Every other terminal stop_reason (:stop, :length, :stop_sequence,
-    :end_turn, :content_filter, and any future provider atom) MUST be treated
-    as a completed turn → exit 0. This inversion ensures new provider atoms
-    default to success rather than misreporting as crashes.
+  - The drain loop MUST decide continuation vs. termination in this order:
+    1. CONTENT-FIRST (f-2 fix): if msg.content contains ANY %{type: :tool_call}
+       block, CONTINUE regardless of stop_reason. This is required because Gemini
+       and Bedrock emit stop_reason: :stop even on tool-call turns (finishReason:
+       "STOP" for all turns). The Session FSM itself dispatches tools by content
+       (session.ex ~line 1806: Enum.filter(msg.content, &match?(%{type: :tool_call}, &1)));
+       the drain loop MUST mirror that decision. Exiting on a Gemini tool-call
+       turn (stop_reason :stop, tool_call content present) kills the session
+       before the FSM dispatches the tool — tau run --provider gemini cannot
+       complete any tool-using turn. The :tool_use stop_reason (Anthropic/OpenAI)
+       is subsumed by this check; those providers always populate tool_call content
+       blocks alongside :tool_use, so step 1 catches them.
+    2. FAILURE stop_reasons → exit 1. The explicit failure set:
+         :error            — session-level error
+         :tool_loop_aborted — tool iteration cap reached
+         :aborted          — coding-agent subprocess exited with status -2
+         :compaction_failed — 3 consecutive compaction failures
+    3. Everything else (:stop, :length, :stop_sequence, :end_turn,
+       :content_filter, and any future provider atom) MUST be treated as a
+       completed turn → exit 0. This inversion ensures new provider atoms
+       default to success rather than misreporting as crashes.
+  - On MessageEnd with tool_call content: continue waiting (step 1 above). Do NOT exit.
   - On MessageEnd with stop_reason in the failure set: print to stderr,
     call Tau.stop/1, await SessionEnd. Exit code 1.
-  - On MessageEnd with stop_reason :tool_use: continue waiting (tool iteration
-    in progress). Do NOT exit.
-  - On MessageEnd with any other stop_reason: print assistant text to stdout,
-    call Tau.stop/1 to flush JSONL, await SessionEnd. Exit code 0.
+  - On MessageEnd with any other stop_reason (and no tool_call content): print
+    assistant text to stdout, call Tau.stop/1 to flush JSONL, await SessionEnd.
+    Exit code 0.
   - Tau.stop/1 MUST be called on every exit path INCLUDING the timeout branch so
     JSONL is flushed. After calling Tau.stop/1, drain_session_end/2 MUST be
     awaited (bounded 10 s) before returning — the timeout branch is NOT exempt.
@@ -449,7 +460,7 @@ Each entry: id, statement, severity, detection_method, source_constraint.
 | D-048 | **:compacting-state exit invariant (C67-B4).** Every exit edge from the `:compacting` gen_statem state MUST land in `:awaiting_user` with both `data.compaction_task` and `data.compaction_monitor` set to `nil`. Five terminal clauses cover all exit paths: (1) worker success `{ref, result}`; (2a) benign `{:DOWN, :normal}` (keep-state, result pending); (2b) crash `{:DOWN, reason}`; (3) live timeout; (4) stale timeout (no-op). `{:next_state, :awaiting_user, data}` is the return form for clauses 1, 2b, 3; clause 2a uses `{:keep_state, data}` because the result message is still pending. | high | `test/tau/session/compaction_test.exs`: happy path; postpone-and-flush; stale-result-drop after cancel; `:swap_model` busy during `:compacting` | [C67-B4] |
 | D-049 | **Compaction worker crash/timeout/cancel recovery (C67-B4).** The session FSM MUST NOT wedge when the compaction worker crashes, times out, or is cancelled — it MUST return to `:awaiting_user`. It MUST NOT trigger a spurious crash-recovery notice when `{ref,result}` and `{:DOWN, :normal}` arrive back-to-back (the double-message race). Achieved by: Clause 2a (`{:DOWN, :normal}`) is a `{:keep_state}` that preserves the pending result, so Clause 1 still processes it; all five typed clauses clear worker fields, so stale messages fail guards and reach the catch-all no-op. | high | `test/tau/session/compaction_test.exs`: worker-crash recovery (session not wedged); race test `{ref,result}` + `{:DOWN}` × 50 (NO spurious crash recovery); late-timeout-after-success (no FSM crash); `/cancel` outside `:compacting` (no FSM crash) | [C67-B4] |
 | D-056 | **Copilot API token refresh contract (C82-B8).** `Tau.Providers.Copilot.Auth.token/1` MUST refresh the short-lived API token when `expires_at - now < 5 min` (300,000 ms). The refresh path is: (1) call `resolve_oauth/1` to obtain the long-lived OAuth token; (2) `POST https://api.github.com/copilot_internal/v2/token` with `Authorization: token <oauth_token>`; (3) parse `{"token": "...", "expires_at": "ISO8601"}` from the 200 response; (4) store the result in `Tau.Providers.Copilot.TokenStore` (supervised GenServer, NOT module-level state). Any non-200 response or network error MUST return `{:error, :oauth_refresh_failed}` and emit `[:tau, :copilot, :auth, :refresh_failed]` telemetry. Missing OAuth token MUST return `{:error, :no_auth}`. All errors MUST surface a user-actionable message via `Auth.describe_error/1` naming the `gh auth login --scopes copilot` renewal path. | high | `test/tau/providers/copilot/auth_test.exs`: hosts.json parsing; apps.json fallback; env-var override; refresh/1 success (Bypass stub); refresh/1 non-200 → `:oauth_refresh_failed`; token/1 proactive-refresh when nearing expiry; token/1 skips refresh when token is fresh; missing file → `:no_auth`; malformed JSON → `:oauth_malformed` | [C82-B8] |
-| D-058 | **Headless FSM-backed `tau run` (C83-B2).** `tau run <prompt>` MUST start a full `Tau.Session` FSM via `Tau.start_session/1`, send the prompt via `Tau.send/2`, and consume the PubSub event stream until `%SessionEnd{}`. It MUST NOT call `provider.stream/3` directly (which bypasses tools, JSONL persistence, and permissions). The PubSub subscription MUST be established BEFORE `Tau.start_session/1` returns (D-004). `Tau.stop/1` MUST be called on every exit path (failure, success, timeout) to flush JSONL before the process exits; the timeout path MUST also await `drain_session_end/2` (bounded 10 s) before returning. Exit code: 1 iff the stop_reason is in the explicit failure set `[:error, :tool_loop_aborted, :aborted, :compaction_failed]` or `%SessionEnd{reason: :error}` arrives; 0 for every other completed turn (`:stop`, `:length`, `:stop_sequence`, `:content_filter`, and any future provider atom). This inversion ensures new provider atoms default to success rather than misreporting as crashes. `--system-prompt <text>` and `--system-prompt-file <path>` inject the text as `%Tau.Skill{}` with `:persona_lifetime :session`; the skill is prepended to `data.skills` in `Session.init/1` BEFORE `prepend_skill_messages/2` runs so it reaches the model-visible system blob — setting only `active_skill` is NOT sufficient. | high | `test/tau/cli/headless_run_test.exs` (AC-10): replay run exits 0; JSONL persisted; :length → exit 0; :tool_loop_aborted → exit 1; :error → exit 1; :stop_sequence → exit 0; :tool_use continuation; --system-prompt body in session messages; CLI option parser | [C83-B2] |
+| D-058 | **Headless FSM-backed `tau run` (C83-B2).** `tau run <prompt>` MUST start a full `Tau.Session` FSM via `Tau.start_session/1`, send the prompt via `Tau.send/2`, and consume the PubSub event stream until `%SessionEnd{}`. It MUST NOT call `provider.stream/3` directly (which bypasses tools, JSONL persistence, and permissions). The PubSub subscription MUST be established BEFORE `Tau.start_session/1` returns (D-004). `Tau.stop/1` MUST be called on every exit path (failure, success, timeout) to flush JSONL before the process exits; the timeout path MUST also await `drain_session_end/2` (bounded 10 s) before returning. **Turn-completion is decided by content, not `stop_reason` (f-2 fix):** a `MessageEnd` whose `msg.content` contains any `%{type: :tool_call}` block MUST be treated as a continuation regardless of `stop_reason` — Gemini/Bedrock emit `stop_reason: :stop` on tool-call turns. The drain loop checks content first (mirroring session.ex ~line 1806), then failure stop_reasons, then defaults to completed-turn. Exit code: 1 iff the stop_reason is in the explicit failure set `[:error, :tool_loop_aborted, :aborted, :compaction_failed]` or `%SessionEnd{reason: :error}` arrives (and no tool_call content was present); 0 for every other completed turn (`:stop`, `:length`, `:stop_sequence`, `:content_filter`, and any future provider atom). This inversion ensures new provider atoms default to success rather than misreporting as crashes. `--system-prompt <text>` and `--system-prompt-file <path>` inject the text as `%Tau.Skill{}` with `:persona_lifetime :session`; the skill is prepended to `data.skills` in `Session.init/1` BEFORE `prepend_skill_messages/2` runs so it reaches the model-visible system blob — setting only `active_skill` is NOT sufficient. | high | `test/tau/cli/headless_run_test.exs` (AC-10): replay run exits 0; JSONL persisted; :length → exit 0; :tool_loop_aborted → exit 1; :error → exit 1; :stop_sequence → exit 0; :tool_use continuation; tool_call-content+:stop (Gemini shape) → continuation (f-3); run_cmd/1 end-to-end (f-4); --system-prompt body in session messages; helper unit tests; CLI option parser | [C83-B2] |
 
 30 D-xxx entries. Each is enforceable. None require speculation.
 
@@ -521,7 +532,11 @@ These are the bar for closing the umbrella issue (#153/#149) and unblocking the 
     `:stop_sequence`, `:content_filter`, and any future provider atom).
     This inversion ensures new provider atoms default to success rather than
     misreporting as crashes.
-  - Continue looping (not exit) on `:tool_use` — more tool iterations follow.
+  - Continue looping (not exit) when `msg.content` contains any `%{type: :tool_call}` block,
+    regardless of `stop_reason` (f-2 fix — content-first rule). Gemini and Bedrock emit
+    `stop_reason: :stop` on tool-call turns; keying on `stop_reason` alone exits the session
+    before the FSM can dispatch the tool. The `:tool_use` stop_reason case is subsumed:
+    Anthropic/OpenAI always populate tool_call content alongside `:tool_use`.
   - Persist the session to JSONL; `tau sessions list` shows the session after the run.
 - `tau run "prompt" --system-prompt "text"` injects the text into the model-visible
   system blob; the skill body MUST appear in `data.messages` as a system-role
@@ -531,7 +546,9 @@ These are the bar for closing the umbrella issue (#153/#149) and unblocking the 
   (bounded 10 s) before returning exit code 1 (B3 fix).
 - Tests: `test/tau/cli/headless_run_test.exs` — replay run, JSONL persistence,
   stop_reason matrix (:stop/:length/:tool_loop_aborted/:error/:tool_use continuation/
-  :stop_sequence), system-prompt body in messages, helper unit tests, CLI option parser.
+  :stop_sequence), tool_call-content+:stop Gemini shape → continuation (f-3),
+  run_cmd/1 end-to-end via real @doc-false entry (f-4, including resolve_system_prompt
+  {:error,_} → exit 1), system-prompt body in messages, helper unit tests, CLI option parser.
   Tests exercise `Tau.CLI`'s real public/@doc-false functions, not private duplicates.
 - This test runs in CI on every PR and is a blocking gate.
 

--- a/docs/spec/SPEC-USER-TURN.md
+++ b/docs/spec/SPEC-USER-TURN.md
@@ -8,7 +8,7 @@
 | **Method** | PSDH (`.claude/skills/design-reasoning`); L0 + L1 + boundary contracts. L2 deferred. |
 | **Self-hosting target** | Working TUI is the prerequisite for Tau replacing the vendored claude-harness as the dev tool for Tau itself (see memory: `project_1_0_self_hosting.md`). |
 
-**Changelog:** WI-C / #202: D-009 reworded — visible-content guarantee unified into `Assembler.finalize/3`. #211: C53, D-040 — plain-release CLI dispatch via `TAU_CLI_ARGV`; B2 contract amended with three argv sources. #179: C54, D-041 — mid-session model swap via `/model`; AC-8 added; D-002 amended to name the sanctioned swap path; B4 boundary contract note added. #227: C55, D-042 — built-in slash-command registry + inline dispatch; B4 amended with built-in outcome INV; D-042 added. #178 PR2b: C67, D-016 (implemented), D-048, D-049, AC-9 — async `/compact` built-in; `:compacting` FSM state; B4 amended with `{:async_compact, binary}` outcome; [C26] partially resolved; Appendix B updated. #181 PR2: C68 — OpenAI-compatible provider failure surface (synchronous missing-key vs. in-stream HTTP error); Appendix B updated. #181 PR5: C80 — Azure OpenAI auth/URL shape constraint (api-key header, deployment-based URL); Appendix B updated. #181 PR6: C81 — Custom configure-by-URL provider; nil api_key valid (omits Authorization header); synchronous error only on missing_base_url; Appendix B updated. #182 PR-A: C82, D-056 — Copilot OAuth auth subsystem + API token refresh contract; Appendix B updated.
+**Changelog:** WI-C / #202: D-009 reworded — visible-content guarantee unified into `Assembler.finalize/3`. #211: C53, D-040 — plain-release CLI dispatch via `TAU_CLI_ARGV`; B2 contract amended with three argv sources. #179: C54, D-041 — mid-session model swap via `/model`; AC-8 added; D-002 amended to name the sanctioned swap path; B4 boundary contract note added. #227: C55, D-042 — built-in slash-command registry + inline dispatch; B4 amended with built-in outcome INV; D-042 added. #178 PR2b: C67, D-016 (implemented), D-048, D-049, AC-9 — async `/compact` built-in; `:compacting` FSM state; B4 amended with `{:async_compact, binary}` outcome; [C26] partially resolved; Appendix B updated. #181 PR2: C68 — OpenAI-compatible provider failure surface (synchronous missing-key vs. in-stream HTTP error); Appendix B updated. #181 PR5: C80 — Azure OpenAI auth/URL shape constraint (api-key header, deployment-based URL); Appendix B updated. #181 PR6: C81 — Custom configure-by-URL provider; nil api_key valid (omits Authorization header); synchronous error only on missing_base_url; Appendix B updated. #182 PR-A: C82, D-056 — Copilot OAuth auth subsystem + API token refresh contract; Appendix B updated. #252: C83, D-058, AC-10 — headless FSM-backed `tau run`; B2 contract amended with headless run path INV; D-058 added; AC-10 added; Appendix B updated. Closes #213 (tau run bypassed the Session FSM).
 
 ## 0. Why this spec exists
 
@@ -65,6 +65,7 @@ Each question lists raw constraints. Format: `[Cn-Bm]` = constraint number + bou
 - **[C3-B1]** Burrito cache directory `~/.local/share/.burrito/...` extracted on first run. Two simultaneous binary invocations on a fresh install race on extraction. (Plausibly idempotent if extraction is atomic; verify.)
 - **[C4-B6]** Vault entries (OS keychain) — concurrent `Vault.put/2` from two sessions on the same key races at the OS level. Backend-dependent.
 - **★ [C5-B7]** `Tau.Settings.Cache` (`:persistent_term`) is updated on every `Settings.Watcher` reload. Subscribers to the settings PubSub topic re-read mid-turn. A turn that started with model X may finalize against model Y if a reload landed mid-stream.
+- **★ [C83-B2]** `tau run` (headless mode) calls `Tau.stop/1` to trigger JSONL flush and `%SessionEnd{}`. If `Tau.stop/1` is not called on all exit paths (including timeout), the JSONL file may be incomplete and the session FSM process leaks until the BEAM exits. The FSM is `:transient` under `Tau.Sessions.Supervisor`; a supervisor restart would clean it, but the user-facing symptom is a persisted session with a truncated transcript. Detection: the JSONL stream for a completed `tau run` must contain both `user_message` and `assistant_message` event kinds.
 
 ### Q2: What ordering assumptions are implicit?
 
@@ -191,6 +192,28 @@ INV
   - Positional VM arguments passed to a plain `mix release` launcher MUST NOT
     influence dispatch. A :no_cli resolution MUST leave the OTP app running
     with no System.halt. (Closes [C53-B2].)
+INV (headless run — D-058 / #252 / Closes #213)
+  - `tau run <prompt>` MUST drive a full Tau.Session FSM (start_session → send
+    → PubSub event drain → stop), NOT call provider.stream/3 directly. The FSM
+    provides: tool registration (Agent, Bash, all builtins), JSONL persistence,
+    PubSub lifecycle events, and permissions enforcement. A headless run that
+    bypasses the FSM cannot support the Agent tool (M1 self-hosting requirement).
+  - The headless run loop MUST subscribe to "session:<id>" PubSub BEFORE calling
+    Tau.start_session/1 (D-004 compliance — SessionStart is broadcast
+    synchronously inside FSM init and would be lost if subscription comes after).
+  - On MessageEnd with stop_reason in [:end_turn, :stop, :max_tokens]: print
+    assistant text to stdout, call Tau.stop/1 to flush JSONL, await SessionEnd.
+    Exit code 0.
+  - On MessageEnd with stop_reason :tool_use: continue waiting (tool iteration
+    in progress). Do NOT exit.
+  - On MessageEnd with stop_reason :tool_loop_aborted or :error: print to stderr,
+    call Tau.stop/1, await SessionEnd. Exit code 1.
+  - Tau.stop/1 MUST be called on every exit path (including timeout) so JSONL
+    is flushed. (Closes [C83-B2].)
+  - --system-prompt <text> (and --system-prompt-file <path>) inject the text
+    as a %Tau.Skill{} with :persona_lifetime :session, reaching the model via
+    the existing prepend_skill_messages/2 path (no new injection mechanism). The
+    seam is intentionally minimal — coordinator persona is a separate concern.
 ```
 
 ### B3 — `Tau.CLI` ↔ `Tau.TUI.App.run/0` (TUI runtime start)
@@ -411,6 +434,7 @@ Each entry: id, statement, severity, detection_method, source_constraint.
 | D-048 | **:compacting-state exit invariant (C67-B4).** Every exit edge from the `:compacting` gen_statem state MUST land in `:awaiting_user` with both `data.compaction_task` and `data.compaction_monitor` set to `nil`. Five terminal clauses cover all exit paths: (1) worker success `{ref, result}`; (2a) benign `{:DOWN, :normal}` (keep-state, result pending); (2b) crash `{:DOWN, reason}`; (3) live timeout; (4) stale timeout (no-op). `{:next_state, :awaiting_user, data}` is the return form for clauses 1, 2b, 3; clause 2a uses `{:keep_state, data}` because the result message is still pending. | high | `test/tau/session/compaction_test.exs`: happy path; postpone-and-flush; stale-result-drop after cancel; `:swap_model` busy during `:compacting` | [C67-B4] |
 | D-049 | **Compaction worker crash/timeout/cancel recovery (C67-B4).** The session FSM MUST NOT wedge when the compaction worker crashes, times out, or is cancelled — it MUST return to `:awaiting_user`. It MUST NOT trigger a spurious crash-recovery notice when `{ref,result}` and `{:DOWN, :normal}` arrive back-to-back (the double-message race). Achieved by: Clause 2a (`{:DOWN, :normal}`) is a `{:keep_state}` that preserves the pending result, so Clause 1 still processes it; all five typed clauses clear worker fields, so stale messages fail guards and reach the catch-all no-op. | high | `test/tau/session/compaction_test.exs`: worker-crash recovery (session not wedged); race test `{ref,result}` + `{:DOWN}` × 50 (NO spurious crash recovery); late-timeout-after-success (no FSM crash); `/cancel` outside `:compacting` (no FSM crash) | [C67-B4] |
 | D-056 | **Copilot API token refresh contract (C82-B8).** `Tau.Providers.Copilot.Auth.token/1` MUST refresh the short-lived API token when `expires_at - now < 5 min` (300,000 ms). The refresh path is: (1) call `resolve_oauth/1` to obtain the long-lived OAuth token; (2) `POST https://api.github.com/copilot_internal/v2/token` with `Authorization: token <oauth_token>`; (3) parse `{"token": "...", "expires_at": "ISO8601"}` from the 200 response; (4) store the result in `Tau.Providers.Copilot.TokenStore` (supervised GenServer, NOT module-level state). Any non-200 response or network error MUST return `{:error, :oauth_refresh_failed}` and emit `[:tau, :copilot, :auth, :refresh_failed]` telemetry. Missing OAuth token MUST return `{:error, :no_auth}`. All errors MUST surface a user-actionable message via `Auth.describe_error/1` naming the `gh auth login --scopes copilot` renewal path. | high | `test/tau/providers/copilot/auth_test.exs`: hosts.json parsing; apps.json fallback; env-var override; refresh/1 success (Bypass stub); refresh/1 non-200 → `:oauth_refresh_failed`; token/1 proactive-refresh when nearing expiry; token/1 skips refresh when token is fresh; missing file → `:no_auth`; malformed JSON → `:oauth_malformed` | [C82-B8] |
+| D-058 | **Headless FSM-backed `tau run` (C83-B2).** `tau run <prompt>` MUST start a full `Tau.Session` FSM via `Tau.start_session/1`, send the prompt via `Tau.send/2`, and consume the PubSub event stream until `%SessionEnd{}`. It MUST NOT call `provider.stream/3` directly (which bypasses tools, JSONL persistence, and permissions). The PubSub subscription MUST be established BEFORE `Tau.start_session/1` returns (D-004). `Tau.stop/1` MUST be called on every exit path (`:end_turn`, `:stop`, `:max_tokens`, `:tool_loop_aborted`, error, timeout) to flush JSONL before the process exits. Exit code: 0 on clean stop (`stop_reason in [:end_turn, :stop, :max_tokens]`); 1 otherwise. `--system-prompt <text>` and `--system-prompt-file <path>` inject the text as `%Tau.Skill{}` with `:persona_lifetime :session` via the existing `prepend_skill_messages/2` path — no new injection mechanism. | high | `test/tau/cli/headless_run_test.exs` (AC-10): replay provider produces assistant text and exits 0; JSONL persisted after run; --system-prompt injection; CLI option parser accepts --system-prompt/--system-prompt-file | [C83-B2] |
 
 30 D-xxx entries. Each is enforceable. None require speculation.
 
@@ -470,6 +494,18 @@ These are the bar for closing the umbrella issue (#153/#149) and unblocking the 
 - `/cancel` outside `:compacting` MUST NOT crash the FSM (guarded demonitor, C67-B4).
 - 3 consecutive compaction failures (sync or async, shared counter): FSM aborts the next sync turn with `stop_reason: :compaction_failed` (D-016).
 - Tests: `test/tau/session/compaction_test.exs` (all cases) and `test/tau/commands/builtin/compact_test.exs`.
+
+### AC-10: Headless FSM-backed run (D-058, C83-B2, #252, Closes #213)
+
+- `tau run "prompt" --provider replay --model replay` MUST:
+  - Start a full `Tau.Session` FSM (not a bare provider.stream/3 call).
+  - Print the assistant text response to stdout.
+  - Exit with code 0 on a clean stop (stop_reason in [:end_turn, :stop, :max_tokens]).
+  - Persist the session to JSONL; `tau sessions list` shows the session after the run.
+- `tau run "prompt" --system-prompt "text"` injects the text as a system-level skill; the session starts without error and the CLI option is parsed correctly.
+- `tau run "prompt" --system-prompt-file <path>` reads the file and applies it the same way.
+- Tests: `test/tau/cli/headless_run_test.exs` (11 cases) — replay run, JSONL persistence, system-prompt injection, CLI option parser.
+- This test runs in CI on every PR and is a blocking gate.
 
 ## 8. Out-of-scope hazards (explicitly deferred)
 
@@ -552,5 +588,7 @@ For each constraint, the file:line where it lives in the current codebase:
 | C81 | `lib/tau/providers/custom.ex` — `Tau.Providers.Custom` (`@behaviour Tau.Provider`; `build_headers/2` omits `Authorization` when `api_key` nil; `resolve_config/0` returns `{:error, :missing_base_url}` as sole synchronous hard-config error); `lib/tau/providers/shared/tool_spec.ex` — `shape/2` clause for `Tau.Providers.Custom`; `lib/tau/cli.ex` — `resolve_provider("custom")` + `doctor_cmd` Custom base_url/api_key report; `docs/providers/custom.md`; `docs/spec/SPEC-USER-TURN.md` — C81, this Appendix B entry; `test/tau/providers/custom_test.exs` |
 
 | C82 | `lib/tau/providers/copilot/auth.ex` — `Tau.Providers.Copilot.Auth` (`resolve_oauth/1`, `token/1`, `refresh/2`, `describe_error/1`); `lib/tau/providers/copilot/token_store.ex` — `Tau.Providers.Copilot.TokenStore` (supervised GenServer; `get/0`, `put/1`, `clear/0`); `lib/tau/application.ex` — `Tau.Providers.Copilot.TokenStore` child spec; `lib/tau/cli.ex` — `doctor_cmd` Copilot auth-status report; `docs/spec/SPEC-USER-TURN.md` — C82, D-056; `test/tau/providers/copilot/auth_test.exs` |
+
+| C83, D-058 | `lib/tau/cli.ex` — `run_cmd/1` (FSM-backed headless path: `Tau.start_session`, `Tau.send`, `drain_run_loop`, `drain_session_end`, `extract_assistant_text`, `extract_error_text`, `resolve_system_prompt`, `build_headless_skill`, `put_if_not_nil`); `spec/0` `run` subcommand amended with `--system-prompt` and `--system-prompt-file` options; `alias Tau.Session.Events` replaces `alias Tau.Provider.Event`; `docs/spec/SPEC-USER-TURN.md` — C83, D-058, AC-10, B2 headless-run INV, Appendix B; `test/tau/cli/headless_run_test.exs` |
 
 Other constraints map to sites named in their text.

--- a/docs/spec/SPEC-USER-TURN.md
+++ b/docs/spec/SPEC-USER-TURN.md
@@ -201,19 +201,34 @@ INV (headless run — D-058 / #252 / Closes #213)
   - The headless run loop MUST subscribe to "session:<id>" PubSub BEFORE calling
     Tau.start_session/1 (D-004 compliance — SessionStart is broadcast
     synchronously inside FSM init and would be lost if subscription comes after).
-  - On MessageEnd with stop_reason in [:end_turn, :stop, :max_tokens]: print
-    assistant text to stdout, call Tau.stop/1 to flush JSONL, await SessionEnd.
-    Exit code 0.
+  - Terminal stop_reason atoms are those providers actually emit after
+    normalisation by their wire decoders:
+      :stop   — Anthropic end_turn, OpenAI stop, Replay done (all normalised
+                 to :stop by anthropic.ex:234 / openai_chat_wire.ex:193).
+      :length — Anthropic/OpenAI max_tokens / length (normalised by
+                 anthropic.ex:235 and openai_chat_wire.ex:194). Context-window
+                 exhausted; still a usable response.
+    Note: the wire strings "end_turn" and "max_tokens" are NOT atoms emitted
+    by providers. Using :end_turn or :max_tokens in the terminal set would cause
+    context-window stops (:length) to fall through to the error branch.
+  - On MessageEnd with stop_reason in [:stop, :length]: print assistant text to
+    stdout, call Tau.stop/1 to flush JSONL, await SessionEnd. Exit code 0.
   - On MessageEnd with stop_reason :tool_use: continue waiting (tool iteration
     in progress). Do NOT exit.
   - On MessageEnd with stop_reason :tool_loop_aborted or :error: print to stderr,
     call Tau.stop/1, await SessionEnd. Exit code 1.
-  - Tau.stop/1 MUST be called on every exit path (including timeout) so JSONL
-    is flushed. (Closes [C83-B2].)
+  - Tau.stop/1 MUST be called on every exit path INCLUDING the timeout branch so
+    JSONL is flushed. After calling Tau.stop/1, drain_session_end/2 MUST be
+    awaited (bounded 10 s) before returning — the timeout branch is NOT exempt.
+    (Closes [C83-B2].)
   - --system-prompt <text> (and --system-prompt-file <path>) inject the text
-    as a %Tau.Skill{} with :persona_lifetime :session, reaching the model via
-    the existing prepend_skill_messages/2 path (no new injection mechanism). The
-    seam is intentionally minimal — coordinator persona is a separate concern.
+    as a %Tau.Skill{} with :persona_lifetime :session. The skill is prepended
+    to data.skills in Session.init/1 (before prepend_skill_messages/2 runs) so
+    the body reaches the model-visible system blob. Setting only active_skill
+    (without adding to data.skills) is NOT sufficient — active_skill gates
+    permissions only, not system blob content. No new injection mechanism is
+    introduced; the skill enters via the existing prepend_skill_messages/2 path.
+    The seam is intentionally minimal — coordinator persona is a separate concern.
 ```
 
 ### B3 — `Tau.CLI` ↔ `Tau.TUI.App.run/0` (TUI runtime start)
@@ -434,7 +449,7 @@ Each entry: id, statement, severity, detection_method, source_constraint.
 | D-048 | **:compacting-state exit invariant (C67-B4).** Every exit edge from the `:compacting` gen_statem state MUST land in `:awaiting_user` with both `data.compaction_task` and `data.compaction_monitor` set to `nil`. Five terminal clauses cover all exit paths: (1) worker success `{ref, result}`; (2a) benign `{:DOWN, :normal}` (keep-state, result pending); (2b) crash `{:DOWN, reason}`; (3) live timeout; (4) stale timeout (no-op). `{:next_state, :awaiting_user, data}` is the return form for clauses 1, 2b, 3; clause 2a uses `{:keep_state, data}` because the result message is still pending. | high | `test/tau/session/compaction_test.exs`: happy path; postpone-and-flush; stale-result-drop after cancel; `:swap_model` busy during `:compacting` | [C67-B4] |
 | D-049 | **Compaction worker crash/timeout/cancel recovery (C67-B4).** The session FSM MUST NOT wedge when the compaction worker crashes, times out, or is cancelled — it MUST return to `:awaiting_user`. It MUST NOT trigger a spurious crash-recovery notice when `{ref,result}` and `{:DOWN, :normal}` arrive back-to-back (the double-message race). Achieved by: Clause 2a (`{:DOWN, :normal}`) is a `{:keep_state}` that preserves the pending result, so Clause 1 still processes it; all five typed clauses clear worker fields, so stale messages fail guards and reach the catch-all no-op. | high | `test/tau/session/compaction_test.exs`: worker-crash recovery (session not wedged); race test `{ref,result}` + `{:DOWN}` × 50 (NO spurious crash recovery); late-timeout-after-success (no FSM crash); `/cancel` outside `:compacting` (no FSM crash) | [C67-B4] |
 | D-056 | **Copilot API token refresh contract (C82-B8).** `Tau.Providers.Copilot.Auth.token/1` MUST refresh the short-lived API token when `expires_at - now < 5 min` (300,000 ms). The refresh path is: (1) call `resolve_oauth/1` to obtain the long-lived OAuth token; (2) `POST https://api.github.com/copilot_internal/v2/token` with `Authorization: token <oauth_token>`; (3) parse `{"token": "...", "expires_at": "ISO8601"}` from the 200 response; (4) store the result in `Tau.Providers.Copilot.TokenStore` (supervised GenServer, NOT module-level state). Any non-200 response or network error MUST return `{:error, :oauth_refresh_failed}` and emit `[:tau, :copilot, :auth, :refresh_failed]` telemetry. Missing OAuth token MUST return `{:error, :no_auth}`. All errors MUST surface a user-actionable message via `Auth.describe_error/1` naming the `gh auth login --scopes copilot` renewal path. | high | `test/tau/providers/copilot/auth_test.exs`: hosts.json parsing; apps.json fallback; env-var override; refresh/1 success (Bypass stub); refresh/1 non-200 → `:oauth_refresh_failed`; token/1 proactive-refresh when nearing expiry; token/1 skips refresh when token is fresh; missing file → `:no_auth`; malformed JSON → `:oauth_malformed` | [C82-B8] |
-| D-058 | **Headless FSM-backed `tau run` (C83-B2).** `tau run <prompt>` MUST start a full `Tau.Session` FSM via `Tau.start_session/1`, send the prompt via `Tau.send/2`, and consume the PubSub event stream until `%SessionEnd{}`. It MUST NOT call `provider.stream/3` directly (which bypasses tools, JSONL persistence, and permissions). The PubSub subscription MUST be established BEFORE `Tau.start_session/1` returns (D-004). `Tau.stop/1` MUST be called on every exit path (`:end_turn`, `:stop`, `:max_tokens`, `:tool_loop_aborted`, error, timeout) to flush JSONL before the process exits. Exit code: 0 on clean stop (`stop_reason in [:end_turn, :stop, :max_tokens]`); 1 otherwise. `--system-prompt <text>` and `--system-prompt-file <path>` inject the text as `%Tau.Skill{}` with `:persona_lifetime :session` via the existing `prepend_skill_messages/2` path — no new injection mechanism. | high | `test/tau/cli/headless_run_test.exs` (AC-10): replay provider produces assistant text and exits 0; JSONL persisted after run; --system-prompt injection; CLI option parser accepts --system-prompt/--system-prompt-file | [C83-B2] |
+| D-058 | **Headless FSM-backed `tau run` (C83-B2).** `tau run <prompt>` MUST start a full `Tau.Session` FSM via `Tau.start_session/1`, send the prompt via `Tau.send/2`, and consume the PubSub event stream until `%SessionEnd{}`. It MUST NOT call `provider.stream/3` directly (which bypasses tools, JSONL persistence, and permissions). The PubSub subscription MUST be established BEFORE `Tau.start_session/1` returns (D-004). `Tau.stop/1` MUST be called on every exit path (`:stop`, `:length`, `:tool_loop_aborted`, error, timeout) to flush JSONL before the process exits; the timeout path MUST also await `drain_session_end/2` (bounded 10 s) before returning. Exit code: 0 on clean stop (`stop_reason in [:stop, :length]`); 1 otherwise. Note: provider wire decoders normalise `"end_turn"`/`"max_tokens"` to `:stop`/`:length` — the atoms `:end_turn` and `:max_tokens` are NOT emitted by any provider. `--system-prompt <text>` and `--system-prompt-file <path>` inject the text as `%Tau.Skill{}` with `:persona_lifetime :session`; the skill is prepended to `data.skills` in `Session.init/1` BEFORE `prepend_skill_messages/2` runs so it reaches the model-visible system blob — setting only `active_skill` is NOT sufficient. | high | `test/tau/cli/headless_run_test.exs` (AC-10): replay run exits 0; JSONL persisted; :length → exit 0; :tool_loop_aborted → exit 1; :error → exit 1; --system-prompt body in session messages; CLI option parser | [C83-B2] |
 
 30 D-xxx entries. Each is enforceable. None require speculation.
 
@@ -500,11 +515,21 @@ These are the bar for closing the umbrella issue (#153/#149) and unblocking the 
 - `tau run "prompt" --provider replay --model replay` MUST:
   - Start a full `Tau.Session` FSM (not a bare provider.stream/3 call).
   - Print the assistant text response to stdout.
-  - Exit with code 0 on a clean stop (stop_reason in [:end_turn, :stop, :max_tokens]).
+  - Exit with code 0 on a clean stop (`stop_reason in [:stop, :length]`).
+    Note: `:end_turn` and `:max_tokens` are NOT emitted by providers (they are
+    wire strings normalised to `:stop`/`:length` by provider decoders).
+  - Exit with code 1 on `:tool_loop_aborted`, `:error`, or unknown stop_reason.
   - Persist the session to JSONL; `tau sessions list` shows the session after the run.
-- `tau run "prompt" --system-prompt "text"` injects the text as a system-level skill; the session starts without error and the CLI option is parsed correctly.
+- `tau run "prompt" --system-prompt "text"` injects the text into the model-visible
+  system blob; the skill body MUST appear in `data.messages` as a system-role
+  skill message after `Session.init/1` completes.
 - `tau run "prompt" --system-prompt-file <path>` reads the file and applies it the same way.
-- Tests: `test/tau/cli/headless_run_test.exs` (11 cases) — replay run, JSONL persistence, system-prompt injection, CLI option parser.
+- The timeout exit path MUST also call `Tau.stop/1` and await `drain_session_end/2`
+  (bounded 10 s) before returning exit code 1 (B3 fix).
+- Tests: `test/tau/cli/headless_run_test.exs` (22 cases) — replay run, JSONL persistence,
+  stop_reason matrix (:stop/:length/:tool_loop_aborted/:error), system-prompt body in
+  messages, helper unit tests, CLI option parser. Tests exercise `Tau.CLI`'s real
+  public/@doc-false functions, not private duplicates.
 - This test runs in CI on every PR and is a blocking gate.
 
 ## 8. Out-of-scope hazards (explicitly deferred)

--- a/lib/tau/cli.ex
+++ b/lib/tau/cli.ex
@@ -325,16 +325,23 @@ defmodule Tau.CLI do
   end
 
   # Consume PubSub events for the headless run until SessionEnd.
-  # Returns 0 on :end_turn, 1 on any error or abnormal end.
-  defp drain_run_loop(session_id) do
+  # Returns 0 on a clean stop, 1 on any error or abnormal end.
+  #
+  # Terminal stop_reason atoms are those providers actually emit:
+  #   :stop   — Anthropic `end_turn`, OpenAI `stop`, Replay done (all
+  #              normalised to :stop by their respective wire decoders).
+  #   :length — Anthropic/OpenAI `max_tokens` / `length` (normalised by
+  #              openai_chat_wire.ex:194 and anthropic.ex:235); context
+  #              window exhausted but still a usable response → exit 0.
+  # Note: `:end_turn` and `:max_tokens` are NOT emitted by any provider;
+  # they were wire-format strings, not normalised atoms. Using them here
+  # would cause context-window stops to fall through to the error branch.
+  @doc false
+  def drain_run_loop(session_id) do
     receive do
       %Events.MessageEnd{session_id: ^session_id, message: msg} ->
         case msg.stop_reason do
-          stop when stop in [:end_turn, :stop, :max_tokens] ->
-            # `:end_turn` — Anthropic/OpenAI clean stop.
-            # `:stop` — Replay and OpenAI-compatible providers.
-            # `:max_tokens` — model hit its context window; still a usable
-            #   response; surface to stdout and exit 0.
+          stop when stop in [:stop, :length] ->
             text = extract_assistant_text(msg)
             if text != "", do: IO.puts(text)
             # Stop the session to flush JSONL, then await SessionEnd.
@@ -371,14 +378,18 @@ defmodule Tau.CLI do
         drain_run_loop(session_id)
     after
       120_000 ->
+        # B3 fix (D-058): timeout MUST also flush JSONL before returning.
+        # Tau.stop/1 is async; drain_session_end/2 blocks until SessionEnd
+        # (bounded by 10 s) so the flush completes before we exit.
         IO.puts(:stderr, "run timed out waiting for session response")
         Tau.stop(session_id)
-        1
+        drain_session_end(session_id, 1)
     end
   end
 
   # After calling Tau.stop/1, wait for SessionEnd to confirm JSONL flush.
-  defp drain_session_end(session_id, exit_code) do
+  @doc false
+  def drain_session_end(session_id, exit_code) do
     receive do
       %Events.SessionEnd{session_id: ^session_id} -> exit_code
       _ -> drain_session_end(session_id, exit_code)
@@ -388,8 +399,9 @@ defmodule Tau.CLI do
   end
 
   # Extract plain text from an assistant message (TextBlock type: :text).
-  defp extract_assistant_text(%Tau.Message.Assistant{content: blocks})
-       when is_list(blocks) do
+  @doc false
+  def extract_assistant_text(%Tau.Message.Assistant{content: blocks})
+      when is_list(blocks) do
     blocks
     |> Enum.flat_map(fn
       %{type: :text, text: t} when is_binary(t) -> [t]
@@ -398,38 +410,42 @@ defmodule Tau.CLI do
     |> Enum.join("")
   end
 
-  defp extract_assistant_text(_), do: ""
+  def extract_assistant_text(_), do: ""
 
   # Extract error_message or synthesise one from content blocks.
-  defp extract_error_text(%Tau.Message.Assistant{error_message: msg})
-       when is_binary(msg) and msg != "",
-       do: msg
+  @doc false
+  def extract_error_text(%Tau.Message.Assistant{error_message: msg})
+      when is_binary(msg) and msg != "",
+      do: msg
 
-  defp extract_error_text(msg), do: extract_assistant_text(msg)
+  # Fallback: no dedicated error_message field — synthesise from text blocks.
+  def extract_error_text(message), do: extract_assistant_text(message)
 
   # Resolve --system-prompt / --system-prompt-file to {:ok, text | nil}.
-  defp resolve_system_prompt(%{system_prompt: text})
-       when is_binary(text) and text != "",
-       do: {:ok, text}
+  @doc false
+  def resolve_system_prompt(%{system_prompt: text})
+      when is_binary(text) and text != "",
+      do: {:ok, text}
 
-  defp resolve_system_prompt(%{system_prompt_file: path})
-       when is_binary(path) and path != "" do
+  def resolve_system_prompt(%{system_prompt_file: path})
+      when is_binary(path) and path != "" do
     case File.read(path) do
       {:ok, text} -> {:ok, text}
       {:error, reason} -> {:error, "could not read #{path}: #{:file.format_error(reason)}"}
     end
   end
 
-  defp resolve_system_prompt(_), do: {:ok, nil}
+  def resolve_system_prompt(_), do: {:ok, nil}
 
   # Build a transient %Tau.Skill{} from inline system-prompt text so the
   # session FSM injects it as a system-role message via prepend_skill_messages/2
   # (the same mechanism used by on-disk skills loaded from CLAUDE.md / .claude/
   # skills). :persona_lifetime :session is set by run_cmd/1 so the persona
   # survives multi-turn tool iteration within a single `tau run` invocation.
-  defp build_headless_skill(nil), do: nil
+  @doc false
+  def build_headless_skill(nil), do: nil
 
-  defp build_headless_skill(text) when is_binary(text) do
+  def build_headless_skill(text) when is_binary(text) do
     %Tau.Skill{
       name: "headless-system-prompt",
       body: text,

--- a/lib/tau/cli.ex
+++ b/lib/tau/cli.ex
@@ -284,7 +284,8 @@ defmodule Tau.CLI do
   # happens AFTER start_session returns, violating D-004. We therefore
   # subscribe manually, start the session, send the message, then enumerate
   # the PubSub mailbox via receive instead of going through Tau.stream/2.
-  defp run_cmd(parsed) do
+  @doc false
+  def run_cmd(parsed) do
     prompt = parsed.args.prompt
     provider = resolve_provider(parsed.options[:provider])
     model = parsed.options[:model]
@@ -327,39 +328,60 @@ defmodule Tau.CLI do
   # Consume PubSub events for the headless run until SessionEnd.
   # Returns 0 on a clean stop, 1 on any error or abnormal end.
   #
-  # Logic: enumerate FAILURE stop_reasons (exit 1) and the CONTINUE
-  # stop_reason (loop); every other terminal stop_reason means the model
-  # produced a final assistant message → exit 0.
+  # Decision order on MessageEnd (f-1 fix, D-058 amendment):
   #
-  # Failure set (verified against session.ex, message.ex, providers/):
-  #   :error            — session-level error (session.ex:972, 1004, 2526, 2816)
-  #   :tool_loop_aborted — tool iteration cap reached (session.ex:1844)
-  #   :aborted          — coding-agent subprocess exited -2 (session.ex:2871)
-  #   :compaction_failed — 3 consecutive compaction failures (session.ex:1743)
+  #   1. CONTENT-FIRST: if msg.content has any %{type: :tool_call} block,
+  #      CONTINUE regardless of stop_reason. This is necessary because Gemini
+  #      and Bedrock emit stop_reason: :stop even on tool-call turns (they set
+  #      finishReason: "STOP" for all turns). The Session FSM itself dispatches
+  #      tools by content (session.ex ~line 1806:
+  #      Enum.filter(msg.content, &match?(%{type: :tool_call}, &1))), so we
+  #      mirror that exact decision. Killing the session on a Gemini tool-call
+  #      turn defeats M1 self-hosting (tau run --provider gemini cannot complete
+  #      any tool-using turn). The :tool_use arm below is subsumed by this check
+  #      (Anthropic/OpenAI :tool_use turns always have tool_call content).
   #
-  # Continue: :tool_use — more tool iterations follow; do NOT exit.
+  #   2. FAILURE stop_reasons → exit 1:
+  #      :error            — session-level error (session.ex:972, 1004, 2526, 2816)
+  #      :tool_loop_aborted — tool iteration cap reached (session.ex:1844)
+  #      :aborted          — coding-agent subprocess exited -2 (session.ex:2871)
+  #      :compaction_failed — 3 consecutive compaction failures (session.ex:1743)
   #
-  # Everything else (:stop, :length, :stop_sequence, :end_turn,
-  # :content_filter, and any future provider atom) means "model finished
-  # its turn and produced a usable response" → exit 0.  This inversion
-  # ensures new provider atoms default to success rather than misreporting
-  # as crashes (f-1 fix, D-058 amendment).
+  #   3. Everything else (:stop, :length, :stop_sequence, :end_turn,
+  #      :content_filter, and any future provider atom) means "model finished
+  #      its turn and produced a usable response" → exit 0. This inversion
+  #      ensures new provider atoms default to success rather than misreporting
+  #      as crashes.
+  #
+  # Grep verification: can :tool_use arrive with empty content?
+  #   lib/tau/providers/shared/openai_chat_wire.ex:195 maps "tool_calls" →
+  #   :tool_use stop_reason, but the ToolCallStart/ToolCallEnd events that
+  #   populate content blocks are emitted in the SAME stream, so the Assembler
+  #   will have decoded them into content blocks before Done fires. A :tool_use
+  #   MessageEnd with empty content would require a provider that sets
+  #   stop_reason: :tool_use but emits no ToolCallStart events — no such
+  #   provider exists in the codebase. We therefore do NOT add an explicit
+  #   :tool_use guard; step 1 (content check) subsumes it entirely.
   @doc false
   def drain_run_loop(session_id) do
     receive do
       %Events.MessageEnd{session_id: ^session_id, message: msg} ->
-        case msg.stop_reason do
-          :tool_use ->
-            # More tool iterations follow in the same session; keep waiting.
+        tool_calls =
+          is_list(msg.content) && Enum.any?(msg.content, &match?(%{type: :tool_call}, &1))
+
+        cond do
+          tool_calls ->
+            # Tool-call content present: the FSM will dispatch the tool(s).
+            # MUST continue regardless of stop_reason — Gemini emits :stop here.
             drain_run_loop(session_id)
 
-          failure when failure in [:error, :tool_loop_aborted, :aborted, :compaction_failed] ->
+          msg.stop_reason in [:error, :tool_loop_aborted, :aborted, :compaction_failed] ->
             error_text = extract_error_text(msg)
-            IO.puts(:stderr, "session error (#{failure}): #{error_text}")
+            IO.puts(:stderr, "session error (#{msg.stop_reason}): #{error_text}")
             Tau.stop(session_id)
             drain_session_end(session_id, 1)
 
-          _completed ->
+          true ->
             # Any other stop_reason means the model produced a final assistant
             # message (:stop, :length, :stop_sequence, :content_filter, etc.).
             text = extract_assistant_text(msg)

--- a/lib/tau/cli.ex
+++ b/lib/tau/cli.ex
@@ -35,7 +35,12 @@ defmodule Tau.CLI do
   `Tau.start_session/1` (D-004 compliance), sends the prompt, and consumes
   the event stream until `%Tau.Session.Events.SessionEnd{}` is received.
   Text output is written to stdout; tool events are silently consumed.
-  Exit code: 0 on `:end_turn`, 1 on error or abnormal session end.
+  Exit code: 0 for any terminal stop_reason that is not in the failure set
+  (`[:error, :tool_loop_aborted, :aborted, :compaction_failed]`); 1 for
+  failure stop_reasons or abnormal `SessionEnd` reason. Tool-call content
+  (regardless of stop_reason) causes the loop to continue rather than exit,
+  so Gemini-shaped turns (`stop_reason: :stop` + tool_call content) are
+  handled correctly.
 
   Optional `--system-prompt <text>` (or `--system-prompt-file <path>`)
   prepends a system-level persona to the session. The content is injected

--- a/lib/tau/cli.ex
+++ b/lib/tau/cli.ex
@@ -5,7 +5,7 @@ defmodule Tau.CLI do
   Subcommands currently registered in `spec/0`:
 
       tau                              # interactive TUI (M6+)
-      tau run "prompt" [opts]          # one-shot non-interactive
+      tau run "prompt" [opts]          # one-shot non-interactive, FSM-backed
       tau resume <session-id>          # replay <session-id>'s JSONL into
                                        # a NEW session (returns the new
                                        # session's id; the original is
@@ -23,9 +23,27 @@ defmodule Tau.CLI do
 
   `tau init` walks a fresh user from a clean clone to a working
   `.tau/settings.local.json`; see `Tau.CLI.Init`.
+
+  ## Headless FSM-backed run (D-058 / AC-10 / SPEC-USER-TURN §4 B2)
+
+  `tau run` drives a full `Tau.Session` FSM: tools (including `Agent` and
+  `Bash`) are registered, every turn is persisted to JSONL, and the session
+  receives the same permissions/compaction/PubSub infrastructure as a TUI
+  session. This resolves issue #213 (tau run bypassed the FSM entirely).
+
+  The run loop subscribes to the session's PubSub topic BEFORE calling
+  `Tau.start_session/1` (D-004 compliance), sends the prompt, and consumes
+  the event stream until `%Tau.Session.Events.SessionEnd{}` is received.
+  Text output is written to stdout; tool events are silently consumed.
+  Exit code: 0 on `:end_turn`, 1 on error or abnormal session end.
+
+  Optional `--system-prompt <text>` (or `--system-prompt-file <path>`)
+  prepends a system-level persona to the session. The content is injected
+  as an `active_skill` with `:persona_lifetime :session` so it survives
+  multi-turn iteration inside a single `tau run` invocation.
   """
 
-  alias Tau.Provider.Event
+  alias Tau.Session.Events
 
   def main(argv \\ []) do
     Application.ensure_all_started(:tau)
@@ -121,12 +139,23 @@ defmodule Tau.CLI do
       subcommands: [
         run: [
           name: "run",
-          about: "Run a single prompt non-interactively (streams to stdout).",
+          about: "Run a single prompt non-interactively via the FSM (streams to stdout).",
           args: [prompt: [help: "The prompt", required: true]],
           options: [
             provider: [short: "-p", long: "--provider", help: "Provider id"],
             model: [short: "-m", long: "--model", help: "Model id"],
-            session: [short: "-s", long: "--session", help: "Session id (resume)"]
+            session: [short: "-s", long: "--session", help: "Session id (resume)"],
+            # D-058 / AC-10 (SPEC-USER-TURN): headless system-prompt injection
+            # seam. Contents are injected as an active_skill with
+            # :persona_lifetime :session so they survive multi-turn iteration.
+            system_prompt: [
+              long: "--system-prompt",
+              help: "System prompt text prepended to the session (persona injection seam)"
+            ],
+            system_prompt_file: [
+              long: "--system-prompt-file",
+              help: "Path to a file whose contents become the system prompt"
+            ]
           ]
         ],
         resume: [
@@ -240,37 +269,177 @@ defmodule Tau.CLI do
     )
   end
 
+  # D-058 / AC-10 (SPEC-USER-TURN §4 B2): headless FSM-backed session run.
+  #
+  # Drives a full Tau.Session FSM so that tools (Agent, Bash, etc.) are
+  # registered, every turn is JSONL-persisted, and the session is
+  # lifecycle-identical to a TUI session. Prior to this, `tau run` called
+  # provider.stream/3 directly — no FSM, no tools, no persistence (#213).
+  #
+  # Subscribe-before-start ordering (D-004): Phoenix.PubSub.subscribe/2 is
+  # called BEFORE Tau.start_session/1 returns so that the SessionStart event
+  # (broadcast synchronously inside init/1) is not lost even though we don't
+  # consume it here. Tau.stream/2 subscribes inside its Stream.resource
+  # setup function, which runs when we first pull from the stream — that
+  # happens AFTER start_session returns, violating D-004. We therefore
+  # subscribe manually, start the session, send the message, then enumerate
+  # the PubSub mailbox via receive instead of going through Tau.stream/2.
   defp run_cmd(parsed) do
     prompt = parsed.args.prompt
     provider = resolve_provider(parsed.options[:provider])
-    model = parsed.options[:model] || provider.default_model()
+    model = parsed.options[:model]
 
-    msgs = [Tau.Message.User.new(prompt)]
-
-    case provider.stream(msgs, %{model: model}, %{}) do
-      {:ok, stream} ->
-        Enum.reduce_while(stream, 0, fn
-          %Event.TextDelta{text: t}, _ ->
-            IO.write(t)
-            {:cont, 0}
-
-          %Event.Done{}, _ ->
-            IO.puts("")
-            {:halt, 0}
-
-          %Event.Error{reason: r}, _ ->
-            IO.puts("\nerror: #{inspect(r)}")
-            {:halt, 1}
-
-          _, acc ->
-            {:cont, acc}
-        end)
-
+    case resolve_system_prompt(parsed.options) do
       {:error, reason} ->
-        IO.puts(:stderr, "provider error: #{inspect(reason)}")
+        IO.puts(:stderr, "system-prompt error: #{reason}")
+        1
+
+      {:ok, system_prompt_text} ->
+        session_id = Tau.Session.generate_id()
+
+        # D-004: subscribe BEFORE start_session so SessionStart is not missed.
+        Phoenix.PubSub.subscribe(Tau.PubSub, "session:#{session_id}")
+
+        start_opts =
+          [session_id: session_id, provider: provider]
+          |> put_if_not_nil(:model, model)
+          |> put_if_not_nil(:active_skill, build_headless_skill(system_prompt_text))
+          |> put_if_not_nil(:persona_lifetime, system_prompt_text && :session)
+
+        case Tau.start_session(start_opts) do
+          {:ok, ^session_id} ->
+            case Tau.send(session_id, prompt) do
+              :ok ->
+                drain_run_loop(session_id)
+
+              {:error, reason} ->
+                IO.puts(:stderr, "send error: #{inspect(reason)}")
+                1
+            end
+
+          {:error, reason} ->
+            IO.puts(:stderr, "session start error: #{inspect(reason)}")
+            1
+        end
+    end
+  end
+
+  # Consume PubSub events for the headless run until SessionEnd.
+  # Returns 0 on :end_turn, 1 on any error or abnormal end.
+  defp drain_run_loop(session_id) do
+    receive do
+      %Events.MessageEnd{session_id: ^session_id, message: msg} ->
+        case msg.stop_reason do
+          stop when stop in [:end_turn, :stop, :max_tokens] ->
+            # `:end_turn` — Anthropic/OpenAI clean stop.
+            # `:stop` — Replay and OpenAI-compatible providers.
+            # `:max_tokens` — model hit its context window; still a usable
+            #   response; surface to stdout and exit 0.
+            text = extract_assistant_text(msg)
+            if text != "", do: IO.puts(text)
+            # Stop the session to flush JSONL, then await SessionEnd.
+            Tau.stop(session_id)
+            drain_session_end(session_id, 0)
+
+          :tool_use ->
+            # More tool iterations follow in the same session; keep waiting.
+            drain_run_loop(session_id)
+
+          :tool_loop_aborted ->
+            IO.puts(:stderr, "session aborted: tool iteration cap reached")
+            Tau.stop(session_id)
+            drain_session_end(session_id, 1)
+
+          reason ->
+            error_text = extract_error_text(msg)
+            IO.puts(:stderr, "session error (#{reason}): #{error_text}")
+            Tau.stop(session_id)
+            drain_session_end(session_id, 1)
+        end
+
+      %Events.SessionEnd{session_id: ^session_id, reason: reason} ->
+        # SessionEnd may arrive before we call Tau.stop (e.g. error path).
+        case reason do
+          :normal -> 0
+          :user -> 0
+          _ -> 1
+        end
+
+      # Ignore other events (ToolStart, ToolEnd, MessageStart, MessageUpdate,
+      # SessionStart, SystemNotice, SkillActivated, Cancelled).
+      _ ->
+        drain_run_loop(session_id)
+    after
+      120_000 ->
+        IO.puts(:stderr, "run timed out waiting for session response")
+        Tau.stop(session_id)
         1
     end
   end
+
+  # After calling Tau.stop/1, wait for SessionEnd to confirm JSONL flush.
+  defp drain_session_end(session_id, exit_code) do
+    receive do
+      %Events.SessionEnd{session_id: ^session_id} -> exit_code
+      _ -> drain_session_end(session_id, exit_code)
+    after
+      10_000 -> exit_code
+    end
+  end
+
+  # Extract plain text from an assistant message (TextBlock type: :text).
+  defp extract_assistant_text(%Tau.Message.Assistant{content: blocks})
+       when is_list(blocks) do
+    blocks
+    |> Enum.flat_map(fn
+      %{type: :text, text: t} when is_binary(t) -> [t]
+      _ -> []
+    end)
+    |> Enum.join("")
+  end
+
+  defp extract_assistant_text(_), do: ""
+
+  # Extract error_message or synthesise one from content blocks.
+  defp extract_error_text(%Tau.Message.Assistant{error_message: msg})
+       when is_binary(msg) and msg != "",
+       do: msg
+
+  defp extract_error_text(msg), do: extract_assistant_text(msg)
+
+  # Resolve --system-prompt / --system-prompt-file to {:ok, text | nil}.
+  defp resolve_system_prompt(%{system_prompt: text})
+       when is_binary(text) and text != "",
+       do: {:ok, text}
+
+  defp resolve_system_prompt(%{system_prompt_file: path})
+       when is_binary(path) and path != "" do
+    case File.read(path) do
+      {:ok, text} -> {:ok, text}
+      {:error, reason} -> {:error, "could not read #{path}: #{:file.format_error(reason)}"}
+    end
+  end
+
+  defp resolve_system_prompt(_), do: {:ok, nil}
+
+  # Build a transient %Tau.Skill{} from inline system-prompt text so the
+  # session FSM injects it as a system-role message via prepend_skill_messages/2
+  # (the same mechanism used by on-disk skills loaded from CLAUDE.md / .claude/
+  # skills). :persona_lifetime :session is set by run_cmd/1 so the persona
+  # survives multi-turn tool iteration within a single `tau run` invocation.
+  defp build_headless_skill(nil), do: nil
+
+  defp build_headless_skill(text) when is_binary(text) do
+    %Tau.Skill{
+      name: "headless-system-prompt",
+      body: text,
+      path: "<cli:--system-prompt>",
+      description: "System prompt injected via --system-prompt / --system-prompt-file"
+    }
+  end
+
+  defp put_if_not_nil(opts, _key, nil), do: opts
+  defp put_if_not_nil(opts, key, value), do: Keyword.put(opts, key, value)
 
   defp resume_cmd(parsed) do
     case Tau.resume(parsed.args.id) do

--- a/lib/tau/cli.ex
+++ b/lib/tau/cli.ex
@@ -327,41 +327,46 @@ defmodule Tau.CLI do
   # Consume PubSub events for the headless run until SessionEnd.
   # Returns 0 on a clean stop, 1 on any error or abnormal end.
   #
-  # Terminal stop_reason atoms are those providers actually emit:
-  #   :stop   — Anthropic `end_turn`, OpenAI `stop`, Replay done (all
-  #              normalised to :stop by their respective wire decoders).
-  #   :length — Anthropic/OpenAI `max_tokens` / `length` (normalised by
-  #              openai_chat_wire.ex:194 and anthropic.ex:235); context
-  #              window exhausted but still a usable response → exit 0.
-  # Note: `:end_turn` and `:max_tokens` are NOT emitted by any provider;
-  # they were wire-format strings, not normalised atoms. Using them here
-  # would cause context-window stops to fall through to the error branch.
+  # Logic: enumerate FAILURE stop_reasons (exit 1) and the CONTINUE
+  # stop_reason (loop); every other terminal stop_reason means the model
+  # produced a final assistant message → exit 0.
+  #
+  # Failure set (verified against session.ex, message.ex, providers/):
+  #   :error            — session-level error (session.ex:972, 1004, 2526, 2816)
+  #   :tool_loop_aborted — tool iteration cap reached (session.ex:1844)
+  #   :aborted          — coding-agent subprocess exited -2 (session.ex:2871)
+  #   :compaction_failed — 3 consecutive compaction failures (session.ex:1743)
+  #
+  # Continue: :tool_use — more tool iterations follow; do NOT exit.
+  #
+  # Everything else (:stop, :length, :stop_sequence, :end_turn,
+  # :content_filter, and any future provider atom) means "model finished
+  # its turn and produced a usable response" → exit 0.  This inversion
+  # ensures new provider atoms default to success rather than misreporting
+  # as crashes (f-1 fix, D-058 amendment).
   @doc false
   def drain_run_loop(session_id) do
     receive do
       %Events.MessageEnd{session_id: ^session_id, message: msg} ->
         case msg.stop_reason do
-          stop when stop in [:stop, :length] ->
+          :tool_use ->
+            # More tool iterations follow in the same session; keep waiting.
+            drain_run_loop(session_id)
+
+          failure when failure in [:error, :tool_loop_aborted, :aborted, :compaction_failed] ->
+            error_text = extract_error_text(msg)
+            IO.puts(:stderr, "session error (#{failure}): #{error_text}")
+            Tau.stop(session_id)
+            drain_session_end(session_id, 1)
+
+          _completed ->
+            # Any other stop_reason means the model produced a final assistant
+            # message (:stop, :length, :stop_sequence, :content_filter, etc.).
             text = extract_assistant_text(msg)
             if text != "", do: IO.puts(text)
             # Stop the session to flush JSONL, then await SessionEnd.
             Tau.stop(session_id)
             drain_session_end(session_id, 0)
-
-          :tool_use ->
-            # More tool iterations follow in the same session; keep waiting.
-            drain_run_loop(session_id)
-
-          :tool_loop_aborted ->
-            IO.puts(:stderr, "session aborted: tool iteration cap reached")
-            Tau.stop(session_id)
-            drain_session_end(session_id, 1)
-
-          reason ->
-            error_text = extract_error_text(msg)
-            IO.puts(:stderr, "session error (#{reason}): #{error_text}")
-            Tau.stop(session_id)
-            drain_session_end(session_id, 1)
         end
 
       %Events.SessionEnd{session_id: ^session_id, reason: reason} ->

--- a/lib/tau/session.ex
+++ b/lib/tau/session.ex
@@ -471,6 +471,23 @@ defmodule Tau.Session do
 
         skills = load_skills(cwd)
 
+        # D-058 / AC-10 (SPEC-USER-TURN §4 B2): if a headless skill was
+        # injected via `:active_skill` opt (e.g. `--system-prompt` from
+        # `tau run`), prepend it to the skill list so
+        # `prepend_skill_messages/2` includes its body in the model-visible
+        # system blob. Without this the skill only gates permissions
+        # (`eval_ctx`) but never reaches the provider call. The entry is
+        # prepended (highest priority) and deliberately has no
+        # `disable_model_invocation` flag so it is always model-visible.
+        skills =
+          case opts[:active_skill] do
+            %Tau.Skill{name: name} = skill ->
+              [{name, skill} | skills]
+
+            _ ->
+              skills
+          end
+
         # ADR-0013 / ADR-0015: skills with `disable_model_invocation: true`
         # are background-only — their bodies (and `# Skill: <name>` headings)
         # MUST NOT enter the model-visible system_blob, lest internal

--- a/test/tau/cli/headless_run_test.exs
+++ b/test/tau/cli/headless_run_test.exs
@@ -1,0 +1,335 @@
+defmodule Tau.CLI.HeadlessRunTest do
+  @moduledoc """
+  AC-10 / D-058 (SPEC-USER-TURN §4 B2): headless FSM-backed `tau run`.
+
+  Verifies that `tau run` drives a full Tau.Session FSM (not a bare
+  provider.stream/3 call), that JSONL is persisted, and that the command
+  surface works correctly with the Replay provider.
+
+  Tests do NOT invoke `Tau.CLI.main/1` directly because that function
+  calls `System.halt/1`. Instead they call `run_cmd_for_test/2` which
+  invokes the same session machinery the rewritten `run_cmd/1` uses, so
+  all observable contracts (PubSub ordering, JSONL output, exit code) are
+  tested against real FSM behaviour.
+
+  Replay provider is used for hermeticity; the default fixture emits
+  `"(replay) hello"` via a TextDelta event so stdout assertions are stable.
+  """
+
+  use ExUnit.Case, async: false
+
+  import Tau.Test.SessionHelper, only: [start_session_for_test: 1]
+
+  alias Tau.Provider.Event
+  alias Tau.Session.Events, as: SE
+  alias Tau.Persistence.Jsonl, as: PJsonl
+
+  setup do
+    tmp = Path.join(System.tmp_dir!(), "tau-headless-run-#{System.unique_integer([:positive])}")
+    File.mkdir_p!(tmp)
+    Application.put_env(:tau, :data_dir, tmp)
+
+    on_exit(fn ->
+      File.rm_rf!(tmp)
+      Application.delete_env(:tau, :data_dir)
+    end)
+
+    %{data_dir: tmp}
+  end
+
+  # ---------------------------------------------------------------------------
+  # Helper: run the headless FSM-backed session logic directly (no System.halt)
+  # ---------------------------------------------------------------------------
+
+  # Mirrors run_cmd/1 logic in Tau.CLI but returns {stdout_text, exit_code}
+  # instead of calling System.halt. Accepts :provider, :model, :system_prompt,
+  # :provider_ctx. All callers supply explicit opts.
+  defp run_headless(prompt, opts) do
+    provider = Keyword.get(opts, :provider, Tau.Providers.Replay)
+    model = Keyword.get(opts, :model, "replay")
+    system_prompt = Keyword.get(opts, :system_prompt)
+    provider_ctx = Keyword.get(opts, :provider_ctx, %{})
+
+    session_id = Tau.Session.generate_id()
+
+    # D-004: subscribe BEFORE start_session (mirrors run_cmd/1 discipline).
+    Phoenix.PubSub.subscribe(Tau.PubSub, "session:#{session_id}")
+
+    start_opts =
+      [session_id: session_id, provider: provider, model: model, provider_ctx: provider_ctx]
+      |> then(fn o ->
+        if system_prompt do
+          skill = %Tau.Skill{
+            name: "headless-system-prompt",
+            body: system_prompt,
+            path: "<test>",
+            description: "test system prompt"
+          }
+
+          o
+          |> Keyword.put(:active_skill, skill)
+          |> Keyword.put(:persona_lifetime, :session)
+        else
+          o
+        end
+      end)
+
+    {:ok, ^session_id} = start_session_for_test(start_opts)
+
+    :ok = Tau.send(session_id, prompt)
+
+    {output, exit_code} = drain_headless(session_id)
+    {output, exit_code}
+  end
+
+  # Drain PubSub events and return {stdout_text, exit_code} — mirrors
+  # drain_run_loop/1 + drain_session_end/2 in Tau.CLI.
+  # After a terminal MessageEnd, calls Tau.stop/1 to flush JSONL,
+  # then awaits SessionEnd.
+  defp drain_headless(session_id, acc \\ "") do
+    receive do
+      %SE.MessageEnd{session_id: ^session_id, message: msg} ->
+        case msg.stop_reason do
+          stop when stop in [:end_turn, :stop, :max_tokens] ->
+            text = extract_text(msg)
+            new_acc = if text != "", do: acc <> text <> "\n", else: acc
+            Tau.stop(session_id)
+            drain_session_end(session_id, new_acc, 0)
+
+          :tool_use ->
+            drain_headless(session_id, acc)
+
+          :tool_loop_aborted ->
+            Tau.stop(session_id)
+            drain_session_end(session_id, acc, 1)
+
+          _other ->
+            Tau.stop(session_id)
+            drain_session_end(session_id, acc, 1)
+        end
+
+      %SE.SessionEnd{session_id: ^session_id, reason: reason} ->
+        exit_code = if reason in [:normal, :user], do: 0, else: 1
+        {acc, exit_code}
+
+      _ ->
+        drain_headless(session_id, acc)
+    after
+      15_000 ->
+        Tau.stop(session_id)
+        {acc, 1}
+    end
+  end
+
+  defp drain_session_end(session_id, acc, exit_code) do
+    receive do
+      %SE.SessionEnd{session_id: ^session_id} -> {acc, exit_code}
+      _ -> drain_session_end(session_id, acc, exit_code)
+    after
+      5_000 -> {acc, exit_code}
+    end
+  end
+
+  defp extract_text(%Tau.Message.Assistant{content: blocks}) when is_list(blocks) do
+    Enum.flat_map(blocks, fn
+      %{type: :text, text: t} when is_binary(t) -> [t]
+      _ -> []
+    end)
+    |> Enum.join("")
+  end
+
+  defp extract_text(_), do: ""
+
+  # Default Replay fixture so tests can inject deterministic events.
+  defp replay_fixture do
+    [
+      %Event.Start{request_id: "r", model: "replay"},
+      %Event.TextStart{block_id: "b"},
+      %Event.TextDelta{block_id: "b", text: "(replay) hello"},
+      %Event.TextEnd{block_id: "b"},
+      %Event.Done{stop_reason: :stop, usage: %{}}
+    ]
+  end
+
+  # ---------------------------------------------------------------------------
+  # AC-10 / D-058: core headless run tests
+  # ---------------------------------------------------------------------------
+
+  describe "headless FSM-backed session run (AC-10, D-058)" do
+    test "replay provider produces assistant text and exits 0", %{data_dir: _tmp} do
+      {output, exit_code} =
+        run_headless("ping",
+          provider: Tau.Providers.Replay,
+          model: "replay",
+          provider_ctx: %{replay_fixture: replay_fixture()}
+        )
+
+      assert exit_code == 0,
+             "expected exit code 0 from a clean replay run; got #{exit_code}"
+
+      assert output =~ "(replay) hello",
+             "expected Replay fixture token in captured output; got:\n#{inspect(output)}"
+    end
+
+    test "JSONL is persisted after headless run", %{data_dir: _tmp} do
+      session_id = Tau.Session.generate_id()
+
+      Phoenix.PubSub.subscribe(Tau.PubSub, "session:#{session_id}")
+
+      start_opts = [
+        session_id: session_id,
+        provider: Tau.Providers.Replay,
+        model: "replay",
+        provider_ctx: %{replay_fixture: replay_fixture()}
+      ]
+
+      {:ok, ^session_id} = start_session_for_test(start_opts)
+      :ok = Tau.send(session_id, "persist-test")
+      drain_headless(session_id)
+
+      # Verify JSONL file exists and has content.
+      sessions = Tau.list_sessions()
+      matching = Enum.filter(sessions, &(&1.id == session_id))
+
+      assert length(matching) == 1,
+             "expected the session to appear in Tau.list_sessions/0"
+
+      # Read the raw JSONL and confirm user + assistant events landed.
+      events = PJsonl.stream(session_id) |> Enum.to_list()
+      assert length(events) > 0, "expected non-empty JSONL for session #{session_id}"
+
+      kinds = Enum.map(events, & &1["kind"])
+
+      assert "user_message" in kinds,
+             "expected a user_message event in JSONL; got kinds: #{inspect(kinds)}"
+    end
+
+    test "default Replay provider used when none specified", %{data_dir: _tmp} do
+      # Explicitly pass the Replay provider; confirms the resolver path is wired.
+      {output, exit_code} =
+        run_headless("hello",
+          provider: Tau.Providers.Replay,
+          model: "replay",
+          provider_ctx: %{replay_fixture: replay_fixture()}
+        )
+
+      assert exit_code == 0
+      assert is_binary(output)
+    end
+  end
+
+  describe "--system-prompt injection seam (D-058 §system-prompt)" do
+    test "system prompt is prepended as a system-role skill message" do
+      # We verify by running a session with a system_prompt and confirming
+      # the session starts successfully with no error (the skill injection
+      # path is exercised via Session.init/1's prepend_skill_messages/2).
+      {_output, exit_code} =
+        run_headless("hello",
+          provider: Tau.Providers.Replay,
+          model: "replay",
+          provider_ctx: %{replay_fixture: replay_fixture()},
+          system_prompt: "You are a test assistant."
+        )
+
+      assert exit_code == 0,
+             "session with system_prompt should exit 0"
+    end
+
+    test "system prompt nil does not inject a skill" do
+      # No system_prompt → no active_skill → clean session.
+      {_output, exit_code} =
+        run_headless("hello",
+          provider: Tau.Providers.Replay,
+          model: "replay",
+          provider_ctx: %{replay_fixture: replay_fixture()}
+        )
+
+      assert exit_code == 0
+    end
+  end
+
+  describe "resolve_system_prompt (CLI option parsing)" do
+    # These tests verify the option-parsing logic in Tau.CLI directly
+    # since we cannot call main/1 (it halts).
+
+    test "--system-prompt text is passed through correctly" do
+      # Simulate parsed options map as Optimus delivers it.
+      opts = %{system_prompt: "inline system prompt", system_prompt_file: nil}
+
+      # Call the private helper via the module's logic:
+      # build_headless_skill(text) should produce a %Tau.Skill{}.
+      text = "inline system prompt"
+
+      skill = %Tau.Skill{
+        name: "headless-system-prompt",
+        body: text,
+        path: "<cli:--system-prompt>",
+        description: "System prompt injected via --system-prompt / --system-prompt-file"
+      }
+
+      assert skill.body == opts.system_prompt
+      assert skill.name == "headless-system-prompt"
+    end
+
+    test "--system-prompt-file reads file contents" do
+      path = Path.join(System.tmp_dir!(), "tau-sp-#{System.unique_integer([:positive])}.txt")
+      File.write!(path, "file system prompt")
+
+      on_exit(fn -> File.rm(path) end)
+
+      {:ok, text} = File.read(path)
+      assert text == "file system prompt"
+    end
+
+    test "missing --system-prompt-file returns error" do
+      path = "/tmp/tau-nonexistent-sp-#{System.unique_integer([:positive])}.txt"
+      assert {:error, reason} = File.read(path)
+      assert reason in [:enoent, :eacces]
+    end
+  end
+
+  describe "spec/0 argument parser (no System.halt)" do
+    test "run subcommand accepts --system-prompt option" do
+      result =
+        Optimus.parse!(Tau.CLI.spec(), [
+          "run",
+          "hello",
+          "--provider",
+          "replay",
+          "--model",
+          "replay",
+          "--system-prompt",
+          "you are a test agent"
+        ])
+
+      assert {[:run], parsed} = result
+      assert parsed.args.prompt == "hello"
+      assert parsed.options.system_prompt == "you are a test agent"
+    end
+
+    test "run subcommand accepts --system-prompt-file option" do
+      path = "/tmp/tau-sp-#{System.unique_integer([:positive])}.txt"
+
+      result =
+        Optimus.parse!(Tau.CLI.spec(), [
+          "run",
+          "hello",
+          "--system-prompt-file",
+          path
+        ])
+
+      assert {[:run], parsed} = result
+      assert parsed.options.system_prompt_file == path
+    end
+
+    test "run subcommand works without system prompt options" do
+      result =
+        Optimus.parse!(Tau.CLI.spec(), ["run", "hello", "--provider", "replay"])
+
+      assert {[:run], parsed} = result
+      assert parsed.args.prompt == "hello"
+      assert parsed.options.system_prompt == nil
+      assert parsed.options.system_prompt_file == nil
+    end
+  end
+end

--- a/test/tau/cli/headless_run_test.exs
+++ b/test/tau/cli/headless_run_test.exs
@@ -2,18 +2,21 @@ defmodule Tau.CLI.HeadlessRunTest do
   @moduledoc """
   AC-10 / D-058 (SPEC-USER-TURN §4 B2): headless FSM-backed `tau run`.
 
-  Verifies that `tau run` drives a full Tau.Session FSM (not a bare
+  Verifies that `tau run` drives a full `Tau.Session` FSM (not a bare
   provider.stream/3 call), that JSONL is persisted, and that the command
   surface works correctly with the Replay provider.
 
-  Tests do NOT invoke `Tau.CLI.main/1` directly because that function
-  calls `System.halt/1`. Instead they call `run_cmd_for_test/2` which
-  invokes the same session machinery the rewritten `run_cmd/1` uses, so
-  all observable contracts (PubSub ordering, JSONL output, exit code) are
-  tested against real FSM behaviour.
+  Tests exercise `Tau.CLI`'s real public/doc-false functions — NOT private
+  duplicates — so the AC-10 gate validates shipped code, not a parallel copy.
 
-  Replay provider is used for hermeticity; the default fixture emits
-  `"(replay) hello"` via a TextDelta event so stdout assertions are stable.
+  Functions under test:
+    - `Tau.CLI.drain_run_loop/1`   — event-drain loop (B2, B3)
+    - `Tau.CLI.drain_session_end/2` — post-stop flush wait
+    - `Tau.CLI.extract_assistant_text/1` — text extraction helper
+    - `Tau.CLI.extract_error_text/1`     — error text helper
+    - `Tau.CLI.resolve_system_prompt/1`  — CLI option resolver
+    - `Tau.CLI.build_headless_skill/1`   — skill builder (B1)
+    - `Tau.CLI.spec/0`                   — Optimus parser spec
   """
 
   use ExUnit.Case, async: false
@@ -21,7 +24,6 @@ defmodule Tau.CLI.HeadlessRunTest do
   import Tau.Test.SessionHelper, only: [start_session_for_test: 1]
 
   alias Tau.Provider.Event
-  alias Tau.Session.Events, as: SE
   alias Tau.Persistence.Jsonl, as: PJsonl
 
   setup do
@@ -38,109 +40,9 @@ defmodule Tau.CLI.HeadlessRunTest do
   end
 
   # ---------------------------------------------------------------------------
-  # Helper: run the headless FSM-backed session logic directly (no System.halt)
+  # Shared fixture helpers
   # ---------------------------------------------------------------------------
 
-  # Mirrors run_cmd/1 logic in Tau.CLI but returns {stdout_text, exit_code}
-  # instead of calling System.halt. Accepts :provider, :model, :system_prompt,
-  # :provider_ctx. All callers supply explicit opts.
-  defp run_headless(prompt, opts) do
-    provider = Keyword.get(opts, :provider, Tau.Providers.Replay)
-    model = Keyword.get(opts, :model, "replay")
-    system_prompt = Keyword.get(opts, :system_prompt)
-    provider_ctx = Keyword.get(opts, :provider_ctx, %{})
-
-    session_id = Tau.Session.generate_id()
-
-    # D-004: subscribe BEFORE start_session (mirrors run_cmd/1 discipline).
-    Phoenix.PubSub.subscribe(Tau.PubSub, "session:#{session_id}")
-
-    start_opts =
-      [session_id: session_id, provider: provider, model: model, provider_ctx: provider_ctx]
-      |> then(fn o ->
-        if system_prompt do
-          skill = %Tau.Skill{
-            name: "headless-system-prompt",
-            body: system_prompt,
-            path: "<test>",
-            description: "test system prompt"
-          }
-
-          o
-          |> Keyword.put(:active_skill, skill)
-          |> Keyword.put(:persona_lifetime, :session)
-        else
-          o
-        end
-      end)
-
-    {:ok, ^session_id} = start_session_for_test(start_opts)
-
-    :ok = Tau.send(session_id, prompt)
-
-    {output, exit_code} = drain_headless(session_id)
-    {output, exit_code}
-  end
-
-  # Drain PubSub events and return {stdout_text, exit_code} — mirrors
-  # drain_run_loop/1 + drain_session_end/2 in Tau.CLI.
-  # After a terminal MessageEnd, calls Tau.stop/1 to flush JSONL,
-  # then awaits SessionEnd.
-  defp drain_headless(session_id, acc \\ "") do
-    receive do
-      %SE.MessageEnd{session_id: ^session_id, message: msg} ->
-        case msg.stop_reason do
-          stop when stop in [:end_turn, :stop, :max_tokens] ->
-            text = extract_text(msg)
-            new_acc = if text != "", do: acc <> text <> "\n", else: acc
-            Tau.stop(session_id)
-            drain_session_end(session_id, new_acc, 0)
-
-          :tool_use ->
-            drain_headless(session_id, acc)
-
-          :tool_loop_aborted ->
-            Tau.stop(session_id)
-            drain_session_end(session_id, acc, 1)
-
-          _other ->
-            Tau.stop(session_id)
-            drain_session_end(session_id, acc, 1)
-        end
-
-      %SE.SessionEnd{session_id: ^session_id, reason: reason} ->
-        exit_code = if reason in [:normal, :user], do: 0, else: 1
-        {acc, exit_code}
-
-      _ ->
-        drain_headless(session_id, acc)
-    after
-      15_000 ->
-        Tau.stop(session_id)
-        {acc, 1}
-    end
-  end
-
-  defp drain_session_end(session_id, acc, exit_code) do
-    receive do
-      %SE.SessionEnd{session_id: ^session_id} -> {acc, exit_code}
-      _ -> drain_session_end(session_id, acc, exit_code)
-    after
-      5_000 -> {acc, exit_code}
-    end
-  end
-
-  defp extract_text(%Tau.Message.Assistant{content: blocks}) when is_list(blocks) do
-    Enum.flat_map(blocks, fn
-      %{type: :text, text: t} when is_binary(t) -> [t]
-      _ -> []
-    end)
-    |> Enum.join("")
-  end
-
-  defp extract_text(_), do: ""
-
-  # Default Replay fixture so tests can inject deterministic events.
   defp replay_fixture do
     [
       %Event.Start{request_id: "r", model: "replay"},
@@ -151,142 +53,344 @@ defmodule Tau.CLI.HeadlessRunTest do
     ]
   end
 
-  # ---------------------------------------------------------------------------
-  # AC-10 / D-058: core headless run tests
-  # ---------------------------------------------------------------------------
+  # Start a session and subscribe, then send a prompt. Returns session_id.
+  defp start_and_send(prompt, extra_opts \\ []) do
+    session_id = Tau.Session.generate_id()
 
-  describe "headless FSM-backed session run (AC-10, D-058)" do
-    test "replay provider produces assistant text and exits 0", %{data_dir: _tmp} do
-      {output, exit_code} =
-        run_headless("ping",
-          provider: Tau.Providers.Replay,
-          model: "replay",
-          provider_ctx: %{replay_fixture: replay_fixture()}
-        )
+    # D-004: subscribe BEFORE start_session.
+    Phoenix.PubSub.subscribe(Tau.PubSub, "session:#{session_id}")
 
-      assert exit_code == 0,
-             "expected exit code 0 from a clean replay run; got #{exit_code}"
-
-      assert output =~ "(replay) hello",
-             "expected Replay fixture token in captured output; got:\n#{inspect(output)}"
-    end
-
-    test "JSONL is persisted after headless run", %{data_dir: _tmp} do
-      session_id = Tau.Session.generate_id()
-
-      Phoenix.PubSub.subscribe(Tau.PubSub, "session:#{session_id}")
-
-      start_opts = [
+    start_opts =
+      [
         session_id: session_id,
         provider: Tau.Providers.Replay,
         model: "replay",
         provider_ctx: %{replay_fixture: replay_fixture()}
-      ]
+      ] ++ extra_opts
 
-      {:ok, ^session_id} = start_session_for_test(start_opts)
-      :ok = Tau.send(session_id, "persist-test")
-      drain_headless(session_id)
+    {:ok, ^session_id} = start_session_for_test(start_opts)
+    :ok = Tau.send(session_id, prompt)
+    session_id
+  end
 
-      # Verify JSONL file exists and has content.
+  # ---------------------------------------------------------------------------
+  # B4: tests exercise Tau.CLI's real drain_run_loop/1 (not a duplicate).
+  # ---------------------------------------------------------------------------
+
+  describe "headless FSM-backed session run (AC-10, D-058)" do
+    test "replay provider produces assistant text and exits 0", %{data_dir: _tmp} do
+      session_id = start_and_send("ping")
+      exit_code = Tau.CLI.drain_run_loop(session_id)
+
+      assert exit_code == 0,
+             "expected exit code 0 from a clean replay run; got #{exit_code}"
+    end
+
+    test "JSONL is persisted after headless run", %{data_dir: _tmp} do
+      session_id = start_and_send("persist-test")
+      _exit_code = Tau.CLI.drain_run_loop(session_id)
+
       sessions = Tau.list_sessions()
       matching = Enum.filter(sessions, &(&1.id == session_id))
+      assert length(matching) == 1, "expected session to appear in Tau.list_sessions/0"
 
-      assert length(matching) == 1,
-             "expected the session to appear in Tau.list_sessions/0"
-
-      # Read the raw JSONL and confirm user + assistant events landed.
       events = PJsonl.stream(session_id) |> Enum.to_list()
       assert length(events) > 0, "expected non-empty JSONL for session #{session_id}"
 
       kinds = Enum.map(events, & &1["kind"])
-
-      assert "user_message" in kinds,
-             "expected a user_message event in JSONL; got kinds: #{inspect(kinds)}"
+      assert "user_message" in kinds, "expected user_message event; got: #{inspect(kinds)}"
     end
 
     test "default Replay provider used when none specified", %{data_dir: _tmp} do
-      # Explicitly pass the Replay provider; confirms the resolver path is wired.
-      {output, exit_code} =
-        run_headless("hello",
-          provider: Tau.Providers.Replay,
-          model: "replay",
-          provider_ctx: %{replay_fixture: replay_fixture()}
-        )
-
-      assert exit_code == 0
-      assert is_binary(output)
-    end
-  end
-
-  describe "--system-prompt injection seam (D-058 §system-prompt)" do
-    test "system prompt is prepended as a system-role skill message" do
-      # We verify by running a session with a system_prompt and confirming
-      # the session starts successfully with no error (the skill injection
-      # path is exercised via Session.init/1's prepend_skill_messages/2).
-      {_output, exit_code} =
-        run_headless("hello",
-          provider: Tau.Providers.Replay,
-          model: "replay",
-          provider_ctx: %{replay_fixture: replay_fixture()},
-          system_prompt: "You are a test assistant."
-        )
-
-      assert exit_code == 0,
-             "session with system_prompt should exit 0"
-    end
-
-    test "system prompt nil does not inject a skill" do
-      # No system_prompt → no active_skill → clean session.
-      {_output, exit_code} =
-        run_headless("hello",
-          provider: Tau.Providers.Replay,
-          model: "replay",
-          provider_ctx: %{replay_fixture: replay_fixture()}
-        )
+      session_id = start_and_send("hello")
+      exit_code = Tau.CLI.drain_run_loop(session_id)
 
       assert exit_code == 0
     end
   end
 
-  describe "resolve_system_prompt (CLI option parsing)" do
-    # These tests verify the option-parsing logic in Tau.CLI directly
-    # since we cannot call main/1 (it halts).
+  # ---------------------------------------------------------------------------
+  # B2: stop_reason matrix — test that :stop, :length, :tool_loop_aborted,
+  #     and :error all produce the correct exit codes.
+  # ---------------------------------------------------------------------------
 
-    test "--system-prompt text is passed through correctly" do
-      # Simulate parsed options map as Optimus delivers it.
-      opts = %{system_prompt: "inline system prompt", system_prompt_file: nil}
+  describe "drain_run_loop stop_reason matrix (B2 fix)" do
+    test ":stop maps to exit 0" do
+      session_id = Tau.Session.generate_id()
+      Phoenix.PubSub.subscribe(Tau.PubSub, "session:#{session_id}")
 
-      # Call the private helper via the module's logic:
-      # build_headless_skill(text) should produce a %Tau.Skill{}.
-      text = "inline system prompt"
+      fixture = [
+        %Event.Start{request_id: "r", model: "replay"},
+        %Event.TextStart{block_id: "b"},
+        %Event.TextDelta{block_id: "b", text: "ok"},
+        %Event.TextEnd{block_id: "b"},
+        %Event.Done{stop_reason: :stop, usage: %{}}
+      ]
 
-      skill = %Tau.Skill{
-        name: "headless-system-prompt",
-        body: text,
-        path: "<cli:--system-prompt>",
-        description: "System prompt injected via --system-prompt / --system-prompt-file"
-      }
+      {:ok, ^session_id} =
+        start_session_for_test(
+          session_id: session_id,
+          provider: Tau.Providers.Replay,
+          model: "replay",
+          provider_ctx: %{replay_fixture: fixture}
+        )
 
-      assert skill.body == opts.system_prompt
+      :ok = Tau.send(session_id, "test")
+      assert Tau.CLI.drain_run_loop(session_id) == 0
+    end
+
+    test ":length maps to exit 0 (B2 — context-window stop)" do
+      # :length is what Anthropic/OpenAI emit for max_tokens;
+      # it MUST map to exit 0, not fall through to the error branch.
+      session_id = Tau.Session.generate_id()
+      Phoenix.PubSub.subscribe(Tau.PubSub, "session:#{session_id}")
+
+      fixture = [
+        %Event.Start{request_id: "r", model: "replay"},
+        %Event.TextStart{block_id: "b"},
+        %Event.TextDelta{block_id: "b", text: "truncated"},
+        %Event.TextEnd{block_id: "b"},
+        %Event.Done{stop_reason: :length, usage: %{}}
+      ]
+
+      {:ok, ^session_id} =
+        start_session_for_test(
+          session_id: session_id,
+          provider: Tau.Providers.Replay,
+          model: "replay",
+          provider_ctx: %{replay_fixture: fixture}
+        )
+
+      :ok = Tau.send(session_id, "test")
+      assert Tau.CLI.drain_run_loop(session_id) == 0
+    end
+
+    test ":tool_loop_aborted maps to exit 1" do
+      session_id = Tau.Session.generate_id()
+      Phoenix.PubSub.subscribe(Tau.PubSub, "session:#{session_id}")
+
+      fixture = [
+        %Event.Start{request_id: "r", model: "replay"},
+        %Event.TextStart{block_id: "b"},
+        %Event.TextDelta{block_id: "b", text: "aborting"},
+        %Event.TextEnd{block_id: "b"},
+        %Event.Done{stop_reason: :tool_loop_aborted, usage: %{}}
+      ]
+
+      {:ok, ^session_id} =
+        start_session_for_test(
+          session_id: session_id,
+          provider: Tau.Providers.Replay,
+          model: "replay",
+          provider_ctx: %{replay_fixture: fixture}
+        )
+
+      :ok = Tau.send(session_id, "test")
+      assert Tau.CLI.drain_run_loop(session_id) == 1
+    end
+
+    test ":error stop_reason maps to exit 1" do
+      session_id = Tau.Session.generate_id()
+      Phoenix.PubSub.subscribe(Tau.PubSub, "session:#{session_id}")
+
+      fixture = [
+        %Event.Start{request_id: "r", model: "replay"},
+        %Event.Done{stop_reason: :error, usage: %{}}
+      ]
+
+      {:ok, ^session_id} =
+        start_session_for_test(
+          session_id: session_id,
+          provider: Tau.Providers.Replay,
+          model: "replay",
+          provider_ctx: %{replay_fixture: fixture}
+        )
+
+      :ok = Tau.send(session_id, "test")
+      assert Tau.CLI.drain_run_loop(session_id) == 1
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # B1: --system-prompt injection — text reaches the model (via session.ex).
+  # ---------------------------------------------------------------------------
+
+  describe "--system-prompt injection seam (B1 fix, D-058)" do
+    test "system prompt text is injected into the session's message list" do
+      # We start a session with an active_skill (the headless skill) and
+      # verify via Tau.Session.snapshot/1 that the skill body appears in the
+      # model-visible message list (prepended by prepend_skill_messages/2
+      # during session.ex init/1).
+      system_text = "You are a test assistant. Reply only with 'ok'."
+      skill = Tau.CLI.build_headless_skill(system_text)
+
+      session_id = Tau.Session.generate_id()
+      Phoenix.PubSub.subscribe(Tau.PubSub, "session:#{session_id}")
+
+      fixture = [
+        %Event.Start{request_id: "r", model: "replay"},
+        %Event.TextStart{block_id: "b"},
+        %Event.TextDelta{block_id: "b", text: "(reply)"},
+        %Event.TextEnd{block_id: "b"},
+        %Event.Done{stop_reason: :stop, usage: %{}}
+      ]
+
+      {:ok, ^session_id} =
+        start_session_for_test(
+          session_id: session_id,
+          provider: Tau.Providers.Replay,
+          model: "replay",
+          provider_ctx: %{replay_fixture: fixture},
+          active_skill: skill,
+          persona_lifetime: :session
+        )
+
+      # Snapshot the session immediately after start (before sending a prompt)
+      # so we can inspect the initial message list built by init/1.
+      {:ok, snap} = Tau.Session.snapshot(session_id)
+
+      # The system prompt skill should appear as a user message (system-role)
+      # prepended to snap.messages by prepend_skill_messages/2.
+      system_messages =
+        Enum.filter(snap.messages, fn
+          %Tau.Message.User{metadata: %{role: :system, source: :skill}} -> true
+          _ -> false
+        end)
+
+      assert length(system_messages) >= 1,
+             "expected at least one system-role skill message in data.messages; " <>
+               "got: #{inspect(system_messages)}"
+
+      # Check the skill body is present in the rendered message.
+      bodies = Enum.map(system_messages, & &1.content)
+
+      assert Enum.any?(bodies, &String.contains?(&1, system_text)),
+             "expected system_text '#{system_text}' in messages; got: #{inspect(bodies)}"
+
+      :ok = Tau.send(session_id, "hello")
+      assert Tau.CLI.drain_run_loop(session_id) == 0
+    end
+
+    test "nil system prompt does not inject a headless-system-prompt skill" do
+      assert Tau.CLI.build_headless_skill(nil) == nil
+
+      session_id = start_and_send("hello")
+
+      {:ok, snap} = Tau.Session.snapshot(session_id)
+
+      # Specifically check that the "headless-system-prompt" skill is NOT
+      # injected. Other bundled/on-disk skills may be present in the skill list
+      # (e.g. the example skill in priv/skills/); we only care that the
+      # headless injection path was not triggered.
+      headless_messages =
+        Enum.filter(snap.messages, fn
+          %Tau.Message.User{
+            metadata: %{role: :system, source: :skill, name: "headless-system-prompt"}
+          } ->
+            true
+
+          _ ->
+            false
+        end)
+
+      assert length(headless_messages) == 0,
+             "expected no headless-system-prompt skill message when --system-prompt is not given; " <>
+               "got: #{inspect(headless_messages)}"
+
+      assert Tau.CLI.drain_run_loop(session_id) == 0
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Unit tests for the public helper functions (B4)
+  # ---------------------------------------------------------------------------
+
+  describe "build_headless_skill/1" do
+    test "nil returns nil" do
+      assert Tau.CLI.build_headless_skill(nil) == nil
+    end
+
+    test "text produces a %Tau.Skill{} with correct fields" do
+      skill = Tau.CLI.build_headless_skill("be helpful")
+
+      assert %Tau.Skill{} = skill
       assert skill.name == "headless-system-prompt"
+      assert skill.body == "be helpful"
+      assert skill.path == "<cli:--system-prompt>"
+    end
+  end
+
+  describe "resolve_system_prompt/1" do
+    test "--system-prompt text is returned as {:ok, text}" do
+      opts = %{system_prompt: "inline text", system_prompt_file: nil}
+      assert {:ok, "inline text"} = Tau.CLI.resolve_system_prompt(opts)
     end
 
     test "--system-prompt-file reads file contents" do
       path = Path.join(System.tmp_dir!(), "tau-sp-#{System.unique_integer([:positive])}.txt")
       File.write!(path, "file system prompt")
-
       on_exit(fn -> File.rm(path) end)
 
-      {:ok, text} = File.read(path)
-      assert text == "file system prompt"
+      opts = %{system_prompt: nil, system_prompt_file: path}
+      assert {:ok, "file system prompt"} = Tau.CLI.resolve_system_prompt(opts)
     end
 
-    test "missing --system-prompt-file returns error" do
+    test "missing --system-prompt-file returns {:error, reason}" do
       path = "/tmp/tau-nonexistent-sp-#{System.unique_integer([:positive])}.txt"
-      assert {:error, reason} = File.read(path)
-      assert reason in [:enoent, :eacces]
+      opts = %{system_prompt: nil, system_prompt_file: path}
+      assert {:error, reason} = Tau.CLI.resolve_system_prompt(opts)
+      assert is_binary(reason)
+    end
+
+    test "neither option returns {:ok, nil}" do
+      assert {:ok, nil} = Tau.CLI.resolve_system_prompt(%{})
     end
   end
+
+  describe "extract_assistant_text/1" do
+    test "extracts text blocks from an Assistant message" do
+      msg = %Tau.Message.Assistant{
+        timestamp: DateTime.utc_now(),
+        content: [
+          %{type: :text, text: "hello"},
+          %{type: :tool_use, id: "t1"},
+          %{type: :text, text: " world"}
+        ]
+      }
+
+      assert Tau.CLI.extract_assistant_text(msg) == "hello world"
+    end
+
+    test "returns empty string for non-Assistant messages" do
+      assert Tau.CLI.extract_assistant_text(%{}) == ""
+      assert Tau.CLI.extract_assistant_text(nil) == ""
+    end
+  end
+
+  describe "extract_error_text/1" do
+    test "returns error_message field when present" do
+      msg = %Tau.Message.Assistant{
+        timestamp: DateTime.utc_now(),
+        error_message: "something went wrong",
+        content: []
+      }
+
+      assert Tau.CLI.extract_error_text(msg) == "something went wrong"
+    end
+
+    test "falls back to extract_assistant_text when no error_message" do
+      msg = %Tau.Message.Assistant{
+        timestamp: DateTime.utc_now(),
+        content: [%{type: :text, text: "fallback text"}]
+      }
+
+      assert Tau.CLI.extract_error_text(msg) == "fallback text"
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # spec/0 argument parser (no System.halt)
+  # ---------------------------------------------------------------------------
 
   describe "spec/0 argument parser (no System.halt)" do
     test "run subcommand accepts --system-prompt option" do

--- a/test/tau/cli/headless_run_test.exs
+++ b/test/tau/cli/headless_run_test.exs
@@ -328,6 +328,56 @@ defmodule Tau.CLI.HeadlessRunTest do
       assert exit_code == 1,
              "expected exit 1 for :compaction_failed; got #{exit_code}"
     end
+
+    # f-3 regression: Gemini emits stop_reason: :stop even on tool-call turns.
+    # The prior implementation keyed on stop_reason only — it would exit 0 on a
+    # tool-call MessageEnd whose stop_reason was :stop, killing the session
+    # before the FSM could dispatch the tool. This test exercises exactly that
+    # shape: msg.content has a :tool_call block, stop_reason is :stop.
+    #
+    # The existing :tool_use test (above) uses content: [] — that is the blind
+    # spot this test covers. Do NOT remove the empty-content test; it locks the
+    # :tool_use atom case. This test locks the content-first rule.
+    test "tool_call content + stop_reason :stop (Gemini shape) causes loop to continue" do
+      # Inject the exact Gemini shape: a MessageEnd whose content has a
+      # %{type: :tool_call} block AND stop_reason is :stop (not :tool_use).
+      # The drain loop MUST continue (not exit) when tool_call content is present,
+      # regardless of stop_reason. It exits 0 only after the subsequent terminal
+      # MessageEnd (no tool_call content, :stop stop_reason).
+      session_id = Tau.Session.generate_id()
+
+      # First event: Gemini-style tool-call turn — :stop + tool_call content.
+      msg_gemini_tool = %Tau.Message.Assistant{
+        timestamp: DateTime.utc_now(),
+        content: [
+          %{
+            type: :tool_call,
+            id: "call-gemini-1",
+            name: "bash",
+            arguments: %{"command" => "echo hi"}
+          }
+        ],
+        stop_reason: :stop
+      }
+
+      # Second event: terminal turn — :stop, no tool_call content.
+      msg_terminal = %Tau.Message.Assistant{
+        timestamp: DateTime.utc_now(),
+        content: [%{type: :text, text: "all done"}],
+        stop_reason: :stop
+      }
+
+      send(self(), %Tau.Session.Events.MessageEnd{session_id: session_id, message: msg_gemini_tool})
+      send(self(), %Tau.Session.Events.MessageEnd{session_id: session_id, message: msg_terminal})
+      # drain_session_end awaits SessionEnd after Tau.stop/1; inject it.
+      send(self(), %Tau.Session.Events.SessionEnd{session_id: session_id, reason: :normal})
+
+      exit_code = Tau.CLI.drain_run_loop(session_id)
+
+      assert exit_code == 0,
+             "expected exit 0 after Gemini tool-call turn (:stop+tool_call content) " <>
+               "followed by terminal :stop; got #{exit_code}"
+    end
   end
 
   # ---------------------------------------------------------------------------
@@ -553,6 +603,120 @@ defmodule Tau.CLI.HeadlessRunTest do
       assert parsed.args.prompt == "hello"
       assert parsed.options.system_prompt == nil
       assert parsed.options.system_prompt_file == nil
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # f-4: run_cmd/1 end-to-end against the replay provider.
+  #
+  # run_cmd/1 was defp and exercised by no test; the start_and_send helper
+  # re-implemented its orchestration. Making it @doc false public allows this
+  # test to call the SAME code that main/1 calls: build opts from parsed,
+  # subscribe, start_session, send, drain_run_loop. If run_cmd/1 diverges from
+  # the tested path, this test will catch it.
+  #
+  # Uses Optimus.parse!/2 to produce a real parsed struct (same as main/1),
+  # then calls run_cmd/1 directly — not start_and_send, not drain_run_loop
+  # directly. The production path and the tested path are identical.
+  # ---------------------------------------------------------------------------
+
+  describe "run_cmd/1 end-to-end (f-4)" do
+    test "run_cmd/1 with replay provider exits 0 and persists JSONL", %{data_dir: _tmp} do
+      # Use Optimus.parse! to get the same struct that main/1 passes to run_cmd/1.
+      # The replay provider's fixture path goes through resolve_provider("replay")
+      # → Tau.Providers.Replay, then start_session, send, drain_run_loop —
+      # the full production path, nothing duplicated.
+      {[:run], parsed} =
+        Optimus.parse!(Tau.CLI.spec(), [
+          "run",
+          "hello from run_cmd",
+          "--provider",
+          "replay",
+          "--model",
+          "replay"
+        ])
+
+      exit_code = Tau.CLI.run_cmd(parsed)
+
+      assert exit_code == 0,
+             "expected run_cmd/1 to exit 0 via replay provider; got #{exit_code}"
+
+      # Prove JSONL was persisted — same guarantee as the B2 JSONL test, but now
+      # exercised through the real run_cmd/1 entry point.
+      sessions = Tau.list_sessions()
+      # Find a session with a user_message containing our prompt text.
+      session_with_events =
+        Enum.find(sessions, fn s ->
+          case PJsonl.stream(s.id) |> Enum.to_list() do
+            [] -> false
+            events -> Enum.any?(events, &(&1["kind"] == "user_message"))
+          end
+        end)
+
+      assert session_with_events != nil,
+             "expected run_cmd/1 to persist JSONL with a user_message event"
+    end
+
+    test "run_cmd/1 --system-prompt injects skill into session (build_headless_skill/active_skill/persona_lifetime path)",
+         %{data_dir: _tmp} do
+      # Prove that the build_headless_skill/active_skill/persona_lifetime opts
+      # assembled by run_cmd/1 actually reach Tau.start_session — i.e. the real
+      # run_cmd/1 wiring, not a duplicated test version.
+      system_text = "You are a test oracle. Reply with 'oracle ok'."
+
+      {[:run], parsed} =
+        Optimus.parse!(Tau.CLI.spec(), [
+          "run",
+          "test prompt",
+          "--provider",
+          "replay",
+          "--model",
+          "replay",
+          "--system-prompt",
+          system_text
+        ])
+
+      # run_cmd/1 calls Tau.start_session with active_skill+persona_lifetime; we
+      # need to observe the session state. We intercept by subscribing to PubSub
+      # and capturing the session_id from SessionStart before run_cmd/1 drains it.
+      # Simpler: run run_cmd/1 and then scan list_sessions for the skill message.
+      exit_code = Tau.CLI.run_cmd(parsed)
+
+      assert exit_code == 0,
+             "expected run_cmd/1 with --system-prompt to exit 0; got #{exit_code}"
+
+      # The system prompt was injected — prove via JSONL (the user_message event
+      # confirms the session ran; the system_prompt reaching the FSM is verified
+      # by the --system-prompt injection tests above that use the same code path).
+      sessions = Tau.list_sessions()
+
+      persisted =
+        Enum.find(sessions, fn s ->
+          PJsonl.stream(s.id) |> Enum.any?(&(&1["kind"] == "user_message"))
+        end)
+
+      assert persisted != nil,
+             "expected JSONL persistence when run_cmd/1 is called with --system-prompt"
+    end
+
+    test "run_cmd/1 with missing --system-prompt-file returns exit 1 (resolve_system_prompt error path)",
+         %{data_dir: _tmp} do
+      # Exercises the {:error, reason} branch of resolve_system_prompt/1 inside
+      # run_cmd/1 — the branch that was defp-private and untested.
+      missing_path = "/tmp/tau-nonexistent-runprompt-#{System.unique_integer([:positive])}.txt"
+
+      {[:run], parsed} =
+        Optimus.parse!(Tau.CLI.spec(), [
+          "run",
+          "hello",
+          "--system-prompt-file",
+          missing_path
+        ])
+
+      exit_code = Tau.CLI.run_cmd(parsed)
+
+      assert exit_code == 1,
+             "expected exit 1 when --system-prompt-file path does not exist; got #{exit_code}"
     end
   end
 end

--- a/test/tau/cli/headless_run_test.exs
+++ b/test/tau/cli/headless_run_test.exs
@@ -212,6 +212,125 @@ defmodule Tau.CLI.HeadlessRunTest do
   end
 
   # ---------------------------------------------------------------------------
+  # f-1 regression: :tool_use continuation and success-atom coverage (f-3)
+  # ---------------------------------------------------------------------------
+
+  describe "drain_run_loop stop_reason inverted-logic coverage (f-1 fix)" do
+    # Inject PubSub events directly into the test process mailbox so we can
+    # exercise drain_run_loop/1's logic without a full multi-turn FSM session.
+
+    test ":tool_use causes loop to continue, then terminal stop exits 0" do
+      # Regression test: :tool_use must NOT exit — it must keep waiting.
+      # We inject a :tool_use MessageEnd followed by a :stop MessageEnd and
+      # a SessionEnd into the mailbox, then assert exit_code == 0.
+      session_id = Tau.Session.generate_id()
+
+      msg_tool_use = %Tau.Message.Assistant{
+        timestamp: DateTime.utc_now(),
+        content: [],
+        stop_reason: :tool_use
+      }
+
+      msg_stop = %Tau.Message.Assistant{
+        timestamp: DateTime.utc_now(),
+        content: [%{type: :text, text: "done"}],
+        stop_reason: :stop
+      }
+
+      send(self(), %Tau.Session.Events.MessageEnd{session_id: session_id, message: msg_tool_use})
+      send(self(), %Tau.Session.Events.MessageEnd{session_id: session_id, message: msg_stop})
+      # drain_session_end waits for SessionEnd after Tau.stop/1 is called; inject it.
+      send(self(), %Tau.Session.Events.SessionEnd{session_id: session_id, reason: :normal})
+
+      exit_code = Tau.CLI.drain_run_loop(session_id)
+
+      assert exit_code == 0,
+             "expected exit 0 after :tool_use continuation + :stop terminal; got #{exit_code}"
+    end
+
+    test ":stop_sequence maps to exit 0 (f-1 regression lock)" do
+      # :stop_sequence is emitted by Anthropic when a stop_sequence is hit
+      # (anthropic.ex:237). Under the old enumeration it fell through to exit 1.
+      # Under the new failure-list logic it must be exit 0.
+      session_id = Tau.Session.generate_id()
+
+      msg = %Tau.Message.Assistant{
+        timestamp: DateTime.utc_now(),
+        content: [%{type: :text, text: "stopped at seq"}],
+        stop_reason: :stop_sequence
+      }
+
+      send(self(), %Tau.Session.Events.MessageEnd{session_id: session_id, message: msg})
+      send(self(), %Tau.Session.Events.SessionEnd{session_id: session_id, reason: :normal})
+
+      exit_code = Tau.CLI.drain_run_loop(session_id)
+
+      assert exit_code == 0,
+             "expected exit 0 for :stop_sequence (completed turn); got #{exit_code}"
+    end
+
+    test ":content_filter maps to exit 0 (unknown-atom defaults to success)" do
+      # OpenAI may emit "content_filter" which maps to :content_filter via
+      # String.to_atom (openai_chat_wire.ex:196). Must exit 0.
+      session_id = Tau.Session.generate_id()
+
+      msg = %Tau.Message.Assistant{
+        timestamp: DateTime.utc_now(),
+        content: [%{type: :text, text: "filtered"}],
+        stop_reason: :content_filter
+      }
+
+      send(self(), %Tau.Session.Events.MessageEnd{session_id: session_id, message: msg})
+      send(self(), %Tau.Session.Events.SessionEnd{session_id: session_id, reason: :normal})
+
+      exit_code = Tau.CLI.drain_run_loop(session_id)
+
+      assert exit_code == 0,
+             "expected exit 0 for :content_filter (unknown provider atom → success); got #{exit_code}"
+    end
+
+    test ":aborted maps to exit 1" do
+      # :aborted is produced by session.ex:2871 when coding agent exits with -2.
+      session_id = Tau.Session.generate_id()
+
+      msg = %Tau.Message.Assistant{
+        timestamp: DateTime.utc_now(),
+        content: [],
+        stop_reason: :aborted,
+        error_message: "aborted"
+      }
+
+      send(self(), %Tau.Session.Events.MessageEnd{session_id: session_id, message: msg})
+      send(self(), %Tau.Session.Events.SessionEnd{session_id: session_id, reason: :error})
+
+      exit_code = Tau.CLI.drain_run_loop(session_id)
+
+      assert exit_code == 1,
+             "expected exit 1 for :aborted; got #{exit_code}"
+    end
+
+    test ":compaction_failed maps to exit 1" do
+      # :compaction_failed is produced by session.ex:1743 after 3 failures.
+      session_id = Tau.Session.generate_id()
+
+      msg = %Tau.Message.Assistant{
+        timestamp: DateTime.utc_now(),
+        content: [],
+        stop_reason: :compaction_failed,
+        error_message: "compaction failed"
+      }
+
+      send(self(), %Tau.Session.Events.MessageEnd{session_id: session_id, message: msg})
+      send(self(), %Tau.Session.Events.SessionEnd{session_id: session_id, reason: :error})
+
+      exit_code = Tau.CLI.drain_run_loop(session_id)
+
+      assert exit_code == 1,
+             "expected exit 1 for :compaction_failed; got #{exit_code}"
+    end
+  end
+
+  # ---------------------------------------------------------------------------
   # B1: --system-prompt injection — text reaches the model (via session.ex).
   # ---------------------------------------------------------------------------
 

--- a/test/tau/cli/headless_run_test.exs
+++ b/test/tau/cli/headless_run_test.exs
@@ -219,10 +219,16 @@ defmodule Tau.CLI.HeadlessRunTest do
     # Inject PubSub events directly into the test process mailbox so we can
     # exercise drain_run_loop/1's logic without a full multi-turn FSM session.
 
-    test ":tool_use causes loop to continue, then terminal stop exits 0" do
-      # Regression test: :tool_use must NOT exit — it must keep waiting.
-      # We inject a :tool_use MessageEnd followed by a :stop MessageEnd and
-      # a SessionEnd into the mailbox, then assert exit_code == 0.
+    test ":tool_use with empty content exits 0 (not in failure set; empty content is not a tool-call turn)" do
+      # What this test actually asserts: a :tool_use MessageEnd whose content is []
+      # (no %{type: :tool_call} blocks) is treated as a terminal turn by the
+      # content-first rule. The loop exits 0 immediately on this MessageEnd because:
+      #   1. tool_calls = false (empty content)
+      #   2. :tool_use is NOT in the failure set [:error, :tool_loop_aborted, ...]
+      #   3. true branch fires → drain_session_end(session_id, 0)
+      #
+      # The subsequent msg_stop and SessionEnd are injected so drain_session_end
+      # (which ignores non-SessionEnd messages) can complete cleanly.
       session_id = Tau.Session.generate_id()
 
       msg_tool_use = %Tau.Message.Assistant{
@@ -245,7 +251,7 @@ defmodule Tau.CLI.HeadlessRunTest do
       exit_code = Tau.CLI.drain_run_loop(session_id)
 
       assert exit_code == 0,
-             "expected exit 0 after :tool_use continuation + :stop terminal; got #{exit_code}"
+             "expected exit 0 for :tool_use with empty content (terminal turn by content-first rule); got #{exit_code}"
     end
 
     test ":stop_sequence maps to exit 0 (f-1 regression lock)" do
@@ -329,54 +335,95 @@ defmodule Tau.CLI.HeadlessRunTest do
              "expected exit 1 for :compaction_failed; got #{exit_code}"
     end
 
-    # f-3 regression: Gemini emits stop_reason: :stop even on tool-call turns.
-    # The prior implementation keyed on stop_reason only — it would exit 0 on a
-    # tool-call MessageEnd whose stop_reason was :stop, killing the session
-    # before the FSM could dispatch the tool. This test exercises exactly that
-    # shape: msg.content has a :tool_call block, stop_reason is :stop.
+    # f-1 regression: Gemini emits stop_reason: :stop even on tool-call turns.
+    # The prior implementation keyed on stop_reason only — it would call
+    # Tau.stop/1 and exit after turn 1, so the FSM never dispatched the tool,
+    # no ToolResult was persisted, and the second assistant turn never reached
+    # JSONL. Under the fixed (content-first) logic the loop continues on turn 1,
+    # the FSM dispatches the tool, and JSONL records both assistant turns.
     #
-    # The existing :tool_use test (above) uses content: [] — that is the blind
-    # spot this test covers. Do NOT remove the empty-content test; it locks the
-    # :tool_use atom case. This test locks the content-first rule.
-    test "tool_call content + stop_reason :stop (Gemini shape) causes loop to continue" do
-      # Inject the exact Gemini shape: a MessageEnd whose content has a
-      # %{type: :tool_call} block AND stop_reason is :stop (not :tool_use).
-      # The drain loop MUST continue (not exit) when tool_call content is present,
-      # regardless of stop_reason. It exits 0 only after the subsequent terminal
-      # MessageEnd (no tool_call content, :stop stop_reason).
-      session_id = Tau.Session.generate_id()
+    # Observable difference:
+    #   Buggy  (stop_reason-only): JSONL has 1 assistant_message. No tool_result.
+    #   Fixed  (content-first):    JSONL has 2 assistant_messages + 1 tool_result.
+    #
+    # This test drives a REAL two-turn FSM session via MultiFixtureProvider so
+    # the JSONL difference is actually produced by the production code path,
+    # not by injected mailbox events. The mandatory verification step in the
+    # task brief confirms this test FAILS against the buggy logic and PASSES
+    # against the fixed logic — see the commit message for the empirical output.
+    @tag :regression_f1
+    test "Gemini-shape two-turn run: JSONL contains 2 assistant_messages (f-1 regression)",
+         %{data_dir: _tmp} do
+      alias Tau.Test.MultiFixtureProvider
+      alias Tau.Provider.Event
 
-      # First event: Gemini-style tool-call turn — :stop + tool_call content.
-      msg_gemini_tool = %Tau.Message.Assistant{
-        timestamp: DateTime.utc_now(),
-        content: [
-          %{
-            type: :tool_call,
-            id: "call-gemini-1",
-            name: "bash",
-            arguments: %{"command" => "echo hi"}
-          }
-        ],
-        stop_reason: :stop
+      parent_sid = Tau.Session.generate_id()
+      Phoenix.PubSub.subscribe(Tau.PubSub, "session:#{parent_sid}")
+
+      # A readable temp file the Read tool can resolve without error.
+      read_path =
+        Path.join(System.tmp_dir!(), "tau-f1-probe-#{System.unique_integer([:positive])}.txt")
+
+      File.write!(read_path, "f1 probe")
+      on_exit(fn -> File.rm(read_path) end)
+
+      call_id = "gemini-read-#{System.unique_integer([:positive])}"
+
+      # Turn 1 — Gemini shape: ToolCallStart + ToolCallEnd + Done{stop_reason: :stop}.
+      # The content-first rule must detect the tool_call block and recurse rather
+      # than calling Tau.stop/1 and exiting.
+      gemini_turn_1 = [
+        %Event.Start{request_id: "gemini-r1", model: "multi-fixture"},
+        %Event.ToolCallStart{tool_call_id: call_id, name: "Read"},
+        %Event.ToolCallEnd{tool_call_id: call_id, params: %{"path" => read_path}},
+        %Event.Done{stop_reason: :stop, usage: %{}}
+      ]
+
+      # Turn 2 — terminal text response after the FSM dispatches the tool.
+      terminal_turn_2 = [
+        %Event.Start{request_id: "gemini-r2", model: "multi-fixture"},
+        %Event.TextStart{block_id: "b2"},
+        %Event.TextDelta{block_id: "b2", text: "all done after tool"},
+        %Event.TextEnd{block_id: "b2"},
+        %Event.Done{stop_reason: :stop, usage: %{}}
+      ]
+
+      provider_ctx = %{
+        parent_session_id: parent_sid,
+        parent_first_fixture: gemini_turn_1,
+        parent_second_fixture: terminal_turn_2
       }
 
-      # Second event: terminal turn — :stop, no tool_call content.
-      msg_terminal = %Tau.Message.Assistant{
-        timestamp: DateTime.utc_now(),
-        content: [%{type: :text, text: "all done"}],
-        stop_reason: :stop
-      }
+      {:ok, ^parent_sid} =
+        start_session_for_test(
+          session_id: parent_sid,
+          provider: MultiFixtureProvider,
+          model: "multi-fixture",
+          provider_ctx: provider_ctx
+        )
 
-      send(self(), %Tau.Session.Events.MessageEnd{session_id: session_id, message: msg_gemini_tool})
-      send(self(), %Tau.Session.Events.MessageEnd{session_id: session_id, message: msg_terminal})
-      # drain_session_end awaits SessionEnd after Tau.stop/1; inject it.
-      send(self(), %Tau.Session.Events.SessionEnd{session_id: session_id, reason: :normal})
+      :ok = Tau.send(parent_sid, "run the read tool")
 
-      exit_code = Tau.CLI.drain_run_loop(session_id)
+      exit_code = Tau.CLI.drain_run_loop(parent_sid)
 
       assert exit_code == 0,
-             "expected exit 0 after Gemini tool-call turn (:stop+tool_call content) " <>
-               "followed by terminal :stop; got #{exit_code}"
+             "expected exit 0 after two-turn Gemini-shape run; got #{exit_code}"
+
+      # Assert JSONL completeness — the key regression guard.
+      # Buggy logic stops after turn 1 → only 1 assistant_message, no tool_result.
+      # Fixed logic continues through tool dispatch → 2 assistant_messages + tool_result.
+      events = PJsonl.stream(parent_sid) |> Enum.to_list()
+      kinds = Enum.map(events, & &1["kind"])
+
+      assert "tool_result" in kinds,
+             "expected 'tool_result' in JSONL (loop must continue past turn 1 to dispatch the Read tool); " <>
+               "got kinds: #{inspect(kinds)}"
+
+      assistant_msg_count = Enum.count(kinds, &(&1 == "assistant_message"))
+
+      assert assistant_msg_count == 2,
+             "expected 2 assistant_messages in JSONL (turn 1 tool-call + turn 2 terminal); " <>
+               "got #{assistant_msg_count}: #{inspect(kinds)}"
     end
   end
 


### PR DESCRIPTION
## Summary

Routes `tau run` through a full `Tau.Session` FSM (instead of calling `provider.stream/3` directly). The FSM path provides tool registration (`Agent`, `Bash`, all builtins), JSONL persistence, PubSub lifecycle events, and permissions enforcement — prerequisites for **M1 self-hosting** where the `Agent` tool must be reachable from a `tau run` invocation.

Adds `--system-prompt <text>` / `--system-prompt-file <path>` injection seam (the coordinator persona artifact itself is a separate follow-up). Resolves the `tau run` Session-FSM-bypass that broke JSONL persistence for non-TUI invocations.

## Linked issues

Closes #252
Closes #213

## Gate verdicts

- **critic**: PASS (`ok: true`, 4 review rounds) — 3 non-blocking SUGGESTIONs (test flakiness risk; SPEC `f-3`↔`f-1` naming drift; comment expansion).
- **reviewer**: PASS (`verdict: PASS`) — 993 tests + 75 properties, 0 failures; `mix format` and `mix credo --strict` clean (no new issues in production code; 3 `length/1` test-style warnings).

## Design — drain loop is content-first, not stop_reason-keyed

The drain loop decides tool continuation by **content**, not `stop_reason`:

- If `msg.content` carries any `%{type: :tool_call}` block → **continue**, regardless of `stop_reason`.
- Else if `stop_reason ∈ [:error, :tool_loop_aborted, :aborted, :compaction_failed]` → exit 1.
- Else → exit 0.

This avoids enumerating provider-specific success atoms (Anthropic emits `:tool_use`; Gemini and Bedrock emit `:stop` on tool turns; OpenAI may pass `:length` / `:stop_sequence` / `:content_filter`). New provider atoms default to success.

## SPEC amendment

`docs/spec/SPEC-USER-TURN.md`: adds **C83**, **D-058**, **AC-10**, the B2 headless-run INV block, and an Appendix B source-map entry. Changelog updated.

## Test plan

- [x] `mix test test/tau/cli/headless_run_test.exs` — 31 tests, 0 failures
- [x] Full `mix test` — 918 tests + 75 properties, 0 failures
- [x] Gemini-shape regression test — real two-turn FSM; asserts JSONL contains tool_result + 2 assistant_messages; empirically fails against pre-fix logic
- [x] `mix format --check-formatted`, `mix compile --warnings-as-errors`, `mix credo --strict` clean

## Follow-ups (non-blocking)

- f-5: `Tau.Message` `@type stop_reason` typespec drift — pre-existing, separate issue.
- s-1: regression test relies on a race between `Tau.stop` cast and tool dispatch — a blocking probe tool would be more deterministic.
- f-2 (reviewer): `Tau.send/2` failure path after `start_session` does not call `Tau.stop` — session self-cleans via `:transient` supervision; no user-visible consequence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)