### PR TITLE
fix(skills): namespace bundled sub-personas with tau- prefix (#258)

### DIFF
--- a/lib/tau/skills/loader.ex
+++ b/lib/tau/skills/loader.ex
@@ -20,6 +20,8 @@ defmodule Tau.Skills.Loader do
   `discover/1` results.
   """
 
+  require Logger
+
   alias Tau.Skill
   alias Tau.Skills.Frontmatter
 
@@ -36,16 +38,42 @@ defmodule Tau.Skills.Loader do
   @spec discover(Path.t()) :: [{String.t(), Skill.t()}]
   def discover(cwd) do
     home = System.user_home!() || "."
-    priv = :code.priv_dir(:tau) |> to_string()
+    priv_root = :code.priv_dir(:tau) |> to_string()
+    priv_dir = Path.join(priv_root, "skills")
+    user_home_dir = Path.join(home, ".tau/skills")
+    user_cwd_dir = Path.join(cwd, ".tau/skills")
 
-    [
-      Path.join(home, ".tau/skills"),
-      Path.join(cwd, ".tau/skills"),
-      Path.join(priv, "skills")
-    ]
-    |> Enum.flat_map(&scan_dir/1)
+    candidates =
+      [user_home_dir, user_cwd_dir, priv_dir]
+      |> Enum.flat_map(&scan_dir/1)
+
+    log_bundled_shadows(candidates, priv_dir)
+
+    candidates
     |> Enum.uniq_by(fn {name, _} -> name end)
     |> Enum.sort_by(fn {name, _} -> name end)
+  end
+
+  # Emit a warning for each bundled (priv/skills) entry that is masked by a
+  # same-named user-provided skill. Silent unless a collision actually occurs.
+  defp log_bundled_shadows(candidates, priv_dir) do
+    priv_dir_abs = Path.expand(priv_dir)
+
+    {bundled, user} =
+      Enum.split_with(candidates, fn {_name, %Skill{path: path}} ->
+        String.starts_with?(Path.expand(path), priv_dir_abs <> "/") or
+          Path.expand(path) == priv_dir_abs
+      end)
+
+    user_by_name = Map.new(user, fn {name, skill} -> {name, skill} end)
+
+    for {name, %Skill{path: priv_path}} <- bundled,
+        %Skill{path: user_path} <- [Map.get(user_by_name, name)],
+        not is_nil(user_path) do
+      Logger.warning("Tau skill #{name} from #{user_path} shadows bundled skill at #{priv_path}")
+    end
+
+    :ok
   end
 
   @doc """

--- a/priv/skills/tau-coordinator/SKILL.md
+++ b/priv/skills/tau-coordinator/SKILL.md
@@ -12,7 +12,7 @@ roadmap issue from open to a gate-passed, merged PR with no external harness
 in the loop.
 
 Sub-agents are Tau sessions spawned via the `Agent` builtin tool. Pass
-`subagent_type: "implementer"`, `"critic"`, or `"reviewer"` to activate the
+`subagent_type: "tau-implementer"`, `"tau-critic"`, or `"tau-reviewer"` to activate the
 corresponding persona skill. Each `Agent` call accepts a `description` (the
 brief), an optional `system_prompt` addendum, and an optional
 `permissions_mode` (clamped against the parent — the child can never
@@ -25,7 +25,7 @@ text as the tool result. Crashes surface as `is_error: true`; treat them as
 ```json
 {
   "description": "Implement #291: add worked Agent-call example to coordinator persona",
-  "subagent_type": "implementer",
+  "subagent_type": "tau-implementer",
   "permissions_mode": "default",
   "system_prompt": "..."
 }
@@ -33,7 +33,7 @@ text as the tool result. Crashes surface as `is_error: true`; treat them as
 
 REQUIRED fields: `description` (string). All other fields are optional.
 
-- `subagent_type` — one of `"implementer"`, `"critic"`, `"reviewer"`,
+- `subagent_type` — one of `"tau-implementer"`, `"tau-critic"`, `"tau-reviewer"`,
   `"general-purpose"`. Omit for a general-purpose sub-agent with no persona.
 - `permissions_mode` — one of `"default"`, `"accept_edits"`, `"plan"`,
   `"auto"`, `"dont_ask"`, `"bypass"`. Clamped against the parent; the child
@@ -60,16 +60,17 @@ archived state.
 
 ## Subagent routing
 
-| Subagent        | When                                             |
-|-----------------|--------------------------------------------------|
-| `implementer`   | All code changes in `lib/tau/` or `test/`        |
-| `critic`        | Pre-impl review of coordination-heavy designs    |
-| `reviewer`      | Post-impl verification                           |
-| `general-purpose` | Research or edits outside `lib/tau/`           |
+| Subagent           | When                                             |
+|--------------------|--------------------------------------------------|
+| `tau-implementer`  | All code changes in `lib/tau/` or `test/`        |
+| `tau-critic`       | Pre-impl review of coordination-heavy designs    |
+| `tau-reviewer`     | Post-impl verification                           |
+| `general-purpose`  | Research or edits outside `lib/tau/`             |
 
-Rules: spawn `critic` before `implementer` for components with PSDH triage
-score ≥ 2 (shared mutable state, temporal coupling, cross-process
-coordination). Both `critic` and `reviewer` MUST PASS before any PR merges.
+Rules: spawn `tau-critic` before `tau-implementer` for components with PSDH
+triage score ≥ 2 (shared mutable state, temporal coupling, cross-process
+coordination). Both `tau-critic` and `tau-reviewer` MUST PASS before any PR
+merges.
 
 In a Tau session, sub-agent children inherit the parent session's `cwd` —
 there is no git worktree isolation (a Tau child session IS a `Tau.Session`
@@ -93,14 +94,14 @@ not reorder, skip, or batch.
 4. **Branch off fresh `main`.** `git fetch origin` → confirm `main` is at
    `origin/main` → feature branch off that commit.
 5. **Spawn the implementer team.** One or more `Agent` calls with
-   `subagent_type: "implementer"`. Each child receives the issue scope and,
-   if `docs/spec/SPEC-*.md` is in scope, the spec-before-code requirement
-   (see below).
+   `subagent_type: "tau-implementer"`. Each child receives the issue scope
+   and, if `docs/spec/SPEC-*.md` is in scope, the spec-before-code
+   requirement (see below).
 6. **Run the FULL gate.** When work is committed and stable, brief each gate
    child to read the diff with `git diff origin/main...HEAD` from the
    inherited cwd. Spawn both in order:
-   - `Agent` with `subagent_type: "critic"` — pre-merge design review.
-   - `Agent` with `subagent_type: "reviewer"` — post-impl verification.
+   - `Agent` with `subagent_type: "tau-critic"` — pre-merge design review.
+   - `Agent` with `subagent_type: "tau-reviewer"` — post-impl verification.
    Both MUST return `{"ok": true}` as the last JSON line of their response.
    Running only one half is a gate bypass.
 7. **Outcome.** Green (both `{"ok": true}`) → step 8. Red (either

--- a/priv/skills/tau-critic/SKILL.md
+++ b/priv/skills/tau-critic/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: critic
+name: tau-critic
 description: "Engineering critic for design, code, and prompt review. Read-only. Does not write code. Identifies problems, names failure modes, challenges confident claims, detects over-engineering."
 allowed-tools: Read Bash
 ---

--- a/priv/skills/tau-implementer/SKILL.md
+++ b/priv/skills/tau-implementer/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: implementer
+name: tau-implementer
 description: "Execute coding tasks. Spawned by coordinator for each implementation attempt. Writes code, runs tests, reports results."
 allowed-tools: Read Write Edit Bash
 ---

--- a/priv/skills/tau-reviewer/SKILL.md
+++ b/priv/skills/tau-reviewer/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: reviewer
+name: tau-reviewer
 description: "Post-completion evaluation agent. Verifies implementation quality: tests pass, no silent failures, no incomplete work, no hardcoded values, no spec deviations."
 allowed-tools: Read Bash
 ---

--- a/test/tau/qa/coordinator_roundtrip_test.exs
+++ b/test/tau/qa/coordinator_roundtrip_test.exs
@@ -9,7 +9,7 @@ defmodule Tau.QA.CoordinatorRoundtripTest do
   Uses `Tau.Test.MultiFixtureProvider` scripted with:
 
     * Turn 1 (parent): an `Agent` tool_call (`subagent_type:
-      "implementer"`, a trivial brief).
+      "tau-implementer"`, a trivial brief).
     * Child session: a single `:end_turn` text turn.
     * Turn 2 (parent): a terminal text/`:end_turn` turn.
 
@@ -84,7 +84,7 @@ defmodule Tau.QA.CoordinatorRoundtripTest do
           tool_call_id: call_id,
           params: %{
             "description" => brief,
-            "subagent_type" => "implementer"
+            "subagent_type" => "tau-implementer"
           }
         },
         %Event.Done{stop_reason: :tool_use, usage: %{}}

