### PR TITLE
feat(tui): surface sub-agent dispatch & progress in the transcript (#335)

### DIFF
--- a/docs/MISSION.md
+++ b/docs/MISSION.md
@@ -129,6 +129,7 @@ elaboration briefs independently claimed D-066.
 | D-120–D-129 | SPEC-EXTENSIONS (new, #180) |
 | D-130–D-139 | reserved — SPEC-CLUSTER (M9, future) |
 | D-140–D-149 | SPEC-TUI-HEADLESS extension — input editor invariants (#338) |
+| D-150–D-159 | SPEC-TUI-HEADLESS extension — sub-agent visibility invariants (#335) |
 
 A SPEC author who needs a D-NNN outside their block MUST update this
 registry and SPEC-TUI-HEADLESS §5 note before using the new identifier.

--- a/docs/spec/SPEC-TUI-HEADLESS.md
+++ b/docs/spec/SPEC-TUI-HEADLESS.md
@@ -330,6 +330,13 @@ SPEC-CODING-AGENT (D-031 parity) and conforms to its boundary contract:
 `Subagent*` events extend, not replace, the `ToolStart`/`ToolEnd` pair
 so existing audit consumers continue to receive the flattened triad.
 
+**`child_session_id` for `:coding_agent` Path B:** `SubagentStart` events emitted
+on Path B (coding-agent dispatcher) carry `child_session_id: nil` because the
+coding agent subprocess runs inside the parent's own session id — it does not
+spawn a distinct Tau session via `Tau.start_session/1`. Only the builtin `Agent`
+tool (Path A) spawns a real child session; Path A therefore carries a non-nil
+`child_session_id` equal to the child's session id.
+
 | ID | Statement | Severity | Detection | Source |
 |---|---|---|---|---|
 | D-150 | Sub-agent lifecycle events (`SubagentStart`, `SubagentProgress`, `SubagentCost`, `SubagentEnd`) MUST be broadcast on the **parent** session PubSub topic `"session:<parent_id>"`. Child-topic emission is invisible to the TUI EventBridge (which subscribes only to the parent topic). Both dispatch paths (builtin `Agent` tool and coding-agent dispatcher) MUST use the parent topic. | high | unit test: observe events on parent topic after Agent.execute/2; assert no event arrives on child topic for the TUI EventBridge. | B1 / elaboration §3.1 |
@@ -340,7 +347,7 @@ so existing audit consumers continue to receive the flattened triad.
 | D-155 | `SubagentProgress` events with `activity: {:tool_call, name}` MUST increment `SubagentNode.tool_calls` by 1. Non-tool_call activity (`:assistant_text`, `:file_edit`, `:tool_result`) MUST NOT increment the counter. | medium | property test: generate N tool_call progress events; assert node.tool_calls == N. | AC-3 |
 | D-156 | The `Tau.TUI.SubagentTree` module MUST be a pure fold module — no GenServer, no process, no behaviour. All state is threaded through the MVU model's `subagents` field. A "SubagentManager" GenServer would violate OTP non-negotiables §1/#3. | high | structural: assert module has no `use GenServer` or supervised start. | D2 / OTP non-negotiables §3/#8 |
 | D-157 | State transitions in `SubagentNode` are monotone: once `:done`, `:failed`, or `:cancelled`, no further event may revert the node to `:running`. A `SubagentProgress` arriving after `SubagentEnd` is silently discarded. | medium | property test: fold SubagentEnd; fold SubagentProgress; assert state unchanged. | D-154 monotonicity |
-| D-158 | The `Tau.TUI.App.update/2` handler for `%SubagentStart{}` MUST append a `"┌─ sub-agent: <label> [running]"` line to `model.transcript`. The handler for `%SubagentEnd{}` MUST append a `"└─ sub-agent: <label> [<state> · ...]"` end marker. Both markers are part of the single-column transcript (S3 / no right-hand panel for this PR). | medium | unit test: fold SubagentStart then SubagentEnd; assert transcript contains expected marker strings. | AC-1, AC-2 |
+| D-158 | In-flight sub-agent display uses a **live region** derived from `model.subagents` every render frame. `%SubagentStart{}` MUST NOT append a frozen start marker to `model.transcript`; instead `render/1` produces one `"▶ sub-agent: <label> · <N> tool calls · <excerpt>"` line per `:running` node, re-computed each frame so the count and excerpt update live (AC-3). `%SubagentEnd{}` MUST append a permanent `"└─ sub-agent: <label> [<state> · ...]"` end marker to `model.transcript` (AC-2). The live region is a compact single-column element within the existing transcript panel (S3 / no right-hand panel for this PR). | medium | unit test: (a) SubagentStart — transcript unchanged, node in subagents tree with :running state; (b) SubagentProgress — format_live_line shows increased tool-call count; (c) SubagentEnd — end marker in transcript, node not :running. | AC-1, AC-2, AC-3 |
 | D-159 | `[:tau, :session, :subagent, :start]` and `[:tau, :session, :subagent, :stop]` telemetry spans MUST fire per sub-agent dispatch. The existing span pair in `Tau.Tools.Builtin.Agent.execute/2` is the canonical source; a second competing `[:tau, :session, :subagent, :start]` from the relay path MUST NOT be emitted (S5 critic finding). Separate `[:tau, :session, :subagent, :progress]` and `[:tau, :session, :subagent, :cost]` metrics events are out of scope for this PR. | medium | ExUnit telemetry handler: assert :start and :stop events fire per Agent.execute/2 invocation. | AC-8 |
 
 ## 6. Acceptance criteria — UX surface

--- a/docs/spec/SPEC-TUI-HEADLESS.md
+++ b/docs/spec/SPEC-TUI-HEADLESS.md
@@ -319,6 +319,30 @@ the input editor feature (#338). See `docs/MISSION.md` registry.
 | D-148 | **Known limitation:** Two concurrent `tau` sessions in the same cwd each maintain independent in-memory history. `Store.append/3` writes are POSIX-atomic (single `:append` write ≤ 4 KiB), so line-level interleaving does not occur. However, each session's in-memory ring does not see the other session's appends until a new session starts and calls `Store.load/2`. This is acceptable for v1 (history is advisory, not correctness-bearing). | low | No test required; documented here so it is not filed as a bug. | [HC26] |
 | D-149 | The `Tau.TUI.Editor` and `Tau.TUI.History` modules MUST be pure value modules — no GenServer, no process, no behaviour. All state is threaded through the Ratatouille MVU model. | high | Structural: assert neither module has a `use GenServer` or `@behaviour` directive. | OTP non-negotiables §3, §8 |
 
+## 5c. PSDH catalog (D-150–D-159) — sub-agent visibility runtime invariants
+
+D-NNN allocation: this SPEC owns D-150–D-159 as an extension block for
+the sub-agent visibility feature (#335). See `docs/MISSION.md` registry.
+
+This block was introduced in PR #362 (feat/subagent-visibility-335).
+Path B (coding-agent CAEvent FSM handlers) is in scope of
+SPEC-CODING-AGENT (D-031 parity) and conforms to its boundary contract:
+`Subagent*` events extend, not replace, the `ToolStart`/`ToolEnd` pair
+so existing audit consumers continue to receive the flattened triad.
+
+| ID | Statement | Severity | Detection | Source |
+|---|---|---|---|---|
+| D-150 | Sub-agent lifecycle events (`SubagentStart`, `SubagentProgress`, `SubagentCost`, `SubagentEnd`) MUST be broadcast on the **parent** session PubSub topic `"session:<parent_id>"`. Child-topic emission is invisible to the TUI EventBridge (which subscribes only to the parent topic). Both dispatch paths (builtin `Agent` tool and coding-agent dispatcher) MUST use the parent topic. | high | unit test: observe events on parent topic after Agent.execute/2; assert no event arrives on child topic for the TUI EventBridge. | B1 / elaboration §3.1 |
+| D-151 | `SubagentProgress.child_tool_call_id` is the correlation key for the render-layer de-dup rule (B1): a parent-topic `%ToolStart{}` / `%ToolEnd{}` whose `tool_call_id` is present in any node's `owned_tool_call_ids` set MUST NOT be rendered as an inline `[tool_call]` line — the sub-agent start/end markers own its visual representation. | high | unit test: SubagentProgress with child_tool_call_id "x"; ToolStart with tool_call_id "x"; assert no bare [tool_call] line appended to transcript. | B1 / issue #335 |
+| D-152 | An unknown `subagent_id` in `SubagentProgress`, `SubagentCost`, or `SubagentEnd` MUST be silently ignored (tree unchanged). An unknown `kind` atom in `SubagentStart` MUST also be silently ignored. No exception, no crash. The closed `kind` set is `{:builtin_agent, :coding_agent}`; future kinds may be added by amending this invariant. | high | property test: generate arbitrary unknown subagent_id and unknown kind; fold into tree; assert tree unchanged. | D-152 / S4 critic finding |
+| D-153 | Sub-agent cost reported via `SubagentCost` MUST NOT be folded into the parent session's own cost display. The `SubagentNode` owns its cost; the parent status bar shows parent-only cost. This prevents double-counting (R4). | high | unit test: apply SubagentCost; assert parent model cost fields unchanged. | R4 / AC-4 |
+| D-154 | `SubagentEnd` MUST be emitted on **all five** terminal branches of `await_child/4` in `Tau.Tools.Builtin.Agent`: (1) natural MessageEnd, (2) failure MessageEnd, (3) `%SessionEnd{}`, (4) `{:DOWN, parent_ref}`, (5) `after`-timeout. A missed branch leaves the node stuck `▶ running` after the parent turn ends (AC-7 failure). | high | unit test: trigger each terminal branch via a stub child session; assert SubagentEnd arrives on the parent topic for each. | B2 / AC-7 |
+| D-155 | `SubagentProgress` events with `activity: {:tool_call, name}` MUST increment `SubagentNode.tool_calls` by 1. Non-tool_call activity (`:assistant_text`, `:file_edit`, `:tool_result`) MUST NOT increment the counter. | medium | property test: generate N tool_call progress events; assert node.tool_calls == N. | AC-3 |
+| D-156 | The `Tau.TUI.SubagentTree` module MUST be a pure fold module — no GenServer, no process, no behaviour. All state is threaded through the MVU model's `subagents` field. A "SubagentManager" GenServer would violate OTP non-negotiables §1/#3. | high | structural: assert module has no `use GenServer` or supervised start. | D2 / OTP non-negotiables §3/#8 |
+| D-157 | State transitions in `SubagentNode` are monotone: once `:done`, `:failed`, or `:cancelled`, no further event may revert the node to `:running`. A `SubagentProgress` arriving after `SubagentEnd` is silently discarded. | medium | property test: fold SubagentEnd; fold SubagentProgress; assert state unchanged. | D-154 monotonicity |
+| D-158 | The `Tau.TUI.App.update/2` handler for `%SubagentStart{}` MUST append a `"┌─ sub-agent: <label> [running]"` line to `model.transcript`. The handler for `%SubagentEnd{}` MUST append a `"└─ sub-agent: <label> [<state> · ...]"` end marker. Both markers are part of the single-column transcript (S3 / no right-hand panel for this PR). | medium | unit test: fold SubagentStart then SubagentEnd; assert transcript contains expected marker strings. | AC-1, AC-2 |
+| D-159 | `[:tau, :session, :subagent, :start]` and `[:tau, :session, :subagent, :stop]` telemetry spans MUST fire per sub-agent dispatch. The existing span pair in `Tau.Tools.Builtin.Agent.execute/2` is the canonical source; a second competing `[:tau, :session, :subagent, :start]` from the relay path MUST NOT be emitted (S5 critic finding). Separate `[:tau, :session, :subagent, :progress]` and `[:tau, :session, :subagent, :cost]` metrics events are out of scope for this PR. | medium | ExUnit telemetry handler: assert :start and :stop events fire per Agent.execute/2 invocation. | AC-8 |
+
 ## 6. Acceptance criteria — UX surface
 
 These criteria define the M1.1 UX bar. Each maps to one or more protocol
@@ -837,7 +861,11 @@ Files this SPEC touches (or proposes touching) on landing:
 | `Tau.TUI.App.init/1` | `lib/tau/tui/app.ex:18-37` |
 | `Tau.TUI.App.run/0` quit_events | `lib/tau/tui/app.ex:115-119` |
 | `Tau.TUI.InputEditor` (proposed, #338) | `lib/tau/tui/input_editor.ex` |
-| `Tau.TUI.SubAgentPanel` (proposed, #335) | `lib/tau/tui/sub_agent_panel.ex` |
+| `Tau.TUI.SubagentTree` (#335, landed) | `lib/tau/tui/subagent_tree.ex` |
+| `Tau.TUI.App.subagents` model field (#335, landed) | `lib/tau/tui/app.ex` |
+| `Tau.Session.Events.SubagentStart/Progress/Cost/End` (#335, landed) | `lib/tau/session/events.ex` |
+| `Tau.Tools.Builtin.Agent.await_child/4` relay (#335, landed) | `lib/tau/tools/builtin/agent.ex` |
+| `Tau.TUI.SubAgentPanel` (proposed, #361 follow-up) | `lib/tau/tui/sub_agent_panel.ex` |
 | `Tau.TUI.StatusBar` (proposed, #340) | `lib/tau/tui/status_bar.ex` |
 | `Tau.Provider.context_window/1` (proposed, #340) | `lib/tau/provider.ex` |
 | `Tau.TUI.Theme` (proposed, #345) | `lib/tau/tui/theme.ex` |

--- a/lib/tau/session.ex
+++ b/lib/tau/session.ex
@@ -4033,6 +4033,24 @@ defmodule Tau.Session do
 
         broadcast(data.id, %Events.MessageStart{session_id: data.id, message: pending})
 
+        # B1 / D-150 (SPEC-TUI-HEADLESS §5c): emit SubagentStart on the parent
+        # topic so the TUI can surface the coding agent as a named sub-agent
+        # node rather than flattened parent [tool_call] lines. The subagent_id
+        # is derived from the parent session id and is stable for this turn.
+        # The coding-agent dispatcher is a single-run process; at most one is
+        # active at a time, so the derived id is unique per session per turn.
+        ca_subagent_id = "#{data.id}:ca"
+        label = agent_to_string(data.coding_agent) || "coding-agent"
+
+        broadcast(data.id, %Events.SubagentStart{
+          session_id: data.id,
+          subagent_id: ca_subagent_id,
+          kind: :coding_agent,
+          label: label,
+          parent_tool_call_id: nil,
+          child_session_id: nil
+        })
+
         {:next_state, :coding_agent_streaming,
          %{
            data
@@ -4134,6 +4152,19 @@ defmodule Tau.Session do
       arguments: input || %{}
     })
 
+    # B1 / D-151 (SPEC-TUI-HEADLESS §5c): ADDITIONALLY emit SubagentProgress
+    # on the parent topic. The child_tool_call_id enables the render layer to
+    # de-dup: a ToolStart/ToolEnd whose tool_call_id is owned by a known
+    # sub-agent is NOT rendered as an inline tool call (B1 rule).
+    ca_subagent_id = "#{data.id}:ca"
+
+    broadcast(data.id, %Events.SubagentProgress{
+      session_id: data.id,
+      subagent_id: ca_subagent_id,
+      activity: {:tool_call, name},
+      child_tool_call_id: id
+    })
+
     {:keep_state, %{data | coding_agent_blocks: blocks, coding_agent_pending: pending}}
   end
 
@@ -4208,6 +4239,19 @@ defmodule Tau.Session do
       },
       %{session_id: data.id, agent: data.coding_agent, tokens: cost.tokens}
     )
+
+    # D-153 (SPEC-TUI-HEADLESS §5c): emit SubagentCost on the parent topic so
+    # the TUI can display cost in the sub-agent end marker without folding it
+    # into the parent's own cost (no double-counting, R4).
+    ca_subagent_id = "#{data.id}:ca"
+
+    broadcast(data.id, %Events.SubagentCost{
+      session_id: data.id,
+      subagent_id: ca_subagent_id,
+      tokens: cost.tokens,
+      usd: cost.usd,
+      duration_ms: cost.duration_ms
+    })
 
     {:keep_state, maybe_apply_cost_hook(data, cost)}
   end
@@ -4322,6 +4366,31 @@ defmodule Tau.Session do
         stop_reason: stop_reason
       }
     )
+
+    # D-154 (SPEC-TUI-HEADLESS §5c): emit SubagentEnd on the parent topic.
+    # The end state maps from the coding-agent stop_reason.
+    ca_subagent_id = "#{data.id}:ca"
+
+    end_state =
+      cond do
+        status == -2 -> :cancelled
+        stop_reason == :end_turn -> :done
+        true -> :failed
+      end
+
+    end_summary =
+      case end_state do
+        :done -> "completed"
+        :cancelled -> "cancelled"
+        :failed -> "failed (exit #{status})"
+      end
+
+    broadcast(data.id, %Events.SubagentEnd{
+      session_id: data.id,
+      subagent_id: ca_subagent_id,
+      state: end_state,
+      summary: end_summary
+    })
 
     {:next_state, :awaiting_user,
      %{

--- a/lib/tau/session/events.ex
+++ b/lib/tau/session/events.ex
@@ -142,4 +142,80 @@ defmodule Tau.Session.Events do
     defstruct [:session_id, :messages]
     @type t :: %__MODULE__{}
   end
+
+  defmodule SubagentStart do
+    @moduledoc """
+    Broadcast on the **parent** session topic when a sub-agent is dispatched.
+
+    D-150 (SPEC-TUI-HEADLESS §5c): sub-agent lifecycle events MUST be emitted
+    on the parent topic `"session:<parent_id>"` so the TUI EventBridge, which
+    subscribes only to the parent topic, receives them without needing a
+    per-child subscription.
+
+    `kind` is a closed atom set: `:builtin_agent` (the `Agent` builtin tool,
+    Path A) or `:coding_agent` (the coding-agent dispatcher, Path B). Consumers
+    MUST pattern-match on atoms; unknown `kind` values MUST be ignored, not
+    crashed (D-152).
+
+    `parent_tool_call_id` is the parent FSM's tool-call id for this Agent
+    invocation, used by the render layer to de-dup owned child tool calls (B1).
+    """
+    @enforce_keys [:session_id, :subagent_id, :kind, :label]
+    defstruct [:session_id, :subagent_id, :kind, :label, :parent_tool_call_id, :child_session_id]
+    @type t :: %__MODULE__{}
+  end
+
+  defmodule SubagentProgress do
+    @moduledoc """
+    Broadcast on the **parent** session topic for each notable child activity:
+    a tool call, an assistant-text chunk, or a file edit.
+
+    D-151 (SPEC-TUI-HEADLESS §5c): progress is coalesced — one event per child
+    tool-call / text chunk, never per token — to bound mailbox and render cost.
+
+    `child_tool_call_id` is the child session's tool-call id (may be `nil` for
+    non-tool activity). The render layer uses it to correlate: a parent-topic
+    `%ToolStart{}` / `%ToolEnd{}` whose `tool_call_id` belongs to a known
+    sub-agent is NOT rendered inline — the sub-agent markers own it (B1 rule).
+
+    `activity` is one of:
+      - `{:tool_call, name}` — child invoked a tool
+      - `{:assistant_text, excerpt}` — child produced assistant text (short excerpt)
+      - `{:file_edit, path, kind}` — child performed a file edit
+    """
+    @enforce_keys [:session_id, :subagent_id, :activity]
+    defstruct [:session_id, :subagent_id, :activity, :child_tool_call_id]
+    @type t :: %__MODULE__{}
+  end
+
+  defmodule SubagentCost do
+    @moduledoc """
+    Broadcast on the **parent** session topic when the sub-agent reports cost
+    information (e.g. on completion or via a cost event from the adapter).
+
+    D-153 (SPEC-TUI-HEADLESS §5c): sub-agent cost MUST NOT be folded into the
+    parent's own cost line. The node owns its cost; the parent status bar shows
+    parent-only cost. This prevents double-counting (R4).
+    """
+    @enforce_keys [:session_id, :subagent_id]
+    defstruct [:session_id, :subagent_id, :tokens, :usd, :duration_ms]
+    @type t :: %__MODULE__{}
+  end
+
+  defmodule SubagentEnd do
+    @moduledoc """
+    Broadcast on the **parent** session topic when the sub-agent terminates.
+
+    D-154 (SPEC-TUI-HEADLESS §5c): `SubagentEnd` MUST be emitted on ALL FIVE
+    terminal branches of `await_child/4`: `natural_end`, `failure_end`,
+    `SessionEnd`, `{:DOWN, …}`, and the `after`-timeout. A missed branch
+    produces a node stuck `▶ running` after the parent turn ends (AC-7 failure).
+
+    `state` is a closed atom set: `:done`, `:failed`, or `:cancelled`.
+    `summary` is a short human-readable string for the transcript end marker.
+    """
+    @enforce_keys [:session_id, :subagent_id, :state]
+    defstruct [:session_id, :subagent_id, :state, :summary]
+    @type t :: %__MODULE__{}
+  end
 end

--- a/lib/tau/tools/builtin/agent.ex
+++ b/lib/tau/tools/builtin/agent.ex
@@ -528,6 +528,14 @@ defmodule Tau.Tools.Builtin.Agent do
       %SE.MessageUpdate{session_id: ^child_id} ->
         await_child(child_id, ctx, parent_ref, started)
 
+      # B2 (FIX-4): discard any other child-session event not explicitly
+      # matched above — SystemNotice, ProviderFallback, QueueRestored,
+      # CommandCatalog, etc. Without this catch-all they accumulate in the
+      # tool-task mailbox and the "B2 any non-forwarded child event is
+      # discarded" guarantee only partially holds.
+      %{session_id: ^child_id} ->
+        await_child(child_id, ctx, parent_ref, started)
+
       # Terminal branch 3: SessionEnd.
       %SE.SessionEnd{session_id: ^child_id, reason: reason} ->
         duration = System.monotonic_time(:millisecond) - started

--- a/lib/tau/tools/builtin/agent.ex
+++ b/lib/tau/tools/builtin/agent.ex
@@ -82,7 +82,14 @@ defmodule Tau.Tools.Builtin.Agent do
   # turns; their unbounded counterpart is the parent's. We use a
   # generous default and let the parent FSM cascade `:cancel` if the
   # parent itself is cancelled or crashes.
+  #
+  # Test override: set `Application.put_env(:tau, :subagent_await_timeout_ms, N)`
+  # to inject a short timeout in unit tests exercising the timeout branch.
   @await_timeout_ms 10 * 60 * 1000
+
+  defp await_timeout_ms do
+    Application.get_env(:tau, :subagent_await_timeout_ms, @await_timeout_ms)
+  end
 
   @impl Tau.Tool
   def name, do: "Agent"
@@ -528,14 +535,6 @@ defmodule Tau.Tools.Builtin.Agent do
       %SE.MessageUpdate{session_id: ^child_id} ->
         await_child(child_id, ctx, parent_ref, started)
 
-      # B2 (FIX-4): discard any other child-session event not explicitly
-      # matched above — SystemNotice, ProviderFallback, QueueRestored,
-      # CommandCatalog, etc. Without this catch-all they accumulate in the
-      # tool-task mailbox and the "B2 any non-forwarded child event is
-      # discarded" guarantee only partially holds.
-      %{session_id: ^child_id} ->
-        await_child(child_id, ctx, parent_ref, started)
-
       # Terminal branch 3: SessionEnd.
       %SE.SessionEnd{session_id: ^child_id, reason: reason} ->
         duration = System.monotonic_time(:millisecond) - started
@@ -578,25 +577,37 @@ defmodule Tau.Tools.Builtin.Agent do
           "Sub-agent aborted: parent session terminated",
           details: %{kind: :parent_down, child_session_id: child_id}
         )
+
+      # B2 (FIX-4): discard any other child-session event not explicitly
+      # matched above — SystemNotice, ProviderFallback, QueueRestored,
+      # CommandCatalog, etc. Without this catch-all they accumulate in the
+      # tool-task mailbox and the "B2 any non-forwarded child event is
+      # discarded" guarantee only partially holds.
+      # MUST be the LAST receive clause so specific terminal/relay clauses
+      # (MessageEnd/ToolStart/ToolEnd/MessageUpdate/SessionEnd/Cancelled/DOWN)
+      # always match first.
+      %{session_id: ^child_id} ->
+        await_child(child_id, ctx, parent_ref, started)
     after
       # Terminal branch 5: timeout.
-      @await_timeout_ms ->
+      await_timeout_ms() ->
+        timeout = await_timeout_ms()
         Tau.cancel(child_id)
 
         broadcast_subagent_end(
           ctx.session_id,
           child_id,
           :cancelled,
-          @await_timeout_ms,
-          "timed out after #{div(@await_timeout_ms, 1000)}s"
+          timeout,
+          "timed out after #{div(timeout, 1000)}s"
         )
 
         Result.error(
-          "Sub-agent timed out after #{@await_timeout_ms}ms",
+          "Sub-agent timed out after #{timeout}ms",
           details: %{
             kind: :subagent_timeout,
             child_session_id: child_id,
-            timeout_ms: @await_timeout_ms
+            timeout_ms: timeout
           }
         )
     end

--- a/lib/tau/tools/builtin/agent.ex
+++ b/lib/tau/tools/builtin/agent.ex
@@ -71,6 +71,11 @@ defmodule Tau.Tools.Builtin.Agent do
   alias Tau.Session.Events, as: SE
   alias Tau.Tool.Result
 
+  # D-150 (SPEC-TUI-HEADLESS §5c): relay child events as Subagent* on the
+  # PARENT topic so the TUI EventBridge (subscribed only to the parent topic)
+  # receives them. The tool task is the natural relay point — it is the one
+  # process bridging child topic and parent identity.
+
   @general_purpose "general-purpose"
 
   # Bounded await for the child's `:end_turn`. Sub-agents are model
@@ -193,6 +198,21 @@ defmodule Tau.Tools.Builtin.Agent do
 
         # ADR-0008: monitor lives in this tool task, NOT the FSM.
         parent_ref = parent_pid && Process.monitor(parent_pid)
+
+        # D-150 (SPEC-TUI-HEADLESS §5c): emit SubagentStart on the PARENT
+        # topic before sending the brief. The label is the subagent_type
+        # (or "general-purpose" when nil). The parent_tool_call_id is the
+        # correlation key for the B1 de-dup rule in the render layer.
+        label = subagent_type || @general_purpose
+
+        Phoenix.PubSub.broadcast(Tau.PubSub, "session:#{ctx.session_id}", %SE.SubagentStart{
+          session_id: ctx.session_id,
+          subagent_id: child_id,
+          kind: :builtin_agent,
+          label: label,
+          parent_tool_call_id: ctx.tool_call_id,
+          child_session_id: child_id
+        })
 
         :ok = Tau.send(child_id, brief)
 
@@ -410,23 +430,53 @@ defmodule Tau.Tools.Builtin.Agent do
   @subagent_natural_end [:stop, :end_turn, :length, :stop_sequence]
   @subagent_failure_end [:error, :aborted, :tool_loop_aborted, :compaction_failed]
 
+  # B2 (SPEC-TUI-HEADLESS §5c): relay child events as Subagent* on the parent
+  # topic. SubagentEnd MUST be emitted on ALL FIVE terminal branches:
+  #   1. natural_end (MessageEnd with natural stop_reason)
+  #   2. failure_end (MessageEnd with failure stop_reason)
+  #   3. SessionEnd (child FSM terminated)
+  #   4. {:DOWN, parent_ref} (parent died)
+  #   5. after-timeout
+  # A missed branch leaves the node stuck running (AC-7 failure).
+  #
+  # MessageUpdate MUST be explicitly matched-and-discarded. Otherwise the
+  # tool-task mailbox grows unbounded on a chatty child (B2 / F-mode).
   defp await_child(child_id, ctx, parent_ref, started) do
     receive do
       %SE.MessageEnd{session_id: ^child_id, message: %Assistant{} = msg} ->
         cond do
           msg.stop_reason in @subagent_natural_end ->
             content = extract_text(msg)
+            duration = System.monotonic_time(:millisecond) - started
+
+            broadcast_subagent_end(
+              ctx.session_id,
+              child_id,
+              :done,
+              duration,
+              "completed in #{div(duration, 1000)}s"
+            )
 
             Result.text(content,
               details: %{
                 kind: :subagent_result,
                 child_session_id: child_id,
                 stop_reason: msg.stop_reason,
-                duration_ms: System.monotonic_time(:millisecond) - started
+                duration_ms: duration
               }
             )
 
           msg.stop_reason in @subagent_failure_end ->
+            duration = System.monotonic_time(:millisecond) - started
+
+            broadcast_subagent_end(
+              ctx.session_id,
+              child_id,
+              :failed,
+              duration,
+              "failed: #{inspect(msg.stop_reason)}"
+            )
+
             Result.error(
               "Sub-agent failed (stop_reason: #{inspect(msg.stop_reason)}). " <>
                 (msg.error_message || ""),
@@ -442,7 +492,54 @@ defmodule Tau.Tools.Builtin.Agent do
             await_child(child_id, ctx, parent_ref, started)
         end
 
+      # Relay child ToolStart as SubagentProgress on the parent topic.
+      # The child_tool_call_id is the correlation key for B1 de-dup.
+      %SE.ToolStart{session_id: ^child_id, tool_call_id: tcid, name: name} ->
+        Phoenix.PubSub.broadcast(Tau.PubSub, "session:#{ctx.session_id}", %SE.SubagentProgress{
+          session_id: ctx.session_id,
+          subagent_id: child_id,
+          activity: {:tool_call, name},
+          child_tool_call_id: tcid
+        })
+
+        await_child(child_id, ctx, parent_ref, started)
+
+      # Relay child ToolEnd as SubagentProgress (activity carries result summary).
+      %SE.ToolEnd{session_id: ^child_id, tool_call_id: tcid, result: result} ->
+        summary =
+          if is_binary(result.content), do: String.slice(result.content, 0..80), else: ""
+
+        Phoenix.PubSub.broadcast(Tau.PubSub, "session:#{ctx.session_id}", %SE.SubagentProgress{
+          session_id: ctx.session_id,
+          subagent_id: child_id,
+          activity: {:tool_result, summary},
+          child_tool_call_id: tcid
+        })
+
+        await_child(child_id, ctx, parent_ref, started)
+
+      # D-031 parity: relay child MessageEnd (non-natural) as progress.
+      # Natural MessageEnd is handled above in the top clause.
+      %SE.MessageEnd{session_id: ^child_id} ->
+        await_child(child_id, ctx, parent_ref, started)
+
+      # B2: explicitly discard MessageUpdate — never forward, never accumulate.
+      # The child may emit one per token; ignoring keeps the mailbox bounded.
+      %SE.MessageUpdate{session_id: ^child_id} ->
+        await_child(child_id, ctx, parent_ref, started)
+
+      # Terminal branch 3: SessionEnd.
       %SE.SessionEnd{session_id: ^child_id, reason: reason} ->
+        duration = System.monotonic_time(:millisecond) - started
+
+        broadcast_subagent_end(
+          ctx.session_id,
+          child_id,
+          :failed,
+          duration,
+          "session ended: #{inspect(reason)}"
+        )
+
         Result.error(
           "Sub-agent session ended before :end_turn (#{inspect(reason)})",
           details: %{
@@ -458,6 +555,7 @@ defmodule Tau.Tools.Builtin.Agent do
         # parent, or another MessageEnd if the parent un-cancels.
         await_child(child_id, ctx, parent_ref, started)
 
+      # Terminal branch 4: parent died.
       {:DOWN, ^parent_ref, :process, _pid, _reason} ->
         # Parent died. Cascade-cancel the child to flush its persistence
         # then return an is_error. The FSM cancel cast is fire-and-
@@ -466,13 +564,24 @@ defmodule Tau.Tools.Builtin.Agent do
         # tool task is on borrowed time too. Return promptly.
         Tau.cancel(child_id)
 
+        broadcast_subagent_end(ctx.session_id, child_id, :cancelled, 0, "parent terminated")
+
         Result.error(
           "Sub-agent aborted: parent session terminated",
           details: %{kind: :parent_down, child_session_id: child_id}
         )
     after
+      # Terminal branch 5: timeout.
       @await_timeout_ms ->
         Tau.cancel(child_id)
+
+        broadcast_subagent_end(
+          ctx.session_id,
+          child_id,
+          :cancelled,
+          @await_timeout_ms,
+          "timed out after #{div(@await_timeout_ms, 1000)}s"
+        )
 
         Result.error(
           "Sub-agent timed out after #{@await_timeout_ms}ms",
@@ -483,6 +592,26 @@ defmodule Tau.Tools.Builtin.Agent do
           }
         )
     end
+  end
+
+  # Emit SubagentEnd on the parent topic. Best-effort: PubSub.broadcast
+  # is fire-and-forget; a failure here does not affect the result.
+  defp broadcast_subagent_end(parent_session_id, child_id, state, duration_ms, summary) do
+    Phoenix.PubSub.broadcast(Tau.PubSub, "session:#{parent_session_id}", %SE.SubagentEnd{
+      session_id: parent_session_id,
+      subagent_id: child_id,
+      state: state,
+      summary: summary
+    })
+
+    # Also emit cost with whatever duration we tracked.
+    Phoenix.PubSub.broadcast(Tau.PubSub, "session:#{parent_session_id}", %SE.SubagentCost{
+      session_id: parent_session_id,
+      subagent_id: child_id,
+      tokens: nil,
+      usd: nil,
+      duration_ms: duration_ms
+    })
   end
 
   defp extract_text(%Assistant{content: blocks}) when is_list(blocks) do

--- a/lib/tau/tui/app.ex
+++ b/lib/tau/tui/app.ex
@@ -94,7 +94,6 @@ if Code.ensure_loaded?(Ratatouille.Runtime) do
         history_data_dir: data_dir,
         history_cwd: cwd,
         transcript: [],
-        tool_output: [],
         # D-150 (SPEC-TUI-HEADLESS §5c): sub-agent tree — pure derived
         # render state, folded synchronously by on_subagent_*/2 handlers.
         # Map of subagent_id => %SubagentTree.SubagentNode{}.
@@ -492,6 +491,18 @@ if Code.ensure_loaded?(Ratatouille.Runtime) do
                 for sub <- Wrap.wrap("[streaming] " <> model.last_assistant, model.wrap_width) do
                   label(content: sub)
                 end
+              end
+
+              # D-158 / AC-3 (SPEC-TUI-HEADLESS §5c): live region — one line
+              # per *running* sub-agent, derived from model.subagents every
+              # frame so the tool-call count and activity excerpt update each
+              # tick without a static frozen marker in the transcript.
+              # Each line: "▶ sub-agent: <label> · <N> tool calls · <excerpt>"
+              for {_id, node} <- model.subagents,
+                  node.state == :running,
+                  line <- [SubagentTree.format_live_line(node)],
+                  sub <- Wrap.wrap(line, model.wrap_width) do
+                label(content: sub)
               end
             end
           end
@@ -1031,23 +1042,20 @@ if Code.ensure_loaded?(Ratatouille.Runtime) do
       %{model | editor: Editor.new(), search: nil}
     end
 
-    # D-150 (SPEC-TUI-HEADLESS §5c): fold SubagentStart into the tree and
-    # append a boxed start marker to the transcript (AC-1).
-    # If the fold rejects the event (unknown kind, D-152), skip the marker too.
+    # D-150 / D-158 (SPEC-TUI-HEADLESS §5c): fold SubagentStart into the tree.
+    # No static start marker is appended to the transcript — the running sub-agent
+    # appears in the live region (rendered every frame from model.subagents by render/1)
+    # so the tool-call count and activity excerpt update live (AC-3).
+    # The permanent `└─` end marker is appended by on_subagent_end/2 when the
+    # node transitions to a terminal state (AC-2).
+    # If the fold rejects the event (unknown kind, D-152), model is unchanged.
     defp on_subagent_start(model, e) do
       new_tree = SubagentTree.fold(model.subagents, e)
 
       if Map.has_key?(new_tree, e.subagent_id) do
-        node = new_tree[e.subagent_id]
-        marker = SubagentTree.format_start_marker(node)
-
-        %{
-          model
-          | subagents: new_tree,
-            transcript: bounded_append(model.transcript, {marker, []})
-        }
+        %{model | subagents: new_tree}
       else
-        # Unknown kind — tree unchanged, no marker (D-152).
+        # Unknown kind — tree unchanged (D-152).
         model
       end
     end
@@ -1145,31 +1153,13 @@ if Code.ensure_loaded?(Ratatouille.Runtime) do
       }
     end
 
-    defp on_tool_start(model, %{tool_call_id: tcid, name: n, arguments: args}) do
-      # B1 rule (D-151): skip tool calls owned by a known sub-agent — the
-      # sub-agent marker owns the render. Still record non-owned calls.
-      if SubagentTree.tool_call_owned?(model.subagents, tcid) do
-        model
-      else
-        %{model | tool_output: model.tool_output ++ ["▶ " <> n <> " " <> inspect(args)]}
-      end
-    end
+    # B1 rule (D-151): ToolStart/ToolEnd on the parent topic are no-ops.
+    # Calls owned by a sub-agent: the live region and end marker own the
+    # visual representation. Non-owned calls: tool_output was removed in
+    # FIX-3; a future PR may surface non-owned tool calls in the transcript.
+    defp on_tool_start(model, _e), do: model
 
-    defp on_tool_end(model, %{tool_call_id: tcid, result: %{content: c, is_error: e}}) do
-      # B1 rule (D-151): skip tool results owned by a known sub-agent.
-      if SubagentTree.tool_call_owned?(model.subagents, tcid) do
-        model
-      else
-        prefix = if e, do: "✗", else: "✓"
-
-        summary =
-          if is_binary(c),
-            do: String.slice(c, 0..160),
-            else: c |> inspect() |> String.slice(0..160)
-
-        %{model | tool_output: model.tool_output ++ [prefix <> " " <> summary]}
-      end
-    end
+    defp on_tool_end(model, _e), do: model
 
     defp on_cancelled(model, %{reason: reason}) do
       reason_str = inspect(reason)

--- a/lib/tau/tui/app.ex
+++ b/lib/tau/tui/app.ex
@@ -17,6 +17,7 @@ if Code.ensure_loaded?(Ratatouille.Runtime) do
     alias Tau.TUI.Editor
     alias Tau.TUI.History
     alias Tau.TUI.History.Store
+    alias Tau.TUI.SubagentTree
     alias Tau.Commands.Builtin
 
     # Adaptive tick: 16 ms while a turn is streaming (last_assistant non-nil);
@@ -94,6 +95,11 @@ if Code.ensure_loaded?(Ratatouille.Runtime) do
         history_cwd: cwd,
         transcript: [],
         tool_output: [],
+        # D-150 (SPEC-TUI-HEADLESS §5c): sub-agent tree — pure derived
+        # render state, folded synchronously by on_subagent_*/2 handlers.
+        # Map of subagent_id => %SubagentTree.SubagentNode{}.
+        # No GenServer; no process. OTP non-negotiables #1/#3.
+        subagents: %{},
         status: :idle,
         last_assistant: nil,
         coding_agent: Map.get(runtime_opts, :coding_agent),
@@ -198,6 +204,24 @@ if Code.ensure_loaded?(Ratatouille.Runtime) do
 
         %Tau.Session.Events.QueueRestored{} ->
           model
+
+        # D-150..D-154 (SPEC-TUI-HEADLESS §5c): sub-agent lifecycle events.
+        # Fold into the sub-agent tree AND append boxed markers to the transcript.
+        # SubagentStart: add node + append start marker line.
+        %Tau.Session.Events.SubagentStart{} = e ->
+          on_subagent_start(model, e)
+
+        # SubagentProgress: update node state (tool_calls, last_activity).
+        %Tau.Session.Events.SubagentProgress{} = e ->
+          on_subagent_progress(model, e)
+
+        # SubagentCost: update node cost fields.
+        %Tau.Session.Events.SubagentCost{} = e ->
+          on_subagent_cost(model, e)
+
+        # SubagentEnd: transition node to terminal state + append end marker line.
+        %Tau.Session.Events.SubagentEnd{} = e ->
+          on_subagent_end(model, e)
 
         _ ->
           model
@@ -1007,6 +1031,62 @@ if Code.ensure_loaded?(Ratatouille.Runtime) do
       %{model | editor: Editor.new(), search: nil}
     end
 
+    # D-150 (SPEC-TUI-HEADLESS §5c): fold SubagentStart into the tree and
+    # append a boxed start marker to the transcript (AC-1).
+    # If the fold rejects the event (unknown kind, D-152), skip the marker too.
+    defp on_subagent_start(model, e) do
+      new_tree = SubagentTree.fold(model.subagents, e)
+
+      if Map.has_key?(new_tree, e.subagent_id) do
+        node = new_tree[e.subagent_id]
+        marker = SubagentTree.format_start_marker(node)
+
+        %{
+          model
+          | subagents: new_tree,
+            transcript: bounded_append(model.transcript, {marker, []})
+        }
+      else
+        # Unknown kind — tree unchanged, no marker (D-152).
+        model
+      end
+    end
+
+    # D-151 (SPEC-TUI-HEADLESS §5c): fold SubagentProgress — updates the node's
+    # tool_calls count and last_activity. No transcript line; the end marker
+    # carries the final rollup (AC-3).
+    defp on_subagent_progress(model, e) do
+      %{model | subagents: SubagentTree.fold(model.subagents, e)}
+    end
+
+    # D-153 (SPEC-TUI-HEADLESS §5c): fold SubagentCost — updates cost fields
+    # in the node. Does NOT affect the parent's own cost display (R4/AC-4).
+    defp on_subagent_cost(model, e) do
+      %{model | subagents: SubagentTree.fold(model.subagents, e)}
+    end
+
+    # D-154 (SPEC-TUI-HEADLESS §5c): fold SubagentEnd — transitions node to
+    # terminal state and appends the boxed end marker to the transcript (AC-2).
+    # If the fold ignores the event (unknown subagent_id, D-152), skip marker.
+    defp on_subagent_end(model, e) do
+      new_tree = SubagentTree.fold(model.subagents, e)
+
+      case Map.get(new_tree, e.subagent_id) do
+        nil ->
+          # Unknown subagent_id — no node, no marker (D-152).
+          model
+
+        node ->
+          marker = SubagentTree.format_end_marker(node)
+
+          %{
+            model
+            | subagents: new_tree,
+              transcript: bounded_append(model.transcript, {marker, []})
+          }
+      end
+    end
+
     defp on_message_start(model, _e), do: %{model | status: :streaming, last_assistant: ""}
 
     defp on_message_update(model, %{message: msg}) do
@@ -1037,6 +1117,18 @@ if Code.ensure_loaded?(Ratatouille.Runtime) do
             %{type: :thinking, text: t} when is_binary(t) and t != "" ->
               [{"[thinking] " <> t, []}]
 
+            # B1 rule (D-151): if this tool call's id is owned by a known
+            # sub-agent, do NOT render it as a bare [tool_call] line —
+            # the sub-agent start/end markers own the visual representation.
+            # For Agent tool calls without an owned id, fall back to the
+            # legacy inline render (backwards compat).
+            %{type: :tool_call, id: tcid, name: n} when is_binary(tcid) ->
+              if SubagentTree.tool_call_owned?(model.subagents, tcid) do
+                []
+              else
+                [{"[tool_call] " <> n <> "(...)", []}]
+              end
+
             %{type: :tool_call, name: n} ->
               [{"[tool_call] " <> n <> "(...)", []}]
 
@@ -1053,19 +1145,30 @@ if Code.ensure_loaded?(Ratatouille.Runtime) do
       }
     end
 
-    defp on_tool_start(model, %{name: n, arguments: args}) do
-      %{model | tool_output: model.tool_output ++ ["▶ " <> n <> " " <> inspect(args)]}
+    defp on_tool_start(model, %{tool_call_id: tcid, name: n, arguments: args}) do
+      # B1 rule (D-151): skip tool calls owned by a known sub-agent — the
+      # sub-agent marker owns the render. Still record non-owned calls.
+      if SubagentTree.tool_call_owned?(model.subagents, tcid) do
+        model
+      else
+        %{model | tool_output: model.tool_output ++ ["▶ " <> n <> " " <> inspect(args)]}
+      end
     end
 
-    defp on_tool_end(model, %{result: %{content: c, is_error: e}}) do
-      prefix = if e, do: "✗", else: "✓"
+    defp on_tool_end(model, %{tool_call_id: tcid, result: %{content: c, is_error: e}}) do
+      # B1 rule (D-151): skip tool results owned by a known sub-agent.
+      if SubagentTree.tool_call_owned?(model.subagents, tcid) do
+        model
+      else
+        prefix = if e, do: "✗", else: "✓"
 
-      summary =
-        if is_binary(c),
-          do: String.slice(c, 0..160),
-          else: c |> inspect() |> String.slice(0..160)
+        summary =
+          if is_binary(c),
+            do: String.slice(c, 0..160),
+            else: c |> inspect() |> String.slice(0..160)
 
-      %{model | tool_output: model.tool_output ++ [prefix <> " " <> summary]}
+        %{model | tool_output: model.tool_output ++ [prefix <> " " <> summary]}
+      end
     end
 
     defp on_cancelled(model, %{reason: reason}) do

--- a/lib/tau/tui/subagent_tree.ex
+++ b/lib/tau/tui/subagent_tree.ex
@@ -190,7 +190,7 @@ defmodule Tau.TUI.SubagentTree do
   """
   @spec format_live_line(SubagentNode.t()) :: String.t()
   def format_live_line(%SubagentNode{label: label, tool_calls: n, last_activity: act}) do
-    base = "▶ sub-agent: #{label} · #{n} tool calls"
+    base = "▶ sub-agent: #{label} · #{n} #{if n == 1, do: "tool call", else: "tool calls"}"
 
     case act do
       nil ->
@@ -232,7 +232,10 @@ defmodule Tau.TUI.SubagentTree do
         _ -> "ended"
       end
 
-    parts = [state_str, "#{node.tool_calls} tool calls"]
+    tool_call_str =
+      "#{node.tool_calls} #{if node.tool_calls == 1, do: "tool call", else: "tool calls"}"
+
+    parts = [state_str, tool_call_str]
 
     parts =
       if node.duration_ms do

--- a/lib/tau/tui/subagent_tree.ex
+++ b/lib/tau/tui/subagent_tree.ex
@@ -1,0 +1,252 @@
+defmodule Tau.TUI.SubagentTree do
+  @moduledoc """
+  Pure fold module for the sub-agent tree maintained in the TUI MVU model.
+
+  No process, no GenServer — this is stateless derived render state folded
+  synchronously in `Tau.TUI.App.update/2` (OTP non-negotiables #1/#3).
+
+  The tree is keyed by `subagent_id`. `Tau.TUI.SubagentTree.fold/2` accepts
+  any `%Tau.Session.Events.Subagent*{}` event and returns an updated tree map
+  `%{subagent_id => SubagentNode.t()}`.
+
+  ## Invariants (SPEC-TUI-HEADLESS §5c, D-150..D-154)
+
+  - **D-150**: events arrive on the parent topic; this module has no topic
+    awareness — callers route the right events here.
+  - **D-152**: an unknown `subagent_id` or unknown `kind` is silently ignored
+    (returns the tree unchanged). A crash on unknown input would violate OTP
+    non-negotiable #8 (pure functions are safe by default).
+  - **D-153**: cost stored in the node MUST NOT be folded into the parent's
+    own cost. Caller's responsibility.
+  - **D-154**: state transitions are monotone — once `:done`, `:failed`, or
+    `:cancelled`, no further event can revert to `:running`.
+  """
+
+  alias Tau.Session.Events
+
+  defmodule SubagentNode do
+    @moduledoc """
+    Per-sub-agent accumulated state for TUI rendering.
+
+    `kind` is `:builtin_agent` or `:coding_agent` (closed set, D-152).
+    `state` transitions monotonically: `:running` → `:done` | `:failed` | `:cancelled`.
+    `owned_tool_call_ids` is the set of child tool-call ids whose render is
+    owned by this node (used for de-dup by the transcript render, B1 rule).
+    """
+    defstruct [
+      :subagent_id,
+      :kind,
+      :label,
+      :parent_tool_call_id,
+      :child_session_id,
+      state: :running,
+      tool_calls: 0,
+      last_activity: nil,
+      tokens: nil,
+      usd: nil,
+      duration_ms: nil,
+      summary: nil,
+      owned_tool_call_ids: MapSet.new()
+    ]
+
+    @type state :: :running | :done | :failed | :cancelled
+    @type kind :: :builtin_agent | :coding_agent
+
+    @type t :: %__MODULE__{
+            subagent_id: String.t(),
+            kind: kind(),
+            label: String.t(),
+            parent_tool_call_id: String.t() | nil,
+            child_session_id: String.t() | nil,
+            state: state(),
+            tool_calls: non_neg_integer(),
+            last_activity: term(),
+            tokens: map() | nil,
+            usd: float() | nil,
+            duration_ms: non_neg_integer() | nil,
+            summary: String.t() | nil,
+            owned_tool_call_ids: MapSet.t()
+          }
+  end
+
+  @type tree :: %{String.t() => SubagentNode.t()}
+
+  @valid_kinds [:builtin_agent, :coding_agent]
+  @terminal_states [:done, :failed, :cancelled]
+
+  @doc """
+  Fold a `%Tau.Session.Events.Subagent*{}` event into the tree.
+
+  Unknown `subagent_id` (for Progress/Cost/End) and unknown `kind` (for Start)
+  are silently ignored — returns the tree unchanged. This is D-152.
+
+  State transitions are monotone: a node already in a terminal state ignores
+  further non-Start events.
+  """
+  @spec fold(tree(), term()) :: tree()
+  def fold(tree, %Events.SubagentStart{subagent_id: id, kind: kind} = ev)
+      when kind in @valid_kinds do
+    node = %SubagentNode{
+      subagent_id: id,
+      kind: kind,
+      label: ev.label,
+      parent_tool_call_id: ev.parent_tool_call_id,
+      child_session_id: ev.child_session_id,
+      state: :running
+    }
+
+    Map.put(tree, id, node)
+  end
+
+  # Unknown kind — ignored (D-152).
+  def fold(tree, %Events.SubagentStart{}), do: tree
+
+  def fold(tree, %Events.SubagentProgress{subagent_id: id} = ev) do
+    case Map.get(tree, id) do
+      nil ->
+        # Unknown subagent_id — ignore (D-152).
+        tree
+
+      %SubagentNode{state: s} when s in @terminal_states ->
+        # Terminal — monotone, no revert.
+        tree
+
+      node ->
+        updated =
+          node
+          |> maybe_increment_tool_calls(ev.activity)
+          |> maybe_track_tool_call_id(ev.child_tool_call_id)
+          |> Map.put(:last_activity, ev.activity)
+
+        Map.put(tree, id, updated)
+    end
+  end
+
+  def fold(tree, %Events.SubagentCost{subagent_id: id} = ev) do
+    case Map.get(tree, id) do
+      nil ->
+        tree
+
+      node ->
+        updated = %{node | tokens: ev.tokens, usd: ev.usd, duration_ms: ev.duration_ms}
+        Map.put(tree, id, updated)
+    end
+  end
+
+  def fold(tree, %Events.SubagentEnd{subagent_id: id, state: state} = ev)
+      when state in @terminal_states do
+    case Map.get(tree, id) do
+      nil ->
+        tree
+
+      node ->
+        updated = %{node | state: state, summary: ev.summary}
+        Map.put(tree, id, updated)
+    end
+  end
+
+  # Unknown terminal state or non-matching SubagentEnd — ignore.
+  def fold(tree, %Events.SubagentEnd{}), do: tree
+
+  # Non-subagent events — pass through unchanged.
+  def fold(tree, _other), do: tree
+
+  @doc """
+  Returns true if the given `tool_call_id` is owned by any sub-agent node
+  in the tree. Used by the render layer to de-dup: a parent-topic
+  `%ToolStart{}` / `%ToolEnd{}` whose tool_call_id is owned MUST NOT be
+  rendered as an inline tool call — the sub-agent marker owns it (B1 rule,
+  D-151).
+  """
+  @spec tool_call_owned?(tree(), String.t() | nil) :: boolean()
+  def tool_call_owned?(_tree, nil), do: false
+
+  def tool_call_owned?(tree, tool_call_id) do
+    Enum.any?(tree, fn {_id, node} ->
+      MapSet.member?(node.owned_tool_call_ids, tool_call_id)
+    end)
+  end
+
+  @doc """
+  Returns the sub-agent node that owns the given `tool_call_id`, or `nil`.
+  """
+  @spec node_for_tool_call(tree(), String.t() | nil) :: SubagentNode.t() | nil
+  def node_for_tool_call(_tree, nil), do: nil
+
+  def node_for_tool_call(tree, tool_call_id) do
+    Enum.find_value(tree, fn {_id, node} ->
+      if MapSet.member?(node.owned_tool_call_ids, tool_call_id), do: node
+    end)
+  end
+
+  @doc """
+  Format the start marker line for a sub-agent.
+  Returns `"┌─ sub-agent: <label> [running]"`.
+  """
+  @spec format_start_marker(SubagentNode.t()) :: String.t()
+  def format_start_marker(%SubagentNode{label: label}) do
+    "┌─ sub-agent: #{label} [running]"
+  end
+
+  @doc """
+  Format the end marker line for a sub-agent.
+  Returns `"└─ sub-agent: <label> [<state> · <N> tool calls · <duration> · $<cost>]"`.
+  """
+  @spec format_end_marker(SubagentNode.t()) :: String.t()
+  def format_end_marker(%SubagentNode{} = node) do
+    state_str =
+      case node.state do
+        :done -> "done"
+        :failed -> "failed"
+        :cancelled -> "cancelled"
+        _ -> "ended"
+      end
+
+    parts = [state_str, "#{node.tool_calls} tool calls"]
+
+    parts =
+      if node.duration_ms do
+        parts ++ [format_duration(node.duration_ms)]
+      else
+        parts
+      end
+
+    parts =
+      if node.usd do
+        parts ++ ["$#{:erlang.float_to_binary(node.usd, decimals: 4)}"]
+      else
+        parts
+      end
+
+    summary = Enum.join(parts, " · ")
+    "└─ sub-agent: #{node.label} [#{summary}]"
+  end
+
+  # --- Private helpers ---
+
+  defp maybe_increment_tool_calls(node, {:tool_call, _name}) do
+    %{node | tool_calls: node.tool_calls + 1}
+  end
+
+  defp maybe_increment_tool_calls(node, _activity), do: node
+
+  defp maybe_track_tool_call_id(node, nil), do: node
+
+  defp maybe_track_tool_call_id(node, tool_call_id) do
+    %{node | owned_tool_call_ids: MapSet.put(node.owned_tool_call_ids, tool_call_id)}
+  end
+
+  defp format_duration(ms) when is_integer(ms) do
+    secs = div(ms, 1000)
+    mins = div(secs, 60)
+    rem_secs = rem(secs, 60)
+
+    if mins > 0 do
+      "#{mins}m#{String.pad_leading(Integer.to_string(rem_secs), 2, "0")}s"
+    else
+      "#{secs}s"
+    end
+  end
+
+  defp format_duration(_), do: "?"
+end

--- a/lib/tau/tui/subagent_tree.ex
+++ b/lib/tau/tui/subagent_tree.ex
@@ -180,8 +180,38 @@ defmodule Tau.TUI.SubagentTree do
   end
 
   @doc """
+  Format the live-region line for a running sub-agent (rendered every frame).
+
+  Returns `"▶ sub-agent: <label> · <N> tool calls · <activity_excerpt>"`.
+  The line is re-derived each render tick so the count and excerpt update
+  as `SubagentProgress` events are folded in — this is the AC-3 live
+  criterion. Only `:running` nodes should be passed; callers filter on
+  `node.state == :running` before calling this function.
+  """
+  @spec format_live_line(SubagentNode.t()) :: String.t()
+  def format_live_line(%SubagentNode{label: label, tool_calls: n, last_activity: act}) do
+    base = "▶ sub-agent: #{label} · #{n} tool calls"
+
+    case act do
+      nil ->
+        base
+
+      {:tool_call, name} ->
+        base <> " · calling #{name}"
+
+      {:tool_result, summary} when is_binary(summary) and summary != "" ->
+        base <> " · #{summary}"
+
+      _ ->
+        base
+    end
+  end
+
+  @doc """
   Format the start marker line for a sub-agent.
   Returns `"┌─ sub-agent: <label> [running]"`.
+  Retained for use in tests and legacy callers; the live region supersedes
+  this as the in-flight display (D-158 / AC-3).
   """
   @spec format_start_marker(SubagentNode.t()) :: String.t()
   def format_start_marker(%SubagentNode{label: label}) do

--- a/test/tau/tools/builtin/agent_subagent_end_test.exs
+++ b/test/tau/tools/builtin/agent_subagent_end_test.exs
@@ -1,0 +1,395 @@
+defmodule Tau.Tools.Builtin.AgentSubagentEndTest do
+  @moduledoc """
+  D-154 (SPEC-TUI-HEADLESS §5c): unit tests for all five terminal branches of
+  `Tau.Tools.Builtin.Agent.await_child/4`.
+
+  Each test triggers exactly one terminal branch and asserts that
+  `%SE.SubagentEnd{}` arrives on the parent topic with the correct `state`.
+
+  Branches under test:
+    1. natural_end  — MessageEnd with natural stop_reason → state: :done
+    2. failure_end  — MessageEnd with failure stop_reason → state: :failed
+    3. SessionEnd   — child FSM terminates abnormally   → state: :failed
+    4. {:DOWN, …}   — parent FSM process killed         → state: :cancelled
+    5. after-timeout — await_timeout_ms fires           → state: :cancelled
+
+  Branch 3 (`%SE.SessionEnd{}`) is the regression introduced when the
+  catch-all `%{session_id: ^child_id}` was placed BEFORE `%SE.SessionEnd{}` in
+  the receive block, causing SessionEnd to be consumed by the catch-all and
+  the tool-task to hang until timeout (returning `:cancelled` instead of the
+  correct `:failed`). This test MUST fail against the pre-fix clause order.
+
+  Uses `async: false` because it touches global application env and PubSub.
+  """
+  use ExUnit.Case, async: false
+
+  import Tau.Test.SessionHelper, only: [start_session_for_test: 1]
+
+  alias Tau.Provider.Event
+  alias Tau.Session.Events, as: SE
+
+  # ---------------------------------------------------------------------------
+  # Providers
+  # ---------------------------------------------------------------------------
+
+  # Parent drives a single Agent tool call; child fixture selected by function.
+  defmodule MultiRouteProvider do
+    @moduledoc false
+    @behaviour Tau.Provider
+
+    @impl true
+    def default_model, do: "multi-route"
+
+    @impl true
+    def capabilities,
+      do: %{
+        thinking: false,
+        tools: true,
+        vision: false,
+        prompt_caching: false,
+        parallel_tools: true
+      }
+
+    @impl true
+    def stream(messages, _opts, ctx) do
+      parent_sid = ctx[:parent_session_id]
+      this_sid = ctx[:session_id]
+      has_tool_result? = Enum.any?(messages, &match?(%Tau.Message.ToolResult{}, &1))
+
+      events =
+        cond do
+          this_sid == parent_sid and has_tool_result? ->
+            ctx[:parent_second_fixture] || default_parent_done()
+
+          this_sid == parent_sid ->
+            ctx[:parent_first_fixture]
+
+          true ->
+            # Child: delegate to the :child_stream_fn stored in ctx, or hang.
+            stream_fn = ctx[:child_stream_fn] || (&hanging_stream/0)
+            stream_fn.()
+        end
+
+      {:ok, events}
+    end
+
+    defp default_parent_done do
+      [
+        %Event.Start{request_id: "mrp-done", model: "multi-route"},
+        %Event.TextStart{block_id: "b0"},
+        %Event.TextDelta{block_id: "b0", text: "parent done"},
+        %Event.TextEnd{block_id: "b0"},
+        %Event.Done{stop_reason: :end_turn, usage: %{}}
+      ]
+    end
+
+    defp hanging_stream do
+      Stream.resource(
+        fn -> :ok end,
+        fn :ok ->
+          Process.sleep(:infinity)
+          {:halt, :ok}
+        end,
+        fn _ -> :ok end
+      )
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Helpers
+  # ---------------------------------------------------------------------------
+
+  defp agent_tool_call_fixture(call_id, description) do
+    [
+      %Event.Start{request_id: "se-parent-r1", model: "multi-route"},
+      %Event.ToolCallStart{tool_call_id: call_id, name: "Agent"},
+      %Event.ToolCallEnd{tool_call_id: call_id, params: %{"description" => description}},
+      %Event.Done{stop_reason: :tool_use, usage: %{}}
+    ]
+  end
+
+  defp parent_done_fixture do
+    [
+      %Event.Start{request_id: "se-parent-r2", model: "multi-route"},
+      %Event.TextStart{block_id: "b0"},
+      %Event.TextDelta{block_id: "b0", text: "done"},
+      %Event.TextEnd{block_id: "b0"},
+      %Event.Done{stop_reason: :end_turn, usage: %{}}
+    ]
+  end
+
+  defp child_natural_end_fixture do
+    fn ->
+      [
+        %Event.Start{request_id: "se-child-nat", model: "multi-route"},
+        %Event.TextStart{block_id: "b0"},
+        %Event.TextDelta{block_id: "b0", text: "child result"},
+        %Event.TextEnd{block_id: "b0"},
+        %Event.Done{stop_reason: :end_turn, usage: %{}}
+      ]
+    end
+  end
+
+  defp child_failure_end_fixture do
+    fn ->
+      [
+        %Event.Start{request_id: "se-child-err", model: "multi-route"},
+        %Event.Error{reason: :test_failure, retryable?: false}
+      ]
+    end
+  end
+
+  defp hanging_child_fixture do
+    fn ->
+      Stream.resource(
+        fn -> :ok end,
+        fn :ok ->
+          Process.sleep(:infinity)
+          {:halt, :ok}
+        end,
+        fn _ -> :ok end
+      )
+    end
+  end
+
+  defp await_child_registered(parent_sid, timeout \\ 10_000) do
+    test_pid = self()
+    handler_id = "subagent-end-child-reg-#{System.unique_integer()}"
+
+    :telemetry.attach(
+      handler_id,
+      [:tau, :session, :child_registered],
+      fn _event, _m, meta, _ ->
+        if meta.session_id == parent_sid do
+          send(test_pid, {:child_registered, meta.child_id})
+        end
+      end,
+      nil
+    )
+
+    receive do
+      {:child_registered, child_id} ->
+        :telemetry.detach(handler_id)
+        child_id
+    after
+      timeout ->
+        :telemetry.detach(handler_id)
+        flunk("timeout waiting for child_registered telemetry")
+    end
+  end
+
+  setup do
+    tmp =
+      Path.join(
+        System.tmp_dir!(),
+        "tau-subagent-end-#{System.unique_integer([:positive])}"
+      )
+
+    File.mkdir_p!(tmp)
+    Application.put_env(:tau, :data_dir, tmp)
+
+    on_exit(fn ->
+      Application.delete_env(:tau, :subagent_await_timeout_ms)
+      File.rm_rf!(tmp)
+      Application.delete_env(:tau, :data_dir)
+    end)
+
+    %{tmp: tmp}
+  end
+
+  # ---------------------------------------------------------------------------
+  # Branch 1: natural_end — MessageEnd with natural stop_reason → state: :done
+  # ---------------------------------------------------------------------------
+  @tag :integration
+  test "branch 1 natural_end: SubagentEnd{state: :done} when child ends with :end_turn",
+       %{tmp: tmp} do
+    parent_sid = Tau.Session.generate_id()
+    Phoenix.PubSub.subscribe(Tau.PubSub, "session:#{parent_sid}")
+    call_id = "se-b1-call"
+
+    provider_ctx = %{
+      parent_session_id: parent_sid,
+      parent_first_fixture: agent_tool_call_fixture(call_id, "branch1"),
+      parent_second_fixture: parent_done_fixture(),
+      child_stream_fn: child_natural_end_fixture()
+    }
+
+    {:ok, ^parent_sid} =
+      start_session_for_test(
+        provider: MultiRouteProvider,
+        session_id: parent_sid,
+        cwd: tmp,
+        metadata: %{permissions_mode: :bypass},
+        provider_ctx: provider_ctx
+      )
+
+    Tau.send(parent_sid, "branch 1 test")
+
+    assert_receive %SE.SubagentEnd{state: :done}, 10_000
+  end
+
+  # ---------------------------------------------------------------------------
+  # Branch 2: failure_end — MessageEnd with failure stop_reason → state: :failed
+  # ---------------------------------------------------------------------------
+  @tag :integration
+  test "branch 2 failure_end: SubagentEnd{state: :failed} when child MessageEnd has :error stop_reason",
+       %{tmp: tmp} do
+    parent_sid = Tau.Session.generate_id()
+    Phoenix.PubSub.subscribe(Tau.PubSub, "session:#{parent_sid}")
+    call_id = "se-b2-call"
+
+    provider_ctx = %{
+      parent_session_id: parent_sid,
+      parent_first_fixture: agent_tool_call_fixture(call_id, "branch2"),
+      parent_second_fixture: parent_done_fixture(),
+      child_stream_fn: child_failure_end_fixture()
+    }
+
+    {:ok, ^parent_sid} =
+      start_session_for_test(
+        provider: MultiRouteProvider,
+        session_id: parent_sid,
+        cwd: tmp,
+        metadata: %{permissions_mode: :bypass},
+        provider_ctx: provider_ctx
+      )
+
+    Tau.send(parent_sid, "branch 2 test")
+
+    assert_receive %SE.SubagentEnd{state: :failed}, 10_000
+  end
+
+  # ---------------------------------------------------------------------------
+  # Branch 3: SessionEnd — child FSM terminated → state: :failed
+  #
+  # This is the regression case for FIX-1. When the catch-all
+  # `%{session_id: ^child_id}` was placed BEFORE `%SE.SessionEnd{}` in the
+  # receive block, the SessionEnd struct (which IS a map with session_id key)
+  # matched the catch-all and was silently discarded. The tool task then hung
+  # until the timeout, returning SubagentEnd{state: :cancelled} instead of
+  # SubagentEnd{state: :failed}. This test MUST fail against the pre-fix order.
+  # ---------------------------------------------------------------------------
+  @tag :integration
+  test "branch 3 SessionEnd: SubagentEnd{state: :failed} when child FSM terminates (D-154 regression)",
+       %{tmp: tmp} do
+    # Use a very short timeout so the test fails fast if branch 3 is shadowed
+    # by the catch-all (it would fall through to the :cancelled timeout branch).
+    Application.put_env(:tau, :subagent_await_timeout_ms, 2_000)
+
+    parent_sid = Tau.Session.generate_id()
+    Phoenix.PubSub.subscribe(Tau.PubSub, "session:#{parent_sid}")
+    call_id = "se-b3-call"
+
+    provider_ctx = %{
+      parent_session_id: parent_sid,
+      parent_first_fixture: agent_tool_call_fixture(call_id, "branch3"),
+      parent_second_fixture: parent_done_fixture(),
+      child_stream_fn: hanging_child_fixture()
+    }
+
+    {:ok, ^parent_sid} =
+      start_session_for_test(
+        provider: MultiRouteProvider,
+        session_id: parent_sid,
+        cwd: tmp,
+        metadata: %{permissions_mode: :bypass},
+        provider_ctx: provider_ctx
+      )
+
+    Tau.send(parent_sid, "branch 3 test")
+
+    # Wait for the child to be registered so we have its id.
+    child_id = await_child_registered(parent_sid)
+
+    # Terminate the child FSM abnormally. This causes the child's
+    # `terminate/3` to run and broadcast `%SE.SessionEnd{session_id: child_id}`.
+    # In the pre-FIX-1 code, the catch-all `%{session_id: ^child_id}` would
+    # swallow this struct (because all Elixir structs are maps), causing the
+    # tool task to hang. Post-fix, `%SE.SessionEnd{}` matches first.
+    Tau.stop(child_id)
+
+    # Must receive :failed (not :cancelled) and within 1s (not the 2s timeout).
+    assert_receive %SE.SubagentEnd{state: :failed}, 1_500
+  end
+
+  # ---------------------------------------------------------------------------
+  # Branch 4: {:DOWN, parent_ref} — parent FSM process killed → state: :cancelled
+  # ---------------------------------------------------------------------------
+  @tag :integration
+  test "branch 4 parent_down: SubagentEnd{state: :cancelled} when parent process is killed",
+       %{tmp: tmp} do
+    parent_sid = Tau.Session.generate_id()
+    Phoenix.PubSub.subscribe(Tau.PubSub, "session:#{parent_sid}")
+    call_id = "se-b4-call"
+
+    provider_ctx = %{
+      parent_session_id: parent_sid,
+      parent_first_fixture: agent_tool_call_fixture(call_id, "branch4"),
+      parent_second_fixture: parent_done_fixture(),
+      child_stream_fn: hanging_child_fixture()
+    }
+
+    {:ok, ^parent_sid} =
+      start_session_for_test(
+        provider: MultiRouteProvider,
+        session_id: parent_sid,
+        cwd: tmp,
+        metadata: %{permissions_mode: :bypass},
+        provider_ctx: provider_ctx
+      )
+
+    Tau.send(parent_sid, "branch 4 test")
+
+    # Wait for the child to be registered and the tool task to start awaiting.
+    _child_id = await_child_registered(parent_sid)
+
+    # Get the parent FSM pid and kill it. The tool task monitors the parent pid
+    # via `Process.monitor/1`; when it dies the {:DOWN, ^parent_ref, ...} fires.
+    [{parent_pid, _}] = Registry.lookup(Tau.Sessions.Registry, parent_sid)
+    Process.exit(parent_pid, :kill)
+
+    # The tool task broadcasts SubagentEnd{state: :cancelled} on the parent topic
+    # before returning. Since we subscribed to "session:#{parent_sid}", we should
+    # receive it even though the parent FSM is dead (PubSub delivers to us, not
+    # to the FSM).
+    assert_receive %SE.SubagentEnd{state: :cancelled}, 5_000
+  end
+
+  # ---------------------------------------------------------------------------
+  # Branch 5: after-timeout — await_timeout_ms fires → state: :cancelled
+  # ---------------------------------------------------------------------------
+  @tag :integration
+  test "branch 5 timeout: SubagentEnd{state: :cancelled} when await_timeout_ms fires",
+       %{tmp: tmp} do
+    # Inject a short timeout so the test doesn't block for 10 minutes.
+    Application.put_env(:tau, :subagent_await_timeout_ms, 300)
+
+    parent_sid = Tau.Session.generate_id()
+    Phoenix.PubSub.subscribe(Tau.PubSub, "session:#{parent_sid}")
+    call_id = "se-b5-call"
+
+    provider_ctx = %{
+      parent_session_id: parent_sid,
+      parent_first_fixture: agent_tool_call_fixture(call_id, "branch5"),
+      parent_second_fixture: parent_done_fixture(),
+      child_stream_fn: hanging_child_fixture()
+    }
+
+    {:ok, ^parent_sid} =
+      start_session_for_test(
+        provider: MultiRouteProvider,
+        session_id: parent_sid,
+        cwd: tmp,
+        metadata: %{permissions_mode: :bypass},
+        provider_ctx: provider_ctx
+      )
+
+    Tau.send(parent_sid, "branch 5 test")
+
+    # SubagentEnd{state: :cancelled} must arrive after ~300ms timeout fires.
+    assert_receive %SE.SubagentEnd{state: :cancelled, summary: summary}, 5_000
+
+    assert summary =~ "timed out",
+           "summary should mention timeout, got: #{inspect(summary)}"
+  end
+end

--- a/test/tau/tui/app_test.exs
+++ b/test/tau/tui/app_test.exs
@@ -1284,7 +1284,7 @@ if Code.ensure_loaded?(Ratatouille.Runtime) do
         node_after = next.subagents["child-2"]
         live_after = SubagentTree.format_live_line(node_after)
 
-        assert String.contains?(live_after, "1 tool calls"),
+        assert String.contains?(live_after, "1 tool call"),
                "live region MUST show 1 tool call after SubagentProgress; got: #{inspect(live_after)}"
 
         assert String.contains?(live_after, "Bash"),

--- a/test/tau/tui/app_test.exs
+++ b/test/tau/tui/app_test.exs
@@ -17,6 +17,7 @@ if Code.ensure_loaded?(Ratatouille.Runtime) do
     alias Tau.TUI.App
     alias Tau.TUI.Editor
     alias Tau.TUI.History
+    alias Tau.TUI.SubagentTree
 
     defp model do
       %{
@@ -27,7 +28,6 @@ if Code.ensure_loaded?(Ratatouille.Runtime) do
         history_data_dir: System.tmp_dir!(),
         history_cwd: File.cwd!(),
         transcript: [],
-        tool_output: [],
         # D-150 (SPEC-TUI-HEADLESS §5c): sub-agent tree in model.
         subagents: %{},
         status: :streaming,
@@ -1127,7 +1127,11 @@ if Code.ensure_loaded?(Ratatouille.Runtime) do
     # D-150..D-154 (SPEC-TUI-HEADLESS §5c): sub-agent event folding in update/2
     # -------------------------------------------------------------------------
     describe "update/2 — sub-agent events (D-150..D-154, AC-1, AC-2, AC-7)" do
-      test "SubagentStart adds node to subagents tree and start marker to transcript (AC-1)" do
+      test "SubagentStart adds node to subagents tree with :running state (AC-1 / D-158)" do
+        # AC-1 / D-158: SubagentStart MUST add the node to the tree.
+        # The in-flight display is the live region derived from model.subagents
+        # each frame (not a static frozen transcript entry — that was the bug).
+        # Permanent markers are end markers only (AC-2).
         m = %{model() | status: :idle, last_assistant: nil}
 
         next =
@@ -1142,11 +1146,39 @@ if Code.ensure_loaded?(Ratatouille.Runtime) do
 
         assert Map.has_key?(next.subagents, "child-1")
         assert next.subagents["child-1"].state == :running
+        assert next.subagents["child-1"].label == "general-purpose"
 
-        assert Enum.any?(next.transcript, fn {line, _} ->
-                 String.contains?(line, "┌─ sub-agent: general-purpose [running]")
-               end),
-               "Start marker must appear in transcript (AC-1)"
+        # No static frozen start marker in the transcript — the live region
+        # handles in-flight display; transcript is unchanged.
+        assert next.transcript == m.transcript,
+               "SubagentStart must NOT append a frozen start marker to transcript (live region handles it)"
+      end
+
+      test "SubagentStart live region shows running sub-agent (AC-1 / AC-3)" do
+        # The live region is derived from model.subagents every frame.
+        # After SubagentStart, render/1 must include a live-region line for the node.
+        m = %{model() | status: :idle, last_assistant: nil}
+
+        next =
+          App.update(m, %Events.SubagentStart{
+            session_id: "sess-test",
+            subagent_id: "child-live",
+            kind: :builtin_agent,
+            label: "live-agent",
+            parent_tool_call_id: nil,
+            child_session_id: "child-live"
+          })
+
+        # Live region line is derived from SubagentNode state, not transcript.
+        node = next.subagents["child-live"]
+        assert node.state == :running
+        live_line = SubagentTree.format_live_line(node)
+
+        assert String.contains?(live_line, "▶ sub-agent: live-agent"),
+               "live region line MUST contain the sub-agent label; got: #{inspect(live_line)}"
+
+        assert String.contains?(live_line, "0 tool calls"),
+               "live region line MUST show 0 tool calls before any progress; got: #{inspect(live_line)}"
       end
 
       test "SubagentEnd transitions node to :done and appends end marker to transcript (AC-2)" do
@@ -1213,7 +1245,11 @@ if Code.ensure_loaded?(Ratatouille.Runtime) do
                end)
       end
 
-      test "SubagentProgress updates node tool_calls (AC-3)" do
+      test "SubagentProgress updates node tool_calls and live-region count rises (AC-3)" do
+        # AC-3 live criterion: the rendered tool-call count MUST rise as
+        # SubagentProgress events are folded in. The live region is derived
+        # from model.subagents state every frame — so the count update in
+        # SubagentNode.tool_calls directly drives the next-frame render.
         m = %{model() | status: :idle, last_assistant: nil}
 
         m =
@@ -1226,6 +1262,13 @@ if Code.ensure_loaded?(Ratatouille.Runtime) do
             child_session_id: nil
           })
 
+        # Before any progress: live region shows 0 tool calls
+        node_before = m.subagents["child-2"]
+        live_before = SubagentTree.format_live_line(node_before)
+
+        assert String.contains?(live_before, "0 tool calls"),
+               "live region MUST show 0 tool calls before any progress; got: #{inspect(live_before)}"
+
         next =
           App.update(m, %Events.SubagentProgress{
             session_id: "sess-test",
@@ -1236,6 +1279,16 @@ if Code.ensure_loaded?(Ratatouille.Runtime) do
 
         assert next.subagents["child-2"].tool_calls == 1
         assert next.subagents["child-2"].last_activity == {:tool_call, "Bash"}
+
+        # After progress: live region now shows 1 tool call and activity excerpt
+        node_after = next.subagents["child-2"]
+        live_after = SubagentTree.format_live_line(node_after)
+
+        assert String.contains?(live_after, "1 tool calls"),
+               "live region MUST show 1 tool call after SubagentProgress; got: #{inspect(live_after)}"
+
+        assert String.contains?(live_after, "Bash"),
+               "live region MUST show last-activity tool name; got: #{inspect(live_after)}"
       end
 
       test "SubagentCost updates node cost without affecting transcript (AC-4/D-153)" do
@@ -1270,7 +1323,12 @@ if Code.ensure_loaded?(Ratatouille.Runtime) do
                "SubagentCost must not append a transcript line"
       end
 
-      test "ToolStart owned by sub-agent does not append to tool_output (B1/D-151)" do
+      test "ToolStart owned by sub-agent does not produce a [tool_call] transcript line (B1/D-151)" do
+        # B1 rule (D-151): a ToolStart whose tool_call_id is owned by a
+        # sub-agent MUST NOT appear as a bare [tool_call] line in the transcript.
+        # The owned call's visual representation is the sub-agent live region
+        # and end marker. We verify via on_message_end which is where the
+        # [tool_call] suppression for owned calls is enforced.
         m = %{model() | status: :idle, last_assistant: nil}
 
         m =
@@ -1291,34 +1349,39 @@ if Code.ensure_loaded?(Ratatouille.Runtime) do
             child_tool_call_id: "tc-owned"
           })
 
-        tool_output_before = m.tool_output
+        # MessageEnd carrying the owned tool_call as a tool_call block:
+        # it must be suppressed in the transcript (B1 / on_message_end de-dup).
+        msg = %Tau.Message.Assistant{
+          content: [%{type: :tool_call, id: "tc-owned", name: "Bash"}],
+          timestamp: DateTime.utc_now(),
+          stop_reason: :stop
+        }
 
-        # ToolStart with an owned tool_call_id must be skipped (B1).
-        next =
-          App.update(m, %Events.ToolStart{
-            session_id: "sess-test",
-            tool_call_id: "tc-owned",
-            name: "Bash",
-            arguments: %{"command" => "ls"}
-          })
+        next = App.update(m, %Events.MessageEnd{session_id: "sess-test", message: msg})
 
-        assert next.tool_output == tool_output_before,
-               "ToolStart owned by sub-agent must not append to tool_output (B1/D-151)"
+        refute Enum.any?(next.transcript, fn {line, _} ->
+                 String.contains?(line, "[tool_call] Bash")
+               end),
+               "B1: tool_call block with owned id must NOT produce a [tool_call] transcript line"
       end
 
-      test "ToolStart NOT owned by sub-agent is rendered normally (B1)" do
+      test "ToolStart NOT owned by sub-agent produces a [tool_call] transcript line via MessageEnd (B1)" do
+        # Non-owned tool calls MUST produce a [tool_call] line in the transcript
+        # (the un-owned path in on_message_end).
         m = %{model() | status: :idle, last_assistant: nil}
 
-        next =
-          App.update(m, %Events.ToolStart{
-            session_id: "sess-test",
-            tool_call_id: "tc-unowned",
-            name: "Read",
-            arguments: %{"path" => "/tmp/foo"}
-          })
+        msg = %Tau.Message.Assistant{
+          content: [%{type: :tool_call, id: "tc-unowned", name: "Read"}],
+          timestamp: DateTime.utc_now(),
+          stop_reason: :stop
+        }
 
-        assert length(next.tool_output) == 1
-        assert hd(next.tool_output) =~ "Read"
+        next = App.update(m, %Events.MessageEnd{session_id: "sess-test", message: msg})
+
+        assert Enum.any?(next.transcript, fn {line, _} ->
+                 String.contains?(line, "[tool_call] Read")
+               end),
+               "B1: non-owned tool_call MUST produce a [tool_call] transcript line"
       end
 
       test "unknown SubagentProgress subagent_id does not crash (D-152)" do

--- a/test/tau/tui/app_test.exs
+++ b/test/tau/tui/app_test.exs
@@ -28,6 +28,8 @@ if Code.ensure_loaded?(Ratatouille.Runtime) do
         history_cwd: File.cwd!(),
         transcript: [],
         tool_output: [],
+        # D-150 (SPEC-TUI-HEADLESS §5c): sub-agent tree in model.
+        subagents: %{},
         status: :streaming,
         last_assistant: "partial",
         wrap_width: 80,
@@ -1118,6 +1120,238 @@ if Code.ensure_loaded?(Ratatouille.Runtime) do
         assert Ratatouille.EventManager in ids
         assert Ratatouille.Window in ids
         assert Ratatouille.Runtime in ids
+      end
+    end
+
+    # -------------------------------------------------------------------------
+    # D-150..D-154 (SPEC-TUI-HEADLESS §5c): sub-agent event folding in update/2
+    # -------------------------------------------------------------------------
+    describe "update/2 — sub-agent events (D-150..D-154, AC-1, AC-2, AC-7)" do
+      test "SubagentStart adds node to subagents tree and start marker to transcript (AC-1)" do
+        m = %{model() | status: :idle, last_assistant: nil}
+
+        next =
+          App.update(m, %Events.SubagentStart{
+            session_id: "sess-test",
+            subagent_id: "child-1",
+            kind: :builtin_agent,
+            label: "general-purpose",
+            parent_tool_call_id: "tc-parent",
+            child_session_id: "child-1"
+          })
+
+        assert Map.has_key?(next.subagents, "child-1")
+        assert next.subagents["child-1"].state == :running
+
+        assert Enum.any?(next.transcript, fn {line, _} ->
+                 String.contains?(line, "┌─ sub-agent: general-purpose [running]")
+               end),
+               "Start marker must appear in transcript (AC-1)"
+      end
+
+      test "SubagentEnd transitions node to :done and appends end marker to transcript (AC-2)" do
+        m = %{model() | status: :idle, last_assistant: nil}
+
+        m =
+          App.update(m, %Events.SubagentStart{
+            session_id: "sess-test",
+            subagent_id: "child-1",
+            kind: :builtin_agent,
+            label: "test-agent",
+            parent_tool_call_id: nil,
+            child_session_id: nil
+          })
+
+        next =
+          App.update(m, %Events.SubagentEnd{
+            session_id: "sess-test",
+            subagent_id: "child-1",
+            state: :done,
+            summary: "completed"
+          })
+
+        assert next.subagents["child-1"].state == :done
+
+        assert Enum.any?(next.transcript, fn {line, _} ->
+                 String.contains?(line, "└─ sub-agent: test-agent") and
+                   String.contains?(line, "done")
+               end),
+               "End marker must appear in transcript (AC-2)"
+      end
+
+      test "SubagentEnd :failed produces failed end marker — no node left :running (AC-7)" do
+        m = %{model() | status: :idle, last_assistant: nil}
+
+        m =
+          App.update(m, %Events.SubagentStart{
+            session_id: "sess-test",
+            subagent_id: "crash-agent",
+            kind: :builtin_agent,
+            label: "crash-agent",
+            parent_tool_call_id: nil,
+            child_session_id: nil
+          })
+
+        next =
+          App.update(m, %Events.SubagentEnd{
+            session_id: "sess-test",
+            subagent_id: "crash-agent",
+            state: :failed,
+            summary: "crashed"
+          })
+
+        # No node left in :running state after terminal event (AC-7).
+        running_count =
+          next.subagents
+          |> Map.values()
+          |> Enum.count(&(&1.state == :running))
+
+        assert running_count == 0, "No sub-agent node should remain :running after SubagentEnd"
+
+        assert Enum.any?(next.transcript, fn {line, _} ->
+                 String.contains?(line, "failed")
+               end)
+      end
+
+      test "SubagentProgress updates node tool_calls (AC-3)" do
+        m = %{model() | status: :idle, last_assistant: nil}
+
+        m =
+          App.update(m, %Events.SubagentStart{
+            session_id: "sess-test",
+            subagent_id: "child-2",
+            kind: :builtin_agent,
+            label: "worker",
+            parent_tool_call_id: nil,
+            child_session_id: nil
+          })
+
+        next =
+          App.update(m, %Events.SubagentProgress{
+            session_id: "sess-test",
+            subagent_id: "child-2",
+            activity: {:tool_call, "Bash"},
+            child_tool_call_id: "tc-child-x"
+          })
+
+        assert next.subagents["child-2"].tool_calls == 1
+        assert next.subagents["child-2"].last_activity == {:tool_call, "Bash"}
+      end
+
+      test "SubagentCost updates node cost without affecting transcript (AC-4/D-153)" do
+        m = %{model() | status: :idle, last_assistant: nil}
+
+        m =
+          App.update(m, %Events.SubagentStart{
+            session_id: "sess-test",
+            subagent_id: "child-3",
+            kind: :builtin_agent,
+            label: "worker",
+            parent_tool_call_id: nil,
+            child_session_id: nil
+          })
+
+        transcript_len_before = length(m.transcript)
+
+        next =
+          App.update(m, %Events.SubagentCost{
+            session_id: "sess-test",
+            subagent_id: "child-3",
+            tokens: %{input: 100},
+            usd: 0.005,
+            duration_ms: 5000
+          })
+
+        assert next.subagents["child-3"].usd == 0.005
+        assert next.subagents["child-3"].duration_ms == 5000
+
+        # Cost event must NOT add a transcript line (D-153: no double-count risk).
+        assert length(next.transcript) == transcript_len_before,
+               "SubagentCost must not append a transcript line"
+      end
+
+      test "ToolStart owned by sub-agent does not append to tool_output (B1/D-151)" do
+        m = %{model() | status: :idle, last_assistant: nil}
+
+        m =
+          App.update(m, %Events.SubagentStart{
+            session_id: "sess-test",
+            subagent_id: "child-4",
+            kind: :builtin_agent,
+            label: "worker",
+            parent_tool_call_id: nil,
+            child_session_id: nil
+          })
+
+        m =
+          App.update(m, %Events.SubagentProgress{
+            session_id: "sess-test",
+            subagent_id: "child-4",
+            activity: {:tool_call, "Bash"},
+            child_tool_call_id: "tc-owned"
+          })
+
+        tool_output_before = m.tool_output
+
+        # ToolStart with an owned tool_call_id must be skipped (B1).
+        next =
+          App.update(m, %Events.ToolStart{
+            session_id: "sess-test",
+            tool_call_id: "tc-owned",
+            name: "Bash",
+            arguments: %{"command" => "ls"}
+          })
+
+        assert next.tool_output == tool_output_before,
+               "ToolStart owned by sub-agent must not append to tool_output (B1/D-151)"
+      end
+
+      test "ToolStart NOT owned by sub-agent is rendered normally (B1)" do
+        m = %{model() | status: :idle, last_assistant: nil}
+
+        next =
+          App.update(m, %Events.ToolStart{
+            session_id: "sess-test",
+            tool_call_id: "tc-unowned",
+            name: "Read",
+            arguments: %{"path" => "/tmp/foo"}
+          })
+
+        assert length(next.tool_output) == 1
+        assert hd(next.tool_output) =~ "Read"
+      end
+
+      test "unknown SubagentProgress subagent_id does not crash (D-152)" do
+        m = %{model() | status: :idle, last_assistant: nil}
+
+        # Should not raise.
+        next =
+          App.update(m, %Events.SubagentProgress{
+            session_id: "sess-test",
+            subagent_id: "nonexistent",
+            activity: {:tool_call, "Bash"},
+            child_tool_call_id: "tc-x"
+          })
+
+        assert next.subagents == %{}, "no node should be created for unknown subagent_id"
+      end
+
+      test "SubagentStart with unknown kind does not crash and tree unchanged (D-152)" do
+        m = %{model() | status: :idle, last_assistant: nil}
+
+        next =
+          App.update(m, %Events.SubagentStart{
+            session_id: "sess-test",
+            subagent_id: "x",
+            kind: :some_future_kind,
+            label: "future",
+            parent_tool_call_id: nil,
+            child_session_id: nil
+          })
+
+        assert next.subagents == %{}
+        # No marker appended for unknown kind — transcript unchanged.
+        assert next.transcript == m.transcript
       end
     end
   end

--- a/test/tau/tui/subagent_telemetry_test.exs
+++ b/test/tau/tui/subagent_telemetry_test.exs
@@ -1,0 +1,91 @@
+defmodule Tau.TUI.SubagentTelemetryTest do
+  @moduledoc """
+  AC-8 (SPEC-TUI-HEADLESS §5c): asserts that `[:tau, :session, :subagent, :start]`
+  and `[:tau, :session, :subagent, :stop]` telemetry events fire per sub-agent.
+
+  This is an ExUnit telemetry assertion (not a tmux test). It drives the
+  `Tau.Tools.Builtin.Agent.execute/2` path and asserts the telemetry span pair.
+
+  Note: requires a running PubSub and session supervisor. Uses the standard
+  ExUnit test setup; replay provider keeps it headless.
+  """
+  use ExUnit.Case, async: false
+
+  @moduletag :integration
+
+  setup do
+    # The telemetry events are emitted in agent.ex execute/2.
+    # Attach a handler that collects events into the test process.
+    test_pid = self()
+    handler_id = "subagent-telemetry-test-#{System.unique_integer()}"
+
+    :telemetry.attach_many(
+      handler_id,
+      [
+        [:tau, :session, :subagent, :start],
+        [:tau, :session, :subagent, :stop],
+        [:tau, :session, :subagent, :exception]
+      ],
+      fn event, measurements, metadata, _config ->
+        send(test_pid, {:telemetry, event, measurements, metadata})
+      end,
+      nil
+    )
+
+    on_exit(fn -> :telemetry.detach(handler_id) end)
+
+    :ok
+  end
+
+  @tag :integration
+  test "[:tau, :session, :subagent, :start] and :stop fire for Agent tool execute" do
+    # This test drives the telemetry path without a real session by calling
+    # the telemetry execute directly, mirroring what agent.ex does.
+    # A full integration test would start a real session; that's guarded behind
+    # the :integration tag and requires the full application.
+
+    parent_session_id = "test-parent-#{System.unique_integer()}"
+    subagent_type = "test-agent"
+    child_mode = :default
+
+    # Simulate the :start span (as agent.ex does before Tau.start_session).
+    :telemetry.execute(
+      [:tau, :session, :subagent, :start],
+      %{system_time: System.system_time()},
+      %{
+        parent_session_id: parent_session_id,
+        parent_tool_call_id: "tc-test",
+        subagent_type: subagent_type,
+        permissions_mode: child_mode
+      }
+    )
+
+    # Assert :start fired.
+    assert_receive {:telemetry, [:tau, :session, :subagent, :start], _measurements, metadata},
+                   1000
+
+    assert metadata.parent_session_id == parent_session_id
+    assert metadata.subagent_type == subagent_type
+
+    # Simulate the :stop span (as agent.ex does after result).
+    :telemetry.execute(
+      [:tau, :session, :subagent, :stop],
+      %{duration: 100},
+      %{
+        parent_session_id: parent_session_id,
+        child_session_id: "child-test",
+        subagent_type: subagent_type,
+        is_error: false
+      }
+    )
+
+    # Assert :stop fired.
+    assert_receive {:telemetry, [:tau, :session, :subagent, :stop], measurements, stop_meta},
+                   1000
+
+    assert stop_meta.parent_session_id == parent_session_id
+    assert measurements.duration > 0 or measurements.duration == 0
+    # is_error is false for a successful sub-agent.
+    assert stop_meta.is_error == false
+  end
+end

--- a/test/tau/tui/subagent_telemetry_test.exs
+++ b/test/tau/tui/subagent_telemetry_test.exs
@@ -1,21 +1,71 @@
 defmodule Tau.TUI.SubagentTelemetryTest do
   @moduledoc """
-  AC-8 (SPEC-TUI-HEADLESS §5c): asserts that `[:tau, :session, :subagent, :start]`
-  and `[:tau, :session, :subagent, :stop]` telemetry events fire per sub-agent.
+  AC-8 (SPEC-TUI-HEADLESS §5c, D-159): asserts that `[:tau, :session, :subagent, :start]`
+  and `[:tau, :session, :subagent, :stop]` telemetry events fire per sub-agent dispatch.
 
-  This is an ExUnit telemetry assertion (not a tmux test). It drives the
-  `Tau.Tools.Builtin.Agent.execute/2` path and asserts the telemetry span pair.
+  This test drives the **real production path**: it starts a parent session that causes the
+  `Tau.Tools.Builtin.Agent` tool to execute (via `MultiFixtureProvider`), attaches a
+  telemetry handler, and asserts the span pair fires **from `agent.ex`** — not from a
+  hand-crafted `telemetry.execute` call.
 
-  Note: requires a running PubSub and session supervisor. Uses the standard
-  ExUnit test setup; replay provider keeps it headless.
+  The test MUST fail if the `:telemetry.execute/3` calls in `agent.ex` are removed, because
+  no production code would fire those events. This distinguishes it from the prior tautological
+  test (refine-2 critic finding) which would have passed even with no telemetry in agent.ex.
+
+  Uses `async: false` because it attaches a process-wide telemetry handler.
   """
   use ExUnit.Case, async: false
 
-  @moduletag :integration
+  import Tau.Test.SessionHelper, only: [start_session_for_test: 1]
+
+  alias Tau.Provider.Event
+  alias Tau.Session.Events, as: SE
+  alias Tau.Test.MultiFixtureProvider
+
+  # Fixtures identical to those in agent_test.exs — parent triggers Agent tool,
+  # child responds with :end_turn, parent receives ToolResult and completes.
+  defp agent_tool_call_fixture(call_id, description) do
+    [
+      %Event.Start{request_id: "telm-parent-r1", model: "multi-fixture"},
+      %Event.ToolCallStart{tool_call_id: call_id, name: "Agent"},
+      %Event.ToolCallEnd{
+        tool_call_id: call_id,
+        params: %{"description" => description}
+      },
+      %Event.Done{stop_reason: :tool_use, usage: %{}}
+    ]
+  end
+
+  defp parent_end_turn_fixture do
+    [
+      %Event.Start{request_id: "telm-parent-r2", model: "multi-fixture"},
+      %Event.TextStart{block_id: "b0"},
+      %Event.TextDelta{block_id: "b0", text: "telm-parent done"},
+      %Event.TextEnd{block_id: "b0"},
+      %Event.Done{stop_reason: :end_turn, usage: %{}}
+    ]
+  end
+
+  defp child_text_fixture(text) do
+    [
+      %Event.Start{request_id: "telm-child-r1", model: "multi-fixture"},
+      %Event.TextStart{block_id: "b0"},
+      %Event.TextDelta{block_id: "b0", text: text},
+      %Event.TextEnd{block_id: "b0"},
+      %Event.Done{stop_reason: :end_turn, usage: %{}}
+    ]
+  end
 
   setup do
-    # The telemetry events are emitted in agent.ex execute/2.
-    # Attach a handler that collects events into the test process.
+    tmp =
+      Path.join(
+        System.tmp_dir!(),
+        "tau-subagent-telm-#{System.unique_integer([:positive])}"
+      )
+
+    File.mkdir_p!(tmp)
+    Application.put_env(:tau, :data_dir, tmp)
+
     test_pid = self()
     handler_id = "subagent-telemetry-test-#{System.unique_integer()}"
 
@@ -32,60 +82,71 @@ defmodule Tau.TUI.SubagentTelemetryTest do
       nil
     )
 
-    on_exit(fn -> :telemetry.detach(handler_id) end)
+    on_exit(fn ->
+      :telemetry.detach(handler_id)
+      File.rm_rf!(tmp)
+      Application.delete_env(:tau, :data_dir)
+    end)
 
-    :ok
+    %{tmp: tmp}
   end
 
   @tag :integration
-  test "[:tau, :session, :subagent, :start] and :stop fire for Agent tool execute" do
-    # This test drives the telemetry path without a real session by calling
-    # the telemetry execute directly, mirroring what agent.ex does.
-    # A full integration test would start a real session; that's guarded behind
-    # the :integration tag and requires the full application.
+  test "[:tau, :session, :subagent, :start] and :stop fire from Agent.execute/2 (AC-8 / D-159)",
+       %{tmp: tmp} do
+    # This test exercises the REAL production path: Tau.Tools.Builtin.Agent.execute/2
+    # is the canonical source of the telemetry span pair (D-159). It MUST fail if the
+    # :telemetry.execute/3 calls in agent.ex are removed.
 
-    parent_session_id = "test-parent-#{System.unique_integer()}"
-    subagent_type = "test-agent"
-    child_mode = :default
+    parent_sid = Tau.Session.generate_id()
+    Phoenix.PubSub.subscribe(Tau.PubSub, "session:#{parent_sid}")
 
-    # Simulate the :start span (as agent.ex does before Tau.start_session).
-    :telemetry.execute(
-      [:tau, :session, :subagent, :start],
-      %{system_time: System.system_time()},
-      %{
-        parent_session_id: parent_session_id,
-        parent_tool_call_id: "tc-test",
-        subagent_type: subagent_type,
-        permissions_mode: child_mode
-      }
-    )
+    call_id = "telm-agent-call-1"
+    child_text = "child result from telemetry test"
 
-    # Assert :start fired.
-    assert_receive {:telemetry, [:tau, :session, :subagent, :start], _measurements, metadata},
-                   1000
+    provider_ctx = %{
+      parent_session_id: parent_sid,
+      parent_first_fixture: agent_tool_call_fixture(call_id, "run a sub-task"),
+      parent_second_fixture: parent_end_turn_fixture(),
+      child_fixture: child_text_fixture(child_text)
+    }
 
-    assert metadata.parent_session_id == parent_session_id
-    assert metadata.subagent_type == subagent_type
+    {:ok, ^parent_sid} =
+      start_session_for_test(
+        provider: MultiFixtureProvider,
+        session_id: parent_sid,
+        cwd: tmp,
+        # bypass permissions so Agent tool runs without permission gate
+        metadata: %{permissions_mode: :bypass},
+        provider_ctx: provider_ctx
+      )
 
-    # Simulate the :stop span (as agent.ex does after result).
-    :telemetry.execute(
-      [:tau, :session, :subagent, :stop],
-      %{duration: 100},
-      %{
-        parent_session_id: parent_session_id,
-        child_session_id: "child-test",
-        subagent_type: subagent_type,
-        is_error: false
-      }
-    )
+    Tau.send(parent_sid, "please run the sub-agent")
 
-    # Assert :stop fired.
-    assert_receive {:telemetry, [:tau, :session, :subagent, :stop], measurements, stop_meta},
-                   1000
+    # Wait for parent to complete its second turn — confirms the full Agent.execute/2
+    # path ran (parent got ToolResult → issued second provider call → :end_turn).
+    assert_receive %SE.MessageEnd{message: %{stop_reason: :end_turn}}, 15_000
 
-    assert stop_meta.parent_session_id == parent_session_id
-    assert measurements.duration > 0 or measurements.duration == 0
-    # is_error is false for a successful sub-agent.
-    assert stop_meta.is_error == false
+    # D-159: [:tau, :session, :subagent, :start] MUST have fired from agent.ex before
+    # the child was spawned. The metadata carries the parent_session_id.
+    assert_receive {:telemetry, [:tau, :session, :subagent, :start], _measurements, start_meta},
+                   1_000
+
+    assert start_meta.parent_session_id == parent_sid,
+           "subagent :start metadata MUST carry the parent session id; got: #{inspect(start_meta)}"
+
+    # D-159: [:tau, :session, :subagent, :stop] MUST have fired from agent.ex after
+    # the child completed. The metadata must have is_error: false for a clean result.
+    assert_receive {:telemetry, [:tau, :session, :subagent, :stop], stop_measurements, stop_meta},
+                   1_000
+
+    assert stop_meta.parent_session_id == parent_sid,
+           "subagent :stop metadata MUST carry the parent session id; got: #{inspect(stop_meta)}"
+
+    assert stop_meta.is_error == false,
+           "subagent :stop metadata MUST have is_error: false for a clean child result"
+
+    assert is_integer(stop_measurements.duration) and stop_measurements.duration >= 0,
+           "subagent :stop measurements MUST include a non-negative duration; got: #{inspect(stop_measurements)}"
   end
 end

--- a/test/tau/tui/subagent_tree_test.exs
+++ b/test/tau/tui/subagent_tree_test.exs
@@ -1,0 +1,542 @@
+defmodule Tau.TUI.SubagentTreeTest do
+  @moduledoc """
+  Tests for `Tau.TUI.SubagentTree` — the pure fold module for the sub-agent
+  tree maintained in the TUI MVU model.
+
+  Covers D-150..D-154 invariants from SPEC-TUI-HEADLESS §5c:
+  - Property tests: monotone state transitions, additive cost, unknown
+    subagent_id / unknown kind ignored (not crashed).
+  - Unit tests: fold round-trips, format_start_marker/1, format_end_marker/1,
+    tool_call_owned?/2, and B1 de-dup logic.
+  - AC-8 telemetry assertions are in a separate integration test file.
+  """
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  alias Tau.Session.Events
+  alias Tau.TUI.SubagentTree
+  alias Tau.TUI.SubagentTree.SubagentNode
+
+  # --- Generators -----------------------------------------------------------
+
+  defp gen_subagent_id, do: StreamData.string(:alphanumeric, min_length: 1, max_length: 20)
+  defp gen_kind, do: StreamData.member_of([:builtin_agent, :coding_agent])
+  defp gen_label, do: StreamData.string(:alphanumeric, min_length: 1, max_length: 20)
+
+  defp gen_start_event do
+    ExUnitProperties.gen all(
+                           id <- gen_subagent_id(),
+                           kind <- gen_kind(),
+                           label <- gen_label()
+                         ) do
+      %Events.SubagentStart{
+        session_id: "sess-1",
+        subagent_id: id,
+        kind: kind,
+        label: label,
+        parent_tool_call_id: nil,
+        child_session_id: nil
+      }
+    end
+  end
+
+  defp gen_end_state do
+    StreamData.member_of([:done, :failed, :cancelled])
+  end
+
+  # --- Property tests (D-152, D-154) ----------------------------------------
+
+  property "unknown kind in SubagentStart is ignored — tree unchanged (D-152)" do
+    check all(
+            id <- gen_subagent_id(),
+            label <- gen_label()
+          ) do
+      tree = %{}
+
+      # :unknown_kind is not in the valid set
+      event = %Events.SubagentStart{
+        session_id: "sess",
+        subagent_id: id,
+        kind: :unknown_kind,
+        label: label,
+        parent_tool_call_id: nil,
+        child_session_id: nil
+      }
+
+      result = SubagentTree.fold(tree, event)
+      assert result == %{}, "unknown kind must leave tree unchanged (D-152)"
+    end
+  end
+
+  property "unknown subagent_id in SubagentProgress is ignored (D-152)" do
+    check all(id <- gen_subagent_id()) do
+      tree = %{}
+
+      event = %Events.SubagentProgress{
+        session_id: "sess",
+        subagent_id: id,
+        activity: {:tool_call, "Bash"},
+        child_tool_call_id: nil
+      }
+
+      result = SubagentTree.fold(tree, event)
+      assert result == %{}, "unknown subagent_id in Progress must leave tree unchanged (D-152)"
+    end
+  end
+
+  property "unknown subagent_id in SubagentCost is ignored (D-152)" do
+    check all(id <- gen_subagent_id()) do
+      tree = %{}
+
+      event = %Events.SubagentCost{
+        session_id: "sess",
+        subagent_id: id,
+        tokens: %{input: 10},
+        usd: 0.001,
+        duration_ms: 1000
+      }
+
+      result = SubagentTree.fold(tree, event)
+      assert result == %{}, "unknown subagent_id in Cost must leave tree unchanged (D-152)"
+    end
+  end
+
+  property "unknown subagent_id in SubagentEnd is ignored (D-152)" do
+    check all(
+            id <- gen_subagent_id(),
+            state <- gen_end_state()
+          ) do
+      tree = %{}
+
+      event = %Events.SubagentEnd{
+        session_id: "sess",
+        subagent_id: id,
+        state: state,
+        summary: "done"
+      }
+
+      result = SubagentTree.fold(tree, event)
+      assert result == %{}, "unknown subagent_id in End must leave tree unchanged (D-152)"
+    end
+  end
+
+  property "state transitions are monotone — terminal state cannot revert (D-154)" do
+    check all(
+            start <- gen_start_event(),
+            terminal_state <- gen_end_state(),
+            next_activity <- StreamData.member_of([:tool_call, :assistant_text])
+          ) do
+      id = start.subagent_id
+      tree = SubagentTree.fold(%{}, start)
+
+      end_event = %Events.SubagentEnd{
+        session_id: "sess",
+        subagent_id: id,
+        state: terminal_state,
+        summary: "finished"
+      }
+
+      tree = SubagentTree.fold(tree, end_event)
+      assert Map.get(tree, id).state == terminal_state, "state should be #{terminal_state}"
+
+      # Now try to send a progress event — state must not revert to :running
+      progress = %Events.SubagentProgress{
+        session_id: "sess",
+        subagent_id: id,
+        activity: {next_activity, "test"},
+        child_tool_call_id: nil
+      }
+
+      tree_after = SubagentTree.fold(tree, progress)
+
+      assert Map.get(tree_after, id).state == terminal_state,
+             "terminal state #{terminal_state} must not revert after Progress (D-154)"
+    end
+  end
+
+  property "cost is additive — later SubagentCost overwrites the cost fields (D-153)" do
+    check all(
+            start <- gen_start_event(),
+            usd1 <- StreamData.float(min: 0.0, max: 1.0),
+            usd2 <- StreamData.float(min: 0.0, max: 1.0)
+          ) do
+      id = start.subagent_id
+      tree = SubagentTree.fold(%{}, start)
+
+      tree =
+        SubagentTree.fold(tree, %Events.SubagentCost{
+          session_id: "sess",
+          subagent_id: id,
+          tokens: %{input: 10},
+          usd: usd1,
+          duration_ms: 1000
+        })
+
+      tree =
+        SubagentTree.fold(tree, %Events.SubagentCost{
+          session_id: "sess",
+          subagent_id: id,
+          tokens: %{input: 20},
+          usd: usd2,
+          duration_ms: 2000
+        })
+
+      node = Map.get(tree, id)
+      assert node.usd == usd2, "cost should be updated to latest value"
+      assert node.duration_ms == 2000
+    end
+  end
+
+  property "SubagentStart with valid kind creates a node in :running state" do
+    check all(start <- gen_start_event()) do
+      tree = SubagentTree.fold(%{}, start)
+      node = Map.get(tree, start.subagent_id)
+      assert node != nil
+      assert node.state == :running
+      assert node.kind == start.kind
+      assert node.label == start.label
+      assert node.tool_calls == 0
+    end
+  end
+
+  # --- Unit tests -----------------------------------------------------------
+
+  describe "fold/2 — SubagentStart" do
+    test "creates node with :running state for :builtin_agent" do
+      tree =
+        SubagentTree.fold(%{}, %Events.SubagentStart{
+          session_id: "sess",
+          subagent_id: "child-1",
+          kind: :builtin_agent,
+          label: "general-purpose",
+          parent_tool_call_id: "tc-parent",
+          child_session_id: "child-session-1"
+        })
+
+      node = tree["child-1"]
+      assert node.state == :running
+      assert node.kind == :builtin_agent
+      assert node.label == "general-purpose"
+      assert node.parent_tool_call_id == "tc-parent"
+      assert node.child_session_id == "child-session-1"
+      assert node.tool_calls == 0
+    end
+
+    test "creates node with :running state for :coding_agent" do
+      tree =
+        SubagentTree.fold(%{}, %Events.SubagentStart{
+          session_id: "sess",
+          subagent_id: "sess:ca",
+          kind: :coding_agent,
+          label: "claude-code",
+          parent_tool_call_id: nil,
+          child_session_id: nil
+        })
+
+      node = tree["sess:ca"]
+      assert node.state == :running
+      assert node.kind == :coding_agent
+    end
+
+    test "ignores unknown kind atom without crashing (D-152)" do
+      tree =
+        SubagentTree.fold(%{}, %Events.SubagentStart{
+          session_id: "sess",
+          subagent_id: "x",
+          kind: :some_future_kind,
+          label: "future",
+          parent_tool_call_id: nil,
+          child_session_id: nil
+        })
+
+      assert tree == %{}
+    end
+  end
+
+  describe "fold/2 — SubagentProgress" do
+    test "increments tool_calls and tracks last_activity on :tool_call activity" do
+      tree =
+        %{}
+        |> SubagentTree.fold(%Events.SubagentStart{
+          session_id: "sess",
+          subagent_id: "child-1",
+          kind: :builtin_agent,
+          label: "test",
+          parent_tool_call_id: nil,
+          child_session_id: nil
+        })
+        |> SubagentTree.fold(%Events.SubagentProgress{
+          session_id: "sess",
+          subagent_id: "child-1",
+          activity: {:tool_call, "Bash"},
+          child_tool_call_id: "tc-child-1"
+        })
+
+      node = tree["child-1"]
+      assert node.tool_calls == 1
+      assert node.last_activity == {:tool_call, "Bash"}
+    end
+
+    test "tracks owned tool_call_ids for B1 de-dup" do
+      tree =
+        %{}
+        |> SubagentTree.fold(%Events.SubagentStart{
+          session_id: "sess",
+          subagent_id: "child-1",
+          kind: :builtin_agent,
+          label: "test",
+          parent_tool_call_id: nil,
+          child_session_id: nil
+        })
+        |> SubagentTree.fold(%Events.SubagentProgress{
+          session_id: "sess",
+          subagent_id: "child-1",
+          activity: {:tool_call, "Bash"},
+          child_tool_call_id: "tc-child-1"
+        })
+        |> SubagentTree.fold(%Events.SubagentProgress{
+          session_id: "sess",
+          subagent_id: "child-1",
+          activity: {:tool_call, "Read"},
+          child_tool_call_id: "tc-child-2"
+        })
+
+      assert SubagentTree.tool_call_owned?(tree, "tc-child-1")
+      assert SubagentTree.tool_call_owned?(tree, "tc-child-2")
+      refute SubagentTree.tool_call_owned?(tree, "tc-parent-unrelated")
+    end
+
+    test "nil child_tool_call_id does not crash (D-152)" do
+      tree =
+        %{}
+        |> SubagentTree.fold(%Events.SubagentStart{
+          session_id: "sess",
+          subagent_id: "child-1",
+          kind: :builtin_agent,
+          label: "test",
+          parent_tool_call_id: nil,
+          child_session_id: nil
+        })
+        |> SubagentTree.fold(%Events.SubagentProgress{
+          session_id: "sess",
+          subagent_id: "child-1",
+          activity: {:assistant_text, "hello"},
+          child_tool_call_id: nil
+        })
+
+      node = tree["child-1"]
+      assert node.state == :running
+      assert node.last_activity == {:assistant_text, "hello"}
+      assert node.tool_calls == 0
+    end
+
+    test "does not increment tool_calls for non-tool_call activity" do
+      tree =
+        %{}
+        |> SubagentTree.fold(%Events.SubagentStart{
+          session_id: "sess",
+          subagent_id: "c",
+          kind: :builtin_agent,
+          label: "test",
+          parent_tool_call_id: nil,
+          child_session_id: nil
+        })
+        |> SubagentTree.fold(%Events.SubagentProgress{
+          session_id: "sess",
+          subagent_id: "c",
+          activity: {:assistant_text, "thinking..."},
+          child_tool_call_id: nil
+        })
+
+      assert tree["c"].tool_calls == 0
+    end
+  end
+
+  describe "fold/2 — SubagentCost" do
+    test "updates cost fields in the node" do
+      tree =
+        %{}
+        |> SubagentTree.fold(%Events.SubagentStart{
+          session_id: "sess",
+          subagent_id: "c",
+          kind: :builtin_agent,
+          label: "test",
+          parent_tool_call_id: nil,
+          child_session_id: nil
+        })
+        |> SubagentTree.fold(%Events.SubagentCost{
+          session_id: "sess",
+          subagent_id: "c",
+          tokens: %{input: 100, output: 50},
+          usd: 0.005,
+          duration_ms: 3000
+        })
+
+      node = tree["c"]
+      assert node.usd == 0.005
+      assert node.duration_ms == 3000
+      assert node.tokens == %{input: 100, output: 50}
+    end
+  end
+
+  describe "fold/2 — SubagentEnd" do
+    test "transitions node to :done state" do
+      tree =
+        %{}
+        |> SubagentTree.fold(%Events.SubagentStart{
+          session_id: "sess",
+          subagent_id: "c",
+          kind: :builtin_agent,
+          label: "test",
+          parent_tool_call_id: nil,
+          child_session_id: nil
+        })
+        |> SubagentTree.fold(%Events.SubagentEnd{
+          session_id: "sess",
+          subagent_id: "c",
+          state: :done,
+          summary: "completed"
+        })
+
+      assert tree["c"].state == :done
+      assert tree["c"].summary == "completed"
+    end
+
+    test "transitions node to :failed state" do
+      tree =
+        %{}
+        |> SubagentTree.fold(%Events.SubagentStart{
+          session_id: "sess",
+          subagent_id: "c",
+          kind: :builtin_agent,
+          label: "test",
+          parent_tool_call_id: nil,
+          child_session_id: nil
+        })
+        |> SubagentTree.fold(%Events.SubagentEnd{
+          session_id: "sess",
+          subagent_id: "c",
+          state: :failed,
+          summary: "crashed"
+        })
+
+      assert tree["c"].state == :failed
+    end
+
+    test "transitions node to :cancelled state" do
+      tree =
+        %{}
+        |> SubagentTree.fold(%Events.SubagentStart{
+          session_id: "sess",
+          subagent_id: "c",
+          kind: :builtin_agent,
+          label: "test",
+          parent_tool_call_id: nil,
+          child_session_id: nil
+        })
+        |> SubagentTree.fold(%Events.SubagentEnd{
+          session_id: "sess",
+          subagent_id: "c",
+          state: :cancelled,
+          summary: "parent died"
+        })
+
+      assert tree["c"].state == :cancelled
+    end
+  end
+
+  describe "tool_call_owned?/2" do
+    test "returns false for nil tool_call_id" do
+      assert SubagentTree.tool_call_owned?(%{}, nil) == false
+    end
+
+    test "returns false for empty tree" do
+      assert SubagentTree.tool_call_owned?(%{}, "tc-1") == false
+    end
+
+    test "returns true for an owned tool_call_id" do
+      tree =
+        %{}
+        |> SubagentTree.fold(%Events.SubagentStart{
+          session_id: "sess",
+          subagent_id: "child-1",
+          kind: :builtin_agent,
+          label: "test",
+          parent_tool_call_id: nil,
+          child_session_id: nil
+        })
+        |> SubagentTree.fold(%Events.SubagentProgress{
+          session_id: "sess",
+          subagent_id: "child-1",
+          activity: {:tool_call, "Bash"},
+          child_tool_call_id: "tc-owned"
+        })
+
+      assert SubagentTree.tool_call_owned?(tree, "tc-owned")
+    end
+  end
+
+  describe "format_start_marker/1" do
+    test "returns boxed start marker with [running]" do
+      node = %SubagentNode{
+        subagent_id: "c",
+        kind: :builtin_agent,
+        label: "my-agent"
+      }
+
+      marker = SubagentTree.format_start_marker(node)
+      assert marker == "┌─ sub-agent: my-agent [running]"
+    end
+  end
+
+  describe "format_end_marker/1" do
+    test "done with tool calls and duration" do
+      node = %SubagentNode{
+        subagent_id: "c",
+        kind: :builtin_agent,
+        label: "my-agent",
+        state: :done,
+        tool_calls: 5,
+        duration_ms: 64_000,
+        usd: 0.03
+      }
+
+      marker = SubagentTree.format_end_marker(node)
+      assert String.starts_with?(marker, "└─ sub-agent: my-agent [done")
+      assert String.contains?(marker, "5 tool calls")
+      assert String.contains?(marker, "1m04s")
+      assert String.contains?(marker, "$")
+    end
+
+    test "failed state" do
+      node = %SubagentNode{
+        subagent_id: "c",
+        kind: :builtin_agent,
+        label: "crashy",
+        state: :failed,
+        tool_calls: 2,
+        duration_ms: 1000,
+        usd: nil
+      }
+
+      marker = SubagentTree.format_end_marker(node)
+      assert String.contains?(marker, "failed")
+      refute String.contains?(marker, "$")
+    end
+
+    test "cancelled state" do
+      node = %SubagentNode{
+        subagent_id: "c",
+        kind: :coding_agent,
+        label: "claude-code",
+        state: :cancelled,
+        tool_calls: 0,
+        duration_ms: nil,
+        usd: nil
+      }
+
+      marker = SubagentTree.format_end_marker(node)
+      assert String.contains?(marker, "cancelled")
+    end
+  end
+end


### PR DESCRIPTION
## Closes

Closes #335

Surface sub-agent dispatch & progress in the TUI transcript — a uniform
event contract for both dispatch paths, a fold model, and boxed transcript
markers.

## Background — plan of record

The pre-implementation `critic` gave APPROVE-WITH-BLOCKERS. All three
BLOCKING items + the key SUGGESTION fold in here:

- **B1 — Path B is "additionally", not "instead".** The coding-agent path
  keeps emitting the existing `%Events.ToolStart{}`/`%Events.ToolEnd{}` on the
  parent topic (no regression for audit/existing consumers) AND additionally
  emits the new `Subagent*` events. The **render layer de-dups by ownership**:
  a `ToolStart`/`ToolEnd` whose `tool_call_id` belongs to a known sub-agent is
  NOT rendered inline — the sub-agent markers own it. This requires
  `SubagentProgress` to carry the **child `tool_call_id`** for correlation.
- **B2 — the Path A relay contract is written down.** The `Agent` builtin's
  `await_child/4` receive loop (`lib/tau/tools/builtin/agent.ex`) is extended
  to re-emit child events as `Subagent*` on the **parent** topic. It MUST:
  forward `MessageEnd`/`ToolStart`/`ToolEnd`/`SessionEnd`; **explicitly
  match-and-discard `MessageUpdate`** (and any other non-forwarded child event)
  so the tool-task mailbox does not grow unbounded on a chatty child; and emit
  `SubagentEnd` on **all FIVE** terminal branches — `natural_end`,
  `failure_end`, `SessionEnd`, `{:DOWN, …}`, and the `after`-timeout — a missed
  branch is a stuck `▶ running` node (AC-7 failure).
- **B3 — AC-6 is the deferral form, single falsifiable predicate.**
  Interactive drill-in and the two-column right-hand panel are **out of scope**
  for this PR — split to filed follow-up issue #361 (sub-agent panel +
  interactive drill-in). AC-6 here is exactly: the transcript marker carries
  the `child_session_id` and the child session JSONL exists on disk.
- **S3 — single-column transcript markers only; NO two-column panel.** The
  boxed transcript markers satisfy the visually-distinct / live-state / rollup
  ACs without a right-hand panel — this keeps #335 off the #334 (resize /
  wrap-width) critical path. The panel is the follow-up issue.

## Scope & order

1. **SPEC.** Amend `docs/spec/SPEC-TUI-HEADLESS.md` (its committed
   `spec-before-code.md` spec home) with a sub-agent-visibility section: the
   `Subagent*` event contract, the parent-topic emission rule (D1), the
   always-emit-`SubagentEnd` 5-branch guarantee (B2/R2), cost-additivity / no
   double-count (R4), the closed `kind` atom set. **New D-NNN block
   `D-150..D-159`** — SPEC-TUI-HEADLESS's D-066..D-075 and D-140..D-149 blocks
   are consumed; `grep` to confirm D-150..D-159 free and **record the block in
   `docs/MISSION.md`**. Path B touches the FSM's `CAEvent` handlers — name the
   SPEC-CODING-AGENT AC/D-NNN this conforms to / amends.
2. **`Subagent*` event union** in `lib/tau/session/events.ex` — four structs:
   `SubagentStart{session_id, subagent_id, kind, label, parent_tool_call_id}`
   (`kind ∈ {:builtin_agent, :coding_agent}` — closed set);
   `SubagentProgress{session_id, subagent_id, child_tool_call_id, activity}`
   (the `child_tool_call_id` is the B1 correlation key — may be `nil` for
   non-tool activity); `SubagentCost{session_id, subagent_id, tokens, usd,
   duration_ms}`; `SubagentEnd{session_id, subagent_id, state, summary}`
   (`state ∈ {:done, :failed, :cancelled}`).
3. **Path A relay** — extend `agent.ex` `await_child/4` per B2.
4. **Path B emission** — the FSM, on a coding-agent `CAEvent`, additionally
   emits `Subagent*` on the parent topic (B1 "additionally").
5. **`Tau.TUI.SubagentTree`** — a **pure fold module** (no GenServer, no
   process — OTP non-negotiables #1/#3) + a `SubagentNode` struct. Property
   tests: monotone state transitions, additive cost, an unknown `subagent_id`
   OR unknown `kind` is **ignored, not crashed**. The tree is a real tree
   (`parent_subagent_id`) even though v1 renders flat.
6. **TUI wiring** — a `subagents` field on the MVU model + `on_subagent_*`
   fold handlers (mirroring `on_tool_start/2`), drained through the existing
   `EventBridge` tick. Transcript: a sub-agent dispatch renders a **boxed
   marker** — `┌─ sub-agent: <label> [running]` on start, `└─ sub-agent:
   <label> [done · N tool calls · <duration> · $<cost>]` (or `failed` /
   `cancelled`) on end — instead of a bare `[tool_call] Agent(...)` line. The
   render layer de-dups owned child tool calls (B1). **Single-column** — no
   right-hand panel.
7. **Telemetry** — reuse the existing `agent.ex` sub-agent lifetime
   `:start`/`:stop`/`:exception` span (do NOT emit a competing `:start`); add
   `[:tau, :session, :subagent, :progress]` and `:cost` as metrics events.

**Out of scope** (→ #361): the two-column right-hand
sub-agent panel; interactive arrow-key drill-in. Also out: #341/#342/#343
surfaces, inline images. Recursive depth > 2 *interactive* display deferred —
the data model stays a real tree.

## SPECs

Amends **`docs/spec/SPEC-TUI-HEADLESS.md`** (D-150..D-159 new block — update
`docs/MISSION.md`). In scope of **SPEC-CODING-AGENT** (Path B touches the
`CAEvent` FSM handlers) — conforms; name the AC/D-NNN. PSDH triage 4/5.

## Acceptance criteria (verifiable via the #336 tmux harness; pure modules also get StreamData property tests)

- **AC-1** a sub-agent dispatch shows a boxed `┌─ sub-agent: <label> [running]`
  marker, NOT a bare `[tool_call] Agent(...)` line.
- **AC-2** live state: the marker / node shows `running` while the child runs,
  then `done` / `failed` / `cancelled`.
- **AC-3** progress: the rendered tool-call count rises and the last-activity
  excerpt changes as the child makes tool calls.
- **AC-4** rollup: the end marker shows token/cost/duration; the parent
  status-bar cost is NOT inflated by the child's cost (R4).
- **AC-5** coding-agent path parity: `tau tui --coding-agent <replay-adapter>`
  surfaces the coding agent as a sub-agent (`kind: :coding_agent`), not as
  flattened parent `[tool_call]` lines.
- **AC-6** (deferral form) the transcript marker carries the
  `child_session_id` and the child session JSONL exists on disk. (Interactive
  drill-in is follow-up issue #361.)
- **AC-7** no orphaned nodes: a sub-agent that crashes / times out reaches a
  terminal glyph — no node left `running` after the parent turn ends.
- **AC-8** telemetry: `[:tau, :session, :subagent, :start]` / `:stop` fire per
  sub-agent (ExUnit telemetry assertion).

Every AC has a test failing-before / passing-after. A replay-backed sub-agent
fixture is in scope so the tmux ACs are deterministic.

## Test plan

- Property tests for `Tau.TUI.SubagentTree` (monotone state, additive cost,
  unknown-id/kind ignored).
- Unit/integration tests for both relay paths + the de-dup ownership rule.
- `mix tau.tui_ux` tmux steps for AC-1..AC-5, AC-7; ExUnit telemetry for AC-8.
- `mix compile --warnings-as-errors`, `mix format --check-formatted`,
  `mix credo --strict`, full `mix test` green.

## Gate verdicts

- critic: PASS (`ok: true`) — on `56248d3` after 3 refine cycles; the `await_child/4` receive-clause-shadowing bug fixed + a discriminating 5-branch terminal test. 1 SUGGESTION (docstring framing).
- reviewer: PASS (`verdict: PASS`) — `binary-qa` green on both CI runs on `56248d3`; SPEC-TUI-HEADLESS §5c + D-150–D-159; parent-topic emission, B1 'additionally', pure `SubagentTree`; AC-3 live region, AC-7 five-branch test, AC-8 real-path telemetry all genuine. 2 cosmetic WARNINGs (docstring mislabels).

