### PR TITLE
fix(factory): Gate 5.1 + 5.3 precision — scoped AC scan, project-creation N/A (#380, #381)

### DIFF
--- a/.claude/rules/factory-loop.md
+++ b/.claude/rules/factory-loop.md
@@ -138,11 +138,14 @@ no brief/PR drift. It MUST state:
 - **Dependencies** — issues or PRs this is blocked-by or blocks.
 - **SPECs** — every `docs/spec/SPEC-*.md` in scope, whether this PR authors,
   amends, or merely conforms to each, and the `AC-N` / `D-NNN` it advances.
-- **Acceptance criteria** — list each `AC-N` the PR advances. An AC verified
-  by CI wiring or inspection (not a unit gating test) MUST be marked
-  `AC-N (meta)` immediately after its identifier (e.g. `**AC-4 (meta)**`).
-  Gate 5.1 exempts meta-ACs from the test-linkage check; non-meta ACs MUST
-  have a matching gating-test name or `@tag`.
+- **Acceptance criteria** — the single authoritative claims list for Gate
+  5.1. List each `AC-N` AND each `D-NNN` the PR advances here. Gate 5.1
+  scans ONLY this section for claimed tokens; tokens cited elsewhere in the
+  PR body (e.g. in Background prose) are context, not claims, and are not
+  checked. An AC verified by CI wiring or inspection (not a unit gating test)
+  MUST be marked `AC-N (meta)` immediately after its identifier (e.g.
+  `**AC-4 (meta)**`). Gate 5.1 exempts meta-ACs from the test-linkage check;
+  non-meta ACs MUST have a matching gating-test name or `@tag`.
 - **Gating-test paths** — the exact `test/...` file paths the test-author owns
   for this PR (filled in at cycle step 4b; absent for PRs claiming no
   `AC-N`/`D-NNN`). This path set is the boundary the mechanical gates key on;
@@ -292,8 +295,11 @@ provides the three pure functions; `mix tau.gate.ac_linkage`,
 `mix tau.gate.masking`, and `mix tau.gate.mutation` are the CLI wrappers;
 `.github/workflows/ci.yml` wires them into the `lint` and `mutation-check` jobs.
 
-**Gate 5.1 — AC-to-test linkage.** Every `AC-N`/`D-NNN` the draft-PR body
-claims MUST appear in a gating-test name or `@tag`. Verified by CI via
+**Gate 5.1 — AC-to-test linkage.** Every `AC-N`/`D-NNN` token in the
+draft-PR body's `## Acceptance criteria` section MUST appear in a
+gating-test name or `@tag`. The scan is scoped to that section only —
+tokens cited outside it (e.g. in a Background or Context section) are
+background prose and are NOT treated as claims. Verified by CI via
 `mix tau.gate.ac_linkage` in the `lint` job (blocking).
 
 *Meta-AC exemption:* an AC whose identifier is immediately followed by the
@@ -321,6 +327,17 @@ restored separately, so reverting "everything else" to the merge-base reverts
 no test-author work. Path-based rather than commit-based so it survives
 refine-cycle rebases. Verified by CI via `mix tau.gate.mutation` in the
 dedicated `mutation-check` job (blocking).
+
+*Project-creation N/A:* when every declared gating-test path lives in a Mix
+project whose nearest-ancestor `mix.exs` is absent at the merge-base (the
+entire sub-project is PR-created), Gate 5.3 reports `:not_applicable` and
+exits 0 rather than failing. No pre-implementer production code exists in the
+reverted tree, so the mutation check cannot meaningfully evaluate the suite.
+
+*Runner crash:* if `mix test` exits without producing a valid
+`"N tests, M failures"` summary (e.g. a compile error or process crash), Gate
+5.3 prints a diagnostic and exits 3 (`CaseClauseError` is no longer possible —
+issue #372). Exit 3 indicates an infrastructure failure, not a gate decision.
 
 ### Residual — what these gates do NOT close
 

--- a/lib/mix/tasks/tau.gate.mutation.ex
+++ b/lib/mix/tasks/tau.gate.mutation.ex
@@ -25,9 +25,10 @@ defmodule Mix.Tasks.Tau.Gate.Mutation do
 
   | code | meaning |
   |------|---------|
-  | 0    | ≥1 gating test failed against the reverted tree (discriminating) |
+  | 0    | ≥1 gating test failed against the reverted tree (discriminating); OR N/A (project-creation PR — no pre-implementer code to mutate) |
   | 1    | all gating tests passed against the reverted tree (vacuous suite) |
   | 2    | usage error |
+  | 3    | test runner crashed — gate could not evaluate (compile error or process crash) |
   """
 
   use Mix.Task
@@ -44,12 +45,25 @@ defmodule Mix.Tasks.Tau.Gate.Mutation do
               "tau.gate.mutation: OK — ≥1 gating test failed against reverted tree (suite is discriminating)"
             )
 
+          :not_applicable ->
+            Mix.shell().info(
+              "tau.gate.mutation: N/A — project-creation PR; no pre-implementer production code to mutate"
+            )
+
           {:error, :all_passed} ->
             Mix.shell().error(
               "tau.gate.mutation: FAIL — all gating tests passed against the reverted tree (vacuous suite)"
             )
 
             System.halt(1)
+
+          {:error, {:runner_crashed, detail}} ->
+            Mix.shell().error(
+              "tau.gate.mutation: ERROR — test runner crashed before producing a summary " <>
+                "(compile error or process crash — gate could not evaluate); detail: #{detail}"
+            )
+
+            System.halt(3)
         end
 
       _ ->

--- a/lib/tau/factory/gate.ex
+++ b/lib/tau/factory/gate.ex
@@ -9,9 +9,11 @@ defmodule Tau.Factory.Gate do
 
   ## Gate 5.1 — AC-to-test linkage (`ac_linkage/2`)
 
-  Parses every `AC-N` / `D-NNN` token from the draft-PR body and returns
-  the subset not found (as a test name substring or `@tag`) in any of the
-  supplied gating-test source strings.
+  Parses every `AC-N` / `D-NNN` token from the `## Acceptance criteria`
+  section of the draft-PR body and returns the subset not found (as a test
+  name substring or `@tag`) in any of the supplied gating-test source
+  strings. Tokens cited only outside that section (e.g. in a Background
+  section) are background prose and are NOT checked.
 
   ## Gate 5.2 — Masking detection (`masking_violations/1`)
 
@@ -33,6 +35,10 @@ defmodule Tau.Factory.Gate do
 
   - `:ok` when ≥1 test fails (the tests are discriminating).
   - `{:error, :all_passed}` when no test fails (the gating suite is vacuous).
+  - `:not_applicable` when every declared gating-test path lives in a Mix
+    project whose nearest-ancestor `mix.exs` is absent at `base_ref` (i.e.
+    the entire sub-project is PR-created). In this case there is no
+    pre-implementer production code to mutate; the check is skipped.
   - `{:error, {:runner_crashed, detail}}` when `mix test` does not emit a
     valid `"N tests, M failures"` summary — e.g. a compile error or process
     crash crashed the runner before it could produce a summary. This outcome
@@ -45,9 +51,16 @@ defmodule Tau.Factory.Gate do
   # ---------------------------------------------------------------------------
 
   @doc """
-  Returns `:ok` when every `AC-N` / `D-NNN` token in `pr_body` appears in
-  at least one of `gating_test_sources` (as a test name substring or
-  `@tag`), or `{:error, missing}` listing those that do not.
+  Returns `:ok` when every `AC-N` / `D-NNN` token in the `## Acceptance
+  criteria` section of `pr_body` appears in at least one of
+  `gating_test_sources` (as a test name substring or `@tag`), or
+  `{:error, missing}` listing those that do not.
+
+  Only tokens in the `## Acceptance criteria` section are treated as claims.
+  Tokens cited outside that section (e.g. in a Background or Context section)
+  are background prose and are NOT checked. If no `## Acceptance criteria`
+  heading exists in the PR body, the claims region is empty and `:ok` is
+  returned.
 
   Token format:
   - `AC-N` — one or more digits, e.g. `AC-1`, `AC-12`
@@ -63,7 +76,8 @@ defmodule Tau.Factory.Gate do
   verified by CI wiring or inspection, not a unit gating test. Meta-ACs
   are exempt from the linkage check: they are never reported as missing.
   An AC is considered meta if ANY occurrence of `AC-N (meta)` exists in
-  `pr_body` (allowing optional whitespace between the token and the marker).
+  the `## Acceptance criteria` section (allowing optional whitespace between
+  the token and the marker).
 
   Examples of meta-AC forms recognised in a PR body:
   - `AC-4 (meta)` — plain
@@ -72,8 +86,9 @@ defmodule Tau.Factory.Gate do
   @spec ac_linkage(String.t(), [String.t()]) :: :ok | {:error, [String.t()]}
   def ac_linkage(pr_body, gating_test_sources)
       when is_binary(pr_body) and is_list(gating_test_sources) do
-    meta_acs = parse_meta_ac_tokens(pr_body)
-    claimed = parse_ac_tokens(pr_body)
+    ac_section = extract_acceptance_criteria_section(pr_body)
+    meta_acs = parse_meta_ac_tokens(ac_section)
+    claimed = parse_ac_tokens(ac_section)
     non_meta = Enum.reject(claimed, &MapSet.member?(meta_acs, &1))
     missing = Enum.reject(non_meta, &token_covered?(&1, gating_test_sources))
 
@@ -83,27 +98,58 @@ defmodule Tau.Factory.Gate do
     end
   end
 
+  # Extract the content of the "## Acceptance criteria" section from the PR body.
+  # The section starts after the heading line whose text (stripped of leading #,
+  # trimmed, downcased) begins with "acceptance criteria".
+  # The section ends at the next markdown heading line (matching ~r/^#{1,6}\s/)
+  # or EOF. Returns "" if no such heading is found.
+  defp extract_acceptance_criteria_section(pr_body) do
+    lines = String.split(pr_body, "\n")
+    heading_pattern = ~r/^[#]{1,6}\s/
+
+    # Find the index of the acceptance criteria heading
+    ac_heading_idx =
+      Enum.find_index(lines, fn line ->
+        stripped = line |> String.replace(~r/^#+\s*/, "") |> String.trim() |> String.downcase()
+
+        String.starts_with?(stripped, "acceptance criteria") and
+          String.match?(line, heading_pattern)
+      end)
+
+    case ac_heading_idx do
+      nil ->
+        ""
+
+      idx ->
+        # Take lines after the heading, up to the next heading or EOF
+        lines
+        |> Enum.drop(idx + 1)
+        |> Enum.take_while(&(not String.match?(&1, heading_pattern)))
+        |> Enum.join("\n")
+    end
+  end
+
   # Parse AC-N tokens that are marked as meta (exempt from the linkage gate).
-  # An AC is meta if ANY occurrence in pr_body is immediately followed by
-  # "(meta)" (optionally with surrounding ** bold markers and optional
+  # An AC is meta if ANY occurrence in the section text is immediately followed
+  # by "(meta)" (optionally with surrounding ** bold markers and optional
   # whitespace between the token and the marker).
-  defp parse_meta_ac_tokens(pr_body) do
+  defp parse_meta_ac_tokens(section_text) do
     # Matches forms like: AC-4 (meta), **AC-4 (meta)**, AC-4  (meta)
     meta_pattern = ~r/\bAC-(\d+)\s*\(meta\)/
 
-    Regex.scan(meta_pattern, pr_body, capture: :all_but_first)
+    Regex.scan(meta_pattern, section_text, capture: :all_but_first)
     |> List.flatten()
     |> Enum.map(&"AC-#{&1}")
     |> MapSet.new()
   end
 
-  # Parse all AC-N and D-NNN tokens from the PR body.
-  defp parse_ac_tokens(pr_body) do
+  # Parse all AC-N and D-NNN tokens from the given text.
+  defp parse_ac_tokens(section_text) do
     ac_pattern = ~r/\bAC-\d+\b/
     d_pattern = ~r/\bD-\d+\b/
 
-    ac_tokens = Regex.scan(ac_pattern, pr_body) |> List.flatten()
-    d_tokens = Regex.scan(d_pattern, pr_body) |> List.flatten()
+    ac_tokens = Regex.scan(ac_pattern, section_text) |> List.flatten()
+    d_tokens = Regex.scan(d_pattern, section_text) |> List.flatten()
 
     (ac_tokens ++ d_tokens) |> Enum.uniq()
   end
@@ -217,6 +263,10 @@ defmodule Tau.Factory.Gate do
 
   Returns:
   - `:ok` when ≥1 gating test fails against the reverted tree (tests discriminate).
+  - `:not_applicable` when every declared gating-test path lives in a Mix
+    project whose nearest-ancestor `mix.exs` is absent at `base_ref` (the entire
+    sub-project is PR-created). No pre-implementer production code exists to
+    mutate; the check is skipped rather than failing.
   - `{:error, :all_passed}` when no gating test fails (vacuous suite).
   - `{:error, {:runner_crashed, detail}}` when `mix test` exits without
     producing a valid `"N tests, M failures"` summary — e.g. a compile error
@@ -229,11 +279,77 @@ defmodule Tau.Factory.Gate do
   check, then restored.
   """
   @spec mutation_check([String.t()], String.t()) ::
-          :ok | {:error, :all_passed} | {:error, {:runner_crashed, String.t()}}
+          :ok
+          | :not_applicable
+          | {:error, :all_passed}
+          | {:error, {:runner_crashed, String.t()}}
   def mutation_check(gating_test_paths, base_ref)
       when is_list(gating_test_paths) and is_binary(base_ref) do
     repo_dir = locate_repo_for_gating_tests(gating_test_paths, File.cwd!(), base_ref)
-    mutation_check_in(gating_test_paths, base_ref, repo_dir)
+
+    if project_creation_pr?(gating_test_paths, base_ref, repo_dir) do
+      :not_applicable
+    else
+      mutation_check_in(gating_test_paths, base_ref, repo_dir)
+    end
+  end
+
+  # Returns true iff the gating_test_paths list is non-empty AND every path's
+  # enclosing Mix project (nearest ancestor mix.exs) is absent at base_ref —
+  # i.e. every gating test lives in a PR-created project.
+  #
+  # Conservative: a path with NO ancestor mix.exs is treated as NOT PR-created.
+  # A mixed PR (some paths in existing projects, some in new ones) returns false
+  # — the N/A short-circuit applies only when ALL paths are PR-created.
+  defp project_creation_pr?([], _base_ref, _repo_dir), do: false
+
+  defp project_creation_pr?(gating_test_paths, base_ref, repo_dir) do
+    Enum.all?(gating_test_paths, fn test_path ->
+      case find_enclosing_mix_exs(test_path, repo_dir) do
+        nil ->
+          # No ancestor mix.exs found — conservative: treat as NOT PR-created
+          false
+
+        mix_exs_relpath ->
+          # PR-created iff the mix.exs is absent at base_ref
+          not path_exists_at_ref?(mix_exs_relpath, base_ref, repo_dir)
+      end
+    end)
+  end
+
+  # Walk up from a gating-test file's directory to find the nearest ancestor
+  # directory containing a mix.exs file, returning the repo-relative path of
+  # that mix.exs (e.g. "sub/mix.exs" or "mix.exs"), or nil if none found.
+  defp find_enclosing_mix_exs(test_path, repo_dir) do
+    # Start from the directory containing the test file
+    start_dir = test_path |> Path.dirname()
+    do_find_mix_exs(start_dir, repo_dir)
+  end
+
+  # Recursively walk up toward the repo root, looking for a mix.exs.
+  # Returns the repo-relative path of the first mix.exs found, or nil.
+  defp do_find_mix_exs(rel_dir, repo_dir) do
+    mix_exs_relpath =
+      if rel_dir == "." do
+        "mix.exs"
+      else
+        Path.join(rel_dir, "mix.exs")
+      end
+
+    abs_mix_exs = Path.join(repo_dir, mix_exs_relpath)
+
+    if File.exists?(abs_mix_exs) do
+      mix_exs_relpath
+    else
+      parent = Path.dirname(rel_dir)
+
+      if parent == rel_dir do
+        # Reached the filesystem root — no mix.exs found
+        nil
+      else
+        do_find_mix_exs(parent, repo_dir)
+      end
+    end
   end
 
   # Locate the git repo root that contains the gating test files AND the given

--- a/test/tau/factory/gate_precision_test.exs
+++ b/test/tau/factory/gate_precision_test.exs
@@ -1,0 +1,196 @@
+defmodule Tau.Factory.GatePrecisionTest do
+  @moduledoc """
+  Precision gating tests for PR #382 (issues #380 + #381).
+
+  Tests AC-2, AC-4, and AC-5 — the gate-precision fixes for
+  `Tau.Factory.Gate`. Written as failing fail-before tests (AC-2, AC-4)
+  and a regression guard (AC-5) before the implementer lands the fix.
+
+  AC-1, AC-3, AC-6 are meta-ACs (CI/inspection-verified) and are out of
+  this file's scope.
+  """
+  use ExUnit.Case, async: true
+
+  alias Tau.Factory.Gate
+
+  # ---------------------------------------------------------------------------
+  # AC-2 — mutation_check/2 returns :not_applicable for a project-creation PR
+  #
+  # When every declared gating-test path lives in a Mix project whose nearest-
+  # ancestor mix.exs is absent at base_ref, the check cannot meaningfully
+  # mutate the pre-implementer tree (the project didn't exist yet).
+  # The fix makes mutation_check/2 detect this and return :not_applicable.
+  #
+  # Fail-before: the current implementation has no N/A detection — it attempts
+  # to revert the sub-project files and the runner crashes or returns an error
+  # (NOT :not_applicable). The assertion `== :not_applicable` fails.
+  # ---------------------------------------------------------------------------
+
+  describe "mutation_check/2 (AC-2)" do
+    @describetag :ac_2
+    @describetag tmp_dir: true
+
+    setup %{tmp_dir: tmp_dir} do
+      run = fn args -> {_, 0} = System.cmd("git", args, cd: tmp_dir) end
+
+      run.(["init", "-q"])
+      run.(["config", "user.email", "test@example.com"])
+      run.(["config", "user.name", "Test"])
+
+      # --- base commit: a root-level project only (NO sub/ directory) ---
+      File.mkdir_p!(Path.join(tmp_dir, "lib"))
+      File.write!(Path.join(tmp_dir, "mix.exs"), """
+      defmodule Root.MixProject do
+        use Mix.Project
+        def project, do: [app: :root, version: "0.1.0"]
+      end
+      """)
+      File.write!(Path.join(tmp_dir, "lib/root.ex"), """
+      defmodule Root do
+        def hello, do: :world
+      end
+      """)
+      run.(["add", "-A"])
+      run.(["commit", "-q", "-m", "base: root project only"])
+      {base_ref, 0} = System.cmd("git", ["rev-parse", "HEAD"], cd: tmp_dir)
+      base_ref = String.trim(base_ref)
+
+      # --- HEAD commit: adds an entirely new sub-project (sub/) ---
+      File.mkdir_p!(Path.join(tmp_dir, "sub/lib"))
+      File.mkdir_p!(Path.join(tmp_dir, "sub/test"))
+      File.write!(Path.join(tmp_dir, "sub/mix.exs"), """
+      defmodule Sub.MixProject do
+        use Mix.Project
+        def project, do: [app: :sub, version: "0.1.0"]
+      end
+      """)
+      File.write!(Path.join(tmp_dir, "sub/lib/sub.ex"), """
+      defmodule Sub do
+        def run, do: :ok
+      end
+      """)
+      File.write!(Path.join(tmp_dir, "sub/test/sub_gate_test.exs"), """
+      defmodule SubGateTest do
+        use ExUnit.Case
+        @tag :ac_2
+        test "AC-2: sub project runs ok" do
+          assert Sub.run() == :ok
+        end
+      end
+      """)
+      run.(["add", "-A"])
+      run.(["commit", "-q", "-m", "head: add sub project"])
+
+      {:ok, tmp_dir: tmp_dir, base_ref: base_ref}
+    end
+
+    test "AC-2: returns :not_applicable when gating tests are in a PR-created Mix project",
+         %{tmp_dir: tmp_dir, base_ref: base_ref} do
+      # The gating test lives in sub/test/sub_gate_test.exs. The nearest-
+      # ancestor mix.exs for that path is sub/mix.exs, which does NOT exist at
+      # base_ref (the sub/ project is PR-created). The fix should detect this
+      # and return :not_applicable without attempting to run the tests.
+      #
+      # Fail-before: current implementation returns {:error, {:runner_crashed, _}}
+      # or similar — NOT :not_applicable.
+      original_dir = File.cwd!()
+
+      try do
+        File.cd!(tmp_dir)
+        result = Gate.mutation_check(["sub/test/sub_gate_test.exs"], base_ref)
+        assert result == :not_applicable
+      after
+        File.cd!(original_dir)
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # AC-4 — ac_linkage/2 ignores tokens cited only as background prose
+  #
+  # The current whole-body scan extracts AC/D tokens from ALL sections —
+  # including Background sections where tokens are mentioned as context, not
+  # claimed as acceptance criteria to be tested. The fix should restrict
+  # extraction to the "Acceptance criteria" section only (or an equivalent
+  # claimed-tokens section), ignoring prose references.
+  #
+  # Fail-before: the current implementation finds D-090 in the Background
+  # section, treats it as a claimed token, finds no coverage, and returns
+  # {:error, ["D-090"]} instead of :ok.
+  # ---------------------------------------------------------------------------
+
+  describe "ac_linkage/2 (AC-4)" do
+    @describetag :ac_4
+
+    @pr_body_with_background_prose """
+    ## Background
+
+    This PR is related to the permission system (D-090 describes the
+    permission FSM invariants). It does not claim D-090 as a gating
+    acceptance criterion — D-090 is cited for context only.
+
+    ## Acceptance criteria
+
+    - **AC-1** the fix is implemented and tested.
+
+    ## Test plan
+
+    See gating test.
+    """
+
+    test "AC-4: ignores AC/D-NNN tokens cited only in background prose (not in AC section)" do
+      # We provide a gating source that covers AC-1 (the only claimed token),
+      # but nothing for D-090 (which appears only in the Background section).
+      # The fix should return :ok because D-090 is not a claimed AC.
+      #
+      # Fail-before: current whole-body scan sees D-090, marks it missing,
+      # returns {:error, ["D-090"]}.
+      covering_source = """
+      defmodule FixGateTest do
+        @tag :ac_1
+        test "AC-1: fix implemented" do
+          assert true
+        end
+      end
+      """
+
+      result = Gate.ac_linkage(@pr_body_with_background_prose, [covering_source])
+      assert result == :ok
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # AC-5 — regression guard: ac_linkage/2 STILL flags a genuinely claimed token
+  #
+  # This test verifies that the AC-4 fix (section-scoped extraction) does NOT
+  # accidentally suppress legitimate missing-token detection. A token that
+  # appears in the Acceptance criteria section and has no gating coverage MUST
+  # still be reported as missing.
+  #
+  # NOTE: This is a regression guard — the behavior is preserved by the fix,
+  # so this test passes BOTH before and after the change. There is no
+  # fail-before for AC-5. This is expected and correct.
+  # ---------------------------------------------------------------------------
+
+  describe "ac_linkage/2 (AC-5)" do
+    @describetag :ac_5
+
+    @pr_body_with_uncovered_ac """
+    ## Acceptance criteria
+
+    - **AC-9** a claimed acceptance criterion with no gating test.
+
+    ## Test plan
+
+    No test provided for AC-9 — this exercises the missing-token path.
+    """
+
+    test "AC-5: still flags a genuinely claimed AC-9 that has no gating test coverage" do
+      # AC-9 is in the Acceptance criteria section with no covering source.
+      # The gate MUST still return {:error, missing} with "AC-9" in missing.
+      result = Gate.ac_linkage(@pr_body_with_uncovered_ac, [])
+      assert {:error, missing} = result
+      assert "AC-9" in missing
+    end
+  end
+end

--- a/test/tau/factory/gate_precision_test.exs
+++ b/test/tau/factory/gate_precision_test.exs
@@ -92,23 +92,78 @@ defmodule Tau.Factory.GatePrecisionTest do
     end
 
     test "AC-2: returns :not_applicable when gating tests are in a PR-created Mix project",
-         %{tmp_dir: tmp_dir, base_ref: base_ref} do
+         %{base_ref: base_ref} do
       # The gating test lives in sub/test/sub_gate_test.exs. The nearest-
       # ancestor mix.exs for that path is sub/mix.exs, which does NOT exist at
       # base_ref (the sub/ project is PR-created). The fix should detect this
       # and return :not_applicable without attempting to run the tests.
       #
+      # No File.cd! — the repo-locator fallback (locate_repo_for_gating_tests →
+      # find_repo_containing_path_and_ref) searches under File.cwd!() for the
+      # synthetic :tmp_dir repo, exactly as gate_test.exs AC-3 already does.
+      #
       # Fail-before: current implementation returns {:error, {:runner_crashed, _}}
       # or similar — NOT :not_applicable.
-      original_dir = File.cwd!()
+      result = Gate.mutation_check(["sub/test/sub_gate_test.exs"], base_ref)
+      assert result == :not_applicable
+    end
 
-      try do
-        File.cd!(tmp_dir)
-        result = Gate.mutation_check(["sub/test/sub_gate_test.exs"], base_ref)
-        assert result == :not_applicable
-      after
-        File.cd!(original_dir)
+    @tag :ac_2
+    test "AC-2: negative control — does NOT return :not_applicable for a non-project-creation PR",
+         %{tmp_dir: tmp_dir, base_ref: _base_ref} do
+      # Build a SEPARATE synthetic repo with NO mix.exs anywhere.
+      # The project-creation detection walks up the directory tree looking for
+      # mix.exs — when none is found, the check does NOT classify this as a
+      # project-creation PR and must return a real verdict, not :not_applicable.
+      #
+      # Repo shape:
+      #   base commit: lib/widget.ex  → returns :wrong  (gating test would FAIL)
+      #   HEAD commit: lib/widget.ex  → returns :ok     (gating test PASSES)
+      #                test/widget_gate_test.exs added at HEAD
+      #
+      # No mix.exs at any level — kills the over-broad-fix class (a fix that
+      # returns :not_applicable too eagerly, e.g. for any PR with added files).
+      nc_dir = Path.join(tmp_dir, "no_mix_project")
+      File.mkdir_p!(Path.join(nc_dir, "lib"))
+      File.mkdir_p!(Path.join(nc_dir, "test"))
+
+      run = fn args -> {_, 0} = System.cmd("git", args, cd: nc_dir) end
+      run.(["init", "-q"])
+      run.(["config", "user.email", "test@example.com"])
+      run.(["config", "user.name", "Test"])
+
+      prod = Path.join(nc_dir, "lib/widget.ex")
+
+      # base commit: no mix.exs, production code returns :wrong
+      File.write!(prod, "defmodule Widget do\n  def run, do: :wrong\nend\n")
+      run.(["add", "-A"])
+      run.(["commit", "-q", "-m", "base"])
+      {nc_base_ref, 0} = System.cmd("git", ["rev-parse", "HEAD"], cd: nc_dir)
+      nc_base_ref = String.trim(nc_base_ref)
+
+      # HEAD commit: production code fixed + gating test added (still no mix.exs)
+      File.write!(prod, "defmodule Widget do\n  def run, do: :ok\nend\n")
+
+      gating = Path.join(nc_dir, "test/widget_gate_test.exs")
+
+      File.write!(gating, """
+      defmodule WidgetGateTest do
+        use ExUnit.Case
+        @tag :ac_2
+        test "AC-2: widget runs ok" do
+          assert Widget.run() == :ok
+        end
       end
+      """)
+
+      run.(["add", "-A"])
+      run.(["commit", "-q", "-m", "head: fix widget, add gating test"])
+
+      # No mix.exs → NOT a project-creation PR → must NOT return :not_applicable.
+      # The gating test fails against the reverted base tree (run() == :wrong),
+      # so the gate returns :ok — a real discriminating verdict.
+      result = Gate.mutation_check(["test/widget_gate_test.exs"], nc_base_ref)
+      assert result == :ok
     end
   end
 

--- a/test/tau/factory/gate_precision_test.exs
+++ b/test/tau/factory/gate_precision_test.exs
@@ -39,17 +39,20 @@ defmodule Tau.Factory.GatePrecisionTest do
 
       # --- base commit: a root-level project only (NO sub/ directory) ---
       File.mkdir_p!(Path.join(tmp_dir, "lib"))
+
       File.write!(Path.join(tmp_dir, "mix.exs"), """
       defmodule Root.MixProject do
         use Mix.Project
         def project, do: [app: :root, version: "0.1.0"]
       end
       """)
+
       File.write!(Path.join(tmp_dir, "lib/root.ex"), """
       defmodule Root do
         def hello, do: :world
       end
       """)
+
       run.(["add", "-A"])
       run.(["commit", "-q", "-m", "base: root project only"])
       {base_ref, 0} = System.cmd("git", ["rev-parse", "HEAD"], cd: tmp_dir)
@@ -58,17 +61,20 @@ defmodule Tau.Factory.GatePrecisionTest do
       # --- HEAD commit: adds an entirely new sub-project (sub/) ---
       File.mkdir_p!(Path.join(tmp_dir, "sub/lib"))
       File.mkdir_p!(Path.join(tmp_dir, "sub/test"))
+
       File.write!(Path.join(tmp_dir, "sub/mix.exs"), """
       defmodule Sub.MixProject do
         use Mix.Project
         def project, do: [app: :sub, version: "0.1.0"]
       end
       """)
+
       File.write!(Path.join(tmp_dir, "sub/lib/sub.ex"), """
       defmodule Sub do
         def run, do: :ok
       end
       """)
+
       File.write!(Path.join(tmp_dir, "sub/test/sub_gate_test.exs"), """
       defmodule SubGateTest do
         use ExUnit.Case
@@ -78,6 +84,7 @@ defmodule Tau.Factory.GatePrecisionTest do
         end
       end
       """)
+
       run.(["add", "-A"])
       run.(["commit", "-q", "-m", "head: add sub project"])
 


### PR DESCRIPTION
## Closes

Closes #380 — Gate 5.3 mutation-check cannot evaluate project-creation PRs (subsumes #372).
Closes #381 — Gate 5.1 AC-linkage scans the whole PR body and flags background citations.
Closes #372 — the `:runner_crashed` `CaseClauseError` in `tau.gate.mutation` (subsumed by #380).

## Background

The three mechanical oracle-separation gates shipped in PR #371. Two precision
defects surfaced under real factory use:

1. **Gate 5.3 cannot evaluate a project-creation PR.** When a PR adds a whole
   new Mix project (PR #375 added the `web/` poncho), the mutation check reverts
   every non-gating path to the merge-base — which deletes the new project
   *including its test harness*. The gating test then cannot compile, the
   runner crashes, and `tau.gate.mutation` dies with an unhandled
   `CaseClauseError` on the runner-crashed outcome instead of reporting a clean
   result.
2. **Gate 5.1 scans the entire PR body.** `ac_linkage/2` extracts every
   acceptance-criterion token from the whole body, so an invariant token cited
   as background prose (a prior PR's invariants, named for context) is treated
   as a claim and hard-fails the `lint` job. PR #373 hit this; the workaround
   was to reword the body to dodge the literal tokens — a brittle tax on
   authors.

Both are precision fixes to the #371 gates. `Tau.Factory.Gate` is a pure
module; it is not in the `spec-before-code.md` SPEC catalog, so this PR
authors/amends no `docs/spec/SPEC-*.md`.

## Scope & order

One coherent PR — both issues touch `lib/tau/factory/gate.ex` and
`.claude/rules/factory-loop.md`, so they cannot be split without a file
conflict. Commits, in order:

1. **Gate 5.3 — project-creation N/A detection** (`lib/tau/factory/gate.ex`).
   Add a new `:not_applicable` outcome to `mutation_check/2`. Before the revert,
   detect the project-creation class: for each declared gating-test path, walk
   up from the test file's directory to the nearest ancestor mix-project file;
   if that mix-project file is absent at `base_ref`, the
   test's enclosing Mix project is PR-created. When **every** declared
   gating-test path is in a PR-created project, `mutation_check/2` returns
   `:not_applicable` without running the revert. Update the `@spec` and
   moduledoc. (A PR mixing existing-project and new-project gating tests is
   out of scope — the "all paths" rule matches the issue; note it as a possible
   follow-up.)

2. **Gate 5.3 — `tau.gate.mutation` exhaustive `case`** (`lib/mix/tasks/tau.gate.mutation.ex`).
   Add the missing runner-crashed branch — print a clear diagnostic naming the
   crash and the captured detail, `System.halt(3)`. Add a `:not_applicable`
   branch — print an N/A info line, exit 0 (not a failure). Update the moduledoc
   exit-code table: add code 3 ("test runner crashed — gate could not
   evaluate") and note `:not_applicable` exits 0.

3. **Gate 5.1 — scope the scan to the claims region** (`lib/tau/factory/gate.ex`).
   `ac_linkage/2` extracts acceptance-criterion tokens only from the PR body's
   `## Acceptance criteria` section (the heading line matched case-insensitively;
   the section runs to the next markdown heading or EOF). Tokens elsewhere in
   the body are background citations and are not checked. A body with no
   `## Acceptance criteria` section yields no claims (returns `:ok`). The
   meta-AC exemption continues to apply within the section.

4. **Doc updates** (`.claude/rules/factory-loop.md`). Update the Gate 5.1
   description to state the scan is scoped to the Acceptance-criteria section;
   update the Gate 5.3 description to document the project-creation N/A rule
   and the runner-crashed clean diagnostic. Update the draft-PR-body
   "Acceptance criteria" bullet so the Acceptance-criteria section is named as
   the single authoritative claims list (covering both AC and invariant
   tokens).

## Dependencies

None. No blocked-by, blocks nothing. Branches off current `origin/main`.

## SPECs

No `docs/spec/SPEC-*.md` in scope — `lib/tau/factory/gate.ex` is a pure module
not in the `spec-before-code.md` catalog. `.claude/rules/factory-loop.md` is an
operating rule, not a SPEC; this PR amends its gate descriptions as the issues
require.

## Acceptance criteria

- **AC-1 (meta)** — `mix tau.gate.mutation` no longer raises `CaseClauseError`
  on a runner-crashed outcome: the task `case` is exhaustive and prints a clear
  diagnostic, exiting 3. Marked meta because the mix-task layer calls
  `System.halt` and is not amenable to a unit gating test under the mutation
  gate; verified by inspecting the now-exhaustive `case` and the updated
  moduledoc exit-code table.
- **AC-2** — `Tau.Factory.Gate.mutation_check/2` returns `:not_applicable` for
  a project-creation PR: one where every declared gating-test path lives in a
  Mix project whose nearest-ancestor mix-project file is absent at `base_ref`.
- **AC-3 (meta)** — `.claude/rules/factory-loop.md` Gate 5.3 description
  documents both the runner-crashed clean diagnostic and the project-creation
  N/A rule. Verified by inspection of the rule file.
- **AC-4** — `Tau.Factory.Gate.ac_linkage/2` returns `:ok` for a PR body that
  cites an acceptance-criterion token only as background prose outside the
  `## Acceptance criteria` section.
- **AC-5** — `ac_linkage/2` still returns an `{:error, [token]}` result for a
  token genuinely claimed inside the `## Acceptance criteria` section with no
  matching gating test (regression guard against over-scoping).
- **AC-6 (meta)** — `factory-loop.md` Gate 5.1 description and the draft-PR-body
  Acceptance-criteria bullet are updated to match the scoped scan. Verified by
  inspection of the rule file.

## Gating-test paths

Per phase 4b, the `test-author` owns and the implementer treats as **read-only**:

- `test/tau/factory/gate_precision_test.exs`

A new file (a fresh AC namespace, kept separate from the #370 gating tests).
AC-2, AC-4, AC-5 are exercised here against the real `Tau.Factory.Gate` public
functions. AC-1, AC-3, AC-6 are meta (CI/inspection-verified) and have no
gating test.

## Gate verdicts

- critic: PASS (`ok: true`) — attempt 2; both attempt-1 BLOCKING findings (under-asserting AC-2 test; `File.cd!` async cwd race) resolved. Only deferred SUGGESTIONs f-3 (fail-open on a malformed AC heading) and f-4 (unbounded `do_find_mix_exs` walk) remain — filed as a follow-up.
- reviewer: PASS (`verdict: PASS`) — all CI gates green: `binary-qa`, `lint`/Gate 5.1, `mutation-check`/Gate 5.3, `test`×2, `dialyzer`, `escript`, `web`. AC-1..AC-6 met; scope limited to the four declared files.
