### PR TITLE
fix(agent): await_child accepts :stop (M1 unblocker, #315)

### DIFF
--- a/lib/tau/tools/builtin/agent.ex
+++ b/lib/tau/tools/builtin/agent.ex
@@ -395,27 +395,40 @@ defmodule Tau.Tools.Builtin.Agent do
     end
   end
 
-  # --- Awaiting the child's :end_turn --------------------------------------
+  # --- Awaiting the child's :end_turn / :stop ------------------------------
+  #
+  # #315: provider adapters (Anthropic, OpenAI, Bedrock, Gemini, etc.) normalise
+  # the model's `"end_turn"` to `:stop` via their `normalise_stop/1`. Children
+  # driven by a real provider therefore end with `stop_reason: :stop`, not the
+  # literal `:end_turn` atom. We accept both — plus `:length` (max_tokens) and
+  # `:stop_sequence` which are also natural-end terminals where the model is
+  # done producing output. Failure stop_reasons are enumerated explicitly so
+  # the union shrinks predictably: any unknown stop_reason continues waiting
+  # for the next MessageEnd (matches Tau.CLI.drain_run_loop's D-058 / #252 f-1
+  # inversion: enumerate failures, treat everything else as natural end).
+
+  @subagent_natural_end [:stop, :end_turn, :length, :stop_sequence]
+  @subagent_failure_end [:error, :aborted, :tool_loop_aborted, :compaction_failed]
 
   defp await_child(child_id, ctx, parent_ref, started) do
     receive do
       %SE.MessageEnd{session_id: ^child_id, message: %Assistant{} = msg} ->
         cond do
-          msg.stop_reason == :end_turn ->
+          msg.stop_reason in @subagent_natural_end ->
             content = extract_text(msg)
 
             Result.text(content,
               details: %{
                 kind: :subagent_result,
                 child_session_id: child_id,
-                stop_reason: :end_turn,
+                stop_reason: msg.stop_reason,
                 duration_ms: System.monotonic_time(:millisecond) - started
               }
             )
 
-          msg.stop_reason in [:error, :aborted] ->
+          msg.stop_reason in @subagent_failure_end ->
             Result.error(
-              "Sub-agent ended without :end_turn (stop_reason: #{inspect(msg.stop_reason)}). " <>
+              "Sub-agent failed (stop_reason: #{inspect(msg.stop_reason)}). " <>
                 (msg.error_message || ""),
               details: %{
                 kind: :subagent_failed,

--- a/test/tau/tools/builtin/agent_test.exs
+++ b/test/tau/tools/builtin/agent_test.exs
@@ -53,6 +53,18 @@ defmodule Tau.Tools.Builtin.AgentTest do
     ]
   end
 
+  # Child success events with `:stop` instead of `:end_turn` — mirrors the
+  # normalised form emitted by every real provider adapter (#315 regression).
+  defp child_text_fixture_normalized(text) do
+    [
+      %Event.Start{request_id: "child-r1", model: "multi-fixture"},
+      %Event.TextStart{block_id: "b0"},
+      %Event.TextDelta{block_id: "b0", text: text},
+      %Event.TextEnd{block_id: "b0"},
+      %Event.Done{stop_reason: :stop, usage: %{}}
+    ]
+  end
+
   # Child error events (simulates a crash mid-stream).
   defp child_error_fixture do
     [
@@ -134,6 +146,50 @@ defmodule Tau.Tools.Builtin.AgentTest do
       kinds = jsonl_kinds(path)
       assert "tool_result" in kinds
       assert "assistant_message" in kinds
+    end
+
+    # #315 regression: real provider adapters normalise `"end_turn"` → `:stop`,
+    # so `await_child` must accept `:stop` as natural-end, not just the literal
+    # `:end_turn` atom. Prior to #315 every M1 verification timed out at 600s
+    # because the child's clean `:stop` was treated as continuation.
+    test "child ending with normalised :stop returns cleanly (no timeout)", %{tmp: tmp} do
+      parent_sid = Tau.Session.generate_id()
+      Phoenix.PubSub.subscribe(Tau.PubSub, "session:#{parent_sid}")
+
+      call_id = "agent-call-stop"
+      child_text = "child completed via :stop"
+
+      provider_ctx = %{
+        parent_session_id: parent_sid,
+        parent_first_fixture: agent_tool_call_fixture(call_id, "do something"),
+        parent_second_fixture: parent_end_turn_fixture(),
+        child_fixture: child_text_fixture_normalized(child_text)
+      }
+
+      {:ok, ^parent_sid} =
+        start_session_for_test(
+          provider: MultiFixtureProvider,
+          session_id: parent_sid,
+          cwd: tmp,
+          provider_ctx: provider_ctx
+        )
+
+      Tau.send(parent_sid, "please delegate")
+
+      # The fix surfaces as: ToolEnd arrives within seconds (was 600s timeout).
+      assert_receive %SE.ToolEnd{
+                       tool_call_id: ^call_id,
+                       result: %Tau.Message.ToolResult{
+                         tool_name: "Agent",
+                         is_error: false,
+                         content: content,
+                         details: %{stop_reason: :stop}
+                       }
+                     },
+                     10_000
+
+      content_text = if is_binary(content), do: content, else: inspect(content)
+      assert content_text =~ child_text
     end
   end
 


### PR DESCRIPTION
## Summary

**The M1 unblocker.** `Tau.Tools.Builtin.Agent.await_child/4` was checking `msg.stop_reason == :end_turn` literally, but every real provider adapter (Anthropic, OpenAI, Bedrock, Gemini) normalises `"end_turn"` → `:stop` via its `normalise_stop/1`. Result: children driven by a real provider ended with `stop_reason: :stop`, the literal-`:end_turn` check never matched, the parent fell into "keep waiting" and timed out 10 min later.

This single bug killed every M1 verification at the sub-Agent boundary. The 7th verification today caught it: implementer child opened PR #314 cleanly, said "Ready for the critic + reviewer gate", emitted `stop_reason: :stop` — and the parent's await loop ignored it until the 600 s `@await_timeout_ms` fired. Same fate for three subsequent critic attempts.

## The fix

Replace literal `:end_turn` with `@subagent_natural_end = [:stop, :end_turn, :length, :stop_sequence]`. Failure atoms enumerated as `@subagent_failure_end = [:error, :aborted, :tool_loop_aborted, :compaction_failed]`. Mirrors the inverse-enumeration pattern from `Tau.CLI.drain_run_loop` (D-058 / #252 f-1).

## Linked issues

Closes #315

## Why the bug hid

Existing `test/tau/tools/builtin/agent_test.exs` uses stub providers that emit `stop_reason: :end_turn` directly, bypassing the normalizer. So the unit tests have always passed; the bug only manifested against real providers.

## Gate verdicts

- critic: PASS — literal `:end_turn` check replaced with module-attribute list of natural-end atoms; failure path enumerated explicitly; pattern mirrors `drain_run_loop` (D-058); the comment explains WHY this is correct (provider normalisation).
- reviewer: PASS — `mix compile --warnings-as-errors` clean; all 9 agent tests pass (8 pre-existing + 1 new regression test that uses `:stop` and asserts ToolEnd within 10 s).

## Test plan

- [x] Existing 8 agent tests still pass
- [x] New regression test asserts the `:stop` (normalised) path returns cleanly
- [x] Compile clean

## Empirical evidence

PR #314 (opened by `tau-implementer` sub-Agent during 7th M1 verify) exists and is mergeable: https://github.com/smug-haus/tau/pull/314. The whole chain WORKED except for await_child not recognizing completion.