### PR TITLE
fix(assembler): drop incomplete tool_call blocks on Event.Error (#298, M1 blocker)

### DIFF
--- a/lib/tau/message/assembler.ex
+++ b/lib/tau/message/assembler.ex
@@ -54,7 +54,7 @@ defmodule Tau.Message.Assembler do
   end
 
   def step(state, %Event.TextStart{block_id: id}) do
-    block = %{type: :text, text: "", id: id}
+    block = %{type: :text, text: "", id: id, _complete?: false}
     %{state | blocks: Map.put(state.blocks, id, block), order: state.order ++ [id]}
   end
 
@@ -65,7 +65,7 @@ defmodule Tau.Message.Assembler do
   def step(state, %Event.TextEnd{block_id: id}), do: finalize_block(state, id)
 
   def step(state, %Event.ThinkingStart{block_id: id}) do
-    block = %{type: :thinking, text: "", signature: nil, id: id}
+    block = %{type: :thinking, text: "", signature: nil, id: id, _complete?: false}
     %{state | blocks: Map.put(state.blocks, id, block), order: state.order ++ [id]}
   end
 
@@ -79,7 +79,15 @@ defmodule Tau.Message.Assembler do
   end
 
   def step(state, %Event.ToolCallStart{tool_call_id: id, name: name}) do
-    block = %{type: :tool_call, id: id, name: name, arguments: %{}, _args_buf: ""}
+    block = %{
+      type: :tool_call,
+      id: id,
+      name: name,
+      arguments: %{},
+      _args_buf: "",
+      _complete?: false
+    }
+
     %{state | blocks: Map.put(state.blocks, id, block), order: state.order ++ [id]}
   end
 
@@ -98,6 +106,8 @@ defmodule Tau.Message.Assembler do
   end
 
   def step(state, %Event.Error{reason: r, retryable?: _}) do
+    state = drop_incomplete_tool_calls(state)
+
     msg = %{
       state.message
       | stop_reason: :error,
@@ -126,10 +136,25 @@ defmodule Tau.Message.Assembler do
     end
   end
 
-  defp finalize_block(state, _id), do: state
+  defp finalize_block(state, id) do
+    update_block(state, id, fn b -> Map.put(b, :_complete?, true) end)
+  end
 
-  defp strip_internals(%{type: :tool_call} = b), do: Map.drop(b, [:_args_buf])
-  defp strip_internals(b), do: Map.drop(b, [:id])
+  defp drop_incomplete_tool_calls(state) do
+    incomplete_ids =
+      state.blocks
+      |> Enum.filter(fn {_id, b} -> b[:type] == :tool_call and not b[:_complete?] end)
+      |> Enum.map(fn {id, _b} -> id end)
+
+    %{
+      state
+      | blocks: Map.drop(state.blocks, incomplete_ids),
+        order: Enum.reject(state.order, &(&1 in incomplete_ids))
+    }
+  end
+
+  defp strip_internals(%{type: :tool_call} = b), do: Map.drop(b, [:_args_buf, :_complete?])
+  defp strip_internals(b), do: Map.drop(b, [:id, :_complete?])
 
   defp format_reason({:http_status, n, %{type: type, message: msg}}) when is_binary(type),
     do: "HTTP #{n} (#{type}): #{msg}"

--- a/test/tau/message/assembler_test.exs
+++ b/test/tau/message/assembler_test.exs
@@ -75,6 +75,41 @@ defmodule Tau.Message.AssemblerTest do
       assert msg.error_message =~ "503"
       assert [%{type: :text, text: "partial"}] = msg.content
     end
+
+    test "Event.Error drops in-progress tool_call blocks" do
+      state = Assembler.new()
+      state = Assembler.step(state, %Event.TextStart{block_id: "t1"})
+      state = Assembler.step(state, %Event.TextDelta{block_id: "t1", text: "hello"})
+      state = Assembler.step(state, %Event.TextEnd{block_id: "t1"})
+      state = Assembler.step(state, %Event.ToolCallStart{tool_call_id: "tc1", name: "Agent"})
+      # NO ToolCallEnd — stream errors mid-tool-use
+      state =
+        Assembler.step(state, %Event.Error{reason: {"overloaded_error", "..."}, retryable?: true})
+
+      msg = state.message
+      assert msg.stop_reason == :error
+      assert Enum.any?(msg.content, &match?(%{type: :text, text: "hello"}, &1))
+      refute Enum.any?(msg.content, &match?(%{type: :tool_call}, &1))
+    end
+
+    test "Event.Error keeps completed tool_call blocks" do
+      events = [
+        %Event.Start{request_id: "r1", model: "m"},
+        %Event.ToolCallStart{tool_call_id: "tc1", name: "Read"},
+        %Event.ToolCallDelta{tool_call_id: "tc1", json_fragment: "{\"path\":\"a.txt\"}"},
+        %Event.ToolCallEnd{tool_call_id: "tc1", params: %{"path" => "a.txt"}},
+        %Event.ToolCallStart{tool_call_id: "tc2", name: "Agent"},
+        # tc2 never gets ToolCallEnd — stream errors
+        %Event.Error{reason: {"overloaded_error", "..."}, retryable?: true}
+      ]
+
+      msg = run(events) |> Assembler.assistant()
+      assert msg.stop_reason == :error
+      # completed tool_call tc1 must survive
+      assert Enum.any?(msg.content, fn b -> b[:type] == :tool_call and b[:id] == "tc1" end)
+      # incomplete tool_call tc2 must be dropped
+      refute Enum.any?(msg.content, fn b -> b[:type] == :tool_call and b[:id] == "tc2" end)
+    end
   end
 
   describe "finalize/3 — source-agnostic terminal fold (D-009)" do


### PR DESCRIPTION
## Summary

Root cause of the 2026-05-20 M1 verification failure: Anthropic streams that error mid-tool-use (e.g. on `overloaded_error` / `529` between `content_block_start` and `content_block_stop` of a `tool_use` block) caused `Tau.Message.Assembler` to surface a tool_call block with `arguments: %{}` as if the model had emitted it. Session.ex D-058 content-first rule then dispatched the synthesized empty Agent call, which the schema validator rejected; the cycle repeated until #293's brake fired after 3 retries.

Fix: track per-block completion via `_complete?` (initialised `false` on `*Start`, set `true` in `finalize_block/2` from `*End`). On `Event.Error`, drop incomplete `tool_call` blocks before `build_content/1`. Text and thinking partials are deliberately preserved — they are legitimate user-visible content the model produced before the error.

## Linked issues

Closes #298

## Gate verdicts

- critic: PASS — fix is minimal and correct; the `_complete?` flag is stripped by extended `strip_internals/1` so it never leaks into persisted content; partial text/thinking still surfaces (correct trade-off); diff context confirmed against `lib/tau/providers/anthropic.ex` stream-event dispatch.
- reviewer: PASS — `mix tau.qa` exit 0 `tau.qa: OK (linux_amd64)`. Two new tests in `test/tau/message/assembler_test.exs`: drop-incomplete (positive) and keep-completed (negative). Implementer reported fails-before: `1 property, 11 tests, 2 failures` against pre-fix code.

## Test plan

- [x] New assembler tests pass; both fail without the fix
- [x] `mix tau.qa` six-layer gate green
- [x] Anthropic adapter (`lib/tau/providers/anthropic.ex:226`) confirmed to emit `Event.Error` on overloaded/api/rate-limit errors — the exact path this fix guards