### PR TITLE
test(permissions): cover :auto-mode Agent allow (#355)

### DIFF
--- a/test/tau/permissions/evaluator_test.exs
+++ b/test/tau/permissions/evaluator_test.exs
@@ -113,6 +113,19 @@ defmodule Tau.Permissions.EvaluatorTest do
       assert Evaluator.evaluate(rs, "Bash", %{"command" => "npm test"}, %{}, :accept_edits) ==
                :deny
     end
+
+    test ":auto mode allows Agent (dispatch infrastructure, issue #354)" do
+      # "Agent" is dispatch infrastructure — :auto must not gate sub-agent
+      # delegation. This test will fail if "Agent" is removed from the
+      # :auto allow-set in default_for_mode/3.
+      assert Evaluator.evaluate({}, "Agent", %{}, %{}, :auto) == :allow
+    end
+
+    test ":auto mode falls through to :ask for non-exempt tools" do
+      # Baseline: tools not in the :auto allow-set still produce :ask,
+      # confirming the allow above is not a blanket-allow.
+      assert Evaluator.evaluate({}, "Write", %{}, %{}, :auto) == :ask
+    end
   end
 
   describe "matchers" do


### PR DESCRIPTION
## Closes

Closes #355

## Background

PR #354 (#341 PR-A) added `"Agent"` to the `:auto` permission mode's
allow-set in `Tau.Permissions.Evaluator` — a necessary consequence of
making `:ask` actually gate. The #341 PR-A reviewer flagged that this
one-line change has no dedicated unit test.

## Scope

**Test-only maintenance.** Add a unit test to
`test/tau/permissions/evaluator_test.exs` asserting
`Tau.Permissions.Evaluator.evaluate(_, "Agent", _, _, :auto)` resolves
to `:allow`. The test must drive the real `evaluate/5` (the user-facing
evaluator entry point), not a hand-built shortcut, and must genuinely
fail if `"Agent"` were removed from the `:auto` allow-set.

This is a **maintenance PR** — it advances no `AC-N`/`D-NNN` (it closes
a test-coverage gap in already-merged code), so the factory phase-4b
test-authoring step is skipped. No production code change.

## Verification

- `mix test test/tau/permissions/evaluator_test.exs` — green, including
  the new `:auto`/`Agent` test.
- `mix compile --warnings-as-errors`, `mix format --check-formatted`,
  `mix credo --strict`, full `mix test` green.

## Gate verdicts

- critic: PASS (`ok: true`, empty findings) — both tests drive the real
  `evaluate/5`; the `Agent`→`:allow` test is non-tautological
  (independently mutation-verified) and the `Write`→`:ask` test is a
  genuine negative control; no production code, no deleted assertions.
- reviewer: PASS (`verdict: PASS`) — `lint` + both `test` matrix cells +
  `dialyzer` + `escript` + `binary-qa` + `mutation-check` green on
  `7a97dcb`; diff is exactly the declared +13-line test-only change.

