### PR TITLE
fix(gate): critic = design only; reviewer = artifact + spec only

### DIFF
--- a/.claude/agents/critic.md
+++ b/.claude/agents/critic.md
@@ -79,6 +79,13 @@ demonstrates this? What would failure look like?"
 - Reinventing the wheel: "This exists in the stack. Use it."
 - OTP non-negotiables: flag any process holding state outside a supervisor; any new GenServer wrapping pure functions; any cross-process `send/2` to a `Process.whereis/1` lookup; any `try/rescue` across process boundaries; any HTTP client besides Finch/Mint; any `IO.puts` for logging. Reference `.claude/rules/otp-non-negotiables.md` in the finding.
 
+## Scope — design review only
+
+Do NOT build the Burrito binary, do NOT run `mix tau.smoke`, do NOT run
+`mix test` for empirical re-verification. Those are the reviewer's job.
+The critic reads the diff, reasons about design correctness and adversarial
+cases, and emits structured findings.
+
 ## When invoked by `/pr`
 
 Read the diff (`git diff main...HEAD`). Apply the PSDH triage checklist via the `design-reasoning` skill to any new component. Reference `.claude/rules/otp-non-negotiables.md` and the `tau-architecture` skill. Output a single JSON object as the final line of your response: `{"ok": true}` or `{"ok": false, "reason": "<specific blocking concern>"}`.

--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -38,24 +38,28 @@ edit, write, or delete any files. Report findings only.
    operate on the parent. To review a specific branch, fetch and check
    it out explicitly inside the worktree before evaluating.
 2. Read the original task specification.
-3. Run the test suite: `mix test`. Record pass/fail counts.
-4. Run the formatter: `mix format --check-formatted`. Record any unformatted files.
-5. Run the linter: `mix credo --strict`. Record issues by category.
-6. **Confirm the `binary-smoke` CI check is green on this PR.** Run
+3. **Confirm the `binary-smoke` CI check is green on this PR.** Run
    `gh pr checks <n>` (the PR number is in the spawn brief or via
    `gh pr view --json number`). The `binary-smoke (mix tau.smoke ·
    linux_amd64)` check MUST be `pass` or `skipping` — a skip is
    acceptable ONLY when the path filter excluded the change (docs-only
    PR); state that explicitly in the verdict. CI runs the deployed-
    artifact smoke; do NOT run `mix release` or `mix tau.smoke` by hand.
-7. Inspect modified files against the spec.
-8. Report findings in structured format.
+4. Inspect modified files against the spec.
+5. Report findings in structured format.
+
+## Scope — deployed artifact + spec/AC
+
+Trust the implementer's pre-commit on source-tree gates (mix test / format
+/ credo / compile-WAE); CI's source-tree job confirms them. The reviewer's
+local work: (1) `mix tau.smoke` (or confirm CI `binary-smoke` green via
+`gh pr checks <n>`), (2) diff-vs-spec / AC compliance, (3) verdict.
+
+Do NOT re-run `mix test`, `mix format`, `mix credo`, or
+`mix compile --warnings-as-errors` — they're covered upstream.
 
 ## What to Check
 
-- **Tests pass?** Run `mix test`. If any fail, report which and why.
-- **Format clean?** `mix format --check-formatted` must exit 0.
-- **Credo clean?** `mix credo --strict` issues must be addressed or justified.
 - **Binary-smoke CI green?** `gh pr checks <n>` must show
   `binary-smoke` as `pass` (or `skipping` for a docs-only PR with the
   path filter engaged). A FAIL or pending check is a blocking finding.

--- a/priv/skills/critic/SKILL.md
+++ b/priv/skills/critic/SKILL.md
@@ -65,6 +65,13 @@ demonstrates this? What would failure look like?"
   a `Process.whereis/1` lookup; any `try/rescue` across process boundaries;
   any HTTP client besides Finch/Mint; any `IO.puts` for logging.
 
