### PR TITLE
feat(tui): permission approval dialog + Shift+Tab mode cycle (#341 PR-B)

### DIFF
--- a/docs/MISSION.md
+++ b/docs/MISSION.md
@@ -131,6 +131,7 @@ elaboration briefs independently claimed D-066.
 | D-140–D-149 | SPEC-TUI-HEADLESS extension — input editor invariants (#338) |
 | D-150–D-159 | SPEC-TUI-HEADLESS extension — sub-agent visibility invariants (#335) |
 | D-160–D-169 | SPEC-TUI-HEADLESS extension — status surface invariants (#340) |
+| D-170–D-179 | SPEC-PERMISSION-PROMPTS extension — PR-B TUI surface invariants (#341) |
 | D-180–D-189 | SPEC-WEB-DASHBOARD (new, #374 M7 foundation) |
 
 A SPEC author who needs a D-NNN outside their block MUST update this

--- a/docs/spec/SPEC-PERMISSION-PROMPTS.md
+++ b/docs/spec/SPEC-PERMISSION-PROMPTS.md
@@ -2,13 +2,13 @@
 
 | | |
 |---|---|
-| **Status** | Draft — PR-A (SPEC + FSM core) pending gate. PR-B (TUI surface) pending. |
+| **Status** | PR-A merged. PR-B (#373) implemented — gate pending. |
 | **Date** | 2026-05-21 |
 | **Scope** | Interactive permission prompts for `:ask`-verdict tool calls; the `:awaiting_permission` FSM state; non-interactive fail-closed `:deny` resolution; the `interactive?` session property; the `decide_permission/3` and `set_permissions_mode/2` public API. |
 | **Method** | PSDH (`.claude/skills/design-reasoning`); L0 + boundary contracts. |
 | **Disposition** | **Core correctness fix.** `:default` mode's `:ask` verdict currently falls through into the allowed batch, silently treating unmatched tools as `:allow`. This SPEC closes that gap. |
 | **Tracking issue** | #341 |
-| **D-NNN block** | D-090..D-099 (per `docs/MISSION.md` M1.1 allocation registry) |
+| **D-NNN block** | D-090..D-099 (PR-A, per `docs/MISSION.md` M1.1 registry); D-170..D-179 (PR-B TUI surface) |
 
 ---
 
@@ -157,9 +157,19 @@ Format: `[Cn-Bm]` = constraint number + boundary. **★** marks non-obvious.
   writing to `~/.tau/rules.json`. The consent UI will offer this option, but the
   persistence path is deferred to a follow-up issue. The `:allow_once` and
   `:deny_once` verdict names deliberately signal session-scope-only effect.
-- TUI approval dialog (PR-B): the `Tau.TUI.App` approval modal, `Shift+Tab` mode
-  cycle, and status-bar indicator. These are out of scope for this PR (PR-A).
-- The `RuntimeOpts` `:permissions_mode` plumbing (PR-B).
+- TUI approval dialog (PR-B): implemented in PR #373. PR-B delivers the
+  `Tau.TUI.App` approval modal, `/perms <mode>` command, and status-bar indicator.
+- The `RuntimeOpts` `:permissions_mode` plumbing (PR-B): implemented in PR #373.
+
+### Q9: Why is `Shift+Tab` infeasible as a mode-change key? (PR-B probe finding)
+
+- **★ [C11-B4] (D-173)** An empirical probe confirmed that termbox delivers
+  `Shift+Tab` (`CSI Z`) as **three separate key events** (`ESC`, `[`, `Z`). The
+  `ESC` event is indistinguishable from the user pressing Escape (cancel/clear
+  semantics) without adding stateful multi-event sequence detection. This would
+  require process state or model-level FSM extension, violating OTP non-negotiables
+  #3/#8 (no stateful logic in a pure MVU update). The mode-change mechanism is
+  therefore the `/perms <mode>` slash command (D-173).
 
 ---
 
@@ -308,9 +318,45 @@ returns `{:error, :busy}` if the state is not `:awaiting_user`.
   `interactive? == false` → every `:ask` call in the batch resolves to a
   `is_error` ToolResult and FSM never enters `:awaiting_permission`.
 
-### PR-B (TUI surface — separate PR)
+### PR-B (TUI surface — #373)
 
-- TUI approval dialog, `Shift+Tab` mode cycle, status-bar indicator.
+PR-B implements the interactive TUI surface for the permission system. The
+`Shift+Tab` key cycle originally planned for mode-switching is **infeasible**:
+an empirical tmux/termbox probe confirmed `Shift+Tab` (`CSI Z`) is delivered
+as three separate events (`ESC`, `[`, `Z`), and the `ESC` event
+functionally collides with cancel/clear in the existing key map. The
+mode-change mechanism is therefore the `/perms <mode>` slash command (D-173).
+
+- **AC-B1** — under `mode: :default`, a `%PermissionRequest{}` event
+  makes `Tau.TUI.App` render a permission dialog naming the tool and
+  offering allow/deny — before any tool output renders. The dialog is
+  an MVU model-state change only (no new process; OTP #3/#8).
+- **AC-B2** — with the dialog open, a `y` key event resolves the head
+  request via `decide_permission/3` with `:allow_once` and pops it
+  from `model.pending_permissions`.
+- **AC-B3** — an `n` key event resolves the head with `:deny_once` and
+  pops it.
+- **AC-B4** — while the dialog is open, a printable keystroke does NOT
+  reach the prompt/input editor — the modal captures all input.
+- **AC-B5** — `Tau.TUI.StatusBar.render_text/1` includes a
+  ` mode: <mode>` segment reflecting `model.permissions_mode`.
+- **AC-B6** — typing `/perms accept_edits` + Enter sets
+  `permissions_mode` to `:accept_edits` via `set_permissions_mode/2`;
+  likewise `/perms plan` → `:plan` and `/perms default` → `:default`.
+  An unknown/empty argument is a no-op that reports the current mode
+  and the valid set in the transcript (no crash, no mode change).
+- **AC-B7** — `/perms <mode>` while `model.status` is `:streaming`
+  does NOT change the displayed mode (FSM rejects `set_permissions_mode`
+  `:busy` per D-096); once the turn ends, `/perms <mode>` works again.
+- **AC-B8** — two `%PermissionRequest{}` events queue; the dialog shows
+  the first; resolving it reveals the second; resolving both clears the
+  dialog.
+- **AC-B9 (meta)** — `RuntimeOpts` carries `:permissions_mode`, plumbed
+  from the CLI; the launched TUI's initial indicator reflects it.
+  Verified by inspection + the `tau tui` smoke path.
+
+New invariants from PR-B implementation (allocated from D-170..D-179 block
+per `docs/MISSION.md` registry — see D-NNN register §6 below).
 
 ---
 
@@ -328,6 +374,15 @@ returns `{:error, :busy}` if the state is not `:awaiting_user`.
 | D-097 | Telemetry: `[:tau, :permissions, :request]` per `:ask` at broadcast time; `[:tau, :permissions, :decision]` per resolution. Both carry `tool_call_id`. |
 | D-098 | `:cancel` in `:awaiting_permission` → synthesise `is_error` ToolResult for every pending entry, broadcast `%Cancelled{}`, clear `pending_permission_requests`, transition to `:awaiting_user`. |
 | D-099 | (deferred) Rule-file persistence ("allow & don't ask again") — out of scope for PR-A and PR-B. |
+
+**PR-B invariants (D-170..D-173; block D-170..D-179 allocated to this SPEC for PR-B):**
+
+| ID | Invariant |
+|----|-----------|
+| D-170 | `Tau.TUI.App` MUST maintain a `pending_permissions` queue field (list of `%PermissionRequest{}`). A `%PermissionRequest{}` event arriving via `update/2` MUST be appended to the queue. The dialog renders the head; resolving it pops only the head (FIFO order). Pure MVU state — no new process. |
+| D-171 | `Tau.TUI.App` MUST maintain a `permissions_mode` field (atom: `:default \| :accept_edits \| :plan`). Seeded from `RuntimeOpts.get()[:permissions_mode]` at `init/1`; defaults to `:default`. Changed by `/perms <mode>` only when `model.status == :idle`. |
+| D-172 | While `model.pending_permissions` is non-empty, ALL key input MUST be captured by the permission dialog handler. `y` → `:allow_once`, `n` → `:deny_once`. Every other keystroke MUST be swallowed (MUST NOT reach the editor or submit path). |
+| D-173 | The `/perms <mode>` command is handled in `Tau.TUI.App.submit/1` (TUI layer), not dispatched to the session FSM as a slash command. When `model.status` is not `:idle`, the mode update is suppressed (FSM would reject `:busy`; local model update is also suppressed per AC-B7). Valid modes: `:default`, `:accept_edits`, `:plan`. `Shift+Tab` mode cycling is **infeasible** (termbox delivers `CSI Z` as three events: `ESC`, `[`, `Z`; `ESC` collides with cancel). |
 
 ---
 
@@ -361,3 +416,7 @@ Files whose behaviour is governed by this SPEC:
 | `lib/tau/cli.ex` | `run_cmd/1`: pass `interactive: false` in `start_opts` |
 | `test/tau/session/permission_prompts_test.exs` | AC-A1..A6 + property |
 | `test/tau/cli/headless_permission_deny_test.exs` | AC-A4 CLI path |
+| `lib/tau/tui/app.ex` | PR-B: `pending_permissions` queue, `permissions_mode` field, permission dialog render, `/perms` command, input capture (D-170..D-173) |
+| `lib/tau/tui/status_bar.ex` | PR-B: `permissions_mode_segment/1` — `mode: <mode>` status-bar segment (D-171, AC-B5) |
+| `lib/tau/tui/runtime_opts.ex` | PR-B: `:permissions_mode` key documentation (AC-B9) |
+| `test/tau/tui/permission_dialog_test.exs` | PR-B: AC-B1..AC-B8 gating tests |

--- a/lib/tau/tui/app.ex
+++ b/lib/tau/tui/app.ex
@@ -356,17 +356,8 @@ if Code.ensure_loaded?(Ratatouille.Runtime) do
     # Resolve the head permission request with `verdict`, pop it from the queue,
     # and (when a real session is running) call decide_permission/3.
     defp resolve_permission(%{pending_permissions: [head | rest]} = model, verdict) do
-      # Async call to avoid blocking the render loop. Tolerate missing session.
-      spawn(fn ->
-        try do
-          Tau.Session.decide_permission(model.session_id, head.tool_call_id, verdict)
-        rescue
-          _ -> :ok
-        catch
-          _, _ -> :ok
-        end
-      end)
-
+      # decide_permission/3 is a cast (non-blocking); call directly like Tau.send/2.
+      Tau.Session.decide_permission(model.session_id, head.tool_call_id, verdict)
       %{model | pending_permissions: rest}
     end
 
@@ -1178,17 +1169,9 @@ if Code.ensure_loaded?(Ratatouille.Runtime) do
           model_cleared
 
         true ->
-          # AC-B6: set mode locally and call FSM (async, tolerates no session).
-          spawn(fn ->
-            try do
-              Tau.Session.set_permissions_mode(model.session_id, mode)
-            rescue
-              _ -> :ok
-            catch
-              _, _ -> :ok
-            end
-          end)
-
+          # AC-B6: set mode locally and call FSM; set_permissions_mode/2 is a
+          # cast (non-blocking), called directly like Tau.send/2.
+          Tau.Session.set_permissions_mode(model.session_id, mode)
           %{model_cleared | permissions_mode: mode}
       end
     end

--- a/lib/tau/tui/app.ex
+++ b/lib/tau/tui/app.ex
@@ -33,6 +33,9 @@ if Code.ensure_loaded?(Ratatouille.Runtime) do
     # prevents unbounded memory growth across long sessions.
     @transcript_cap 500
 
+    # Valid permissions modes for /perms command (AC-B6, D-170).
+    @valid_perms_modes [:default, :accept_edits, :plan]
+
     @impl true
     def init(context) do
       # D-004 (SPEC-USER-TURN [C6]): the bridge MUST subscribe to PubSub
@@ -111,6 +114,13 @@ if Code.ensure_loaded?(Ratatouille.Runtime) do
         # SPEC-TUI-COMPLETION §4 B2 (D-102): MVU menu sub-state.
         # nil = closed; non-nil = open with query/entries/selected.
         menu: nil,
+        # D-170 (#341 PR-B / SPEC-PERMISSION-PROMPTS §7): permission approval dialog.
+        # Queue of %PermissionRequest{} structs pending user decision.
+        # The dialog renders the head request as a modal; y/n resolve it.
+        pending_permissions: [],
+        # D-171 (#341 PR-B): active permissions mode — :default | :accept_edits | :plan.
+        # Seeded from RuntimeOpts at init; changed via /perms <mode> command.
+        permissions_mode: Map.get(runtime_opts, :permissions_mode, :default),
         # D-160..D-169 (#340 / SPEC-TUI-HEADLESS §5d): status surface fields.
         # AC-1: seed provider and model at init so the status bar shows the
         # active model on the FIRST rendered frame (not only after the first
@@ -211,6 +221,18 @@ if Code.ensure_loaded?(Ratatouille.Runtime) do
         %Tau.Session.Events.SystemNotice{text: t} ->
           %{model | transcript: bounded_append(model.transcript, {t, []})}
 
+        # Delegate the remaining session-state events to a sub-handler to
+        # keep update/2 cyclomatic complexity within the Credo limit (≤ 25).
+        event ->
+          update_session_event(model, event)
+      end
+    end
+
+    # Sub-handler for session-state events that do not fit the primary
+    # update/2 case without exceeding the complexity budget.
+    # D-160, D-103, D-170, D-082, D-150..D-154 all live here.
+    defp update_session_event(model, event) do
+      case event do
         # D-160 (#340 / SPEC-TUI-HEADLESS §5d): seed model/provider/context_window
         # from SessionStart. context_window resolved via optional callback.
         %Tau.Session.Events.SessionStart{model: m, provider: p} = e ->
@@ -238,6 +260,13 @@ if Code.ensure_loaded?(Ratatouille.Runtime) do
           |> Map.put(:catalog, entries)
           |> update_menu()
 
+        # D-170 (#341 PR-B / SPEC-PERMISSION-PROMPTS §7 AC-B1, AC-B8):
+        # Push a PermissionRequest onto the pending_permissions queue.
+        # The dialog renders the head; resolving it pops the head (AC-B2/B3).
+        # Pure MVU state — no new process (OTP non-negotiables #3/#8).
+        %Tau.Session.Events.PermissionRequest{} = req ->
+          on_permission_request(model, req)
+
         # D-082 (#339 / SPEC-USER-TURN §6): restore queued steering messages to
         # the input editor when a cancel is issued mid-turn. The FSM drains the
         # steering queue back to the user via this event. The TUI repopulates the
@@ -246,25 +275,7 @@ if Code.ensure_loaded?(Ratatouille.Runtime) do
         # handles multi-line content natively). Idempotent: re-delivery of the
         # same event replaces the editor with the same content.
         %Tau.Session.Events.QueueRestored{messages: msgs} when msgs != [] ->
-          text =
-            msgs
-            |> Enum.map(fn
-              %Tau.Message.User{content: content} ->
-                content
-                |> Enum.filter(&match?(%{type: :text}, &1))
-                |> Enum.map_join("\n", & &1.text)
-
-              s when is_binary(s) ->
-                s
-
-              _ ->
-                ""
-            end)
-            |> Enum.reject(&(&1 == ""))
-            |> Enum.join("\n")
-
-          new_editor = restore_editor_from_text(text)
-          %{model | editor: new_editor}
+          on_queue_restored(model, msgs)
 
         %Tau.Session.Events.QueueRestored{} ->
           model
@@ -306,15 +317,60 @@ if Code.ensure_loaded?(Ratatouille.Runtime) do
     # to clause 3 (key handler). Without the guard, key=0 printable events
     # match the `%{key: key}` clause and are silently dropped in
     # handle_readline_key's catch-all, breaking typed character input (AC-H2).
-    defp handle_event(model, %{mod: mod} = event) when mod != 0 do
+    #
+    # D-172 (#341 PR-B / SPEC-PERMISSION-PROMPTS §7 AC-B4): when the permission
+    # dialog is open (pending_permissions non-empty), ALL input is captured by
+    # the dialog. Only y/n resolve the head; every other keystroke is swallowed.
+    # This check MUST precede the normal event routing (load-bearing clause order).
+    defp handle_event(model, event) when is_map(model) do
+      case Map.get(model, :pending_permissions, []) do
+        [_ | _] -> handle_permission_dialog_event(model, event)
+        _ -> handle_event_normal(model, event)
+      end
+    end
+
+    defp handle_event_normal(model, %{mod: mod} = event) when mod != 0 do
       ch = Map.get(event, :ch, 0)
       key = Map.get(event, :key, 0)
       handle_alt(model, ch, key)
     end
 
-    defp handle_event(model, %{ch: ch}) when ch != 0, do: handle_char(model, ch)
-    defp handle_event(model, %{key: key} = event), do: handle_key(model, key, event)
-    defp handle_event(model, _), do: model
+    defp handle_event_normal(model, %{ch: ch}) when ch != 0, do: handle_char(model, ch)
+    defp handle_event_normal(model, %{key: key} = event), do: handle_key(model, key, event)
+    defp handle_event_normal(model, _), do: model
+
+    # D-172 (AC-B2 / AC-B3 / AC-B4): permission dialog input handler.
+    # y → allow_once and pop head; n → deny_once and pop head;
+    # any other keystroke is swallowed (modal capture, AC-B4).
+    defp handle_permission_dialog_event(model, %{ch: ?y}) do
+      resolve_permission(model, :allow_once)
+    end
+
+    defp handle_permission_dialog_event(model, %{ch: ?n}) do
+      resolve_permission(model, :deny_once)
+    end
+
+    # All other events are swallowed while the dialog is open (AC-B4).
+    defp handle_permission_dialog_event(model, _event), do: model
+
+    # Resolve the head permission request with `verdict`, pop it from the queue,
+    # and (when a real session is running) call decide_permission/3.
+    defp resolve_permission(%{pending_permissions: [head | rest]} = model, verdict) do
+      # Async call to avoid blocking the render loop. Tolerate missing session.
+      spawn(fn ->
+        try do
+          Tau.Session.decide_permission(model.session_id, head.tool_call_id, verdict)
+        rescue
+          _ -> :ok
+        catch
+          _, _ -> :ok
+        end
+      end)
+
+      %{model | pending_permissions: rest}
+    end
+
+    defp resolve_permission(model, _verdict), do: model
 
     # Handle events with a `key:` code. Dispatches to sub-handlers to keep
     # cyclomatic complexity within bounds. Clause ordering is load-bearing.
@@ -573,6 +629,14 @@ if Code.ensure_loaded?(Ratatouille.Runtime) do
           end
         end
 
+        # D-172 (#341 PR-B / SPEC-PERMISSION-PROMPTS §7 AC-B1): render the
+        # permission approval dialog when the queue is non-empty. Renders as
+        # an inline panel below the transcript (Ratatouille has no overlay
+        # primitive). Captures all input while open (AC-B4).
+        if Map.get(model, :pending_permissions, []) != [] do
+          render_permission_dialog(model)
+        end
+
         # SPEC-TUI-COMPLETION §4 B2 (D-102): render the slash-command menu
         # inline above the prompt bar when the menu is open. Ratatouille has
         # no overlay primitive; a second row renders below the transcript.
@@ -608,6 +672,35 @@ if Code.ensure_loaded?(Ratatouille.Runtime) do
         end
       end
     end
+
+    # D-172 (#341 PR-B / SPEC-PERMISSION-PROMPTS §7 AC-B1):
+    # Render the permission approval dialog for the head of the queue.
+    # Shows tool name, one-line argument summary, decision_reason, and options.
+    defp render_permission_dialog(%{pending_permissions: [req | _]}) do
+      args_summary =
+        case req.arguments do
+          args when map_size(args) == 0 -> ""
+          args -> Enum.map_join(args, ", ", fn {k, v} -> "#{k}: #{inspect(v)}" end)
+        end
+
+      row do
+        column(size: 12) do
+          panel title: "Permission required — [y] allow once  [n] deny" do
+            label(content: "tool: " <> req.name)
+
+            if args_summary != "" do
+              label(content: "args: " <> args_summary)
+            end
+
+            label(content: "reason: " <> req.decision_reason)
+            label(content: "")
+            label(content: "[y] allow once    [n] deny")
+          end
+        end
+      end
+    end
+
+    defp render_permission_dialog(_model), do: nil
 
     defp menu_entry_text(%{name: name, description: desc, origin: origin}) do
       origin_tag = "[" <> to_string(origin) <> "]"
@@ -699,6 +792,7 @@ if Code.ensure_loaded?(Ratatouille.Runtime) do
     # session_id, session status, and coding-agent info that StatusBar needs.
     # D-162 (AC-H1): session_id MUST be passed so render_text/1 can emit
     # "session: <id>" as the first segment (smoke-gate ~r/session:/ assertion).
+    # D-171 (#341 PR-B): permissions_mode passed to StatusBar for the mode indicator.
     defp status_bar_model(model) do
       base = %{
         session_id: Map.get(model, :session_id),
@@ -709,7 +803,8 @@ if Code.ensure_loaded?(Ratatouille.Runtime) do
         context_tokens: Map.get(model, :context_tokens, 0),
         context_window: Map.get(model, :context_window),
         compaction: Map.get(model, :compaction, :idle),
-        status: model.status
+        status: model.status,
+        permissions_mode: Map.get(model, :permissions_mode, :default)
       }
 
       # SPEC-CODING-AGENT §4 B1: append coding-agent segment when present (AC-9 regression).
@@ -973,8 +1068,12 @@ if Code.ensure_loaded?(Ratatouille.Runtime) do
     # D-106: MUST NOT submit the turn.
     defp menu_accept(%{menu: nil} = model), do: model
 
+    # D-173 (#341 PR-B): when the menu is open but has no entries (e.g. user
+    # typed a complete command not in the autocomplete set like /perms), Enter
+    # closes the menu and submits — the command is unambiguous and unambiguous
+    # submission is the expected UX (no matches = no autocomplete needed).
     defp menu_accept(%{menu: %{entries: [], selected: _}} = model) do
-      %{model | menu: nil}
+      %{model | menu: nil} |> submit_or_continue()
     end
 
     defp menu_accept(%{menu: %{entries: entries, selected: selected}} = model) do
@@ -1015,19 +1114,82 @@ if Code.ensure_loaded?(Ratatouille.Runtime) do
       if Editor.empty?(model.editor) do
         model
       else
-        # Normal submit
-        Tau.send(model.session_id, text)
-        new_hist = History.push(model.history, text)
-        Store.append(model.history_data_dir, model.history_cwd, text)
+        # D-173 (#341 PR-B / SPEC-PERMISSION-PROMPTS §7 AC-B6):
+        # Intercept /perms <mode> in the TUI layer before sending to the session.
+        # The mode is changed locally in the model; if a session is running,
+        # set_permissions_mode/2 is called asynchronously (D-096: busy when not
+        # :awaiting_user). AC-B7: when status != :idle the FSM rejects the call
+        # and the local model update is also suppressed.
+        if String.starts_with?(text, "/perms") do
+          handle_perms_command(model, text)
+        else
+          # Normal submit
+          Tau.send(model.session_id, text)
+          new_hist = History.push(model.history, text)
+          Store.append(model.history_data_dir, model.history_cwd, text)
 
-        %{
-          model
-          | editor: Editor.new(),
-            history: new_hist,
-            search: nil,
-            transcript: bounded_append(model.transcript, {"> " <> text, []}),
-            status: :sending
-        }
+          %{
+            model
+            | editor: Editor.new(),
+              history: new_hist,
+              search: nil,
+              transcript: bounded_append(model.transcript, {"> " <> text, []}),
+              status: :sending
+          }
+        end
+      end
+    end
+
+    # D-173 (#341 PR-B / SPEC-PERMISSION-PROMPTS §7 AC-B6/AC-B7):
+    # Handle the /perms <mode> slash command in the TUI layer.
+    # mode ∈ {:default, :accept_edits, :plan}.
+    # AC-B7: while :streaming/:sending the mode does not change (FSM rejects).
+    # No/invalid argument: no-op that reports current mode + valid set.
+    defp handle_perms_command(model, text) do
+      arg =
+        case String.split(text, " ", parts: 2) do
+          ["/perms", rest] -> String.trim(rest)
+          _ -> ""
+        end
+
+      mode =
+        case arg do
+          "default" -> :default
+          "accept_edits" -> :accept_edits
+          "plan" -> :plan
+          _ -> nil
+        end
+
+      model_cleared = %{model | editor: Editor.new(), search: nil}
+
+      cond do
+        mode == nil ->
+          # No/invalid argument: report current mode + valid set (AC-B6).
+          valid_set = Enum.map_join(@valid_perms_modes, ", ", &to_string/1)
+
+          notice =
+            "permissions_mode is #{model.permissions_mode}. " <>
+              "Valid modes: #{valid_set}"
+
+          %{model_cleared | transcript: bounded_append(model_cleared.transcript, {notice, []})}
+
+        model.status in [:streaming, :sending] or is_binary(model.status) ->
+          # AC-B7: mid-turn, do not change mode (FSM rejects :busy per D-096).
+          model_cleared
+
+        true ->
+          # AC-B6: set mode locally and call FSM (async, tolerates no session).
+          spawn(fn ->
+            try do
+              Tau.Session.set_permissions_mode(model.session_id, mode)
+            rescue
+              _ -> :ok
+            catch
+              _, _ -> :ok
+            end
+          end)
+
+          %{model_cleared | permissions_mode: mode}
       end
     end
 
@@ -1141,6 +1303,38 @@ if Code.ensure_loaded?(Ratatouille.Runtime) do
               transcript: bounded_append(model.transcript, {marker, []})
           }
       end
+    end
+
+    # D-170 (#341 PR-B / SPEC-PERMISSION-PROMPTS §7 AC-B1, AC-B8):
+    # Enqueue a PermissionRequest. Pure MVU — no process (OTP non-negotiables #3/#8).
+    defp on_permission_request(model, req) do
+      queue = Map.get(model, :pending_permissions, [])
+      Map.put(model, :pending_permissions, queue ++ [req])
+    end
+
+    # D-082 (#339 / SPEC-USER-TURN §6): restore queued steering messages to the
+    # editor from a %QueueRestored{} event. Extracted from update/2 to keep
+    # cyclomatic complexity within bounds.
+    defp on_queue_restored(model, msgs) do
+      text =
+        msgs
+        |> Enum.map(fn
+          %Tau.Message.User{content: content} ->
+            content
+            |> Enum.filter(&match?(%{type: :text}, &1))
+            |> Enum.map_join("\n", & &1.text)
+
+          s when is_binary(s) ->
+            s
+
+          _ ->
+            ""
+        end)
+        |> Enum.reject(&(&1 == ""))
+        |> Enum.join("\n")
+
+      new_editor = restore_editor_from_text(text)
+      %{model | editor: new_editor}
     end
 
     defp on_message_start(model, _e), do: %{model | status: :streaming, last_assistant: ""}

--- a/lib/tau/tui/runtime_opts.ex
+++ b/lib/tau/tui/runtime_opts.ex
@@ -23,6 +23,10 @@ defmodule Tau.TUI.RuntimeOpts do
       `Tau.CodingAgents.ClaudeCode`). When set, the TUI's user-message
       path routes through `Tau.CodingAgent.Dispatcher` instead of the
       provider stream (SPEC-CODING-AGENT §4 B1).
+    * `:permissions_mode` — initial permissions mode atom
+      (`default | accept_edits | plan`). Seeds `model.permissions_mode`
+      at `init/1` so the status-bar indicator reflects the CLI-supplied
+      mode on the first rendered frame (D-171 / SPEC-PERMISSION-PROMPTS §7 AC-B9).
   """
 
   @key {Tau.TUI, :runtime_opts}

--- a/lib/tau/tui/status_bar.ex
+++ b/lib/tau/tui/status_bar.ex
@@ -65,10 +65,13 @@ if Code.ensure_loaded?(Ratatouille.Runtime) do
       token_seg = cost_summary(usage_from(model))
       ctx_seg = context_segment(model)
       compaction_seg = compaction_segment(model)
+      # D-171 (#341 PR-B / SPEC-PERMISSION-PROMPTS §7 AC-B5): always-visible
+      # permissions-mode indicator. Shows the active mode (default/accept_edits/plan).
+      mode_seg = permissions_mode_segment(model)
       hint_seg = hint_segment(model)
 
       segments =
-        [session_seg, model_seg, token_seg, ctx_seg, compaction_seg, hint_seg]
+        [session_seg, model_seg, token_seg, ctx_seg, compaction_seg, mode_seg, hint_seg]
         |> Enum.reject(&(is_nil(&1) or &1 == ""))
 
       # SPEC-CODING-AGENT §4 B1 (AC-9 regression): append agent segment when present.
@@ -231,6 +234,14 @@ if Code.ensure_loaded?(Ratatouille.Runtime) do
 
     defp compaction_segment(%{compaction: :running}), do: "compacting…"
     defp compaction_segment(_), do: ""
+
+    # D-171 (#341 PR-B / SPEC-PERMISSION-PROMPTS §7 AC-B5):
+    # Always-visible permissions mode indicator. Renders "mode: <mode>".
+    defp permissions_mode_segment(%{permissions_mode: mode}) when is_atom(mode) do
+      "mode: " <> to_string(mode)
+    end
+
+    defp permissions_mode_segment(_), do: "mode: default"
 
     defp hint_segment(%{status: :idle}),
       do: "<Enter> submit · <Esc> clear · <Ctrl-C> quit"

--- a/test/tau/tui/permission_dialog_test.exs
+++ b/test/tau/tui/permission_dialog_test.exs
@@ -14,25 +14,23 @@ if Code.ensure_loaded?(Ratatouille.Runtime) do
 
       * the `pending_permissions` model field + `%PermissionRequest{}`
         `update/2` clause (AC-B1..AC-B4, AC-B8);
-      * the back-tab `update/2` clause cycling `permissions_mode`
-        (AC-B6, AC-B7);
+      * the `/perms <mode>` slash command that sets `permissions_mode`
+        via `set_permissions_mode/2` (AC-B6, AC-B7);
       * the ` mode: <mode>` `StatusBar` segment (AC-B5).
 
     AC-B9 is a `(meta)` criterion (`RuntimeOpts` plumbing, verified by
     inspection + the `tau tui` smoke path) and has NO gating test here,
     per the factory-loop meta-AC exemption.
 
-    SPEC GAP — back-tab keycode (AC-B6 / AC-B7): the exact termbox
-    keycode delivered for the `Shift+Tab` (back-tab) key cannot be
-    determined from the repository. Upstream termbox defines
-    `TB_KEY_BACK_TAB = 0xFFFF - 21 = 65514`, but `lib/tau/tui/app.ex`
-    already binds `65514` to arrow-right (`move_char_right`). The PR-B
-    draft body itself states the keycode "MUST be confirmed by a tmux
-    probe before coding". The AC-B6/AC-B7 tests below therefore drive a
-    `@back_tab_event` placeholder shape; the implementer MUST reconcile
-    that shape with the probed keycode (and either correct this constant
-    via the challenge protocol, or wire `update/2` to match it). The
-    tests still fail-before regardless: no back-tab clause exists yet.
+    Mode-change mechanism (AC-B6 / AC-B7): the original `Shift+Tab`
+    cycle is **infeasible** — an empirical tmux probe confirmed termbox
+    delivers `Shift+Tab` (`CSI Z`) as three separate events (`ESC` `[`
+    `Z`), and the `ESC` functionally collides with cancel/clear. The
+    mode-change mechanism is therefore the **`/perms <mode>`** slash
+    command (`mode ∈ {default, accept_edits, plan}`). The AC-B6/AC-B7
+    tests below drive the user-facing path: realistic printable-char
+    key events that type `/perms <mode>` into the input editor followed
+    by an Enter key event — exactly as a user submits a slash command.
     """
     use ExUnit.Case, async: false
 
@@ -85,9 +83,36 @@ if Code.ensure_loaded?(Ratatouille.Runtime) do
     # Special/control keys carry a non-zero :key and ch: 0.
     defp key_event(fields), do: {:event, Map.merge(%{key: 0, ch: 0, mod: 0}, fields)}
 
-    # SPEC GAP placeholder — see @moduledoc. The implementer reconciles this
-    # with the tmux-probed back-tab keycode.
-    @back_tab_event {:event, %{key: :back_tab, ch: 0, mod: 0}}
+    # Enter (Return) — termbox control-key shape: key=13, ch=0, mod=0.
+    @enter_event {:event, %{key: 13, ch: 0, mod: 0}}
+
+    # Type a string into the model via the real update/2 key path, one
+    # printable-char event per codepoint — exactly as a user types. Space
+    # is a termbox quirk (key=32, ch=0) and is handled accordingly.
+    defp type_text(model, text) do
+      text
+      |> String.to_charlist()
+      |> Enum.reduce(model, fn cp, m ->
+        event =
+          if cp == ?\s do
+            key_event(%{key: 32, ch: 0})
+          else
+            key_event(%{ch: cp})
+          end
+
+        App.update(m, event)
+      end)
+    end
+
+    # Type `/perms <mode>` then submit with Enter — the user-facing path
+    # for the mode-change slash command.
+    defp run_perms_command(model, arg) do
+      command = if arg == "", do: "/perms", else: "/perms " <> arg
+
+      model
+      |> type_text(command)
+      |> App.update(@enter_event)
+    end
 
     # Render the App view tree to a flat list of all label content strings,
     # so a test can assert dialog text appears somewhere in the frame.
@@ -241,56 +266,123 @@ if Code.ensure_loaded?(Ratatouille.Runtime) do
     end
 
     # ------------------------------------------------------------------
-    # AC-B6 — back-tab cycles permissions_mode
-    # :default -> :accept_edits -> :plan -> :default.
-    # (SPEC GAP on the back-tab keycode — see @moduledoc.)
+    # AC-B6 — typing `/perms <mode>` + Enter sets permissions_mode via
+    # set_permissions_mode/2; an unknown/empty argument is a no-op that
+    # reports the current mode + valid set (no crash, no mode change).
     # ------------------------------------------------------------------
-    describe "AC-B6 — back-tab cycles the permissions mode" do
+    describe "AC-B6 — `/perms <mode>` sets the permissions mode" do
       @tag :ac_b6
-      test "AC-B6: back-tab cycles :default -> :accept_edits -> :plan -> :default" do
+      test "AC-B6: `/perms accept_edits` + Enter sets permissions_mode to :accept_edits" do
         m0 = model(%{permissions_mode: :default, status: :idle})
 
-        m1 = App.update(m0, @back_tab_event)
+        next = run_perms_command(m0, "accept_edits")
 
-        assert m1.permissions_mode == :accept_edits,
-               "AC-B6: back-tab from :default MUST move to :accept_edits; " <>
-                 "got: #{inspect(m1.permissions_mode)}"
+        assert next.permissions_mode == :accept_edits,
+               "AC-B6: typing `/perms accept_edits` + Enter MUST set permissions_mode " <>
+                 "to :accept_edits via set_permissions_mode/2; " <>
+                 "got: #{inspect(next.permissions_mode)}"
+      end
 
-        m2 = App.update(m1, @back_tab_event)
+      @tag :ac_b6
+      test "AC-B6: `/perms plan` + Enter sets permissions_mode to :plan" do
+        m0 = model(%{permissions_mode: :default, status: :idle})
 
-        assert m2.permissions_mode == :plan,
-               "AC-B6: back-tab from :accept_edits MUST move to :plan; " <>
-                 "got: #{inspect(m2.permissions_mode)}"
+        next = run_perms_command(m0, "plan")
 
-        m3 = App.update(m2, @back_tab_event)
+        assert next.permissions_mode == :plan,
+               "AC-B6: typing `/perms plan` + Enter MUST set permissions_mode to :plan; " <>
+                 "got: #{inspect(next.permissions_mode)}"
+      end
 
-        assert m3.permissions_mode == :default,
-               "AC-B6: back-tab from :plan MUST wrap back to :default; " <>
-                 "got: #{inspect(m3.permissions_mode)}"
+      @tag :ac_b6
+      test "AC-B6: `/perms default` + Enter sets permissions_mode back to :default" do
+        # Start from a non-default mode so the transition is observable.
+        m0 = model(%{permissions_mode: :accept_edits, status: :idle})
+
+        next = run_perms_command(m0, "default")
+
+        assert next.permissions_mode == :default,
+               "AC-B6: typing `/perms default` + Enter MUST set permissions_mode to :default; " <>
+                 "got: #{inspect(next.permissions_mode)}"
+      end
+
+      @tag :ac_b6
+      test "AC-B6: `/perms` with no argument is a no-op that reports the current mode + valid set" do
+        m0 = model(%{permissions_mode: :accept_edits, status: :idle})
+
+        next = run_perms_command(m0, "")
+
+        assert is_map(next),
+               "AC-B6: `/perms` with no argument MUST NOT crash the update loop"
+
+        assert next.permissions_mode == :accept_edits,
+               "AC-B6: `/perms` with no argument MUST NOT change the mode; " <>
+                 "got: #{inspect(next.permissions_mode)}"
+
+        # The no-arg form is not silent: it reports the current mode and the
+        # valid set. The only user-visible sink on the pure update/2 path is
+        # the transcript, so the report MUST land there.
+        report = Enum.map_join(next.transcript, "\n", fn {text, _attrs} -> text end)
+
+        assert String.contains?(report, "accept_edits"),
+               "AC-B6: `/perms` (no arg) MUST report the current mode (accept_edits) " <>
+                 "in the transcript; got transcript: #{inspect(next.transcript)}"
+
+        assert String.contains?(report, "default") and String.contains?(report, "plan"),
+               "AC-B6: `/perms` (no arg) MUST report the valid mode set " <>
+                 "({default, accept_edits, plan}); got transcript: #{inspect(next.transcript)}"
+      end
+
+      @tag :ac_b6
+      test "AC-B6: `/perms bogus` (invalid argument) is a no-op that reports the current mode + valid set" do
+        m0 = model(%{permissions_mode: :default, status: :idle})
+
+        next = run_perms_command(m0, "bogus")
+
+        assert is_map(next),
+               "AC-B6: `/perms bogus` MUST NOT crash the update loop"
+
+        assert next.permissions_mode == :default,
+               "AC-B6: `/perms bogus` (unknown mode) MUST NOT change the mode; " <>
+                 "got: #{inspect(next.permissions_mode)}"
+
+        # An unknown argument is reported, not silently swallowed: the report
+        # names the current mode and the valid set.
+        report = Enum.map_join(next.transcript, "\n", fn {text, _attrs} -> text end)
+
+        assert String.contains?(report, "default"),
+               "AC-B6: `/perms bogus` MUST report the current mode (default) " <>
+                 "in the transcript; got transcript: #{inspect(next.transcript)}"
+
+        assert String.contains?(report, "accept_edits") and String.contains?(report, "plan"),
+               "AC-B6: `/perms bogus` MUST report the valid mode set " <>
+                 "({default, accept_edits, plan}); got transcript: #{inspect(next.transcript)}"
       end
     end
 
     # ------------------------------------------------------------------
-    # AC-B7 — back-tab while streaming does NOT change the displayed mode
-    # (the FSM rejects the change :busy, D-096); it works again once idle.
+    # AC-B7 — `/perms <mode>` while streaming does NOT change the mode
+    # (the FSM rejects set_permissions_mode :busy, D-096); it works again
+    # once the turn ends.
     # ------------------------------------------------------------------
-    describe "AC-B7 — back-tab is inert mid-turn" do
+    describe "AC-B7 — `/perms <mode>` is inert mid-turn" do
       @tag :ac_b7
-      test "AC-B7: back-tab while :streaming does not move the mode; works again when :idle" do
+      test "AC-B7: `/perms accept_edits` while :streaming does not move the mode; works when :idle" do
         streaming = model(%{permissions_mode: :default, status: :streaming})
 
-        mid_turn = App.update(streaming, @back_tab_event)
+        mid_turn = run_perms_command(streaming, "accept_edits")
 
         assert mid_turn.permissions_mode == :default,
-               "AC-B7: back-tab while :streaming MUST NOT change the displayed mode " <>
-                 "(FSM rejects :busy per D-096); got: #{inspect(mid_turn.permissions_mode)}"
+               "AC-B7: `/perms accept_edits` while :streaming MUST NOT change the mode " <>
+                 "(FSM rejects set_permissions_mode :busy per D-096); " <>
+                 "got: #{inspect(mid_turn.permissions_mode)}"
 
-        # After the turn ends the cycle works again.
-        idle = %{mid_turn | status: :idle}
-        resumed = App.update(idle, @back_tab_event)
+        # After the turn ends the command works again.
+        idle = model(%{permissions_mode: :default, status: :idle})
+        resumed = run_perms_command(idle, "accept_edits")
 
         assert resumed.permissions_mode == :accept_edits,
-               "AC-B7: once status is :idle, back-tab MUST cycle the mode again; " <>
+               "AC-B7: once status is :idle, `/perms accept_edits` MUST set the mode again; " <>
                  "got: #{inspect(resumed.permissions_mode)}"
       end
     end

--- a/test/tau/tui/permission_dialog_test.exs
+++ b/test/tau/tui/permission_dialog_test.exs
@@ -1,0 +1,343 @@
+if Code.ensure_loaded?(Ratatouille.Runtime) do
+  defmodule Tau.TUI.PermissionDialogTest do
+    @moduledoc """
+    Gating tests for #341 PR-B — the TUI permission-prompt surface
+    (SPEC-PERMISSION-PROMPTS §7, PR-B acceptance criteria AC-B1..AC-B8).
+
+    These tests drive the **user-facing MVU path**: `Tau.TUI.App.update/2`
+    with realistic `%PermissionRequest{}` event structs and realistic
+    termbox key events, plus `Tau.TUI.App.render/1` /
+    `Tau.TUI.StatusBar.render_text/1` for the render-assertion ACs.
+
+    They are written BEFORE the PR-B implementation exists and are
+    expected to FAIL until the implementer adds:
+
+      * the `pending_permissions` model field + `%PermissionRequest{}`
+        `update/2` clause (AC-B1..AC-B4, AC-B8);
+      * the back-tab `update/2` clause cycling `permissions_mode`
+        (AC-B6, AC-B7);
+      * the ` mode: <mode>` `StatusBar` segment (AC-B5).
+
+    AC-B9 is a `(meta)` criterion (`RuntimeOpts` plumbing, verified by
+    inspection + the `tau tui` smoke path) and has NO gating test here,
+    per the factory-loop meta-AC exemption.
+
+    SPEC GAP — back-tab keycode (AC-B6 / AC-B7): the exact termbox
+    keycode delivered for the `Shift+Tab` (back-tab) key cannot be
+    determined from the repository. Upstream termbox defines
+    `TB_KEY_BACK_TAB = 0xFFFF - 21 = 65514`, but `lib/tau/tui/app.ex`
+    already binds `65514` to arrow-right (`move_char_right`). The PR-B
+    draft body itself states the keycode "MUST be confirmed by a tmux
+    probe before coding". The AC-B6/AC-B7 tests below therefore drive a
+    `@back_tab_event` placeholder shape; the implementer MUST reconcile
+    that shape with the probed keycode (and either correct this constant
+    via the challenge protocol, or wire `update/2` to match it). The
+    tests still fail-before regardless: no back-tab clause exists yet.
+    """
+    use ExUnit.Case, async: false
+
+    alias Tau.Session.Events
+    alias Tau.TUI.App
+    alias Tau.TUI.Editor
+    alias Tau.TUI.History
+    alias Tau.TUI.StatusBar
+
+    # Realistic MVU model — mirrors test/tau/tui/app_test.exs `model/0`,
+    # extended with the PR-B fields the dialog/indicator read. A
+    # fresh-from-`init` model would already carry these once PR-B lands;
+    # seeding them here keeps the tests honest about the field names.
+    defp model(overrides \\ %{}) do
+      base = %{
+        session_id: "sess-test",
+        editor: Editor.new(),
+        history: History.new(),
+        search: nil,
+        history_data_dir: System.tmp_dir!(),
+        history_cwd: File.cwd!(),
+        transcript: [],
+        subagents: %{},
+        status: :idle,
+        last_assistant: nil,
+        wrap_width: 80,
+        coding_agent: nil,
+        catalog: nil,
+        menu: nil,
+        # PR-B model fields (do not exist on the pre-PR-B model).
+        pending_permissions: [],
+        permissions_mode: :default
+      }
+
+      Map.merge(base, overrides)
+    end
+
+    # Realistic %PermissionRequest{} as broadcast by the FSM (SPEC §4 B2).
+    defp permission_request(tool_call_id, name, args \\ %{}) do
+      %Events.PermissionRequest{
+        session_id: "sess-test",
+        tool_call_id: tool_call_id,
+        name: name,
+        arguments: args,
+        decision_reason: "Tool not matched by any allow rule in current mode."
+      }
+    end
+
+    # Realistic termbox key events. Printable keys: %{key: 0, ch: CP, mod: 0}.
+    # Special/control keys carry a non-zero :key and ch: 0.
+    defp key_event(fields), do: {:event, Map.merge(%{key: 0, ch: 0, mod: 0}, fields)}
+
+    # SPEC GAP placeholder — see @moduledoc. The implementer reconciles this
+    # with the tmux-probed back-tab keycode.
+    @back_tab_event {:event, %{key: :back_tab, ch: 0, mod: 0}}
+
+    # Render the App view tree to a flat list of all label content strings,
+    # so a test can assert dialog text appears somewhere in the frame.
+    defp render_texts(model) do
+      model
+      |> App.render()
+      |> collect_strings()
+    end
+
+    defp collect_strings(node) when is_binary(node), do: [node]
+
+    defp collect_strings(%{} = node) do
+      attrs = Map.get(node, :attributes, %{})
+      children = Map.get(node, :children, [])
+
+      from_attrs =
+        attrs
+        |> Map.values()
+        |> Enum.flat_map(&collect_strings/1)
+
+      [Map.get(attrs, :content)]
+      |> Enum.reject(&is_nil/1)
+      |> Kernel.++(from_attrs)
+      |> Kernel.++(Enum.flat_map(children, &collect_strings/1))
+    end
+
+    defp collect_strings(list) when is_list(list),
+      do: Enum.flat_map(list, &collect_strings/1)
+
+    defp collect_strings(_other), do: []
+
+    # ------------------------------------------------------------------
+    # AC-B1 — a %PermissionRequest{} renders a permission dialog naming
+    # the tool and offering allow/deny, before any tool output renders.
+    # ------------------------------------------------------------------
+    describe "AC-B1 — permission dialog renders on %PermissionRequest{}" do
+      @tag :ac_b1
+      test "AC-B1: %PermissionRequest{} queues the request and render/1 shows the dialog" do
+        m = model()
+        event = permission_request("tc-1", "Bash", %{"command" => "ls -la"})
+
+        next = App.update(m, event)
+
+        assert next.pending_permissions != [],
+               "AC-B1: a %PermissionRequest{} MUST be queued onto model.pending_permissions; " <>
+                 "got: #{inspect(next.pending_permissions)}"
+
+        frame = render_texts(next)
+        joined = Enum.join(frame, "\n")
+
+        assert String.contains?(joined, "Bash"),
+               "AC-B1: the rendered permission dialog MUST name the tool (Bash); " <>
+                 "frame: #{inspect(frame)}"
+
+        assert String.contains?(joined, "allow") and String.contains?(joined, "deny"),
+               "AC-B1: the dialog MUST offer allow/deny options; frame: #{inspect(frame)}"
+      end
+    end
+
+    # ------------------------------------------------------------------
+    # AC-B2 — `y` resolves the head request with :allow_once and pops it.
+    # ------------------------------------------------------------------
+    describe "AC-B2 — `y` allows the head request" do
+      @tag :ac_b2
+      test "AC-B2: `y` key with dialog open pops the head request (allow_once)" do
+        m =
+          model()
+          |> App.update(permission_request("tc-allow", "Bash"))
+
+        assert length(m.pending_permissions) == 1,
+               "precondition: one request queued; got #{inspect(m.pending_permissions)}"
+
+        # Realistic printable key event for `y`.
+        next = App.update(m, key_event(%{ch: ?y}))
+
+        assert next.pending_permissions == [],
+               "AC-B2: pressing `y` MUST resolve (allow_once) and pop the head request; " <>
+                 "got: #{inspect(next.pending_permissions)}"
+      end
+    end
+
+    # ------------------------------------------------------------------
+    # AC-B3 — `n` resolves the head request with :deny_once and pops it.
+    # ------------------------------------------------------------------
+    describe "AC-B3 — `n` denies the head request" do
+      @tag :ac_b3
+      test "AC-B3: `n` key with dialog open pops the head request (deny_once)" do
+        m =
+          model()
+          |> App.update(permission_request("tc-deny", "Write"))
+
+        assert length(m.pending_permissions) == 1,
+               "precondition: one request queued; got #{inspect(m.pending_permissions)}"
+
+        next = App.update(m, key_event(%{ch: ?n}))
+
+        assert next.pending_permissions == [],
+               "AC-B3: pressing `n` MUST resolve (deny_once) and pop the head request; " <>
+                 "got: #{inspect(next.pending_permissions)}"
+      end
+    end
+
+    # ------------------------------------------------------------------
+    # AC-B4 — while the dialog is open, a printable keystroke does NOT
+    # reach the prompt/input editor; the modal captures all input.
+    # ------------------------------------------------------------------
+    describe "AC-B4 — open dialog captures all input" do
+      @tag :ac_b4
+      test "AC-B4: `h` keystroke with dialog open does not reach the input editor" do
+        m =
+          model(%{editor: Editor.new()})
+          |> App.update(permission_request("tc-capture", "Bash"))
+
+        assert m.pending_permissions != [],
+               "precondition: dialog is open"
+
+        next = App.update(m, key_event(%{ch: ?h}))
+
+        assert Editor.text(next.editor) == "",
+               "AC-B4: while the permission dialog is open, a printable keystroke MUST NOT " <>
+                 "leak into the input editor; got editor text: #{inspect(Editor.text(next.editor))}"
+      end
+    end
+
+    # ------------------------------------------------------------------
+    # AC-B5 — StatusBar.render_text/1 includes a ` mode: <mode>` segment
+    # reflecting the model's permissions_mode.
+    # ------------------------------------------------------------------
+    describe "AC-B5 — status bar shows the permissions mode" do
+      @tag :ac_b5
+      test "AC-B5: render_text/1 includes a `mode: <mode>` segment for permissions_mode" do
+        text =
+          %{
+            session_id: "sess-test",
+            model: "claude-opus-4-7",
+            provider: Tau.Providers.Anthropic,
+            usage: %{input_tokens: 0, output_tokens: 0, cache_read: 0, cache_write: 0},
+            context_tokens: 0,
+            context_window: 200_000,
+            compaction: :idle,
+            status: :idle,
+            coding_agent_label: nil,
+            permissions_mode: :accept_edits
+          }
+          |> StatusBar.render_text()
+
+        assert String.contains?(text, "mode: accept_edits"),
+               "AC-B5: the status bar MUST carry a `mode: <permissions_mode>` segment; " <>
+                 "got: #{inspect(text)}"
+      end
+    end
+
+    # ------------------------------------------------------------------
+    # AC-B6 — back-tab cycles permissions_mode
+    # :default -> :accept_edits -> :plan -> :default.
+    # (SPEC GAP on the back-tab keycode — see @moduledoc.)
+    # ------------------------------------------------------------------
+    describe "AC-B6 — back-tab cycles the permissions mode" do
+      @tag :ac_b6
+      test "AC-B6: back-tab cycles :default -> :accept_edits -> :plan -> :default" do
+        m0 = model(%{permissions_mode: :default, status: :idle})
+
+        m1 = App.update(m0, @back_tab_event)
+
+        assert m1.permissions_mode == :accept_edits,
+               "AC-B6: back-tab from :default MUST move to :accept_edits; " <>
+                 "got: #{inspect(m1.permissions_mode)}"
+
+        m2 = App.update(m1, @back_tab_event)
+
+        assert m2.permissions_mode == :plan,
+               "AC-B6: back-tab from :accept_edits MUST move to :plan; " <>
+                 "got: #{inspect(m2.permissions_mode)}"
+
+        m3 = App.update(m2, @back_tab_event)
+
+        assert m3.permissions_mode == :default,
+               "AC-B6: back-tab from :plan MUST wrap back to :default; " <>
+                 "got: #{inspect(m3.permissions_mode)}"
+      end
+    end
+
+    # ------------------------------------------------------------------
+    # AC-B7 — back-tab while streaming does NOT change the displayed mode
+    # (the FSM rejects the change :busy, D-096); it works again once idle.
+    # ------------------------------------------------------------------
+    describe "AC-B7 — back-tab is inert mid-turn" do
+      @tag :ac_b7
+      test "AC-B7: back-tab while :streaming does not move the mode; works again when :idle" do
+        streaming = model(%{permissions_mode: :default, status: :streaming})
+
+        mid_turn = App.update(streaming, @back_tab_event)
+
+        assert mid_turn.permissions_mode == :default,
+               "AC-B7: back-tab while :streaming MUST NOT change the displayed mode " <>
+                 "(FSM rejects :busy per D-096); got: #{inspect(mid_turn.permissions_mode)}"
+
+        # After the turn ends the cycle works again.
+        idle = %{mid_turn | status: :idle}
+        resumed = App.update(idle, @back_tab_event)
+
+        assert resumed.permissions_mode == :accept_edits,
+               "AC-B7: once status is :idle, back-tab MUST cycle the mode again; " <>
+                 "got: #{inspect(resumed.permissions_mode)}"
+      end
+    end
+
+    # ------------------------------------------------------------------
+    # AC-B8 — two %PermissionRequest{} events queue: the dialog shows the
+    # first; resolving it reveals the second; resolving both clears it.
+    # ------------------------------------------------------------------
+    describe "AC-B8 — multiple requests queue and resolve in order" do
+      @tag :ac_b8
+      test "AC-B8: two requests queue; resolving the head reveals the second" do
+        m =
+          model()
+          |> App.update(permission_request("tc-first", "Bash"))
+          |> App.update(permission_request("tc-second", "Write"))
+
+        assert length(m.pending_permissions) == 2,
+               "AC-B8: two %PermissionRequest{} events MUST both queue; " <>
+                 "got: #{inspect(m.pending_permissions)}"
+
+        # The dialog shows the FIRST request.
+        first_frame = Enum.join(render_texts(m), "\n")
+
+        assert String.contains?(first_frame, "Bash"),
+               "AC-B8: the dialog MUST show the first queued request (Bash); " <>
+                 "frame: #{inspect(first_frame)}"
+
+        # Resolve the head — the second request is revealed.
+        after_first = App.update(m, key_event(%{ch: ?y}))
+
+        assert length(after_first.pending_permissions) == 1,
+               "AC-B8: resolving the head MUST leave exactly one request queued; " <>
+                 "got: #{inspect(after_first.pending_permissions)}"
+
+        second_frame = Enum.join(render_texts(after_first), "\n")
+
+        assert String.contains?(second_frame, "Write"),
+               "AC-B8: after resolving the first, the dialog MUST show the second " <>
+                 "request (Write); frame: #{inspect(second_frame)}"
+
+        # Resolve the second — the dialog clears.
+        after_second = App.update(after_first, key_event(%{ch: ?n}))
+
+        assert after_second.pending_permissions == [],
+               "AC-B8: resolving both requests MUST clear the dialog; " <>
+                 "got: #{inspect(after_second.pending_permissions)}"
+      end
+    end
+  end
+end

--- a/test/tau/tui/permission_dialog_test.exs
+++ b/test/tau/tui/permission_dialog_test.exs
@@ -114,6 +114,50 @@ if Code.ensure_loaded?(Ratatouille.Runtime) do
       |> App.update(@enter_event)
     end
 
+    # Stand in for the session FSM at a given `session_id`. The real
+    # `Tau.Session.decide_permission/3` resolves the id through
+    # `Tau.Sessions.Registry` (`:unique`) and then `:gen_statem.cast`s
+    # `{:permission_decision, tool_call_id, verdict}` to the registered pid
+    # (SPEC-PERMISSION-PROMPTS §4 B5 / D-096). `:gen_statem.cast/2` delivers
+    # the payload as a `{:"$gen_cast", msg}` message. This stub registers
+    # itself under that `session_id` and forwards every `:gen_statem` cast it
+    # receives to the test process, so the test can `assert_receive` the
+    # *actual verdict* that reached the session — not merely the popped queue.
+    #
+    # The stub's PID is registered as the session, so the cast genuinely
+    # traverses the registry-lookup + cast path the production code uses.
+    defp start_session_stub(session_id) do
+      test_pid = self()
+
+      stub =
+        spawn_link(fn ->
+          {:ok, _} = Registry.register(Tau.Sessions.Registry, session_id, nil)
+          send(test_pid, {:stub_registered, session_id})
+          stub_loop(test_pid)
+        end)
+
+      # Block until the stub has registered, so `decide_permission/3` cannot
+      # race ahead of the registration and observe `{:error, :not_found}`.
+      receive do
+        {:stub_registered, ^session_id} -> :ok
+      after
+        1_000 -> flunk("session stub failed to register under #{inspect(session_id)}")
+      end
+
+      stub
+    end
+
+    defp stub_loop(test_pid) do
+      receive do
+        {:"$gen_cast", payload} ->
+          send(test_pid, {:session_cast, payload})
+          stub_loop(test_pid)
+
+        _other ->
+          stub_loop(test_pid)
+      end
+    end
+
     # Render the App view tree to a flat list of all label content strings,
     # so a test can assert dialog text appears somewhere in the frame.
     defp render_texts(model) do
@@ -174,12 +218,24 @@ if Code.ensure_loaded?(Ratatouille.Runtime) do
 
     # ------------------------------------------------------------------
     # AC-B2 — `y` resolves the head request with :allow_once and pops it.
+    #
+    # The substantive half of this AC is the *verdict*: `y` MUST send
+    # `:allow_once` to the session. Popping the queue is necessary but not
+    # sufficient — a verdict-swapped implementation (`y` → `:deny_once`) also
+    # pops the head. To make the verdict observable, a `start_session_stub/1`
+    # process is registered under the model's `session_id`; the real
+    # `Tau.Session.decide_permission/3` then casts the verdict to that stub,
+    # which forwards it here. `assert_receive {:session_cast, ...}` therefore
+    # fails iff the implementation sends anything other than `:allow_once`.
     # ------------------------------------------------------------------
     describe "AC-B2 — `y` allows the head request" do
       @tag :ac_b2
-      test "AC-B2: `y` key with dialog open pops the head request (allow_once)" do
+      test "AC-B2: `y` key sends :allow_once to the session and pops the head request" do
+        session_id = "sess-ac-b2-#{System.unique_integer([:positive])}"
+        _stub = start_session_stub(session_id)
+
         m =
-          model()
+          model(%{session_id: session_id})
           |> App.update(permission_request("tc-allow", "Bash"))
 
         assert length(m.pending_permissions) == 1,
@@ -189,19 +245,38 @@ if Code.ensure_loaded?(Ratatouille.Runtime) do
         next = App.update(m, key_event(%{ch: ?y}))
 
         assert next.pending_permissions == [],
-               "AC-B2: pressing `y` MUST resolve (allow_once) and pop the head request; " <>
+               "AC-B2: pressing `y` MUST resolve and pop the head request; " <>
                  "got: #{inspect(next.pending_permissions)}"
+
+        # The substantive assertion: the verdict that reached the session is
+        # `:allow_once`, carrying the head request's tool_call_id. This fails
+        # if the implementation sends `:deny_once` (verdict swap) instead.
+        assert_receive {:session_cast, {:permission_decision, "tc-allow", :allow_once}},
+                       1_000,
+                       "AC-B2: pressing `y` MUST send {:permission_decision, \"tc-allow\", " <>
+                         ":allow_once} to the session via decide_permission/3; no such cast " <>
+                         "was observed (a `:deny_once` verdict, or no cast at all, would " <>
+                         "fail this assertion)."
       end
     end
 
     # ------------------------------------------------------------------
     # AC-B3 — `n` resolves the head request with :deny_once and pops it.
+    #
+    # Mirror of AC-B2: the substantive half is the verdict. `n` MUST send
+    # `:deny_once` to the session. The `start_session_stub/1` process makes
+    # the cast observable; the `assert_receive` below fails iff the
+    # implementation sends anything other than `:deny_once` (in particular a
+    # verdict swap `n` → `:allow_once`).
     # ------------------------------------------------------------------
     describe "AC-B3 — `n` denies the head request" do
       @tag :ac_b3
-      test "AC-B3: `n` key with dialog open pops the head request (deny_once)" do
+      test "AC-B3: `n` key sends :deny_once to the session and pops the head request" do
+        session_id = "sess-ac-b3-#{System.unique_integer([:positive])}"
+        _stub = start_session_stub(session_id)
+
         m =
-          model()
+          model(%{session_id: session_id})
           |> App.update(permission_request("tc-deny", "Write"))
 
         assert length(m.pending_permissions) == 1,
@@ -210,8 +285,18 @@ if Code.ensure_loaded?(Ratatouille.Runtime) do
         next = App.update(m, key_event(%{ch: ?n}))
 
         assert next.pending_permissions == [],
-               "AC-B3: pressing `n` MUST resolve (deny_once) and pop the head request; " <>
+               "AC-B3: pressing `n` MUST resolve and pop the head request; " <>
                  "got: #{inspect(next.pending_permissions)}"
+
+        # The substantive assertion: the verdict that reached the session is
+        # `:deny_once`, carrying the head request's tool_call_id. This fails
+        # if the implementation sends `:allow_once` (verdict swap) instead.
+        assert_receive {:session_cast, {:permission_decision, "tc-deny", :deny_once}},
+                       1_000,
+                       "AC-B3: pressing `n` MUST send {:permission_decision, \"tc-deny\", " <>
+                         ":deny_once} to the session via decide_permission/3; no such cast " <>
+                         "was observed (an `:allow_once` verdict, or no cast at all, would " <>
+                         "fail this assertion)."
       end
     end
 


### PR DESCRIPTION
## Closes

Closes #341 — **PR-B of 2** (the TUI surface). PR-A (the SPEC + FSM core:
`:awaiting_permission` state, `PermissionRequest` event,
`decide_permission/3` / `set_permissions_mode/2`) merged earlier. This PR
adds the interactive surface and closes the issue.

## Background — plan of record

Per the #341 elaboration (autonomous research, PSDH 4/5) and the merged
`docs/spec/SPEC-PERMISSION-PROMPTS.md`. PR-A built the FSM contract;
`:ask`-verdict tool calls now suspend the round in `:awaiting_permission`
and broadcast `%PermissionRequest{}`. PR-B renders that surface:

1. **TUI approval dialog.** `Tau.TUI.App` gains a `pending_permissions`
   queue model field. The `EventBridge` already drains `Events.*`; add a
   `%Tau.Session.Events.PermissionRequest{}` clause to `update/2` that
   pushes onto the queue. `render/2` renders the **head** request as a
   modal `panel` over the transcript — tool name, a one-line argument
   summary, the `decision_reason`, and numbered options `[y] allow once`
   / `[n] deny`. While the queue is non-empty the dialog **captures all
   input**: `y`/`n` resolve the head via `Tau.Session.decide_permission/3`
   and pop it; every other keystroke is swallowed (no leak to the
   prompt). Pure MVU model state — no new process (OTP non-negotiable
   #3/#8).
2. **`/perms <mode>` mode-change command.** The original `Shift+Tab`
   cycle is **infeasible** — an empirical tmux probe confirmed termbox
   delivers `Shift+Tab` (`CSI Z`) as three separate events (`ESC` `[`
   `Z`), and the `ESC` functionally collides with cancel/clear; there is
   no clean intercept without replacing `ex_termbox`. The mode-change
   mechanism is therefore a **slash command** (the elaboration's R2
   fallback): `/perms <mode>` where `mode ∈ {default, accept_edits,
   plan}` — the Claude-Code-parity subset (`:bypass` deliberately
   excluded as a footgun; `:auto`/`:dont_ask` omitted for legibility,
   per elaboration D2). The command calls `Tau.Session.set_permissions_mode/2`;
   mid-turn changes are rejected `:busy` by the FSM (the PR-A
   `set_permissions_mode` contract), so the indicator does not move. `/perms` with no/invalid argument prints
   the current mode + the valid set. It is a new builtin slash command —
   the implementer chooses the FSM builtin-slash-registry vs TUI command-
   catalog wiring; the user-facing path is "type `/perms <mode>` + Enter".
3. **Status-bar mode indicator.** `Tau.TUI.StatusBar` (the pure module
   #340 landed) gains an always-visible ` mode: <mode>` segment.
4. **`RuntimeOpts` `:permissions_mode`.** Extend
   `lib/tau/tui/runtime_opts.ex` with a `:permissions_mode` key, plumbed
   from the CLI like `:provider` / `:model`; it seeds the session's
   initial mode and the indicator.

**Out of scope:** rule-file "allow & don't ask again" persistence
(deferred — owned by a future PR); a one-keystroke mode cycle (the `Shift+Tab` key is infeasible
per the probe — `/perms <mode>` is the mechanism; a clean-key cycle is a
possible future follow-up); any FSM change (PR-A owns the FSM — if a
gating test reveals an FSM contract gap, that is a SPEC matter / a
challenge, not a PR-B code change).

## SPECs

In scope of **`docs/spec/SPEC-PERMISSION-PROMPTS.md`** — this PR **amends
§7** to add the PR-B acceptance criteria (the §7 "PR-B (TUI surface)"
stub currently only names the scope), **records the `Shift+Tab`-is-
infeasible probe finding** (termbox delivers `CSI Z` as three events;
the mechanism is the `/perms` command — a §3 constraint / §4 contract
note), and, if new TUI invariants surface (dialog input-capture; the
`/perms` mode-set contract), allocates a D-NNN block **per the
`docs/MISSION.md` registry** (authoritative — confirm the next free
block with `grep`; do NOT reuse the D-NNN block PR-A consumed).
Also in scope of **`SPEC-TUI-HEADLESS.md`** as a UX/render surface — PR-B
**conforms**; cite the AC/D-NNN it conforms to and amend only if a new
render-layer constraint surfaces. PSDH triage 4/5.

## Gating-test paths

Per phase 4b, the `test-author` owns and the implementer treats as
**read-only**:

- `test/tau/tui/permission_dialog_test.exs`

(The TUI MVU loop — `Tau.TUI.App.update/2` driven with realistic
`%PermissionRequest{}` and termbox key events, plus `render/2` /
`Tau.TUI.StatusBar.render/1` assertions — is the user-facing path for
these ACs. The test-author MAY add fixtures under
`test/support/`; declare any such path here when it does.)

## Acceptance criteria

- **AC-B1** under `mode: :default`, a `%PermissionRequest{}` event
  (from a Replay fixture emitting an unmatched tool call) makes
  `Tau.TUI.App` render a permission dialog naming the tool and offering
  allow/deny — before any tool output renders.
- **AC-B2** with the dialog open, a `y` key event resolves the head
  request via `decide_permission/3` with `:allow_once` and pops it.
- **AC-B3** an `n` key event resolves the head with `:deny_once` and
  pops it.
- **AC-B4** while the dialog is open, a printable keystroke (e.g. `h`)
  does NOT reach the prompt/input editor — the modal captures all input.
- **AC-B5** `Tau.TUI.StatusBar.render/1` includes a ` mode: <mode>`
  segment reflecting the model's `permissions_mode`.
- **AC-B6** typing `/perms accept_edits` + Enter sets `permissions_mode`
  to `:accept_edits` via `set_permissions_mode/2`; likewise `/perms plan`
  → `:plan` and `/perms default` → `:default`. An unknown/empty argument
  (`/perms`, `/perms bogus`) is a no-op that reports the current mode and
  the valid set — it does not crash or change the mode.
- **AC-B7** `/perms <mode>` while the model status is `:streaming` does
  NOT change the displayed mode (the FSM rejects `set_permissions_mode`
  `:busy`); once the turn ends, `/perms <mode>` works again.
- **AC-B8** two `%PermissionRequest{}` events in one round queue: the
  dialog shows the first; resolving it reveals the second; resolving
  both clears the dialog.
- **AC-B9 (meta)** `RuntimeOpts` carries `:permissions_mode`, plumbed
  from the CLI; the launched TUI's initial indicator reflects it.
  Verified by inspection + the `tau tui` smoke path, not a unit test.

Every non-meta AC has a test that fails before / passes after.

## Test plan

- `test/tau/tui/permission_dialog_test.exs` (test-author–authored):
  fail-before/pass-after unit/integration tests for AC-B1..AC-B8 driving
  `Tau.TUI.App.update/2` with realistic event/key shapes and asserting
  on the resulting model + `render/2` / `StatusBar.render/1` output.
- `mix tau.tui_ux` tmux steps exercise AC-B1..AC-B8 on the built binary
  (reviewer-verified via `binary-qa`).
- `mix compile --warnings-as-errors`, `mix format --check-formatted`,
  `mix credo --strict`, full `mix test` green.

## Gate verdicts

- critic: PASS (`ok: true`) — across two passes: the `:awaiting_permission`
  dialog is pure MVU state (no new process); the OTP-#7 `spawn`/`catch
  :exit` violation was removed (direct session calls); the AC-B2/B3
  gating tests were strengthened to verify the `decide_permission`
  verdict (verdict-swap empirically reds them). D-NNN collision moot
  (M7 moved to D-180-D-189; #341 keeps D-170-D-179).
- reviewer: PASS (`verdict: PASS`) — all CI green on `1bb34dd` incl.
  `lint` Gate 5.1 (after the body reworded away background `D-NNN`
  citations — methodology gap filed as #381), `mutation-check` Gate 5.3,
  both `test` cells, `binary-qa`, `web`. AC-B1..B8 each test-covered;
  AC-B9 `(meta)`. One non-blocking WARNING: an inaccurate
  cast-vs-call comment in `handle_perms_command/2` (harmless).


