### PR TITLE
test(ci): finish binary-qa de-flake — rate_limiter_test:57,63,79 (#352)

### DIFF
--- a/test/tau/providers/rate_limiter_test.exs
+++ b/test/tau/providers/rate_limiter_test.exs
@@ -11,27 +11,24 @@ defmodule Tau.Providers.RateLimiterTest do
 
   alias Tau.Providers.RateLimiter
 
-  defmodule FakeProvider do
-    @moduledoc false
-  end
-
-  setup do
-    on_exit(fn ->
-      RateLimiter
-      |> apply(:state, [FakeProvider])
-      |> case do
-        :no_limiter -> :ok
-        _ -> Tau.Providers.RateLimiter.Supervisor.stop(FakeProvider)
-      end
-    end)
-
-    :ok
-  end
+  # No shared module-level FakeProvider: every test that starts a limiter uses
+  # a unique atom derived from System.unique_integer/1 and registers its own
+  # on_exit to stop it. This avoids a TOCTOU window where a previous test's
+  # DynamicSupervisor.terminate_child returns (process dead) but the Registry
+  # has not yet processed the DOWN and deregistered the entry — a subsequent
+  # GenServer.call on the stale pid crashes the on_exit runner, and ExUnit
+  # reports the *next* test as failed (pointing to the on_exit line).
 
   describe "acquire/3 with available budget" do
     test "returns :ok immediately and emits :acquired telemetry" do
+      # Unique atom: isolates this limiter from concurrent on_exit cleanup.
+      provider =
+        String.to_atom("FakeProviderAcquire_#{System.unique_integer([:positive])}")
+
+      on_exit(fn -> Tau.Providers.RateLimiter.Supervisor.stop(provider) end)
+
       {:ok, _pid} =
-        Tau.Providers.RateLimiter.Supervisor.ensure_started(FakeProvider, rpm: 600, tpm: 6_000)
+        Tau.Providers.RateLimiter.Supervisor.ensure_started(provider, rpm: 600, tpm: 6_000)
 
       ref = make_ref()
 
@@ -49,7 +46,7 @@ defmodule Tau.Providers.RateLimiterTest do
       send(self(), {ref, :primer, %{}, %{}})
       _ = receive(do: ({^ref, :primer, _, _} -> :ok))
 
-      assert :ok = RateLimiter.acquire(FakeProvider, 100, 1_000)
+      assert :ok = RateLimiter.acquire(provider, 100, 1_000)
 
       :telemetry.detach("rl-test-#{inspect(ref)}")
     end
@@ -61,17 +58,23 @@ defmodule Tau.Providers.RateLimiterTest do
 
   describe "acquire/3 starvation" do
     test "with zero budget and zero refill returns :rate_limit_timeout quickly" do
+      # Unique atom — same isolation rationale as the other tests in this file.
+      provider =
+        String.to_atom("FakeProviderStarve_#{System.unique_integer([:positive])}")
+
+      on_exit(fn -> Tau.Providers.RateLimiter.Supervisor.stop(provider) end)
+
       # rpm: 0 == "no gating" per TokenBucket spec, so use a tiny budget
       # with a high request count.
       {:ok, _} =
-        Tau.Providers.RateLimiter.Supervisor.ensure_started(FakeProvider, rpm: 60, tpm: 60)
+        Tau.Providers.RateLimiter.Supervisor.ensure_started(provider, rpm: 60, tpm: 60)
 
       # Drain the rpm bucket. rate_per_sec = 60/60 = 1, so refill is
       # 1 token/sec — easy to starve.
-      Enum.each(1..60, fn _ -> RateLimiter.acquire(FakeProvider, 0, 5_000) end)
+      Enum.each(1..60, fn _ -> RateLimiter.acquire(provider, 0, 5_000) end)
 
       # Now ask for one more with a 50ms timeout — should reject.
-      assert {:error, :rate_limit_timeout} = RateLimiter.acquire(FakeProvider, 0, 50)
+      assert {:error, :rate_limit_timeout} = RateLimiter.acquire(provider, 0, 50)
     end
   end
 


### PR DESCRIPTION
## Closes

Closes #352

Completes the `binary-qa` Layer-A de-flake — `rate_limiter_test.exs:57,63,79`.

## Background

#353 (merged) de-flaked `rate_limiter_test.exs` lines 107/115 (a shared
`FakeProvider2`-atom / `on_exit` race) and the `coding_agent_resume` /
`skill_activation` tests. But `rate_limiter_test.exs` **still flakes** in
`binary-qa` Layer A (`mix test --seed 0 --max-cases 1`) at **lines 57 / 63 / 79**
— a different region. Confirmed flaking PR #356's CI on identical SHA `6aced7c`
(one run passed, one failed on exactly these lines), and earlier PRs.

## Scope

De-flake `test/tau/providers/rate_limiter_test.exs` at lines 57, 63, 79 (and
any sibling test in that file with the same root cause). Find the actual
cause — a timing race, a shared named process / ETS table not isolated
per-test, `Process.sleep` used as a synchronisation primitive, or `on_exit`
cleanup racing the next test (the same class #353 fixed at 107/115).

Make each deterministic: **await a real signal** (`assert_receive`, a
telemetry handler, a monitor ref, polling a genuine condition) and/or
**isolate shared named state per test** (unique process/registry/ETS names
via `System.unique_integer/1`, `start_supervised!` with per-test teardown).
Do NOT paper over a flake with a longer timeout.

This is **test-only** — no `lib/` change, no SPEC.

## Verification

- Run the file in a loop to prove determinism — e.g.
  `for i in $(seq 1 30); do mix test test/tau/providers/rate_limiter_test.exs --seed $i --max-cases 1 || break; done`
  — and `--seed 0`; all iterations green.
- `mix test` full suite green; `mix compile --warnings-as-errors`,
  `mix format --check-formatted`, `mix credo --strict` clean.

## Gate verdicts

- critic: PASS (`ok: true`) — root cause (the shared-`setup` `on_exit` `Registry.lookup`+`GenServer.call` TOCTOU) eliminated, not masked; assertions intact; no timeout band-aid. 1 non-blocking SUGGESTION (bounded per-test atom leak).
- reviewer: PASS (`verdict: PASS`) — `binary-qa` green on BOTH CI runs on `9a86700`; local seed-loop 0–10 deterministic; test-only, no `lib/` change, all 8 assertions preserved.

