### PR TITLE
feat(gate): mix tau.smoke + CI binary-smoke; reviewer persona checks CI

### DIFF
--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -41,14 +41,24 @@ edit, write, or delete any files. Report findings only.
 3. Run the test suite: `mix test`. Record pass/fail counts.
 4. Run the formatter: `mix format --check-formatted`. Record any unformatted files.
 5. Run the linter: `mix credo --strict`. Record issues by category.
-6. Inspect modified files against the spec.
-7. Report findings in structured format.
+6. **Confirm the `binary-smoke` CI check is green on this PR.** Run
+   `gh pr checks <n>` (the PR number is in the spawn brief or via
+   `gh pr view --json number`). The `binary-smoke (mix tau.smoke ·
+   linux_amd64)` check MUST be `pass` or `skipping` — a skip is
+   acceptable ONLY when the path filter excluded the change (docs-only
+   PR); state that explicitly in the verdict. CI runs the deployed-
+   artifact smoke; do NOT run `mix release` or `mix tau.smoke` by hand.
+7. Inspect modified files against the spec.
+8. Report findings in structured format.
 
 ## What to Check
 
 - **Tests pass?** Run `mix test`. If any fail, report which and why.
 - **Format clean?** `mix format --check-formatted` must exit 0.
 - **Credo clean?** `mix credo --strict` issues must be addressed or justified.
+- **Binary-smoke CI green?** `gh pr checks <n>` must show
+  `binary-smoke` as `pass` (or `skipping` for a docs-only PR with the
+  path filter engaged). A FAIL or pending check is a blocking finding.
 - **Silent failures?** Look for: empty `try/rescue` blocks, functions
   returning defaults instead of computing, tests that assert nothing
   meaningful, swallowed errors that should be tagged tuples or

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -286,6 +286,83 @@ jobs:
         if: steps.dialyzer_step.outcome == 'failure'
         run: exit 1
 
+  binary-smoke:
+    name: binary-smoke (mix tau.smoke · linux_amd64)
+    # Deployed-artifact gate — issue #262. Builds the Burrito binary and
+    # exercises a replay round-trip end-to-end. The unit suite cannot
+    # catch a non-functional binary; this job can. Path-filtered so
+    # docs-only PRs are not blocked on a 4-minute release build.
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Detect non-docs changes
+        id: changes
+        uses: dorny/paths-filter@v3
+        with:
+          # `build: true` when at least one changed path is NOT in the
+          # docs/markdown-only set. The negation prefix `!` excludes a
+          # path from the match. Conservative: anything that could
+          # change build output (lib/, test/, mix.exs, mix.lock, .github/,
+          # scripts/, priv/, config/) flips `build` to true.
+          filters: |
+            build:
+              - '!docs/**'
+              - '!**/*.md'
+              - '!**/*.org'
+              - '!LICENSE'
+              - '!CHANGELOG.md'
+              - '!.gitignore'
+
+      - name: Setup Python (3.10 for ex_termbox waf)
+        if: steps.changes.outputs.build == 'true'
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Setup BEAM
+        if: steps.changes.outputs.build == 'true'
+        uses: erlef/setup-beam@v1
+        with:
+          version-file: .tool-versions
+          version-type: strict
+
+      - name: Setup Zig (Burrito launcher cross-compiler)
+        if: steps.changes.outputs.build == 'true'
+        uses: mlugg/setup-zig@v1
+        with:
+          version: "0.15.2"
+
+      - name: Setup xz (Burrito tarball compressor)
+        if: steps.changes.outputs.build == 'true'
+        run: sudo apt-get update && sudo apt-get install -y xz-utils
+
+      - name: Cache deps
+        if: steps.changes.outputs.build == 'true'
+        uses: actions/cache@v4
+        with:
+          path: |
+            deps
+            _build
+          key: ${{ runner.os }}-mix-binary-smoke-${{ hashFiles('**/mix.lock', 'mix.exs') }}
+
+      - name: Fetch deps
+        if: steps.changes.outputs.build == 'true'
+        run: mix deps.get
+        env:
+          MIX_ENV: prod
+
+      - name: mix tau.smoke
+        if: steps.changes.outputs.build == 'true'
+        run: mix tau.smoke
+        env:
+          BURRITO_TARGET: linux_amd64
+
+      - name: Note skip on docs-only PR
+        if: steps.changes.outputs.build != 'true'
+        run: |
+          echo "binary-smoke skipped: docs-only diff"
+
   escript:
     name: escript build
     runs-on: ubuntu-24.04