+## Scope — design review only
+
+Do NOT build the Burrito binary, do NOT run `mix tau.smoke`, do NOT run
+`mix test` for empirical re-verification. Those are the reviewer's job.
+The critic reads the diff, reasons about design correctness and adversarial
+cases, and emits structured findings.
+
 ## When the coordinator calls you via Agent for the gate
 
 Read the PR diff with `git diff origin/main...HEAD` from the inherited cwd.

--- a/priv/skills/reviewer/SKILL.md
+++ b/priv/skills/reviewer/SKILL.md
@@ -15,22 +15,26 @@ linters). You MUST NOT edit, write, or delete any files. Report findings only.
 
 1. Run `pwd` and `git branch --show-current` to confirm your position.
 2. Read the original task specification.
-3. Run the test suite: `mix test`. Record pass/fail counts.
-4. Run the formatter: `mix format --check-formatted`. Record any unformatted files.
-5. Run the linter: `mix credo --strict`. Record issues by category.
-6. Confirm the `binary-smoke` CI check on the PR is green via
+3. Confirm the `binary-smoke` CI check on the PR is green via
    `gh pr checks <n>`. A `skipping` status is acceptable ONLY when the
    path filter excluded the change (docs-only PR); note that
    explicitly. Do NOT run `mix release` or `mix tau.smoke` by hand —
    CI runs the deployed-artifact smoke.
-7. Inspect modified files against the spec.
-8. Report findings in structured format.
+4. Inspect modified files against the spec.
+5. Report findings in structured format.
+
+## Scope — deployed artifact + spec/AC
+
+Trust the implementer's pre-commit on source-tree gates (mix test / format
+/ credo / compile-WAE); CI's source-tree job confirms them. The reviewer's
+local work: (1) `mix tau.smoke` (or confirm CI `binary-smoke` green via
+`gh pr checks <n>`), (2) diff-vs-spec / AC compliance, (3) verdict.
+
+Do NOT re-run `mix test`, `mix format`, `mix credo`, or
+`mix compile --warnings-as-errors` — they're covered upstream.
 
 ## What to Check
 
-- **Tests pass?** Run `mix test`. If any fail, report which and why.
-- **Format clean?** `mix format --check-formatted` must exit 0.
-- **Credo clean?** `mix credo --strict` issues must be addressed or justified.
 - **Binary-smoke CI green?** `gh pr checks <n>` must show
   `binary-smoke` as `pass` (or `skipping` for a docs-only PR). A FAIL
   or pending check is a blocking finding; do NOT smoke by hand.


### PR DESCRIPTION
## Summary

Tightens both gate halves to eliminate redundant work per gate cycle (~50% wall-time savings).

- **Critic** now explicitly prohibits running `mix tau.smoke` / `mix release` / `mix test` for empirical re-verification. Reads diff, reasons about design, emits structured findings.
- **Reviewer** drops the redundant source-tree gates (`mix test` / `mix format --check-formatted` / `mix credo --strict` / `mix compile --warnings-as-errors`). The implementer's pre-commit and CI's source-tree job confirm those. The reviewer's local work is `mix tau.smoke` (deployed-artifact) + diff-vs-spec/AC compliance.

## Linked issues

Closes #271

## Gate verdicts

- **critic**: PASS (~2 min wall via the new lean brief pattern — vs ~10-15 min on the prior bloated pattern; same depth of review).
- **reviewer**: PASS — confirmed via `mix tau.smoke OK (linux_amd64)`, all 4 persona files parse cleanly, frontmatter intact.

## Files

4 persona text files:
- `.claude/agents/critic.md` + `priv/skills/critic/SKILL.md` — add "Scope — design review only" section.
- `.claude/agents/reviewer.md` + `priv/skills/reviewer/SKILL.md` — drop redundant source-tree steps; add "Scope — deployed artifact + spec/AC" section.

Persona-text only. No code changes. Reviewer dog-fooded `mix tau.smoke` (the bundled `priv/skills/*/SKILL.md` files are loaded into the binary so a broken frontmatter would have surfaced).

🤖 Generated with [Claude Code](https://claude.com/claude-code)