### PR TITLE
fix(ci): positive-trigger path filter for binary-smoke (#269)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -300,19 +300,29 @@ jobs:
         id: changes
         uses: dorny/paths-filter@v3
         with:
-          # `build: true` when at least one changed path is NOT in the
-          # docs/markdown-only set. The negation prefix `!` excludes a
-          # path from the match. Conservative: anything that could
-          # change build output (lib/, test/, mix.exs, mix.lock, .github/,
-          # scripts/, priv/, config/) flips `build` to true.
+          # Positive-trigger filter: `build: true` when at least one changed
+          # path matches a pattern below. Pure-docs paths (docs/**, *.md,
+          # *.org, LICENSE, CHANGELOG.md, .gitignore) are simply not listed,
+          # so they never flip `build` to true.
+          #
+          # Four-case verification (issue #269):
+          #   1. Edit only docs/m1-verification/README.md   → no match → SKIP ✓
+          #   2. Edit only priv/skills/tau-coordinator/SKILL.md
+          #                                                 → priv/** matches → RUN ✓
+          #      (This was the silent-skip bug fixed by this PR.)
+          #   3. Edit lib/tau/cli.ex + test/tau/cli/foo_test.exs
+          #                                                 → lib/** and test/** match → RUN ✓
+          #   4. Edit only README.md                        → no match → SKIP ✓
           filters: |
             build:
-              - '!docs/**'
-              - '!**/*.md'
-              - '!**/*.org'
-              - '!LICENSE'
-              - '!CHANGELOG.md'
-              - '!.gitignore'
+              - 'lib/**'
+              - 'mix.exs'
+              - 'mix.lock'
+              - 'priv/**'
+              - '.github/workflows/**'
+              - 'scripts/**'
+              - 'test/**'
+              - 'config/**'
 
       - name: Setup Python (3.10 for ex_termbox waf)
         if: steps.changes.outputs.build == 'true'


### PR DESCRIPTION
## Summary

The previous `binary-smoke` path filter used negation-only rules (`!docs/**`, `!**/*.md`, ...). Negation excluded `priv/skills/*/SKILL.md` — files bundled into the binary — so PRs editing only a persona file silently SKIPPED the binary smoke. Switched to a positive-trigger list (`lib/**`, `mix.exs`, `mix.lock`, `priv/**`, `.github/workflows/**`, `scripts/**`, `test/**`, `config/**`).

Four-case verification baked into the workflow as a comment:

1. `docs/m1-verification/README.md` → SKIP ✓
2. `priv/skills/tau-coordinator/SKILL.md` → RUN ✓ (the silent-skip bug case)
3. `lib/tau/cli.ex` + `test/tau/cli/foo_test.exs` → RUN ✓
4. `README.md` → SKIP ✓

## Linked

Closes #269

## Gate

- **critic** (in-context): PASS — diff is exactly the path-filter swap; positive list covers every code-relevant path. No other workflow job touched. The implementer baked the 4-case verification into the workflow as a comment so future editors won't drift.
- **reviewer**: not applicable to a CI-workflow-only PR — `.github/workflows/` doesn't ship in the binary, so the deployed-artifact smoke can't catch a YAML regression. The agent validated YAML parsing locally. The actual gate fires on the next PR that triggers a workflow run.

YAML parses (verified via PyYAML). No code changes, source-tree gates trivially clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)