### PR TITLE
feat(tui): operationalize the TUI UX testing protocol as a CI gate (#336)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -362,9 +362,9 @@ jobs:
           echo "$RUNNER_TEMP/zig-x86_64-linux-0.15.2" >> "$GITHUB_PATH"
           "$RUNNER_TEMP/zig-x86_64-linux-0.15.2/zig" version
 
-      - name: Setup xz (Burrito tarball compressor)
+      - name: Setup xz and tmux (Burrito + TUI UX protocol)
         if: steps.changes.outputs.build == 'true'
-        run: sudo apt-get update && sudo apt-get install -y xz-utils
+        run: sudo apt-get update && sudo apt-get install -y xz-utils tmux
 
       - name: Cache deps
         if: steps.changes.outputs.build == 'true'
@@ -386,6 +386,16 @@ jobs:
       - name: mix tau.qa
         if: steps.changes.outputs.build == 'true'
         run: mix tau.qa
+        env:
+          BURRITO_TARGET: linux_amd64
+
+      - name: mix tau.tui_ux (TUI UX protocol gate — closes #336)
+        # Runs the tmux-driven TUI UX protocol (SPEC-TUI-HEADLESS §7 steps 1–3).
+        # tau.qa already built the binary; tau.tui_ux locates it via the
+        # pre-built path and skips the build. tmux was installed above.
+        # Blocking (no continue-on-error): a TUI protocol failure is CI-blocking.
+        if: steps.changes.outputs.build == 'true'
+        run: mix tau.tui_ux
         env:
           BURRITO_TARGET: linux_amd64
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -394,6 +394,11 @@ jobs:
         # tau.qa already built the binary; tau.tui_ux locates it via the
         # pre-built path and skips the build. tmux was installed above.
         # Blocking (no continue-on-error): a TUI protocol failure is CI-blocking.
+        #
+        # Note: tau.tui_ux runs `mix test` under MIX_ENV=test (the default).
+        # tau.qa ran under MIX_ENV=prod; switching env forces a full test-env
+        # recompile here (~30s on a cold cache). This is expected and unavoidable
+        # given ExUnit requires MIX_ENV=test.
         if: steps.changes.outputs.build == 'true'
         run: mix tau.tui_ux
         env:

--- a/docs/spec/SPEC-TUI-HEADLESS.md
+++ b/docs/spec/SPEC-TUI-HEADLESS.md
@@ -289,9 +289,12 @@ to `idle`.
 
 #### AC-H3: Provider error visibility
 
-`start/2` with empty `~/.tau` and unset auth. `send "hi"`, `send
-:enter`, `await/3` for `Error|auth|expired` within 5s. Pane MUST NOT be
-empty after submit.
+`start/2` with `HOME` pointed at `tmpdir` (so `~/.claude/.credentials.json`
+does not exist) and `ANTHROPIC_API_KEY` set to `""` (overrides any ambient
+host value). Auth resolves locally to `{:error, :no_auth}` — no network
+round-trip. `send "hi"`, `send :enter`, `await/3` for
+`Error|auth|expired|missing|key` within 5s. Pane MUST NOT be empty after
+submit. Test MUST pass deterministically offline.
 
 #### AC-H4: Quit ergonomics
 
@@ -501,7 +504,9 @@ Code render streaming tokens progressively.
 
 #### AC-Z1: Resize handled without crash
 
-While the TUI is idle, change the tmux pane geometry (`tmux resize-pane`).
+While the TUI is idle, change the tmux window geometry (`tmux resize-window`).
+`resize-window` is used (not `resize-pane`) because the session is detached;
+`resize-window` resizes the pseudoterminal that the binary's tty is attached to.
 The TUI MUST re-render within one tick interval. Pane MUST show no
 corrupted layout.
 
@@ -549,12 +554,26 @@ Tag: `@tag :tui_smoke`
 
 ### Protocol step 3 — Provider error surface (AC-H3)
 
+Offline no-auth approach: configure the binary so auth resolves locally
+to nothing — no `ANTHROPIC_API_KEY` in env (`""` overrides any ambient
+host value), and `HOME` pointed at `tmpdir` so the OAuth path
+(`~/.claude/.credentials.json`) resolves to `<tmpdir>/.claude/...`
+which does not exist. The binary's `Auth.resolve/1` returns
+`{:error, :no_auth}` locally without any network round-trip. The
+session FSM maps that to `:missing_api_key` and routes the error to the
+transcript via `MessageEnd` ([C12]/[C19]). Timeout is 5s (local error,
+no network latency).
+
 ```
-start(binary_path, env: [TAU_DATA_DIR: tmpdir, TAU_ANTHROPIC_API_KEY: "invalid"])
+start(binary_path, env: [
+  {"TAU_DATA_DIR", tmpdir},
+  {"HOME", tmpdir},
+  {"ANTHROPIC_API_KEY", ""}
+])
 await(session, "> ")
 send(session, "hi")
 send(session, :enter)
-await(session, ~r/Error|auth|expired/, timeout_ms: 5_000)
+await(session, ~r/Error|auth|expired|missing|key/i, timeout_ms: 5_000)
 ```
 
 Tag: `@tag :tui_smoke`
@@ -619,11 +638,15 @@ Tag: `@tag :tui_ux`
 
 ### Protocol step 8 — Terminal resize (AC-Z1)
 
+`tmux_resize/2` issues `tmux resize-window` (not `resize-pane`) because
+the session is detached; `resize-window` resizes the pseudoterminal the
+binary's tty is attached to.
+
 ```
 start(binary_path, ..., geometry: {200, 50})
 await(session, "> ")
-tmux_resize(session, {120, 30})
-Process.sleep(500)              # wait ≥ 2 ticks
+tmux_resize(session, {120, 30})   # resize-window under the hood
+Process.sleep(500)                # wait ≥ 2 ticks
 {:ok, pane} = capture(session)
 assert String.length(pane) > 0
 refute pane =~ ~r/corrupt|error/i

--- a/lib/mix/tasks/tau.tui_ux.ex
+++ b/lib/mix/tasks/tau.tui_ux.ex
@@ -1,0 +1,221 @@
+defmodule Mix.Tasks.Tau.TuiUx do
+  @shortdoc "Build the Burrito binary and run the TUI UX protocol tests (closes #336)."
+
+  @moduledoc """
+  TUI UX protocol runner — issue #336.
+
+  Locates (or builds) the host-architecture Burrito binary, then runs the
+  `:tui_smoke` and `:tui_ux` tagged protocol tests against it via the
+  `Tau.Test.TuiPtyHelper` tmux harness. Reports per-step pass/fail.
+  Exits non-zero if any step FAILs.
+
+  Mirrors the structure and XDG isolation of `mix tau.qa`.
+
+  ## Runtime dependency
+
+  `tmux` MUST be on `$PATH`. The task checks for this before running
+  tests and exits with code 3 if absent.
+
+  ## Binary location / build
+
+  The task checks for a pre-built Burrito binary at
+  `burrito_out/tau_<target>`. If found, it uses it. If absent, it builds
+  one via `MIX_ENV=prod mix release tau --overwrite` (same as layer B of
+  `mix tau.qa`).
+
+  ## XDG isolation
+
+  `XDG_DATA_HOME` is set to `<cwd>/.xdg-data` when the caller has not
+  set one, preventing the Burrito unpack-cache race against concurrent
+  agents. Honours an externally-set `XDG_DATA_HOME` unchanged.
+
+  ## Exit codes
+
+  | exit | meaning                                              |
+  |------|------------------------------------------------------|
+  | 0    | all protocol steps green                            |
+  | 2    | unsupported host (cannot derive Burrito target)     |
+  | 3    | `tmux` not found on PATH                            |
+  | 4    | binary build failed                                 |
+  | 5    | one or more protocol steps FAILED                   |
+  """
+
+  use Mix.Task
+
+  @exit_unsupported_host 2
+  @exit_tmux_missing 3
+  @exit_build_failed 4
+  @exit_tests_failed 5
+
+  @impl Mix.Task
+  def run(_argv) do
+    with :ok <- ensure_xdg_isolation(),
+         {:ok, target} <- resolve_target(),
+         :ok <- ensure_tmux(),
+         {:ok, binary} <- ensure_binary(target),
+         :ok <- run_protocol(binary) do
+      Mix.shell().info("tau.tui_ux: OK (#{target})")
+      :ok
+    else
+      {:error, code, message} ->
+        Mix.shell().error("tau.tui_ux: #{message}")
+        System.halt(code)
+    end
+  end
+
+  # --- XDG isolation ---------------------------------------------------------
+
+  defp ensure_xdg_isolation do
+    case System.get_env("XDG_DATA_HOME") do
+      v when is_binary(v) and v != "" ->
+        :ok
+
+      _ ->
+        path = Path.expand(".xdg-data", File.cwd!())
+        File.mkdir_p!(path)
+        System.put_env("XDG_DATA_HOME", path)
+        Mix.shell().info("tau.tui_ux: XDG_DATA_HOME=#{path} (auto-isolated)")
+        :ok
+    end
+  end
+
+  # --- target resolution -----------------------------------------------------
+
+  defp resolve_target do
+    case System.get_env("BURRITO_TARGET") do
+      value when is_binary(value) and value != "" ->
+        {:ok, value}
+
+      _ ->
+        detect_host_target()
+    end
+  end
+
+  defp detect_host_target do
+    arch = :erlang.system_info(:system_architecture) |> to_string()
+
+    case {:os.type(), arch} do
+      {{:unix, :linux}, a} ->
+        cond do
+          String.contains?(a, "aarch64") -> {:ok, "linux_arm64"}
+          String.contains?(a, "x86_64") -> {:ok, "linux_amd64"}
+          true -> unsupported("linux arch #{inspect(a)} not supported")
+        end
+
+      {{:unix, :darwin}, a} ->
+        cond do
+          String.contains?(a, "aarch64") -> {:ok, "macos_arm64"}
+          String.contains?(a, "x86_64") -> {:ok, "macos_amd64"}
+          true -> unsupported("darwin arch #{inspect(a)} not supported")
+        end
+
+      other ->
+        unsupported("host #{inspect(other)} not supported (set BURRITO_TARGET to override)")
+    end
+  end
+
+  defp unsupported(msg), do: {:error, @exit_unsupported_host, "UNSUPPORTED_HOST: " <> msg}
+
+  # --- tmux check ------------------------------------------------------------
+
+  defp ensure_tmux do
+    case System.find_executable("tmux") do
+      nil ->
+        {:error, @exit_tmux_missing,
+         "TMUX_MISSING: install tmux to run the TUI UX protocol (apt/brew install tmux)"}
+
+      path ->
+        Mix.shell().info("tau.tui_ux: tmux found at #{path}")
+        :ok
+    end
+  end
+
+  # --- binary location / build -----------------------------------------------
+
+  defp ensure_binary(target) do
+    path = Path.expand("burrito_out/tau_#{target}", File.cwd!())
+
+    if File.regular?(path) do
+      Mix.shell().info("tau.tui_ux: using pre-built binary #{path}")
+      {:ok, path}
+    else
+      Mix.shell().info("tau.tui_ux: no binary at #{path} — building")
+      build_and_locate(target)
+    end
+  end
+
+  defp build_and_locate(target) do
+    Mix.shell().info("tau.tui_ux: MIX_ENV=prod mix release tau --overwrite (target=#{target})")
+
+    env = [
+      {"MIX_ENV", "prod"},
+      {"BURRITO_TARGET", target},
+      {"HEX_HTTP_TIMEOUT", "120"}
+    ]
+
+    case System.cmd("mix", ["release", "tau", "--overwrite"],
+           env: env,
+           stderr_to_stdout: true,
+           into: IO.stream(:stdio, :line)
+         ) do
+      {_io, 0} ->
+        path = Path.expand("burrito_out/tau_#{target}", File.cwd!())
+
+        if File.regular?(path) do
+          {:ok, path}
+        else
+          {:error, @exit_build_failed, "BUILD_FAILED: build succeeded but #{path} not found"}
+        end
+
+      {_io, code} ->
+        {:error, @exit_build_failed, "BUILD_FAILED: `mix release tau --overwrite` exited #{code}"}
+    end
+  end
+
+  # --- protocol run ----------------------------------------------------------
+
+  defp run_protocol(binary) do
+    Mix.shell().info("tau.tui_ux: running protocol (steps 1–3, tags :tui_smoke :tui_ux)")
+    Mix.shell().info("tau.tui_ux: binary=#{binary}")
+
+    # The TAU_TUI_BINARY env var tells the smoke test module which binary to
+    # use. The test's setup calls binary_for_host/0 which checks for Burrito
+    # binaries at predictable paths; we set TAU_TUI_BINARY to short-circuit
+    # that and point directly at the binary we've already located/built.
+    #
+    # Tests are tagged :tui_smoke (steps 1–3) + :tui_ux (steps 4–10, to be
+    # added by feature steps). We run both tags so a single invocation of
+    # `mix tau.tui_ux` covers the full protocol as it grows.
+    System.put_env("TAU_TUI_BINARY", binary)
+
+    # Run tests tagged :tui_smoke OR :tui_ux. ExUnit's --only applies AND
+    # logic when specified multiple times; to get OR semantics we use
+    # --include for both tags and --exclude test (the default tag on all
+    # tests), which is the same thing --only does internally.
+    test_args = [
+      "test",
+      "--include",
+      "tui_smoke",
+      "--include",
+      "tui_ux",
+      "--exclude",
+      "test",
+      "--trace",
+      "test/tau/cli/tui_smoke_test.exs"
+    ]
+
+    Mix.shell().info("tau.tui_ux: mix #{Enum.join(test_args, " ")}")
+
+    case System.cmd("mix", test_args,
+           stderr_to_stdout: true,
+           into: IO.stream(:stdio, :line)
+         ) do
+      {_io, 0} ->
+        :ok
+
+      {_io, code} ->
+        {:error, @exit_tests_failed,
+         "TESTS_FAILED: protocol test run exited #{code} — see output above for per-step failures"}
+    end
+  end
+end

--- a/test/support/tui_pty_helper.ex
+++ b/test/support/tui_pty_helper.ex
@@ -19,12 +19,14 @@ defmodule Tau.Test.TuiPtyHelper do
 
   D-NNN invariants enforced (see `docs/spec/SPEC-TUI-HEADLESS.md` §5):
 
-  - **D-020**: `start/2` waits for alt-screen activation before returning.
-  - **D-021**: `await/3` polls `capture-pane` at `:poll_ms` intervals.
-  - **D-022**: each `start/2` gets a unique tmux session name; callers
+  - **D-066**: `start/2` waits for alt-screen activation before returning.
+  - **D-067**: `await/3` polls `capture-pane` at `:poll_ms` intervals.
+  - **D-068**: each `start/2` gets a unique tmux session name; callers
     MUST set a per-run `TAU_DATA_DIR` to isolate session JSONL writes.
-  - **D-023**: `capture/1` snapshots pane state; safe before quit.
-  - **D-024**: `send/2` sleeps `:settle_ms` after the keystroke.
+  - **D-069**: `capture/1` snapshots pane state; safe before quit.
+  - **D-070**: `send/2` sleeps `:settle_ms` after the keystroke.
+  - **D-071**: Ratatouille render warnings are expected stderr; harness
+    tolerates them without masking actual rendering errors.
   """
 
   import Bitwise, only: [&&&: 2]
@@ -106,6 +108,17 @@ defmodule Tau.Test.TuiPtyHelper do
       :ctrl_c          → C-c
       :tab             → Tab
       :backspace       → BSpace
+      :up              → Up arrow
+      :down            → Down arrow
+      :left            → Left arrow
+      :right           → Right arrow
+      :ctrl_k          → C-k (kill to end of line)
+      :ctrl_y          → C-y (yank kill-ring)
+      :ctrl_a          → C-a (move to start of line)
+      :ctrl_e          → C-e (move to end of line)
+      :ctrl_u          → C-u (kill to start of line)
+      :ctrl_l          → C-l (clear screen)
+      :ctrl_r          → C-r (reverse history search)
   """
   @spec send(session(), iodata() | atom()) :: :ok
   def send(%{tmux_name: name} = sess, input) do
@@ -162,6 +175,26 @@ defmodule Tau.Test.TuiPtyHelper do
     end
   end
 
+  @doc """
+  Resize the tmux pane to `{cols, rows}`. Used by protocol step 8 (AC-Z1).
+  Returns `:ok` or raises on tmux error.
+  """
+  @spec tmux_resize(session(), {pos_integer(), pos_integer()}) :: :ok
+  def tmux_resize(%{tmux_name: name}, {cols, rows}) do
+    case System.cmd("tmux", [
+           "resize-window",
+           "-t",
+           name,
+           "-x",
+           "#{cols}",
+           "-y",
+           "#{rows}"
+         ]) do
+      {_, 0} -> :ok
+      {out, code} -> raise "tmux resize-window failed (code #{code}): #{out}"
+    end
+  end
+
   # --- internals -----------------------------------------------------------
 
   defp ensure_tmux do
@@ -201,7 +234,7 @@ defmodule Tau.Test.TuiPtyHelper do
     else
       case capture_raw(sess) do
         {:ok, raw} ->
-          # D-020: alt-screen sequence indicates the runtime is up.
+          # D-066: alt-screen sequence indicates the runtime is up.
           # Status-bar text is a stronger signal once present.
           if String.contains?(raw, "session:") or String.contains?(raw, "transcript") do
             :ok
@@ -249,6 +282,17 @@ defmodule Tau.Test.TuiPtyHelper do
   defp key_for(:ctrl_c), do: ["C-c"]
   defp key_for(:tab), do: ["Tab"]
   defp key_for(:backspace), do: ["BSpace"]
+  defp key_for(:up), do: ["Up"]
+  defp key_for(:down), do: ["Down"]
+  defp key_for(:left), do: ["Left"]
+  defp key_for(:right), do: ["Right"]
+  defp key_for(:ctrl_k), do: ["C-k"]
+  defp key_for(:ctrl_y), do: ["C-y"]
+  defp key_for(:ctrl_a), do: ["C-a"]
+  defp key_for(:ctrl_e), do: ["C-e"]
+  defp key_for(:ctrl_u), do: ["C-u"]
+  defp key_for(:ctrl_l), do: ["C-l"]
+  defp key_for(:ctrl_r), do: ["C-r"]
   defp key_for(s) when is_binary(s), do: [s]
   defp key_for(s) when is_list(s), do: [IO.iodata_to_binary(s)]
 end

--- a/test/tau/cli/tui_smoke_test.exs
+++ b/test/tau/cli/tui_smoke_test.exs
@@ -94,21 +94,21 @@ defmodule Tau.CLI.TuiSmokeTest do
   end
 
   describe "AC-H3: provider error visibility (mirrors SPEC-USER-TURN AC-3)" do
-    @tag :pending
-    test "submitting with no auth surfaces an error in transcript", %{
+    test "submitting with invalid auth surfaces an error in transcript", %{
       binary: binary,
       tmpdir: tmpdir
     } do
-      # Pending: requires the SPEC-USER-TURN AC-3 fix to land first.
-      # Currently the TUI reaches `:sending` and the transcript pane
-      # stays empty — the error_message field on the synthetic
-      # Assistant message isn't routed to render. Tracked in #149/#153
-      # and addressed by D-009 / [C12]/[C19] (already partially fixed
-      # on feat/anthropic-oauth — verify when this branch merges).
-
+      # SPEC-TUI-HEADLESS §7 protocol step 3 (D-066..D-071 enforced by harness).
+      # Supply an invalid API key so the provider attempt produces a 401
+      # auth error. The session FSM must route the error to the transcript
+      # via MessageEnd (D-009 / [C12]/[C19] fix). The match covers the
+      # [assistant] line that wraps the "Error: ..." notice.
       {:ok, sess} =
         TuiPtyHelper.start(binary,
-          env: [{"TAU_DATA_DIR", tmpdir}, {"ANTHROPIC_API_KEY", ""}]
+          env: [
+            {"TAU_DATA_DIR", tmpdir},
+            {"ANTHROPIC_API_KEY", "invalid-key-tui-ux-test"}
+          ]
         )
 
       on_exit(fn -> TuiPtyHelper.quit(sess) end)
@@ -116,14 +116,15 @@ defmodule Tau.CLI.TuiSmokeTest do
       :ok = TuiPtyHelper.send(sess, "hi")
       :ok = TuiPtyHelper.send(sess, :enter)
 
-      case TuiPtyHelper.await(sess, ~r/Error|auth|expired/i, timeout_ms: 5_000) do
+      case TuiPtyHelper.await(sess, ~r/Error|auth|expired|invalid|unauthorized/i,
+             timeout_ms: 15_000
+           ) do
         {:ok, _pane} ->
           :ok
 
         {:error, :timeout, last_pane} ->
           flunk(
-            "AC-H3 violation: TUI did not surface an error within 5s. " <>
-              "This is the [C12]/[C19] error-message-lost-in-render bug. " <>
+            "AC-H3 violation: TUI did not surface an error within 15s. " <>
               "Pane:\n#{last_pane}"
           )
       end
@@ -165,17 +166,25 @@ defmodule Tau.CLI.TuiSmokeTest do
   # --- helpers --------------------------------------------------------
 
   defp binary_for_host do
-    candidates = [
-      "burrito_out/tau_linux_#{host_arch()}",
-      "burrito_out/tau_linux_amd64",
-      "burrito_out/tau_linux_arm64",
-      "_build/prod/rel/tau/bin/tau"
-    ]
+    # TAU_TUI_BINARY is set by `mix tau.tui_ux` to point at the binary it
+    # has already located or built. When set, skip candidate detection.
+    case System.get_env("TAU_TUI_BINARY") do
+      path when is_binary(path) and path != "" ->
+        if File.regular?(path), do: path, else: nil
 
-    Enum.find(candidates, fn path ->
-      full = Path.join(File.cwd!(), path)
-      File.regular?(full)
-    end)
+      _ ->
+        candidates = [
+          "burrito_out/tau_linux_#{host_arch()}",
+          "burrito_out/tau_linux_amd64",
+          "burrito_out/tau_linux_arm64",
+          "_build/prod/rel/tau/bin/tau"
+        ]
+
+        Enum.find(candidates, fn path ->
+          full = Path.join(File.cwd!(), path)
+          File.regular?(full)
+        end)
+    end
   end
 
   defp host_arch do

--- a/test/tau/cli/tui_smoke_test.exs
+++ b/test/tau/cli/tui_smoke_test.exs
@@ -18,152 +18,209 @@ defmodule Tau.CLI.TuiSmokeTest do
   @moduletag :tui_smoke
   @moduletag timeout: 60_000
 
-  setup do
-    # Arch-aware binary selection; if the matching binary doesn't exist,
-    # skip rather than fail.
-    case binary_for_host() do
-      nil ->
-        {:skip, "No matching Burrito binary for host arch — run `mix release` first"}
+  # setup_all/1 detects whether the host can run these tests and stores
+  # the result in the context. setup/1 then creates per-test isolation
+  # (tmpdir) when a binary is available.
+  #
+  # ExUnit 1.18.1 does not support {:skip, reason} from setup/1 or
+  # setup_all/1 (only compile-time @tag skip: works for true ExUnit
+  # "skipped" semantics). This module uses skip_if_unavailable/1 at the
+  # top of each test body — it prints a "[SKIP]" notice and causes the
+  # test to return without any assertions (counted as 0 failures, no
+  # RuntimeError). This is the correct runtime-conditional skip pattern
+  # for ExUnit 1.18.1.
+  setup_all do
+    skip_reason =
+      cond do
+        is_nil(System.find_executable("tmux")) ->
+          "tmux not found on PATH"
 
-      bin ->
-        unless System.find_executable("tmux") do
-          {:skip, "tmux not found on PATH"}
-        else
-          tmpdir = System.tmp_dir!() |> Path.join("tau-tui-smoke-#{:rand.uniform(1_000_000)}")
-          File.mkdir_p!(tmpdir)
+        is_nil(binary_for_host()) ->
+          "No matching Burrito binary for host arch — run `mix release` first"
 
-          on_exit(fn ->
-            File.rm_rf(tmpdir)
-          end)
+        true ->
+          nil
+      end
 
-          {:ok, binary: bin, tmpdir: tmpdir}
-        end
+    {:ok, binary: binary_for_host(), skip_reason: skip_reason}
+  end
+
+  setup ctx do
+    if is_nil(ctx[:skip_reason]) do
+      tmpdir = System.tmp_dir!() |> Path.join("tau-tui-smoke-#{:rand.uniform(1_000_000)}")
+      File.mkdir_p!(tmpdir)
+
+      on_exit(fn ->
+        File.rm_rf(tmpdir)
+      end)
+
+      {:ok, Map.put(ctx, :tmpdir, tmpdir)}
+    else
+      {:ok, ctx}
     end
   end
 
   describe "AC-H1: first-run smoke (mirrors SPEC-USER-TURN AC-1)" do
-    test "TUI renders status bar, transcript panel, prompt", %{
-      binary: binary,
-      tmpdir: tmpdir
-    } do
-      {:ok, sess} = TuiPtyHelper.start(binary, env: [{"TAU_DATA_DIR", tmpdir}])
-
-      on_exit(fn -> TuiPtyHelper.quit(sess) end)
-
-      {:ok, pane} = TuiPtyHelper.capture(sess)
-
-      assert pane =~ ~r/session:/, "status bar missing session id; pane:\n#{pane}"
-      assert pane =~ "transcript", "transcript panel header missing; pane:\n#{pane}"
-      assert pane =~ "<Enter> submit", "prompt help missing; pane:\n#{pane}"
-
-      # D-026 ([C51-B3]): the prompt MUST render a visible cursor glyph
-      # so the user can see the insertion point. "█" (U+2588) is appended
-      # after model.input by the render/1 path.
-      Process.sleep(150)
-      {:ok, pane2} = TuiPtyHelper.capture(sess)
-      assert pane2 =~ "█", "cursor glyph missing from prompt; pane:\n#{pane2}"
+    test "TUI renders status bar, transcript panel, prompt", ctx do
+      if skip_if_unavailable(ctx), do: nil, else: run_ac_h1(ctx)
     end
   end
 
   describe "AC-H4: quit ergonomics (mirrors SPEC-USER-TURN AC-4)" do
-    test "literal 'q' in input does not quit", %{binary: binary, tmpdir: tmpdir} do
-      {:ok, sess} = TuiPtyHelper.start(binary, env: [{"TAU_DATA_DIR", tmpdir}])
-      on_exit(fn -> TuiPtyHelper.quit(sess) end)
-
-      :ok = TuiPtyHelper.send(sess, "abcq")
-      Process.sleep(300)
-      {:ok, pane} = TuiPtyHelper.capture(sess)
-
-      # The literal "q" should appear in the prompt line, NOT have
-      # exited the TUI. Status bar must still render.
-      assert pane =~ "abcq", "input not echoed in prompt; pane:\n#{pane}"
-      assert pane =~ ~r/session:/, "TUI exited on 'q' as part of input — bug; pane:\n#{pane}"
+    test "literal 'q' in input does not quit", ctx do
+      if skip_if_unavailable(ctx), do: nil, else: run_ac_h4_no_quit(ctx)
     end
 
-    test "'q' on empty prompt quits with exit 0", %{binary: binary, tmpdir: tmpdir} do
-      {:ok, sess} = TuiPtyHelper.start(binary, env: [{"TAU_DATA_DIR", tmpdir}])
-
-      # Capture before quitting (D-023).
-      {:ok, _pane} = TuiPtyHelper.capture(sess)
-
-      :ok = TuiPtyHelper.send(sess, "q")
-      Process.sleep(500)
-
-      {:ok, _} = TuiPtyHelper.quit(sess)
+    test "'q' on empty prompt quits with exit 0", ctx do
+      if skip_if_unavailable(ctx), do: nil, else: run_ac_h4_quit(ctx)
     end
   end
 
   describe "AC-H3: provider error visibility (mirrors SPEC-USER-TURN AC-3)" do
-    test "submitting with invalid auth surfaces an error in transcript", %{
-      binary: binary,
-      tmpdir: tmpdir
-    } do
-      # SPEC-TUI-HEADLESS §7 protocol step 3 (D-066..D-071 enforced by harness).
-      # Supply an invalid API key so the provider attempt produces a 401
-      # auth error. The session FSM must route the error to the transcript
-      # via MessageEnd (D-009 / [C12]/[C19] fix). The match covers the
-      # [assistant] line that wraps the "Error: ..." notice.
-      {:ok, sess} =
-        TuiPtyHelper.start(binary,
-          env: [
-            {"TAU_DATA_DIR", tmpdir},
-            {"ANTHROPIC_API_KEY", "invalid-key-tui-ux-test"}
-          ]
-        )
-
-      on_exit(fn -> TuiPtyHelper.quit(sess) end)
-
-      :ok = TuiPtyHelper.send(sess, "hi")
-      :ok = TuiPtyHelper.send(sess, :enter)
-
-      case TuiPtyHelper.await(sess, ~r/Error|auth|expired|invalid|unauthorized/i,
-             timeout_ms: 15_000
-           ) do
-        {:ok, _pane} ->
-          :ok
-
-        {:error, :timeout, last_pane} ->
-          flunk(
-            "AC-H3 violation: TUI did not surface an error within 15s. " <>
-              "Pane:\n#{last_pane}"
-          )
-      end
+    test "submitting with no auth surfaces an error in transcript", ctx do
+      if skip_if_unavailable(ctx), do: nil, else: run_ac_h3(ctx)
     end
   end
 
   describe "AC-H2: single turn round-trip (mirrors SPEC-USER-TURN AC-2)" do
-    test "replay provider produces assistant response in transcript", %{
-      binary: binary,
-      tmpdir: tmpdir
-    } do
-      # The bar for "working TUI": user types, hits Enter, the assistant
-      # response appears in the transcript pane. Replay produces a
-      # deterministic "(replay) hello" so this test is hermetic.
-      {:ok, sess} =
-        TuiPtyHelper.start(binary,
-          env: [{"TAU_DATA_DIR", tmpdir}],
-          args: ["tui", "--provider", "replay", "--model", "replay"]
+    test "replay provider produces assistant response in transcript", ctx do
+      if skip_if_unavailable(ctx), do: nil, else: run_ac_h2(ctx)
+    end
+  end
+
+  # --- test implementations -----------------------------------------------
+
+  defp run_ac_h1(%{binary: binary, tmpdir: tmpdir}) do
+    {:ok, sess} = TuiPtyHelper.start(binary, env: [{"TAU_DATA_DIR", tmpdir}])
+
+    on_exit(fn -> TuiPtyHelper.quit(sess) end)
+
+    {:ok, pane} = TuiPtyHelper.capture(sess)
+
+    assert pane =~ ~r/session:/, "status bar missing session id; pane:\n#{pane}"
+    assert pane =~ "transcript", "transcript panel header missing; pane:\n#{pane}"
+    assert pane =~ "<Enter> submit", "prompt help missing; pane:\n#{pane}"
+
+    # D-026 ([C51-B3]): the prompt MUST render a visible cursor glyph
+    # so the user can see the insertion point. "█" (U+2588) is appended
+    # after model.input by the render/1 path.
+    Process.sleep(150)
+    {:ok, pane2} = TuiPtyHelper.capture(sess)
+    assert pane2 =~ "█", "cursor glyph missing from prompt; pane:\n#{pane2}"
+  end
+
+  defp run_ac_h4_no_quit(%{binary: binary, tmpdir: tmpdir}) do
+    {:ok, sess} = TuiPtyHelper.start(binary, env: [{"TAU_DATA_DIR", tmpdir}])
+    on_exit(fn -> TuiPtyHelper.quit(sess) end)
+
+    :ok = TuiPtyHelper.send(sess, "abcq")
+    Process.sleep(300)
+    {:ok, pane} = TuiPtyHelper.capture(sess)
+
+    # The literal "q" should appear in the prompt line, NOT have
+    # exited the TUI. Status bar must still render.
+    assert pane =~ "abcq", "input not echoed in prompt; pane:\n#{pane}"
+    assert pane =~ ~r/session:/, "TUI exited on 'q' as part of input — bug; pane:\n#{pane}"
+  end
+
+  defp run_ac_h4_quit(%{binary: binary, tmpdir: tmpdir}) do
+    {:ok, sess} = TuiPtyHelper.start(binary, env: [{"TAU_DATA_DIR", tmpdir}])
+
+    # Capture before quitting (D-023).
+    {:ok, _pane} = TuiPtyHelper.capture(sess)
+
+    :ok = TuiPtyHelper.send(sess, "q")
+    Process.sleep(500)
+
+    {:ok, _} = TuiPtyHelper.quit(sess)
+  end
+
+  defp run_ac_h3(%{binary: binary, tmpdir: tmpdir}) do
+    # SPEC-TUI-HEADLESS §7 protocol step 3 (D-066..D-071 enforced by harness).
+    #
+    # Offline no-auth approach: configure the session so auth resolves
+    # locally to nothing — no ANTHROPIC_API_KEY in env, and HOME pointed
+    # at a tmpdir that has no ~/.claude/.credentials.json. The binary's
+    # Auth.resolve/1 hits both the vault (env empty) and the OAuth file
+    # path (~/<HOME>/.claude/.credentials.json, which doesn't exist) and
+    # returns {:error, :no_auth}. The session FSM maps that to
+    # :missing_api_key and routes the error to the transcript via
+    # MessageEnd (D-009 / [C12]/[C19] fix). No network round-trip occurs.
+    #
+    # This test MUST pass deterministically offline. Timeout is short
+    # because the error is produced locally, not over the wire.
+    {:ok, sess} =
+      TuiPtyHelper.start(binary,
+        env: [
+          {"TAU_DATA_DIR", tmpdir},
+          # Empty HOME so ~/.claude/.credentials.json resolves to a
+          # path under tmpdir that does not exist. Also unset any
+          # ambient ANTHROPIC_API_KEY (set explicitly to empty so tmux
+          # does not inherit the caller's value).
+          {"HOME", tmpdir},
+          {"ANTHROPIC_API_KEY", ""}
+        ]
+      )
+
+    on_exit(fn -> TuiPtyHelper.quit(sess) end)
+
+    :ok = TuiPtyHelper.send(sess, "hi")
+    :ok = TuiPtyHelper.send(sess, :enter)
+
+    case TuiPtyHelper.await(sess, ~r/Error|auth|expired|missing|key/i, timeout_ms: 5_000) do
+      {:ok, _pane} ->
+        :ok
+
+      {:error, :timeout, last_pane} ->
+        flunk(
+          "AC-H3 violation: TUI did not surface an auth error within 5s " <>
+            "(offline no-auth path). Pane:\n#{last_pane}"
         )
+    end
+  end
 
-      on_exit(fn -> TuiPtyHelper.quit(sess) end)
+  defp run_ac_h2(%{binary: binary, tmpdir: tmpdir}) do
+    # The bar for "working TUI": user types, hits Enter, the assistant
+    # response appears in the transcript pane. Replay produces a
+    # deterministic "(replay) hello" so this test is hermetic.
+    {:ok, sess} =
+      TuiPtyHelper.start(binary,
+        env: [{"TAU_DATA_DIR", tmpdir}],
+        args: ["tui", "--provider", "replay", "--model", "replay"]
+      )
 
-      :ok = TuiPtyHelper.send(sess, "hello")
-      :ok = TuiPtyHelper.send(sess, :enter)
+    on_exit(fn -> TuiPtyHelper.quit(sess) end)
 
-      case TuiPtyHelper.await(sess, ~r/\(replay\)/, timeout_ms: 30_000) do
-        {:ok, _pane} ->
-          :ok
+    :ok = TuiPtyHelper.send(sess, "hello")
+    :ok = TuiPtyHelper.send(sess, :enter)
 
-        {:error, :timeout, last_pane} ->
-          flunk(
-            "AC-H2 violation: assistant response did not appear in the " <>
-              "transcript pane within 30s. Pane:\n#{last_pane}"
-          )
-      end
+    case TuiPtyHelper.await(sess, ~r/\(replay\)/, timeout_ms: 30_000) do
+      {:ok, _pane} ->
+        :ok
+
+      {:error, :timeout, last_pane} ->
+        flunk(
+          "AC-H2 violation: assistant response did not appear in the " <>
+            "transcript pane within 30s. Pane:\n#{last_pane}"
+        )
     end
   end
 
   # --- helpers --------------------------------------------------------
+
+  # Returns true and prints a "[SKIP]" notice when the host is missing the
+  # binary or tmux; returns false when the host can run the test.
+  # Callers: `if skip_if_unavailable(ctx), do: nil, else: run_impl(ctx)`.
+  #
+  # ExUnit 1.18.1 has no runtime skip mechanism from setup/setup_all —
+  # only compile-time @tag skip: produces the "skipped" ExUnit state.
+  # This helper produces 0 failures and a clear console notice.
+  defp skip_if_unavailable(%{skip_reason: reason}) when is_binary(reason) do
+    IO.puts("[SKIP] #{reason}")
+    true
+  end
+
+  defp skip_if_unavailable(_ctx), do: false
 
   defp binary_for_host do
     # TAU_TUI_BINARY is set by `mix tau.tui_ux` to point at the binary it

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -3,4 +3,4 @@
 #   :tui_smoke  — TUI PTY harness (needs tmux + a built binary)
 #   :external   — coding-agent adapter tests that spawn real CLIs
 #                 (`INTEGRATION=1 mix test --only external`).
-ExUnit.start(exclude: [:smoke, :tui_smoke, :external])
+ExUnit.start(exclude: [:smoke, :tui_smoke, :tui_ux, :external])


### PR DESCRIPTION
## Summary

Finishes #336 — operationalizes the TUI UX testing protocol as a runnable,
CI-blocking gate (the implementation half; the SPEC was merged in #348).

- `lib/mix/tasks/tau.tui_ux.ex` — new `mix tau.tui_ux` runner: locates/builds
  the host binary (XDG-isolated), runs the `:tui_smoke`+`:tui_ux` protocol
  tests, exits non-zero on any FAIL.
- `test/support/tui_pty_helper.ex` — D-020..D-024 → D-066..D-071; §H1 API
  completion (`tmux_resize/2`, full key set).
- `test/tau/cli/tui_smoke_test.exs` — protocol steps 1–3 green; AC-H3 reworked
  to an offline/deterministic no-auth test (no network); `setup_all`-based
  skip when binary/tmux absent.
- `test/test_helper.exs` — `:tui_ux` added to the default ExUnit exclude.
- `docs/spec/SPEC-TUI-HEADLESS.md` — §7 step 3 / step 8 amended to match.
- `.github/workflows/ci.yml` — `tmux` installed; `mix tau.tui_ux` a blocking
  step in `binary-qa`.

## Linked issues

Closes #336

## Gate verdicts

- critic: PASS (`ok: true`) — re-gate; first gate raised 2 BLOCKING (AC-H3
  network-dependence + SPEC divergence, missing `:tui_ux` exclude), both fixed.
- reviewer: PASS (`verdict: PASS`) — compile/format clean, 996 tests 0
  failures, offline AC-H3 confirmed, scope = 6 files.

## Test plan

- [x] `mix tau.tui_ux` — 5 protocol tests pass, exit 0 (AC-H3 offline, 4.1s)
- [x] skip path clean when no binary present
- [ ] CI `binary-qa` runs `mix tau.tui_ux` as a blocking gate
