### PR TITLE
fix(burrito): include build-time epoch in dirty release version (#266)

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -163,7 +163,14 @@ defmodule Tau.MixProject do
               _ -> false
             end
 
-          suffix = if dirty?, do: ".dirty", else: ""
+          suffix =
+            if dirty? do
+              epoch = System.os_time(:second)
+              ".dirty.#{epoch}"
+            else
+              ""
+            end
+
           "+" <> String.trim(sha) <> suffix
 
         _ ->


### PR DESCRIPTION
## Summary

Burrito unpacks at `$XDG_DATA_HOME/.burrito/tau_erts-<erts>_<release-version>/`. The release version was `@version <> git_descriptor()` where the dirty-tree suffix was the static `.dirty` — so two consecutive dirty rebuilds produced the same cache key and Burrito reused the prior unpacked tree (mismatched against the freshly-built payload, surface: `XZ/LZMA Decode Failed` or stale-NIF errors at runtime).

Fix: dirty suffix is now `.dirty.<unix-epoch-seconds>` via `System.os_time(:second)` at `mix release` time. Clean commits unaffected (suffix stays empty / `+<sha>`).

## Linked

Closes #266

## Gate

- **critic** in-context: PASS — minimal one-function change; clean commits behave identically; dirty rebuilds within the same second still collide (correct — same payload, same cache).
- **reviewer** (implementer-run): 943 tests / 0 failures; `mix tau.smoke` exit 0.

## Empirical proof (verbatim)

Two consecutive dirty `mix tau.smoke` invocations with a 2-second gap produced distinct caches:

- Build 1: `tau_erts-15.2_0.2.0+ea0b197.dirty.1779293066`
- Build 2: `tau_erts-15.2_0.2.0+ea0b197.dirty.1779293202`

Distinct epoch → distinct cache → no stale-NIF re-use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)