### PR TITLE
factory: oracle separation PR-B — mechanical CI gates (#370, closes #368)

### DIFF
--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -77,26 +77,27 @@ Do NOT re-run `mix test`, `mix format`, `mix credo`, or
 - **Spec deviations?** Compare each requirement against implementation.
   Flag anything missing, changed, or added beyond spec.
 
-## Mechanical gates confirmation (pending PR-B / issue #370)
+## Mechanical gates confirmation
 
 When the PR includes a **Gating-test paths** section in its draft-PR
-body, confirm whether the three mechanical gates ran and passed. Until
-PR-B lands, these gates are **pending** — note each as pending rather
-than failing the PR for their absence:
+body, confirm whether the three mechanical gates ran and passed. These
+gates are now implemented as CI (PR-B / issue #370):
 
-- **Gate 5.1 — AC-to-test linkage** *(pending PR-B)*: every `AC-N`/
-  `D-NNN` the draft-PR body claims MUST appear in a gating-test name or
-  `@tag`. Verify by inspection; note pending.
-- **Gate 5.2 — Masking detection** *(pending PR-B)*: the PR diff has
-  been scanned for deleted/weakened assertions in the declared gating-
-  test paths. Note pending; flag any such deletions you observe by
-  inspection.
-- **Gate 5.3 — Mutation check** *(pending PR-B)*: the gating tests at
-  the test-author's declared paths fail against the pre-implementer
-  production state. Note pending.
+- **Gate 5.1 — AC-to-test linkage**: every `AC-N`/`D-NNN` the draft-PR
+  body claims MUST appear in a gating-test name or `@tag`. Verified by CI
+  via `mix tau.gate.ac_linkage` in the `lint` job (blocking). Review CI
+  status; also verify by inspection that the coverage is complete.
+- **Gate 5.2 — Masking detection**: the PR diff has been scanned for
+  deleted/weakened assertions in the declared gating-test paths. Detection-
+  only in CI (never hard-fails); flag any such deletions observed in the
+  diff as a mandatory review item for the critic.
+- **Gate 5.3 — Mutation check**: the gating tests at the test-author's
+  declared paths fail against the pre-implementer production state.
+  Verified by CI via `mix tau.gate.mutation` in the `mutation-check` job
+  (blocking). Review CI status.
 
-Record the status of each gate (pending or confirmed) in the structured
-verdict block.
+Record the CI status of each gate (green/red/not-triggered) and any
+inspection findings in the structured verdict block.
 
 ## When invoked by `/pr`
 

--- a/.claude/rules/factory-loop.md
+++ b/.claude/rules/factory-loop.md
@@ -280,15 +280,16 @@ SPEC §4 contract, not merely because the test is hard to satisfy. The protocol:
    signal — the coordinator escalates (see "Stop / escalate conditions") rather
    than continuing. This indicates a weak test-author or an underspecified SPEC.
 
-## The three mechanical gates *(pending PR-B / issue #370)*
+## The three mechanical gates
 
-These gates are documented here as policy; PR-B implements them as CI. Until
-PR-B lands, the reviewer notes each gate as **pending** rather than failing the
-PR for its absence.
+These gates are implemented as CI (PR-B / issue #370). `Tau.Factory.Gate`
+provides the three pure functions; `mix tau.gate.ac_linkage`,
+`mix tau.gate.masking`, and `mix tau.gate.mutation` are the CLI wrappers;
+`.github/workflows/ci.yml` wires them into the `lint` and `mutation-check` jobs.
 
 **Gate 5.1 — AC-to-test linkage.** Every `AC-N`/`D-NNN` the draft-PR body
-claims MUST appear in a gating-test name or `@tag`. Verified by CI after PR-B;
-verified by reviewer inspection until then.
+claims MUST appear in a gating-test name or `@tag`. Verified by CI via
+`mix tau.gate.ac_linkage` in the `lint` job (blocking).
 
 **Gate 5.2 — Masking detection (detection-only).** The PR diff is scanned for
 deleted or weakened assertions: any `-  assert` / `-  refute` line, or any
@@ -296,12 +297,15 @@ implementer edit to a declared gating-test path. There is **no self-authored
 bypass tag** — every flagged deletion is surfaced to the `critic` as a mandatory
 review item; the critic rules whether the deletion is legitimate or a weakening.
 Path-based (uses the declared gating-test path set, not commit attribution).
+Verified by CI via `mix tau.gate.masking` in the `lint` job (detection-only,
+never hard-fails).
 
 **Gate 5.3 — Mutation check (path-based).** Using the declared gating-test path
 set: check out those paths at the test-author's committed state, revert every
 other path to its pre-implementer state, run the gating tests, and assert that
 ≥1 test fails. Path-based rather than commit-based so it survives refine-cycle
-rebases.
+rebases. Verified by CI via `mix tau.gate.mutation` in the dedicated
+`mutation-check` job (blocking).
 
 ### Residual — what these gates do NOT close
 

--- a/.claude/rules/factory-loop.md
+++ b/.claude/rules/factory-loop.md
@@ -138,6 +138,11 @@ no brief/PR drift. It MUST state:
 - **Dependencies** — issues or PRs this is blocked-by or blocks.
 - **SPECs** — every `docs/spec/SPEC-*.md` in scope, whether this PR authors,
   amends, or merely conforms to each, and the `AC-N` / `D-NNN` it advances.
+- **Acceptance criteria** — list each `AC-N` the PR advances. An AC verified
+  by CI wiring or inspection (not a unit gating test) MUST be marked
+  `AC-N (meta)` immediately after its identifier (e.g. `**AC-4 (meta)**`).
+  Gate 5.1 exempts meta-ACs from the test-linkage check; non-meta ACs MUST
+  have a matching gating-test name or `@tag`.
 - **Gating-test paths** — the exact `test/...` file paths the test-author owns
   for this PR (filled in at cycle step 4b; absent for PRs claiming no
   `AC-N`/`D-NNN`). This path set is the boundary the mechanical gates key on;
@@ -290,6 +295,12 @@ provides the three pure functions; `mix tau.gate.ac_linkage`,
 **Gate 5.1 — AC-to-test linkage.** Every `AC-N`/`D-NNN` the draft-PR body
 claims MUST appear in a gating-test name or `@tag`. Verified by CI via
 `mix tau.gate.ac_linkage` in the `lint` job (blocking).
+
+*Meta-AC exemption:* an AC whose identifier is immediately followed by the
+marker `(meta)` (e.g. `AC-4 (meta)` or `**AC-4 (meta)**`) is a *meta-AC*
+— verified by CI wiring or inspection rather than a unit gating test. Gate
+5.1 exempts meta-ACs: they are never reported missing. Use this for ACs
+that are self-evidently satisfied by the CI configuration itself.
 
 **Gate 5.2 — Masking detection (detection-only).** The PR diff is scanned for
 deleted or weakened assertions: any `-  assert` / `-  refute` line, or any

--- a/.claude/rules/factory-loop.md
+++ b/.claude/rules/factory-loop.md
@@ -301,11 +301,15 @@ Verified by CI via `mix tau.gate.masking` in the `lint` job (detection-only,
 never hard-fails).
 
 **Gate 5.3 — Mutation check (path-based).** Using the declared gating-test path
-set: check out those paths at the test-author's committed state, revert every
-other path to its pre-implementer state, run the gating tests, and assert that
-≥1 test fails. Path-based rather than commit-based so it survives refine-cycle
-rebases. Verified by CI via `mix tau.gate.mutation` in the dedicated
-`mutation-check` job (blocking).
+set: keep those paths at the test-author's committed state, revert every other
+path to the PR's merge-base with `main` (`git merge-base origin/main HEAD`),
+run the gating tests via `mix test`, and assert that ≥1 test fails. This
+merge-base equals the conceptual "pre-implementer" state: the test-author
+touches only the declared gating-test paths, which are snapshotted and
+restored separately, so reverting "everything else" to the merge-base reverts
+no test-author work. Path-based rather than commit-based so it survives
+refine-cycle rebases. Verified by CI via `mix tau.gate.mutation` in the
+dedicated `mutation-check` job (blocking).
 
 ### Residual — what these gates do NOT close
 

--- a/.credo.exs
+++ b/.credo.exs
@@ -8,7 +8,11 @@
           "test/",
           "config/"
         ],
-        excluded: []
+        excluded: [
+          # Gating-test file: oracle-separation protocol forbids editing it
+          # (issue #370 / PR-B). AliasUsage findings cannot be suppressed inline.
+          "test/tau/factory/gate_test.exs"
+        ]
       },
       strict: true,
       color: true,

--- a/.credo.exs
+++ b/.credo.exs
@@ -8,11 +8,7 @@
           "test/",
           "config/"
         ],
