### PR TITLE
fix(burrito): vec0.so must not be linked with -fvisibility=hidden (#304)

### DIFF
--- a/lib/tau/burrito_steps/relink_vec0_nif.ex
+++ b/lib/tau/burrito_steps/relink_vec0_nif.ex
@@ -34,6 +34,20 @@ defmodule Tau.BurritoSteps.RelinkVec0Nif do
      release work tree at `lib/sqlite_vec-*/priv/<version>/vec0.so`.
 
   Mirrors the structure of `Tau.BurritoSteps.RelinkSqliteNif`.
+
+  ## Why no -fvisibility=hidden
+
+  `RelinkSqliteNif` uses `-fvisibility=hidden` to prevent internal SQLite
+  symbols from polluting the global symbol namespace. That is appropriate
+  for an Erlang NIF because its internal symbols are not part of its API.
+
+  `vec0.so` is a SQLite *loadable extension*, not a NIF. SQLite's
+  `load_extension()` locates the extension's entry point via `dlsym()`.
+  With `-fvisibility=hidden` the entry point symbol (`sqlite3_vec_init` /
+  `sqlite3_extension_init`) is hidden from `dlsym`, so the lookup returns
+  NULL, SQLite fails to initialise the extension, and every subsequent
+  `CREATE VIRTUAL TABLE ... USING vec0` returns "no such module: vec0" —
+  even though `load_extension` returned success (issue #304).
   """
 
   alias Burrito.Builder.Context
@@ -98,7 +112,14 @@ defmodule Tau.BurritoSteps.RelinkVec0Nif do
       "-O2",
       "-fPIC",
       "-shared",
-      "-fvisibility=hidden",
+      # Do NOT pass -fvisibility=hidden for SQLite loadable extensions.
+      # Unlike ERLang NIFs (where hiding internal symbols prevents pollution),
+      # SQLite extension .so files MUST export their entry-point symbol so that
+      # SQLite's dlsym() call in load_extension() can find it. With
+      # -fvisibility=hidden every symbol (including sqlite3_vec_init /
+      # sqlite3_extension_init) becomes hidden, dlsym returns NULL, and SQLite
+      # reports "no such module: vec0" — even though the .so was loaded
+      # successfully. See issue #304.
       "-I#{wrapper_dir}",
       "-I#{sqlite_include}",
       "-o",

--- a/lib/tau/memory/store/sqlite.ex
+++ b/lib/tau/memory/store/sqlite.ex
@@ -343,14 +343,42 @@ defmodule Tau.Memory.Store.SQLite do
   end
 
   defp load_vec_extension(db) do
-    with :ok <- Exqlite.Sqlite3.enable_load_extension(db, true),
-         {:ok, stmt} <- Exqlite.Sqlite3.prepare(db, "SELECT load_extension(?1)"),
-         :ok <- Exqlite.Sqlite3.bind(stmt, [SqliteVec.path()]),
-         _result <- Exqlite.Sqlite3.step(db, stmt),
-         :ok <- Exqlite.Sqlite3.release(db, stmt) do
-      # Disable general extension loading after the vec extension is loaded.
-      # This closes the extension-loading channel while keeping vec0 active.
-      Exqlite.Sqlite3.enable_load_extension(db, false)
+    # Allow tests to override the SqliteVec path via application config so they
+    # can exercise the missing-so error branch without modifying the filesystem.
+    path = Application.get_env(:tau, :sqlite_vec_path_override, SqliteVec.path())
+
+    # Verify the shared library file exists before attempting to load it.
+    # SQLite's load_extension() gives an opaque "no such module" error when the
+    # file is absent; this check surfaces the real cause (missing .so) so the
+    # boot log is actionable. The path returned by SqliteVec.path/0 has no
+    # extension — SQLite appends the platform suffix (.so/.dylib/.dll).
+    so_path = path <> native_lib_extension()
+
+    case File.stat(so_path) do
+      {:error, posix_err} ->
+        {:error, {:vec_so_missing, so_path, posix_err}}
+
+      {:ok, _} ->
+        with :ok <- Exqlite.Sqlite3.enable_load_extension(db, true),
+             {:ok, stmt} <- Exqlite.Sqlite3.prepare(db, "SELECT load_extension(?1)"),
+             :ok <- Exqlite.Sqlite3.bind(stmt, [path]),
+             step_result <- Exqlite.Sqlite3.step(db, stmt),
+             :ok <- Exqlite.Sqlite3.release(db, stmt) do
+          # step/2 returns :done or {:row, _} on success; {:error, reason} on failure.
+          # Ignoring the result here silently swallowed load failures (issue #304).
+          case step_result do
+            :done ->
+              # Disable general extension loading after the vec extension is loaded.
+              # This closes the extension-loading channel while keeping vec0 active.
+              Exqlite.Sqlite3.enable_load_extension(db, false)
+
+            {:row, _} ->
+              Exqlite.Sqlite3.enable_load_extension(db, false)
+
+            {:error, reason} ->
+              {:error, {:vec_load_failed, reason, path}}
+          end
+        end
     end
   end
 
@@ -657,6 +685,16 @@ defmodule Tau.Memory.Store.SQLite do
       "created_at" => created_at,
       "updated_at" => updated_at
     }
+  end
+
+  # Returns the platform-specific shared library extension that SQLite's
+  # load_extension() would append to the path returned by SqliteVec.path/0.
+  defp native_lib_extension do
+    case :os.type() do
+      {:unix, :darwin} -> ".dylib"
+      {:win32, _} -> ".dll"
+      _ -> ".so"
+    end
   end
 
   defp required_string(map, key) do

--- a/test/tau/memory/store_sqlite_test.exs
+++ b/test/tau/memory/store_sqlite_test.exs
@@ -149,6 +149,29 @@ defmodule Tau.Memory.Store.SQLiteTest do
   end
 
   # ---------------------------------------------------------------------------
+  # Issue #304 regression: vec_so_missing diagnostic error
+  # ---------------------------------------------------------------------------
+
+  describe "load_vec_extension — missing .so diagnostic (issue #304)" do
+    test "start returns {:error, {:db_open_failed, {:vec_so_missing, _, _}}} when path does not exist" do
+      Application.put_env(:tau, :sqlite_vec_path_override, "/nonexistent/path/to/vec0")
+
+      on_exit(fn -> Application.delete_env(:tau, :sqlite_vec_path_override) end)
+
+      db_path = Briefly.create!(extname: ".db")
+      name = :"test_vec_missing_#{System.unique_integer([:positive])}"
+
+      # Use GenServer.start (unlinked) so the init-failure exit does not
+      # propagate to the test process; start_link would crash the test.
+      assert {:error, {:db_open_failed, {:vec_so_missing, so_path, _posix_err}}} =
+               GenServer.start(SQLite, [db_path: db_path, name: name], name: name)
+
+      # The reported path should include the platform extension suffix.
+      assert String.starts_with?(so_path, "/nonexistent/path/to/vec0")
+    end
+  end
+
+  # ---------------------------------------------------------------------------
   # D-047: migration hard-fail / D-045: connection escape
   # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

**Root cause:** `RelinkVec0Nif` passed `-fvisibility=hidden` to `zig cc` when building `vec0.so`. SQLite locates a loadable extension's entry point via `dlsym(sqlite3_vec_init)` / `dlsym(sqlite3_extension_init)`. With `-fvisibility=hidden`, the symbol is hidden from `dlsym`, the lookup returns NULL, SQLite fails to initialise the extension — and every subsequent `CREATE VIRTUAL TABLE ... USING vec0` returns the misleading `"no such module: vec0"`.

The flag is correct for Erlang NIFs (`RelinkSqliteNif` keeps it — internal symbols shouldn't pollute) but **wrong for SQLite loadable extensions**, which must export their entry point.

## Secondary fix (diagnostic)

`Tau.Memory.Store.SQLite.load_vec_extension/1` previously used `_result <- Exqlite.Sqlite3.step(db, stmt)` — the wildcard silently swallowed `{:error, _}` from `step/2`. The root cause was hidden as "no such module: vec0" from migration 007.

Now: file-existence check up front returns `{:vec_so_missing, path, posix_err}`; explicit `case` on `step/2` returns `{:vec_load_failed, reason, path}`. Future failures of this class will name the real cause in the boot log.

## Linked issues

Closes #304

## Gate verdicts

- critic: PASS — minimal one-flag change to the build step with comprehensive comment explaining WHY (NIF vs extension semantic difference); diagnostic fix is defensive and adds zero behavioural change to the success path; platform-aware suffix helper handles `.so`/`.dylib`/`.dll`.
- reviewer: PASS — implementer verified locally: pre-fix binary exited 1 with `{:migration_failed, "no such module: vec0"}` on `help run`; post-fix binary exits 0. Regression test asserts `{:vec_so_missing, _, _}` via `Application` env override (`:sqlite_vec_path_override`).

## Test plan

- [x] `mix tau.qa` exit 0 locally
- [x] New regression test in `test/tau/memory/store_sqlite_test.exs`
- [ ] CI binary-qa will only fully exercise this once #302 (zig install) is also merged