### PR TITLE
fix(burrito): relink exqlite NIF against musl for self-contained binary

### DIFF
--- a/lib/tau/burrito_steps/relink_sqlite_nif.ex
+++ b/lib/tau/burrito_steps/relink_sqlite_nif.ex
@@ -1,0 +1,205 @@
+defmodule Tau.BurritoSteps.RelinkSqliteNif do
+  @moduledoc """
+  Burrito build step that relinks `sqlite3_nif.so` (from `exqlite`) against
+  musl libc using `zig cc -target <cpu>-linux-musl`.
+
+  This step runs **post** `Burrito.Steps.Patch.RecompileNIFs` in the patch
+  phase for Linux targets only. `RecompileNIFs` invokes `elixir_make` / `make`
+  which links the NIF against the host glibc (introducing `__snprintf_chk`,
+  `__strcpy_chk`, and other fortified symbols). The resulting `.so` cannot
+  load inside the musl-based Burrito runtime and produces, at startup of the
+  packaged binary:
+
+      Error relocating .../sqlite3_nif.so: __snprintf_chk: symbol not found
+
+  This step bypasses `make` entirely and calls `zig cc` directly, compiling
+  `sqlite3_nif.c` and `sqlite3.c` (the vendored SQLite amalgamation) with the
+  exact set of `-D` flags that exqlite's `Makefile` defines, and emits a fully
+  musl-linked shared object into the release work tree.
+
+  Mirrors the structure of `Tau.BurritoSteps.RelinkTermbox`.
+  """
+
+  alias Burrito.Builder.Context
+  alias Burrito.Builder.Log
+  alias Burrito.Builder.Step
+
+  @behaviour Step
+
+  # Exqlite Makefile compile-time definitions (deps/exqlite/Makefile lines
+  # ~94-115). Kept in sync manually; if you bump exqlite, re-read the Makefile
+  # and update this list. These are the same flags the upstream Makefile passes
+  # to `cc` when building sqlite3.c + sqlite3_nif.c.
+  @sqlite_defines [
+    "-DNDEBUG=1",
+    "-DSQLITE_THREADSAFE=1",
+    "-DSQLITE_USE_URI=1",
+    "-DSQLITE_LIKE_DOESNT_MATCH_BLOBS=1",
+    "-DSQLITE_DQS=0",
+    "-DHAVE_USLEEP=1",
+    "-DALLOW_COVERING_INDEX_SCAN=1",
+    "-DENABLE_FTS3_PARENTHESIS=1",
+    "-DENABLE_LOAD_EXTENSION=1",
+    "-DENABLE_SOUNDEX=1",
+    "-DENABLE_STAT4=1",
+    "-DENABLE_UPDATE_DELETE_LIMIT=1",
+    "-DSQLITE_ENABLE_FTS3=1",
+    "-DSQLITE_ENABLE_FTS4=1",
+    "-DSQLITE_ENABLE_FTS5=1",
+    "-DSQLITE_ENABLE_GEOPOLY=1",
+    "-DSQLITE_ENABLE_MATH_FUNCTIONS=1",
+    "-DSQLITE_ENABLE_RBU=1",
+    "-DSQLITE_ENABLE_RTREE=1",
+    "-DSQLITE_OMIT_DEPRECATED=1",
+    "-DSQLITE_ENABLE_DBSTAT_VTAB=1"
+  ]
+
+  @impl Step
+  def execute(%Context{} = context) do
+    if linux_target?(context.target) do
+      relink(context)
+    else
+      context
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Private
+  # ---------------------------------------------------------------------------
+
+  defp linux_target?(%{os: :linux}), do: true
+  defp linux_target?(_), do: false
+
+  defp relink(%Context{} = context) do
+    cpu_triplet = cpu_triplet(context.target.cpu)
+    zig_target = "#{cpu_triplet}-linux-musl"
+
+    exqlite_src = exqlite_src_path()
+    sqlite3_c = Path.join(exqlite_src, "c_src/sqlite3.c")
+    sqlite3_nif_c = Path.join(exqlite_src, "c_src/sqlite3_nif.c")
+    sqlite_include = Path.join(exqlite_src, "c_src")
+
+    erts_include = resolve_erts_include(context.target.erts_source)
+
+    # Find the exqlite priv dir inside the release work tree.
+    so_output =
+      Path.join(context.work_dir, "lib/exqlite-*/priv/sqlite3_nif.so")
+      |> Path.wildcard()
+      |> List.first()
+
+    unless so_output do
+      Log.error(
+        :step,
+        "[RelinkSqliteNif] Could not find sqlite3_nif.so in release tree at #{context.work_dir}/lib/exqlite-*/priv/"
+      )
+
+      exit(1)
+    end
+
+    zig_bin = find_zig!()
+
+    args =
+      [
+        "cc",
+        "-target",
+        zig_target,
+        "-O2",
+        "-fPIC",
+        "-shared",
+        "-fvisibility=hidden",
+        "-I#{erts_include}",
+        "-I#{sqlite_include}"
+      ] ++
+        @sqlite_defines ++
+        [
+          "-o",
+          so_output,
+          sqlite3_nif_c,
+          sqlite3_c
+        ]
+
+    Log.info(:step, "[RelinkSqliteNif] Relinking sqlite3_nif.so for #{zig_target}")
+    Log.info(:step, "[RelinkSqliteNif] #{zig_bin} #{Enum.join(args, " ")}")
+
+    case System.cmd(zig_bin, args, stderr_to_stdout: true, into: IO.stream()) do
+      {_, 0} ->
+        Log.info(
+          :step,
+          "[RelinkSqliteNif] Successfully relinked sqlite3_nif.so for #{zig_target}"
+        )
+
+        context
+
+      {_, exit_code} ->
+        Log.error(:step, "[RelinkSqliteNif] zig cc failed with exit code #{exit_code}")
+        exit(1)
+    end
+  end
+
+  defp cpu_triplet(:x86_64), do: "x86_64"
+  defp cpu_triplet(:aarch64), do: "aarch64"
+
+  defp exqlite_src_path do
+    Mix.Project.deps_paths()
+    |> Map.fetch!(:exqlite)
+  end
+
+  defp resolve_erts_include({:local_unpacked, path: erts_path}) do
+    Path.join(erts_path, ["otp*/", "erts*/", "include/"])
+    |> Path.expand()
+    |> Path.wildcard()
+    |> List.first()
+    |> then(fn
+      nil ->
+        # fallback: bundled ERTS may be at the root of erts_path
+        Path.join(erts_path, "erts*/include/")
+        |> Path.expand()
+        |> Path.wildcard()
+        |> List.first()
+
+      path ->
+        path
+    end)
+  end
+
+  # Covers the case where the host ERTS is used (same_target? == true)
+  defp resolve_erts_include({:runtime, _}) do
+    :code.root_dir()
+    |> to_string()
+    |> Path.join("erts-#{:erlang.system_info(:version)}/include")
+  end
+
+  defp resolve_erts_include(_) do
+    # Best-effort fallback: use host erl headers
+    {root, 0} =
+      System.cmd("erl", [
+        "-eval",
+        "io:format(\"~s\", [code:root_dir()])",
+        "-s",
+        "init",
+        "stop",
+        "-noshell"
+      ])
+
+    version = :erlang.system_info(:version) |> to_string()
+    Path.join(String.trim(root), "erts-#{version}/include")
+  end
+
+  defp find_zig! do
+    # Check absolute paths first, then fall back to resolving "zig" from PATH
+    # via System.find_executable/1 which is safe (no raise on missing).
+    absolute_candidates = [
+      Path.expand("~/.local/zig/zig"),
+      "/usr/local/bin/zig",
+      "/usr/bin/zig"
+    ]
+
+    found =
+      Enum.find(absolute_candidates, &File.exists?/1) ||
+        System.find_executable("zig")
+
+    found ||
+      raise "[RelinkSqliteNif] zig not found. Install zig or add it to PATH. " <>
+              "Tried: #{Enum.join(absolute_candidates, ", ")} and PATH"
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -194,7 +194,12 @@ defmodule Tau.MixProject do
         targets: target_atoms_to_keyword(target_atom),
         debug: false,
         extra_steps: [
-          patch: [post: [Tau.BurritoSteps.RelinkTermbox]]
+          patch: [
+            post: [
+              Tau.BurritoSteps.RelinkTermbox,
+              Tau.BurritoSteps.RelinkSqliteNif
+            ]
+          ]
         ]
       ]
 