--- a/lib/mix/tasks/tau.smoke.ex
+++ b/lib/mix/tasks/tau.smoke.ex
@@ -1,0 +1,194 @@
+defmodule Mix.Tasks.Tau.Smoke do
+  @shortdoc "Build the Burrito binary and run a replay smoke. Closes #262."
+
+  @moduledoc """
+  Deployed-artifact smoke gate.
+
+  One command, deterministic, machine-checkable:
+
+      mix tau.smoke
+
+  Builds the host-architecture Burrito release of `tau`, invokes the
+  produced binary with `run "hello" --provider replay --model replay`,
+  and asserts:
+
+    * The binary exits 0.
+    * Stdout contains `(replay) hello` — the canonical Replay fixture
+      token from `Tau.Providers.Replay.default_events/0`.
+
+  Exits 0 on full success. Exits non-zero on every failure with a
+  distinct exit code so CI logs name the failure mode:
+
+  | exit | symbol               | meaning                                     |
+  |------|----------------------|---------------------------------------------|
+  | 0    | OK                   | Built and smoke-ran cleanly.                |
+  | 2    | UNSUPPORTED_HOST     | Not a host we know how to target.           |
+  | 3    | BUILD_FAILED         | `mix release tau --overwrite` exited != 0.  |
+  | 4    | BINARY_MISSING       | Build returned 0 but no `burrito_out/tau_*` |
+  | 5    | BINARY_NONZERO_EXIT  | Binary ran but exited != 0.                 |
+  | 6    | OUTPUT_MISMATCH      | Binary ran 0 but stdout missing fixture.    |
+
+  ## Host assumption
+
+  When `BURRITO_TARGET` is set in the environment it is honoured.
+  Otherwise this task detects the host: on Linux/x86_64 it sets
+  `BURRITO_TARGET=linux_amd64` (the only target CI runs this on); on
+  Linux/aarch64 `linux_arm64`; on macOS x86_64/aarch64 the matching
+  `macos_*`. Other hosts (notably Windows) exit with
+  `UNSUPPORTED_HOST` (2) — the task is intended for the CI smoke job
+  and the Linux dev box, not Windows.
+
+  ## Burrito unpack-cache bust (#266)
+
+  Burrito caches the unpacked ERTS bundle under
+  `~/.local/share/.burrito/tau_erts-*`. The cache key does NOT include
+  the binary's content hash, so a stale cache can silently mask a
+  freshly-built broken binary — see #266. To remove that trap this
+  task wipes any matching cache directory before the smoke runs.
+  """
+
+  use Mix.Task
+
+  @cache_glob_basename "tau_erts-*"
+  @exit_unsupported_host 2
+  @exit_build_failed 3
+  @exit_binary_missing 4
+  @exit_binary_nonzero_exit 5
+  @exit_output_mismatch 6
+
+  @smoke_token "(replay) hello"
+
+  @impl Mix.Task
+  def run(_argv) do
+    with {:ok, target} <- resolve_target(),
+         :ok <- bust_burrito_cache(),
+         :ok <- build_release(target),
+         {:ok, binary} <- locate_binary(target),
+         :ok <- smoke_binary(binary) do
+      Mix.shell().info("tau.smoke: OK (#{target})")
+      :ok
+    else
+      {:error, code, message} ->
+        Mix.shell().error("tau.smoke: #{message}")
+        System.halt(code)
+    end
+  end
+
+  # --- target resolution ---------------------------------------------------
+
+  defp resolve_target do
+    case System.get_env("BURRITO_TARGET") do
+      value when is_binary(value) and value != "" ->
+        {:ok, value}
+
+      _ ->
+        detect_host_target()
+    end
+  end
+
+  defp detect_host_target do
+    arch = :erlang.system_info(:system_architecture) |> to_string()
+
+    case {:os.type(), arch} do
+      {{:unix, :linux}, a} ->
+        cond do
+          String.contains?(a, "aarch64") -> {:ok, "linux_arm64"}
+          String.contains?(a, "x86_64") -> {:ok, "linux_amd64"}
+          true -> unsupported("linux arch #{inspect(a)} not supported")
+        end
+
+      {{:unix, :darwin}, a} ->
+        cond do
+          String.contains?(a, "aarch64") -> {:ok, "macos_arm64"}
+          String.contains?(a, "x86_64") -> {:ok, "macos_amd64"}
+          true -> unsupported("darwin arch #{inspect(a)} not supported")
+        end
+
+      other ->
+        unsupported("host #{inspect(other)} not supported (set BURRITO_TARGET to override)")
+    end
+  end
+
+  defp unsupported(msg), do: {:error, @exit_unsupported_host, "UNSUPPORTED_HOST: " <> msg}
+
+  # --- cache bust ----------------------------------------------------------
+
+  defp bust_burrito_cache do
+    cache_root =
+      case System.get_env("XDG_DATA_HOME") do
+        v when is_binary(v) and v != "" -> Path.join(v, ".burrito")
+        _ -> Path.expand("~/.local/share/.burrito")
+      end
+
+    cache_root
+    |> Path.join(@cache_glob_basename)
+    |> Path.wildcard()
+    |> Enum.each(fn dir ->
+      Mix.shell().info("tau.smoke: bust burrito cache #{dir}")
+      File.rm_rf!(dir)
+    end)
+
+    :ok
+  end
+
+  # --- release build -------------------------------------------------------
+
+  defp build_release(target) do
+    env = [
+      {"MIX_ENV", "prod"},
+      {"BURRITO_TARGET", target},
+      {"HEX_HTTP_TIMEOUT", "120"}
+    ]
+
+    Mix.shell().info("tau.smoke: mix release tau --overwrite (target=#{target})")
+
+    case System.cmd("mix", ["release", "tau", "--overwrite"],
+           env: env,
+           stderr_to_stdout: true,
+           into: IO.stream(:stdio, :line)
+         ) do
+      {_io, 0} ->
+        :ok
+
+      {_io, code} ->
+        {:error, @exit_build_failed, "BUILD_FAILED: `mix release tau --overwrite` exited #{code}"}
+    end
+  end
+
+  # --- binary location -----------------------------------------------------
+
+  defp locate_binary(target) do
+    path = Path.expand("burrito_out/tau_#{target}", File.cwd!())
+
+    if File.regular?(path) do
+      {:ok, path}
+    else
+      {:error, @exit_binary_missing, "BINARY_MISSING: expected #{path} after a successful build"}
+    end
+  end
+
+  # --- smoke run -----------------------------------------------------------
+
+  defp smoke_binary(binary) do
+    Mix.shell().info("tau.smoke: #{binary} run \"hello\" --provider replay --model replay")
+
+    {output, exit_code} =
+      System.cmd(binary, ["run", "hello", "--provider", "replay", "--model", "replay"],
+        stderr_to_stdout: true
+      )
+
+    cond do
+      exit_code != 0 ->
+        {:error, @exit_binary_nonzero_exit,
+         "BINARY_NONZERO_EXIT: binary exited #{exit_code}; output:\n#{output}"}
+
+      not String.contains?(output, @smoke_token) ->
+        {:error, @exit_output_mismatch,
+         "OUTPUT_MISMATCH: stdout missing #{inspect(@smoke_token)}; got:\n#{output}"}
+
+      true ->
+        IO.write(output)
+        :ok
+    end
+  end
+end