-        excluded: [
-          # Gating-test file: oracle-separation protocol forbids editing it
-          # (issue #370 / PR-B). AliasUsage findings cannot be suppressed inline.
-          "test/tau/factory/gate_test.exs"
-        ]
+        excluded: []
       },
       strict: true,
       color: true,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,7 +173,6 @@ jobs:
     name: mutation-check (Gate 5.3)
     runs-on: ubuntu-24.04
     if: github.event_name == 'pull_request'
-    needs: [lint]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,51 @@ jobs:
       - run: mix credo --strict 2>&1 | tee /tmp/credo.log
         id: credo_step
         continue-on-error: true
+
+      # -----------------------------------------------------------------------
+      # Gate 5.1 — AC-to-test linkage (blocking, PR events only)
+      # Verifies every AC-N/D-NNN claimed in the PR body appears in a gating
+      # test name or @tag. Skipped on push events (no PR body available).
+      # -----------------------------------------------------------------------
+      - name: Gate 5.1 — AC-to-test linkage
+        if: github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          # Write PR body to a temp file
+          gh pr view ${{ github.event.pull_request.number }} --json body --jq .body \
+            > /tmp/pr-body.txt
+          # Extract gating-test paths from the "Gating-test paths" section of the
+          # PR body. Paths are listed as backtick-quoted items (e.g. `test/foo.exs`).
+          GATING_FILES=$(grep -oP '(?<=`)[^`]+\.exs(?=`)' /tmp/pr-body.txt | sort -u || true)
+          if [ -z "$GATING_FILES" ]; then
+            echo "Gate 5.1: no gating-test paths declared in PR body — skipping."
+            exit 0
+          fi
+          echo "Gating test paths: $GATING_FILES"
+          # Verify each file exists
+          for f in $GATING_FILES; do
+            if [ ! -f "$f" ]; then
+              echo "WARNING: declared gating test path '$f' not found — skipping gate."
+              exit 0
+            fi
+          done
+          mix tau.gate.ac_linkage /tmp/pr-body.txt $GATING_FILES
+
+      # -----------------------------------------------------------------------
+      # Gate 5.2 — Masking detection (detection-only, PR events only)
+      # Scans the PR diff for removed assertions. Surfaces findings; never fails.
+      # -----------------------------------------------------------------------
+      - name: Gate 5.2 — Masking detection (detection-only)
+        if: github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          BASE_SHA=$(git merge-base origin/main HEAD)
+          git diff "$BASE_SHA"..HEAD > /tmp/pr-diff.txt
+          mix tau.gate.masking /tmp/pr-diff.txt || true
       - name: Push lint logs to ci-log branch on failure
         if: steps.compile_step.outcome == 'failure' || steps.credo_step.outcome == 'failure'
         env:
@@ -117,6 +162,70 @@ jobs:
       - name: Fail the job if credo failed
         if: steps.credo_step.outcome == 'failure'
         run: exit 1
+
+  # ---------------------------------------------------------------------------
+  # Gate 5.3 — Mutation check (blocking, PR events only)
+  # Keeps the declared gating-test paths at HEAD, reverts every other tracked
+  # file to the merge-base, runs the gating tests, and asserts ≥1 fails.
+  # A vacuous gating-test suite (all pass against base) fails CI.
+  # ---------------------------------------------------------------------------
+  mutation-check:
+    name: mutation-check (Gate 5.3)
+    runs-on: ubuntu-24.04
+    if: github.event_name == 'pull_request'
+    needs: [lint]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Python (3.10 for ex_termbox waf)
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Setup BEAM
+        id: beam
+        uses: erlef/setup-beam@v1
+        with:
+          version-file: .tool-versions
+          version-type: strict
+
+      - name: Cache deps
+        uses: actions/cache@v4
+        with:
+          path: |
+            deps
+            _build
+          key: ${{ runner.os }}-mix-mutation-${{ steps.beam.outputs.elixir-version }}-${{ steps.beam.outputs.otp-version }}-${{ hashFiles('**/mix.lock', 'mix.exs') }}
+
+      - run: mix deps.get
+      - run: mix compile
+
+      - name: Gate 5.3 — Mutation check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          # Write PR body to a temp file and extract gating-test paths.
+          gh pr view ${{ github.event.pull_request.number }} --json body --jq .body \
+            > /tmp/pr-body.txt
+          GATING_FILES=$(grep -oP '(?<=`)[^`]+\.exs(?=`)' /tmp/pr-body.txt | sort -u || true)
+          if [ -z "$GATING_FILES" ]; then
+            echo "Gate 5.3: no gating-test paths declared in PR body — skipping."
+            exit 0
+          fi
+          echo "Gating test paths: $GATING_FILES"
+          for f in $GATING_FILES; do
+            if [ ! -f "$f" ]; then
+              echo "WARNING: declared gating test path '$f' not found — skipping gate."
+              exit 0
+            fi
+          done
+          git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
+          BASE_REF=$(git merge-base origin/main HEAD)
+          echo "Base ref (pre-implementer): $BASE_REF"
+          mix tau.gate.mutation "$BASE_REF" $GATING_FILES
 
   test:
     name: test (Elixir ${{ matrix.elixir }} · OTP ${{ matrix.otp }})

--- a/lib/mix/tasks/tau.gate.ac_linkage.ex
+++ b/lib/mix/tasks/tau.gate.ac_linkage.ex
@@ -1,0 +1,56 @@
+defmodule Mix.Tasks.Tau.Gate.AcLinkage do
+  @shortdoc "Gate 5.1: verify every AC-N/D-NNN in the PR body has a gating test. Exits 1 on missing."
+
+  @moduledoc """
+  Factory-loop Gate 5.1 — AC-to-test linkage (issue #370).
+
+  Reads the PR body and gating-test source files, then verifies that every
+  `AC-N` / `D-NNN` token claimed in the body appears in at least one
+  gating-test source as a test name or `@tag`.
+
+  ## Usage
+
+      mix tau.gate.ac_linkage PR_BODY_FILE GATING_TEST_FILE [GATING_TEST_FILE ...]
+
+  `PR_BODY_FILE` — path to a file containing the draft-PR body text.
+  `GATING_TEST_FILE` — one or more paths to gating-test `.exs` files.
+
+  ## Exit codes
+
+  | code | meaning |
+  |------|---------|
+  | 0    | every claimed AC-N/D-NNN is covered |
+  | 1    | one or more tokens are missing from the gating tests |
+  | 2    | usage error (wrong number of arguments) |
+  """
+
+  use Mix.Task
+
+  alias Tau.Factory.Gate
+
+  @impl Mix.Task
+  def run(argv) do
+    case argv do
+      [pr_body_file | gating_files] when gating_files != [] ->
+        pr_body = File.read!(pr_body_file)
+        sources = Enum.map(gating_files, &File.read!/1)
+
+        case Gate.ac_linkage(pr_body, sources) do
+          :ok ->
+            Mix.shell().info("tau.gate.ac_linkage: OK — all claimed AC/D-NNN tokens covered")
+
+          {:error, missing} ->
+            Mix.shell().error(
+              "tau.gate.ac_linkage: FAIL — missing tokens: #{Enum.join(missing, ", ")}"
+            )
+
+            System.halt(1)
+        end
+
+      _ ->
+        Mix.shell().error("usage: mix tau.gate.ac_linkage PR_BODY_FILE GATING_TEST_FILE [...]")
+
+        System.halt(2)
+    end
+  end
+end

--- a/lib/mix/tasks/tau.gate.masking.ex
+++ b/lib/mix/tasks/tau.gate.masking.ex
@@ -1,0 +1,64 @@
+defmodule Mix.Tasks.Tau.Gate.Masking do
+  @shortdoc "Gate 5.2: scan a unified diff for removed assertions. Detection-only; never exits 1."
+
+  @moduledoc """
+  Factory-loop Gate 5.2 — Masking detection (issue #370).
+
+  Scans a unified diff for removed assertion lines (`assert`, `refute`,
+  `assert_receive`, `assert_raise` on `-` lines). Detection-only: outputs
+  any violations found for the `critic` to review but never fails CI by
+  itself (always exits 0).
+
+  ## Usage
+
+      mix tau.gate.masking DIFF_FILE
+
+  `DIFF_FILE` — path to a file containing a unified diff. Use `-` to read
+  from stdin.
+
+  ## Exit codes
+
+  | code | meaning |
+  |------|---------|
+  | 0    | always (detection-only gate) |
+  | 2    | usage error |
+
+  Violations are written to stdout even when found; CI should capture and
+  surface them to the `critic` for review.
+  """
+
+  use Mix.Task
+
+  alias Tau.Factory.Gate
+
+  @impl Mix.Task
+  def run(argv) do
+    case argv do
+      [diff_source] ->
+        diff =
+          if diff_source == "-" do
+            IO.read(:all)
+          else
+            File.read!(diff_source)
+          end
+
+        violations = Gate.masking_violations(diff)
+
+        if violations == [] do
+          Mix.shell().info("tau.gate.masking: OK — no removed assertions detected")
+        else
+          Mix.shell().info("tau.gate.masking: VIOLATIONS DETECTED (surfaced for critic review)")
+
+          Enum.each(violations, fn %{file: file, line: line, removed: removed} ->
+            Mix.shell().info("  #{file}:#{line}: -#{removed}")
+          end)
+        end
+
+        :ok
+
+      _ ->
+        Mix.shell().error("usage: mix tau.gate.masking DIFF_FILE")
+        System.halt(2)
+    end
+  end
+end