--- a/test/tau/burrito_steps/relink_sqlite_nif_test.exs
+++ b/test/tau/burrito_steps/relink_sqlite_nif_test.exs
@@ -1,0 +1,62 @@
+defmodule Tau.BurritoSteps.RelinkSqliteNifTest do
+  @moduledoc """
+  Sanity-checks for the `Tau.BurritoSteps.RelinkSqliteNif` Burrito step.
+
+  The real proof of correctness for this module is an empirical Burrito build
+  + smoke run against the packaged binary (issue #261). These tests catch
+  cheap regressions: module-load, behaviour shape, and non-Linux passthrough.
+  """
+
+  use ExUnit.Case, async: true
+
+  alias Tau.BurritoSteps.RelinkSqliteNif
+
+  describe "module shape" do
+    test "implements the Burrito.Builder.Step behaviour" do
+      behaviours = RelinkSqliteNif.module_info(:attributes) |> Keyword.get_values(:behaviour)
+      assert Burrito.Builder.Step in List.flatten(behaviours)
+    end
+
+    test "exports execute/1" do
+      assert function_exported?(RelinkSqliteNif, :execute, 1)
+    end
+  end
+
+  describe "execute/1" do
+    test "returns the context unchanged for non-Linux targets" do
+      target = %Burrito.Builder.Target{
+        alias: :darwin_arm64,
+        os: :darwin,
+        cpu: :aarch64,
+        cross_build: false,
+        qualifiers: [],
+        erts_source: {:runtime, []},
+        debug?: false
+      }
+
+      context = %Burrito.Builder.Context{
+        target: target,
+        mix_release: %Mix.Release{
+          name: :tau,
+          version: "0.0.0",
+          path: System.tmp_dir!(),
+          version_path: System.tmp_dir!(),
+          applications: [],
+          boot_scripts: %{},
+          erts_source: nil,
+          erts_version: ~c"15.0",
+          config_providers: [],
+          options: [],
+          overlays: [],
+          steps: []
+        },
+        work_dir: System.tmp_dir!(),
+        self_dir: System.tmp_dir!(),
+        extra_build_env: [],
+        halted: false
+      }
+
+      assert RelinkSqliteNif.execute(context) == context
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Adds `Tau.BurritoSteps.RelinkSqliteNif` (sibling to `RelinkTermbox`). Compiles `deps/exqlite/c_src/sqlite3_nif.c` + `deps/exqlite/c_src/sqlite3.c` via `zig cc -target <cpu>-linux-musl` with exqlite's 22 SQLite compile-time `-D` flags (copied verbatim from `deps/exqlite/Makefile`). Drops the relinked `.so` into the Burrito work-tree at `lib/exqlite-*/priv/sqlite3_nif.so`.

