### PR TITLE
fix(lint): gate new credo findings via credo diff baseline (#285)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,9 @@ jobs:
         id: compile_step
         continue-on-error: true
       - name: Credo diff (blocking — new findings only)
-        run: mix credo diff --strict --from-git-merge-base origin/main
+        run: |
+          git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
+          mix credo diff --strict --from-git-merge-base origin/main
       - run: mix credo --strict 2>&1 | tee /tmp/credo.log
         id: credo_step
         continue-on-error: true
@@ -376,6 +378,10 @@ jobs:
       - name: Fetch deps
         if: steps.changes.outputs.build == 'true'
         run: mix deps.get
+
+      - name: Fetch origin/main (for tau.qa credo-diff layer)
+        if: steps.changes.outputs.build == 'true'
+        run: git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
 
       - name: mix tau.qa
         if: steps.changes.outputs.build == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,8 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       # Pin Python 3.10 so :ex_termbox's waf 2.0.14 build compiles.
       # waf uses `import imp` (removed in 3.12) and `open(..., 'rUb')`
@@ -59,6 +61,8 @@ jobs:
       - run: mix compile --warnings-as-errors 2>&1 | tee /tmp/compile.log
         id: compile_step
         continue-on-error: true
+      - name: Credo diff (blocking — new findings only)
+        run: mix credo diff --strict --from-git-merge-base origin/main
       - run: mix credo --strict 2>&1 | tee /tmp/credo.log
         id: credo_step
         continue-on-error: true
@@ -302,6 +306,8 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Detect non-docs changes
         id: changes

--- a/lib/mix/tasks/tau.qa.ex
+++ b/lib/mix/tasks/tau.qa.ex
@@ -14,7 +14,7 @@ defmodule Mix.Tasks.Tau.Qa do
 
   | # | Layer | What it runs | Defect class it catches |
   |---|---|---|---|
-  | A | source quality | `mix compile --warnings-as-errors && mix test && mix format --check-formatted && mix credo --strict` | code defects |
+  | A | source quality | `mix compile --warnings-as-errors && mix test && mix format --check-formatted` then `mix credo diff --strict --from-git-merge-base origin/main` (skipped when origin/main is unavailable) | code defects |
   | B | artifact build | `BURRITO_TARGET=<host> MIX_ENV=prod mix release tau --overwrite` (with `XDG_DATA_HOME` isolation) | NIF cross-compile failures, broken Burrito post-steps |
   | C | artifact boot  | `<binary> help run`; assert exit 0; assert `--system-prompt-file` flag present | flag drift, escript/binary packaging gaps |
   | D | replay smoke   | `<binary> run "hello" --provider replay --model replay`; assert exit 0; stdout contains `(replay) hello` | NIF load failures (#264) |
@@ -73,6 +73,7 @@ defmodule Mix.Tasks.Tau.Qa do
     with :ok <- ensure_xdg_isolation(),
          {:ok, target} <- resolve_target(),
          :ok <- layer_a(),
+         :ok <- layer_a_credo_diff(),
          :ok <- bust_burrito_cache(),
          :ok <- layer_b(target),
          {:ok, binary} <- locate_binary(target),
@@ -202,6 +203,40 @@ defmodule Mix.Tasks.Tau.Qa do
           {:halt, {:error, @exit_layer_a, "LAYER_A_FAILED: `#{label}` exited #{code}"}}
       end
     end)
+  end
+
+  # --- (A) credo diff — new findings only ------------------------------------
+
+  defp layer_a_credo_diff do
+    cmd = "mix credo diff --strict --from-git-merge-base origin/main"
+    Mix.shell().info("tau.qa:   - #{cmd}")
+
+    case origin_main_available?() do
+      false ->
+        Mix.shell().info("tau.qa:   - credo diff skipped: origin/main unavailable")
+        :ok
+
+      true ->
+        case System.cmd(
+               "mix",
+               ["credo", "diff", "--strict", "--from-git-merge-base", "origin/main"],
+               stderr_to_stdout: true,
+               into: IO.stream(:stdio, :line)
+             ) do
+          {_io, 0} ->
+            :ok
+
+          {_io, code} ->
+            {:error, @exit_layer_a, "LAYER_A_FAILED: `#{cmd}` exited #{code}"}
+        end
+    end
+  end
+
+  defp origin_main_available? do
+    case System.cmd("git", ["rev-parse", "--verify", "origin/main"], stderr_to_stdout: true) do
+      {_output, 0} -> true
+      _ -> false
+    end
   end
 
   # --- (B) artifact build --------------------------------------------------

--- a/test/tau/cli/headless_run_test.exs
+++ b/test/tau/cli/headless_run_test.exs
@@ -96,7 +96,7 @@ defmodule Tau.CLI.HeadlessRunTest do
       assert length(matching) == 1, "expected session to appear in Tau.list_sessions/0"
 
       events = PJsonl.stream(session_id) |> Enum.to_list()
-      assert length(events) > 0, "expected non-empty JSONL for session #{session_id}"
+      assert events != [], "expected non-empty JSONL for session #{session_id}"
 
       kinds = Enum.map(events, & &1["kind"])
       assert "user_message" in kinds, "expected user_message event; got: #{inspect(kinds)}"
@@ -474,7 +474,7 @@ defmodule Tau.CLI.HeadlessRunTest do
           _ -> false
         end)
 