--- a/lib/mix/tasks/tau.gate.mutation.ex
+++ b/lib/mix/tasks/tau.gate.mutation.ex
@@ -1,0 +1,61 @@
+defmodule Mix.Tasks.Tau.Gate.Mutation do
+  @shortdoc "Gate 5.3: mutation check — verifies ≥1 gating test fails against the pre-implementer tree."
+
+  @moduledoc """
+  Factory-loop Gate 5.3 — Mutation check (issue #370).
+
+  Keeps the declared gating-test paths at HEAD, reverts every other path
+  to `base_ref` (the pre-implementer commit), runs the gating tests, and
+  exits 0 when ≥1 test fails (the suite is discriminating) or exits 1 when
+  all tests pass (the suite is vacuous — the gating tests do not bind to
+  the implementation change).
+
+  ## Usage
+
+      mix tau.gate.mutation BASE_REF GATING_TEST_FILE [GATING_TEST_FILE ...]
+
+  `BASE_REF` — a git ref (SHA, branch, or tag) representing the
+  pre-implementer state (the test-author's commit, before the implementer
+  added production code).
+
+  `GATING_TEST_FILE` — one or more paths to gating-test files (relative to
+  the repo root).
+
+  ## Exit codes
+
+  | code | meaning |
+  |------|---------|
+  | 0    | ≥1 gating test failed against the reverted tree (discriminating) |
+  | 1    | all gating tests passed against the reverted tree (vacuous suite) |
+  | 2    | usage error |
+  """
+
+  use Mix.Task
+
+  alias Tau.Factory.Gate
+
+  @impl Mix.Task
+  def run(argv) do
+    case argv do
+      [base_ref | gating_files] when gating_files != [] ->
+        case Gate.mutation_check(gating_files, base_ref) do
+          :ok ->
+            Mix.shell().info(
+              "tau.gate.mutation: OK — ≥1 gating test failed against reverted tree (suite is discriminating)"
+            )
+
+          {:error, :all_passed} ->
+            Mix.shell().error(
+              "tau.gate.mutation: FAIL — all gating tests passed against the reverted tree (vacuous suite)"
+            )
+
+            System.halt(1)
+        end
+
+      _ ->
+        Mix.shell().error("usage: mix tau.gate.mutation BASE_REF GATING_TEST_FILE [...]")
+
+        System.halt(2)
+    end
+  end
+end

--- a/lib/tau/factory/gate.ex
+++ b/lib/tau/factory/gate.ex
@@ -21,10 +21,23 @@ defmodule Tau.Factory.Gate do
 
   ## Gate 5.3 — Mutation check (`mutation_check/2`)
 
+  `base_ref` is the PR's merge-base with `main` (computed by
+  `git merge-base origin/main HEAD`). In practice this equals the
+  "pre-implementer" state because the test-author's commits touch only the
+  declared gating-test paths — which the mutation check snapshots and
+  restores separately — so reverting every other path to the merge-base
+  reverts no test-author work.
+
   Keeps the declared gating-test paths at HEAD, reverts every other path
-  to `base_ref`, runs the gating tests, and returns `:ok` when ≥1 test
-  fails (the tests are discriminating) or `{:error, :all_passed}` when
-  none fail (the gating suite is vacuous).
+  to `base_ref`, runs the gating tests via `mix test`, and returns:
+
+  - `:ok` when ≥1 test fails (the tests are discriminating).
+  - `{:error, :all_passed}` when no test fails (the gating suite is vacuous).
+  - `{:error, {:runner_crashed, detail}}` when `mix test` does not emit a
+    valid `"N tests, M failures"` summary — e.g. a compile error or process
+    crash crashed the runner before it could produce a summary. This outcome
+    is DISTINCT from both `:ok` and `{:error, :all_passed}`; callers MUST
+    NOT treat a runner crash as a genuine test result.
   """
 
   # ---------------------------------------------------------------------------
@@ -164,19 +177,30 @@ defmodule Tau.Factory.Gate do
   Orchestrates the mutation check in the current working directory's git repo.
 
   Keeps `gating_test_paths` at HEAD (test-author's state), reverts all other
-  paths to `base_ref` (pre-implementer state), runs the gating tests, then
-  restores the repo to HEAD.
+  paths to `base_ref` (the PR's merge-base with `main`), runs the gating
+  tests via `mix test`, then restores the repo to HEAD.
+
+  `base_ref` is the PR's merge-base with `main` (i.e. `git merge-base
+  origin/main HEAD`). The test-author touches only the declared gating-test
+  paths, which the mutation check snapshots and restores separately, so
+  reverting "everything else" to the merge-base reverts no test-author work —
+  the merge-base and the conceptual "pre-implementer" state are equivalent.
 
   Returns:
   - `:ok` when ≥1 gating test fails against the reverted tree (tests discriminate).
   - `{:error, :all_passed}` when no gating test fails (vacuous suite).
+  - `{:error, {:runner_crashed, detail}}` when `mix test` exits without
+    producing a valid `"N tests, M failures"` summary — e.g. a compile error
+    or process crash prevented the run from completing. Callers MUST treat this
+    as an infrastructure failure, not a genuine test result.
 
   The check is performed in the process's current working directory, which must
   be a git repository. The gating-test paths are kept at their HEAD state;
   all other tracked files are reverted to `base_ref` for the duration of the
   check, then restored.
   """
-  @spec mutation_check([String.t()], String.t()) :: :ok | {:error, :all_passed}
+  @spec mutation_check([String.t()], String.t()) ::
+          :ok | {:error, :all_passed} | {:error, {:runner_crashed, String.t()}}
   def mutation_check(gating_test_paths, base_ref)
       when is_list(gating_test_paths) and is_binary(base_ref) do
     repo_dir = locate_repo_for_gating_tests(gating_test_paths, File.cwd!(), base_ref)
@@ -259,13 +283,16 @@ defmodule Tau.Factory.Gate do
     # Files to revert = all tracked files minus the gating test paths
     paths_to_revert = all_files -- gating_test_paths
 
-    # Revert non-gating files to base_ref (pre-implementer state)
+    # Revert non-gating files to base_ref (pre-implementer state).
+    # PR-added files are absent at base_ref and must be deleted rather than
+    # checked out — git checkout base -- <absent-path> fails or is a no-op.
     revert_to_base(paths_to_revert, base_ref, repo_dir)
 
     # Restore gating test files to their HEAD content (test-author state)
     restore_snapshots(gating_snapshots, repo_dir)
 
-    # Run the gating tests against the reverted tree
+    # Run the gating tests against the reverted tree via mix test.
+    # mix resolves compile order correctly, avoiding fs-order require issues.
     result = run_gating_tests(gating_test_paths, repo_dir)
 
     # Restore all files to HEAD (clean up mutation state)
@@ -288,11 +315,37 @@ defmodule Tau.Factory.Gate do
     end)
   end
 
+  # Revert each non-gating path to base_ref individually, handling two cases:
+  #   - path exists at base_ref: git checkout base_ref -- <path>
+  #   - path was PR-added (absent at base_ref): delete it
   defp revert_to_base([], _base_ref, _repo_dir), do: :ok
 
   defp revert_to_base(paths, base_ref, repo_dir) do
-    {_, 0} = System.cmd("git", ["checkout", base_ref, "--" | paths], cd: repo_dir)
+    Enum.each(paths, fn rel_path ->
+      if path_exists_at_ref?(rel_path, base_ref, repo_dir) do
+        {_, 0} = System.cmd("git", ["checkout", base_ref, "--", rel_path], cd: repo_dir)
+      else
+        # PR-added file: absent at base_ref, must be removed to produce the
+        # pre-implementer tree. git checkout base -- <absent> would fail.
+        abs = Path.join(repo_dir, rel_path)
+        _ = File.rm(abs)
+      end
+    end)
+
     :ok
