### PR TITLE
test(tui): de-flake editor D-142 grapheme-cursor property (#363)

### DIFF
--- a/test/tau/tui/editor_test.exs
+++ b/test/tau/tui/editor_test.exs
@@ -17,6 +17,40 @@ defmodule Tau.TUI.EditorTest do
 
   # --- Properties (OTP non-negotiable #6: properties before examples) --------
 
+  # Curated grapheme set for D-142 properties.
+  #
+  # Rationale: string(:utf8) generates bare combining diacritics (U+0300..U+036F
+  # etc.) which appear as lone graphemes at the start of a string. When ASCII is
+  # inserted before such a grapheme the combiner attaches to the inserted char,
+  # reducing the grapheme count by 1 and falsifying the count assertion. This is
+  # a test-generator artifact — not a production bug — because Editor.insert/2
+  # correctly operates on grapheme clusters; the assertion's additive model only
+  # holds when no grapheme in the string is a lone combining character.
+  #
+  # The curated set exercises the D-142 invariant (multi-byte grapheme cursor
+  # movement) without the pathological case:
+  #   - Precomposed Latin (multi-byte, single codepoint each): é ñ ü ô ì æ ø ß
+  #   - CJK: 中 文 日 本
+  #   - Emoji / symbols: 😀 🎉 ✓
+  #   - ASCII: a–z, 0–9, space (to form interior boundaries)
+  #
+  # Every entry in the set is a single grapheme cluster, so inserting any member
+  # between two others always yields exactly +1 grapheme.
+  @grapheme_pool ~w(
+    a b c d e f g h i j k l m n o p q r s t u v w x y z
+    0 1 2 3 4 5 6 7 8 9
+    é ñ ü ô ì æ ø ß
+    中 文 日 本
+    😀 🎉 ✓
+  )
+
+  # Generator: list_of a curated grapheme → join into a string.
+  # Each element is a self-contained grapheme cluster; no lone combiners.
+  defp grapheme_string(min_len, max_len) do
+    list_of(member_of(@grapheme_pool), min_length: min_len, max_length: max_len)
+    |> map(&Enum.join/1)
+  end
+
   describe "property: grapheme-cursor invariant (D-142)" do
     # FIX-5: properties exercise mid-string cursor positions, not just EOL.
     # The generator inserts a string, moves cursor to a random interior grapheme
@@ -26,10 +60,10 @@ defmodule Tau.TUI.EditorTest do
     # Would fail if cursor arithmetic were byte-based.
     property "insert/2 at random interior position never splits a UTF-8 grapheme" do
       check all(
-              text <- string(:utf8, min_length: 2, max_length: 20),
-              # Use :ascii for insert_text so combining chars don't merge with
-              # adjacent graphemes (making additive count assertion unreliable).
-              insert_text <- string(:ascii, min_length: 1, max_length: 5),
+              text <- grapheme_string(2, 20),
+              # insert_text from the same curated pool — every member is a single
+              # grapheme cluster that cannot form combining sequences with neighbors.
+              insert_text <- grapheme_string(1, 5),
               # Generate interior_col as a StreamData integer so shrinking works.
               # Bound after text so we can clamp to the grapheme count.
               interior_col_raw <- non_negative_integer()
@@ -52,8 +86,8 @@ defmodule Tau.TUI.EditorTest do
         full = Editor.text(ed2)
         # Every grapheme in output is a valid grapheme (no split codepoints)
         assert String.valid?(full)
-        # Grapheme count is sum of original + inserted (ASCII insert_text cannot
-        # form combining sequences with the adjacent UTF-8 graphemes)
+        # Grapheme count is sum of original + inserted. The curated pool guarantees
+        # no member is a lone combining character, so no re-segmentation occurs.
         assert length(String.graphemes(full)) == grapheme_count + insert_grapheme_count
         # All graphemes in output round-trip correctly
         assert Enum.all?(String.graphemes(full), &String.valid?/1)
@@ -62,7 +96,7 @@ defmodule Tau.TUI.EditorTest do
 
     property "backspace/1 at random interior position never splits a grapheme" do
       check all(
-              text <- string(:utf8, min_length: 2, max_length: 20),
+              text <- grapheme_string(2, 20),
               interior_col_raw <- positive_integer()
             ) do
         text_graphemes = String.graphemes(text)
@@ -87,7 +121,7 @@ defmodule Tau.TUI.EditorTest do
     end
 
     property "move_char_left/right keeps cursor in [0, len] and text unchanged" do
-      check all(text <- string(:utf8, min_length: 0, max_length: 15)) do
+      check all(text <- grapheme_string(0, 15)) do
         ed = Editor.new() |> Editor.insert(text)
         ed_left = Editor.move_char_left(ed)
         ed_right = Editor.move_char_right(ed)


### PR DESCRIPTION
## Closes

Closes #363

## Background

The `Tau.TUI.EditorTest` property `grapheme-cursor invariant (D-142)`
for `insert/2` flakes intermittently in CI. Root cause (per #363):
`StreamData.string(:utf8)` generates private-use-plane / supplementary
codepoints whose grapheme segmentation the property's count assertion
mishandles. Introduced with #338's input editor; not a regression of a
later PR.

## Scope

**Test-only maintenance.** Fix the flake in `test/tau/tui/editor_test.exs`
— constrain the property's generator (e.g. a curated grapheme set, or
`string(:alphanumeric)` plus a few known CJK/emoji), or correct the
property's grapheme-count expectation to use `String.graphemes/1`
consistently. The D-142 invariant being tested is unchanged — the
property must still genuinely exercise multi-byte grapheme cursor
movement; the fix removes only the non-deterministic PUA-codepoint
input, not the test's teeth.

This is a **maintenance PR** — it advances no `AC-N`/`D-NNN` (it repairs
an existing test), so the factory phase-4b test-authoring step is
skipped. No production code change is expected; if the investigation
finds the flake is a genuine `Tau.TUI.Editor` grapheme bug rather than a
test-generator artifact, that is an in-scope production fix and the
implementer must say so explicitly.

## Verification

- `mix test test/tau/tui/editor_test.exs` run repeatedly / with varied
  seeds — the D-142 property is deterministic (0 failures across runs).
- `mix compile --warnings-as-errors`, `mix format --check-formatted`,
  `mix credo --strict`, full `mix test` green.

## Gate verdicts

- critic: PASS (`ok: true`) — diagnosis verified (test-generator artifact:
  a lone leading combining diacritic causes `String.graphemes/1`
  re-segmentation; production `Tau.TUI.Editor` is correct, unchanged).
  The curated pool spans 1/2/3/4-byte graphemes — the D-142 property
  keeps its teeth. No masking. SUGGESTION: a dedicated combining-sequence
  property is a worthwhile follow-up (out of scope here).
- reviewer: PASS (`verdict: PASS`) — `lint` + both `test` matrix cells +
  `dialyzer` + `escript` + `mutation-check` green on `260e85c`; the lone
  `binary-qa` red was an unrelated `delegate_test.exs` async-concurrency
  flake (a second `binary-qa` cell on the identical commit passed).
  Diff is exactly the declared 1-file test-only generator swap.