--- a/priv/skills/reviewer/SKILL.md
+++ b/priv/skills/reviewer/SKILL.md
@@ -17,14 +17,22 @@ linters). You MUST NOT edit, write, or delete any files. Report findings only.
 3. Run the test suite: `mix test`. Record pass/fail counts.
 4. Run the formatter: `mix format --check-formatted`. Record any unformatted files.
 5. Run the linter: `mix credo --strict`. Record issues by category.
-6. Inspect modified files against the spec.
-7. Report findings in structured format.
+6. Confirm the `binary-smoke` CI check on the PR is green via
+   `gh pr checks <n>`. A `skipping` status is acceptable ONLY when the
+   path filter excluded the change (docs-only PR); note that
+   explicitly. Do NOT run `mix release` or `mix tau.smoke` by hand —
+   CI runs the deployed-artifact smoke.
+7. Inspect modified files against the spec.
+8. Report findings in structured format.
 
 ## What to Check
 
 - **Tests pass?** Run `mix test`. If any fail, report which and why.
 - **Format clean?** `mix format --check-formatted` must exit 0.
 - **Credo clean?** `mix credo --strict` issues must be addressed or justified.
+- **Binary-smoke CI green?** `gh pr checks <n>` must show
+  `binary-smoke` as `pass` (or `skipping` for a docs-only PR). A FAIL
+  or pending check is a blocking finding; do NOT smoke by hand.
 - **Silent failures?** Look for: empty `try/rescue` blocks, functions
   returning defaults instead of computing, tests that assert nothing
   meaningful, swallowed errors that should be tagged tuples or


