### PR TITLE
fix(providers): also bump Finch's own receive_timeout (#307 follow-up, M1 blocker)

### DIFF
--- a/lib/tau/providers/shared/finch_stream.ex
+++ b/lib/tau/providers/shared/finch_stream.ex
@@ -64,12 +64,26 @@ defmodule Tau.Providers.Shared.FinchStream do
 
     task =
       Task.async(fn ->
-        Finch.stream(request, Tau.Providers.Finch, nil, fn
-          {:status, n}, _ -> Process.send(parent, {ref, {:status, n}}, [])
-          {:headers, h}, _ -> Process.send(parent, {ref, {:headers, h}}, [])
-          {:data, c}, _ -> Process.send(parent, {ref, {:data, c}}, [])
-          {:done}, _ -> Process.send(parent, {ref, :done}, [])
-        end)
+        # Finch's default `receive_timeout` is 15s — far too short for
+        # LLM streaming where opus on deep deliberation can pause 60-180s
+        # between chunks. The consumer loop below uses a 300s budget;
+        # match it at the Finch layer so the inner timer is the one that
+        # gets to fire on a stuck stream, not Mint's. Transport-level
+        # failures (RST, conn close, Mint connect errors) still surface
+        # fast via `{:error, e}` from `Finch.stream/5`.
+        Finch.stream(
+          request,
+          Tau.Providers.Finch,
+          nil,
+          fn
+            {:status, n}, _ -> Process.send(parent, {ref, {:status, n}}, [])
+            {:headers, h}, _ -> Process.send(parent, {ref, {:headers, h}}, [])
+            {:data, c}, _ -> Process.send(parent, {ref, {:data, c}}, [])
+            {:done}, _ -> Process.send(parent, {ref, :done}, [])
+          end,
+          receive_timeout: 300_000,
+          request_timeout: :infinity
+        )
         |> case do
           {:ok, _} ->
             Process.send(parent, {ref, :end}, [])


### PR DESCRIPTION
## Summary

#307 bumped the consumer loop's per-chunk timeout to 300s, but Finch's default `receive_timeout` of 15s fires *before* the consumer loop ever sees a chunk wait. The empirical proof: 4th M1 verification (session 019e472c, 2026-05-20 16:55) died at ~2:43 wall time — too soon for the consumer-loop 300s budget. Mint received the 15s timeout from Finch and surfaced it as `%Mint.TransportError{reason: :timeout}`.

Fix: pass `receive_timeout: 300_000, request_timeout: :infinity` to `Finch.stream/5`. The inner timer is now the one that fires on a stuck stream. Transport-level failures (RST, conn close) still surface fast.

## Linked issues

Refs #307 (follow-up — the original issue's premise was correct but the fix targeted the wrong timer).

## Test plan

- [x] `mix compile --warnings-as-errors`, `mix format --check-formatted` clean
- [ ] After merge: rebuild, re-run M1 verification — 5th attempt