-      assert length(system_messages) >= 1,
+      assert system_messages != [],
              "expected at least one system-role skill message in data.messages; " <>
                "got: #{inspect(system_messages)}"
 
@@ -510,7 +510,7 @@ defmodule Tau.CLI.HeadlessRunTest do
             false
         end)
 
-      assert length(headless_messages) == 0,
+      assert headless_messages == [],
              "expected no headless-system-prompt skill message when --system-prompt is not given; " <>
                "got: #{inspect(headless_messages)}"
 


### PR DESCRIPTION
## Summary

Makes credo a blocking gate on **new** findings without firing on the
~161 pre-existing R/C/D findings (issue #285's recommended approach
(4)+(2): fix the warnings, then baseline). A full 164-finding cleanup is
explicitly deferred.

- **Fix the 3 `W` findings** — all three were `length/1`-on-a-list
  emptiness checks in `test/tau/cli/headless_run_test.exs` (lines 99,
  477, 510). Replaced with the direct `== []` / `!= []` form. After:
  `mix credo --strict` reports 0 W (was 3).
- **Baseline via `mix credo diff`** — the CI `lint` job gains a blocking
  `mix credo diff --strict --from-git-merge-base origin/main` step (no
  `continue-on-error`): only findings *introduced relative to `main`*
  fail the gate. The existing advisory `mix credo --strict` step is
  retained for the full-debt log.
- **`mix tau.qa`** gains a `layer_a_credo_diff` step running the same
  `credo diff`, which skips gracefully when `origin/main` is unavailable
  (local runs without a remote).
- Both the `lint` and `binary-qa` jobs get `fetch-depth: 0` and an
  explicit `git fetch ... main:refs/remotes/origin/main` so `credo diff`
  can always resolve its merge-base regardless of GitHub event type.

## Linked issues

Closes #285

## Gate verdicts

- critic: PASS (`ok: true`) — first gate vetoed an un-guarded
  `origin/main` reference in the `lint` job (would fail every PR);
  refined by prepending an explicit fetch. Re-gate: no blocking
  findings, 3 non-blocking SUGGESTIONs (CI fail-closed vs `tau.qa`
  fail-open skip asymmetry; cosmetic).
- reviewer: PASS (`verdict: PASS`) — `mix credo --strict` 0 W;
  `mix credo diff` exit 0; full suite 996 tests, 0 failures;
  format + compile-WAE clean.

## Test plan

- [x] `mix credo --strict` → 0 W (was 3); R/C/D baseline unchanged
- [x] `mix credo diff --strict --from-git-merge-base origin/main` → exit 0
- [x] `mix test test/tau/cli/headless_run_test.exs` → 35/0
- [x] `mix format --check-formatted`, `mix compile --warnings-as-errors` → clean
- [ ] CI `binary-qa` exercises the new `tau.qa` credo-diff layer