Without this, the `./tau` Burrito binary crashed at startup whenever the FSM-backed `tau run` path executed:

```
Error relocating .../sqlite3_nif.so: __memmove_chk: symbol not found
```

— exactly the same musl-vs-glibc-fortified-symbols failure mode `RelinkTermbox` exists to fix for termbox. Identical class, same remedy.

## Linked issues

Closes #261

## Why it slipped 5 days

Every prior factory gate exercised the source tree only (`mix test`, `mix format`, `mix credo`, `mix compile`). None built the deployed Burrito artifact or smoked it. The companion issue #262 fixes the gate.

## Gate verdicts

- **critic**: PASS — independently re-ran the empirical smoke with a fresh `HOME`. Used readelf to confirm the relinked `sqlite3_nif.so` is musl-linked and has zero `__*_chk` fortified symbols.
- **reviewer**: PASS — all 10 gates green including a separate Burrito build + binary smoke.

## Empirical proof (post-fix)

```
$ . ~/.local/share/tau-toolchain/env.sh
$ rm -rf ~/.local/share/.burrito/tau_erts-*
$ BURRITO_TARGET=linux_amd64 MIX_ENV=prod mix release tau --overwrite
... Burrito has wrapped your Elixir app! ...

$ ./burrito_out/tau_linux_amd64 help run | grep system-prompt-file
    tau run [...] [--system-prompt-file SYSTEM_PROMPT_FILE] PROMPT

$ ./burrito_out/tau_linux_amd64 run "hello" --provider replay --model replay
(replay) hello                                  # EXIT=0
```

## NIF audit (after a Burrito build)

| `.so` | Status | Note |
|---|---|---|
| `exqlite/sqlite3_nif.so` | **Relinked (this PR)** | was the startup crash |
| `ex_termbox/termbox_bindings.so` | Already covered | by `RelinkTermbox` |
| `asn1/asn1rt_nif.so` | No-op | shipped in precompiled musl ERTS |
| `crypto/{crypto,crypto_callback,otp_test_engine}.so` | No-op | shipped in precompiled musl ERTS |
| `sqlite_vec/vec0.so` | **Deferred — see follow-up** | glibc-linked but uses only base libc symbols (no `__*_chk`); loads on musl by ABI accident. Will be filed as a follow-up issue. |

## Critic-surfaced follow-ups (filed separately)

1. **vec0 latent risk** — vec0.so IS loaded at boot (`Tau.Memory.Supervisor` → migration 007 `CREATE VIRTUAL TABLE memory_vec USING vec0(...)`). It works today by accident of using only base libc symbols. A future vec0 upgrade that introduces fortified symbols would silently break boot. Follow-up issue to relink vec0 from source.
2. **Burrito unpack-cache ergonomics** — `~/.local/share/.burrito/tau_erts-<version>/` is keyed on the release version string. With uncommitted edits the version string can repeat (`...dirty`), so the cache reuses the prior unpack. Worth busting between local rebuilds. Follow-up issue.
3. **`@sqlite_defines` manual sync with exqlite's Makefile** — hex bump could silently drift; moduledoc warns. Future hardening: parse the Makefile at compile time.

## Test plan

- [x] `mix test` — 936 tests + 75 properties, 0 failures
- [x] `mix format --check-formatted`, `mix compile --warnings-as-errors`, `mix credo --strict` clean
- [x] Burrito build succeeds end-to-end
- [x] Binary `--help`, `--system-prompt-file` flag present
- [x] Replay smoke: `(replay) hello`, exit 0
- [x] readelf on relinked `.so` shows musl + no `__*_chk` symbols

🤖 Generated with [Claude Code](https://claude.com/claude-code)