### PR TITLE
fix(coordinator): worked Agent call shape in persona (#291)

### DIFF
--- a/priv/skills/tau-coordinator/SKILL.md
+++ b/priv/skills/tau-coordinator/SKILL.md
@@ -20,6 +20,31 @@ escalate). The child runs to its first `:end_turn` and returns its assistant
 text as the tool result. Crashes surface as `is_error: true`; treat them as
 `killed` outcomes.
 
+### Agent call shape (literal example)
+
+```json
+{
+  "description": "Implement #291: add worked Agent-call example to coordinator persona",
+  "subagent_type": "implementer",
+  "permissions_mode": "default",
+  "system_prompt": "..."
+}
+```
+
+REQUIRED fields: `description` (string). All other fields are optional.
+
+- `subagent_type` — one of `"implementer"`, `"critic"`, `"reviewer"`,
+  `"general-purpose"`. Omit for a general-purpose sub-agent with no persona.
+- `permissions_mode` — one of `"default"`, `"accept_edits"`, `"plan"`,
+  `"auto"`, `"dont_ask"`, `"bypass"`. Clamped against the parent; the child
+  can never escalate.
+- `system_prompt` — optional string prepended to the brief.
+
+A call missing `description` is rejected synchronously by the session with
+`"Invalid arguments for tool Agent: #: Required property description was not
+present."` — do NOT retry the same shape; supply the missing field and
+reissue.
+
 ## Kill switch
 
 Check `.claude/STOP-FACTORY` before every factory step. If the file exists:


### PR DESCRIPTION
## Summary

Coordinator persona now contains a literal worked example of the Agent tool call shape, the required-field list, the `permissions_mode` enum verbatim, and the exact session-side error message returned on a missing `description`. Closes #291.

## Linked issues

Closes #291

## Gate verdicts

- critic: PASS — single-file persona doc edit; schema claims verified against `lib/tau/tools/builtin/agent.ex` (`required: ["description"]`, `permissions_mode` enum exactly matches); error-message claim verified against `lib/tau/session.ex:2259`.
- reviewer: PASS — `mix tau.qa` returned `tau.qa: OK (linux_amd64)` exit 0.

## Test plan

- [x] `mix compile --warnings-as-errors` clean
- [x] `mix format --check-formatted` clean
- [x] `mix test test/tau/skills/` — 21 tests, 0 failures
- [x] `mix tau.qa` — exit 0 (all six layers green)