+  end
+
+  # Returns true iff rel_path exists as a blob object at base_ref in the repo.
+  defp path_exists_at_ref?(rel_path, base_ref, repo_dir) do
+    case System.cmd(
+           "git",
+           ["cat-file", "-e", "#{base_ref}:#{rel_path}"],
+           cd: repo_dir,
+           stderr_to_stdout: true
+         ) do
+      {_, 0} -> true
+      _ -> false
+    end
   end
 
   defp restore_snapshots(snapshots, repo_dir) do
@@ -310,37 +363,84 @@ defmodule Tau.Factory.Gate do
     :ok
   end
 
+  # Run the gating tests, distinguishing three outcomes by parsing the ExUnit
+  # "N tests, M failures" summary line:
+  #
+  #   - summary present, M > 0  → :ok                           (tests discriminate)
+  #   - summary present, M == 0 → {:error, :all_passed}         (vacuous suite)
+  #   - no summary at all       → {:error, {:runner_crashed, output}}
+  #                               (compile error / process crash / no mix.exs)
+  #
+  # Uses `mix test` when a mix.exs is present in repo_dir (the normal CI case).
+  # Falls back to a direct `elixir` runner for minimal synthetic repos (tests).
+  # Both paths parse the same ExUnit summary line.
   defp run_gating_tests(gating_test_paths, repo_dir) do
-    # Collect lib/*.ex source files to require (production code at current state)
+    output =
+      if File.exists?(Path.join(repo_dir, "mix.exs")) do
+        run_via_mix(gating_test_paths, repo_dir)
+      else
+        run_via_elixir(gating_test_paths, repo_dir)
+      end
+
+    case parse_test_summary(output) do
+      {:ok, failures} when failures > 0 ->
+        :ok
+
+      {:ok, 0} ->
+        {:error, :all_passed}
+
+      :no_summary ->
+        {:error, {:runner_crashed, output}}
+    end
+  end
+
+  # Run gating tests with `mix test` (compile-order-correct; requires mix.exs).
+  defp run_via_mix(gating_test_paths, repo_dir) do
+    {output, _} =
+      System.cmd("mix", ["test" | gating_test_paths], cd: repo_dir, stderr_to_stdout: true)
+
+    output
+  end
+
+  # Run gating tests with `elixir` directly for minimal synthetic repos.
+  # Requires lib/*.ex files in the repo, then requires the gating test files.
+  # For single-module mini-repos this is compile-order-safe.
+  defp run_via_elixir(gating_test_paths, repo_dir) do
     lib_files = find_lib_files_recursive(repo_dir)
 
-    # Build a runner script: start ExUnit, require production files, require
-    # gating test files, run, halt with 1 on any failure.
     requires =
       (lib_files ++ gating_test_paths)
-      |> Enum.map_join("\n", fn p -> ~s[Code.require_file("#{p}")] end)
+      |> Enum.map_join("\n", fn p -> ~s[Code.require_file("#{p}", "#{repo_dir}")] end)
 
     runner = """
     ExUnit.start()
     #{requires}
-    result = ExUnit.run()
-    if result.failures > 0, do: System.halt(1)
+    ExUnit.run()
     """
 
-    runner_path = Path.join(repo_dir, "_mutation_runner_#{:erlang.unique_integer([:positive])}.exs")
+    runner_path =
+      Path.join(repo_dir, "_mutation_runner_#{:erlang.unique_integer([:positive])}.exs")
+
     File.write!(runner_path, runner)
 
-    result =
+    {output, _} =
       try do
-        case System.cmd("elixir", [runner_path], cd: repo_dir, stderr_to_stdout: true) do
-          {_, 0} -> {:error, :all_passed}
-          {_, _} -> :ok
-        end
+        System.cmd("elixir", [runner_path], cd: repo_dir, stderr_to_stdout: true)
       after
         File.rm(runner_path)
       end
 
-    result
+    output
+  end
+
+  # Parse the ExUnit summary line, e.g. "3 tests, 1 failure" or "3 tests, 0 failures".
+  # Returns {:ok, failure_count} or :no_summary.
+  defp parse_test_summary(output) do
+    # Match lines like "3 tests, 1 failure" or "5 tests, 2 failures" or "1 test, 0 failures"
+    case Regex.run(~r/\d+ tests?,\s*(\d+) failures?/, output) do
+      [_, failures_str] -> {:ok, String.to_integer(failures_str)}
+      nil -> :no_summary
+    end
   end
 
   # Recursively collect .ex files under the repo's lib/ directory.

--- a/lib/tau/factory/gate.ex
+++ b/lib/tau/factory/gate.ex
@@ -55,17 +55,46 @@ defmodule Tau.Factory.Gate do
 
   Matching is case-insensitive on the tag side (`:ac_1`, `:d_200`) and
   substring on the test-name side (`"AC-1: ..."`, `"D-200: ..."`).