### PR DESCRIPTION
## Summary

Automates the deployed-artifact (Burrito binary) smoke gate. **Closes the gap that let PRs #253/#257/#260 ship binaries that couldn't even boot** — every prior gate ran source-tree checks only.

- `lib/mix/tasks/tau.smoke.ex` — one-command Mix task. Pipeline: bust Burrito unpack cache → `mix release tau --overwrite` → invoke binary with `run "hello" --provider replay --model replay` → assert exit 0 + `(replay) hello`. 6 distinct exit codes (`0` OK, `2` UNSUPPORTED_HOST, `3` BUILD_FAILED, `4` BINARY_MISSING, `5` BINARY_NONZERO_EXIT, `6` OUTPUT_MISMATCH). Host auto-detected (linux/macOS, x86_64/aarch64); `BURRITO_TARGET` env honoured when set.
- `.github/workflows/ci.yml` — new `binary-smoke` job. `dorny/paths-filter@v3` skips docs-only PRs.
- `.claude/agents/reviewer.md` + `priv/skills/reviewer/SKILL.md` — collapse: the reviewer gate's only smoke step is now "confirm the `binary-smoke` CI check is green." Explicit prohibition on running the smoke manually.

## Linked issues

Closes #262

## Gate verdicts

- **critic**: PASS (`ok: true`) — 5 non-blocking WARNINGs. Most actionable filed as #269 (path filter excludes bundled persona `.md` files).
- **reviewer**: PASS (`ok: true`) — ran `mix tau.smoke` end-to-end in its worktree, got `tau.smoke: OK (linux_amd64)` EXIT 0.

## Empirical proof (dog-fooded)

```
$ mix tau.smoke
tau.smoke: bust burrito cache /home/brentw/.local/share/.burrito/tau_erts-15.2_0.2.0+01a264d.dirty
tau.smoke: mix release tau --overwrite (target=linux_amd64)
tau.smoke: ./burrito_out/tau_linux_amd64 run "hello" --provider replay --model replay
(replay) hello
tau.smoke: OK (linux_amd64)
EXIT=0
```

The critic separately confirmed that on a host without `zig`, the task correctly returns exit 3 (BUILD_FAILED) rather than a generic crash — the exit-code semantics work.

## Critic-surfaced follow-ups (filed)

- **#269**: path filter excludes `priv/skills/*/SKILL.md` (bundled into the binary). A PR that only edits a bundled persona would skip the smoke. Real adversarial hole.

Critic also flagged but not separately filed (rolled into #268's scope or otherwise nice-to-have):
- Exit 3 lumps "toolchain missing" with "code error" — could distinguish.
- Persona doesn't specify "wait for pending check" semantics; literal reading makes pending a blocking finding.
- `mix tau.smoke` is a flat `with` pipeline; #268 will need to extend (acknowledged in #268).

## What this closes systemically

After this lands, every code-touching PR runs `mix tau.smoke` as a blocking CI gate. The Burrito binary's basic boot + replay path is exercised on the deployed artifact, not just the source tree. #268 extends this with tool-exposure (E) and coordinator round-trip (F) layers — the rest of the QA routine.

## Test plan

- [x] `mix test` — 936 tests + 75 properties, 0 failures
- [x] `mix format --check-formatted`, `mix compile --warnings-as-errors`, `mix credo --strict` clean
- [x] `mix tau.smoke` — `EXIT=0`, output matches design
- [x] Reviewer independently ran `mix tau.smoke` and got the same result

🤖 Generated with [Claude Code](https://claude.com/claude-code)