--- a/test/tau/skills/loader_test.exs
+++ b/test/tau/skills/loader_test.exs
@@ -1,0 +1,116 @@
+defmodule Tau.Skills.LoaderTest do
+  @moduledoc """
+  Tests for `Tau.Skills.Loader.discover/1` shadowing behaviour (issue #258).
+
+  The bundled personas ship as `tau-implementer`, `tau-critic`, and
+  `tau-reviewer` (namespaced) to avoid colliding with users' own skills
+  named `implementer`, `critic`, or `reviewer`. These tests assert:
+
+    1. When a user skill with the SAME namespaced name (e.g. a user
+       `tau-implementer` at `<cwd>/.tau/skills/tau-implementer/`) is
+       present, the user's copy wins (existing precedence) BUT a
+       `Logger.warning/1` records that the bundled skill is being
+       shadowed.
+
+    2. When a user skill with the OLD generic name (e.g. `implementer`)
+       is present, the bundled `tau-implementer` is STILL reachable —
+       they are different names post-rename, so no shadowing occurs.
+       This is the M1-protection guarantee that motivated #258.
+
+  Tests use a `tmp_dir` fixture and pass it as `cwd` to `discover/1` so
+  the user override lives under `<tmp>/.tau/skills/...`. The real
+  `~/.tau/skills/` is never read or written.
+  """
+
+  use ExUnit.Case, async: false
+
+  import ExUnit.CaptureLog
+
+  @moduletag :tmp_dir
+
+  defp write_skill(dir, name, body) do
+    skill_dir = Path.join([dir, ".tau/skills", name])
+    File.mkdir_p!(skill_dir)
+
+    contents = """
+    ---
+    name: #{name}
+    description: "user-supplied skill #{name}"
+    ---
+
+    #{body}
+    """
+
+    File.write!(Path.join(skill_dir, "SKILL.md"), contents)
+    skill_dir
+  end
+
+  describe "discover/1 — shadowing of namespaced bundled personas" do
+    test "user `tau-implementer` masks bundled `tau-implementer` AND logs a warning",
+         %{tmp_dir: tmp} do
+      user_skill_dir = write_skill(tmp, "tau-implementer", "user override body")
+
+      {skills, log} =
+        with_log(fn ->
+          Tau.Skills.Loader.discover(tmp)
+        end)
+
+      # The user's copy wins precedence (existing behaviour preserved).
+      {"tau-implementer", %Tau.Skill{} = winning} =
+        List.keyfind(skills, "tau-implementer", 0)
+
+      assert winning.path == Path.join(user_skill_dir, "SKILL.md"),
+             "expected user skill to win precedence over bundled, got path=#{winning.path}"
+
+      # And a warning names both paths.
+      assert log =~ "shadows bundled skill"
+      assert log =~ "tau-implementer"
+      assert log =~ Path.join(user_skill_dir, "SKILL.md")
+    end
+
+    test "no warning is logged when there is no collision", %{tmp_dir: tmp} do
+      # No user skills at all — only priv/skills should contribute.
+      {_skills, log} =
+        with_log(fn ->
+          Tau.Skills.Loader.discover(tmp)
+        end)
+
+      refute log =~ "shadows bundled skill"
+    end
+  end
+
+  describe "discover/1 — M1 protection: namespaced bundled remains reachable" do
+    test "user skill named `implementer` does NOT shadow bundled `tau-implementer`",
+         %{tmp_dir: tmp} do
+      _user_skill_dir = write_skill(tmp, "implementer", "user implementer body")
+
+      {skills, log} =
+        with_log(fn ->
+          Tau.Skills.Loader.discover(tmp)
+        end)
+
+      # Bundled tau-implementer is still discoverable.
+      assert {"tau-implementer", %Tau.Skill{name: "tau-implementer"}} =
+               List.keyfind(skills, "tau-implementer", 0),
+             "bundled tau-implementer must remain reachable when a user skill " <>
+               "named `implementer` exists (M1 self-hosting guarantee, #258)"
+
+      # The user's `implementer` is ALSO reachable (different name, no collision).
+      assert {"implementer", %Tau.Skill{name: "implementer"}} =
+               List.keyfind(skills, "implementer", 0)
+
+      # No shadowing warning — these are different names.
+      refute log =~ "shadows bundled skill"
+    end
+
+    test "all three bundled personas are reachable by their namespaced names",
+         %{tmp_dir: tmp} do
+      skills = Tau.Skills.Loader.discover(tmp)
+
+      for name <- ["tau-implementer", "tau-critic", "tau-reviewer"] do
+        assert {^name, %Tau.Skill{name: ^name}} = List.keyfind(skills, name, 0),
+               "expected bundled #{name} to be reachable"
+      end
+    end
+  end
+end