+
+  ## Meta-AC exemption
+
+  An AC whose identifier is immediately followed by the marker `(meta)`
+  (with optional surrounding `**` markdown bold) is a *meta-AC* — it is
+  verified by CI wiring or inspection, not a unit gating test. Meta-ACs
+  are exempt from the linkage check: they are never reported as missing.
+  An AC is considered meta if ANY occurrence of `AC-N (meta)` exists in
+  `pr_body` (allowing optional whitespace between the token and the marker).
+
+  Examples of meta-AC forms recognised in a PR body:
+  - `AC-4 (meta)` — plain
+  - `**AC-4 (meta)**` — markdown bold
   """
   @spec ac_linkage(String.t(), [String.t()]) :: :ok | {:error, [String.t()]}
   def ac_linkage(pr_body, gating_test_sources)
       when is_binary(pr_body) and is_list(gating_test_sources) do
+    meta_acs = parse_meta_ac_tokens(pr_body)
     claimed = parse_ac_tokens(pr_body)
-    missing = Enum.reject(claimed, &token_covered?(&1, gating_test_sources))
+    non_meta = Enum.reject(claimed, &MapSet.member?(meta_acs, &1))
+    missing = Enum.reject(non_meta, &token_covered?(&1, gating_test_sources))
 
     case missing do
       [] -> :ok
       _ -> {:error, missing}
     end
+  end
+
+  # Parse AC-N tokens that are marked as meta (exempt from the linkage gate).
+  # An AC is meta if ANY occurrence in pr_body is immediately followed by
+  # "(meta)" (optionally with surrounding ** bold markers and optional
+  # whitespace between the token and the marker).
+  defp parse_meta_ac_tokens(pr_body) do
+    # Matches forms like: AC-4 (meta), **AC-4 (meta)**, AC-4  (meta)
+    meta_pattern = ~r/\bAC-(\d+)\s*\(meta\)/
+
+    Regex.scan(meta_pattern, pr_body, capture: :all_but_first)
+    |> List.flatten()
+    |> Enum.map(&"AC-#{&1}")
+    |> MapSet.new()
   end
 
   # Parse all AC-N and D-NNN tokens from the PR body.

--- a/lib/tau/factory/gate.ex
+++ b/lib/tau/factory/gate.ex
@@ -1,0 +1,375 @@
+defmodule Tau.Factory.Gate do
+  @moduledoc """
+  Pure module implementing the three mechanical oracle-separation CI gates
+  for the factory loop (issue #370 / PR-B).
+
+  All three functions are side-effect-free with respect to module state —
+  no process, no ETS, no GenServer. `mutation_check/2` shells out to run
+  tests in the supplied git repo directory; that is its only I/O.
+
+  ## Gate 5.1 — AC-to-test linkage (`ac_linkage/2`)
+
+  Parses every `AC-N` / `D-NNN` token from the draft-PR body and returns
+  the subset not found (as a test name substring or `@tag`) in any of the
+  supplied gating-test source strings.
+
+  ## Gate 5.2 — Masking detection (`masking_violations/1`)
+
+  Scans a unified diff for removed assertion lines (lines starting with
+  `-` that contain `assert`, `refute`, `assert_receive`, or
+  `assert_raise`). Detection-only — returns the list for review.
+
+  ## Gate 5.3 — Mutation check (`mutation_check/2`)
+
+  Keeps the declared gating-test paths at HEAD, reverts every other path
+  to `base_ref`, runs the gating tests, and returns `:ok` when ≥1 test
+  fails (the tests are discriminating) or `{:error, :all_passed}` when
+  none fail (the gating suite is vacuous).
+  """
+
+  # ---------------------------------------------------------------------------
+  # Gate 5.1 — AC-to-test linkage
+  # ---------------------------------------------------------------------------
+
+  @doc """
+  Returns `:ok` when every `AC-N` / `D-NNN` token in `pr_body` appears in
+  at least one of `gating_test_sources` (as a test name substring or
+  `@tag`), or `{:error, missing}` listing those that do not.
+
+  Token format:
+  - `AC-N` — one or more digits, e.g. `AC-1`, `AC-12`
+  - `D-NNN` — one or more digits, e.g. `D-200`, `D-031`
+
+  Matching is case-insensitive on the tag side (`:ac_1`, `:d_200`) and
+  substring on the test-name side (`"AC-1: ..."`, `"D-200: ..."`).
+  """
+  @spec ac_linkage(String.t(), [String.t()]) :: :ok | {:error, [String.t()]}
+  def ac_linkage(pr_body, gating_test_sources)
+      when is_binary(pr_body) and is_list(gating_test_sources) do
+    claimed = parse_ac_tokens(pr_body)
+    missing = Enum.reject(claimed, &token_covered?(&1, gating_test_sources))
+
+    case missing do
+      [] -> :ok
+      _ -> {:error, missing}
+    end
+  end
+
+  # Parse all AC-N and D-NNN tokens from the PR body.
+  defp parse_ac_tokens(pr_body) do
+    ac_pattern = ~r/\bAC-\d+\b/
+    d_pattern = ~r/\bD-\d+\b/
+
+    ac_tokens = Regex.scan(ac_pattern, pr_body) |> List.flatten()
+    d_tokens = Regex.scan(d_pattern, pr_body) |> List.flatten()
+
+    (ac_tokens ++ d_tokens) |> Enum.uniq()
+  end
+
+  # Check if a token (e.g. "AC-1" or "D-200") is covered in any source.
+  defp token_covered?(token, sources) do
+    # Normalise to tag form: "AC-1" -> "ac_1", "D-200" -> "d_200"
+    tag_form = token |> String.downcase() |> String.replace("-", "_")
+    # Also match as substring in test names, e.g. "AC-1: ..." or "D-200: ..."
+    Enum.any?(sources, fn source ->
+      String.contains?(source, ":#{tag_form}") or
+        String.contains?(source, "\"#{token}") or
+        String.contains?(source, "\"#{tag_form}")
+    end)
+  end
+
+  # ---------------------------------------------------------------------------
+  # Gate 5.2 — Masking detection
+  # ---------------------------------------------------------------------------
+
+  @doc """
+  Scans `unified_diff` for removed assertion lines.
+
+  A removed assertion line is a `-`-prefixed line (not `---` file header)
+  whose content contains `assert`, `refute`, `assert_receive`, or
+  `assert_raise`.
+
+  Returns a list of maps `%{file: String.t(), line: integer(), removed: String.t()}`.
+  `line` is the original-file line number (parsed from `@@ -L,N` hunks).
+  `removed` is the raw content of the `-` line (without the leading `-`).
+  """
+  @spec masking_violations(String.t()) :: [
+          %{file: String.t(), line: integer(), removed: String.t()}
+        ]
+  def masking_violations(unified_diff) when is_binary(unified_diff) do
+    lines = String.split(unified_diff, "\n")
+    parse_diff_lines(lines, nil, 0, [])
+  end
+
+  # State machine over diff lines:
+  #   current_file — path of file being diffed (nil until first "diff --git")
+  #   orig_line    — current original-file line counter (reset per hunk)
+  defp parse_diff_lines([], _file, _orig_line, acc), do: Enum.reverse(acc)
+
+  defp parse_diff_lines([h | t], current_file, orig_line, acc) do
+    cond do
+      # File header — e.g. "+++ b/test/foo.exs"
+      String.starts_with?(h, "+++ b/") ->
+        file = String.slice(h, 6..-1//1)
+        parse_diff_lines(t, file, orig_line, acc)
+
+      # Hunk header — e.g. "@@ -3,7 +3,6 @@"
+      String.starts_with?(h, "@@") ->
+        orig = parse_hunk_orig_line(h)
+        parse_diff_lines(t, current_file, orig, acc)
+
+      # Removed line (but not the "---" file header)
+      String.starts_with?(h, "-") and not String.starts_with?(h, "---") ->
+        content = String.slice(h, 1..-1//1)
+
+        acc2 =
+          if assertion_line?(content) do
+            [%{file: current_file, line: orig_line, removed: content} | acc]
+          else
+            acc
+          end
+
+        # Removed lines advance the original-file counter
+        parse_diff_lines(t, current_file, orig_line + 1, acc2)
+
+      # Added line — does NOT advance original-file counter
+      String.starts_with?(h, "+") and not String.starts_with?(h, "+++") ->
+        parse_diff_lines(t, current_file, orig_line, acc)
+
+      # Context line — advances original-file counter
+      true ->
+        parse_diff_lines(t, current_file, orig_line + 1, acc)
+    end
+  end
+
+  @assertion_keywords ~w[assert refute assert_receive assert_raise]
+
+  defp assertion_line?(content) do
+    Enum.any?(@assertion_keywords, &String.contains?(content, &1))
+  end
+
+  # Parse the original starting line from a hunk header like "@@ -3,7 +3,6 @@"
+  defp parse_hunk_orig_line(hunk_header) do
+    case Regex.run(~r/@@ -(\d+)/, hunk_header) do
+      [_, n] -> String.to_integer(n)
+      _ -> 0
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Gate 5.3 — Mutation check
+  # ---------------------------------------------------------------------------
+
+  @doc """
+  Orchestrates the mutation check in the current working directory's git repo.
+
+  Keeps `gating_test_paths` at HEAD (test-author's state), reverts all other
+  paths to `base_ref` (pre-implementer state), runs the gating tests, then
+  restores the repo to HEAD.
+
+  Returns:
+  - `:ok` when ≥1 gating test fails against the reverted tree (tests discriminate).
+  - `{:error, :all_passed}` when no gating test fails (vacuous suite).
+
+  The check is performed in the process's current working directory, which must
+  be a git repository. The gating-test paths are kept at their HEAD state;
+  all other tracked files are reverted to `base_ref` for the duration of the
+  check, then restored.
+  """
+  @spec mutation_check([String.t()], String.t()) :: :ok | {:error, :all_passed}
+  def mutation_check(gating_test_paths, base_ref)
+      when is_list(gating_test_paths) and is_binary(base_ref) do
+    repo_dir = locate_repo_for_gating_tests(gating_test_paths, File.cwd!(), base_ref)
+    mutation_check_in(gating_test_paths, base_ref, repo_dir)
+  end
+
+  # Locate the git repo root that contains the gating test files AND the given
+  # base_ref commit.
+  #
+  # Primary: if the first gating test path resolves under `cwd` AND `base_ref`
+  # is accessible in `cwd`'s git repo, use `cwd` directly.
+  # Fallback: search recursively under `cwd` for a `.git`-bearing directory
+  # that (a) contains the first gating test path and (b) can resolve `base_ref`.
+  # This fallback handles test environments where ExUnit creates a per-test
+  # subdirectory with its own git repo (e.g. `:tmp_dir` tests).
+  defp locate_repo_for_gating_tests([], cwd, _base_ref), do: cwd
+
+  defp locate_repo_for_gating_tests([first | _], cwd, base_ref) do
+    primary = Path.join(cwd, first)
+
+    if File.exists?(primary) and ref_accessible?(base_ref, cwd) do
+      cwd
+    else
+      find_repo_containing_path_and_ref(first, base_ref, cwd) || cwd
+    end
+  end
+
+  # Check if `base_ref` is accessible as a git object in `repo_dir`.
+  defp ref_accessible?(base_ref, repo_dir) do
+    case System.cmd("git", ["cat-file", "-t", base_ref], cd: repo_dir, stderr_to_stdout: true) do
+      {_, 0} -> true
+      _ -> false
+    end
+  end
+
+  # Depth-limited recursive search for a directory that:
+  #   - contains a `.git` subdirectory,
+  #   - has the relative `rel_path` under it, and
+  #   - can resolve `base_ref` as a git object.
+  defp find_repo_containing_path_and_ref(rel_path, base_ref, start_dir, max_depth \\ 5) do
+    do_find_repo(rel_path, base_ref, start_dir, max_depth)
+  end
+
+  defp do_find_repo(_rel_path, _base_ref, _dir, 0), do: nil
+
+  defp do_find_repo(rel_path, base_ref, dir, depth) do
+    case File.ls(dir) do
+      {:error, _} ->
+        nil
+
+      {:ok, entries} ->
+        subdirs =
+          entries
+          |> Enum.map(&Path.join(dir, &1))
+          |> Enum.filter(&File.dir?/1)
+          |> Enum.reject(&(Path.basename(&1) |> String.starts_with?(".")))
+
+        Enum.find_value(subdirs, fn subdir ->
+          git_dir = Path.join(subdir, ".git")
+          candidate = Path.join(subdir, rel_path)
+
+          if File.exists?(git_dir) and File.exists?(candidate) and
+               ref_accessible?(base_ref, subdir) do
+            subdir
+          else
+            do_find_repo(rel_path, base_ref, subdir, depth - 1)
+          end
+        end)
+    end
+  end
+
+  defp mutation_check_in(gating_test_paths, base_ref, repo_dir) do
+    # Capture HEAD content of gating test files (before any reverting)
+    gating_snapshots = snapshot_files(gating_test_paths, repo_dir)
+
+    # Get all tracked files in HEAD of the repo
+    {all_files_str, 0} = System.cmd("git", ["ls-files"], cd: repo_dir)
+    all_files = all_files_str |> String.split("\n", trim: true)
+
+    # Files to revert = all tracked files minus the gating test paths
+    paths_to_revert = all_files -- gating_test_paths
+
+    # Revert non-gating files to base_ref (pre-implementer state)
+    revert_to_base(paths_to_revert, base_ref, repo_dir)
+
+    # Restore gating test files to their HEAD content (test-author state)
+    restore_snapshots(gating_snapshots, repo_dir)
+
+    # Run the gating tests against the reverted tree
+    result = run_gating_tests(gating_test_paths, repo_dir)
+
+    # Restore all files to HEAD (clean up mutation state)
+    restore_head(all_files, repo_dir)
+
+    result
+  end
+
+  defp snapshot_files(paths, repo_dir) do
+    Enum.map(paths, fn rel_path ->
+      abs = Path.join(repo_dir, rel_path)
+
+      content =
+        case File.read(abs) do
+          {:ok, c} -> c
+          {:error, _} -> nil
+        end
+
+      {rel_path, content}
+    end)
+  end
+
+  defp revert_to_base([], _base_ref, _repo_dir), do: :ok
+
+  defp revert_to_base(paths, base_ref, repo_dir) do
+    {_, 0} = System.cmd("git", ["checkout", base_ref, "--" | paths], cd: repo_dir)
+    :ok
+  end
+
+  defp restore_snapshots(snapshots, repo_dir) do
+    Enum.each(snapshots, fn {rel_path, content} ->
+      if content != nil do
+        abs = Path.join(repo_dir, rel_path)
+        File.mkdir_p!(Path.dirname(abs))
+        File.write!(abs, content)
+      end
+    end)
+  end
+
+  defp restore_head(paths, repo_dir) do
+    {_, _} = System.cmd("git", ["checkout", "HEAD", "--" | paths], cd: repo_dir)
+    :ok
+  end
+
+  defp run_gating_tests(gating_test_paths, repo_dir) do
+    # Collect lib/*.ex source files to require (production code at current state)
+    lib_files = find_lib_files_recursive(repo_dir)
+
+    # Build a runner script: start ExUnit, require production files, require
+    # gating test files, run, halt with 1 on any failure.
+    requires =
+      (lib_files ++ gating_test_paths)
+      |> Enum.map_join("\n", fn p -> ~s[Code.require_file("#{p}")] end)
+
+    runner = """
+    ExUnit.start()
+    #{requires}
+    result = ExUnit.run()
+    if result.failures > 0, do: System.halt(1)
+    """
+
+    runner_path = Path.join(repo_dir, "_mutation_runner_#{:erlang.unique_integer([:positive])}.exs")
+    File.write!(runner_path, runner)
+
+    result =
+      try do
+        case System.cmd("elixir", [runner_path], cd: repo_dir, stderr_to_stdout: true) do
+          {_, 0} -> {:error, :all_passed}
+          {_, _} -> :ok
+        end
+      after
+        File.rm(runner_path)
+      end
+
+    result
+  end
+
+  # Recursively collect .ex files under the repo's lib/ directory.
+  defp find_lib_files_recursive(repo_dir) do
+    lib_dir = Path.join(repo_dir, "lib")
+
+    if File.dir?(lib_dir) do
+      do_find_ex_files(lib_dir, repo_dir)
+    else
+      []
+    end
+  end
+
+  defp do_find_ex_files(dir, repo_dir) do
+    case File.ls(dir) do
+      {:error, _} ->
+        []
+
+      {:ok, entries} ->
+        Enum.flat_map(entries, fn entry ->
+          abs = Path.join(dir, entry)
+          rel = Path.relative_to(abs, repo_dir)
+
+          cond do
+            File.regular?(abs) and String.ends_with?(entry, ".ex") -> [rel]
+            File.dir?(abs) -> do_find_ex_files(abs, repo_dir)
+            true -> []
+          end
+        end)
+    end
+  end
+end

--- a/test/support/factory/.gitkeep
+++ b/test/support/factory/.gitkeep
@@ -1,0 +1,4 @@
+# Declared gating-test fixture slot for #370 (Tau.Factory.Gate).
+# The AC-3 mutation_check/2 fixture is a synthetic git repo built at runtime
+# under the per-test ExUnit :tmp_dir, so no static fixture file is needed here.
+# This marker keeps the declared `test/support/factory/` path present.

--- a/test/tau/factory/gate_test.exs
+++ b/test/tau/factory/gate_test.exs
@@ -12,6 +12,8 @@ defmodule Tau.Factory.GateTest do
   """
   use ExUnit.Case, async: true
 
+  alias Tau.Factory.Gate
+
   # ---------------------------------------------------------------------------
   # AC-1 — Tau.Factory.Gate.ac_linkage/2
   #
@@ -52,7 +54,7 @@ defmodule Tau.Factory.GateTest do
         """
       ]
 
-      assert {:error, missing} = Tau.Factory.Gate.ac_linkage(@pr_body, sources)
+      assert {:error, missing} = Gate.ac_linkage(@pr_body, sources)
       assert "AC-2" in missing
       refute "AC-1" in missing
       refute "D-200" in missing
@@ -77,7 +79,7 @@ defmodule Tau.Factory.GateTest do
         """
       ]
 
-      assert :ok = Tau.Factory.Gate.ac_linkage(@pr_body, sources)
+      assert :ok = Gate.ac_linkage(@pr_body, sources)
     end
   end
 
@@ -122,7 +124,7 @@ defmodule Tau.Factory.GateTest do
     """
 
     test "AC-2: returns the removed-assertion list for a diff that deletes an assert" do
-      violations = Tau.Factory.Gate.masking_violations(@diff_with_removed_assert)
+      violations = Gate.masking_violations(@diff_with_removed_assert)
 
       assert is_list(violations)
       assert length(violations) == 1
@@ -135,7 +137,7 @@ defmodule Tau.Factory.GateTest do
     end
 
     test "AC-2: returns [] for a diff that deletes no assertion" do
-      assert [] = Tau.Factory.Gate.masking_violations(@diff_without_removed_assert)
+      assert [] = Gate.masking_violations(@diff_without_removed_assert)
     end
   end
 
@@ -209,7 +211,7 @@ defmodule Tau.Factory.GateTest do
       run.(["commit", "-q", "-m", "head"])
 
       assert :ok =
-               Tau.Factory.Gate.mutation_check(["test/widget_gate_test.exs"], base_ref)
+               Gate.mutation_check(["test/widget_gate_test.exs"], base_ref)
     after
       _ = tmp_dir
     end
@@ -233,7 +235,7 @@ defmodule Tau.Factory.GateTest do
       run.(["commit", "-q", "-m", "head"])
 
       assert {:error, :all_passed} =
-               Tau.Factory.Gate.mutation_check(["test/widget_gate_test.exs"], base_ref)
+               Gate.mutation_check(["test/widget_gate_test.exs"], base_ref)
     after
       _ = tmp_dir
     end

--- a/test/tau/factory/gate_test.exs
+++ b/test/tau/factory/gate_test.exs
@@ -160,6 +160,7 @@ defmodule Tau.Factory.GateTest do
 
   describe "mutation_check/2 (AC-3)" do
     @describetag :ac_3
+    @describetag tmp_dir: true
 
     setup %{tmp_dir: tmp_dir} do
       # Build a synthetic two-state git repo:

--- a/test/tau/factory/gate_test.exs
+++ b/test/tau/factory/gate_test.exs
@@ -81,6 +81,61 @@ defmodule Tau.Factory.GateTest do
 
       assert :ok = Gate.ac_linkage(@pr_body, sources)
     end
+
+    # Meta-AC convention (PR #371): an AC whose identifier is immediately
+    # followed by the marker `(meta)` is verified by CI wiring / inspection,
+    # not by a unit gating test, and is EXEMPT from the linkage gate — it
+    # MUST NOT be reported as missing even with no matching test tag. The
+    # exemption is specific to the `(meta)` marker: a non-meta AC with no
+    # test is still reported missing.
+    @meta_pr_body """
+    ## Acceptance criteria
+
+    - **AC-1** the linkage gate parses claimed ACs.
+    - **AC-2** the masking gate scans diffs.
+    - **AC-3 (meta)** the gates are wired into CI; verified by CI, not a unit test.
+
+    ## Test plan
+    fixture-driven fail-before/pass-after cases.
+    """
+
+    test "AC-1: exempts a (meta)-marked AC from the linkage gate while still flagging a non-meta gap" do
+      # Sources cover AC-1 and AC-2, but NOT AC-3. AC-3 carries the `(meta)`
+      # marker in @meta_pr_body, so it must be exempt — never reported missing.
+      meta_covered_sources = [
+        """
+        defmodule MetaCoverageTest do
+          @tag :ac_1
+          test "AC-1: linkage" do
+          end
+
+          @tag :ac_2
+          test "AC-2: masking" do
+          end
+        end
+        """
+      ]
+
+      assert :ok = Gate.ac_linkage(@meta_pr_body, meta_covered_sources)
+
+      # Negative control: drop AC-2's coverage too. AC-2 is NOT meta-marked,
+      # so it MUST still be reported missing — proving the exemption is
+      # specific to the `(meta)` marker, not a blanket skip. AC-3 stays exempt.
+      non_meta_gap_sources = [
+        """
+        defmodule PartialCoverageTest do
+          @tag :ac_1
+          test "AC-1: linkage" do
+          end
+        end
+        """
+      ]
+
+      assert {:error, missing} = Gate.ac_linkage(@meta_pr_body, non_meta_gap_sources)
+      assert "AC-2" in missing
+      refute "AC-3" in missing
+      refute "AC-1" in missing
+    end
   end
 
   # ---------------------------------------------------------------------------

--- a/test/tau/factory/gate_test.exs
+++ b/test/tau/factory/gate_test.exs
@@ -1,0 +1,240 @@
+defmodule Tau.Factory.GateTest do
+  @moduledoc """
+  Gating tests for #370 — factory "oracle separation" PR-B: the three
+  mechanical CI gates of `Tau.Factory.Gate`.
+
+  Authored by the `test-author` agent BEFORE any production code exists.
+  `Tau.Factory.Gate` does not yet exist; these tests are expected to fail
+  (compile error / UndefinedFunctionError) until the implementer lands the
+  module — that fail-before is the correct state.
+
+  Each test references the AC it gates (AC-1 / AC-2 / AC-3).
+  """
+  use ExUnit.Case, async: true
+
+  # ---------------------------------------------------------------------------
+  # AC-1 — Tau.Factory.Gate.ac_linkage/2
+  #
+  # "ac_linkage/2 returns {:error, [...]} for a PR body whose claimed AC-N has
+  #  no matching gating-test name/tag, and :ok when every claimed AC is present."
+  #
+  # Contract: ac_linkage(pr_body, gating_test_sources) ::
+  #             :ok | {:error, [missing :: String.t()]}
+  # ---------------------------------------------------------------------------
+
+  describe "ac_linkage/2 (AC-1)" do
+    @describetag :ac_1
+
+    @pr_body """
+    ## Acceptance criteria
+
+    - **AC-1** the linkage gate parses claimed ACs.
+    - **AC-2** the masking gate scans diffs.
+    - **D-200** the mutation check reverts non-gating paths.
+
+    ## Test plan
+    fixture-driven fail-before/pass-after cases.
+    """
+
+    test "AC-1: returns {:error, [missing]} when a claimed AC has no matching test name/tag" do
+      # A gating-test source that covers AC-1 and D-200 but NOT AC-2.
+      sources = [
+        """
+        defmodule SomeTest do
+          @tag :ac_1
+          test "AC-1: something" do
+          end
+
+          @tag :d_200
+          test "D-200: mutation revert" do
+          end
+        end
+        """
+      ]
+
+      assert {:error, missing} = Tau.Factory.Gate.ac_linkage(@pr_body, sources)
+      assert "AC-2" in missing
+      refute "AC-1" in missing
+      refute "D-200" in missing
+    end
+
+    test "AC-1: returns :ok when every claimed AC/D-NNN appears in a gating-test source" do
+      sources = [
+        """
+        defmodule FullCoverageTest do
+          @tag :ac_1
+          test "AC-1: linkage" do
+          end
+
+          @tag :ac_2
+          test "AC-2: masking" do
+          end
+
+          @tag :d_200
+          test "D-200: mutation" do
+          end
+        end
+        """
+      ]
+
+      assert :ok = Tau.Factory.Gate.ac_linkage(@pr_body, sources)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # AC-2 — Tau.Factory.Gate.masking_violations/1
+  #
+  # "masking_violations/1 returns the removed-assertion list for a diff that
+  #  deletes an assert, and [] for a diff that deletes no assertion."
+  #
+  # Contract: masking_violations(unified_diff) :: [%{file, line, removed}]
+  # ---------------------------------------------------------------------------
+
+  describe "masking_violations/1 (AC-2)" do
+    @describetag :ac_2
+
+    @diff_with_removed_assert """
+    diff --git a/test/tau/example_test.exs b/test/tau/example_test.exs
+    index 1111111..2222222 100644
+    --- a/test/tau/example_test.exs
+    +++ b/test/tau/example_test.exs
+    @@ -3,7 +3,6 @@ defmodule Tau.ExampleTest do
+       test "it works" do
+         result = Tau.Example.run()
+    -    assert result == :ok
+         refute result == :error
+       end
+     end
+    """
+
+    @diff_without_removed_assert """
+    diff --git a/test/tau/example_test.exs b/test/tau/example_test.exs
+    index 1111111..2222222 100644
+    --- a/test/tau/example_test.exs
+    +++ b/test/tau/example_test.exs
+    @@ -3,6 +3,7 @@ defmodule Tau.ExampleTest do
+       test "it works" do
+         result = Tau.Example.run()
+         assert result == :ok
+    +    refute result == :error
+       end
+     end
+    """
+
+    test "AC-2: returns the removed-assertion list for a diff that deletes an assert" do
+      violations = Tau.Factory.Gate.masking_violations(@diff_with_removed_assert)
+
+      assert is_list(violations)
+      assert length(violations) == 1
+      [violation] = violations
+
+      assert %{file: file, line: line, removed: removed} = violation
+      assert file == "test/tau/example_test.exs"
+      assert is_integer(line)
+      assert removed =~ "assert result == :ok"
+    end
+
+    test "AC-2: returns [] for a diff that deletes no assertion" do
+      assert [] = Tau.Factory.Gate.masking_violations(@diff_without_removed_assert)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # AC-3 — Tau.Factory.Gate.mutation_check/2
+  #
+  # "mutation_check/2 returns {:error, :all_passed} for a synthetic case where
+  #  the gating tests pass against the reverted (pre-implementer) tree, and :ok
+  #  when ≥1 gating test fails against it."
+  #
+  # Contract: mutation_check(gating_test_paths, base_ref) ::
+  #             :ok | {:error, :all_passed}
+  #
+  # The check keeps the declared gating-test paths at HEAD, reverts every other
+  # path to base_ref, runs the gating tests, and reports :ok iff ≥1 gating test
+  # fails against the reverted tree.
+  #
+  # Fixture: a real synthetic git repo under the per-test :tmp_dir, with a base
+  # commit (production module absent / wrong) and a HEAD commit (production
+  # module correct + gating test added). Self-contained and deterministic.
+  # ---------------------------------------------------------------------------
+
+  describe "mutation_check/2 (AC-3)" do
+    @describetag :ac_3
+
+    setup %{tmp_dir: tmp_dir} do
+      # Build a synthetic two-state git repo:
+      #   base commit: prod module returns :wrong  (gating test would FAIL here)
+      #   HEAD commit: prod module returns :ok      (gating test PASSES here)
+      #                + the gating test itself is added at HEAD.
+      run = fn args -> {_, 0} = System.cmd("git", args, cd: tmp_dir) end
+
+      run.(["init", "-q"])
+      run.(["config", "user.email", "test@example.com"])
+      run.(["config", "user.name", "Test"])
+
+      File.mkdir_p!(Path.join(tmp_dir, "lib"))
+      File.mkdir_p!(Path.join(tmp_dir, "test"))
+
+      prod = Path.join(tmp_dir, "lib/widget.ex")
+      gating = Path.join(tmp_dir, "test/widget_gate_test.exs")
+
+      # --- base commit: production code is "wrong", no gating test yet ---
+      File.write!(prod, "defmodule Widget do\n  def run, do: :wrong\nend\n")
+      run.(["add", "-A"])
+      run.(["commit", "-q", "-m", "base"])
+      {base_ref, 0} = System.cmd("git", ["rev-parse", "HEAD"], cd: tmp_dir)
+      base_ref = String.trim(base_ref)
+
+      # --- HEAD commit: production code fixed + gating test added ---
+      File.write!(prod, "defmodule Widget do\n  def run, do: :ok\nend\n")
+
+      %{tmp_dir: tmp_dir, base_ref: base_ref, prod: prod, gating: gating, run: run}
+    end
+
+    test "AC-3: returns :ok when ≥1 gating test fails against the reverted tree",
+         %{tmp_dir: tmp_dir, base_ref: base_ref, gating: gating, run: run} do
+      # The gating test asserts run() == :ok. Against the reverted base tree
+      # (run() == :wrong) it FAILS — so the gate must return :ok.
+      File.write!(gating, """
+      defmodule WidgetGateTest do
+        use ExUnit.Case
+        test "AC: widget runs ok" do
+          assert Widget.run() == :ok
+        end
+      end
+      """)
+
+      run.(["add", "-A"])
+      run.(["commit", "-q", "-m", "head"])
+
+      assert :ok =
+               Tau.Factory.Gate.mutation_check(["test/widget_gate_test.exs"], base_ref)
+    after
+      _ = tmp_dir
+    end
+
+    test "AC-3: returns {:error, :all_passed} when the gating tests pass against the reverted tree",
+         %{tmp_dir: tmp_dir, base_ref: base_ref, gating: gating, run: run} do
+      # This gating test does NOT bind to the implementer's change — it asserts
+      # something true in BOTH trees. Against the reverted base tree it still
+      # PASSES — a vacuous gating suite — so the gate must return
+      # {:error, :all_passed}.
+      File.write!(gating, """
+      defmodule WidgetGateTest do
+        use ExUnit.Case
+        test "AC: widget module is defined" do
+          assert function_exported?(Widget, :run, 0)
+        end
+      end
+      """)
+
+      run.(["add", "-A"])
+      run.(["commit", "-q", "-m", "head"])
+
+      assert {:error, :all_passed} =
+               Tau.Factory.Gate.mutation_check(["test/widget_gate_test.exs"], base_ref)
+    after
+      _ = tmp_dir
+    end
+  end
+end


### PR DESCRIPTION
## Closes

Closes #368 (part 2 of 2) and Closes #370. Part 1 was PR #369 (the
`test-author` process). This PR implements the three mechanical
test-discipline gates that PR #369's `factory-loop.md` specifies and
marks *pending PR-B*.

**This is the first PR dogfooded through the new `test-author` phase 4b**
— its gating tests are authored by a separate `test-author` agent before
the implementer is spawned.

## Scope & order

The three gates are implemented as a pure module `Tau.Factory.Gate` with
no process state (PSDH triage <2 — CI tooling, not a coordination-heavy
runtime component, so no `SPEC-*.md`), plus thin mix-task wrappers and CI
wiring.

1. **`Tau.Factory.Gate.ac_linkage/2`** — `ac_linkage(pr_body, gating_test_sources) :: :ok | {:error, [missing :: String.t()]}`. Parses every `AC-N` / `D-NNN` token the draft-PR body claims; returns the set not found in any supplied gating-test source (test name or `@tag`).
2. **`Tau.Factory.Gate.masking_violations/1`** — `masking_violations(unified_diff) :: [%{file, line, removed}]`. Scans a unified diff for removed assertions (`assert` / `refute` / `assert_receive` / `assert_raise` on `-` lines). Detection-only — it returns the list for the `critic` to review; it does not itself pass/fail on a tag.
3. **`Tau.Factory.Gate.mutation_check/2`** — given the declared gating-test path set and the pre-implementer base ref, orchestrates: keep the gating-test paths at HEAD, revert every other path to the base, run the gating tests, return `:ok` when ≥1 fails / `{:error, :all_passed}` when none fail (a vacuous gating-test suite).
4. **Mix-task wrappers** — `mix tau.gate.ac_linkage`, `mix tau.gate.masking`, `mix tau.gate.mutation` (thin; parse argv, call the module, set exit status).
5. **CI wiring** — `.github/workflows/ci.yml`: AC-linkage + masking as steps in the existing `lint` job (diff-based, fast); the mutation check as a dedicated job. AC-linkage and the mutation check are blocking; masking is detection-only (surfaces to the critic, never hard-fails CI).
6. **Remove the `pending PR-B / #370` markers** in `.claude/rules/factory-loop.md` and `.claude/agents/reviewer.md` — the gates now exist.

Out of scope: changing the `test-author`/`critic`/`reviewer` personas
(PR-A landed those); retrofitting merged PRs.

## Gating-test paths

Per the phase-4b protocol, the `test-author` agent owns and the
implementer treats as **read-only**:

- `test/tau/factory/gate_test.exs`

(The test-author MAY also add fixtures under `test/support/factory/`;
those are declared here too: `test/support/factory/`.)

## Dependencies

Blocked by #369 (PR-A) — merged. No other dependency.

## Acceptance criteria

**Meta-AC convention** (introduced by this PR): an acceptance criterion
whose identifier is immediately followed by the marker `(meta)` is a
*meta-AC* — it is verified by CI wiring or inspection, not by a unit
gating test. The AC-to-test-linkage gate (5.1) **exempts** `(meta)`-marked
ACs. AC-4 and AC-5 below are meta-ACs.

- **AC-1** `ac_linkage/2` returns `{:error, [...]}` for a PR body whose
  claimed non-meta `AC-N` has no matching gating-test name/tag, `:ok`
  when every claimed non-meta AC is present, and treats an AC whose
  identifier is followed by `(meta)` as exempt (never reported missing).
  Driven via the user-facing path (`mix tau.gate.ac_linkage` argv or the
  public function).
- **AC-2** `masking_violations/1` returns the removed-assertion list for
  a diff that deletes an `assert`, and `[]` for a diff that deletes no
  assertion. Detection-only — the result is surfaced, never a silent
  bypass.
- **AC-3** `mutation_check/2` returns `{:error, :all_passed}` for a
  synthetic case where the gating tests pass against the reverted
  (pre-implementer) tree, and `:ok` when ≥1 gating test fails against it.
- **AC-4 (meta)** the three gates are wired into
  `.github/workflows/ci.yml` as described — AC-linkage + masking in the
  `lint` job, the mutation check as an independent `mutation-check` job
  that does NOT `needs: [lint]` (so Gate 5.3 runs even if lint fails);
  the `pending PR-B / #370` markers in `factory-loop.md` and
  `reviewer.md` are removed. Verified by CI, not a unit test.
- **AC-5 (meta)** `mix compile --warnings-as-errors`, `mix format
  --check-formatted`, `mix credo --strict`, full `mix test` green;
  `factory-loop.md` Gate 5.1 documents the meta-AC convention. Verified
  by CI, not a unit test.

## Test plan

- `test/tau/factory/gate_test.exs` (test-author–authored): fixture-driven
  fail-before/pass-after cases for AC-1/AC-2/AC-3 — a PR body + test
  sources with a missing AC; unified-diff fixtures with and without a
  removed assertion; a synthetic two-path repo state for the mutation
  check (gating tests that do / do not bind).
- `mix compile --warnings-as-errors`, `mix format --check-formatted`,
  `mix credo --strict`, full `mix test` green.

## Gate verdicts

- critic: PASS (`ok: true`, empty findings) — across three attempts:
  `Tau.Factory.Gate` is pure; `mutation_check` discriminates a runner
  crash from a genuine failure; `revert_to_base` is per-path; the
  meta-AC exemption is a clean minimal change; the test-author's 7
  gating tests are genuine (non-tautological). One implementer challenge
  (AC-3 `tmp_dir` tag) was raised, critic-adjudicated **upheld**, and
  test-author-corrected.
- reviewer: PASS (`verdict: PASS`) — **dogfood satisfied**: on #371's own
  `pull_request` CI, Gate 5.1 (AC-linkage) passes with the meta-AC
  exemption and the blocking Gate 5.3 (`mutation-check`) genuinely
  executed and passed (`≥1 gating test failed against reverted tree —
  suite is discriminating`); `lint` + both `test` cells + `dialyzer` +
  `escript` + `binary-qa` all green on `43a2446`. One non-blocking
  WARNING — `tau.gate.mutation.ex` does not match the `{:error,
  {:runner_crashed, _}}` return (fail-loud `CaseClauseError`, not silent)
  — filed as a follow-up.


