### PR TITLE
fix(cli): drain-loop marker checks Tau.Message.ToolResult (#299)

### DIFF
--- a/lib/tau/cli.ex
+++ b/lib/tau/cli.ex
@@ -501,10 +501,9 @@ defmodule Tau.CLI do
       # "?" only if the map doesn't have the id (shouldn't happen in practice).
       %Events.ToolEnd{session_id: ^session_id, tool_call_id: call_id, result: result} ->
         name =
-          Map.get(tool_names, call_id) || (is_struct(result, Tau.Tool.Result) && result.tool_name) ||
-            "?"
+          Map.get(tool_names, call_id) || "?"
 
-        marker = if is_struct(result, Tau.Tool.Result) && result.is_error, do: "✗", else: "✓"
+        marker = if is_struct(result, Tau.Message.ToolResult) && result.is_error, do: "✗", else: "✓"
         IO.puts(:stderr, "[tau] ← #{name} #{marker}")
         drain_run_loop(session_id, Map.delete(tool_names, call_id))
 

--- a/test/tau/cli/headless_run_test.exs
+++ b/test/tau/cli/headless_run_test.exs
@@ -21,6 +21,7 @@ defmodule Tau.CLI.HeadlessRunTest do
 
   use ExUnit.Case, async: false
 
+  import ExUnit.CaptureIO
   import Tau.Test.SessionHelper, only: [start_session_for_test: 1]
 
   alias Tau.Provider.Event
@@ -806,6 +807,98 @@ defmodule Tau.CLI.HeadlessRunTest do
 
       assert exit_code == 1,
              "expected exit 1 when --system-prompt-file path does not exist; got #{exit_code}"
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # #299 regression: drain_run_loop marker uses Tau.Message.ToolResult, not
+  # Tau.Tool.Result. Prior bug: is_struct check always false → marker always ✓.
+  # ---------------------------------------------------------------------------
+
+  describe "ToolEnd marker ✗/✓ (issue #299 regression)" do
+    test "marker is ✗ when ToolEnd carries Tau.Message.ToolResult with is_error: true" do
+      session_id = Tau.Session.generate_id()
+      call_id = "call-#{System.unique_integer([:positive])}"
+
+      result = %Tau.Message.ToolResult{
+        tool_call_id: call_id,
+        tool_name: "probe_tool",
+        content: "error text",
+        timestamp: DateTime.utc_now(),
+        is_error: true
+      }
+
+      # Inject: ToolStart (to register the name), ToolEnd with error result, then
+      # a terminal MessageEnd + SessionEnd so the loop exits cleanly.
+      terminal_msg = %Tau.Message.Assistant{
+        timestamp: DateTime.utc_now(),
+        content: [%{type: :text, text: "done"}],
+        stop_reason: :stop
+      }
+
+      send(self(), %Tau.Session.Events.ToolStart{
+        session_id: session_id,
+        tool_call_id: call_id,
+        name: "probe_tool",
+        arguments: %{}
+      })
+
+      send(self(), %Tau.Session.Events.ToolEnd{
+        session_id: session_id,
+        tool_call_id: call_id,
+        result: result
+      })
+
+      send(self(), %Tau.Session.Events.MessageEnd{session_id: session_id, message: terminal_msg})
+      send(self(), %Tau.Session.Events.SessionEnd{session_id: session_id, reason: :normal})
+
+      stderr_output = capture_io(:stderr, fn -> Tau.CLI.drain_run_loop(session_id) end)
+
+      assert stderr_output =~ "✗",
+             "expected ✗ marker for is_error: true ToolEnd; got stderr: #{inspect(stderr_output)}"
+
+      refute stderr_output =~ "← probe_tool ✓",
+             "must not emit ✓ for an error result; got stderr: #{inspect(stderr_output)}"
+    end
+
+    test "marker is ✓ when ToolEnd carries Tau.Message.ToolResult with is_error: false" do
+      session_id = Tau.Session.generate_id()
+      call_id = "call-#{System.unique_integer([:positive])}"
+
+      result = %Tau.Message.ToolResult{
+        tool_call_id: call_id,
+        tool_name: "probe_tool",
+        content: "ok",
+        timestamp: DateTime.utc_now(),
+        is_error: false
+      }
+
+      terminal_msg = %Tau.Message.Assistant{
+        timestamp: DateTime.utc_now(),
+        content: [%{type: :text, text: "done"}],
+        stop_reason: :stop
+      }
+
+      send(self(), %Tau.Session.Events.ToolStart{
+        session_id: session_id,
+        tool_call_id: call_id,
+        name: "probe_tool",
+        arguments: %{}
+      })
+
+      send(self(), %Tau.Session.Events.ToolEnd{
+        session_id: session_id,
+        tool_call_id: call_id,
+        result: result
+      })
+
+      send(self(), %Tau.Session.Events.MessageEnd{session_id: session_id, message: terminal_msg})
+      send(self(), %Tau.Session.Events.SessionEnd{session_id: session_id, reason: :normal})
+
+      stderr_output = capture_io(:stderr, fn -> Tau.CLI.drain_run_loop(session_id) end)
+
+      assert stderr_output =~ "✓",
+             "expected ✓ marker for is_error: false ToolEnd; got stderr: #{inspect(stderr_output)}"
     end
   end
 end


### PR DESCRIPTION
## Summary

The drain-loop's `✗ / ✓` marker check used `is_struct(result, Tau.Tool.Result)` but `Events.ToolEnd.result` is actually `%Tau.Message.ToolResult{}`. Two distinct modules. Result: the marker was always `✓` regardless of `is_error`. User saw `[tau] ← Agent ✓` immediately followed by the loop-brake's `:tool_loop_aborted` halt during 2026-05-20 M1 verification — contradictory signals.

Fix: replace the struct check; drop the now-dead `result.tool_name` fallback (that field doesn't exist on `Tau.Tool.Result` either — the line was unreachable noise).

## Linked issues

Closes #299

## Gate verdicts

- critic: PASS — two-line targeted fix; test asserts both directions (`✗` on error, `✓` on success) via `capture_io(:stderr)`; struct type verified against `session.ex:1416` `broadcast(... result: result_msg)` where `result_msg` is `%ToolResult{}`.
- reviewer: PASS — `mix tau.qa` exit 0 on rebased branch (post-#298). Implementer reported fails-before: `35 tests, 1 failure` on the new ✗ test against pre-fix code.

## Test plan

- [x] New `ToolEnd marker ✗/✓` describe block in `test/tau/cli/headless_run_test.exs`
- [x] `mix tau.qa` six-layer green on rebased branch