### PR TITLE
fix(test): eliminate two intermittent load-race flakes (#283)

### DIFF
--- a/test/tau/burrito_steps/relink_sqlite_nif_test.exs
+++ b/test/tau/burrito_steps/relink_sqlite_nif_test.exs
@@ -18,6 +18,7 @@ defmodule Tau.BurritoSteps.RelinkSqliteNifTest do
     end
 
     test "exports execute/1" do
+      Code.ensure_loaded!(RelinkSqliteNif)
       assert function_exported?(RelinkSqliteNif, :execute, 1)
     end
   end

--- a/test/tau/coding_agent/dispatcher_test.exs
+++ b/test/tau/coding_agent/dispatcher_test.exs
@@ -139,10 +139,10 @@ defmodule Tau.CodingAgent.DispatcherTest do
 
       assert_receive {:coding_agent_event, ^pid,
                       %Event.Error{reason: :inactivity_timeout, recoverable: false}},
-                     2_000
+                     10_000
 
-      assert_receive {:coding_agent_event, ^pid, %Event.Done{exit_status: -1}}, 2_000
-      assert_receive {:DOWN, ^ref, :process, ^pid, :normal}, 1_000
+      assert_receive {:coding_agent_event, ^pid, %Event.Done{exit_status: -1}}, 10_000
+      assert_receive {:DOWN, ^ref, :process, ^pid, :normal}, 10_000
     end
   end
 


### PR DESCRIPTION
## Summary

Fixes two intermittent load-race test flakes (test-only; no `lib/` change).

- `test/tau/burrito_steps/relink_sqlite_nif_test.exs` — the `"exports
  execute/1"` test called `function_exported?/3`, which returns `false`
  for a not-yet-loaded module and so races the parallel compiler. Added
  `Code.ensure_loaded!(RelinkSqliteNif)` before the assertion.
- `test/tau/coding_agent/dispatcher_test.exs` — the
  `"fires after ctx.inactivity_timeout_ms with a stalled adapter"` test
  had `assert_receive` windows (2_000 / 2_000 / 1_000 ms) that scheduler
  starvation under parallel load could expire before the correctly-firing
  events arrived. Raised all three to 10_000 ms. The timeout under test
  (`inactivity_timeout_ms: 100`) is unchanged — only the test-harness
  wait windows widen.

## Linked issues

Closes #283

## Gate verdicts

- critic: PASS (`ok: true`) — 2 SUGGESTION findings, both non-blocking;
  no `lib/` change, no OTP-non-negotiable surface, no spec-before-code
  obligation (no SPEC source-map file touched).
- reviewer: PASS (`verdict: PASS`) — `mix test` on both affected files:
  10 tests, 0 failures (112 parallel cases, random seed).

## Test plan

- [x] `mix test test/tau/burrito_steps/relink_sqlite_nif_test.exs test/tau/coding_agent/dispatcher_test.exs` — 10/0, run 5× (implementer 4×, reviewer 1×)
- [ ] CI `binary-qa` green on this PR