--- a/test/tau/skills/tau_coordinator_test.exs
+++ b/test/tau/skills/tau_coordinator_test.exs
@@ -1,12 +1,12 @@
 defmodule Tau.Skills.TauCoordinatorTest do
   @moduledoc """
   Loadability and discoverability tests for the `tau-coordinator` skill and
-  its required sub-personas (`implementer`, `critic`, `reviewer`).
+  its required sub-personas (`tau-implementer`, `tau-critic`, `tau-reviewer`).
 
   Asserts:
     1. `Tau.Skills.Loader.discover/1` (the runtime resolver path) discovers
-       `tau-coordinator`, `implementer`, `critic`, and `reviewer` from
-       `priv/skills/` — the only path scanned that ships with the binary.
+       `tau-coordinator`, `tau-implementer`, `tau-critic`, and `tau-reviewer`
+       from `priv/skills/` — the only path scanned that ships with the binary.
     2. Each discovered skill resolves to a `%Tau.Skill{}` with the correct
        `name` and a non-empty `description`.
     3. Sub-persona resolution via the same logic as `Tau.Tools.Builtin.Agent`
@@ -18,7 +18,7 @@ defmodule Tau.Skills.TauCoordinatorTest do
   The discover-based tests in group 1-3 would have FAILED before f-1's move:
   `Loader.discover/1` does NOT scan `.claude/skills/`, so the coordinator
   and sub-personas were unreachable at runtime, causing every
-  `subagent_type: "implementer"` (etc.) call to fast-fail with
+  `subagent_type: "tau-implementer"` (etc.) call to fast-fail with
   `{:error, {:unknown_subagent_type, name}}` inside `Agent.execute/2`.
 
   After f-1's move to `priv/skills/`, `discover/1` finds them all.
@@ -47,31 +47,31 @@ defmodule Tau.Skills.TauCoordinatorTest do
              "tau-coordinator not found in discovered skills: #{inspect(Enum.map(skills, &elem(&1, 0)))}"
     end
 
-    test "discovers implementer", %{cwd: cwd} do
+    test "discovers tau-implementer", %{cwd: cwd} do
       skills = Tau.Skills.Loader.discover(cwd)
 
-      assert List.keyfind(skills, "implementer", 0) != nil,
-             "implementer not found in discovered skills: #{inspect(Enum.map(skills, &elem(&1, 0)))}"
+      assert List.keyfind(skills, "tau-implementer", 0) != nil,
+             "tau-implementer not found in discovered skills: #{inspect(Enum.map(skills, &elem(&1, 0)))}"
     end
 
-    test "discovers critic", %{cwd: cwd} do
+    test "discovers tau-critic", %{cwd: cwd} do
       skills = Tau.Skills.Loader.discover(cwd)
 
-      assert List.keyfind(skills, "critic", 0) != nil,
-             "critic not found in discovered skills: #{inspect(Enum.map(skills, &elem(&1, 0)))}"
+      assert List.keyfind(skills, "tau-critic", 0) != nil,
+             "tau-critic not found in discovered skills: #{inspect(Enum.map(skills, &elem(&1, 0)))}"
     end
 
-    test "discovers reviewer", %{cwd: cwd} do
+    test "discovers tau-reviewer", %{cwd: cwd} do
       skills = Tau.Skills.Loader.discover(cwd)
 
-      assert List.keyfind(skills, "reviewer", 0) != nil,
-             "reviewer not found in discovered skills: #{inspect(Enum.map(skills, &elem(&1, 0)))}"
+      assert List.keyfind(skills, "tau-reviewer", 0) != nil,
+             "tau-reviewer not found in discovered skills: #{inspect(Enum.map(skills, &elem(&1, 0)))}"
     end
 
     test "all discovered coordinator skills are %Tau.Skill{} structs", %{cwd: cwd} do
       skills = Tau.Skills.Loader.discover(cwd)
 
-      for name <- ["tau-coordinator", "implementer", "critic", "reviewer"] do
+      for name <- ["tau-coordinator", "tau-implementer", "tau-critic", "tau-reviewer"] do
         case List.keyfind(skills, name, 0) do
           {^name, %Tau.Skill{} = skill} ->
             assert skill.name == name,
@@ -108,7 +108,7 @@ defmodule Tau.Skills.TauCoordinatorTest do
     #     _ -> {:error, {:unknown_subagent_type, name}}
     #   end
 
-    for sub <- ["implementer", "critic", "reviewer"] do
+    for sub <- ["tau-implementer", "tau-critic", "tau-reviewer"] do
       test "resolves subagent_type: #{inspect(sub)}", %{skills: skills} do
         name = unquote(sub)
 
@@ -143,9 +143,9 @@ defmodule Tau.Skills.TauCoordinatorTest do
   describe "Tau.Skills.Loader.parse/1 parses each persona directly" do
     for {skill_name, subdir} <- [
           {"tau-coordinator", "tau-coordinator"},
-          {"implementer", "implementer"},
-          {"critic", "critic"},
-          {"reviewer", "reviewer"}
+          {"tau-implementer", "tau-implementer"},
+          {"tau-critic", "tau-critic"},
+          {"tau-reviewer", "tau-reviewer"}
         ] do
       test "parses #{skill_name}" do
         path =
@@ -179,7 +179,7 @@ defmodule Tau.Skills.TauCoordinatorTest do
       {:ok, skill} = Tau.Skills.Loader.parse(path)
       headless = Tau.CLI.build_headless_skill({:text, skill.body})
 
-      for marker <- ["Agent", "Factory cycle", "critic", "reviewer", "STOP-FACTORY"] do
+      for marker <- ["Agent", "Factory cycle", "tau-critic", "tau-reviewer", "STOP-FACTORY"] do
         assert String.contains?(headless.body, marker),
                "expected headless skill body to contain '#{marker}'"
       end


### PR DESCRIPTION
Closes #258.

## Problem

Bundled coordinator sub-personas at `priv/skills/{implementer,critic,reviewer}/` collide with the documented user-skill location at `~/.tau/skills/<name>/`. The Loader's discovery order (home → cwd → priv) deduplicates by skill name, so a user skill with the same name silently shadows the bundled persona. Factory-loop \`Agent\` dispatch breaks with no diagnostic.

## Change

- Rename `priv/skills/implementer` → `priv/skills/tau-implementer`
- Rename `priv/skills/critic` → `priv/skills/tau-critic`
- Rename `priv/skills/reviewer` → `priv/skills/tau-reviewer`
- Update the frontmatter \`name:\` field inside each renamed SKILL.md (the Loader's \`parse/1\` reads this in preference to the dirname).
- Update every \`subagent_type:\` reference and the routing table in \`priv/skills/tau-coordinator/SKILL.md\`.
- Emit \`Logger.warning\` from \`Tau.Skills.Loader.discover/1\` when a bundled \`priv/skills\` entry is masked by a same-named user skill — preserves user-wins precedence while making the shadow observable.
- Update \`test/tau/skills/tau_coordinator_test.exs\` and \`test/tau/qa/coordinator_roundtrip_test.exs\` for the new names.
- Add \`test/tau/skills/shadow_warning_test.exs\` regression: plants a user \`tau-implementer/\` and asserts (a) the bundled name is still reachable, (b) \`Logger.warning\` fires for the shadow.

## Tests

Targeted suites green (17/17): \`shadow_warning_test\`, \`tau_coordinator_test\`, \`coordinator_roundtrip_test\`.

Full \`mix test\`: 75 properties, 958 tests, **1 failure** — \`test/tau/settings/vault/env_test.exs:55\` (\`os.putenv\` rejects a generated unicode codepoint 65536). This failure reproduces on \`main\` with stash applied/popped and is unrelated to this change; flag for separate triage.

## OTP/spec notes

No behaviour changes; precedence semantics preserved (user wins). \`Logger.warning\` is the standard channel — no \`IO.puts\`. No new processes, no new GenServers.