### PR TITLE
fix(providers): bump per-chunk receive_timeout 60s → 300s (#307, M1 blocker)

### DIFF
--- a/lib/tau/providers/shared/finch_stream.ex
+++ b/lib/tau/providers/shared/finch_stream.ex
@@ -137,14 +137,24 @@ defmodule Tau.Providers.Shared.FinchStream do
   end
 
   # If we hit the 250ms cancel-poll window without a cancel and without
-  # a chunk message, fall through to the original 60s receive that
-  # yields a retryable timeout error. We've already burned 250ms;
-  # budget the remainder.
+  # a chunk message, fall through to the receive that yields a retryable
+  # timeout error. We've already burned 250ms; budget the remainder.
+  #
+  # The per-chunk timeout is 300s. Opus on a deep-deliberation turn can
+  # legitimately pause for 60-180s between chunks while it reasons about
+  # a complex tool call (real-world: empirically observed during M1
+  # coordinator verification, 2026-05-20, issue #307). The prior 60s
+  # budget misread that thinking time as transport failure; D-061 retry
+  # (#303) then re-issued the same prompt, which incurred the same
+  # thinking time, and the session died after exhausting retries.
+  # HTTP transport failures still fail fast at the OS / Mint level
+  # (RST, connection close, etc.); only the legitimate "silent
+  # connection, model is thinking" case is held open longer here.
   defp wait_remainder(s, decoder) do
     receive do
       {ref, msg} when ref == s.ref -> handle(msg, s, decoder) |> recur(decoder)
     after
-      59_750 ->
+      299_750 ->
         {[%Event.Error{reason: :timeout, retryable?: true}], %{s | finished?: true}}
     end
   end


### PR DESCRIPTION
## Summary

Empirically observed during three consecutive 2026-05-20 M1 verification attempts: opus on a deep-deliberation turn pauses >60s between chunks while reasoning about a complex tool call. The prior 60s per-chunk receive timeout misread this as transport failure. D-061 retry (#303) then re-issues the same prompt, which incurs the same thinking time, and the session dies after exhausting retries.

Anthropic API itself was healthy during all three runs (200 OK direct probe in 1.6s). The failure was a per-chunk timeout firing during legitimate model thinking, NOT a real transport error.

Bump from 60s to 300s. HTTP transport failures still fail fast (RST / connection close / Mint-level errors); only the legitimate "silent connection, model is thinking" case is held open.

## Linked issues

Closes #307

## Gate verdicts

- critic: PASS — one-constant change with a multi-paragraph comment documenting WHY (D-061 retry doesn't help thinking-time misdiagnosis); no behavioural change to fast-failing transport errors; complementary to D-061 (retry handles real transient errors, longer timeout handles real model deliberation).
- reviewer: PASS — `mix compile --warnings-as-errors` and `mix format --check-formatted` clean. The change is a single integer constant; no behavioural test is feasible (would require asserting 300s elapsed, which is by-design not run in test).

## Test plan

- [x] Compile clean
- [ ] M1 verification re-run with the new timeout — will be my fourth attempt; the first three died on this exact failure mode