### PR TITLE
refactor(session): decompose Tau.Session into focused sub-modules

### DIFF
--- a/lib/tau/session.ex
+++ b/lib/tau/session.ex
@@ -27,8 +27,7 @@ defmodule Tau.Session do
 
   @behaviour :gen_statem
 
-  alias Tau.Message.{Assembler, Assistant, ToolResult, User}
-  alias Tau.Permissions.Evaluator, as: PermEvaluator
+  alias Tau.Message.{Assistant, ToolResult, User}
   alias Tau.Session.Events
   alias Tau.Provider.Event, as: PEvent
   alias Tau.Settings.Cache, as: SettingsCache
@@ -39,7 +38,6 @@ defmodule Tau.Session do
   # events fold into `data.messages` as `%Assistant{}` / `%ToolResult{}`
   # so the existing TUI render path, persistence, and `/resume` apply
   # unchanged (D-037).
-  alias Tau.CodingAgent.Event, as: CAEvent
   alias Tau.CodingAgent.Workspace, as: CAWorkspace
   alias Tau.Commands.Catalog
 
@@ -48,6 +46,9 @@ defmodule Tau.Session do
   # — interception happens in `dispatch_tools/2` before any executor
   # would see it.
   @activate_skill_tool_name "__activate_skill__"
+
+  @doc false
+  def activate_skill_tool_name, do: @activate_skill_tool_name
 
   @type id :: String.t()
 
@@ -544,7 +545,7 @@ defmodule Tau.Session do
     # settings provides the deployment-wide default.
     coding_agent =
       opts[:coding_agent] ||
-        coding_agent_from_settings()
+        Tau.Session.CodingAgentTurn.coding_agent_from_settings()
 
     coding_agent_workspace_backend =
       opts[:coding_agent_workspace_backend] ||
@@ -884,7 +885,7 @@ defmodule Tau.Session do
 
       {:model_command, new_model, _msg} ->
         # /model <id>: attempt swap
-        handle_slash_model_swap(data, new_model)
+        Tau.Session.ModelSwap.handle_slash_model_swap(data, new_model)
 
       {:unknown_command, name} ->
         # D-101 (SPEC-TUI-COMPLETION AC-2): unrecognized slash command.
@@ -958,236 +959,7 @@ defmodule Tau.Session do
   end
 
   def handle_event(:internal, :start_provider, :provider_streaming, data) do
-    transition(data.id, data, :provider_streaming)
-
-    # ADR-0012: re-derive the fallback chain from settings on every fresh
-    # turn (i.e. only when the chain hasn't already been seeded by a
-    # previous fallback within this same turn). data.provider here is
-    # always the original_provider for the first call of a turn — by
-    # construction, fallback iterations rebuild data with a non-empty
-    # remaining list and do NOT re-enter via this branch's seeding.
-    data =
-      if data.fallback_chain_remaining == [] and data.provider == data.original_provider do
-        %{data | fallback_chain_remaining: lookup_fallback_chain(data.original_provider)}
-      else
-        data
-      end
-
-    parent = self()
-
-    # ADR-0017: cooperative cancellation. Allocate a fresh per-stream
-    # `:counters` ref and thread it through the provider ctx. The
-    # `:cancel` handler flips slot 1 to signal abort; the streaming
-    # engine (and Replay, for tests) checks it at every chunk boundary.
-    cancel_flag = :counters.new(1, [])
-
-    ctx =
-      data.provider_ctx
-      |> Map.merge(%{session_id: data.id, cancel_flag: cancel_flag})
-
-    # D-057 / SPEC-OTEL-REPORTER: per-request discriminator ref so the OTel
-    # reporter correlates *.stop / *.cancelled / *.brutal_kill back to the
-    # right *.start span across concurrent requests. Stored in `data`
-    # immediately so every error branch (including ones that never reach
-    # `{:ok, stream}`) emits a matched terminal.
-    provider_span_ref = make_ref()
-    data = %{data | provider_span_ref: provider_span_ref}
-
-    :telemetry.execute(
-      [:tau, :provider, :request, :start],
-      %{system_time: System.system_time()},
-      %{
-        provider: data.provider,
-        model: data.model,
-        session_id: data.id,
-        span_ref: provider_span_ref
-      }
-    )
-
-    # D-059 (SPEC-USER-TURN §6, AC-10): when `data.active_skill` is set
-    # (e.g. headless `tau run --system-prompt-file` or a sub-agent persona
-    # pinned via `Agent`), the model-visible tool list MUST include the
-    # active skill's `allowed_tools` as discrete tools the provider can
-    # call — not just the synthetic `__activate_skill__` tool. Empty
-    # `allowed_tools` means "no whitelist declared" (matches
-    # `whitelist_from/1` in `Tau.Tools.Builtin.Agent`), so the model sees
-    # every registered built-in. The activate-skill tool is still
-    # included when other model-invokable skills are discoverable.
-    stream_opts =
-      %{model: data.model}
-      |> maybe_put_tools(model_visible_tool_specs(data))
-
-    # AC-7 (SPEC-CIRCUIT-BREAKER): wrap the provider call with the circuit
-    # breaker façade. The thunk returns `{:ok, stream}` or `{:error, reason}`;
-    # the façade records the outcome and, when the breaker is `:open`, short-
-    # circuits with `{:error, :circuit_open}` before the thunk is invoked
-    # (B3 contract, D-043). An open breaker falls through to the synchronous
-    # error path below and surfaces as a user-visible `%Events.MessageEnd{}`
-    # — it does NOT trigger ADR-0012 fallback (the fallback path is only
-    # entered via in-stream `%PEvent.Error{retryable?: true}` events, not by
-    # synchronous `{:error, _}` returns from this call site).
-    case Tau.CircuitBreaker.call(data.provider, [], fn ->
-           data.provider.stream(data.messages, stream_opts, ctx)
-         end) do
-      {:ok, stream} ->
-        # ADR-0012: tag each stream's mailbox traffic with a fresh ref so
-        # stragglers from a killed predecessor (e.g. a provider task whose
-        # `:provider_done` was already in the parent mailbox when fallback
-        # kicked in) get dropped instead of finalising a fresh assembler.
-        stream_ref = make_ref()
-
-        task =
-          Task.async(fn ->
-            try do
-              Enum.each(stream, fn ev ->
-                Process.send(parent, {:provider_event, stream_ref, ev}, [])
-              end)
-
-              Process.send(parent, {:provider_done, stream_ref}, [])
-            rescue
-              e ->
-                Process.send(
-                  parent,
-                  {:provider_failed, stream_ref, Exception.message(e)},
-                  []
-                )
-            end
-          end)
-
-        assembler = Assembler.new(provider: data.provider, model: data.model)
-        broadcast(data.id, %Events.MessageStart{session_id: data.id, message: assembler.message})
-
-        {:next_state, :provider_streaming,
-         %{
-           data
-           | provider_task: task,
-             assembler: assembler,
-             cancel_flag: cancel_flag,
-             stream_ref: stream_ref,
-             provider_span_ref: provider_span_ref
-         }}
-
-      {:error, :circuit_open} ->
-        # D-043 (SPEC-CIRCUIT-BREAKER): an open breaker on one provider MUST
-        # advance the fallback chain rather than killing the turn immediately.
-        # Only when the chain is exhausted (every provider's breaker open or
-        # no fallback left) does the turn surface a terminal error. This
-        # mirrors the in-stream `%PEvent.Error{retryable?: true}` path
-        # (ADR-0012) and guarantees the all-open chain terminates: N providers
-        # all open ⇒ N synchronous `{:error, :circuit_open}` returns ⇒ one
-        # terminal error, no infinite loop (each recursive call pops one
-        # element from `fallback_chain_remaining`).
-        case data.fallback_chain_remaining do
-          [next | rest] ->
-            from_provider = data.provider
-
-            :telemetry.execute(
-              [:tau, :provider, :fallback],
-              %{system_time: System.system_time()},
-              %{
-                from_provider: from_provider,
-                to_provider: next,
-                reason: :circuit_open,
-                session_id: data.id
-              }
-            )
-
-            broadcast(data.id, %Events.ProviderFallback{
-              session_id: data.id,
-              from_provider: from_provider,
-              to_provider: next,
-              reason: :circuit_open
-            })
-
-            data =
-              persist_event(data, "provider_fallback", %{
-                from_provider: inspect(from_provider),
-                to_provider: inspect(next),
-                reason: "circuit_open"
-              })
-
-            # D-057 (SPEC-OTEL-REPORTER): the *.start fired above; emit the
-            # terminal event before recursing into :start_provider so the span
-            # opened at *.start is closed and not leaked as a stale span.
-            emit_provider_request_terminal(:cancelled, data)
-
-            transformed =
-              Tau.Providers.Shared.ContentTransform.transform(
-                data.messages,
-                from_provider,
-                next
-              )
-
-            handle_event(
-              :internal,
-              :start_provider,
-              :provider_streaming,
-              %{
-                data
-                | provider: next,
-                  messages: transformed,
-                  fallback_chain_remaining: rest,
-                  assembler: nil,
-                  provider_task: nil,
-                  stream_ref: nil,
-                  provider_span_ref: nil
-              }
-            )
-
-          [] ->
-            # All providers exhausted — surface terminal error.
-            # D-057 (SPEC-OTEL-REPORTER): emit terminal event before returning
-            # to :awaiting_user so the span opened at *.start is closed.
-            emit_provider_request_terminal(:cancelled, data)
-            reason_str = describe_provider_error(:circuit_open)
-
-            msg =
-              Assistant.new(
-                stop_reason: :error,
-                error_message: reason_str,
-                content: [%{type: :text, text: "Error: " <> reason_str}]
-              )
-
-            broadcast(data.id, %Events.MessageEnd{session_id: data.id, message: msg})
-
-            next_data = %{data | cancel_flag: nil, stream_ref: nil, provider_span_ref: nil}
-            # D-080: drain follow-up on turn-end (error path).
-            actions =
-              if :queue.is_empty(next_data.followup_queue),
-                do: [],
-                else: [{:next_event, :internal, :drain_followups}]
-
-            {:next_state, :awaiting_user, next_data, actions}
-        end
-
-      {:error, reason} ->
-        # Synchronous provider error.
-        # D-009 / SPEC-USER-TURN: the assistant message MUST carry a
-        # non-empty content block; render paths iterate `msg.content`.
-        # D-018: Anthropic auth atoms (`:missing_api_key`, `:oauth_expired`)
-        # become human-readable renewal instructions.
-        # D-057: emit terminal event so the *.start span is closed.
-        emit_provider_request_terminal(:cancelled, data)
-        reason_str = describe_provider_error(reason)
-
-        msg =
-          Assistant.new(
-            stop_reason: :error,
-            error_message: reason_str,
-            content: [%{type: :text, text: "Error: " <> reason_str}]
-          )
-
-        broadcast(data.id, %Events.MessageEnd{session_id: data.id, message: msg})
-
-        next_data = %{data | cancel_flag: nil, stream_ref: nil, provider_span_ref: nil}
-        # D-080: drain follow-up on turn-end (error path).
-        actions =
-          if :queue.is_empty(next_data.followup_queue),
-            do: [],
-            else: [{:next_event, :internal, :drain_followups}]
-
-        {:next_state, :awaiting_user, next_data, actions}
-    end
+    Tau.Session.ProviderTurn.start(data)
   end
 
   # ── coding-agent streaming (SPEC-CODING-AGENT §4 B1 / D-037) ─────
@@ -1199,21 +971,7 @@ defmodule Tau.Session do
   # is dispatched in `handle_event(:info, {:coding_agent_event, ...},
   # :coding_agent_streaming, _)`.
   def handle_event(:internal, :start_coding_agent, :coding_agent_streaming, data) do
-    transition(data.id, data, :coding_agent_streaming)
-
-    :telemetry.execute(
-      [:tau, :session, :coding_agent_streaming, :start],
-      %{system_time: System.system_time()},
-      %{session_id: data.id, agent: data.coding_agent}
-    )
-
-    case ensure_coding_agent_workspace(data) do
-      {:ok, data, workspace_path} ->
-        start_coding_agent_dispatcher(data, workspace_path)
-
-      {:error, reason} ->
-        emit_coding_agent_sync_error(data, reason)
-    end
+    Tau.Session.CodingAgentTurn.handle_start_coding_agent(data)
   end
 
   # Forward dispatcher events into the FSM. Stale events (from a
@@ -1227,9 +985,7 @@ defmodule Tau.Session do
         :coding_agent_streaming,
         data
       ) do
-    if current_run?(data, {:coding_agent, pid}),
-      do: handle_coding_agent_event(event, data),
-      else: {:keep_state, data}
+    Tau.Session.CodingAgentTurn.handle_coding_agent_event_message(pid, event, data)
   end
 
   # Stale or out-of-order event — dispatcher mismatch. Drop silently;
@@ -1240,12 +996,8 @@ defmodule Tau.Session do
   end
 
   # D-061: retryable mid-stream error, no fallback chain remaining,
-  # unspent retry budget. Schedules a same-provider re-entry via
-  # `Process.send_after/3` posting `{:provider_retry, ref, count+1}`.
-  #
-  # CLAUSE ORDERING IS LOAD-BEARING. Both this clause and the ADR-0012
-  # fallback clause head-match `%PEvent.Error{retryable?: true}`; the
-  # `fallback_chain_remaining: []` guard keeps each in its own regime.
+  # unspent retry budget. CLAUSE ORDERING IS LOAD-BEARING — must precede
+  # the ADR-0012 fallback clause (both head-match `%PEvent.Error{retryable?: true}`).
   def handle_event(
         :info,
         {:provider_event, ref, %PEvent.Error{retryable?: true} = ev},
@@ -1257,65 +1009,7 @@ defmodule Tau.Session do
         } = data
       )
       when c < data.provider_retry_max do
-    next_count = c + 1
-    delay = data.provider_retry_base_delay_ms * Integer.pow(2, c)
-
-    :telemetry.execute(
-      [:tau, :session, :provider_retry],
-      %{count: next_count, delay_ms: delay},
-      %{
-        session_id: data.id,
-        provider: data.provider,
-        reason: ev.reason,
-        max: data.provider_retry_max
-      }
-    )
-
-    notice =
-      "provider #{inspect(data.provider)} errored (#{inspect(ev.reason)}); " <>
-        "retrying #{next_count}/#{data.provider_retry_max} after #{delay}ms"
-
-    broadcast(data.id, %Events.SystemNotice{session_id: data.id, text: notice})
-
-    data =
-      persist_event(data, "provider_retry", %{
-        provider: inspect(data.provider),
-        reason: inspect(ev.reason),
-        count: next_count,
-        max: data.provider_retry_max,
-        delay_ms: delay
-      })
-
-    # D-057 (SPEC-OTEL-REPORTER): close the *.start span opened for the
-    # now-aborted attempt BEFORE killing the task, mirroring the ADR-
-    # 0012 fallback path. A brutal_kill event is appropriate because
-    # we are force-terminating a running stream rather than
-    # cooperatively cancelling it.
-    emit_provider_request_terminal(:brutal_kill, data)
-
-    # Shut down the still-running provider task. Stragglers in the
-    # mailbox are tagged with the previous stream_ref and get dropped
-    # by the catch-all clause once :start_provider re-allocates a
-    # fresh ref.
-    if data.provider_task && Process.alive?(data.provider_task.pid) do
-      Task.shutdown(data.provider_task, :brutal_kill)
-    end
-
-    # Bump the counter NOW so a flurry of retryable errors in flight
-    # cannot push the count past `max` (each retry only schedules one
-    # send_after; the FSM is single-threaded so the bump is atomic
-    # w.r.t. the next message).
-    data = %{
-      data
-      | provider_retry_state: %{count: next_count},
-        provider_task: nil,
-        assembler: nil,
-        stream_ref: nil,
-        provider_span_ref: nil
-    }
-
-    Process.send_after(self(), {:provider_retry, next_count}, delay)
-    {:keep_state, data}
+    Tau.Session.ProviderTurn.handle_provider_retry_event(ref, ev, data)
   end
 
   # D-061: deferred retry trigger. Posted by the clause above
@@ -1337,146 +1031,27 @@ defmodule Tau.Session do
     {:keep_state, data}
   end
 
-  # ADR-0012: retryable mid-stream errors fall back to the next provider
-  # in `data.fallback_chain_remaining`. Empty chain falls through to the
-  # generic `:provider_event` clause, which finalises the message with
-  # the error.
-  #
-  # CLAUSE ORDERING IS LOAD-BEARING. The generic `:provider_event` clause
-  # no longer head-discriminates on `stream_ref`; only source order keeps
-  # this fallback clause and the D-061 same-provider retry clause winning
-  # in their respective regimes.
+  # ADR-0012: retryable mid-stream errors fall back to the next provider.
+  # CLAUSE ORDERING IS LOAD-BEARING — must precede the generic :provider_event clause.
   def handle_event(
         :info,
         {:provider_event, ref, %PEvent.Error{retryable?: true} = ev},
         :provider_streaming,
-        %{fallback_chain_remaining: [next | rest], stream_ref: ref} = data
+        %{fallback_chain_remaining: [_next | _rest], stream_ref: ref} = data
       ) do
-    from_provider = data.provider
-
-    :telemetry.execute(
-      [:tau, :provider, :fallback],
-      %{system_time: System.system_time()},
-      %{
-        from_provider: from_provider,
-        to_provider: next,
-        reason: ev.reason,
-        session_id: data.id
-      }
-    )
-
-    broadcast(data.id, %Events.ProviderFallback{
-      session_id: data.id,
-      from_provider: from_provider,
-      to_provider: next,
-      reason: ev.reason
-    })
-
-    data =
-      persist_event(data, "provider_fallback", %{
-        from_provider: inspect(from_provider),
-        to_provider: inspect(next),
-        reason: inspect(ev.reason)
-      })
-
-    # D-057 (SPEC-OTEL-REPORTER): emit the terminal event BEFORE killing the
-    # task so the span opened at *.start is closed with the correct mechanism.
-    # A brutal_kill event is appropriate here because we are force-terminating
-    # a running stream rather than cooperatively cancelling it.
-    emit_provider_request_terminal(:brutal_kill, data)
-
-    # Shut down the still-running provider task (it might still be
-    # emitting events or about to send :provider_done). Stragglers
-    # already in the mailbox are tagged with the *previous* stream_ref
-    # and get dropped by the catch-all `handle_event` clause once
-    # `:start_provider` re-issues a fresh ref.
-    if data.provider_task && Process.alive?(data.provider_task.pid) do
-      Task.shutdown(data.provider_task, :brutal_kill)
-    end
-
-    transformed =
-      Tau.Providers.Shared.ContentTransform.transform(data.messages, from_provider, next)
-
-    handle_event(
-      :internal,
-      :start_provider,
-      :provider_streaming,
-      %{
-        data
-        | provider: next,
-          messages: transformed,
-          fallback_chain_remaining: rest,
-          assembler: nil,
-          provider_task: nil,
-          stream_ref: nil,
-          provider_span_ref: nil
-      }
-    )
+    Tau.Session.ProviderTurn.handle_provider_fallback_event(ref, ev, data)
   end
 
-  def handle_event(
-        :info,
-        {:provider_event, ref, ev},
-        :provider_streaming,
-        data
-      ) do
-    if current_run?(data, {:provider, ref}) do
-      new_assembler = Assembler.step(data.assembler, ev)
-
-      broadcast(data.id, %Events.MessageUpdate{
-        session_id: data.id,
-        event: ev,
-        message: new_assembler.message
-      })
-
-      if Assembler.done?(new_assembler) do
-        finalize_assistant(new_assembler, data)
-      else
-        {:keep_state, %{data | assembler: new_assembler}}
-      end
-    else
-      {:keep_state, data}
-    end
+  def handle_event(:info, {:provider_event, ref, ev}, :provider_streaming, data) do
+    Tau.Session.ProviderTurn.handle_provider_event(ref, ev, data)
   end
 
-  def handle_event(
-        :info,
-        {:provider_done, ref},
-        :provider_streaming,
-        data
-      ) do
-    if current_run?(data, {:provider, ref}) do
-      if data.assembler && Assembler.done?(data.assembler) do
-        {:keep_state, data}
-      else
-        # Stream ended without a Done event — synthesise one.
-        assembler =
-          Assembler.step(data.assembler || Assembler.new(), %PEvent.Done{stop_reason: :stop})
-
-        finalize_assistant(assembler, data)
-      end
-    else
-      {:keep_state, data}
-    end
+  def handle_event(:info, {:provider_done, ref}, :provider_streaming, data) do
+    Tau.Session.ProviderTurn.handle_provider_done(ref, data)
   end
 
-  def handle_event(
-        :info,
-        {:provider_failed, ref, msg},
-        :provider_streaming,
-        data
-      ) do
-    if current_run?(data, {:provider, ref}) do
-      assembler =
-        Assembler.step(data.assembler || Assembler.new(), %PEvent.Error{
-          reason: msg,
-          retryable?: false
-        })
-
-      finalize_assistant(assembler, data)
-    else
-      {:keep_state, data}
-    end
+  def handle_event(:info, {:provider_failed, ref, msg}, :provider_streaming, data) do
+    Tau.Session.ProviderTurn.handle_provider_failed(ref, msg, data)
   end
 
   # ADR-0014: bookkeeping casts from the `Agent` tool task.
@@ -1762,99 +1337,23 @@ defmodule Tau.Session do
   # (provider-only reconfigure) MUST NOT touch data.model. No model_swap
   # event is emitted here — only the single "reconfigure" event below.
   def handle_event(:cast, {:reconfigure, opts}, _state, data) do
-    data =
-      data
-      |> maybe_replace(:provider, opts[:provider])
-      # ADR-0012: keep original_provider in lockstep with the user-
-      # configured provider. Reconfigure replaces both — fallback chains
-      # are looked up keyed by the *new* primary on the next turn.
-      |> maybe_replace(:original_provider, opts[:provider])
-      |> reconfigure_model(opts[:model])
-      |> merge_provider_ctx(opts[:provider_ctx])
-      # SPEC-CODING-AGENT: reconfigure may also adjust the
-      # coding-agent per-run ctx. Used by tests to thread a different
-      # Replay fixture across turns; the production surface lets the
-      # TUI swap inactivity-timeout / cancel-flag without restarting.
-      |> maybe_replace(:coding_agent_ctx, opts[:coding_agent_ctx])
-
-    :telemetry.execute(
-      [:tau, :session, :reconfigure],
-      %{system_time: System.system_time()},
-      %{session_id: data.id, provider: data.provider, model: data.model}
-    )
-
-    data =
-      persist_event(data, "reconfigure", %{
-        provider: inspect(data.provider),
-        model: data.model
-      })
-
-    {:keep_state, data}
+    Tau.Session.ModelSwap.handle_reconfigure(opts, data)
   end
 
   def handle_event(:info, {:tool_done, call_id, result_msg}, :tool_executing, data) do
-    tools = Map.delete(data.tools_in_flight, call_id)
-
-    {lookup, call_lookups_rest} = Map.pop(data.tool_loop_call_lookups, call_id)
-
-    data =
-      data
-      |> append_message(result_msg)
-      |> persist_event("tool_result", tool_result_to_data(result_msg))
-      |> Map.put(:tool_loop_call_lookups, call_lookups_rest)
-
-    broadcast(data.id, %Events.ToolEnd{
-      session_id: data.id,
-      tool_call_id: call_id,
-      result: result_msg
-    })
-
-    # D-060: tool-loop brake. When the SAME `(tool_name,
-    # args_hash, error_message)` triple is rejected
-    # `tool_loop_brake_threshold` consecutive times within one turn,
-    # abort the turn with `stop_reason: :tool_loop_aborted` and emit
-    # a `%SystemNotice{}` naming the wedged call. Errors with
-    # different args OR a different error message reset the counter
-    # for that key — only IDENTICAL re-attempts count.
-    case maybe_apply_tool_loop_brake(data, lookup, result_msg) do
-      {:brake, data} ->
-        emit_tool_loop_brake_abort(data, tools)
-
-      {:continue, data} ->
-        if map_size(tools) == 0 do
-          # D-079 / SPEC-USER-TURN §6 / AC-8: drain one steering message
-          # AFTER all tool_results and BEFORE the next provider call so
-          # no tool_call is orphaned.
-          data = drain_steering_queue_one(data)
-
-          handle_event(
-            :internal,
-            :start_provider,
-            :provider_streaming,
-            %{data | tools_in_flight: tools, tool_dispatcher: nil}
-          )
-        else
-          {:keep_state, %{data | tools_in_flight: tools}}
-        end
-    end
+    Tau.Session.ToolDispatch.handle_tool_done(call_id, result_msg, data)
   end
 
   # D-041: synchronous, state-gated model swap. Allowed only in
   # :awaiting_user with no in-flight command task. Any other state is :busy.
   # do_swap_model/2 is the single data.model mutation site.
   def handle_event({:call, from}, {:swap_model, model}, :awaiting_user, %{command_task: nil} = data) do
-    case apply_model_swap(data, model) do
-      {:error, :invalid_model} ->
-        {:keep_state_and_data, [{:reply, from, {:error, :invalid_model}}]}
-
-      {:ok, data2, result} ->
-        {:keep_state, data2, [{:reply, from, {:ok, result}}]}
-    end
+    Tau.Session.ModelSwap.handle_swap_model_idle(from, model, data)
   end
 
   # Busy: state is not :awaiting_user, or command_task is in flight.
   def handle_event({:call, from}, {:swap_model, _model}, _state, _data) do
-    {:keep_state_and_data, [{:reply, from, {:error, :busy}}]}
+    Tau.Session.ModelSwap.handle_swap_model_busy(from)
   end
 
   # ---------------------------------------------------------------------------
@@ -1880,74 +1379,14 @@ defmodule Tau.Session do
   # Clause 1 — worker success: Task.Supervisor.async_nolink/3 delivers
   # {ref, result} on completion. Guard on compaction_monitor (the ref)
   # ensures stale results from a prior worker (cleared fields) are ignored.
+  # Clause 1 — worker success. Guards on compaction_monitor ref.
   def handle_event(:info, {ref, result}, :compacting, %{compaction_monitor: ref} = data)
       when is_reference(ref) do
-    # Demonitor first to flush any pending {:DOWN} that is already enqueued.
-    # Process.demonitor with [:flush] removes the monitor and purges any
-    # {:DOWN, ref, ...} already in the mailbox. Combined with clearing both
-    # worker fields, stale {:DOWN} messages from this worker can no longer
-    # match Clauses 2a/2b.
-    Process.demonitor(ref, [:flush])
-
-    data = %{data | compaction_task: nil, compaction_monitor: nil}
-
-    {notice, data} =
-      case result do
-        {:ok, new_messages, summary_text} ->
-          data =
-            persist_event(data, "compaction", %{
-              before_count: length(data.messages),
-              after_count: length(new_messages),
-              summary: format_summary_for_persist(summary_text)
-            })
-
-          :telemetry.execute(
-            [:tau, :compaction, :stop],
-            %{system_time: System.system_time()},
-            %{session_id: data.id, after_count: length(new_messages), async: true}
-          )
-
-          data = %{data | messages: new_messages, compaction_failures: 0}
-          {"Compaction complete.", data}
-
-        {:error, reason} ->
-          :telemetry.execute(
-            [:tau, :compaction, :exception],
-            %{system_time: System.system_time()},
-            %{session_id: data.id, reason: reason, kind: :compactor_error, async: true}
-          )
-
-          failures = data.compaction_failures + 1
-          data = %{data | compaction_failures: failures}
-          {"Compaction failed (#{failures} consecutive failure(s)).", data}
-      end
-
-    broadcast(data.id, %Events.SystemNotice{session_id: data.id, text: notice})
-
-    # D-164 (S-2): CompactionFinished MUST fire on every exit from :compacting,
-    # including error paths, so the TUI status bar never sticks on "compacting…".
-    outcome =
-      case result do
-        {:ok, _, _} -> {:ok, :compacted}
-        {:error, reason} -> {:error, reason}
-      end
-
-    broadcast(data.id, %Events.CompactionFinished{session_id: data.id, outcome: outcome})
-
-    # D-080: drain follow-up queue on :awaiting_user transition.
-    actions =
-      if :queue.is_empty(data.followup_queue),
-        do: [],
-        else: [{:next_event, :internal, :drain_followups}]
-
-    {:next_state, :awaiting_user, data, actions}
+    Tau.Session.Compaction.handle_worker_result(ref, result, data)
   end
 
-  # Clause 2a — benign {:DOWN, :normal}: async_nolink emits both {ref, result}
-  # AND {:DOWN, ref, :process, _, :normal} on clean task exit. The mailbox
-  # ordering is non-deterministic; :normal DOWN may arrive before the result.
-  # Guard on compaction_monitor; do NOT demonitor here — the result (Clause 1)
-  # may arrive next and will perform the demonitor+flush. Keep state.
+  # Clause 2a — benign {:DOWN, :normal}: keep waiting for {ref, result}.
+  # Guard on compaction_monitor; do NOT demonitor here.
   def handle_event(
         :info,
         {:DOWN, ref, :process, _pid, :normal},
@@ -1955,13 +1394,10 @@ defmodule Tau.Session do
         %{compaction_monitor: ref} = data
       )
       when is_reference(ref) do
-    # The pending {ref, result} message will drive Clause 1. Keep waiting.
-    {:keep_state, data}
+    Tau.Session.Compaction.handle_worker_down_normal(data)
   end
 
-  # Clause 2b — worker crash: {:DOWN, reason} where reason != :normal means
-  # the task process died without delivering a result. Increment failure counter,
-  # clear worker fields, return to :awaiting_user.
+  # Clause 2b — worker crash: {:DOWN, reason} where reason != :normal.
   def handle_event(
         :info,
         {:DOWN, ref, :process, _pid, reason},
@@ -1969,39 +1405,10 @@ defmodule Tau.Session do
         %{compaction_monitor: ref} = data
       )
       when is_reference(ref) do
-    :telemetry.execute(
-      [:tau, :compaction, :exception],
-      %{system_time: System.system_time()},
-      %{session_id: data.id, reason: reason, kind: :worker_down, async: true}
-    )
-
-    failures = data.compaction_failures + 1
-    notice = "Compaction worker crashed (#{failures} consecutive failure(s))."
-
-    next_data = %{
-      data
-      | compaction_task: nil,
-        compaction_monitor: nil,
-        compaction_failures: failures
-    }
-
-    broadcast(data.id, %Events.SystemNotice{session_id: data.id, text: notice})
-    # D-164: fire on every :compacting exit, including worker crash.
-    broadcast(data.id, %Events.CompactionFinished{session_id: data.id, outcome: {:error, reason}})
-
-    # D-080: drain follow-up queue on :awaiting_user transition.
-    actions =
-      if :queue.is_empty(next_data.followup_queue),
-        do: [],
-        else: [{:next_event, :internal, :drain_followups}]
-
-    {:next_state, :awaiting_user, next_data, actions}
+    Tau.Session.Compaction.handle_worker_crash(ref, reason, data)
   end
 
-  # Clause 3 — live timeout: fired while the worker is still running.
-  # Guard on compaction_task pid ensures this is the timeout for the CURRENT
-  # worker. Only this clause calls demonitor/exit — an unguarded
-  # demonitor(nil) would crash the FSM. MUST be ordered BEFORE Clause 4.
+  # Clause 3 — live timeout. Guards on compaction_task pid. MUST precede Clause 4.
   def handle_event(
         :info,
         {:compaction_timeout, pid, _ms},
@@ -2009,37 +1416,7 @@ defmodule Tau.Session do
         %{compaction_task: pid} = data
       )
       when is_pid(pid) do
-    if data.compaction_monitor, do: Process.demonitor(data.compaction_monitor, [:flush])
-
-    if pid && Process.alive?(pid), do: Process.exit(pid, :brutal_kill)
-
-    :telemetry.execute(
-      [:tau, :compaction, :exception],
-      %{system_time: System.system_time()},
-      %{session_id: data.id, kind: :timeout, async: true}
-    )
-
-    failures = data.compaction_failures + 1
-    notice = "Compaction timed out (#{failures} consecutive failure(s))."
-
-    next_data = %{
-      data
-      | compaction_task: nil,
-        compaction_monitor: nil,
-        compaction_failures: failures
-    }
-
-    broadcast(data.id, %Events.SystemNotice{session_id: data.id, text: notice})
-    # D-164: fire on every :compacting exit, including timeout.
-    broadcast(data.id, %Events.CompactionFinished{session_id: data.id, outcome: {:error, :timeout}})
-
-    # D-080: drain follow-up queue on :awaiting_user transition.
-    actions =
-      if :queue.is_empty(next_data.followup_queue),
-        do: [],
-        else: [{:next_event, :internal, :drain_followups}]
-
-    {:next_state, :awaiting_user, next_data, actions}
+    Tau.Session.Compaction.handle_timeout(pid, data)
   end
 
   # Clause 4 — stale timeout: arrives AFTER the worker already completed
@@ -2078,203 +1455,42 @@ defmodule Tau.Session do
   # only fires when pending_permission_requests is empty (via the
   # permission_decision handlers). Applies only to known non-ask entries.
   def handle_event(:info, {:tool_done, call_id, result_msg}, :awaiting_permission, data) do
-    # Guard: only process if this call_id is in tools_in_flight and is NOT
-    # an :awaiting_permission sentinel (those represent unresolved :ask calls).
-    case Map.get(data.tools_in_flight, call_id) do
-      :awaiting_permission ->
-        # This would be a programming error — :ask calls resolve via
-        # permission_decision, not {:tool_done}. Log and keep state.
-        require Logger
-
-        Logger.warning(
-          "Unexpected {:tool_done} for :awaiting_permission sentinel #{inspect(call_id)}; ignoring"
-        )
-
-        {:keep_state, data}
-
-      nil ->
-        # Stale/unknown call_id — drop silently (same as catch-all below).
-        {:keep_state, data}
-
-      _status ->
-        # Pre-resolved item (deny-rule, whitelist-filtered, skill-activated, etc.).
-        # Process identically to :tool_executing, but stay in :awaiting_permission.
-        tools = Map.delete(data.tools_in_flight, call_id)
-        {_lookup, call_lookups_rest} = Map.pop(data.tool_loop_call_lookups, call_id)
-
-        data =
-          data
-          |> append_message(result_msg)
-          |> persist_event("tool_result", tool_result_to_data(result_msg))
-          |> Map.put(:tool_loop_call_lookups, call_lookups_rest)
-          |> Map.put(:tools_in_flight, tools)
-
-        broadcast(data.id, %Events.ToolEnd{
-          session_id: data.id,
-          tool_call_id: call_id,
-          result: result_msg
-        })
-
-        # Do NOT check for round completion here — that is gated on
-        # pending_permission_requests being empty (resolved by the user).
-        {:keep_state, data}
-    end
+    Tau.Session.ToolDispatch.handle_tool_done_awaiting_permission(call_id, result_msg, data)
   end
 
-  # Clause 1 — :allow_once: add the call to the dispatch batch; if last pending,
-  # dispatch batch and transition to :tool_executing.
+  # Clause 1 — :allow_once. Must precede clause 3 (same state, specific verdict).
   def handle_event(
         :cast,
         {:permission_decision, tool_call_id, :allow_once},
         :awaiting_permission,
         data
       ) do
-    case Map.pop(data.pending_permission_requests, tool_call_id) do
-      {nil, _} ->
-        # Unknown or stale tool_call_id (D-090): logged no-op.
-        require Logger
-
-        Logger.debug(
-          "permission_decision :allow_once for unknown tool_call_id #{inspect(tool_call_id)}"
-        )
-
-        :telemetry.execute(
-          [:tau, :permissions, :stale_decision],
-          %{system_time: System.system_time()},
-          %{session_id: data.id, tool_call_id: tool_call_id, verdict: :allow_once}
-        )
-
-        {:keep_state, data}
-
-      {%{name: name, arguments: args}, remaining} ->
-        :telemetry.execute(
-          [:tau, :permissions, :decision],
-          %{system_time: System.system_time()},
-          %{
-            session_id: data.id,
-            tool_call_id: tool_call_id,
-            tool_name: name,
-            decision: :allow_once
-          }
-        )
-
-        batch = [{tool_call_id, name, args} | data.permission_dispatch_batch]
-        data = %{data | pending_permission_requests: remaining, permission_dispatch_batch: batch}
-
-        if map_size(remaining) == 0 do
-          finish_permission_round(data)
-        else
-          {:keep_state, data}
-        end
-    end
+    Tau.Session.ToolDispatch.handle_permission_allow_once(tool_call_id, data)
   end
 
-  # Clause 2 — :deny_once: synthesise is_error ToolResult; if last pending,
-  # dispatch any accumulated allows and transition.
+  # Clause 2 — :deny_once. Must precede clause 3 (same state, specific verdict).
   def handle_event(
         :cast,
         {:permission_decision, tool_call_id, :deny_once},
         :awaiting_permission,
         data
       ) do
-    case Map.pop(data.pending_permission_requests, tool_call_id) do
-      {nil, _} ->
-        # Unknown or stale tool_call_id (D-090): logged no-op.
-        require Logger
-
-        Logger.debug(
-          "permission_decision :deny_once for unknown tool_call_id #{inspect(tool_call_id)}"
-        )
-
-        :telemetry.execute(
-          [:tau, :permissions, :stale_decision],
-          %{system_time: System.system_time()},
-          %{session_id: data.id, tool_call_id: tool_call_id, verdict: :deny_once}
-        )
-
-        {:keep_state, data}
-
-      {%{name: name}, remaining} ->
-        result =
-          ToolResult.new(
-            tool_call_id: tool_call_id,
-            tool_name: name,
-            content: "Permission denied: #{name} denied by user.",
-            is_error: true
-          )
-
-        # D-091 (whole-round deferral): accumulate the denied result in
-        # permission_pending_results instead of routing through {:tool_done}.
-        # finish_permission_round/1 emits all accumulated results (broadcast
-        # ToolEnd + append to history) when the last :ask call is resolved.
-        # This avoids {:tool_done} messages landing in :awaiting_permission
-        # for multi-:ask rounds where earlier denials precede the last allow.
-        :telemetry.execute(
-          [:tau, :permissions, :decision],
-          %{system_time: System.system_time()},
-          %{
-            session_id: data.id,
-            tool_call_id: tool_call_id,
-            tool_name: name,
-            decision: :deny_once
-          }
-        )
-
-        pending_results = [{tool_call_id, result} | data.permission_pending_results]
-
-        data = %{
-          data
-          | pending_permission_requests: remaining,
-            permission_pending_results: pending_results
-        }
-
-        if map_size(remaining) == 0 do
-          finish_permission_round(data)
-        else
-          {:keep_state, data}
-        end
-    end
+    Tau.Session.ToolDispatch.handle_permission_deny_once(tool_call_id, data)
   end
 
-  # Clause 3 — stale/unknown tool_call_id arriving in :awaiting_permission
-  # for any other verdict form: logged no-op (D-090). Must precede clause 4.
+  # Clause 3 — stale/unknown verdict in :awaiting_permission (D-090). Must precede clause 4.
   def handle_event(
         :cast,
         {:permission_decision, tool_call_id, verdict},
         :awaiting_permission,
         data
       ) do
-    require Logger
-
-    Logger.debug(
-      "permission_decision #{inspect(verdict)} for unknown/stale tool_call_id #{inspect(tool_call_id)}"
-    )
-
-    :telemetry.execute(
-      [:tau, :permissions, :stale_decision],
-      %{system_time: System.system_time()},
-      %{session_id: data.id, tool_call_id: tool_call_id, verdict: verdict}
-    )
-
-    {:keep_state, data}
+    Tau.Session.ToolDispatch.handle_permission_stale(tool_call_id, verdict, data)
   end
 
-  # Clause 4 — {:permission_decision} arriving outside :awaiting_permission:
-  # logged no-op (D-090). Catches stale decisions arriving after state transition.
+  # Clause 4 — decision outside :awaiting_permission (D-090).
   def handle_event(:cast, {:permission_decision, tool_call_id, verdict}, _state, data) do
-    require Logger
-
-    Logger.debug(
-      "permission_decision #{inspect(verdict)} for #{inspect(tool_call_id)} outside :awaiting_permission (state ignored)"
-    )
-
-    :telemetry.execute(
-      [:tau, :permissions, :stale_decision],
-      %{system_time: System.system_time()},
-      %{session_id: data.id, tool_call_id: tool_call_id, verdict: verdict}
-    )
-
-    {:keep_state, data}
+    Tau.Session.ToolDispatch.handle_permission_outside_state(tool_call_id, verdict, data)
   end
 
   # Clause 5 — :cancel in :awaiting_permission is handled by the specific
@@ -2311,36 +1527,17 @@ defmodule Tau.Session do
   # dispatcher pid. Stale events from superseded runs return false and
   # are dropped by the caller (ADR-0012).
   @spec current_run?(map(), {:provider, reference()} | {:coding_agent, pid()}) :: boolean()
-  defp current_run?(%{stream_ref: ref}, {:provider, ref}) when is_reference(ref), do: true
+  @doc false
+  def current_run?(%{stream_ref: ref}, {:provider, ref}) when is_reference(ref), do: true
 
-  defp current_run?(%{coding_agent_dispatcher: pid}, {:coding_agent, pid}) when is_pid(pid),
+  @doc false
+  def current_run?(%{coding_agent_dispatcher: pid}, {:coding_agent, pid}) when is_pid(pid),
     do: true
 
-  defp current_run?(_data, _token), do: false
+  @doc false
+  def current_run?(_data, _token), do: false
 
   # --- Helpers --------------------------------------------------------------
-
-  # D-057 / SPEC-OTEL-REPORTER: close the span opened by
-  # `[:tau, :provider, :request, :start]`. Every path abandoning an
-  # in-flight request MUST call this before re-entering `:start_provider`
-  # or returning to `:awaiting_user`, and MUST clear `provider_span_ref`.
-  # Suffix `:cancelled` for no-task paths (circuit_open / sync error);
-  # `:brutal_kill` for force-terminated streams.
-  defp emit_provider_request_terminal(_suffix, %{provider_span_ref: nil}), do: :ok
-
-  defp emit_provider_request_terminal(suffix, data)
-       when suffix in [:cancelled, :brutal_kill] do
-    :telemetry.execute(
-      [:tau, :provider, :request, suffix],
-      %{system_time: System.system_time()},
-      %{
-        provider: data.provider,
-        model: data.model,
-        session_id: data.id,
-        span_ref: data.provider_span_ref
-      }
-    )
-  end
 
   # ADR-0017: drive the cooperative-then-brutal cancellation handshake
   # for the in-flight provider stream task. Returns `:cooperative` if
@@ -2403,7 +1600,8 @@ defmodule Tau.Session do
   # command, or file-command) and by the
   # handle_event(:info, {:command_done, _, _}, _, _) clause when the
   # slash-command Task delivers its result (ADR-0008).
-  defp process_user_message(msg, data) do
+  @doc false
+  def process_user_message(msg, data) do
     case Tau.Hooks.Dispatcher.run(
            :user_prompt_submit,
            hook_payload(data, :user_prompt_submit, %{message: msg})
@@ -2436,1160 +1634,8 @@ defmodule Tau.Session do
     end
   end
 
-  defp finalize_assistant(assembler, data) do
-    msg = Assembler.assistant(assembler)
-    data = data |> append_message(msg) |> persist_event("assistant_message", message_to_data(msg))
-    broadcast(data.id, %Events.MessageEnd{session_id: data.id, message: msg})
-
-    # Feed Tau.Cost.Tracker (ADR-0010). The tracker subscribes to this
-    # event and folds the per-turn usage into ETS counters keyed by
-    # {date, provider, model, session_id}.
-    :telemetry.execute(
-      [:tau, :provider, :request, :stop],
-      %{system_time: System.system_time(), usage: msg.usage || %{}},
-      %{
-        provider: data.provider,
-        model: data.model,
-        session_id: data.id,
-        stop_reason: msg.stop_reason,
-        # SPEC-OTEL-REPORTER: echo the per-request discriminator so the
-        # OTel reporter can close the span opened at *.start.
-        span_ref: data.provider_span_ref
-      }
-    )
-
-    # SPEC-PROMPT-CACHING AC-4: surface the per-turn prompt-cache
-    # hit/write signal so a silent cache miss (a cost regression) is
-    # observable. The OTel reporter consumes this. Reads the canonical
-    # usage-map keys (B3) directly off the assistant message — no
-    # callback indirection.
-    emit_cache_usage(data, msg.usage || %{})
-
-    # D-016: maybe_compact/2 delegates to do_compact/2 which can return
-    # {:abort, data} when compaction_failures reaches 3 consecutive failures
-    # (shared across sync and async paths — NOT path-tagged). On abort, surface
-    # the failure as a synthetic assistant message with stop_reason:
-    # :compaction_failed and return to :awaiting_user without continuing.
-    # {:soft_error, data} increments the counter but lets the turn continue.
-    # Plain data (or unwrapped soft_error) proceeds to tool dispatch.
-    case maybe_compact(data, msg.usage || %{}) do
-      {:abort, data} ->
-        abort_msg =
-          Assistant.new(
-            stop_reason: :compaction_failed,
-            content: [
-              %{
-                type: :text,
-                text:
-                  "Turn aborted: repeated or background compaction failure (3 consecutive errors). " <>
-                    "Check the compactor configuration or contact support if this persists."
-              }
-            ]
-          )
-
-        data =
-          data
-          |> append_message(abort_msg)
-          |> persist_event("assistant_message", message_to_data(abort_msg))
-
-        broadcast(data.id, %Events.MessageEnd{session_id: data.id, message: abort_msg})
-
-        next_data = %{
-          data
-          | provider_task: nil,
-            assembler: nil,
-            cancel_flag: nil,
-            stream_ref: nil,
-            provider_span_ref: nil,
-            tool_iterations: 0,
-            tool_loop_state: %{},
-            tool_loop_call_lookups: %{},
-            # D-061: provider-retry counter is per-turn; reset.
-            provider_retry_state: %{count: 0}
-        }
-
-        # D-080: drain follow-up queue on turn-completion :awaiting_user transition.
-        actions =
-          if :queue.is_empty(next_data.followup_queue),
-            do: [],
-            else: [{:next_event, :internal, :drain_followups}]
-
-        {:next_state, :awaiting_user, next_data, actions}
-
-      compact_result ->
-        # Unwrap {:soft_error, data} — soft_error increments compaction_failures
-        # but the turn continues normally.
-        data =
-          if match?({:soft_error, _}, compact_result),
-            do: elem(compact_result, 1),
-            else: compact_result
-
-        # ADR-0012: per-message fallback semantics. Restore the working
-        # provider to the user-configured original_provider so the next
-        # turn's :start_provider re-derives the chain freshly and starts
-        # against the primary. A still-running tool call keeps using the
-        # provider that produced *this* message until the next provider
-        # turn — that's correct: the tool result feeds the same model
-        # that asked for the call.
-        data = %{data | provider: data.original_provider, fallback_chain_remaining: []}
-
-        # ADR-0013: skill activation is per-turn by default. The
-        # skill's lifetime ends when the model decides the task is complete
-        # (`:end_turn`). Tool-call turns keep the active skill so subsequent
-        # dispatch is still gated; only `:end_turn` clears it.
-        #
-        # ADR-0015 sub-agent persona: when `:persona_lifetime` is `:session`
-        # (set by `Tau.Tools.Builtin.Agent` at start time) the persona is
-        # pinned for the session's whole life — `:end_turn` does NOT clear
-        # it. The child can't dismiss its own persona this way, which is
-        # the safety property the ADR demands.
-        data =
-          if msg.stop_reason == :end_turn and Map.get(data, :persona_lifetime, :turn) == :turn do
-            %{data | active_skill: nil}
-          else
-            data
-          end
-
-        tool_calls = Enum.filter(msg.content, &match?(%{type: :tool_call}, &1))
-
-        cond do
-          tool_calls == [] ->
-            # Per-turn resets on clean return to :awaiting_user: cancel
-            # flag (ADR-0017), stream_ref (ADR-0012), tool_iterations
-            # (D-005), tool_loop_state (D-060), provider_retry_state
-            # (D-061).
-            #
-            # D-079: a pure-text turn never reached the tool-round drain
-            # point, so any surviving steering messages would otherwise
-            # bleed into the next unrelated turn. Merge them to the front
-            # of `followup_queue` instead so they run immediately as
-            # post-turn continuations.
-            {merged_followup, cleared_steering} =
-              if :queue.is_empty(data.steering_queue) do
-                {data.followup_queue, data.steering_queue}
-              else
-                steering_list = :queue.to_list(data.steering_queue)
-
-                merged =
-                  Enum.reduce(
-                    Enum.reverse(steering_list),
-                    data.followup_queue,
-                    fn msg, q -> :queue.in_r(msg, q) end
-                  )
-
-                {merged, :queue.new()}
-              end
-
-            next_data = %{
-              data
-              | provider_task: nil,
-                assembler: nil,
-                cancel_flag: nil,
-                stream_ref: nil,
-                provider_span_ref: nil,
-                tool_iterations: 0,
-                tool_loop_state: %{},
-                tool_loop_call_lookups: %{},
-                provider_retry_state: %{count: 0},
-                followup_queue: merged_followup,
-                steering_queue: cleared_steering
-            }
-
-            # D-080 / SPEC-USER-TURN §6: drain follow-up queue on
-            # turn-completion :awaiting_user transition (normal end).
-            # The merged steering messages (if any) will drain first.
-            actions =
-              if :queue.is_empty(next_data.followup_queue),
-                do: [],
-                else: [{:next_event, :internal, :drain_followups}]
-
-            {:next_state, :awaiting_user, next_data, actions}
-
-          true ->
-            # D-005 / AC-6 / SPEC-USER-TURN: enforce the per-turn
-            # tool-call iteration cap before dispatching the next round.
-            # Check against the already-dispatched count so that cap=N allows
-            # exactly N dispatches (tool_iterations counts rounds dispatched).
-            cap = data.max_tool_iterations
-
-            if data.tool_iterations >= cap do
-              aborted_iter = data.tool_iterations
-
-              :telemetry.execute(
-                [:tau, :session, :tool_iteration_cap],
-                %{iterations: aborted_iter, cap: cap},
-                %{session_id: data.id}
-              )
-
-              abort_msg =
-                Assistant.new(
-                  stop_reason: :tool_loop_aborted,
-                  content: [
-                    %{
-                      type: :text,
-                      text:
-                        "Tool-call iteration cap (#{cap}) exceeded. Turn aborted to prevent runaway loops."
-                    }
-                  ]
-                )
-
-              data =
-                data
-                |> append_message(abort_msg)
-                |> persist_event("assistant_message", message_to_data(abort_msg))
-
-              broadcast(data.id, %Events.MessageEnd{session_id: data.id, message: abort_msg})
-
-              next_data = %{
-                data
-                | provider_task: nil,
-                  assembler: nil,
-                  cancel_flag: nil,
-                  stream_ref: nil,
-                  provider_span_ref: nil,
-                  tool_iterations: 0,
-                  tool_loop_state: %{},
-                  tool_loop_call_lookups: %{},
-                  # D-061: provider-retry counter is per-turn; reset
-                  # on iteration-cap abort alongside the brake state.
-                  provider_retry_state: %{count: 0}
-              }
-
-              # D-080: drain follow-up queue on turn-abort :awaiting_user transition.
-              actions =
-                if :queue.is_empty(next_data.followup_queue),
-                  do: [],
-                  else: [{:next_event, :internal, :drain_followups}]
-
-              {:next_state, :awaiting_user, next_data, actions}
-            else
-              dispatch_tools(tool_calls, %{data | tool_iterations: data.tool_iterations + 1})
-            end
-        end
-    end
-  end
-
-  # SPEC-PROMPT-CACHING AC-4: emit the per-turn prompt-cache
-  # hit/write telemetry at the `:provider_done` boundary. Measurements
-  # carry the raw token splits; metadata carries the routing context
-  # and the adapter-specific breakdown. Reads the canonical B3
-  # usage-map keys (`:cache_read` / `:cache_write` / `:cache_breakdown`)
-  # off the finalised assistant message.
-  defp emit_cache_usage(data, usage) do
-    read = nonneg_token(usage[:cache_read])
-    write = nonneg_token(usage[:cache_write])
-    breakdown = if is_map(usage[:cache_breakdown]), do: usage[:cache_breakdown], else: %{}
-
-    :telemetry.execute(
-      [:tau, :session, :cache_usage],
-      %{write_tokens: write, read_tokens: read, storage_tokens: 0},
-      %{session_id: data.id, provider: data.provider, breakdown: breakdown}
-    )
-  end
-
-  defp nonneg_token(n) when is_integer(n) and n >= 0, do: n
-  defp nonneg_token(_), do: 0
-
-  # Thin sync adapter: decides whether to compact, then delegates to do_compact/2.
-  # Returns data | {:abort, data} (D-016: on 3 consecutive failures, aborts the turn).
-  defp maybe_compact(data, usage) do
-    compactor = Tau.Compactor.impl()
-
-    if compactor.should_compact?(data.messages, usage) do
-      do_compact(data, %{provider: data.provider, model: data.model})
-    else
-      data
-    end
-  end
-
-  # Shared compaction core — invoked by the sync post-turn path (maybe_compact/2)
-  # and by the async `:compacting` worker handler (Clause 1 in handle_event).
-  #
-  # Returns:
-  #   data2            — {:ok, ...} success; messages swapped, telemetry emitted,
-  #                      compaction_failures reset to 0
-  #   {:soft_error, data2} — {:error, ...} but failures < 3; caller broadcasts
-  #                      a notice and continues
-  #   {:abort, data2}  — {:error, ...} and failures >= 3 (D-016); caller aborts
-  #                      the turn with stop_reason: :compaction_failed
-  #
-  # D-016: compaction_failures is SHARED across sync and async paths (NOT path-tagged).
-  # A broken compactor is a session-level fault; alternating paths must not
-  # mask it by keeping separate counters.
-  defp do_compact(data, ctx) do
-    compactor = Tau.Compactor.impl()
-
-    :telemetry.execute([:tau, :compaction, :start], %{system_time: System.system_time()}, %{
-      session_id: data.id,
-      message_count: length(data.messages)
-    })
-
-    case compactor.compact(data.messages, ctx) do
-      {:ok, new_messages, summary_text} ->
-        data =
-          persist_event(data, "compaction", %{
-            before_count: length(data.messages),
-            after_count: length(new_messages),
-            summary: format_summary_for_persist(summary_text)
-          })
-
-        :telemetry.execute([:tau, :compaction, :stop], %{system_time: System.system_time()}, %{
-          session_id: data.id,
-          after_count: length(new_messages)
-        })
-
-        %{data | messages: new_messages, compaction_failures: 0}
-
-      {:error, reason} ->
-        :telemetry.execute(
-          [:tau, :compaction, :exception],
-          %{system_time: System.system_time()},
-          %{session_id: data.id, reason: reason, kind: :compactor_error}
-        )
-
-        failures = data.compaction_failures + 1
-
-        if failures >= 3 do
-          {:abort, %{data | compaction_failures: failures}}
-        else
-          {:soft_error, %{data | compaction_failures: failures}}
-        end
-    end
-  end
-
-  defp dispatch_tools(tool_calls, data) do
-    parent = self()
-
-    # D-060: build per-turn lookup table mapping call_id ->
-    # `{tool_name, args_hash}` for every dispatched call. The
-    # `{:tool_done, ...}` handler consults this to key the brake
-    # counter on `(tool_name, args_hash)` without re-scanning the
-    # original assistant message content. Hook-rewritten args overwrite
-    # the original entry below so the recorded hash reflects what the
-    # tool actually saw.
-    call_lookups =
-      Enum.into(tool_calls, %{}, fn %{id: id, name: name, arguments: args} ->
-        {id, {name, tool_args_hash(args)}}
-      end)
-
-    # Intercept synthetic `__activate_skill__` tool calls *before*
-    # permissions / hooks. Activation is FSM-internal — it never reaches
-    # the executor pool. The handler updates `data.active_skill` and
-    # synthesises a tool_result so the model's next turn sees an
-    # acknowledgement; subsequent tool calls in the same activation are
-    # then gated by the skill's `allowed_tools` list (ADR-0013).
-    {activation_calls, tool_calls} =
-      Enum.split_with(tool_calls, fn %{name: name} -> name == @activate_skill_tool_name end)
-
-    {data, activated_in_flight} = handle_skill_activations(activation_calls, data, parent)
-
-    # Spawn-time tools_whitelist filter. Runs *before* the permissions
-    # evaluator so the evaluator stays a pure permission-rule decision.
-    # Calls outside the list synthesise an `is_error: true` ToolResult the
-    # same way deny rules do; the filter is a no-op when `:all`.
-    {whitelisted_out, tool_calls} = split_tools_whitelist(tool_calls, data.tools_whitelist)
-
-    Enum.each(whitelisted_out, fn %{id: id, name: name} ->
-      result =
-        ToolResult.new(
-          tool_call_id: id,
-          tool_name: name,
-          content: "Tool '#{name}' not in this session's whitelist.",
-          is_error: true
-        )
-
-      Process.send(parent, {:tool_done, id, result}, [])
-
-      :telemetry.execute(
-        [:tau, :session, :tool_whitelisted],
-        %{system_time: System.system_time()},
-        %{
-          session_id: data.id,
-          tool_name: name,
-          whitelist_size: whitelist_size(data.tools_whitelist)
-        }
-      )
-    end)
-
-    rule_set = Tau.Permissions.RuleSet.get()
-    mode = Map.get(data.metadata, :permissions_mode, :default)
-
-    eval_ctx = %{cwd: data.cwd, active_skill: data.active_skill}
-
-    # SPEC-PERMISSION-PROMPTS §4 B1 (D-091): three-way partition — `:deny`,
-    # `:ask`, `:allow`. The prior two-way split treated `:ask` as `:allow`,
-    # silently exposing unmatched tools. Replace with an explicit three-way
-    # reduce so each verdict class is handled correctly.
-    {gated, ask_calls, allowed} =
-      Enum.reduce(
-        tool_calls,
-        {[], [], []},
-        fn %{name: name, arguments: args} = call, {denied, asking, allowed_acc} ->
-          case PermEvaluator.evaluate(rule_set, name, args, eval_ctx, mode) do
-            :deny -> {[call | denied], asking, allowed_acc}
-            :ask -> {denied, [call | asking], allowed_acc}
-            :allow -> {denied, asking, [call | allowed_acc]}
-          end
-        end
-      )
-
-    # Restore emit order (reduce reverses).
-    gated = Enum.reverse(gated)
-    ask_calls = Enum.reverse(ask_calls)
-    allowed = Enum.reverse(allowed)
-
-    # Synthesise tool_results for deny-rule denied calls — model sees them as
-    # is_error. Always done via {:tool_done} messages; processed by :tool_executing
-    # (non-permission path) or the :awaiting_permission {:tool_done} handler.
-    Enum.each(gated, fn %{id: id, name: name} ->
-      result =
-        ToolResult.new(
-          tool_call_id: id,
-          tool_name: name,
-          content: deny_reason(name, data.active_skill),
-          is_error: true
-        )
-
-      Process.send(parent, {:tool_done, id, result}, [])
-
-      :telemetry.execute([:tau, :permissions, :decision], %{system_time: System.system_time()}, %{
-        tool: name,
-        tool_call_id: id,
-        decision: :deny,
-        session_id: data.id
-      })
-    end)
-
-    # SPEC-PERMISSION-PROMPTS §4 B1 (D-092, D-093): handle the `:ask` batch.
-    #
-    # Non-interactive (D-093): resolve immediately to fail-closed `:deny`.
-    # The FSM never enters `:awaiting_permission`; the factory-loop substrate
-    # (`tau run`) is never deadlocked.
-    #
-    # Interactive (D-092): broadcast `%PermissionRequest{}` per call, collect
-    # into `pending_permission_requests`, enter `:awaiting_permission`.
-    {data, ask_in_flight} =
-      if data.interactive? do
-        # Interactive: broadcast and defer.
-        pending =
-          Enum.reduce(ask_calls, %{}, fn %{id: id, name: name, arguments: args}, acc ->
-            :telemetry.execute(
-              [:tau, :permissions, :request],
-              %{system_time: System.system_time()},
-              %{session_id: data.id, tool_call_id: id, tool_name: name}
-            )
-
-            broadcast(data.id, %Events.PermissionRequest{
-              session_id: data.id,
-              tool_call_id: id,
-              name: name,
-              arguments: args,
-              decision_reason: "Tool not matched by any allow rule in current mode."
-            })
-
-            Map.put(acc, id, %{name: name, arguments: args})
-          end)
-
-        ask_in_flight = Enum.into(ask_calls, %{}, fn %{id: id} -> {id, :awaiting_permission} end)
-        {%{data | pending_permission_requests: pending}, ask_in_flight}
-      else
-        # Non-interactive: fail-closed deny (D-093).
-        Enum.each(ask_calls, fn %{id: id, name: name} ->
-          result =
-            ToolResult.new(
-              tool_call_id: id,
-              tool_name: name,
-              content:
-                "Permission required for #{name} but session is non-interactive; denied by policy.",
-              is_error: true
-            )
-
-          Process.send(parent, {:tool_done, id, result}, [])
-
-          :telemetry.execute(
-            [:tau, :permissions, :decision],
-            %{system_time: System.system_time()},
-            %{
-              session_id: data.id,
-              tool_call_id: id,
-              tool_name: name,
-              decision: :deny_non_interactive
-            }
-          )
-        end)
-
-        ask_in_flight = Enum.into(ask_calls, %{}, fn %{id: id} -> {id, :denied} end)
-        {data, ask_in_flight}
-      end
-
-    # D-091 (whole-round deferral): when entering :awaiting_permission, do NOT
-    # dispatch the :allow calls. Add them raw to permission_dispatch_batch so
-    # finish_permission_round/1 can run hooks and dispatch them after all :ask
-    # calls are resolved. Instant-resolve {:tool_done} messages (gated, whitelist,
-    # activated) are processed by the :awaiting_permission {:tool_done} handler.
-    if data.interactive? and ask_calls != [] do
-      # Pre-approved :allow calls: held raw — hooks run in finish_permission_round/1.
-      allow_batch =
-        Enum.map(allowed, fn %{id: id, name: name, arguments: args} ->
-          {id, name, args}
-        end)
-
-      # tools_in_flight covers: :ask sentinels, gated (deny-rule) instant results,
-      # whitelist-filtered instant results, and activated (skill) instant results.
-      # All these have {:tool_done} messages in the mailbox; the
-      # :awaiting_permission {:tool_done} handler processes them without
-      # triggering the post-round transition (that only fires when
-      # pending_permission_requests is empty).
-      initial_in_flight =
-        ask_in_flight
-        |> Map.merge(Enum.into(gated, %{}, fn %{id: id} -> {id, :denied} end))
-        |> Map.merge(Enum.into(whitelisted_out, %{}, fn %{id: id} -> {id, :whitelist_filtered} end))
-        |> Map.merge(activated_in_flight)
-
-      transition(data.id, data, :awaiting_permission)
-
-      {:next_state, :awaiting_permission,
-       %{
-         data
-         | tools_in_flight: initial_in_flight,
-           tool_dispatcher: nil,
-           # Pre-approved :allow calls + any :allow_once decisions accumulate here.
-           permission_dispatch_batch: allow_batch,
-           permission_pending_results: [],
-           provider_task: nil,
-           assembler: nil,
-           stream_ref: nil,
-           # SPEC-OTEL-REPORTER: clear span discriminator.
-           provider_span_ref: nil,
-           # D-060: merge this round's lookups.
-           tool_loop_call_lookups: Map.merge(data.tool_loop_call_lookups, call_lookups)
-       }}
-    else
-      # Non-permission path: run hooks on :allow calls and dispatch immediately.
-
-      # Run :pre_tool_use synchronously per call. Hook-vetoed calls synthesise
-      # a tool_result on the spot; survivors form the parallel batch handed
-      # to the dispatcher.
-      {_hook_denied, parallel_calls} =
-        Enum.reduce(allowed, {[], []}, fn %{id: id, name: name, arguments: args}, {denied, kept} ->
-          case Tau.Hooks.Dispatcher.run(
-                 :pre_tool_use,
-                 hook_payload(data, :pre_tool_use, %{
-                   tool_name: name,
-                   tool_call_id: id,
-                   tool_input: args
-                 })
-               ) do
-            {:halt, reason} ->
-              result =
-                ToolResult.new(
-                  tool_call_id: id,
-                  tool_name: name,
-                  content: "Hook blocked: #{inspect(reason)}",
-                  is_error: true
-                )
-
-              Process.send(parent, {:tool_done, id, result}, [])
-              {[id | denied], kept}
-
-            {:deny, reason} ->
-              result =
-                ToolResult.new(
-                  tool_call_id: id,
-                  tool_name: name,
-                  content: "Hook denied: #{reason}",
-                  is_error: true
-                )
-
-              Process.send(parent, {:tool_done, id, result}, [])
-              {[id | denied], kept}
-
-            {:cont, payload} ->
-              rewritten_args = Map.get(payload, :tool_input, args)
-              {denied, [{id, name, rewritten_args} | kept]}
-          end
-        end)
-
-      parallel_calls = Enum.reverse(parallel_calls)
-
-      # D-060: refresh lookups for hook-rewritten args so the
-      # recorded hash matches what the tool executed against.
-      call_lookups =
-        Enum.reduce(parallel_calls, call_lookups, fn {id, name, args}, acc ->
-          Map.put(acc, id, {name, tool_args_hash(args)})
-        end)
-
-      dispatcher_pid =
-        case parallel_calls do
-          [] -> nil
-          _ -> spawn_parallel_dispatcher(parallel_calls, data, parent)
-        end
-
-      real_tasks = Enum.into(parallel_calls, %{}, fn {id, _n, _a} -> {id, :running} end)
-
-      initial_in_flight =
-        real_tasks
-        |> Map.merge(ask_in_flight)
-        |> Map.merge(Enum.into(gated, %{}, fn %{id: id} -> {id, :denied} end))
-        |> Map.merge(Enum.into(whitelisted_out, %{}, fn %{id: id} -> {id, :whitelist_filtered} end))
-        |> Map.merge(activated_in_flight)
-
-      transition(data.id, data, :tool_executing)
-
-      {:next_state, :tool_executing,
-       %{
-         data
-         | tools_in_flight: initial_in_flight,
-           tool_dispatcher: dispatcher_pid,
-           provider_task: nil,
-           assembler: nil,
-           stream_ref: nil,
-           # SPEC-OTEL-REPORTER: span closed in `finalize_assistant/2`;
-           # clear the ref so it doesn't linger across tool execution.
-           provider_span_ref: nil,
-           # D-060: merge this round's lookups with any carried from
-           # earlier rounds in the same turn. The `:tool_done` handler
-           # removes its own entry after consuming it.
-           tool_loop_call_lookups: Map.merge(data.tool_loop_call_lookups, call_lookups)
-       }}
-    end
-  end
-
-  # Single iterator over the parallel batch via
-  # Task.Supervisor.async_stream_nolink/4. One process per turn drives the
-  # stream; per-tool tasks run concurrently under Tau.Tools.TaskSupervisor.
-  # Crash isolation: an exiting tool task surfaces as `{:exit, reason}` from
-  # the stream — we synthesise an `is_error: true` ToolResult so the FSM
-  # never loses a tool_call → tool_result correspondence. `ordered: true`
-  # so we can zip the input call back onto each result (needed to recover
-  # the call id on `{:exit, _}`); throughput is unchanged because tool
-  # tasks still run concurrently up to `max_concurrency`.
-  defp spawn_parallel_dispatcher(parallel_calls, data, parent) do
-    {:ok, pid} =
-      Task.Supervisor.start_child(Tau.Tools.TaskSupervisor, fn ->
-        Enum.each(parallel_calls, fn {id, name, args} ->
-          broadcast(data.id, %Events.ToolStart{
-            session_id: data.id,
-            tool_call_id: id,
-            name: name,
-            arguments: args
-          })
-        end)
-
-        Tau.Tools.TaskSupervisor
-        |> Task.Supervisor.async_stream_nolink(
-          parallel_calls,
-          fn {id, name, args} -> run_tool(name, id, args, data) end,
-          max_concurrency: System.schedulers_online(),
-          timeout: :infinity,
-          on_timeout: :kill_task,
-          ordered: true
-        )
-        |> Stream.zip(parallel_calls)
-        |> Enum.each(fn {stream_result, {id, name, _args}} ->
-          result =
-            case stream_result do
-              {:ok, %ToolResult{} = r} ->
-                r
-
-              {:exit, reason} ->
-                ToolResult.new(
-                  tool_call_id: id,
-                  tool_name: name,
-                  content: "Tool task crashed: #{inspect(reason)}",
-                  is_error: true
-                )
-            end
-
-          # :post_tool_use hook may rewrite the result.
-          post_event = if result.is_error, do: :post_tool_use_failure, else: :post_tool_use
-
-          result =
-            case Tau.Hooks.Dispatcher.run(
-                   post_event,
-                   hook_payload(data, post_event, %{
-                     tool_name: name,
-                     tool_call_id: id,
-                     result: result
-                   })
-                 ) do
-              {:cont, %{result: rewritten}} when is_struct(rewritten, ToolResult) -> rewritten
-              _ -> result
-            end
-
-          Process.send(parent, {:tool_done, id, result}, [])
-        end)
-      end)
-
-    pid
-  end
-
-  # Split tool calls into {filtered_out, kept} based on the session's
-  # spawn-time `:tools_whitelist`. `:all` is the no-op identity (everything
-  # in `kept`); a list keeps only calls whose `name` is in the list. Stays
-  # ordering-preserving so downstream `Enum.into/2` and synthesis preserve
-  # the model's emit order.
-  defp split_tools_whitelist(tool_calls, :all), do: {[], tool_calls}
-
-  defp split_tools_whitelist(tool_calls, list) when is_list(list) do
-    Enum.split_with(tool_calls, fn %{name: name} -> name not in list end)
-  end
-
-  defp whitelist_size(:all), do: :all
-  defp whitelist_size(list) when is_list(list), do: length(list)
-
-  # SPEC-PERMISSION-PROMPTS §4 B3 / D-091: called when the last pending
-  # permission request resolves. Emits accumulated instant-resolve
-  # results (`permission_pending_results`) and dispatches the approved
-  # batch (`permission_dispatch_batch`). Remaining `:awaiting_permission`
-  # sentinels in `tools_in_flight` are stripped; the next state's
-  # `tools_in_flight` carries only the newly-dispatched tasks.
-  defp finish_permission_round(data) do
-    parent = self()
-
-    # Remove all :awaiting_permission sentinel entries from tools_in_flight.
-    # They represent :ask calls that have now been resolved. Any remaining
-    # entries (non-sentinel) are pre-resolved items whose {:tool_done} messages
-    # were processed by the :awaiting_permission {:tool_done} handler.
-    tools_in_flight_after =
-      Map.reject(data.tools_in_flight, fn {_id, status} -> status == :awaiting_permission end)
-
-    # Emit all accumulated instant-resolve results (deny_once decisions +
-    # any accumulated permission_pending_results). These are broadcast as
-    # ToolEnd events and appended to history directly — no {:tool_done} routing.
-    data =
-      Enum.reduce(
-        Enum.reverse(data.permission_pending_results),
-        %{data | tools_in_flight: tools_in_flight_after},
-        fn {call_id, result_msg}, acc ->
-          {_lookup, call_lookups_rest} = Map.pop(acc.tool_loop_call_lookups, call_id)
-
-          acc =
-            acc
-            |> append_message(result_msg)
-            |> persist_event("tool_result", tool_result_to_data(result_msg))
-            |> Map.put(:tool_loop_call_lookups, call_lookups_rest)
-
-          broadcast(acc.id, %Events.ToolEnd{
-            session_id: acc.id,
-            tool_call_id: call_id,
-            result: result_msg
-          })
-
-          acc
-        end
-      )
-
-    # Capture the batch before clearing data fields.
-    batch = Enum.reverse(data.permission_dispatch_batch)
-
-    data = %{
-      data
-      | pending_permission_requests: %{},
-        permission_dispatch_batch: [],
-        permission_pending_results: []
-    }
-
-    # Run :pre_tool_use hooks on the approved batch (pre-approved :allow calls
-    # + :allow_once user-approved calls). Hook-denied calls are emitted directly
-    # rather than via {:tool_done} — we are not yet in :tool_executing.
-    {hook_denied_results, parallel_calls} =
-      Enum.reduce(
-        batch,
-        {[], []},
-        fn {id, name, args}, {denied_acc, kept} ->
-          case Tau.Hooks.Dispatcher.run(
-                 :pre_tool_use,
-                 hook_payload(data, :pre_tool_use, %{
-                   tool_name: name,
-                   tool_call_id: id,
-                   tool_input: args
-                 })
-               ) do
-            {:halt, reason} ->
-              result =
-                ToolResult.new(
-                  tool_call_id: id,
-                  tool_name: name,
-                  content: "Hook blocked: #{inspect(reason)}",
-                  is_error: true
-                )
-
-              {[{id, result} | denied_acc], kept}
-
-            {:deny, reason} ->
-              result =
-                ToolResult.new(
-                  tool_call_id: id,
-                  tool_name: name,
-                  content: "Hook denied: #{reason}",
-                  is_error: true
-                )
-
-              {[{id, result} | denied_acc], kept}
-
-            {:cont, payload} ->
-              rewritten_args = Map.get(payload, :tool_input, args)
-              {denied_acc, [{id, name, rewritten_args} | kept]}
-          end
-        end
-      )
-
-    parallel_calls = Enum.reverse(parallel_calls)
-
-    # D-060: update lookups for hook-rewritten args.
-    call_lookups =
-      Enum.reduce(parallel_calls, data.tool_loop_call_lookups, fn {id, name, args}, acc ->
-        Map.put(acc, id, {name, tool_args_hash(args)})
-      end)
-
-    # Emit hook-denied results directly.
-    data =
-      Enum.reduce(hook_denied_results, %{data | tool_loop_call_lookups: call_lookups}, fn {call_id,
-                                                                                           result_msg},
-                                                                                          acc ->
-        {_lookup, call_lookups_rest} = Map.pop(acc.tool_loop_call_lookups, call_id)
-
-        acc =
-          acc
-          |> append_message(result_msg)
-          |> persist_event("tool_result", tool_result_to_data(result_msg))
-          |> Map.put(:tool_loop_call_lookups, call_lookups_rest)
-
-        broadcast(acc.id, %Events.ToolEnd{
-          session_id: acc.id,
-          tool_call_id: call_id,
-          result: result_msg
-        })
-
-        acc
-      end)
-
-    if parallel_calls == [] do
-      # No approved calls to run (all denied or all batch empty). Proceed
-      # directly to the provider with the accumulated results in history.
-      handle_event(
-        :internal,
-        :start_provider,
-        :provider_streaming,
-        %{data | tools_in_flight: %{}, tool_dispatcher: nil}
-      )
-    else
-      dispatcher_pid = spawn_parallel_dispatcher(parallel_calls, data, parent)
-      running = Enum.into(parallel_calls, %{}, fn {id, _n, _a} -> {id, :running} end)
-
-      {:next_state, :tool_executing,
-       %{data | tools_in_flight: running, tool_dispatcher: dispatcher_pid}}
-    end
-  end
-
-  # ADR-0013: format the synthetic ToolResult content for a permissions
-  # :deny. When an active skill is in effect AND the tool is not on its
-  # allowed_tools list, the denial is attributed to the skill; otherwise
-  # the failure originated from a rule-set deny rule.
-  # D-060: tool-loop brake helpers. Co-located with dispatch logic so
-  # the brake's mechanics live next to the iteration cap.
-  defp tool_args_hash(args) do
-    # Canonical-form hash: encode the argument map with `Jason.encode!`
-    # after sorting keys recursively so semantically-equal maps with
-    # different key insertion order produce the same hash. Falls back
-    # to `inspect/1` if Jason can't encode (unusual; tool args are
-    # already constrained to JSON-shaped values by validation).
-    canonical =
-      try do
-        Jason.encode!(canonicalize_for_hash(args || %{}))
-      rescue
-        _ -> inspect(args, limit: :infinity, printable_limit: :infinity)
-      end
-
-    :crypto.hash(:sha256, canonical) |> Base.encode16(case: :lower)
-  end
-
-  defp canonicalize_for_hash(%{} = m) do
-    m
-    |> Enum.map(fn {k, v} -> {to_string(k), canonicalize_for_hash(v)} end)
-    |> Enum.sort_by(fn {k, _} -> k end)
-    |> Enum.into(%{})
-  end
-
-  defp canonicalize_for_hash(list) when is_list(list),
-    do: Enum.map(list, &canonicalize_for_hash/1)
-
-  defp canonicalize_for_hash(other), do: other
-
-  # Returns {:continue, data} for normal flow, {:brake, data} when the
-  # threshold is reached and the FSM MUST abort the turn.
-  defp maybe_apply_tool_loop_brake(data, nil, _result_msg), do: {:continue, data}
-
-  defp maybe_apply_tool_loop_brake(data, _lookup, %ToolResult{is_error: false}),
-    do: {:continue, reset_tool_loop_state(data)}
-
-  defp maybe_apply_tool_loop_brake(data, {name, args_hash}, %ToolResult{
-         is_error: true,
-         content: error_text
-       }) do
-    key = {name, args_hash}
-    error_str = to_string(error_text || "")
-    prev = Map.get(data.tool_loop_state, key)
-
-    cell =
-      case prev do
-        %{count: c, error: ^error_str} -> %{count: c + 1, error: error_str}
-        _ -> %{count: 1, error: error_str}
-      end
-
-    state2 = Map.put(data.tool_loop_state, key, cell)
-    data2 = %{data | tool_loop_state: state2}
-
-    if cell.count >= data2.tool_loop_brake_threshold do
-      {:brake, data2}
-    else
-      {:continue, data2}
-    end
-  end
-
-  # Successful tool result clears the WHOLE brake table for the turn —
-  # a clean dispatch is evidence the model has un-wedged.
-  defp reset_tool_loop_state(data), do: %{data | tool_loop_state: %{}}
-
-  # Synthesise the escalation notice + MessageEnd{stop_reason:
-  # :tool_loop_aborted}, then return to :awaiting_user. Mirrors the
-  # D-027 abort shape so the CLI's drain loop (`Tau.CLI.drain_run_loop`)
-  # exits cleanly on either brake.
-  defp emit_tool_loop_brake_abort(data, tools) do
-    {{name, args_hash}, %{count: count, error: error_str}} =
-      Enum.max_by(data.tool_loop_state, fn {_k, %{count: c}} -> c end)
-
-    notice_text =
-      "Tool '#{name}' has been called with identical arguments #{count}x in a row, " <>
-        "each time rejected with: '#{error_str}'. Halting this turn."
-
-    :telemetry.execute(
-      [:tau, :session, :tool_loop_brake],
-      %{count: count},
-      %{
-        session_id: data.id,
-        tool_name: name,
-        args_hash: args_hash,
-        error: error_str
-      }
-    )
-
-    broadcast(data.id, %Events.SystemNotice{session_id: data.id, text: notice_text})
-
-    abort_msg =
-      Assistant.new(
-        stop_reason: :tool_loop_aborted,
-        content: [%{type: :text, text: notice_text}]
-      )
-
-    data =
-      data
-      |> append_message(abort_msg)
-      |> persist_event("assistant_message", message_to_data(abort_msg))
-
-    broadcast(data.id, %Events.MessageEnd{session_id: data.id, message: abort_msg})
-
-    next_data = %{
-      data
-      | provider_task: nil,
-        assembler: nil,
-        cancel_flag: nil,
-        stream_ref: nil,
-        provider_span_ref: nil,
-        tools_in_flight: tools,
-        tool_dispatcher: nil,
-        tool_iterations: 0,
-        tool_loop_state: %{},
-        tool_loop_call_lookups: %{},
-        # D-061: provider-retry counter is per-turn; reset on
-        # brake-abort alongside the brake state.
-        provider_retry_state: %{count: 0}
-    }
-
-    # D-080: drain follow-up queue on tool-loop-brake :awaiting_user transition.
-    actions =
-      if :queue.is_empty(next_data.followup_queue),
-        do: [],
-        else: [{:next_event, :internal, :drain_followups}]
-
-    {:next_state, :awaiting_user, next_data, actions}
-  end
-
-  defp deny_reason(name, %Tau.Skill{name: skill_name, allowed_tools: list})
-       when is_list(list) and list != [] do
-    if name in list do
-      "Permission denied: #{name} blocked by deny rule"
-    else
-      "Tool '#{name}' not on active skill '#{skill_name}' allowed_tools whitelist"
-    end
-  end
-
-  defp deny_reason(name, _active_skill),
-    do: "Permission denied: #{name} blocked by deny rule"
-
-  defp run_tool(name, call_id, args, data) do
-    started = System.monotonic_time(:millisecond)
-
-    case Tau.Tool.lookup(name) do
-      {:ok, mod} ->
-        case Tau.Tool.Validator.validate(mod, args) do
-          :ok ->
-            run_tool_validated(name, call_id, args, data, mod, started)
-
-          {:error, errors} ->
-            summary = Tau.Tool.Validator.format_errors(errors)
-
-            :telemetry.execute(
-              [:tau, :tool, :validate, :error],
-              %{system_time: System.system_time()},
-              %{tool: name, tool_call_id: call_id, errors: summary}
-            )
-
-            ToolResult.new(
-              tool_call_id: call_id,
-              tool_name: name,
-              content: "Invalid arguments for tool #{name}: #{summary}",
-              is_error: true
-            )
-        end
-
-      :error ->
-        ToolResult.new(
-          tool_call_id: call_id,
-          tool_name: name,
-          content: "Unknown tool: #{name}",
-          is_error: true
-        )
-    end
-  end
-
-  defp run_tool_validated(name, call_id, args, data, mod, started) do
-    ctx =
-      Tau.Tool.Context.new(
-        tool_call_id: call_id,
-        session_id: data.id,
-        cwd: data.cwd,
-        emit: fn payload ->
-          broadcast(data.id, %Events.ToolUpdate{
-            session_id: data.id,
-            tool_call_id: call_id,
-            payload: payload
-          })
-
-          :ok
-        end
-      )
-
-    :telemetry.execute(
-      [:tau, :tool, :execute, :start],
-      %{system_time: System.system_time()},
-      %{tool: name, tool_call_id: call_id}
-    )
-
-    result =
-      try do
-        case mod.execute(args || %{}, ctx) do
-          {:ok, %Tau.Tool.Result{} = r} ->
-            ToolResult.new(
-              tool_call_id: call_id,
-              tool_name: name,
-              content: r.content,
-              details: r.details,
-              is_error: r.is_error
-            )
-
-          {:error, reason} ->
-            ToolResult.new(
-              tool_call_id: call_id,
-              tool_name: name,
-              content: "Tool error: #{inspect(reason)}",
-              is_error: true
-            )
-        end
-      rescue
-        e ->
-          :telemetry.execute(
-            [:tau, :tool, :execute, :exception],
-            %{duration: System.monotonic_time(:millisecond) - started},
-            # D-052 / SPEC-OTEL-REPORTER: tool_call_id MUST be present so
-            # the OTel reporter can correlate this exception span to its *.start span.
-            %{tool: name, tool_call_id: call_id, error: Exception.message(e)}
-          )
-
-          ToolResult.new(
-            tool_call_id: call_id,
-            tool_name: name,
-            content: "Tool exception: #{Exception.message(e)}",
-            is_error: true
-          )
-      end
-
-    :telemetry.execute(
-      [:tau, :tool, :execute, :stop],
-      %{duration: System.monotonic_time(:millisecond) - started},
-      %{tool: name, tool_call_id: call_id, is_error: result.is_error}
-    )
-
-    result
-  end
-
-  defp append_message(data, msg), do: %{data | messages: data.messages ++ [msg]}
-
-  # Single data.model mutation site. Pure function — no side effects.
-  # Returns {:ok, updated_data, from_model} | {:error, :invalid_model}.
-  # "invalid" means nil, empty string, or whitespace-only.
-  defp do_swap_model(data, model) do
-    if is_binary(model) and String.trim(model) != "" do
-      {:ok, %{data | model: model}, data.model}
-    else
-      {:error, :invalid_model}
-    end
-  end
-
-  # D-041: shared helper for swap_model telemetry + persist, used by both the
-  # {:call, from} {:swap_model} FSM clause and the /model slash-command path.
-  defp apply_model_swap(data, model) do
-    case do_swap_model(data, model) do
-      {:error, :invalid_model} ->
-        {:error, :invalid_model}
-
-      {:ok, data2, from_model} ->
-        :telemetry.execute(
-          [:tau, :session, :model_swapped],
-          %{system_time: System.system_time()},
-          %{session_id: data2.id, from: from_model, to: model, provider: data2.provider}
-        )
-
-        data2 = persist_event(data2, "model_swap", %{"from" => from_model, "to" => model})
-        broadcast(data2.id, %Events.ModelSwapped{session_id: data2.id, from: from_model, to: model})
-        {:ok, data2, %{from: from_model, to: model}}
-    end
-  end
-
-  # Route reconfigure's model opt through do_swap_model/2 so
-  # data.model has a single mutation site. nil means "no change" — a
-  # provider-only reconfigure must NOT touch data.model (preserves the
-  # update_provider_test.exs assertion that a model-only reconfigure
-  # persists one "reconfigure" event carrying data.model).
-  defp reconfigure_model(data, nil), do: data
-
-  defp reconfigure_model(data, model) do
-    case do_swap_model(data, model) do
-      {:ok, data2, _from} -> data2
-      {:error, :invalid_model} -> data
-    end
-  end
-
-  # Helpers — in-place data updates for {:reconfigure, opts}.
-  defp maybe_replace(data, _key, nil), do: data
-  defp maybe_replace(data, key, value), do: Map.put(data, key, value)
-
-  defp merge_provider_ctx(data, nil), do: data
-
-  defp merge_provider_ctx(data, ctx) when is_map(ctx) do
-    %{data | provider_ctx: Map.merge(data.provider_ctx || %{}, ctx)}
-  end
+  @doc false
+  def append_message(data, msg), do: %{data | messages: data.messages ++ [msg]}
 
   defp persist_event(data, kind, payload) do
     event = %{
@@ -3606,7 +1652,8 @@ defmodule Tau.Session do
     end
   end
 
-  defp generate_event_id do
+  @doc false
+  def generate_event_id do
     case Code.ensure_loaded?(Uniq.UUID) do
       true -> apply(Uniq.UUID, :uuid7, [])
       _ -> "evt_" <> (:crypto.strong_rand_bytes(10) |> Base.url_encode64(padding: false))
@@ -3615,40 +1662,8 @@ defmodule Tau.Session do
 
   defp parent_event_id(_data), do: nil
 
-  # ADR-0012: read the per-original-provider fallback list from settings.
-  # Returns [] when no chain is configured or when settings carry a typo
-  # (fail-closed via Tau.Settings.Schema.resolve_fallback_chains/1).
-  # Both atom and string keys are accepted (Settings.Loader uses
-  # `keys: :atoms`; Jason leaves *values* as strings, so the resolver
-  # is the canonical str → module step).
-  # SPEC-CODING-AGENT §5 / D-037: deployment-wide default for the
-  # coding-agent surface. Read from the merged settings cascade at
-  # session init only — the CLI flag overrides; in-flight sessions
-  # are not affected by mid-session settings reloads (D-007).
-  defp coding_agent_from_settings do
-    settings = SettingsCache.get()
-
-    raw =
-      get_in(settings, [:coding_agent, :default_agent]) ||
-        get_in(settings, ["coding_agent", "default_agent"])
-
-    case raw do
-      nil -> nil
-      mod when is_atom(mod) -> mod
-      str when is_binary(str) -> Tau.CLI.resolve_coding_agent(str)
-    end
-  end
-
-  defp lookup_fallback_chain(original_provider) when is_atom(original_provider) do
-    settings = Tau.Settings.Cache.get()
-
-    case Tau.Settings.Schema.resolve_fallback_chains(settings) do
-      {:ok, chains} -> Map.get(chains, original_provider, [])
-      {:error, _} -> []
-    end
-  end
-
-  defp transition(id, _data, to) do
+  @doc false
+  def transition(id, _data, to) do
     :telemetry.execute([:tau, :session, :transition], %{system_time: System.system_time()}, %{
       session_id: id,
       to: to
@@ -3657,40 +1672,10 @@ defmodule Tau.Session do
     :ok
   end
 
-  defp broadcast(id, event) do
+  @doc false
+  def broadcast(id, event) do
     Phoenix.PubSub.broadcast(Tau.PubSub, "session:#{id}", event)
   end
-
-  # D-018: translate known provider auth atoms into user-actionable
-  # strings. Other reasons fall through to inspect/1 (the original
-  # D-009 behavior).
-  defp describe_provider_error(:missing_api_key) do
-    Tau.Providers.Anthropic.Auth.describe_error({:error, :no_auth})
-  end
-
-  defp describe_provider_error(:oauth_expired) do
-    Tau.Providers.Anthropic.Auth.describe_error({:error, :oauth_expired})
-  end
-
-  defp describe_provider_error(:oauth_missing_scope) do
-    Tau.Providers.Anthropic.Auth.describe_error({:error, :oauth_missing_scope})
-  end
-
-  defp describe_provider_error(:oauth_malformed) do
-    Tau.Providers.Anthropic.Auth.describe_error({:error, :oauth_malformed})
-  end
-
-  # AC-7 (SPEC-CIRCUIT-BREAKER §4 B3): breaker is open — surface a
-  # user-actionable message. The user can wait for the cooldown or switch
-  # providers; the exact cooldown duration is not surfaced here because it
-  # is an ETS-internal value. Generic wording avoids surfacing internals.
-  defp describe_provider_error(:circuit_open) do
-    "Provider is temporarily unavailable (circuit breaker open). " <>
-      "The provider has returned too many consecutive errors. " <>
-      "Please wait a moment and try again, or switch providers."
-  end
-
-  defp describe_provider_error(other), do: inspect(other)
 
   # ADR-0014: cascade lifecycle operation to children. Both
   # `Tau.cancel/1` and `Tau.stop/1` are fire-and-forget casts; a child
@@ -3709,625 +1694,14 @@ defmodule Tau.Session do
   # may emit :enqueued multiple times if the FSM transitions through
   # several non-idle states before reaching :awaiting_user. Each
   # :enqueued reflects a real postpone-and-rewind decision.
-  defp emit_user_message_telemetry(event, data, state) do
+  @doc false
+  def emit_user_message_telemetry(event, data, state) do
     :telemetry.execute(
       [:tau, :session, :user_message, event],
       %{system_time: System.system_time()},
       %{session_id: data.id, from_state: state}
     )
   end
-
-  # --- Coding-agent streaming (SPEC-CODING-AGENT §4 B1 / D-037) ------------
-  #
-  # Helpers for the `:coding_agent_streaming` FSM state. The split mirrors
-  # the provider path's helpers (Assembler + finalize_assistant +
-  # cancel_provider_task) but operates on `Tau.CodingAgent.Event` instead
-  # of `Tau.Provider.Event`. Folding into a unified message type happens
-  # here so the TUI render, persistence, and `/resume` reuse the provider
-  # path unchanged.
-
-  # Ensure a per-session workspace exists. Re-uses an already-prepared
-  # workspace for subsequent turns within the same session (the worktree
-  # / cwd survives across user turns; only torn down at session end).
-  # Returns `{:ok, data, path}` on success, `{:error, reason}` on failure.
-  defp ensure_coding_agent_workspace(%{coding_agent_workspace: %CAWorkspace{} = ws} = data) do
-    {:ok, data, ws.path}
-  end
-
-  defp ensure_coding_agent_workspace(%{coding_agent_workspace: nil} = data) do
-    backend = data.coding_agent_workspace_backend || CAWorkspace.resolve_default_backend(data.cwd)
-
-    opts =
-      Keyword.merge(
-        [
-          backend: backend,
-          session_id: data.id,
-          cwd: data.cwd
-        ],
-        data.coding_agent_workspace_opts || []
-      )
-
-    case CAWorkspace.prepare(opts) do
-      {:ok, ws} -> {:ok, %{data | coding_agent_workspace: ws}, ws.path}
-      {:error, reason} -> {:error, {:workspace_prepare_failed, reason}}
-    end
-  end
-
-  # Synchronous pre-dispatch error (workspace prepare failed, supervisor
-  # refused to start a dispatcher, …). Surfaces as an `%Assistant{}` with
-  # `stop_reason: :error` and a non-empty content block — mirrors D-009
-  # for the provider path so the existing TUI render path Just Works.
-  defp emit_coding_agent_sync_error(data, reason) do
-    reason_str = describe_coding_agent_error(reason)
-
-    msg =
-      Assistant.new(
-        stop_reason: :error,
-        error_message: reason_str,
-        content: [%{type: :text, text: "Error: " <> reason_str}]
-      )
-
-    data =
-      data
-      |> append_message(msg)
-      |> persist_event("assistant_message", message_to_data(msg))
-
-    broadcast(data.id, %Events.MessageEnd{session_id: data.id, message: msg})
-
-    :telemetry.execute(
-      [:tau, :session, :coding_agent_streaming, :exception],
-      %{system_time: System.system_time()},
-      %{session_id: data.id, agent: data.coding_agent, reason: reason}
-    )
-
-    {:next_state, :awaiting_user,
-     %{data | coding_agent_dispatcher: nil, coding_agent_pending: nil, coding_agent_blocks: []}}
-  end
-
-  # Start a fresh dispatcher under `Tau.CodingAgent.Supervisor` and
-  # broadcast `MessageStart` so the TUI's `:streaming` indicator lights
-  # up immediately (no waiting for the first AssistantText event).
-  defp start_coding_agent_dispatcher(data, workspace_path) do
-    user_text = latest_user_text(data.messages)
-
-    # SPEC-CODING-AGENT §7 Q5: thread the captured adapter-side
-    # session_id (from a previous %Event.Start{}) as
-    # `task.resume_id`. Claude Code picks up where the prior tau
-    # turn left off; other adapters that don't honour `resume_id`
-    # ignore the field. Emits a telemetry event so the audit test
-    # can assert the resume path was taken.
-    resume_id = get_in(data, [:coding_agent_state, :session_id])
-
-    task = %{
-      prompt: user_text,
-      workspace: workspace_path,
-      session_id: data.id,
-      resume_id: resume_id,
-      allowed_tools: :all,
-      mcp_servers: [],
-      timeout: :infinity
-    }
-
-    if is_binary(resume_id) do
-      :telemetry.execute(
-        [:tau, :coding_agent, :resume],
-        %{system_time: System.system_time()},
-        %{
-          session_id: data.id,
-          agent: data.coding_agent,
-          adapter_session_id: resume_id
-        }
-      )
-    end
-
-    ctx =
-      Map.merge(
-        %{
-          session_id: data.id,
-          request_id: generate_event_id()
-        },
-        data.coding_agent_ctx || %{}
-      )
-
-    args = [
-      adapter: data.coding_agent,
-      task: task,
-      ctx: ctx,
-      subscriber: self()
-    ]
-
-    case Tau.CodingAgent.Supervisor.start_dispatcher(args) do
-      {:ok, pid} ->
-        pending =
-          Assistant.new(
-            provider: data.coding_agent,
-            model: nil,
-            api: :coding_agent,
-            content: []
-          )
-
-        broadcast(data.id, %Events.MessageStart{session_id: data.id, message: pending})
-
-        # B1 / D-150 (SPEC-TUI-HEADLESS §5c): emit SubagentStart on the parent
-        # topic so the TUI can surface the coding agent as a named sub-agent
-        # node rather than flattened parent [tool_call] lines. The subagent_id
-        # is derived from the parent session id and is stable for this turn.
-        # The coding-agent dispatcher is a single-run process; at most one is
-        # active at a time, so the derived id is unique per session per turn.
-        ca_subagent_id = "#{data.id}:ca"
-        label = agent_to_string(data.coding_agent) || "coding-agent"
-
-        broadcast(data.id, %Events.SubagentStart{
-          session_id: data.id,
-          subagent_id: ca_subagent_id,
-          kind: :coding_agent,
-          label: label,
-          parent_tool_call_id: nil,
-          child_session_id: nil
-        })
-
-        {:next_state, :coding_agent_streaming,
-         %{
-           data
-           | coding_agent_dispatcher: pid,
-             coding_agent_pending: pending,
-             coding_agent_blocks: []
-         }}
-
-      {:error, reason} ->
-        emit_coding_agent_sync_error(data, {:dispatcher_start_failed, reason})
-    end
-  end
-
-  defp latest_user_text(messages) do
-    # Walk from the end to find the most recent user-supplied text.
-    # The skill/memory injection prepends synthetic User messages with
-    # `metadata.role in [:system, :compaction_summary]`; skip those.
-    messages
-    |> Enum.reverse()
-    |> Enum.find_value("", fn
-      %User{metadata: %{role: r}} when r in [:system, :compaction_summary] ->
-        nil
-
-      %User{content: c} when is_binary(c) ->
-        c
-
-      %User{content: blocks} when is_list(blocks) ->
-        Enum.map_join(blocks, "\n", fn
-          %{type: :text, text: t} -> t
-          %{"type" => "text", "text" => t} -> t
-          _ -> ""
-        end)
-
-      _ ->
-        nil
-    end)
-  end
-
-  # ── Event-by-event handlers (D-031: pattern match on struct module).
-  #
-  # AssistantText accumulates into a single text block per turn (or
-  # restarts when a `turn` jump is observed). ToolUse and ToolResult
-  # emit their own messages so the assembled assistant message reflects
-  # the agent's actual content shape, matching the provider path. Cost
-  # and FileEdit emit telemetry; Cost is also NOT yet aggregated into
-  # session cost totals (Team D's scope). Error / Done finalize.
-
-  defp handle_coding_agent_event(%CAEvent.Start{} = ev, data) do
-    :telemetry.execute(
-      [:tau, :session, :coding_agent_streaming, :adapter_start],
-      %{system_time: System.system_time()},
-      %{session_id: data.id, agent: data.coding_agent, version: ev.version}
-    )
-
-    # SPEC-CODING-AGENT §7 Q5: capture the adapter-side session_id.
-    # Persist a `coding_agent_session` JSONL event so a later
-    # `Tau.resume/1` can recover it and pass it as `task.resume_id`
-    # on the next dispatcher launch. Implementation deliberately
-    # lives below the other handle_coding_agent_event/2 clauses to
-    # keep them grouped (compiler warning otherwise).
-    data = maybe_capture_coding_agent_session(data, ev)
-
-    {:keep_state, data}
-  end
-
-  defp handle_coding_agent_event(%CAEvent.AssistantText{text: t}, data) do
-    blocks = append_assistant_text(data.coding_agent_blocks, t)
-    pending = %{data.coding_agent_pending | content: blocks}
-
-    broadcast(data.id, %Events.MessageUpdate{
-      session_id: data.id,
-      event: %CAEvent.AssistantText{text: t},
-      message: pending
-    })
-
-    {:keep_state, %{data | coding_agent_blocks: blocks, coding_agent_pending: pending}}
-  end
-
-  defp handle_coding_agent_event(%CAEvent.ToolUse{id: id, name: name, input: input}, data) do
-    # Anthropic-compatible content-block shape — same as the provider
-    # path's `%{type: :tool_call, ...}` blocks the Assembler emits.
-    block = %{type: :tool_call, id: id, name: name, arguments: input || %{}}
-    blocks = data.coding_agent_blocks ++ [block]
-    pending = %{data.coding_agent_pending | content: blocks}
-
-    broadcast(data.id, %Events.MessageUpdate{
-      session_id: data.id,
-      event: %CAEvent.ToolUse{id: id, name: name, input: input},
-      message: pending
-    })
-
-    # ToolStart broadcast mirrors the provider path so existing TUI /
-    # audit subscribers see the same tool-call surface regardless of
-    # which event source produced it (D-031).
-    broadcast(data.id, %Events.ToolStart{
-      session_id: data.id,
-      tool_call_id: id,
-      name: name,
-      arguments: input || %{}
-    })
-
-    # B1 / D-151 (SPEC-TUI-HEADLESS §5c): ADDITIONALLY emit SubagentProgress
-    # on the parent topic. The child_tool_call_id enables the render layer to
-    # de-dup: a ToolStart/ToolEnd whose tool_call_id is owned by a known
-    # sub-agent is NOT rendered as an inline tool call (B1 rule).
-    ca_subagent_id = "#{data.id}:ca"
-
-    broadcast(data.id, %Events.SubagentProgress{
-      session_id: data.id,
-      subagent_id: ca_subagent_id,
-      activity: {:tool_call, name},
-      child_tool_call_id: id
-    })
-
-    {:keep_state, %{data | coding_agent_blocks: blocks, coding_agent_pending: pending}}
-  end
-
-  defp handle_coding_agent_event(
-         %CAEvent.ToolResult{tool_use_id: tool_id, content: content, is_error: is_err},
-         data
-       ) do
-    # ToolResult is a separate message in Anthropic's wire format. We
-    # finalise the current assistant message (so the user can see what
-    # the agent said BEFORE the tool result), append a ToolResult
-    # message, broadcast ToolEnd, then start a new pending assistant
-    # message for any subsequent AssistantText.
-    {data, _} = flush_pending_assistant(data, :tool_use)
-
-    tool_result =
-      ToolResult.new(
-        tool_call_id: tool_id,
-        # ToolUse may not have been observed (some adapters emit
-        # ToolResult standalone); we don't have the tool name here, so
-        # fall back to "tool" — matches Anthropic's permissive shape.
-        tool_name: tool_name_for(data, tool_id),
-        content: content,
-        is_error: is_err
-      )
-
-    data =
-      data
-      |> append_message(tool_result)
-      |> persist_event("tool_result", tool_result_to_data(tool_result))
-
-    broadcast(data.id, %Events.ToolEnd{
-      session_id: data.id,
-      tool_call_id: tool_id,
-      result: tool_result
-    })
-
-    # Start a fresh assistant message for any further AssistantText
-    # the agent emits before `Done`.
-    pending =
-      Assistant.new(
-        provider: data.coding_agent,
-        model: nil,
-        api: :coding_agent,
-        content: []
-      )
-
-    broadcast(data.id, %Events.MessageStart{session_id: data.id, message: pending})
-
-    {:keep_state, %{data | coding_agent_pending: pending, coding_agent_blocks: []}}
-  end
-
-  defp handle_coding_agent_event(%CAEvent.FileEdit{path: path, kind: kind}, data) do
-    :telemetry.execute(
-      [:tau, :session, :coding_agent_streaming, :file_edit],
-      %{system_time: System.system_time()},
-      %{session_id: data.id, agent: data.coding_agent, path: path, kind: kind}
-    )
-
-    {:keep_state, data}
-  end
-
-  defp handle_coding_agent_event(%CAEvent.Cost{} = cost, data) do
-    # Team D will fold this into session cost totals; for now we just
-    # surface telemetry so observers (tau doctor, future TUI panel)
-    # can see it. The hook below is the deliberate extension point.
-    :telemetry.execute(
-      [:tau, :session, :coding_agent_streaming, :cost],
-      %{
-        system_time: System.system_time(),
-        duration_ms: cost.duration_ms,
-        usd: cost.usd || 0.0
-      },
-      %{session_id: data.id, agent: data.coding_agent, tokens: cost.tokens}
-    )
-
-    # D-153 (SPEC-TUI-HEADLESS §5c): emit SubagentCost on the parent topic so
-    # the TUI can display cost in the sub-agent end marker without folding it
-    # into the parent's own cost (no double-counting, R4).
-    ca_subagent_id = "#{data.id}:ca"
-
-    broadcast(data.id, %Events.SubagentCost{
-      session_id: data.id,
-      subagent_id: ca_subagent_id,
-      tokens: cost.tokens,
-      usd: cost.usd,
-      duration_ms: cost.duration_ms
-    })
-
-    {:keep_state, maybe_apply_cost_hook(data, cost)}
-  end
-
-  defp handle_coding_agent_event(%CAEvent.Error{reason: reason, recoverable: rec?}, data) do
-    reason_str = describe_coding_agent_error(reason)
-
-    if rec? do
-      # Recoverable: stash an error-content block so the user sees
-      # *something* and let the dispatcher continue.
-      blocks =
-        data.coding_agent_blocks ++ [%{type: :text, text: "[adapter error] " <> reason_str}]
-
-      pending = %{data.coding_agent_pending | content: blocks, error_message: reason_str}
-
-      broadcast(data.id, %Events.MessageUpdate{
-        session_id: data.id,
-        event: %CAEvent.Error{reason: reason, recoverable: rec?},
-        message: pending
-      })
-
-      {:keep_state, %{data | coding_agent_blocks: blocks, coding_agent_pending: pending}}
-    else
-      # Non-recoverable: the dispatcher will follow with a synthetic
-      # Done. Mark the pending message and let the Done finaliser
-      # render. We don't transition here — Done does the FSM move.
-      pending = %{
-        data.coding_agent_pending
-        | error_message: reason_str,
-          stop_reason: :error
-      }
-
-      {:keep_state, %{data | coding_agent_pending: pending}}
-    end
-  end
-
-  defp handle_coding_agent_event(%CAEvent.Done{} = done, data) do
-    finalize_coding_agent_turn(done, data)
-  end
-
-  defp handle_coding_agent_event(_other, data), do: {:keep_state, data}
-
-  # Build / extend the in-progress text block. AssistantText events
-  # within one turn concatenate into a single text content block — this
-  # mirrors how Anthropic's stream-json folds text deltas.
-  defp append_assistant_text(blocks, t) when is_binary(t) do
-    case List.last(blocks) do
-      %{type: :text, text: existing} ->
-        Enum.drop(blocks, -1) ++ [%{type: :text, text: existing <> t}]
-
-      _ ->
-        blocks ++ [%{type: :text, text: t}]
-    end
-  end
-
-  # Push the current pending assistant message into `data.messages`,
-  # persist, broadcast `MessageEnd`. Leaves the FSM state untouched
-  # (caller decides). Returns `{data, msg}`.
-  defp flush_pending_assistant(%{coding_agent_pending: nil} = data, _stop_reason),
-    do: {data, nil}
-
-  defp flush_pending_assistant(data, stop_reason) do
-    effective_stop = data.coding_agent_pending.stop_reason || stop_reason
-
-    msg =
-      Assembler.finalize(data.coding_agent_pending, data.coding_agent_blocks,
-        stop_reason: effective_stop
-      )
-
-    data =
-      data
-      |> append_message(msg)
-      |> persist_event("assistant_message", message_to_data(msg))
-
-    broadcast(data.id, %Events.MessageEnd{session_id: data.id, message: msg})
-
-    {data, msg}
-  end
-
-  defp finalize_coding_agent_turn(%CAEvent.Done{exit_status: status} = done, data) do
-    stop_reason =
-      cond do
-        data.coding_agent_pending && data.coding_agent_pending.stop_reason == :error -> :error
-        # Synthetic cancel sentinel (D-032).
-        status == -2 -> :aborted
-        # Synthetic dispatcher / adapter death.
-        status == -1 -> :error
-        status == 0 -> :end_turn
-        true -> :error
-      end
-
-    # Inject the final_message as a trailing text block if the agent
-    # supplied one and we don't already have content covering it.
-    blocks =
-      case done.final_message do
-        nil -> data.coding_agent_blocks
-        "" -> data.coding_agent_blocks
-        text -> append_assistant_text(data.coding_agent_blocks, "\n" <> text)
-      end
-
-    data = %{data | coding_agent_blocks: blocks}
-
-    {data, _msg} = flush_pending_assistant(data, stop_reason)
-
-    :telemetry.execute(
-      [:tau, :session, :coding_agent_streaming, :stop],
-      %{system_time: System.system_time()},
-      %{
-        session_id: data.id,
-        agent: data.coding_agent,
-        exit_status: status,
-        stop_reason: stop_reason
-      }
-    )
-
-    # D-154 (SPEC-TUI-HEADLESS §5c): emit SubagentEnd on the parent topic.
-    # The end state maps from the coding-agent stop_reason.
-    ca_subagent_id = "#{data.id}:ca"
-
-    end_state =
-      cond do
-        status == -2 -> :cancelled
-        stop_reason == :end_turn -> :done
-        true -> :failed
-      end
-
-    end_summary =
-      case end_state do
-        :done -> "completed"
-        :cancelled -> "cancelled"
-        :failed -> "failed (exit #{status})"
-      end
-
-    broadcast(data.id, %Events.SubagentEnd{
-      session_id: data.id,
-      subagent_id: ca_subagent_id,
-      state: end_state,
-      summary: end_summary
-    })
-
-    {:next_state, :awaiting_user,
-     %{
-       data
-       | coding_agent_dispatcher: nil,
-         coding_agent_pending: nil,
-         coding_agent_blocks: []
-     }}
-  end
-
-  # Recover a tool name from the in-progress message's ToolUse blocks
-  # for a given `tool_use_id`. Falls back to "tool" if the ToolUse
-  # event wasn't observed (some adapters elide it for cheap tools).
-  defp tool_name_for(data, tool_use_id) do
-    blocks = (data.coding_agent_pending && data.coding_agent_pending.content) || []
-
-    Enum.find_value(blocks, "tool", fn
-      %{type: :tool_call, id: ^tool_use_id, name: n} -> n
-      _ -> nil
-    end)
-  end
-
-  # SPEC-CODING-AGENT §7 Q4 / D-038: fold `%Event.Cost{}` into session
-  # totals as an adapter-tagged line item. Three side effects (append to
-  # `data.coding_agent_costs`, persist `coding_agent_cost` JSONL,
-  # emit `[:tau, :coding_agent, :cost]` telemetry), each wrapped per
-  # D-035 so a failure in one MUST NOT crash the session.
-  defp maybe_apply_cost_hook(data, %CAEvent.Cost{} = cost) do
-    try do
-      tagged =
-        Tau.CodingAgent.Cost.from_event(cost,
-          agent: data.coding_agent,
-          session_id: data.id,
-          adapter_session_id: get_in(data, [:coding_agent_state, :session_id])
-        )
-
-      data = persist_event(data, "coding_agent_cost", Tau.CodingAgent.Cost.to_jsonl(tagged))
-
-      :telemetry.execute(
-        [:tau, :coding_agent, :cost],
-        %{
-          system_time: System.system_time(),
-          usd: tagged.usd || 0.0,
-          duration_ms: tagged.duration_ms,
-          input_tokens: tagged.input_tokens,
-          output_tokens: tagged.output_tokens,
-          cache_read: tagged.cache_read,
-          cache_write: tagged.cache_write
-        },
-        %{
-          session_id: data.id,
-          agent: data.coding_agent,
-          model: data.model,
-          source: Tau.CodingAgent.Cost.source(tagged),
-          adapter_session_id: tagged.adapter_session_id
-        }
-      )
-
-      %{data | coding_agent_costs: (data.coding_agent_costs || []) ++ [tagged]}
-    rescue
-      e ->
-        # D-035: cost-folding errors don't crash the session. Surface
-        # diagnostically and continue with the original data.
-        :telemetry.execute(
-          [:tau, :coding_agent, :cost, :failed],
-          %{system_time: System.system_time()},
-          %{
-            session_id: data.id,
-            agent: data.coding_agent,
-            reason: Exception.message(e)
-          }
-        )
-
-        data
-    end
-  end
-
-  # SPEC-CODING-AGENT §7 Q5: only persist when (a) the adapter
-  # actually surfaced a session_id and (b) it's new. This avoids
-  # appending a JSONL line per turn for adapters (e.g. Replay) that
-  # don't expose a session concept, and avoids duplicate writes
-  # when the same id arrives twice.
-  defp maybe_capture_coding_agent_session(data, %CAEvent.Start{session_id: nil}), do: data
-
-  defp maybe_capture_coding_agent_session(data, %CAEvent.Start{session_id: sid} = ev)
-       when is_binary(sid) do
-    state = data.coding_agent_state || %{session_id: nil, agent: nil}
-
-    if state.session_id == sid do
-      data
-    else
-      new_state = %{state | session_id: sid, agent: data.coding_agent}
-
-      data
-      |> Map.put(:coding_agent_state, new_state)
-      |> persist_event("coding_agent_session", %{
-        "session_id" => sid,
-        "agent" => agent_to_string(data.coding_agent),
-        "version" => ev.version
-      })
-    end
-  end
-
-  defp maybe_capture_coding_agent_session(data, _ev), do: data
-
-  defp agent_to_string(nil), do: nil
-  defp agent_to_string(agent) when is_atom(agent), do: Atom.to_string(agent)
-  defp agent_to_string(bin) when is_binary(bin), do: bin
-
-  # Translate a coding-agent error reason into a user-visible string.
-  # Mirrors `describe_provider_error/1` for the provider path.
-  defp describe_coding_agent_error({:workspace_prepare_failed, reason}),
-    do: "Workspace preparation failed: " <> inspect(reason)
-
-  defp describe_coding_agent_error({:dispatcher_start_failed, reason}),
-    do: "Coding-agent dispatcher failed to start: " <> inspect(reason)
-
-  defp describe_coding_agent_error(:cancelled), do: "cancelled"
-  defp describe_coding_agent_error(:inactivity_timeout), do: "Coding-agent inactivity timeout"
-
-  defp describe_coding_agent_error(other) when is_binary(other), do: other
-  defp describe_coding_agent_error(other), do: inspect(other)
 
   # --- Hook payload --------------------------------------------------------
   #
@@ -4336,7 +1710,8 @@ defmodule Tau.Session do
   # transcript_path in addition to event-specific fields. Callers pass only
   # the event-specific extras; the canonical fields are always present.
 
-  defp hook_payload(data, event, extras) when is_map(extras) do
+  @doc false
+  def hook_payload(data, event, extras) when is_map(extras) do
     Map.merge(
       %{
         session_id: data.id,
@@ -4356,162 +1731,6 @@ defmodule Tau.Session do
     # hook payload is always a non-nil binary.
     p.path_for(id, cwd)
   end
-
-  # --- Skill activation -----------------------------------------------------
-  #
-  # Mechanism A (ADR-0013): the model activates a discovered skill by
-  # emitting a tool_call to the synthetic `__activate_skill__` tool. The
-  # tool is FSM-internal — it never reaches the executor pool, never
-  # passes through permissions or hooks. Skills with
-  # `disable_model_invocation: true` are excluded from the exposed enum;
-  # their bodies are still injected as system messages (background
-  # context) by `prepend_skill_messages/2`.
-
-  defp model_invokable_skills(skills) do
-    Enum.reject(skills, fn {_name, s} -> s.disable_model_invocation end)
-  end
-
-  defp skill_activation_tool_spec(skills) do
-    case model_invokable_skills(skills) do
-      [] ->
-        nil
-
-      list ->
-        names = Enum.map(list, fn {name, _s} -> name end)
-
-        descriptions =
-          list
-          |> Enum.map(fn {name, %Tau.Skill{description: d}} ->
-            case d do
-              "" -> "  - #{name}"
-              nil -> "  - #{name}"
-              desc -> "  - #{name}: #{desc}"
-            end
-          end)
-          |> Enum.join("\n")
-
-        description =
-          "Activate one of the available skills for the current turn. " <>
-            "Activation scopes subsequent tool calls to the skill's allowed_tools " <>
-            "whitelist (if set) and ends when you emit `end_turn`. " <>
-            "Available skills:\n" <> descriptions
-
-        %{
-          name: @activate_skill_tool_name,
-          description: description,
-          parameters: %{
-            "type" => "object",
-            "properties" => %{
-              "name" => %{
-                "type" => "string",
-                "enum" => names,
-                "description" => "Name of the skill to activate."
-              }
-            },
-            "required" => ["name"],
-            "additionalProperties" => false
-          }
-        }
-    end
-  end
-
-  defp maybe_put_tools(opts, nil), do: opts
-  defp maybe_put_tools(opts, []), do: opts
-
-  defp maybe_put_tools(opts, tool_specs) when is_list(tool_specs),
-    do: Map.put(opts, :tools, tool_specs)
-
-  defp maybe_put_tools(opts, tool_spec) when is_map(tool_spec),
-    do: Map.put(opts, :tools, [tool_spec])
-
-  # D-059: tool specs exposed to the provider for this turn —
-  # union of (1) the synthetic `__activate_skill__` spec when other
-  # model-invokable skills exist, and (2) the active skill's allowed
-  # tools (semantics mirror `Tau.Tools.Builtin.Agent.whitelist_from/1`:
-  # `[]` exposes every registered built-in; a list narrows by name).
-  # Returns `nil` on empty result so `:tools` stays unset (some providers
-  # reject an empty `:tools` array).
-  defp model_visible_tool_specs(data) do
-    activation = skill_activation_tool_spec(data.skills)
-    skill_specs = active_skill_tool_specs(data.active_skill)
-
-    case {activation, skill_specs} do
-      {nil, []} -> nil
-      {nil, list} -> list
-      {spec, []} -> [spec]
-      {spec, list} -> [spec | list]
-    end
-  end
-
-  # D-059: tool specs derived from the active skill's `allowed_tools`.
-  # `nil` active_skill ⇒ no extra specs (the activate-skill tool, if
-  # any, is the only model-visible tool). Empty `allowed_tools` ⇒ every
-  # registered built-in tool. Otherwise: only the listed names that
-  # actually resolve in `Tau.Tool` (unknown names are silently skipped
-  # rather than crashing the turn — the same posture
-  # `Tau.Permissions.Evaluator` takes for unknown names).
-  defp active_skill_tool_specs(nil), do: []
-
-  defp active_skill_tool_specs(%Tau.Skill{allowed_tools: []}) do
-    Tau.Tool.list()
-    |> Enum.sort()
-    |> Enum.flat_map(&tool_spec_for/1)
-  end
-
-  defp active_skill_tool_specs(%Tau.Skill{allowed_tools: names}) when is_list(names) do
-    names
-    |> Enum.uniq()
-    |> Enum.flat_map(&tool_spec_for/1)
-  end
-
-  # Build the Anthropic-shape `%{name, description, parameters}` map from
-  # a registered tool module. Returns `[]` (not `[nil]`) when the name
-  # is not registered so the caller can `flat_map` cleanly.
-  defp tool_spec_for(name) when is_binary(name) do
-    case Tau.Tool.lookup(name) do
-      {:ok, mod} ->
-        [%{name: mod.name(), description: mod.description(), parameters: mod.parameters()}]
-
-      :error ->
-        []
-    end
-  end
-
-  # Process every `__activate_skill__` call inline. Returns the new
-  # `data` (with `active_skill` set on success) and the partial
-  # `tools_in_flight` map for these calls — they share the `:tool_done`
-  # mailbox path with regular tool results so the FSM bookkeeping is
-  # uniform.
-  defp handle_skill_activations([], data, _parent), do: {data, %{}}
-
-  defp handle_skill_activations(calls, data, parent) do
-    Enum.reduce(calls, {data, %{}}, fn %{id: id, name: tool_name, arguments: args},
-                                       {data_acc, in_flight_acc} ->
-      requested = skill_name_from_args(args)
-
-      {data_acc, result} = activate_skill(data_acc, requested, id)
-
-      :telemetry.execute(
-        [:tau, :session, :skill_activated],
-        %{system_time: System.system_time()},
-        %{
-          session_id: data_acc.id,
-          skill_name: requested,
-          tool_name: tool_name,
-          disabled?: result.is_error
-        }
-      )
-
-      Process.send(parent, {:tool_done, id, result}, [])
-      {data_acc, Map.put(in_flight_acc, id, :activated)}
-    end)
-  end
-
-  defp skill_name_from_args(args) when is_map(args) do
-    Map.get(args, "name") || Map.get(args, :name)
-  end
-
-  defp skill_name_from_args(_), do: nil
 
   # User-initiated slash-command skill activation.
   #
@@ -4544,67 +1763,8 @@ defmodule Tau.Session do
     data
   end
 
-  # Look up `name` on `data.skills`; honour `disable_model_invocation`.
-  # On success, set `data.active_skill`, persist a JSONL event, and
-  # broadcast `%Events.SkillActivated{}`. On failure, return an
-  # `is_error: true` ToolResult and leave `data` unchanged.
-  defp activate_skill(data, nil, call_id) do
-    {data,
-     ToolResult.new(
-       tool_call_id: call_id,
-       tool_name: @activate_skill_tool_name,
-       content: "Skill activation failed: missing 'name' parameter.",
-       is_error: true
-     )}
-  end
-
-  defp activate_skill(data, name, call_id) when is_binary(name) do
-    case List.keyfind(data.skills, name, 0) do
-      {^name, %Tau.Skill{disable_model_invocation: true}} ->
-        {data,
-         ToolResult.new(
-           tool_call_id: call_id,
-           tool_name: @activate_skill_tool_name,
-           content:
-             "Skill '#{name}' has disable-model-invocation set; it cannot be activated by the model.",
-           is_error: true
-         )}
-
-      {^name, %Tau.Skill{} = skill} ->
-        data =
-          %{data | active_skill: skill}
-          |> persist_event("skill_activated", %{
-            skill_name: name,
-            tool_call_id: call_id,
-            allowed_tools: skill.allowed_tools
-          })
-
-        broadcast(data.id, %Events.SkillActivated{
-          session_id: data.id,
-          skill_name: name,
-          tool_call_id: call_id
-        })
-
-        {data,
-         ToolResult.new(
-           tool_call_id: call_id,
-           tool_name: @activate_skill_tool_name,
-           content: "Skill activated: #{name}",
-           is_error: false
-         )}
-
-      nil ->
-        {data,
-         ToolResult.new(
-           tool_call_id: call_id,
-           tool_name: @activate_skill_tool_name,
-           content: "Unknown skill: #{name}",
-           is_error: true
-         )}
-    end
-  end
-
-  defp register_builtins do
+  @doc false
+  def register_builtins do
     Enum.each(
       Application.get_env(:tau, :builtin_tools, []),
       fn mod ->
@@ -4836,20 +1996,6 @@ defmodule Tau.Session do
 
   defp agent_to_atom(a) when is_atom(a), do: a
   defp agent_to_atom(_), do: nil
-
-  # --- Compaction helpers --------------------------------------------------
-  #
-  # We persist the full <conversation_summary>...</conversation_summary>
-  # block as the JSONL "summary" field so events_to_messages/1's
-  # "compaction" clause can reconstruct the synthetic message verbatim
-  # on Tau.fork/2 / Tau.resume/1. The compactor returns just the inner
-  # text via the tri-tuple contract; we wrap it here.
-
-  defp format_summary_for_persist(nil), do: nil
-
-  defp format_summary_for_persist(summary_text) when is_binary(summary_text) do
-    "<conversation_summary>\n#{summary_text}\n</conversation_summary>"
-  end
 
   defp deserialize_blocks(blocks) when is_list(blocks),
     do: Enum.map(blocks, &deserialize_block/1)
@@ -5137,24 +2283,6 @@ defmodule Tau.Session do
   defp outcome_tag({:async_compact, _}), do: :async_compact
   defp outcome_tag(:passthrough), do: :passthrough
 
-  # D-041: /model <id> slash-command handler. Runs the same validate +
-  # mutate + telemetry + persist logic as the {:swap_model} call handler
-  # via the shared apply_model_swap/2 helper. Does NOT start a provider
-  # turn — broadcasts a SystemNotice instead.
-  defp handle_slash_model_swap(data, new_model) do
-    case apply_model_swap(data, new_model) do
-      {:ok, data2, %{from: from, to: to}} ->
-        notice = "Model changed: #{from} → #{to}"
-        broadcast(data2.id, %Events.SystemNotice{session_id: data2.id, text: notice})
-        {:keep_state, data2}
-
-      {:error, :invalid_model} ->
-        notice = "Error: '#{new_model}' is not a valid model id (empty or whitespace)."
-        broadcast(data.id, %Events.SystemNotice{session_id: data.id, text: notice})
-        {:keep_state, data}
-    end
-  end
-
   defp invoke_file_command(path, args, msg) do
     case File.read(path) do
       {:ok, body} -> %Tau.Message.User{msg | content: body <> "\n\n" <> args}
@@ -5174,35 +2302,5 @@ defmodule Tau.Session do
       end,
       metadata: data.metadata
     )
-  end
-
-  # D-079 / SPEC-USER-TURN §6 / AC-8: steering drain helper.
-  # Dequeues one message and appends it AFTER all tool_results and BEFORE
-  # the next provider call so no tool_call is orphaned. Enforced by the
-  # call site, which invokes only when `map_size(tools) == 0`.
-  #
-  # Unlike follow-up drain, this path bypasses `classify_slash_command/4`
-  # — a steering message has already passed the user-intent gate at
-  # enqueue time and must land at the exact mid-turn position; slash
-  # commands aren't meaningful here.
-  defp drain_steering_queue_one(data) do
-    case :queue.out(data.steering_queue) do
-      {:empty, _} ->
-        data
-
-      {{:value, msg}, rest} ->
-        :telemetry.execute(
-          [:tau, :session, :steering, :delivered],
-          %{system_time: System.system_time()},
-          %{session_id: data.id, from_state: :tool_executing}
-        )
-
-        emit_user_message_telemetry(:delivered, data, :tool_executing)
-
-        data
-        |> append_message(msg)
-        |> persist_event("user_message", message_to_data(msg))
-        |> Map.put(:steering_queue, rest)
-    end
   end
 end

--- a/lib/tau/session/coding_agent_turn.ex
+++ b/lib/tau/session/coding_agent_turn.ex
@@ -1,0 +1,752 @@
+defmodule Tau.Session.CodingAgentTurn do
+  @moduledoc """
+  Coding-agent streaming helpers for `Tau.Session`.
+
+  Encapsulates the `:coding_agent_streaming` FSM path introduced by
+  SPEC-CODING-AGENT §4 B1 / D-037. A dispatcher is started under
+  `Tau.CodingAgent.Supervisor`; its normalized event stream lands in the
+  FSM mailbox tagged `{:coding_agent_event, pid, struct}` and is handled by
+  the two public FSM-clause functions at the bottom of this module.
+
+  ## Invariants
+
+  - D-032: the coding-agent dispatcher is subprocess-bound to the session.
+    Cancel broadcasts a synthetic `%Done{exit_status: -2}` sentinel; the
+    session FSM ignores it (cancel has already broadcast `%Cancelled{}`).
+  - D-035: cost-folding errors MUST NOT crash the session. `maybe_apply_cost_hook/2`
+    wraps the side-effect block in `try/rescue` and continues with original data.
+  - D-037: `%Assistant{}` / `%ToolResult{}` messages are appended using the same
+    shapes as the provider path so TUI render, persistence, and `/resume` apply
+    unchanged.
+  - SPEC-CODING-AGENT §7 Q5: the adapter-side `session_id` is captured via
+    `maybe_capture_coding_agent_session/2` when it first appears so a later
+    `Tau.resume/1` can thread it as `task.resume_id`.
+  """
+
+  alias Tau.CodingAgent.Event, as: CAEvent
+  alias Tau.CodingAgent.Workspace, as: CAWorkspace
+  alias Tau.Message.{Assembler, Assistant, ToolResult}
+  alias Tau.Session.Events
+  alias Tau.Settings.Cache, as: SettingsCache
+
+  # --- Public helpers -------------------------------------------------------
+
+  @doc """
+  Ensure the coding-agent workspace is ready, creating it if it does not yet
+  exist.
+
+  Returns `{:ok, data, workspace_path}` or `{:error, reason}`.
+  """
+  @spec ensure_coding_agent_workspace(Tau.Session.Data.t()) ::
+          {:ok, Tau.Session.Data.t(), String.t()} | {:error, term()}
+  def ensure_coding_agent_workspace(%{coding_agent_workspace: %CAWorkspace{} = ws} = data) do
+    {:ok, data, ws.path}
+  end
+
+  def ensure_coding_agent_workspace(%{coding_agent_workspace: nil} = data) do
+    backend = data.coding_agent_workspace_backend || CAWorkspace.resolve_default_backend(data.cwd)
+
+    opts =
+      Keyword.merge(
+        [
+          backend: backend,
+          session_id: data.id,
+          cwd: data.cwd
+        ],
+        data.coding_agent_workspace_opts || []
+      )
+
+    case CAWorkspace.prepare(opts) do
+      {:ok, ws} -> {:ok, %{data | coding_agent_workspace: ws}, ws.path}
+      {:error, reason} -> {:error, {:workspace_prepare_failed, reason}}
+    end
+  end
+
+  @doc """
+  Emit a synchronous pre-dispatch error as an `%Assistant{}` message with
+  `stop_reason: :error` and transition to `:awaiting_user`.
+
+  Mirrors D-009 for the provider path so the existing TUI render path works.
+  """
+  @spec emit_coding_agent_sync_error(Tau.Session.Data.t(), term()) ::
+          :gen_statem.event_handler_result()
+  def emit_coding_agent_sync_error(data, reason) do
+    reason_str = describe_coding_agent_error(reason)
+
+    msg =
+      Assistant.new(
+        stop_reason: :error,
+        error_message: reason_str,
+        content: [%{type: :text, text: "Error: " <> reason_str}]
+      )
+
+    data =
+      data
+      |> Tau.Session.append_message(msg)
+      |> Tau.Session.Journal.persist("assistant_message", Tau.Session.Journal.message_to_data(msg))
+
+    Tau.Session.broadcast(data.id, %Events.MessageEnd{session_id: data.id, message: msg})
+
+    :telemetry.execute(
+      [:tau, :session, :coding_agent_streaming, :exception],
+      %{system_time: System.system_time()},
+      %{session_id: data.id, agent: data.coding_agent, reason: reason}
+    )
+
+    {:next_state, :awaiting_user,
+     %{data | coding_agent_dispatcher: nil, coding_agent_pending: nil, coding_agent_blocks: []}}
+  end
+
+  @doc """
+  Start a fresh dispatcher under `Tau.CodingAgent.Supervisor` and broadcast
+  `MessageStart` so the TUI's `:streaming` indicator lights up immediately.
+
+  Returns an FSM action tuple (`{:next_state, :coding_agent_streaming, ...}` or
+  `{:next_state, :awaiting_user, ...}` on failure).
+  """
+  @spec start_coding_agent_dispatcher(Tau.Session.Data.t(), String.t()) ::
+          :gen_statem.event_handler_result()
+  def start_coding_agent_dispatcher(data, workspace_path) do
+    user_text = latest_user_text(data.messages)
+
+    resume_id = get_in(data, [:coding_agent_state, :session_id])
+
+    task = %{
+      prompt: user_text,
+      workspace: workspace_path,
+      session_id: data.id,
+      resume_id: resume_id,
+      allowed_tools: :all,
+      mcp_servers: [],
+      timeout: :infinity
+    }
+
+    if is_binary(resume_id) do
+      :telemetry.execute(
+        [:tau, :coding_agent, :resume],
+        %{system_time: System.system_time()},
+        %{
+          session_id: data.id,
+          agent: data.coding_agent,
+          adapter_session_id: resume_id
+        }
+      )
+    end
+
+    ctx =
+      Map.merge(
+        %{
+          session_id: data.id,
+          request_id: Tau.Session.generate_event_id()
+        },
+        data.coding_agent_ctx || %{}
+      )
+
+    args = [
+      adapter: data.coding_agent,
+      task: task,
+      ctx: ctx,
+      subscriber: self()
+    ]
+
+    case Tau.CodingAgent.Supervisor.start_dispatcher(args) do
+      {:ok, pid} ->
+        pending =
+          Assistant.new(
+            provider: data.coding_agent,
+            model: nil,
+            api: :coding_agent,
+            content: []
+          )
+
+        Tau.Session.broadcast(data.id, %Events.MessageStart{session_id: data.id, message: pending})
+
+        ca_subagent_id = "#{data.id}:ca"
+        label = agent_to_string(data.coding_agent) || "coding-agent"
+
+        Tau.Session.broadcast(data.id, %Events.SubagentStart{
+          session_id: data.id,
+          subagent_id: ca_subagent_id,
+          kind: :coding_agent,
+          label: label,
+          parent_tool_call_id: nil,
+          child_session_id: nil
+        })
+
+        {:next_state, :coding_agent_streaming,
+         %{
+           data
+           | coding_agent_dispatcher: pid,
+             coding_agent_pending: pending,
+             coding_agent_blocks: []
+         }}
+
+      {:error, reason} ->
+        emit_coding_agent_sync_error(data, {:dispatcher_start_failed, reason})
+    end
+  end
+
+  @doc """
+  Dispatch a single coding-agent event, updating FSM data or finalising the turn.
+
+  Pattern-matched on the CAEvent struct module (D-031). Returns an FSM action tuple.
+  """
+  @spec handle_coding_agent_event(struct(), Tau.Session.Data.t()) ::
+          :gen_statem.event_handler_result()
+  def handle_coding_agent_event(%CAEvent.Start{} = ev, data) do
+    :telemetry.execute(
+      [:tau, :session, :coding_agent_streaming, :adapter_start],
+      %{system_time: System.system_time()},
+      %{session_id: data.id, agent: data.coding_agent, version: ev.version}
+    )
+
+    data = maybe_capture_coding_agent_session(data, ev)
+
+    {:keep_state, data}
+  end
+
+  def handle_coding_agent_event(%CAEvent.AssistantText{text: t}, data) do
+    blocks = append_assistant_text(data.coding_agent_blocks, t)
+    pending = %{data.coding_agent_pending | content: blocks}
+
+    Tau.Session.broadcast(data.id, %Events.MessageUpdate{
+      session_id: data.id,
+      event: %CAEvent.AssistantText{text: t},
+      message: pending
+    })
+
+    {:keep_state, %{data | coding_agent_blocks: blocks, coding_agent_pending: pending}}
+  end
+
+  def handle_coding_agent_event(%CAEvent.ToolUse{id: id, name: name, input: input}, data) do
+    block = %{type: :tool_call, id: id, name: name, arguments: input || %{}}
+    blocks = data.coding_agent_blocks ++ [block]
+    pending = %{data.coding_agent_pending | content: blocks}
+
+    Tau.Session.broadcast(data.id, %Events.MessageUpdate{
+      session_id: data.id,
+      event: %CAEvent.ToolUse{id: id, name: name, input: input},
+      message: pending
+    })
+
+    Tau.Session.broadcast(data.id, %Events.ToolStart{
+      session_id: data.id,
+      tool_call_id: id,
+      name: name,
+      arguments: input || %{}
+    })
+
+    ca_subagent_id = "#{data.id}:ca"
+
+    Tau.Session.broadcast(data.id, %Events.SubagentProgress{
+      session_id: data.id,
+      subagent_id: ca_subagent_id,
+      activity: {:tool_call, name},
+      child_tool_call_id: id
+    })
+
+    {:keep_state, %{data | coding_agent_blocks: blocks, coding_agent_pending: pending}}
+  end
+
+  def handle_coding_agent_event(
+        %CAEvent.ToolResult{tool_use_id: tool_id, content: content, is_error: is_err},
+        data
+      ) do
+    {data, _} = flush_pending_assistant(data, :tool_use)
+
+    tool_result =
+      ToolResult.new(
+        tool_call_id: tool_id,
+        tool_name: tool_name_for(data, tool_id),
+        content: content,
+        is_error: is_err
+      )
+
+    data =
+      data
+      |> Tau.Session.append_message(tool_result)
+      |> Tau.Session.Journal.persist(
+        "tool_result",
+        Tau.Session.Journal.tool_result_to_data(tool_result)
+      )
+
+    Tau.Session.broadcast(data.id, %Events.ToolEnd{
+      session_id: data.id,
+      tool_call_id: tool_id,
+      result: tool_result
+    })
+
+    pending =
+      Assistant.new(
+        provider: data.coding_agent,
+        model: nil,
+        api: :coding_agent,
+        content: []
+      )
+
+    Tau.Session.broadcast(data.id, %Events.MessageStart{session_id: data.id, message: pending})
+
+    {:keep_state, %{data | coding_agent_pending: pending, coding_agent_blocks: []}}
+  end
+
+  def handle_coding_agent_event(%CAEvent.FileEdit{path: path, kind: kind}, data) do
+    :telemetry.execute(
+      [:tau, :session, :coding_agent_streaming, :file_edit],
+      %{system_time: System.system_time()},
+      %{session_id: data.id, agent: data.coding_agent, path: path, kind: kind}
+    )
+
+    {:keep_state, data}
+  end
+
+  def handle_coding_agent_event(%CAEvent.Cost{} = cost, data) do
+    :telemetry.execute(
+      [:tau, :session, :coding_agent_streaming, :cost],
+      %{
+        system_time: System.system_time(),
+        duration_ms: cost.duration_ms,
+        usd: cost.usd || 0.0
+      },
+      %{session_id: data.id, agent: data.coding_agent, tokens: cost.tokens}
+    )
+
+    ca_subagent_id = "#{data.id}:ca"
+
+    Tau.Session.broadcast(data.id, %Events.SubagentCost{
+      session_id: data.id,
+      subagent_id: ca_subagent_id,
+      tokens: cost.tokens,
+      usd: cost.usd,
+      duration_ms: cost.duration_ms
+    })
+
+    {:keep_state, maybe_apply_cost_hook(data, cost)}
+  end
+
+  def handle_coding_agent_event(%CAEvent.Error{reason: reason, recoverable: rec?}, data) do
+    reason_str = describe_coding_agent_error(reason)
+
+    if rec? do
+      blocks =
+        data.coding_agent_blocks ++ [%{type: :text, text: "[adapter error] " <> reason_str}]
+
+      pending = %{data.coding_agent_pending | content: blocks, error_message: reason_str}
+
+      Tau.Session.broadcast(data.id, %Events.MessageUpdate{
+        session_id: data.id,
+        event: %CAEvent.Error{reason: reason, recoverable: rec?},
+        message: pending
+      })
+
+      {:keep_state, %{data | coding_agent_blocks: blocks, coding_agent_pending: pending}}
+    else
+      pending = %{
+        data.coding_agent_pending
+        | error_message: reason_str,
+          stop_reason: :error
+      }
+
+      {:keep_state, %{data | coding_agent_pending: pending}}
+    end
+  end
+
+  def handle_coding_agent_event(%CAEvent.Done{} = done, data) do
+    finalize_coding_agent_turn(done, data)
+  end
+
+  def handle_coding_agent_event(_other, data), do: {:keep_state, data}
+
+  @doc """
+  Build or extend the in-progress text block.
+
+  AssistantText events within one turn concatenate into a single text content
+  block — mirrors how Anthropic's stream-json folds text deltas.
+  """
+  @spec append_assistant_text(list(), String.t()) :: list()
+  def append_assistant_text(blocks, t) when is_binary(t) do
+    case List.last(blocks) do
+      %{type: :text, text: existing} ->
+        Enum.drop(blocks, -1) ++ [%{type: :text, text: existing <> t}]
+
+      _ ->
+        blocks ++ [%{type: :text, text: t}]
+    end
+  end
+
+  @doc """
+  Push the current pending assistant message into `data.messages`, persist, and
+  broadcast `MessageEnd`. Returns `{data, msg}`. If no pending message exists,
+  returns `{data, nil}`.
+  """
+  @spec flush_pending_assistant(Tau.Session.Data.t(), atom()) ::
+          {Tau.Session.Data.t(), struct() | nil}
+  def flush_pending_assistant(%{coding_agent_pending: nil} = data, _stop_reason),
+    do: {data, nil}
+
+  def flush_pending_assistant(data, stop_reason) do
+    effective_stop = data.coding_agent_pending.stop_reason || stop_reason
+
+    msg =
+      Assembler.finalize(data.coding_agent_pending, data.coding_agent_blocks,
+        stop_reason: effective_stop
+      )
+
+    data =
+      data
+      |> Tau.Session.append_message(msg)
+      |> Tau.Session.Journal.persist("assistant_message", Tau.Session.Journal.message_to_data(msg))
+
+    Tau.Session.broadcast(data.id, %Events.MessageEnd{session_id: data.id, message: msg})
+
+    {data, msg}
+  end
+
+  @doc """
+  Finalise the coding-agent turn on `%CAEvent.Done{}`. Flushes the pending
+  assistant message, emits telemetry and `SubagentEnd`, clears per-turn fields,
+  and transitions to `:awaiting_user`.
+  """
+  @spec finalize_coding_agent_turn(struct(), Tau.Session.Data.t()) ::
+          :gen_statem.event_handler_result()
+  def finalize_coding_agent_turn(%CAEvent.Done{exit_status: status} = done, data) do
+    stop_reason =
+      cond do
+        data.coding_agent_pending && data.coding_agent_pending.stop_reason == :error -> :error
+        status == -2 -> :aborted
+        status == -1 -> :error
+        status == 0 -> :end_turn
+        true -> :error
+      end
+
+    blocks =
+      case done.final_message do
+        nil -> data.coding_agent_blocks
+        "" -> data.coding_agent_blocks
+        text -> append_assistant_text(data.coding_agent_blocks, "\n" <> text)
+      end
+
+    data = %{data | coding_agent_blocks: blocks}
+
+    {data, _msg} = flush_pending_assistant(data, stop_reason)
+
+    :telemetry.execute(
+      [:tau, :session, :coding_agent_streaming, :stop],
+      %{system_time: System.system_time()},
+      %{
+        session_id: data.id,
+        agent: data.coding_agent,
+        exit_status: status,
+        stop_reason: stop_reason
+      }
+    )
+
+    ca_subagent_id = "#{data.id}:ca"
+
+    end_state =
+      cond do
+        status == -2 -> :cancelled
+        stop_reason == :end_turn -> :done
+        true -> :failed
+      end
+
+    end_summary =
+      case end_state do
+        :done -> "completed"
+        :cancelled -> "cancelled"
+        :failed -> "failed (exit #{status})"
+      end
+
+    Tau.Session.broadcast(data.id, %Events.SubagentEnd{
+      session_id: data.id,
+      subagent_id: ca_subagent_id,
+      state: end_state,
+      summary: end_summary
+    })
+
+    {:next_state, :awaiting_user,
+     %{
+       data
+       | coding_agent_dispatcher: nil,
+         coding_agent_pending: nil,
+         coding_agent_blocks: []
+     }}
+  end
+
+  @doc """
+  Recover a tool name from the in-progress message's ToolUse blocks for a given
+  `tool_use_id`. Falls back to `"tool"` if the ToolUse event was not observed.
+  """
+  @spec tool_name_for(Tau.Session.Data.t(), String.t()) :: String.t()
+  def tool_name_for(data, tool_use_id) do
+    blocks = (data.coding_agent_pending && data.coding_agent_pending.content) || []
+
+    Enum.find_value(blocks, "tool", fn
+      %{type: :tool_call, id: ^tool_use_id, name: n} -> n
+      _ -> nil
+    end)
+  end
+
+  @doc """
+  Fold `%CAEvent.Cost{}` into session totals as an adapter-tagged line item
+  (SPEC-CODING-AGENT §7 Q4 / D-038).
+
+  Three side effects (append to `data.coding_agent_costs`, persist
+  `coding_agent_cost` JSONL, emit `[:tau, :coding_agent, :cost]` telemetry),
+  each wrapped per D-035 so a failure MUST NOT crash the session.
+  """
+  @spec maybe_apply_cost_hook(Tau.Session.Data.t(), struct()) :: Tau.Session.Data.t()
+  def maybe_apply_cost_hook(data, %CAEvent.Cost{} = cost) do
+    try do
+      tagged =
+        Tau.CodingAgent.Cost.from_event(cost,
+          agent: data.coding_agent,
+          session_id: data.id,
+          adapter_session_id: get_in(data, [:coding_agent_state, :session_id])
+        )
+
+      data =
+        Tau.Session.Journal.persist(
+          data,
+          "coding_agent_cost",
+          Tau.CodingAgent.Cost.to_jsonl(tagged)
+        )
+
+      :telemetry.execute(
+        [:tau, :coding_agent, :cost],
+        %{
+          system_time: System.system_time(),
+          usd: tagged.usd || 0.0,
+          duration_ms: tagged.duration_ms,
+          input_tokens: tagged.input_tokens,
+          output_tokens: tagged.output_tokens,
+          cache_read: tagged.cache_read,
+          cache_write: tagged.cache_write
+        },
+        %{
+          session_id: data.id,
+          agent: data.coding_agent,
+          model: data.model,
+          source: Tau.CodingAgent.Cost.source(tagged),
+          adapter_session_id: tagged.adapter_session_id
+        }
+      )
+
+      %{data | coding_agent_costs: (data.coding_agent_costs || []) ++ [tagged]}
+    rescue
+      e ->
+        :telemetry.execute(
+          [:tau, :coding_agent, :cost, :failed],
+          %{system_time: System.system_time()},
+          %{
+            session_id: data.id,
+            agent: data.coding_agent,
+            reason: Exception.message(e)
+          }
+        )
+
+        data
+    end
+  end
+
+  @doc """
+  Capture the adapter-side `session_id` from `%CAEvent.Start{}` when it is new
+  (SPEC-CODING-AGENT §7 Q5).
+
+  Persists a `coding_agent_session` JSONL event so a later `Tau.resume/1` can
+  recover it and pass it as `task.resume_id`. No-op when `session_id` is nil or
+  already known.
+  """
+  @spec maybe_capture_coding_agent_session(Tau.Session.Data.t(), struct()) ::
+          Tau.Session.Data.t()
+  def maybe_capture_coding_agent_session(data, %CAEvent.Start{session_id: nil}), do: data
+
+  def maybe_capture_coding_agent_session(data, %CAEvent.Start{session_id: sid} = ev)
+      when is_binary(sid) do
+    state = data.coding_agent_state || %{session_id: nil, agent: nil}
+
+    if state.session_id == sid do
+      data
+    else
+      new_state = %{state | session_id: sid, agent: data.coding_agent}
+
+      data
+      |> Map.put(:coding_agent_state, new_state)
+      |> Tau.Session.Journal.persist("coding_agent_session", %{
+        "session_id" => sid,
+        "agent" => agent_to_string(data.coding_agent),
+        "version" => ev.version
+      })
+    end
+  end
+
+  def maybe_capture_coding_agent_session(data, _ev), do: data
+
+  @doc """
+  Translate a coding-agent atom/binary/module to a display string.
+  """
+  @spec agent_to_string(atom() | binary() | nil) :: String.t() | nil
+  def agent_to_string(nil), do: nil
+  def agent_to_string(agent) when is_atom(agent), do: Atom.to_string(agent)
+  def agent_to_string(bin) when is_binary(bin), do: bin
+
+  @doc """
+  Translate a coding-agent error reason into a user-visible string.
+  Mirrors `ProviderTurn.describe_provider_error/1` for the provider path.
+  """
+  @spec describe_coding_agent_error(term()) :: String.t()
+  def describe_coding_agent_error({:workspace_prepare_failed, reason}),
+    do: "Workspace preparation failed: " <> inspect(reason)
+
+  def describe_coding_agent_error({:dispatcher_start_failed, reason}),
+    do: "Coding-agent dispatcher failed to start: " <> inspect(reason)
+
+  def describe_coding_agent_error(:cancelled), do: "cancelled"
+  def describe_coding_agent_error(:inactivity_timeout), do: "Coding-agent inactivity timeout"
+
+  def describe_coding_agent_error(other) when is_binary(other), do: other
+  def describe_coding_agent_error(other), do: inspect(other)
+
+  @doc """
+  Recover the most recent adapter-side session_id from a preload event log
+  (SPEC-CODING-AGENT §7 Q5).
+
+  Walks events in order so the LAST `coding_agent_session` wins.
+  """
+  @spec coding_agent_state_from_preload(list()) :: map() | nil
+  def coding_agent_state_from_preload(preload) when is_list(preload) do
+    Enum.reduce(preload, nil, fn
+      %{"kind" => "coding_agent_session", "data" => %{} = d}, _acc ->
+        %{
+          session_id: d["session_id"],
+          agent: agent_to_atom(d["agent"])
+        }
+
+      _, acc ->
+        acc
+    end)
+  end
+
+  def coding_agent_state_from_preload(_), do: nil
+
+  @doc """
+  Fold persisted `coding_agent_cost` events back into in-memory records
+  (SPEC-CODING-AGENT §7 Q4 / D-038).
+
+  Skips malformed lines silently for forward-compatibility.
+  """
+  @spec coding_agent_costs_from_preload(list()) :: list()
+  def coding_agent_costs_from_preload(preload) when is_list(preload) do
+    preload
+    |> Enum.filter(&match?(%{"kind" => "coding_agent_cost"}, &1))
+    |> Enum.map(fn %{"data" => d} -> Tau.CodingAgent.Cost.from_jsonl(d) end)
+    |> Enum.reject(&is_nil/1)
+  end
+
+  def coding_agent_costs_from_preload(_), do: []
+
+  @doc """
+  Convert a binary agent name back to an atom.
+
+  Uses `String.to_existing_atom/1`; returns `nil` if the atom was not yet
+  loaded (D-035 try/rescue site — preserved as-is).
+  """
+  @spec agent_to_atom(String.t() | nil) :: atom() | nil
+  def agent_to_atom(nil), do: nil
+
+  def agent_to_atom(bin) when is_binary(bin) do
+    String.to_existing_atom(bin)
+  rescue
+    ArgumentError -> nil
+  end
+
+  @doc """
+  Walk `messages` from the end to find the most recent user-supplied text.
+
+  Skips synthetic User messages whose `metadata.role` is `:system` or
+  `:compaction_summary` — these are injected by skill/memory helpers and
+  should not be mistaken for the user's actual input.
+  """
+  @spec latest_user_text(list()) :: String.t()
+  def latest_user_text(messages) do
+    alias Tau.Message.User
+
+    messages
+    |> Enum.reverse()
+    |> Enum.find_value("", fn
+      %User{metadata: %{role: r}} when r in [:system, :compaction_summary] ->
+        nil
+
+      %User{content: c} when is_binary(c) ->
+        c
+
+      %User{content: blocks} when is_list(blocks) ->
+        Enum.map_join(blocks, "\n", fn
+          %{type: :text, text: t} -> t
+          %{"type" => "text", "text" => t} -> t
+          _ -> ""
+        end)
+
+      _ ->
+        nil
+    end)
+  end
+
+  # --- FSM clause handlers ---------------------------------------------------
+
+  @doc """
+  Handle `:start_coding_agent` internal event in `:coding_agent_streaming`.
+
+  Ensures the workspace, then starts the dispatcher. Telemetry is emitted
+  at entry; failure surfaces as an `%Assistant{stop_reason: :error}` message.
+  """
+  @spec handle_start_coding_agent(Tau.Session.Data.t()) :: :gen_statem.event_handler_result()
+  def handle_start_coding_agent(data) do
+    Tau.Session.transition(data.id, data, :coding_agent_streaming)
+
+    :telemetry.execute(
+      [:tau, :session, :coding_agent_streaming, :start],
+      %{system_time: System.system_time()},
+      %{session_id: data.id, agent: data.coding_agent}
+    )
+
+    case ensure_coding_agent_workspace(data) do
+      {:ok, data, workspace_path} ->
+        start_coding_agent_dispatcher(data, workspace_path)
+
+      {:error, reason} ->
+        emit_coding_agent_sync_error(data, reason)
+    end
+  end
+
+  @doc """
+  Handle `{:coding_agent_event, pid, event}` info in `:coding_agent_streaming`.
+
+  Guards on `Tau.Session.current_run?/2` to drop stale events from superseded
+  dispatchers, analogous to `stream_ref` for the provider path (ADR-0012).
+  """
+  @spec handle_coding_agent_event_message(pid(), struct(), Tau.Session.Data.t()) ::
+          :gen_statem.event_handler_result()
+  def handle_coding_agent_event_message(pid, event, data) do
+    if Tau.Session.current_run?(data, {:coding_agent, pid}),
+      do: handle_coding_agent_event(event, data),
+      else: {:keep_state, data}
+  end
+
+  @doc """
+  Read the default coding agent from settings (called from `Tau.Session.init/1`).
+  """
+  @spec coding_agent_from_settings() :: atom() | binary() | nil
+  def coding_agent_from_settings do
+    settings = SettingsCache.get()
+
+    raw =
+      get_in(settings, [:coding_agent, :default_agent]) ||
+        get_in(settings, ["coding_agent", "default_agent"])
+
+    case raw do
+      nil -> nil
+      mod when is_atom(mod) -> mod
+      str when is_binary(str) -> Tau.CLI.resolve_coding_agent(str)
+    end
+  end
+end

--- a/lib/tau/session/compaction.ex
+++ b/lib/tau/session/compaction.ex
@@ -1,0 +1,284 @@
+defmodule Tau.Session.Compaction do
+  @moduledoc """
+  Compaction logic and `:compacting` FSM clause handlers for `Tau.Session`.
+
+  Encapsulates the two-path compaction contract: a synchronous post-turn path
+  (`maybe_compact/2` → `compact/2`) and an asynchronous background-task path
+  (three terminal FSM clauses for `:compacting`).
+
+  ## Invariants
+
+  - D-016: `compaction_failures` is a session-level counter shared across the
+    sync and async paths. It increments on every `{:error, _}` result and
+    resets to 0 only on `{:ok, _, _}`. It is NOT reset by `:cancel`.
+  - After three consecutive failures, the sync path returns `{:abort, data}`
+    and the session turn is aborted with `stop_reason: :compaction_failed`.
+  - D-164: `%Events.CompactionFinished{}` fires on every exit from `:compacting`,
+    including error and timeout paths, so the TUI status bar never sticks.
+  """
+
+  alias Tau.Session.Events
+
+  @doc """
+  Decide whether to compact and, if so, run compaction synchronously.
+
+  Returns:
+  - `data` — no compaction needed, or compaction succeeded.
+  - `{:soft_error, data}` — compaction failed but `compaction_failures < 3`; caller broadcasts a notice and continues.
+  - `{:abort, data}` — `compaction_failures >= 3` (D-016); caller aborts the turn.
+  """
+  @spec maybe_compact(Tau.Session.Data.t(), map()) ::
+          Tau.Session.Data.t()
+          | {:soft_error, Tau.Session.Data.t()}
+          | {:abort, Tau.Session.Data.t()}
+  def maybe_compact(data, usage) do
+    compactor = Tau.Compactor.impl()
+
+    if compactor.should_compact?(data.messages, usage) do
+      compact(data, %{provider: data.provider, model: data.model})
+    else
+      data
+    end
+  end
+
+  @doc """
+  Run compaction synchronously.
+
+  Shared core invoked by both the sync post-turn path and the async worker
+  result handler. Returns `data`, `{:soft_error, data}`, or `{:abort, data}`.
+  """
+  @spec compact(Tau.Session.Data.t(), map()) ::
+          Tau.Session.Data.t()
+          | {:soft_error, Tau.Session.Data.t()}
+          | {:abort, Tau.Session.Data.t()}
+  def compact(data, ctx) do
+    compactor = Tau.Compactor.impl()
+
+    :telemetry.execute([:tau, :compaction, :start], %{system_time: System.system_time()}, %{
+      session_id: data.id,
+      message_count: length(data.messages)
+    })
+
+    case compactor.compact(data.messages, ctx) do
+      {:ok, new_messages, summary_text} ->
+        data =
+          Tau.Session.Journal.persist(data, "compaction", %{
+            before_count: length(data.messages),
+            after_count: length(new_messages),
+            summary: Tau.Session.Journal.format_summary_for_persist(summary_text)
+          })
+
+        :telemetry.execute([:tau, :compaction, :stop], %{system_time: System.system_time()}, %{
+          session_id: data.id,
+          after_count: length(new_messages)
+        })
+
+        %{data | messages: new_messages, compaction_failures: 0}
+
+      {:error, reason} ->
+        :telemetry.execute(
+          [:tau, :compaction, :exception],
+          %{system_time: System.system_time()},
+          %{session_id: data.id, reason: reason, kind: :compactor_error}
+        )
+
+        failures = data.compaction_failures + 1
+
+        if failures >= 3 do
+          {:abort, %{data | compaction_failures: failures}}
+        else
+          {:soft_error, %{data | compaction_failures: failures}}
+        end
+    end
+  end
+
+  @doc """
+  Emit per-turn prompt-cache hit/write telemetry.
+
+  SPEC-PROMPT-CACHING AC-4: surfaces the per-turn prompt-cache signal so a
+  silent cache miss (a cost regression) is observable. Reads canonical B3
+  usage-map keys (`:cache_read` / `:cache_write` / `:cache_breakdown`).
+  """
+  @spec emit_cache_usage(Tau.Session.Data.t(), map()) :: :ok
+  def emit_cache_usage(data, usage) do
+    read = nonneg_token(usage[:cache_read])
+    write = nonneg_token(usage[:cache_write])
+    breakdown = if is_map(usage[:cache_breakdown]), do: usage[:cache_breakdown], else: %{}
+
+    :telemetry.execute(
+      [:tau, :session, :cache_usage],
+      %{write_tokens: write, read_tokens: read, storage_tokens: 0},
+      %{session_id: data.id, provider: data.provider, breakdown: breakdown}
+    )
+  end
+
+  # --- FSM clause handlers ---------------------------------------------------
+
+  @doc """
+  Handle async compaction worker result: `{ref, result}` in `:compacting`.
+
+  Clause 1 of the five `:compacting` terminal clauses. Guards on
+  `compaction_monitor == ref` to reject stale results from superseded workers.
+  Demonitors before clearing worker fields so pending `:DOWN` messages are
+  flushed from the mailbox.
+  """
+  @spec handle_worker_result(reference(), term(), Tau.Session.Data.t()) ::
+          :gen_statem.event_handler_result()
+  def handle_worker_result(ref, result, data) do
+    # Demonitor first to flush any pending {:DOWN} that is already enqueued.
+    Process.demonitor(ref, [:flush])
+
+    data = %{data | compaction_task: nil, compaction_monitor: nil}
+
+    {notice, data} =
+      case result do
+        {:ok, new_messages, summary_text} ->
+          data =
+            Tau.Session.Journal.persist(data, "compaction", %{
+              before_count: length(data.messages),
+              after_count: length(new_messages),
+              summary: Tau.Session.Journal.format_summary_for_persist(summary_text)
+            })
+
+          :telemetry.execute(
+            [:tau, :compaction, :stop],
+            %{system_time: System.system_time()},
+            %{session_id: data.id, after_count: length(new_messages), async: true}
+          )
+
+          data = %{data | messages: new_messages, compaction_failures: 0}
+          {"Compaction complete.", data}
+
+        {:error, reason} ->
+          :telemetry.execute(
+            [:tau, :compaction, :exception],
+            %{system_time: System.system_time()},
+            %{session_id: data.id, reason: reason, kind: :compactor_error, async: true}
+          )
+
+          failures = data.compaction_failures + 1
+          data = %{data | compaction_failures: failures}
+          {"Compaction failed (#{failures} consecutive failure(s)).", data}
+      end
+
+    Tau.Session.broadcast(data.id, %Events.SystemNotice{session_id: data.id, text: notice})
+
+    # D-164: CompactionFinished MUST fire on every exit from :compacting.
+    outcome =
+      case result do
+        {:ok, _, _} -> {:ok, :compacted}
+        {:error, reason} -> {:error, reason}
+      end
+
+    Tau.Session.broadcast(data.id, %Events.CompactionFinished{session_id: data.id, outcome: outcome})
+
+    # D-080: drain follow-up queue on :awaiting_user transition.
+    actions =
+      if :queue.is_empty(data.followup_queue),
+        do: [],
+        else: [{:next_event, :internal, :drain_followups}]
+
+    {:next_state, :awaiting_user, data, actions}
+  end
+
+  @doc """
+  Handle a `:normal` `:DOWN` for the compaction worker in `:compacting`.
+
+  Clause 2a: `async_nolink` emits both `{ref, result}` AND `{:DOWN, :normal}`
+  on clean task exit. The result may arrive after `:DOWN`; keep waiting.
+  """
+  @spec handle_worker_down_normal(Tau.Session.Data.t()) :: :gen_statem.event_handler_result()
+  def handle_worker_down_normal(data) do
+    {:keep_state, data}
+  end
+
+  @doc """
+  Handle an abnormal worker crash (`:DOWN` with non-`:normal` reason) in `:compacting`.
+
+  Clause 2b: the task process died without delivering a result. Increment
+  `compaction_failures`, clear worker fields, return to `:awaiting_user`.
+  """
+  @spec handle_worker_crash(reference(), term(), Tau.Session.Data.t()) ::
+          :gen_statem.event_handler_result()
+  def handle_worker_crash(_ref, reason, data) do
+    :telemetry.execute(
+      [:tau, :compaction, :exception],
+      %{system_time: System.system_time()},
+      %{session_id: data.id, reason: reason, kind: :worker_down, async: true}
+    )
+
+    failures = data.compaction_failures + 1
+    notice = "Compaction worker crashed (#{failures} consecutive failure(s))."
+
+    next_data = %{
+      data
+      | compaction_task: nil,
+        compaction_monitor: nil,
+        compaction_failures: failures
+    }
+
+    Tau.Session.broadcast(data.id, %Events.SystemNotice{session_id: data.id, text: notice})
+    # D-164: fire on every :compacting exit, including worker crash.
+    Tau.Session.broadcast(
+      data.id,
+      %Events.CompactionFinished{session_id: data.id, outcome: {:error, reason}}
+    )
+
+    # D-080: drain follow-up queue on :awaiting_user transition.
+    actions =
+      if :queue.is_empty(next_data.followup_queue),
+        do: [],
+        else: [{:next_event, :internal, :drain_followups}]
+
+    {:next_state, :awaiting_user, next_data, actions}
+  end
+
+  @doc """
+  Handle a live compaction timeout in `:compacting`.
+
+  Clause 3: the worker is still running — kill it, increment the failure
+  counter, and return to `:awaiting_user`. Guards on `compaction_task == pid`
+  to ensure this is for the current worker.
+  """
+  @spec handle_timeout(pid(), Tau.Session.Data.t()) :: :gen_statem.event_handler_result()
+  def handle_timeout(pid, data) do
+    if data.compaction_monitor, do: Process.demonitor(data.compaction_monitor, [:flush])
+    if pid && Process.alive?(pid), do: Process.exit(pid, :brutal_kill)
+
+    :telemetry.execute(
+      [:tau, :compaction, :exception],
+      %{system_time: System.system_time()},
+      %{session_id: data.id, kind: :timeout, async: true}
+    )
+
+    failures = data.compaction_failures + 1
+    notice = "Compaction timed out (#{failures} consecutive failure(s))."
+
+    next_data = %{
+      data
+      | compaction_task: nil,
+        compaction_monitor: nil,
+        compaction_failures: failures
+    }
+
+    Tau.Session.broadcast(data.id, %Events.SystemNotice{session_id: data.id, text: notice})
+    # D-164: fire on every :compacting exit, including timeout.
+    Tau.Session.broadcast(
+      data.id,
+      %Events.CompactionFinished{session_id: data.id, outcome: {:error, :timeout}}
+    )
+
+    # D-080: drain follow-up queue on :awaiting_user transition.
+    actions =
+      if :queue.is_empty(next_data.followup_queue),
+        do: [],
+        else: [{:next_event, :internal, :drain_followups}]
+
+    {:next_state, :awaiting_user, next_data, actions}
+  end
+
+  # --- Private helpers -------------------------------------------------------
+
+  defp nonneg_token(n) when is_integer(n) and n >= 0, do: n
+  defp nonneg_token(_), do: 0
+end

--- a/lib/tau/session/data.ex
+++ b/lib/tau/session/data.ex
@@ -1,0 +1,359 @@
+defmodule Tau.Session.Data do
+  @moduledoc """
+  Typed FSM data struct for `Tau.Session`. Holds all 69 fields that comprise
+  the `:gen_statem` data map, providing Dialyzer-visible types for every
+  helper that receives or returns session state.
+
+  `new/1` absorbs the session-initialisation logic previously in `Tau.Session.init/1`:
+  resolving provider/model, opening persistence, loading skills and memory,
+  and broadcasting the initial catalog snapshot. On success returns
+  `{:ok, t()}` ready to pass as the third element of `{:ok, state, data}`.
+  On persistence failure returns `{:stop, reason}`.
+  """
+
+  alias Tau.Message.{Assistant, ToolResult}
+  alias Tau.Session.Events
+  alias Tau.Settings.Cache, as: SettingsCache
+  alias Tau.CodingAgent.Workspace, as: CAWorkspace
+  alias Tau.Commands.Catalog
+
+  @enforce_keys [
+    :id,
+    :cwd,
+    :provider,
+    :original_provider,
+    :model,
+    :persistence,
+    :persist_handle
+  ]
+
+  @typedoc "The full FSM data for a `Tau.Session` process."
+  @type t :: %__MODULE__{
+          id: String.t(),
+          cwd: String.t(),
+          provider: module(),
+          original_provider: module(),
+          model: String.t(),
+          metadata: map(),
+          provider_ctx: map(),
+          messages: [Tau.Message.t()],
+          skills: [{String.t(), Tau.Skill.t()}],
+          prompt_templates: [{String.t(), Tau.PromptTemplate.t()}],
+          persistence: module(),
+          persist_handle: term(),
+          provider_task: Task.t() | nil,
+          stream_ref: reference() | nil,
+          provider_span_ref: reference() | nil,
+          cancel_flag: :counters.counters_ref() | nil,
+          assembler: Tau.Message.Assembler.t() | nil,
+          fallback_chain_remaining: [module()],
+          tools_in_flight: map(),
+          tool_dispatcher: pid() | nil,
+          command_task: pid() | nil,
+          active_skill: Tau.Skill.t() | nil,
+          persona_lifetime: :turn | :session,
+          tools_whitelist: :all | [String.t()],
+          child_session_ids: MapSet.t(),
+          tool_iterations: non_neg_integer(),
+          max_tool_iterations: pos_integer(),
+          tool_loop_state: map(),
+          tool_loop_brake_threshold: pos_integer(),
+          tool_loop_call_lookups: map(),
+          provider_retry_state: %{count: non_neg_integer()},
+          provider_retry_max: pos_integer(),
+          provider_retry_base_delay_ms: pos_integer(),
+          coding_agent: module() | nil,
+          coding_agent_ctx: map(),
+          coding_agent_workspace_backend: module() | nil,
+          coding_agent_workspace_opts: keyword(),
+          coding_agent_workspace: CAWorkspace.t() | nil,
+          coding_agent_dispatcher: pid() | nil,
+          coding_agent_pending: Assistant.t() | nil,
+          coding_agent_blocks: [map()],
+          coding_agent_state: map(),
+          coding_agent_costs: [Tau.CodingAgent.Cost.t()],
+          compaction_task: Task.t() | nil,
+          compaction_monitor: reference() | nil,
+          compaction_failures: non_neg_integer(),
+          interactive?: boolean(),
+          pending_permission_requests: map(),
+          permission_dispatch_batch: [{String.t(), String.t(), map()}],
+          permission_pending_results: [{String.t(), ToolResult.t()}],
+          steering_queue: :queue.queue(),
+          followup_queue: :queue.queue()
+        }
+
+  defstruct [
+    :id,
+    :cwd,
+    :provider,
+    :original_provider,
+    :model,
+    :persistence,
+    :persist_handle,
+    metadata: %{},
+    provider_ctx: %{},
+    messages: [],
+    skills: [],
+    prompt_templates: [],
+    provider_task: nil,
+    stream_ref: nil,
+    provider_span_ref: nil,
+    cancel_flag: nil,
+    assembler: nil,
+    fallback_chain_remaining: [],
+    tools_in_flight: %{},
+    tool_dispatcher: nil,
+    command_task: nil,
+    active_skill: nil,
+    persona_lifetime: :turn,
+    tools_whitelist: :all,
+    child_session_ids: nil,
+    tool_iterations: 0,
+    max_tool_iterations: 100,
+    tool_loop_state: %{},
+    tool_loop_brake_threshold: 3,
+    tool_loop_call_lookups: %{},
+    provider_retry_state: %{count: 0},
+    provider_retry_max: 3,
+    provider_retry_base_delay_ms: 1000,
+    coding_agent: nil,
+    coding_agent_ctx: %{},
+    coding_agent_workspace_backend: nil,
+    coding_agent_workspace_opts: [],
+    coding_agent_workspace: nil,
+    coding_agent_dispatcher: nil,
+    coding_agent_pending: nil,
+    coding_agent_blocks: [],
+    coding_agent_state: %{session_id: nil, agent: nil},
+    coding_agent_costs: [],
+    compaction_task: nil,
+    compaction_monitor: nil,
+    compaction_failures: 0,
+    interactive?: true,
+    pending_permission_requests: %{},
+    permission_dispatch_batch: [],
+    permission_pending_results: [],
+    steering_queue: nil,
+    followup_queue: nil
+  ]
+
+  @doc """
+  Build initial FSM data from start_link opts and preloaded events.
+
+  Opens the persistence backend, loads skills and memory, broadcasts the
+  initial command catalog, and returns `{:ok, t()}`. Returns
+  `{:stop, reason}` if persistence open fails.
+  """
+  @spec new(keyword()) :: {:ok, t()} | {:stop, term()}
+  def new(opts) do
+    id = Keyword.fetch!(opts, :session_id)
+    cwd = opts[:cwd] || File.cwd!()
+    provider = opts[:provider] || Tau.Provider.default()
+
+    # D-002 / SPEC-USER-TURN: resolve nil model to the provider's default
+    # at session init, NOT at stream-call time. Without this, `data.model`
+    # stays nil through telemetry, persistence header, and the assembler
+    # — all of which expect a real model id.
+    #
+    # D-041: fold the last persisted `model_swap` event from preload so
+    # resume and fork both converge on the swapped model.
+    model =
+      Tau.Session.Journal.model_from_preload(opts[:preload_events] || []) ||
+        opts[:model] || provider.default_model()
+
+    metadata = opts[:metadata] || %{}
+    provider_ctx = opts[:provider_ctx] || %{}
+    persistence = opts[:persistence] || Tau.Persistence.impl()
+    preload = opts[:preload_events] || []
+
+    # SPEC-CODING-AGENT §4 B1 / D-037: coding-agent session mode.
+    coding_agent =
+      opts[:coding_agent] || coding_agent_from_settings()
+
+    coding_agent_workspace_backend =
+      opts[:coding_agent_workspace_backend] ||
+        if(coding_agent, do: CAWorkspace.resolve_default_backend(cwd), else: nil)
+
+    coding_agent_workspace_opts = opts[:coding_agent_workspace_opts] || []
+
+    # SPEC-CODING-AGENT §4 B1: per-run knobs for the coding-agent adapter.
+    coding_agent_ctx = opts[:coding_agent_ctx] || %{}
+
+    case persistence.open(id,
+           cwd: cwd,
+           provider: inspect(provider),
+           model: model,
+           metadata: metadata,
+           parent_event_id: opts[:parent_event_id]
+         ) do
+      {:ok, persist_handle} ->
+        Tau.Session.register_builtins()
+
+        :telemetry.execute(
+          [:tau, :session, :start],
+          %{system_time: System.system_time()},
+          %{session_id: id, provider: provider}
+        )
+
+        Tau.Session.broadcast(id, %Events.SessionStart{
+          session_id: id,
+          provider: provider,
+          model: model,
+          cwd: cwd,
+          metadata: metadata
+        })
+
+        skills = Tau.Session.SkillActivation.load_skills(cwd)
+
+        # D-058 / AC-10 / SPEC-USER-TURN §4 B2: a headless skill injected
+        # via `:active_skill` (e.g. `--system-prompt` from `tau run`) is
+        # prepended to the skill list so `prepend_skill_messages/2`
+        # includes its body in the model-visible system blob.
+        skills =
+          case opts[:active_skill] do
+            %Tau.Skill{name: name} = skill ->
+              [{name, skill} | skills]
+
+            _ ->
+              skills
+          end
+
+        # ADR-0013 / ADR-0015: skills with `disable_model_invocation: true`
+        # are background-only — their bodies MUST NOT enter the model-visible
+        # system_blob. Filter at the assembly site.
+        model_visible_skills =
+          Enum.reject(skills, fn {_name, s} -> s.disable_model_invocation end)
+
+        messages =
+          preload
+          |> Tau.Session.Journal.events_to_messages()
+          |> Tau.Session.SkillActivation.prepend_skill_messages(model_visible_skills)
+          |> Tau.Session.SkillActivation.inject_memory(cwd)
+
+        data = %__MODULE__{
+          id: id,
+          cwd: cwd,
+          provider: provider,
+          # ADR-0012: original_provider is the user-configured provider for
+          # the lifetime of the session. data.provider shape-shifts during
+          # a fallback turn; finalize_assistant/2 restores it from
+          # original_provider so the next turn always starts against the
+          # primary (per-message fallback semantics).
+          original_provider: provider,
+          model: model,
+          metadata: metadata,
+          provider_ctx: provider_ctx,
+          messages: messages,
+          skills: skills,
+          # D-076: prompt templates discovered once at init time.
+          prompt_templates: Tau.PromptTemplates.discover(cwd),
+          persistence: persistence,
+          persist_handle: persist_handle,
+          provider_task: nil,
+          # ADR-0012: per-stream tag distinguishing events from the current
+          # provider task from a killed predecessor's stragglers.
+          stream_ref: nil,
+          # SPEC-OTEL-REPORTER: per-request OTel span discriminator.
+          provider_span_ref: nil,
+          # ADR-0017: per-stream cooperative-cancel flag (a `:counters` ref).
+          cancel_flag: nil,
+          assembler: nil,
+          # ADR-0012: per-turn fallback queue.
+          fallback_chain_remaining: [],
+          tools_in_flight: %{},
+          tool_dispatcher: nil,
+          # ADR-0008: slash-command tasks run under Tau.Tools.TaskSupervisor.
+          command_task: nil,
+          # ADR-0013 / ADR-0015. Per-turn lifetime by default.
+          active_skill: opts[:active_skill],
+          persona_lifetime: opts[:persona_lifetime] || :turn,
+          # Spawn-time tool whitelist (`:all` or `[String.t()]`).
+          tools_whitelist: opts[:tools_whitelist] || :all,
+          # ADR-0014: child session ids spawned by this session via `Agent`.
+          child_session_ids: MapSet.new(),
+          # D-005 / AC-6 / SPEC-USER-TURN: tool-call iteration cap.
+          tool_iterations: 0,
+          max_tool_iterations:
+            opts[:max_tool_iterations] ||
+              get_in(SettingsCache.get(), [:session, :max_tool_iterations]) ||
+              100,
+          # D-060: tool-loop brake — per-turn map keyed by `{tool_name, args_hash}`.
+          tool_loop_state: %{},
+          tool_loop_brake_threshold:
+            opts[:tool_loop_brake_threshold] ||
+              get_in(SettingsCache.get(), [:session, :tool_loop_brake_threshold]) ||
+              3,
+          # D-060: side-table mapping in-flight tool_call_id -> `{tool_name, args_hash}`.
+          tool_loop_call_lookups: %{},
+          # D-061: per-turn same-provider retry counter.
+          provider_retry_state: %{count: 0},
+          provider_retry_max:
+            opts[:provider_retry_max] ||
+              get_in(SettingsCache.get(), [:session, :provider_retry_max]) ||
+              3,
+          provider_retry_base_delay_ms:
+            opts[:provider_retry_base_delay_ms] ||
+              get_in(SettingsCache.get(), [:session, :provider_retry_base_delay_ms]) ||
+              1000,
+          # SPEC-CODING-AGENT. Workspace is lazily prepared on the first
+          # `:coding_agent_streaming` transition; cleaned up in `terminate/3`.
+          coding_agent: coding_agent,
+          coding_agent_ctx: coding_agent_ctx,
+          coding_agent_workspace_backend: coding_agent_workspace_backend,
+          coding_agent_workspace_opts: coding_agent_workspace_opts,
+          coding_agent_workspace: nil,
+          coding_agent_dispatcher: nil,
+          coding_agent_pending: nil,
+          coding_agent_blocks: [],
+          # SPEC-CODING-AGENT §7 Q5 / D-037: adapter-side session state.
+          coding_agent_state:
+            Tau.Session.CodingAgentTurn.coding_agent_state_from_preload(preload) ||
+              %{session_id: nil, agent: nil},
+          # SPEC-CODING-AGENT §7 Q4 / D-038: per-session list of adapter-tagged cost records.
+          coding_agent_costs: Tau.Session.CodingAgentTurn.coding_agent_costs_from_preload(preload),
+          # D-048 / D-049: async compaction worker state.
+          # D-016: `compaction_failures` is NOT reset by `:cancel`.
+          compaction_task: nil,
+          compaction_monitor: nil,
+          compaction_failures: 0,
+          # SPEC-PERMISSION-PROMPTS §4 B4 (D-092, D-093): headless vs interactive.
+          interactive?: opts[:interactive] != false,
+          # SPEC-PERMISSION-PROMPTS §4 B3 (D-091): per-round permission map.
+          pending_permission_requests: %{},
+          # SPEC-PERMISSION-PROMPTS §4 B3 / D-091.
+          permission_dispatch_batch: [],
+          permission_pending_results: [],
+          # D-077 / D-078 / SPEC-USER-TURN §6: two-tier message queues.
+          steering_queue: :queue.new(),
+          followup_queue: :queue.new()
+        }
+
+        # D-103 / D-108 (SPEC-TUI-COMPLETION §4 B1): broadcast the command
+        # catalog once at session start so the TUI menu is pre-populated.
+        catalog_entries = Catalog.list(data)
+        Tau.Session.broadcast(id, %Events.CommandCatalog{session_id: id, entries: catalog_entries})
+
+        {:ok, data}
+
+      err ->
+        {:stop, err}
+    end
+  end
+
+  # SPEC-CODING-AGENT §5 / D-037: deployment-wide default for the coding-agent
+  # adapter. Read from the merged settings cascade at session init only.
+  defp coding_agent_from_settings do
+    settings = SettingsCache.get()
+
+    raw =
+      get_in(settings, [:coding_agent, :default_agent]) ||
+        get_in(settings, ["coding_agent", "default_agent"])
+
+    case raw do
+      nil -> nil
+      mod when is_atom(mod) -> mod
+      str when is_binary(str) -> Tau.CLI.resolve_coding_agent(str)
+    end
+  end
+end

--- a/lib/tau/session/journal.ex
+++ b/lib/tau/session/journal.ex
@@ -1,0 +1,203 @@
+defmodule Tau.Session.Journal do
+  @moduledoc """
+  Pure persistence and serialisation helpers for `Tau.Session`.
+
+  Converts between in-memory `Tau.Message` structs and the JSONL wire
+  format written by `Tau.Persistence`. Also provides event-replay helpers
+  used on fork and resume to reconstruct the message history from persisted
+  events.
+
+  All functions are pure (no process, no ETS, no side effects) except
+  `persist/3`, which calls the persistence backend held on the session data.
+
+  ## Round-trip contract
+
+  For any valid message `m`:
+  `m == event_to_message(message_to_event_data(m) |> wrap_as_event(kind))`
+  """
+
+  alias Tau.Message.{Assistant, ToolResult, User}
+
+  @doc """
+  Append an event to the session's persistence backend and return updated data.
+
+  Generates a fresh event id and appends the event atomically. On persistence
+  error the data is returned unchanged (fire-and-forget contract — a write
+  failure is logged at the persistence layer, not surfaced to the FSM).
+  """
+  @spec persist(Tau.Session.Data.t(), String.t(), map()) :: Tau.Session.Data.t()
+  def persist(data, kind, payload) do
+    event = %{
+      "id" => generate_event_id(),
+      "parent_id" => nil,
+      "ts" => DateTime.utc_now() |> DateTime.to_iso8601(),
+      "kind" => kind,
+      "data" => payload
+    }
+
+    case data.persistence.append(data.persist_handle, event) do
+      {:ok, h} -> %{data | persist_handle: h}
+      {:error, _} -> data
+    end
+  end
+
+  @doc """
+  Serialise a message to the JSONL wire format used by `persist/3`.
+
+  Returns a map suitable for embedding as the `"data"` field of a persisted
+  event.
+  """
+  @spec message_to_data(Tau.Message.t()) :: map()
+  def message_to_data(%User{} = m), do: %{role: "user", content: serialize_content(m.content)}
+
+  def message_to_data(%Assistant{} = m) do
+    %{
+      role: "assistant",
+      content: Enum.map(m.content, &serialize_block/1),
+      stop_reason: m.stop_reason && to_string(m.stop_reason),
+      usage: m.usage,
+      model: m.model
+    }
+  end
+
+  def message_to_data(%ToolResult{} = m), do: tool_result_to_data(m)
+
+  @doc """
+  Serialise a `%ToolResult{}` to the JSONL wire format.
+  """
+  @spec tool_result_to_data(ToolResult.t()) :: map()
+  def tool_result_to_data(%ToolResult{} = m) do
+    %{
+      role: "tool_result",
+      tool_call_id: m.tool_call_id,
+      tool_name: m.tool_name,
+      content: serialize_content(m.content),
+      is_error: m.is_error,
+      details: m.details
+    }
+  end
+
+  @doc """
+  Deserialise a list of raw persisted events into `Tau.Message` structs.
+
+  Used on `Tau.fork/2` and `Tau.resume/1` to rebuild the in-memory history.
+  Events with unknown or undeserializable kinds are silently dropped.
+  """
+  @spec events_to_messages([map()]) :: [Tau.Message.t()]
+  def events_to_messages(events) do
+    events
+    |> Enum.map(&event_to_message/1)
+    |> Enum.reject(&is_nil/1)
+  end
+
+  @doc """
+  Deserialise one raw persisted event to a `Tau.Message` struct, or `nil`
+  if the kind is not deserializable (e.g. telemetry-only events).
+  """
+  @spec event_to_message(map()) :: Tau.Message.t() | nil
+  def event_to_message(%{"kind" => "user_message", "data" => d}) do
+    User.new(d["content"])
+  end
+
+  def event_to_message(%{"kind" => "assistant_message", "data" => d}) do
+    Assistant.new(
+      content: deserialize_blocks(d["content"]),
+      stop_reason: stop_reason_atom(d["stop_reason"]),
+      usage: d["usage"] || %{},
+      model: d["model"]
+    )
+  end
+
+  def event_to_message(%{"kind" => "tool_result", "data" => d}) do
+    ToolResult.new(
+      tool_call_id: d["tool_call_id"],
+      tool_name: d["tool_name"],
+      content: d["content"],
+      details: d["details"] || %{},
+      is_error: d["is_error"] || false
+    )
+  end
+
+  def event_to_message(%{"kind" => "compaction", "data" => %{"summary" => s}})
+      when is_binary(s) and s != "" do
+    User.new(s, metadata: %{role: :compaction_summary})
+  end
+
+  def event_to_message(_), do: nil
+
+  @doc """
+  Return the formatted compaction summary as it should be persisted.
+
+  Wraps the inner summary text in `<conversation_summary>` tags so the
+  "compaction" JSONL event can reconstruct the synthetic user message verbatim
+  on fork/resume.
+  """
+  @spec format_summary_for_persist(String.t() | nil) :: String.t() | nil
+  def format_summary_for_persist(nil), do: nil
+
+  def format_summary_for_persist(summary_text) when is_binary(summary_text) do
+    "<conversation_summary>\n#{summary_text}\n</conversation_summary>"
+  end
+
+  @doc """
+  Extract the most recently swapped model from a preload event list.
+
+  D-041: folds the last `model_swap` event from a preload so resume and fork
+  both converge on the most recently swapped model. Returns `nil` when no swap
+  is recorded.
+  """
+  @spec model_from_preload([map()]) :: String.t() | nil
+  def model_from_preload(preload) when is_list(preload) do
+    Enum.reduce(preload, nil, fn
+      %{"kind" => "model_swap", "data" => %{"to" => to}}, _acc when is_binary(to) -> to
+      _, acc -> acc
+    end)
+  end
+
+  def model_from_preload(_), do: nil
+
+  # --- Private serialisation helpers ----------------------------------------
+
+  defp serialize_content(s) when is_binary(s), do: s
+  defp serialize_content(blocks) when is_list(blocks), do: Enum.map(blocks, &serialize_block/1)
+
+  defp serialize_block(%{type: :text, text: t}), do: %{"type" => "text", "text" => t}
+
+  defp serialize_block(%{type: :image, data: d, media_type: mt}) when is_binary(d) do
+    %{"type" => "image", "media_type" => mt, "data_b64" => Base.encode64(d)}
+  end
+
+  defp serialize_block(%{type: :tool_call} = b),
+    do: %{"type" => "tool_call", "id" => b.id, "name" => b.name, "arguments" => b.arguments}
+
+  defp serialize_block(%{type: :thinking, text: t, signature: s}),
+    do: %{"type" => "thinking", "text" => t, "signature" => s}
+
+  defp serialize_block(other), do: other
+
+  defp deserialize_blocks(blocks) when is_list(blocks),
+    do: Enum.map(blocks, &deserialize_block/1)
+
+  defp deserialize_blocks(other), do: other
+
+  defp deserialize_block(%{"type" => "text", "text" => t}), do: %{type: :text, text: t}
+
+  defp deserialize_block(%{"type" => "tool_call", "id" => id, "name" => n, "arguments" => a}),
+    do: %{type: :tool_call, id: id, name: n, arguments: a}
+
+  defp deserialize_block(%{"type" => "thinking", "text" => t} = b),
+    do: %{type: :thinking, text: t, signature: b["signature"]}
+
+  defp deserialize_block(other), do: other
+
+  defp stop_reason_atom(nil), do: nil
+  defp stop_reason_atom(s) when is_binary(s), do: String.to_atom(s)
+  defp stop_reason_atom(s), do: s
+
+  defp generate_event_id do
+    case Code.ensure_loaded?(Uniq.UUID) do
+      true -> apply(Uniq.UUID, :uuid7, [])
+      _ -> "evt_" <> (:crypto.strong_rand_bytes(10) |> Base.url_encode64(padding: false))
+    end
+  end
+end

--- a/lib/tau/session/model_swap.ex
+++ b/lib/tau/session/model_swap.ex
@@ -1,0 +1,191 @@
+defmodule Tau.Session.ModelSwap do
+  @moduledoc """
+  Model swap and session reconfiguration helpers for `Tau.Session`.
+
+  Provides the single `data.model` mutation site (`swap_model/2`) and the
+  higher-level `apply_model_swap/2` that wires telemetry, persistence, and
+  broadcast. Also handles the `:reconfigure` cast FSM clause and the
+  `/model` slash-command path.
+
+  ## Invariants
+
+  - `data.model` has exactly one mutation site: `swap_model/2`.
+  - A nil, empty, or whitespace-only model id is rejected with `{:error, :invalid_model}`.
+  - Idempotent: swapping to the current model is a valid no-op (no rejection).
+  - Busy-state rejection: `{:swap_model, _}` calls outside `:awaiting_user`
+    (or with a command task in flight) return `{:error, :busy}`.
+  """
+
+  alias Tau.Session.Events
+
+  @doc """
+  Validate and apply a model swap to session data.
+
+  Returns `{:ok, updated_data, old_model}` when `model` is a non-blank string,
+  or `{:error, :invalid_model}` otherwise. Pure function — no side effects.
+  """
+  @spec swap_model(Tau.Session.Data.t(), String.t() | nil) ::
+          {:ok, Tau.Session.Data.t(), String.t()} | {:error, :invalid_model}
+  def swap_model(data, model) do
+    if is_binary(model) and String.trim(model) != "" do
+      {:ok, %{data | model: model}, data.model}
+    else
+      {:error, :invalid_model}
+    end
+  end
+
+  @doc """
+  Apply a model swap with telemetry, persistence, and broadcast.
+
+  Used by both the `{:swap_model}` FSM call handler and the `/model`
+  slash-command path (D-041). Returns `{:ok, updated_data, %{from:, to:}}`
+  or `{:error, :invalid_model}`.
+  """
+  @spec apply_model_swap(Tau.Session.Data.t(), String.t() | nil) ::
+          {:ok, Tau.Session.Data.t(), %{from: String.t(), to: String.t()}}
+          | {:error, :invalid_model}
+  def apply_model_swap(data, model) do
+    case swap_model(data, model) do
+      {:error, :invalid_model} ->
+        {:error, :invalid_model}
+
+      {:ok, data2, from_model} ->
+        :telemetry.execute(
+          [:tau, :session, :model_swapped],
+          %{system_time: System.system_time()},
+          %{session_id: data2.id, from: from_model, to: model, provider: data2.provider}
+        )
+
+        data2 =
+          Tau.Session.Journal.persist(data2, "model_swap", %{"from" => from_model, "to" => model})
+
+        Tau.Session.broadcast(data2.id, %Events.ModelSwapped{
+          session_id: data2.id,
+          from: from_model,
+          to: model
+        })
+
+        {:ok, data2, %{from: from_model, to: model}}
+    end
+  end
+
+  @doc """
+  Route a `:reconfigure` model opt through `swap_model/2`.
+
+  Returns data unchanged when `model` is `nil` — a provider-only reconfigure
+  must not touch `data.model`.
+  """
+  @spec reconfigure_model(Tau.Session.Data.t(), String.t() | nil) :: Tau.Session.Data.t()
+  def reconfigure_model(data, nil), do: data
+
+  def reconfigure_model(data, model) do
+    case swap_model(data, model) do
+      {:ok, data2, _from} -> data2
+      {:error, :invalid_model} -> data
+    end
+  end
+
+  @doc """
+  Replace `key` in `data` with `value`, or return `data` unchanged if `value`
+  is `nil`. Helper for `{:reconfigure, opts}` processing.
+  """
+  @spec maybe_replace(Tau.Session.Data.t(), atom(), term()) :: Tau.Session.Data.t()
+  def maybe_replace(data, _key, nil), do: data
+  def maybe_replace(data, key, value), do: Map.put(data, key, value)
+
+  @doc """
+  Merge `ctx` map into `data.provider_ctx`, or return `data` unchanged if `ctx`
+  is `nil`.
+  """
+  @spec merge_provider_ctx(Tau.Session.Data.t(), map() | nil) :: Tau.Session.Data.t()
+  def merge_provider_ctx(data, nil), do: data
+
+  def merge_provider_ctx(data, ctx) when is_map(ctx) do
+    %{data | provider_ctx: Map.merge(data.provider_ctx || %{}, ctx)}
+  end
+
+  @doc """
+  Handle the `/model <id>` slash-command inline.
+
+  Runs `apply_model_swap/2` and broadcasts a `%SystemNotice{}` with the result.
+  Returns an FSM action tuple.
+  """
+  @spec handle_slash_model_swap(Tau.Session.Data.t(), String.t()) ::
+          :gen_statem.event_handler_result()
+  def handle_slash_model_swap(data, new_model) do
+    case apply_model_swap(data, new_model) do
+      {:ok, data2, %{from: from, to: to}} ->
+        notice = "Model changed: #{from} → #{to}"
+        Tau.Session.broadcast(data2.id, %Events.SystemNotice{session_id: data2.id, text: notice})
+        {:keep_state, data2}
+
+      {:error, :invalid_model} ->
+        notice = "Error: '#{new_model}' is not a valid model id (empty or whitespace)."
+        Tau.Session.broadcast(data.id, %Events.SystemNotice{session_id: data.id, text: notice})
+        {:keep_state, data}
+    end
+  end
+
+  # --- FSM clause handlers ---------------------------------------------------
+
+  @doc """
+  Handle `{:swap_model, model}` call in `:awaiting_user` with no command task.
+  """
+  @spec handle_swap_model_idle(term(), String.t(), Tau.Session.Data.t()) ::
+          :gen_statem.event_handler_result()
+  def handle_swap_model_idle(from, model, data) do
+    case apply_model_swap(data, model) do
+      {:error, :invalid_model} ->
+        {:keep_state_and_data, [{:reply, from, {:error, :invalid_model}}]}
+
+      {:ok, data2, result} ->
+        {:keep_state, data2, [{:reply, from, {:ok, result}}]}
+    end
+  end
+
+  @doc """
+  Handle `{:swap_model, _}` call while the session is busy (any non-idle state,
+  or `:awaiting_user` with a command task in flight).
+  """
+  @spec handle_swap_model_busy(term()) :: :gen_statem.event_handler_result()
+  def handle_swap_model_busy(from) do
+    {:keep_state_and_data, [{:reply, from, {:error, :busy}}]}
+  end
+
+  @doc """
+  Handle `{:reconfigure, opts}` cast in any state.
+
+  Applies provider, model, provider_ctx, and coding_agent_ctx opts.
+  ADR-0012: `original_provider` is kept in lockstep with `provider` so the
+  fallback chain for the next turn uses the new primary.
+  """
+  @spec handle_reconfigure(keyword(), Tau.Session.Data.t()) ::
+          :gen_statem.event_handler_result()
+  def handle_reconfigure(opts, data) do
+    data =
+      data
+      |> maybe_replace(:provider, opts[:provider])
+      # ADR-0012: keep original_provider in lockstep with the user-configured
+      # provider. Reconfigure replaces both — fallback chains are looked up
+      # keyed by the *new* primary on the next turn.
+      |> maybe_replace(:original_provider, opts[:provider])
+      |> reconfigure_model(opts[:model])
+      |> merge_provider_ctx(opts[:provider_ctx])
+      # SPEC-CODING-AGENT: reconfigure may also adjust the coding-agent ctx.
+      |> maybe_replace(:coding_agent_ctx, opts[:coding_agent_ctx])
+
+    :telemetry.execute(
+      [:tau, :session, :reconfigure],
+      %{system_time: System.system_time()},
+      %{session_id: data.id, provider: data.provider, model: data.model}
+    )
+
+    data =
+      Tau.Session.Journal.persist(data, "reconfigure", %{
+        provider: inspect(data.provider),
+        model: data.model
+      })
+
+    {:keep_state, data}
+  end
+end

--- a/lib/tau/session/provider_turn.ex
+++ b/lib/tau/session/provider_turn.ex
@@ -1,0 +1,872 @@
+defmodule Tau.Session.ProviderTurn do
+  @moduledoc """
+  Provider streaming, fallback chain, retry budget, and turn finalisation
+  for `Tau.Session`.
+
+  Encapsulates all provider-side FSM logic: starting a stream, handling
+  per-event callbacks, managing ADR-0012 fallback chains, the D-061 same-
+  provider retry budget, cooperative/brutal task cancellation (ADR-0017),
+  and the `finalize_assistant/2` post-stream processing path.
+
+  ## Invariants
+
+  - ADR-0012: `data.provider` shape-shifts during fallback; `original_provider`
+    is restored at `finalize_assistant/2` so each turn starts against the primary.
+  - `stream_ref` staleness: stale events from a killed predecessor carry a
+    mismatched ref and are dropped.
+  - D-061: the retry counter (`provider_retry_state.count`) is per-turn and
+    resets on clean return to `:awaiting_user`.
+  - Retry-budget monotonicity per turn: once exhausted, retryable errors are
+    treated as terminal.
+  """
+
+  alias Tau.Message.{Assembler, Assistant}
+  alias Tau.Provider.Event, as: PEvent
+  alias Tau.Session.Events
+
+  # --- Helpers called from session.ex ----------------------------------------
+
+  @doc """
+  Resolve a provider atom from a nil, binary, or atom value.
+
+  Returns the module atom if valid, or `Tau.Provider.default()` if nil or if
+  `String.to_existing_atom/1` fails (try/rescue is intentional — inventory §3).
+  """
+  @spec resolve_provider(module() | String.t() | nil) :: module()
+  def resolve_provider(nil), do: Tau.Provider.default()
+
+  def resolve_provider(s) when is_binary(s) do
+    try do
+      String.to_existing_atom(s)
+    rescue
+      _ -> Tau.Provider.default()
+    end
+  end
+
+  def resolve_provider(m) when is_atom(m), do: m
+
+  @doc """
+  Look up the fallback chain for `original_provider` from settings.
+
+  ADR-0012: returns `[]` when no chain is configured or the settings carry
+  a typo (fail-closed via `Tau.Settings.Schema.resolve_fallback_chains/1`).
+  """
+  @spec lookup_fallback_chain(module()) :: [module()]
+  def lookup_fallback_chain(original_provider) when is_atom(original_provider) do
+    settings = Tau.Settings.Cache.get()
+
+    case Tau.Settings.Schema.resolve_fallback_chains(settings) do
+      {:ok, chains} -> Map.get(chains, original_provider, [])
+      {:error, _} -> []
+    end
+  end
+
+  @doc """
+  Emit the telemetry event closing an in-flight provider request span.
+
+  D-057 / SPEC-OTEL-REPORTER: every path abandoning an in-flight request
+  MUST call this before re-entering `:start_provider` or returning to
+  `:awaiting_user`. No-op when `provider_span_ref` is nil.
+  """
+  @spec emit_provider_request_terminal(:cancelled | :brutal_kill, Tau.Session.Data.t()) :: :ok
+  def emit_provider_request_terminal(_suffix, %{provider_span_ref: nil}), do: :ok
+
+  def emit_provider_request_terminal(suffix, data)
+      when suffix in [:cancelled, :brutal_kill] do
+    :telemetry.execute(
+      [:tau, :provider, :request, suffix],
+      %{system_time: System.system_time()},
+      %{
+        provider: data.provider,
+        model: data.model,
+        session_id: data.id,
+        span_ref: data.provider_span_ref
+      }
+    )
+  end
+
+  @doc """
+  Cancel the in-flight provider stream task, cooperatively then brutally.
+
+  ADR-0017: sets the cancel flag and yields up to 250ms. Returns `:cooperative`,
+  `:brutal_kill`, or `:noop` (no task active).
+  """
+  @spec cancel_provider_task(Tau.Session.Data.t()) :: :cooperative | :brutal_kill | :noop
+  def cancel_provider_task(%{provider_task: nil}), do: :noop
+
+  def cancel_provider_task(%{provider_task: task} = data) do
+    if not Process.alive?(task.pid) do
+      :noop
+    else
+      if data.cancel_flag, do: :counters.add(data.cancel_flag, 1, 1)
+
+      mechanism =
+        case Task.yield(task, 250) do
+          {:ok, _} -> :cooperative
+          {:exit, _} -> :cooperative
+          nil -> brutal_kill_provider_task(task)
+        end
+
+      # ADR-0017: telemetry event names decouple from the mechanism atom.
+      telemetry_event_name =
+        case mechanism do
+          :cooperative -> :cancelled
+          :brutal_kill -> :brutal_kill
+        end
+
+      :telemetry.execute(
+        [:tau, :provider, :request, telemetry_event_name],
+        %{system_time: System.system_time()},
+        %{
+          provider: data.provider,
+          model: data.model,
+          session_id: data.id,
+          span_ref: data.provider_span_ref
+        }
+      )
+
+      mechanism
+    end
+  end
+
+  @doc """
+  Describe a known provider error atom as a user-actionable string.
+
+  D-018: translates known auth atoms into human-readable messages.
+  Unknown atoms fall through to `inspect/1`.
+  """
+  @spec describe_provider_error(atom() | term()) :: String.t()
+  def describe_provider_error(:missing_api_key) do
+    Tau.Providers.Anthropic.Auth.describe_error({:error, :no_auth})
+  end
+
+  def describe_provider_error(:oauth_expired) do
+    Tau.Providers.Anthropic.Auth.describe_error({:error, :oauth_expired})
+  end
+
+  def describe_provider_error(:oauth_missing_scope) do
+    Tau.Providers.Anthropic.Auth.describe_error({:error, :oauth_missing_scope})
+  end
+
+  def describe_provider_error(:oauth_malformed) do
+    Tau.Providers.Anthropic.Auth.describe_error({:error, :oauth_malformed})
+  end
+
+  def describe_provider_error(:circuit_open) do
+    "Provider is temporarily unavailable (circuit breaker open). " <>
+      "The provider has returned too many consecutive errors. " <>
+      "Please wait a moment and try again, or switch providers."
+  end
+
+  def describe_provider_error(other), do: inspect(other)
+
+  @doc """
+  Merge `nil` or extra provider context opts into data. No-op for nil.
+  """
+  @spec merge_provider_ctx(Tau.Session.Data.t(), map() | nil) :: Tau.Session.Data.t()
+  def merge_provider_ctx(data, nil), do: data
+
+  def merge_provider_ctx(data, ctx) when is_map(ctx) do
+    %{data | provider_ctx: Map.merge(data.provider_ctx || %{}, ctx)}
+  end
+
+  @doc """
+  Return `nil` when `data.provider_task` is nil; the provider task pid
+  otherwise.
+  """
+  @spec maybe_replace(Tau.Session.Data.t(), atom(), term()) :: Tau.Session.Data.t()
+  def maybe_replace(data, _key, nil), do: data
+  def maybe_replace(data, key, value), do: Map.put(data, key, value)
+
+  @doc """
+  Guard: is the inbound event tagged with the currently-live run token?
+
+  Provider events carry a `stream_ref`; coding-agent events carry a dispatcher
+  pid. Stale events from superseded runs return false (ADR-0012).
+  """
+  @spec current_run?(Tau.Session.Data.t(), {:provider, reference()} | {:coding_agent, pid()}) ::
+          boolean()
+  def current_run?(%{stream_ref: ref}, {:provider, ref}) when is_reference(ref), do: true
+
+  def current_run?(%{coding_agent_dispatcher: pid}, {:coding_agent, pid}) when is_pid(pid),
+    do: true
+
+  def current_run?(_data, _token), do: false
+
+  @doc """
+  Handle a user message after slash-command expansion has resolved.
+
+  Runs the `:user_prompt_submit` hook chain. On `:cont`, appends the message
+  to history, persists it, then routes to the coding-agent or provider
+  streaming path.
+  """
+  @spec process_user_message(Tau.Message.t(), Tau.Session.Data.t()) ::
+          :gen_statem.event_handler_result()
+  def process_user_message(msg, data) do
+    case Tau.Hooks.Dispatcher.run(
+           :user_prompt_submit,
+           Tau.Session.hook_payload(data, :user_prompt_submit, %{message: msg})
+         ) do
+      {:halt, reason} ->
+        Tau.Session.broadcast(data.id, %Events.Cancelled{
+          session_id: data.id,
+          reason: {:hook_halt, reason}
+        })
+
+        {:keep_state, data}
+
+      {:deny, reason} ->
+        Tau.Session.broadcast(data.id, %Events.Cancelled{
+          session_id: data.id,
+          reason: {:hook_deny, reason}
+        })
+
+        {:keep_state, data}
+
+      {:cont, payload} ->
+        msg = Map.get(payload, :message, msg)
+
+        data =
+          data
+          |> Tau.Session.append_message(msg)
+          |> Tau.Session.Journal.persist("user_message", Tau.Session.Journal.message_to_data(msg))
+
+        # SPEC-CODING-AGENT / D-037: route to the coding-agent dispatcher when
+        # one is configured; preserve the legacy provider path otherwise.
+        if data.coding_agent do
+          Tau.Session.handle_event(:internal, :start_coding_agent, :coding_agent_streaming, data)
+        else
+          Tau.Session.handle_event(:internal, :start_provider, :provider_streaming, data)
+        end
+    end
+  end
+
+  @doc """
+  Finalise the assistant message at the end of a provider stream.
+
+  Assembles the message, appends to history, persists, broadcasts, emits
+  telemetry, optionally compacts, and then dispatches tool calls or returns
+  to `:awaiting_user`.
+  """
+  @spec finalize_assistant(Assembler.t(), Tau.Session.Data.t()) ::
+          :gen_statem.event_handler_result()
+  def finalize_assistant(assembler, data) do
+    msg = Assembler.assistant(assembler)
+
+    data =
+      data
+      |> Tau.Session.append_message(msg)
+      |> Tau.Session.Journal.persist(
+        "assistant_message",
+        Tau.Session.Journal.message_to_data(msg)
+      )
+
+    Tau.Session.broadcast(data.id, %Events.MessageEnd{session_id: data.id, message: msg})
+
+    :telemetry.execute(
+      [:tau, :provider, :request, :stop],
+      %{system_time: System.system_time(), usage: msg.usage || %{}},
+      %{
+        provider: data.provider,
+        model: data.model,
+        session_id: data.id,
+        stop_reason: msg.stop_reason,
+        span_ref: data.provider_span_ref
+      }
+    )
+
+    # SPEC-PROMPT-CACHING AC-4
+    Tau.Session.Compaction.emit_cache_usage(data, msg.usage || %{})
+
+    case Tau.Session.Compaction.maybe_compact(data, msg.usage || %{}) do
+      {:abort, data} ->
+        abort_msg =
+          Assistant.new(
+            stop_reason: :compaction_failed,
+            content: [
+              %{
+                type: :text,
+                text:
+                  "Turn aborted: repeated or background compaction failure (3 consecutive errors). " <>
+                    "Check the compactor configuration or contact support if this persists."
+              }
+            ]
+          )
+
+        data =
+          data
+          |> Tau.Session.append_message(abort_msg)
+          |> Tau.Session.Journal.persist(
+            "assistant_message",
+            Tau.Session.Journal.message_to_data(abort_msg)
+          )
+
+        Tau.Session.broadcast(data.id, %Events.MessageEnd{session_id: data.id, message: abort_msg})
+
+        next_data = %{
+          data
+          | provider_task: nil,
+            assembler: nil,
+            cancel_flag: nil,
+            stream_ref: nil,
+            provider_span_ref: nil,
+            tool_iterations: 0,
+            tool_loop_state: %{},
+            tool_loop_call_lookups: %{},
+            provider_retry_state: %{count: 0}
+        }
+
+        actions =
+          if :queue.is_empty(next_data.followup_queue),
+            do: [],
+            else: [{:next_event, :internal, :drain_followups}]
+
+        {:next_state, :awaiting_user, next_data, actions}
+
+      compact_result ->
+        data =
+          if match?({:soft_error, _}, compact_result),
+            do: elem(compact_result, 1),
+            else: compact_result
+
+        # ADR-0012: restore working provider to original_provider.
+        data = %{data | provider: data.original_provider, fallback_chain_remaining: []}
+
+        # ADR-0013 / ADR-0015: per-turn skill lifetime.
+        data =
+          if msg.stop_reason == :end_turn and Map.get(data, :persona_lifetime, :turn) == :turn do
+            %{data | active_skill: nil}
+          else
+            data
+          end
+
+        tool_calls = Enum.filter(msg.content, &match?(%{type: :tool_call}, &1))
+
+        cond do
+          tool_calls == [] ->
+            # D-079: merge surviving steering messages to front of followup_queue.
+            {merged_followup, cleared_steering} =
+              if :queue.is_empty(data.steering_queue) do
+                {data.followup_queue, data.steering_queue}
+              else
+                steering_list = :queue.to_list(data.steering_queue)
+
+                merged =
+                  Enum.reduce(
+                    Enum.reverse(steering_list),
+                    data.followup_queue,
+                    fn m, q -> :queue.in_r(m, q) end
+                  )
+
+                {merged, :queue.new()}
+              end
+
+            next_data = %{
+              data
+              | provider_task: nil,
+                assembler: nil,
+                cancel_flag: nil,
+                stream_ref: nil,
+                provider_span_ref: nil,
+                tool_iterations: 0,
+                tool_loop_state: %{},
+                tool_loop_call_lookups: %{},
+                provider_retry_state: %{count: 0},
+                followup_queue: merged_followup,
+                steering_queue: cleared_steering
+            }
+
+            actions =
+              if :queue.is_empty(next_data.followup_queue),
+                do: [],
+                else: [{:next_event, :internal, :drain_followups}]
+
+            {:next_state, :awaiting_user, next_data, actions}
+
+          true ->
+            cap = data.max_tool_iterations
+
+            if data.tool_iterations >= cap do
+              aborted_iter = data.tool_iterations
+
+              :telemetry.execute(
+                [:tau, :session, :tool_iteration_cap],
+                %{iterations: aborted_iter, cap: cap},
+                %{session_id: data.id}
+              )
+
+              abort_msg =
+                Assistant.new(
+                  stop_reason: :tool_loop_aborted,
+                  content: [
+                    %{
+                      type: :text,
+                      text:
+                        "Tool-call iteration cap (#{cap}) exceeded. Turn aborted to prevent runaway loops."
+                    }
+                  ]
+                )
+
+              data =
+                data
+                |> Tau.Session.append_message(abort_msg)
+                |> Tau.Session.Journal.persist(
+                  "assistant_message",
+                  Tau.Session.Journal.message_to_data(abort_msg)
+                )
+
+              Tau.Session.broadcast(data.id, %Events.MessageEnd{
+                session_id: data.id,
+                message: abort_msg
+              })
+
+              next_data = %{
+                data
+                | provider_task: nil,
+                  assembler: nil,
+                  cancel_flag: nil,
+                  stream_ref: nil,
+                  provider_span_ref: nil,
+                  tool_iterations: 0,
+                  tool_loop_state: %{},
+                  tool_loop_call_lookups: %{},
+                  provider_retry_state: %{count: 0}
+              }
+
+              actions =
+                if :queue.is_empty(next_data.followup_queue),
+                  do: [],
+                  else: [{:next_event, :internal, :drain_followups}]
+
+              {:next_state, :awaiting_user, next_data, actions}
+            else
+              Tau.Session.ToolDispatch.dispatch_tools(
+                tool_calls,
+                %{data | tool_iterations: data.tool_iterations + 1}
+              )
+            end
+        end
+    end
+  end
+
+  # --- FSM clause handlers ---------------------------------------------------
+
+  @doc """
+  Start a provider stream in `:provider_streaming`.
+
+  ADR-0012: re-derives the fallback chain from settings on each fresh turn.
+  ADR-0017: allocates a fresh cancel flag per stream.
+  D-057 / SPEC-OTEL-REPORTER: allocates a fresh `provider_span_ref` per request.
+  """
+  @spec start(Tau.Session.Data.t()) :: :gen_statem.event_handler_result()
+  def start(data) do
+    Tau.Session.transition(data.id, data, :provider_streaming)
+
+    data =
+      if data.fallback_chain_remaining == [] and data.provider == data.original_provider do
+        %{data | fallback_chain_remaining: lookup_fallback_chain(data.original_provider)}
+      else
+        data
+      end
+
+    parent = self()
+    cancel_flag = :counters.new(1, [])
+
+    ctx =
+      data.provider_ctx
+      |> Map.merge(%{session_id: data.id, cancel_flag: cancel_flag})
+
+    provider_span_ref = make_ref()
+    data = %{data | provider_span_ref: provider_span_ref}
+
+    :telemetry.execute(
+      [:tau, :provider, :request, :start],
+      %{system_time: System.system_time()},
+      %{
+        provider: data.provider,
+        model: data.model,
+        session_id: data.id,
+        span_ref: provider_span_ref
+      }
+    )
+
+    stream_opts =
+      %{model: data.model}
+      |> Tau.Session.SkillActivation.maybe_put_tools(
+        Tau.Session.SkillActivation.model_visible_tool_specs(data)
+      )
+
+    case Tau.CircuitBreaker.call(data.provider, [], fn ->
+           data.provider.stream(data.messages, stream_opts, ctx)
+         end) do
+      {:ok, stream} ->
+        stream_ref = make_ref()
+
+        task =
+          Task.async(fn ->
+            try do
+              Enum.each(stream, fn ev ->
+                Process.send(parent, {:provider_event, stream_ref, ev}, [])
+              end)
+
+              Process.send(parent, {:provider_done, stream_ref}, [])
+            rescue
+              e ->
+                Process.send(
+                  parent,
+                  {:provider_failed, stream_ref, Exception.message(e)},
+                  []
+                )
+            end
+          end)
+
+        assembler = Assembler.new(provider: data.provider, model: data.model)
+
+        Tau.Session.broadcast(data.id, %Events.MessageStart{
+          session_id: data.id,
+          message: assembler.message
+        })
+
+        {:next_state, :provider_streaming,
+         %{
+           data
+           | provider_task: task,
+             assembler: assembler,
+             cancel_flag: cancel_flag,
+             stream_ref: stream_ref,
+             provider_span_ref: provider_span_ref
+         }}
+
+      {:error, :circuit_open} ->
+        handle_circuit_open(data)
+
+      {:error, reason} ->
+        handle_sync_error(reason, data)
+    end
+  end
+
+  @doc """
+  Handle a provider event arriving in `:provider_streaming`.
+  """
+  @spec handle_provider_event(reference(), term(), Tau.Session.Data.t()) ::
+          :gen_statem.event_handler_result()
+  def handle_provider_event(ref, ev, data) do
+    if current_run?(data, {:provider, ref}) do
+      new_assembler = Assembler.step(data.assembler, ev)
+
+      Tau.Session.broadcast(data.id, %Events.MessageUpdate{
+        session_id: data.id,
+        event: ev,
+        message: new_assembler.message
+      })
+
+      if Assembler.done?(new_assembler) do
+        finalize_assistant(new_assembler, data)
+      else
+        {:keep_state, %{data | assembler: new_assembler}}
+      end
+    else
+      {:keep_state, data}
+    end
+  end
+
+  @doc """
+  Handle a retryable provider error with an empty fallback chain and retry budget remaining.
+
+  D-061: schedules a same-provider retry after a backoff delay.
+  """
+  @spec handle_provider_retry_event(reference(), PEvent.Error.t(), Tau.Session.Data.t()) ::
+          :gen_statem.event_handler_result()
+  def handle_provider_retry_event(ref, ev, data) do
+    if current_run?(data, {:provider, ref}) do
+      next_count = data.provider_retry_state.count + 1
+      delay = data.provider_retry_base_delay_ms * Integer.pow(2, data.provider_retry_state.count)
+
+      :telemetry.execute(
+        [:tau, :session, :provider_retry],
+        %{count: next_count, delay_ms: delay},
+        %{
+          session_id: data.id,
+          provider: data.provider,
+          reason: ev.reason,
+          max: data.provider_retry_max
+        }
+      )
+
+      notice =
+        "provider #{inspect(data.provider)} errored (#{inspect(ev.reason)}); " <>
+          "retrying #{next_count}/#{data.provider_retry_max} after #{delay}ms"
+
+      Tau.Session.broadcast(data.id, %Events.SystemNotice{session_id: data.id, text: notice})
+
+      data =
+        Tau.Session.Journal.persist(data, "provider_retry", %{
+          provider: inspect(data.provider),
+          reason: inspect(ev.reason),
+          count: next_count,
+          max: data.provider_retry_max,
+          delay_ms: delay
+        })
+
+      emit_provider_request_terminal(:brutal_kill, data)
+
+      if data.provider_task && Process.alive?(data.provider_task.pid) do
+        Task.shutdown(data.provider_task, :brutal_kill)
+      end
+
+      data = %{
+        data
+        | provider_retry_state: %{count: next_count},
+          provider_task: nil,
+          assembler: nil,
+          stream_ref: nil,
+          provider_span_ref: nil
+      }
+
+      Process.send_after(self(), {:provider_retry, next_count}, delay)
+      {:keep_state, data}
+    else
+      {:keep_state, data}
+    end
+  end
+
+  @doc """
+  Handle a retryable provider error with a non-empty fallback chain.
+
+  ADR-0012: advances to the next provider in the chain.
+  """
+  @spec handle_provider_fallback_event(reference(), PEvent.Error.t(), Tau.Session.Data.t()) ::
+          :gen_statem.event_handler_result()
+  def handle_provider_fallback_event(ref, ev, %{fallback_chain_remaining: [next | rest]} = data) do
+    if current_run?(data, {:provider, ref}) do
+      from_provider = data.provider
+
+      :telemetry.execute(
+        [:tau, :provider, :fallback],
+        %{system_time: System.system_time()},
+        %{
+          from_provider: from_provider,
+          to_provider: next,
+          reason: ev.reason,
+          session_id: data.id
+        }
+      )
+
+      Tau.Session.broadcast(data.id, %Events.ProviderFallback{
+        session_id: data.id,
+        from_provider: from_provider,
+        to_provider: next,
+        reason: ev.reason
+      })
+
+      data =
+        Tau.Session.Journal.persist(data, "provider_fallback", %{
+          from_provider: inspect(from_provider),
+          to_provider: inspect(next),
+          reason: inspect(ev.reason)
+        })
+
+      emit_provider_request_terminal(:brutal_kill, data)
+
+      if data.provider_task && Process.alive?(data.provider_task.pid) do
+        Task.shutdown(data.provider_task, :brutal_kill)
+      end
+
+      transformed =
+        Tau.Providers.Shared.ContentTransform.transform(data.messages, from_provider, next)
+
+      Tau.Session.handle_event(
+        :internal,
+        :start_provider,
+        :provider_streaming,
+        %{
+          data
+          | provider: next,
+            messages: transformed,
+            fallback_chain_remaining: rest,
+            assembler: nil,
+            provider_task: nil,
+            stream_ref: nil,
+            provider_span_ref: nil
+        }
+      )
+    else
+      {:keep_state, data}
+    end
+  end
+
+  @doc """
+  Handle `:provider_done` in `:provider_streaming`.
+  """
+  @spec handle_provider_done(reference(), Tau.Session.Data.t()) ::
+          :gen_statem.event_handler_result()
+  def handle_provider_done(ref, data) do
+    if current_run?(data, {:provider, ref}) do
+      if data.assembler && Assembler.done?(data.assembler) do
+        {:keep_state, data}
+      else
+        assembler =
+          Assembler.step(data.assembler || Assembler.new(), %PEvent.Done{stop_reason: :stop})
+
+        finalize_assistant(assembler, data)
+      end
+    else
+      {:keep_state, data}
+    end
+  end
+
+  @doc """
+  Handle `:provider_failed` (task raised) in `:provider_streaming`.
+  """
+  @spec handle_provider_failed(reference(), String.t(), Tau.Session.Data.t()) ::
+          :gen_statem.event_handler_result()
+  def handle_provider_failed(ref, msg, data) do
+    if current_run?(data, {:provider, ref}) do
+      assembler =
+        Assembler.step(data.assembler || Assembler.new(), %PEvent.Error{
+          reason: msg,
+          retryable?: false
+        })
+
+      finalize_assistant(assembler, data)
+    else
+      {:keep_state, data}
+    end
+  end
+
+  @doc """
+  Handle `:finish_provider` internal event in `:provider_streaming`.
+  """
+  @spec handle_finish_provider(Tau.Session.Data.t()) :: :gen_statem.event_handler_result()
+  def handle_finish_provider(data) do
+    handle_provider_done(data.stream_ref, data)
+  end
+
+  @doc """
+  Handle `:end_turn` internal event — provider signals graceful completion.
+  """
+  @spec handle_end_turn(atom(), Tau.Session.Data.t()) :: :gen_statem.event_handler_result()
+  def handle_end_turn(_state, data) do
+    if data.assembler do
+      finalize_assistant(data.assembler, data)
+    else
+      {:keep_state, data}
+    end
+  end
+
+  @doc """
+  Handle a deferred retry trigger `{:provider_retry, count}` in `:provider_streaming`.
+  """
+  @spec handle_provider_retry_trigger(non_neg_integer(), Tau.Session.Data.t()) ::
+          :gen_statem.event_handler_result()
+  def handle_provider_retry_trigger(count, data) do
+    if count == data.provider_retry_state.count do
+      start(data)
+    else
+      {:keep_state, data}
+    end
+  end
+
+  # --- Private helpers -------------------------------------------------------
+
+  defp brutal_kill_provider_task(task) do
+    Task.shutdown(task, :brutal_kill)
+    :brutal_kill
+  end
+
+  defp handle_circuit_open(%{fallback_chain_remaining: [next | rest]} = data) do
+    from_provider = data.provider
+
+    :telemetry.execute(
+      [:tau, :provider, :fallback],
+      %{system_time: System.system_time()},
+      %{
+        from_provider: from_provider,
+        to_provider: next,
+        reason: :circuit_open,
+        session_id: data.id
+      }
+    )
+
+    Tau.Session.broadcast(data.id, %Events.ProviderFallback{
+      session_id: data.id,
+      from_provider: from_provider,
+      to_provider: next,
+      reason: :circuit_open
+    })
+
+    data =
+      Tau.Session.Journal.persist(data, "provider_fallback", %{
+        from_provider: inspect(from_provider),
+        to_provider: inspect(next),
+        reason: "circuit_open"
+      })
+
+    emit_provider_request_terminal(:cancelled, data)
+
+    transformed =
+      Tau.Providers.Shared.ContentTransform.transform(data.messages, from_provider, next)
+
+    Tau.Session.handle_event(
+      :internal,
+      :start_provider,
+      :provider_streaming,
+      %{
+        data
+        | provider: next,
+          messages: transformed,
+          fallback_chain_remaining: rest,
+          assembler: nil,
+          provider_task: nil,
+          stream_ref: nil,
+          provider_span_ref: nil
+      }
+    )
+  end
+
+  defp handle_circuit_open(data) do
+    emit_provider_request_terminal(:cancelled, data)
+    reason_str = describe_provider_error(:circuit_open)
+
+    msg =
+      Assistant.new(
+        stop_reason: :error,
+        error_message: reason_str,
+        content: [%{type: :text, text: "Error: " <> reason_str}]
+      )
+
+    Tau.Session.broadcast(data.id, %Events.MessageEnd{session_id: data.id, message: msg})
+
+    next_data = %{data | cancel_flag: nil, stream_ref: nil, provider_span_ref: nil}
+
+    actions =
+      if :queue.is_empty(next_data.followup_queue),
+        do: [],
+        else: [{:next_event, :internal, :drain_followups}]
+
+    {:next_state, :awaiting_user, next_data, actions}
+  end
+
+  defp handle_sync_error(reason, data) do
+    emit_provider_request_terminal(:cancelled, data)
+    reason_str = describe_provider_error(reason)
+
+    msg =
+      Assistant.new(
+        stop_reason: :error,
+        error_message: reason_str,
+        content: [%{type: :text, text: "Error: " <> reason_str}]
+      )
+
+    Tau.Session.broadcast(data.id, %Events.MessageEnd{session_id: data.id, message: msg})
+
+    next_data = %{data | cancel_flag: nil, stream_ref: nil, provider_span_ref: nil}
+
+    actions =
+      if :queue.is_empty(next_data.followup_queue),
+        do: [],
+        else: [{:next_event, :internal, :drain_followups}]
+
+    {:next_state, :awaiting_user, next_data, actions}
+  end
+end

--- a/lib/tau/session/queue.ex
+++ b/lib/tau/session/queue.ex
@@ -1,0 +1,180 @@
+defmodule Tau.Session.Queue do
+  @moduledoc """
+  Steering and follow-up queue operations for `Tau.Session`.
+
+  Manages the two-tier message queue (D-077 / D-078 / SPEC-USER-TURN §6):
+
+  - `steering_queue` — messages that drain at the tool-round boundary, placed
+    AFTER all tool results and BEFORE the next provider call (D-079).
+  - `followup_queue` — messages that drain on transition into `:awaiting_user`
+    (D-080).
+
+  ## Invariants
+
+  - FIFO order is preserved across enqueue and dequeue (one message at a time).
+  - Hard cap: 32 entries per tier (D-083). Messages past the cap are dropped
+    with a `%SystemNotice{}` broadcast.
+  - `:cancel` empties `steering_queue` and enqueues a `%QueueRestored{}`
+    notification (SPEC-USER-TURN §6).
+  - Steering drain bypasses slash-command classification; follow-up drain
+    re-routes through the full user_message dispatch path.
+  """
+
+  alias Tau.Session.Events
+
+  @queue_cap 32
+
+  @doc """
+  Enqueue `msg` into `data.steering_queue` or `data.followup_queue` based on
+  `tier`, with telemetry. Drops with a `%SystemNotice{}` broadcast when the
+  queue is at the hard cap (D-083).
+
+  Returns updated `data` wrapped in `{:keep_state, data}`.
+  """
+  @spec enqueue(Tau.Session.Data.t(), Tau.Message.t(), :steering | :followup, atom()) ::
+          :gen_statem.event_handler_result()
+  def enqueue(data, msg, tier, from_state) do
+    {queue_field, tier_atom} =
+      case tier do
+        :steering -> {:steering_queue, :steering}
+        _ -> {:followup_queue, :followup}
+      end
+
+    queue = Map.get(data, queue_field)
+    queue_size = :queue.len(queue)
+
+    if queue_size >= @queue_cap do
+      # D-083: hard cap — drop with a %SystemNotice{}, no unbounded growth.
+      notice =
+        "Message queue full (#{@queue_cap} #{tier_atom} messages queued); " <>
+          "message dropped. Wait for the current turn to complete."
+
+      Tau.Session.broadcast(data.id, %Events.SystemNotice{session_id: data.id, text: notice})
+
+      :telemetry.execute(
+        [:tau, :session, tier_atom, :dropped],
+        %{system_time: System.system_time()},
+        %{session_id: data.id, from_state: from_state, queue_size: queue_size}
+      )
+
+      {:keep_state_and_data, []}
+    else
+      new_queue = :queue.in(msg, queue)
+      new_data = Map.put(data, queue_field, new_queue)
+
+      :telemetry.execute(
+        [:tau, :session, tier_atom, :enqueued],
+        %{system_time: System.system_time()},
+        %{session_id: data.id, from_state: from_state, queue_size: queue_size + 1}
+      )
+
+      {:keep_state, new_data}
+    end
+  end
+
+  @doc """
+  Drain one message from `data.steering_queue` and append it to `data.messages`.
+
+  D-079: called after all tool results are in, before the next provider call,
+  so no tool_call is orphaned. Bypasses slash-command classification — a
+  steering message has already passed the user-intent gate at enqueue time.
+
+  Returns updated data (or data unchanged if the queue is empty).
+  """
+  @spec drain_steering_queue_one(Tau.Session.Data.t()) :: Tau.Session.Data.t()
+  def drain_steering_queue_one(data) do
+    case :queue.out(data.steering_queue) do
+      {:empty, _} ->
+        data
+
+      {{:value, msg}, rest} ->
+        :telemetry.execute(
+          [:tau, :session, :steering, :delivered],
+          %{system_time: System.system_time()},
+          %{session_id: data.id, from_state: :tool_executing}
+        )
+
+        Tau.Session.emit_user_message_telemetry(:delivered, data, :tool_executing)
+
+        data
+        |> Tau.Session.append_message(msg)
+        |> Tau.Session.Journal.persist("user_message", Tau.Session.Journal.message_to_data(msg))
+        |> Map.put(:steering_queue, rest)
+    end
+  end
+
+  # --- FSM clause handlers ---------------------------------------------------
+
+  @doc """
+  Handle a user message arriving while a command task is in flight.
+
+  ADR-0008: postpone so the message is re-delivered on the next FSM transition,
+  preserving order.
+  """
+  @spec handle_postpone(Tau.Session.Data.t(), atom()) :: :gen_statem.event_handler_result()
+  def handle_postpone(data, state) do
+    Tau.Session.emit_user_message_telemetry(:enqueued, data, state)
+    {:keep_state_and_data, [{:postpone, true}]}
+  end
+
+  @doc """
+  Handle a user message when the FSM is not in `:awaiting_user`.
+
+  D-077 / D-078: route to the appropriate tier queue.
+  """
+  @spec handle_enqueue(Tau.Message.t(), :steering | atom(), atom(), Tau.Session.Data.t()) ::
+          :gen_statem.event_handler_result()
+  def handle_enqueue(msg, tier, state, data) do
+    Tau.Session.emit_user_message_telemetry(:enqueued, data, state)
+    enqueue(data, msg, tier, state)
+  end
+
+  @doc """
+  Handle `:drain_followups` internal event in `:awaiting_user` with no command task.
+
+  Dequeues one follow-up message and re-routes it through the full user_message
+  dispatch path so slash commands are classified.
+  """
+  @spec handle_drain_followups_idle(Tau.Session.Data.t()) :: :gen_statem.event_handler_result()
+  def handle_drain_followups_idle(data) do
+    case :queue.out(data.followup_queue) do
+      {:empty, _} ->
+        {:keep_state, data}
+
+      {{:value, msg}, rest} ->
+        :telemetry.execute(
+          [:tau, :session, :followup, :delivered],
+          %{system_time: System.system_time()},
+          %{session_id: data.id, from_state: :awaiting_user}
+        )
+
+        # Re-route through the full user_message dispatch path so slash commands
+        # are classified. The :followup tier tag is preserved but irrelevant in
+        # :awaiting_user — the handler delivers immediately.
+        Tau.Session.handle_event(:cast, {:user_message, msg, :followup}, :awaiting_user, %{
+          data
+          | followup_queue: rest
+        })
+    end
+  end
+
+  @doc """
+  Handle `:drain_followups` in a non-idle state or with a command task in flight.
+  Drop — the followup will re-drain on the next `:awaiting_user` transition.
+  """
+  @spec handle_drain_followups_busy(Tau.Session.Data.t()) :: :gen_statem.event_handler_result()
+  def handle_drain_followups_busy(data) do
+    {:keep_state, data}
+  end
+
+  @doc """
+  Handle `{:provider_dispatch, _id}` info messages.
+
+  These are fire-and-forget confirmations from the parallel tool dispatcher;
+  the FSM ignores them (no state change).
+  """
+  @spec handle_provider_dispatch(Tau.Session.Data.t()) :: :gen_statem.event_handler_result()
+  def handle_provider_dispatch(data) do
+    {:keep_state, data}
+  end
+end

--- a/lib/tau/session/skill_activation.ex
+++ b/lib/tau/session/skill_activation.ex
@@ -1,0 +1,374 @@
+defmodule Tau.Session.SkillActivation do
+  @moduledoc """
+  Skill discovery, tool-spec derivation, and skill activation for `Tau.Session`.
+
+  Covers skill loading from disk and extensions, building the model-visible
+  tool-spec list, handling `__activate_skill__` tool calls dispatched by the
+  model, processing user-initiated slash-command activations, and injecting
+  skill and memory system messages into the conversation.
+
+  ## States
+
+  - `:turn` lifetime — `active_skill` is cleared at `:end_turn`.
+  - `:session` lifetime — `active_skill` survives `:end_turn` (sub-agent personas).
+
+  ## Invariants
+
+  - Skill precedence: builtin > extension > file-command > skill > template.
+  - `disable_model_invocation: true` skills are never included in the
+    model-visible tool spec (ADR-0013 / ADR-0015).
+  - `:turn` lifetime clears `active_skill` on `:end_turn`; `:session` survives.
+  """
+
+  alias Tau.Message.ToolResult
+  alias Tau.Session.Events
+
+  @activate_skill_tool_name "__activate_skill__"
+
+  @doc """
+  Load skills from the filesystem and registered extensions for `cwd`.
+
+  Merges extension-provided skills and cwd-discovered skills, deduplicating by
+  name (filesystem wins on conflict). Returns an alphabetically sorted list of
+  `{name, %Tau.Skill{}}` pairs and emits a `:tau, :skills, :loaded` telemetry
+  event when skills are found.
+  """
+  @spec load_skills(String.t()) :: [{String.t(), Tau.Skill.t()}]
+  def load_skills(cwd) do
+    discovered = Tau.Skills.Loader.discover(cwd)
+    extension = Tau.Skills.Loader.list_extension_skills()
+
+    skills =
+      (extension ++ discovered)
+      |> Enum.uniq_by(fn {name, _} -> name end)
+      |> Enum.sort_by(fn {name, _} -> name end)
+
+    if skills != [] do
+      active_count = Enum.count(skills, fn {_n, s} -> not s.disable_model_invocation end)
+
+      :telemetry.execute(
+        [:tau, :skills, :loaded],
+        %{count: length(skills), active: active_count, skipped: length(skills) - active_count},
+        %{cwd: cwd}
+      )
+    end
+
+    skills
+  end
+
+  @doc """
+  Prepend skill system messages to the message list.
+
+  Produces one user-role system message per active (non-disabled) skill,
+  placing them at the front of the history so the model sees them as
+  context before any conversation turns.
+  """
+  @spec prepend_skill_messages([Tau.Message.t()], [{String.t(), Tau.Skill.t()}]) ::
+          [Tau.Message.t()]
+  def prepend_skill_messages(messages, skills) do
+    active = Enum.reject(skills, fn {_name, s} -> s.disable_model_invocation end)
+
+    case active do
+      [] ->
+        messages
+
+      list ->
+        Enum.map(list, fn {name, %Tau.Skill{} = s} ->
+          Tau.Message.User.new(render_skill(name, s),
+            metadata: %{role: :system, source: :skill, name: name, path: s.path}
+          )
+        end) ++ messages
+    end
+  end
+
+  @doc """
+  Prepend memory system messages to the message list.
+
+  Loads the memory cascade for `cwd` and injects each memory file as a
+  user-role system message at the front of the history.
+  """
+  @spec inject_memory([Tau.Message.t()], String.t()) :: [Tau.Message.t()]
+  def inject_memory(messages, cwd) do
+    case Tau.Memory.Loader.load(cwd) do
+      [] ->
+        messages
+
+      cascade ->
+        bytes = Enum.reduce(cascade, 0, fn {_p, b}, acc -> acc + byte_size(b) end)
+
+        :telemetry.execute(
+          [:tau, :memory, :loaded],
+          %{file_count: length(cascade), bytes: bytes},
+          %{cwd: cwd}
+        )
+
+        memory_messages =
+          Enum.map(cascade, fn {path, body} ->
+            Tau.Message.User.new(body, metadata: %{role: :system, source: :memory, path: path})
+          end)
+
+        memory_messages ++ messages
+    end
+  end
+
+  @doc """
+  Return the model-visible tool-spec list for the current session data.
+
+  Combines the synthetic `__activate_skill__` spec (when model-invokable
+  skills exist) with the active skill's allowed-tools specs. Returns `nil`
+  when no tools should be exposed to the provider (some providers reject an
+  empty `:tools` array — D-059).
+  """
+  @spec model_visible_tool_specs(Tau.Session.Data.t()) :: [map()] | nil
+  def model_visible_tool_specs(data) do
+    activation = skill_activation_tool_spec(data.skills)
+    skill_specs = active_skill_tool_specs(data.active_skill)
+
+    case {activation, skill_specs} do
+      {nil, []} -> nil
+      {nil, list} -> list
+      {spec, []} -> [spec]
+      {spec, list} -> [spec | list]
+    end
+  end
+
+  @doc """
+  Place a single tool spec under the `:tools` key in `opts`, or return `opts`
+  unchanged when `spec` is nil or an empty list.
+  """
+  @spec maybe_put_tools(map(), map() | [map()] | nil) :: map()
+  def maybe_put_tools(opts, nil), do: opts
+  def maybe_put_tools(opts, []), do: opts
+
+  def maybe_put_tools(opts, tool_specs) when is_list(tool_specs),
+    do: Map.put(opts, :tools, tool_specs)
+
+  def maybe_put_tools(opts, tool_spec) when is_map(tool_spec),
+    do: Map.put(opts, :tools, [tool_spec])
+
+  @doc """
+  Handle all `__activate_skill__` tool calls in `calls` inline.
+
+  Returns `{updated_data, in_flight_map}` where `in_flight_map` maps each
+  call id to `:activated` so the FSM tracks these alongside regular tool
+  results.
+  """
+  @spec handle_skill_activations(
+          [map()],
+          Tau.Session.Data.t(),
+          pid()
+        ) :: {Tau.Session.Data.t(), map()}
+  def handle_skill_activations([], data, _parent), do: {data, %{}}
+
+  def handle_skill_activations(calls, data, parent) do
+    Enum.reduce(calls, {data, %{}}, fn %{id: id, name: tool_name, arguments: args},
+                                       {data_acc, in_flight_acc} ->
+      requested = skill_name_from_args(args)
+
+      {data_acc, result} = activate_skill(data_acc, requested, id)
+
+      :telemetry.execute(
+        [:tau, :session, :skill_activated],
+        %{system_time: System.system_time()},
+        %{
+          session_id: data_acc.id,
+          skill_name: requested,
+          tool_name: tool_name,
+          disabled?: result.is_error
+        }
+      )
+
+      Process.send(parent, {:tool_done, id, result}, [])
+      {data_acc, Map.put(in_flight_acc, id, :activated)}
+    end)
+  end
+
+  @doc """
+  Handle a user-initiated slash-command skill activation.
+
+  Sets `active_skill` on `data`, persists a JSONL `skill_activated` event,
+  broadcasts `%Events.SkillActivated{}`, and emits telemetry. Returns updated
+  data.
+  """
+  @spec activate_skill_via_slash(Tau.Session.Data.t(), Tau.Skill.t()) :: Tau.Session.Data.t()
+  def activate_skill_via_slash(data, %Tau.Skill{name: name} = skill) do
+    data =
+      %{data | active_skill: skill}
+      |> Tau.Session.Journal.persist("skill_activated", %{
+        skill_name: name,
+        tool_call_id: nil,
+        allowed_tools: skill.allowed_tools
+      })
+
+    Tau.Session.broadcast(data.id, %Events.SkillActivated{
+      session_id: data.id,
+      skill_name: name,
+      tool_call_id: nil
+    })
+
+    :telemetry.execute(
+      [:tau, :session, :skill_activated],
+      %{},
+      %{session_id: data.id, skill_name: name, disabled?: false}
+    )
+
+    data
+  end
+
+  @doc """
+  Look up `name` in `data.skills` and set `active_skill` if found.
+
+  Returns `{updated_data, %ToolResult{}}`. On success, persists and broadcasts
+  the activation event. On failure (unknown name, nil name, or
+  `disable_model_invocation` set), returns `is_error: true` ToolResult and
+  leaves `data` unchanged.
+  """
+  @spec activate_skill(Tau.Session.Data.t(), String.t() | nil, String.t()) ::
+          {Tau.Session.Data.t(), ToolResult.t()}
+  def activate_skill(data, nil, call_id) do
+    {data,
+     ToolResult.new(
+       tool_call_id: call_id,
+       tool_name: @activate_skill_tool_name,
+       content: "Skill activation failed: missing 'name' parameter.",
+       is_error: true
+     )}
+  end
+
+  def activate_skill(data, name, call_id) when is_binary(name) do
+    case List.keyfind(data.skills, name, 0) do
+      {^name, %Tau.Skill{disable_model_invocation: true}} ->
+        {data,
+         ToolResult.new(
+           tool_call_id: call_id,
+           tool_name: @activate_skill_tool_name,
+           content:
+             "Skill '#{name}' has disable-model-invocation set; it cannot be activated by the model.",
+           is_error: true
+         )}
+
+      {^name, %Tau.Skill{} = skill} ->
+        data =
+          %{data | active_skill: skill}
+          |> Tau.Session.Journal.persist("skill_activated", %{
+            skill_name: name,
+            tool_call_id: call_id,
+            allowed_tools: skill.allowed_tools
+          })
+
+        Tau.Session.broadcast(data.id, %Events.SkillActivated{
+          session_id: data.id,
+          skill_name: name,
+          tool_call_id: call_id
+        })
+
+        {data,
+         ToolResult.new(
+           tool_call_id: call_id,
+           tool_name: @activate_skill_tool_name,
+           content: "Skill activated: #{name}",
+           is_error: false
+         )}
+
+      nil ->
+        {data,
+         ToolResult.new(
+           tool_call_id: call_id,
+           tool_name: @activate_skill_tool_name,
+           content: "Unknown skill: #{name}",
+           is_error: true
+         )}
+    end
+  end
+
+  # --- Private helpers -------------------------------------------------------
+
+  defp skill_name_from_args(args) when is_map(args) do
+    Map.get(args, "name") || Map.get(args, :name)
+  end
+
+  defp skill_name_from_args(_), do: nil
+
+  defp skill_activation_tool_spec(skills) do
+    case model_invokable_skills(skills) do
+      [] ->
+        nil
+
+      list ->
+        names = Enum.map(list, fn {name, _s} -> name end)
+
+        descriptions =
+          list
+          |> Enum.map(fn {name, %Tau.Skill{description: d}} ->
+            case d do
+              "" -> "  - #{name}"
+              nil -> "  - #{name}"
+              desc -> "  - #{name}: #{desc}"
+            end
+          end)
+          |> Enum.join("\n")
+
+        description =
+          "Activate one of the available skills for the current turn. " <>
+            "Activation scopes subsequent tool calls to the skill's allowed_tools " <>
+            "whitelist (if set) and ends when you emit `end_turn`. " <>
+            "Available skills:\n" <> descriptions
+
+        %{
+          name: @activate_skill_tool_name,
+          description: description,
+          parameters: %{
+            "type" => "object",
+            "properties" => %{
+              "name" => %{
+                "type" => "string",
+                "enum" => names,
+                "description" => "Name of the skill to activate."
+              }
+            },
+            "required" => ["name"],
+            "additionalProperties" => false
+          }
+        }
+    end
+  end
+
+  defp model_invokable_skills(skills) do
+    Enum.reject(skills, fn {_name, s} -> s.disable_model_invocation end)
+  end
+
+  defp active_skill_tool_specs(nil), do: []
+
+  defp active_skill_tool_specs(%Tau.Skill{allowed_tools: []}) do
+    Tau.Tool.list()
+    |> Enum.sort()
+    |> Enum.flat_map(&tool_spec_for/1)
+  end
+
+  defp active_skill_tool_specs(%Tau.Skill{allowed_tools: names}) when is_list(names) do
+    names
+    |> Enum.uniq()
+    |> Enum.flat_map(&tool_spec_for/1)
+  end
+
+  defp tool_spec_for(name) when is_binary(name) do
+    case Tau.Tool.lookup(name) do
+      {:ok, mod} ->
+        [%{name: mod.name(), description: mod.description(), parameters: mod.parameters()}]
+
+      :error ->
+        []
+    end
+  end
+
+  defp render_skill(name, %Tau.Skill{description: desc, body: body}) do
+    header =
+      if is_binary(desc) and desc != "" do
+        "# Skill: #{name}\n\n_#{desc}_\n\n"
+      else
+        "# Skill: #{name}\n\n"
+      end
+
+    header <> body
+  end
+end

--- a/lib/tau/session/slash_command.ex
+++ b/lib/tau/session/slash_command.ex
@@ -1,0 +1,373 @@
+defmodule Tau.Session.SlashCommand do
+  @moduledoc """
+  Slash-command classification and dispatch for `Tau.Session`.
+
+  Parses incoming user messages for slash-command syntax, routes them to
+  the appropriate handler (built-in, async extension, file-command, skill
+  activation, or prompt template), and manages the supervised command-task
+  lifecycle (ADR-0008).
+
+  ## Precedence
+
+  Outermost wins:
+  `builtin > extension > file-command > skill > template > verbatim`
+
+  D-076: prompt templates sit last before verbatim fall-through so skills
+  and built-ins can shadow same-named templates.
+  """
+
+  alias Tau.Session.Events
+  alias Tau.Commands.Catalog
+
+  @doc """
+  Classify a user message for slash-command routing.
+
+  Returns one of:
+  - `{:builtin, mod, args, msg}` — registered built-in command
+  - `{:async, mod, args, msg}` — extension command with `execute/2`
+  - `{:skill_activation, skill, rewritten_msg}` — skill name match
+  - `{:model_command, args, msg}` — `/model` special case
+  - `{:unknown_command, "/name"}` — unrecognized slash with no args (D-101)
+  - `{:sync, msg}` — pass-through (no slash, or slash with args and no match)
+  """
+  @spec classify_slash_command(
+          Tau.Message.User.t(),
+          [{String.t(), Tau.Skill.t()}],
+          [{String.t(), Tau.PromptTemplate.t()}],
+          String.t()
+        ) ::
+          {:builtin, module(), String.t(), Tau.Message.User.t()}
+          | {:async, module(), String.t(), Tau.Message.User.t()}
+          | {:skill_activation, Tau.Skill.t(), Tau.Message.User.t()}
+          | {:model_command, String.t(), Tau.Message.User.t()}
+          | {:unknown_command, String.t()}
+          | {:sync, Tau.Message.User.t()}
+  def classify_slash_command(%Tau.Message.User{content: c} = msg, skills, templates, cwd)
+      when is_binary(c) do
+    case Tau.Commands.Parser.parse(c) do
+      {:command, "/model", args} ->
+        {:model_command, String.trim(args), msg}
+
+      {:command, "/" <> bare_name = name, args} ->
+        case Tau.Commands.Parser.lookup_builtin(name) do
+          {:ok, mod} ->
+            {:builtin, mod, args, msg}
+
+          :error ->
+            case Tau.Commands.Parser.lookup(name) do
+              {:ok, mod} when is_atom(mod) ->
+                if function_exported?(mod, :execute, 2) do
+                  {:async, mod, args, msg}
+                else
+                  {:sync, msg}
+                end
+
+              {:ok, path} when is_binary(path) ->
+                {:sync, invoke_file_command(path, args, msg)}
+
+              :error ->
+                case Tau.Commands.Parser.lookup_skill(bare_name, skills) do
+                  {:ok, skill} ->
+                    rewritten = %Tau.Message.User{msg | content: args}
+                    {:skill_activation, skill, rewritten}
+
+                  :error ->
+                    # Not a skill — check prompt templates.
+                    # D-076: template match rewrites the user message with the
+                    # rendered body and returns {:sync, msg}.
+                    case List.keyfind(templates, bare_name, 0) do
+                      {_name, template} ->
+                        context = build_template_context(cwd)
+                        {:ok, rendered} = Tau.PromptTemplates.render(template, args, context)
+                        rewritten = %Tau.Message.User{msg | content: rendered}
+                        {:sync, rewritten}
+
+                      nil ->
+                        unknown_or_passthrough(bare_name, args, msg)
+                    end
+                end
+            end
+        end
+
+      _ ->
+        {:sync, msg}
+    end
+  end
+
+  def classify_slash_command(msg, _skills, _templates, _cwd), do: {:sync, msg}
+
+  @doc """
+  Spawn a supervised task for an async slash command.
+
+  Starts a child under `Tau.Tools.TaskSupervisor`, delivers the result to the
+  FSM via `Process.send`, and schedules a timeout. Returns
+  `{:keep_state, updated_data}`.
+  """
+  @spec spawn_command_task(module(), String.t(), Tau.Message.User.t(), Tau.Session.Data.t()) ::
+          :gen_statem.event_handler_result()
+  def spawn_command_task(mod, args, msg, data) do
+    parent = self()
+    ctx = build_command_ctx(data)
+    timeout_ms = Application.get_env(:tau, :slash_command_timeout_ms, 30_000)
+
+    {:ok, pid} =
+      Task.Supervisor.start_child(Tau.Tools.TaskSupervisor, fn ->
+        result =
+          try do
+            case prepare_command_args(mod, args) do
+              {:ok, prepared} -> mod.execute(prepared, ctx)
+              {:error, _} = err -> err
+            end
+          rescue
+            e -> {:crashed, Exception.message(e)}
+          catch
+            kind, value -> {:crashed, "uncaught #{kind}: #{inspect(value)}"}
+          end
+
+        Process.send(parent, {:command_done, result, msg}, [])
+      end)
+
+    Process.send_after(self(), {:command_timeout, pid, msg, timeout_ms}, timeout_ms)
+
+    {:keep_state, %{data | command_task: pid}}
+  end
+
+  @doc """
+  Apply the result of a slash-command task to the original user message.
+
+  Transforms the message content based on the command outcome.
+  """
+  @spec apply_command_result(term(), Tau.Message.User.t()) :: Tau.Message.User.t()
+  def apply_command_result(result, msg) do
+    case result do
+      {:inject, prefix} when is_binary(prefix) ->
+        %Tau.Message.User{msg | content: prefix <> "\n\n" <> msg.content}
+
+      {:replace, replacement} when is_binary(replacement) ->
+        %Tau.Message.User{msg | content: replacement}
+
+      {:run, replacement} when is_binary(replacement) ->
+        %Tau.Message.User{msg | content: replacement}
+
+      :ignore ->
+        msg
+
+      {:crashed, reason} ->
+        %Tau.Message.User{
+          msg
+          | content: "(slash command crashed: #{reason})\n\n" <> msg.content
+        }
+
+      {:timeout, ms} ->
+        %Tau.Message.User{
+          msg
+          | content: "(slash command timed out after #{ms}ms)\n\n" <> msg.content
+        }
+
+      {:error, reason} ->
+        %Tau.Message.User{
+          msg
+          | content:
+              "(slash command argument error: #{Tau.Command.Spec.format_error(reason)})\n\n" <>
+                msg.content
+        }
+
+      _ ->
+        msg
+    end
+  end
+
+  @doc """
+  Dispatch `mod.run(args, data)` for a built-in slash command and map the
+  typed outcome to FSM actions (D-042).
+
+  CRITICAL: `{:notice}`, `{:mutate}`, and `{:error}` branches MUST NOT call
+  `process_user_message/2` — no provider turn is started. Only `:passthrough`
+  falls through to the normal provider path.
+  """
+  @spec handle_builtin_command(module(), String.t(), Tau.Message.User.t(), Tau.Session.Data.t()) ::
+          :gen_statem.event_handler_result()
+  def handle_builtin_command(mod, args, original_msg, data) do
+    outcome = mod.run(args, data)
+
+    :telemetry.execute(
+      [:tau, :session, :builtin_command],
+      %{},
+      %{session_id: data.id, command: mod.name(), outcome: outcome_tag(outcome)}
+    )
+
+    case outcome do
+      {:notice, text} when is_binary(text) ->
+        Tau.Session.broadcast(data.id, %Events.SystemNotice{session_id: data.id, text: text})
+        {:keep_state, data}
+
+      {:notice, lines} when is_list(lines) ->
+        Enum.each(lines, fn line ->
+          Tau.Session.broadcast(data.id, %Events.SystemNotice{session_id: data.id, text: line})
+        end)
+
+        {:keep_state, data}
+
+      {:mutate, fun, notice} when is_function(fun, 1) ->
+        data2 = fun.(data)
+
+        if is_binary(notice) do
+          Tau.Session.broadcast(data2.id, %Events.SystemNotice{
+            session_id: data2.id,
+            text: notice
+          })
+        end
+
+        # D-108 (SPEC-TUI-COMPLETION §4 B1): re-broadcast the catalog after
+        # any {:mutate} outcome so /reload's updated skills and templates are
+        # reflected in the TUI menu immediately.
+        catalog_entries2 = Catalog.list(data2)
+
+        Tau.Session.broadcast(data2.id, %Events.CommandCatalog{
+          session_id: data2.id,
+          entries: catalog_entries2
+        })
+
+        {:keep_state, data2}
+
+      {:error, text} ->
+        Tau.Session.broadcast(
+          data.id,
+          %Events.SystemNotice{session_id: data.id, text: "Error: " <> text}
+        )
+
+        {:keep_state, data}
+
+      {:async_compact, notice} ->
+        # The only outcome that changes FSM state (to :compacting).
+        Tau.Session.broadcast(data.id, %Events.SystemNotice{session_id: data.id, text: notice})
+        # D-163: broadcast CompactionStarted before entering :compacting so the
+        # TUI status bar transitions to :running before the task is spawned.
+        Tau.Session.broadcast(data.id, %Events.CompactionStarted{session_id: data.id})
+
+        ctx = %{provider: data.provider, model: data.model}
+        timeout_ms = Application.get_env(:tau, :compaction_timeout_ms, 60_000)
+
+        task =
+          Task.Supervisor.async_nolink(Tau.Tools.TaskSupervisor, fn ->
+            Tau.Compactor.impl().compact(data.messages, ctx)
+          end)
+
+        :telemetry.execute([:tau, :compaction, :start], %{system_time: System.system_time()}, %{
+          session_id: data.id,
+          message_count: length(data.messages),
+          async: true
+        })
+
+        Process.send_after(self(), {:compaction_timeout, task.pid, timeout_ms}, timeout_ms)
+
+        {:next_state, :compacting,
+         %{data | compaction_task: task.pid, compaction_monitor: task.ref}}
+
+      :passthrough ->
+        # Fall through to the normal provider turn with the original message.
+        Tau.Session.process_user_message(original_msg, data)
+    end
+  end
+
+  @doc """
+  Return the outcome tag atom for telemetry.
+  """
+  @spec outcome_tag(term()) :: atom()
+  def outcome_tag({:notice, _}), do: :notice
+  def outcome_tag({:mutate, _, _}), do: :mutate
+  def outcome_tag({:error, _}), do: :error
+  def outcome_tag({:async_compact, _}), do: :async_compact
+  def outcome_tag(:passthrough), do: :passthrough
+
+  @doc """
+  Handle a `{:command_done, result, original_msg}` info message in any state.
+
+  Applies the command result and routes through `process_user_message/2`.
+  """
+  @spec handle_command_done(term(), Tau.Message.User.t(), Tau.Session.Data.t()) ::
+          :gen_statem.event_handler_result()
+  def handle_command_done(result, original_msg, data) do
+    msg = apply_command_result(result, original_msg)
+    Tau.Session.process_user_message(msg, %{data | command_task: nil})
+  end
+
+  @doc """
+  Handle a live command timeout. Kills the task and routes through
+  `process_user_message/2` with a `{:timeout, ms}` result.
+  """
+  @spec handle_command_timeout_live(
+          pid(),
+          Tau.Message.User.t(),
+          non_neg_integer(),
+          Tau.Session.Data.t()
+        ) ::
+          :gen_statem.event_handler_result()
+  def handle_command_timeout_live(pid, original_msg, ms, data) do
+    if Process.alive?(pid), do: Process.exit(pid, :brutal_kill)
+    msg = apply_command_result({:timeout, ms}, original_msg)
+    Tau.Session.process_user_message(msg, %{data | command_task: nil})
+  end
+
+  @doc """
+  Handle a stale command timeout (task already completed). Drop.
+  """
+  @spec handle_command_timeout_stale(Tau.Session.Data.t()) :: :gen_statem.event_handler_result()
+  def handle_command_timeout_stale(data) do
+    {:keep_state, data}
+  end
+
+  # --- Private helpers -------------------------------------------------------
+
+  # D-101 / SPEC-TUI-COMPLETION: only intercept whitespace-free tokens
+  # (args == "") with no catalog match. When args is non-empty the user provided
+  # arguments, pass through to the model (AC-7 guard).
+  defp unknown_or_passthrough(bare_name, "", _msg), do: {:unknown_command, "/" <> bare_name}
+  defp unknown_or_passthrough(_bare_name, _args, msg), do: {:sync, msg}
+
+  defp build_template_context(cwd) do
+    user =
+      case System.user_home() do
+        nil -> ""
+        home -> Path.basename(home)
+      end
+
+    %{
+      "cwd" => cwd,
+      "date" => DateTime.utc_now() |> DateTime.to_date() |> Date.to_iso8601(),
+      "user" => user,
+      "cursor" => ""
+    }
+  end
+
+  defp prepare_command_args(mod, args) when is_binary(args) do
+    if function_exported?(mod, :parameters, 0) do
+      Tau.Command.Spec.parse(mod.parameters(), args)
+    else
+      {:ok, args}
+    end
+  end
+
+  defp prepare_command_args(_mod, args), do: {:ok, args}
+
+  defp build_command_ctx(data) do
+    sid = data.id
+
+    Tau.Command.Context.new(
+      session_id: sid,
+      cwd: data.cwd,
+      permissions_mode: Map.get(data.metadata, :permissions_mode, :default),
+      emit: fn payload ->
+        Phoenix.PubSub.broadcast(Tau.PubSub, "session:#{sid}", payload)
+      end,
+      metadata: data.metadata
+    )
+  end
+
+  defp invoke_file_command(path, args, msg) do
+    case File.read(path) do
+      {:ok, body} -> %Tau.Message.User{msg | content: body <> "\n\n" <> args}
+      _ -> msg
+    end
+  end
+end

--- a/lib/tau/session/tool_dispatch.ex
+++ b/lib/tau/session/tool_dispatch.ex
@@ -1,0 +1,1060 @@
+defmodule Tau.Session.ToolDispatch do
+  @moduledoc """
+  Tool dispatch, permission round, and tool-loop brake helpers for `Tau.Session`.
+
+  Encapsulates the parallel tool-dispatch contract (D-005 / AC-6 / D-060 /
+  D-091 / SPEC-PERMISSION-PROMPTS §4).
+
+  ## Invariants
+
+  - D-005 / AC-6: per-turn tool-call iteration cap is enforced in
+    `dispatch_tools/2` before dispatching the next round. `tool_iterations`
+    counts dispatched rounds, not individual calls.
+  - D-060: a `(tool_name, args_hash, error_message)` triple that repeats
+    `tool_loop_brake_threshold` consecutive times triggers
+    `emit_tool_loop_brake_abort/2`, which aborts the turn with
+    `stop_reason: :tool_loop_aborted`. A successful dispatch resets the counter.
+  - D-091: when an interactive session has `:ask`-verdict calls, the FSM
+    enters `:awaiting_permission` and ALL calls (including pre-approved
+    `:allow` calls) are held in `permission_dispatch_batch` until the last
+    pending request is resolved in `finish_permission_round/1`.
+  - D-035 (canonical `try/rescue` sites): `tool_args_hash/1` wraps
+    `Jason.encode!/1` in `try/rescue`. `run_tool_validated/6` wraps the tool
+    `execute/2` call. Both are preserved exactly — removal is out of scope.
+  """
+
+  alias Tau.Message.{Assistant, ToolResult}
+  alias Tau.Session.Events
+
+  @doc """
+  Main dispatch entry-point called from `Tau.Session.ProviderTurn.finalize_assistant/2`
+  and by `Tau.Session.ProviderTurn.handle_end_turn/2`.
+
+  Runs skill-activation interception, whitelist filtering, permission evaluation,
+  and either transitions to `:awaiting_permission` (interactive with `:ask` calls)
+  or spawns the parallel dispatcher and transitions to `:tool_executing`.
+  """
+  @spec dispatch_tools(list(), Tau.Session.Data.t()) :: :gen_statem.event_handler_result()
+  def dispatch_tools(tool_calls, data) do
+    parent = self()
+
+    call_lookups =
+      Enum.into(tool_calls, %{}, fn %{id: id, name: name, arguments: args} ->
+        {id, {name, tool_args_hash(args)}}
+      end)
+
+    {activation_calls, tool_calls} =
+      Enum.split_with(tool_calls, fn %{name: name} ->
+        name == Tau.Session.activate_skill_tool_name()
+      end)
+
+    {data, activated_in_flight} =
+      Tau.Session.SkillActivation.handle_skill_activations(activation_calls, data, parent)
+
+    {whitelisted_out, tool_calls} = split_tools_whitelist(tool_calls, data.tools_whitelist)
+
+    Enum.each(whitelisted_out, fn %{id: id, name: name} ->
+      result =
+        ToolResult.new(
+          tool_call_id: id,
+          tool_name: name,
+          content: "Tool '#{name}' not in this session's whitelist.",
+          is_error: true
+        )
+
+      Process.send(parent, {:tool_done, id, result}, [])
+
+      :telemetry.execute(
+        [:tau, :session, :tool_whitelisted],
+        %{system_time: System.system_time()},
+        %{
+          session_id: data.id,
+          tool_name: name,
+          whitelist_size: whitelist_size(data.tools_whitelist)
+        }
+      )
+    end)
+
+    rule_set = Tau.Permissions.RuleSet.get()
+    mode = Map.get(data.metadata, :permissions_mode, :default)
+
+    eval_ctx = %{cwd: data.cwd, active_skill: data.active_skill}
+
+    {gated, ask_calls, allowed} =
+      Enum.reduce(
+        tool_calls,
+        {[], [], []},
+        fn %{name: name, arguments: args} = call, {denied, asking, allowed_acc} ->
+          case Tau.Permissions.Evaluator.evaluate(rule_set, name, args, eval_ctx, mode) do
+            :deny -> {[call | denied], asking, allowed_acc}
+            :ask -> {denied, [call | asking], allowed_acc}
+            :allow -> {denied, asking, [call | allowed_acc]}
+          end
+        end
+      )
+
+    gated = Enum.reverse(gated)
+    ask_calls = Enum.reverse(ask_calls)
+    allowed = Enum.reverse(allowed)
+
+    Enum.each(gated, fn %{id: id, name: name} ->
+      result =
+        ToolResult.new(
+          tool_call_id: id,
+          tool_name: name,
+          content: deny_reason(name, data.active_skill),
+          is_error: true
+        )
+
+      Process.send(parent, {:tool_done, id, result}, [])
+
+      :telemetry.execute(
+        [:tau, :permissions, :decision],
+        %{system_time: System.system_time()},
+        %{
+          tool: name,
+          tool_call_id: id,
+          decision: :deny,
+          session_id: data.id
+        }
+      )
+    end)
+
+    {data, ask_in_flight} =
+      if data.interactive? do
+        pending =
+          Enum.reduce(ask_calls, %{}, fn %{id: id, name: name, arguments: args}, acc ->
+            :telemetry.execute(
+              [:tau, :permissions, :request],
+              %{system_time: System.system_time()},
+              %{session_id: data.id, tool_call_id: id, tool_name: name}
+            )
+
+            Tau.Session.broadcast(data.id, %Events.PermissionRequest{
+              session_id: data.id,
+              tool_call_id: id,
+              name: name,
+              arguments: args,
+              decision_reason: "Tool not matched by any allow rule in current mode."
+            })
+
+            Map.put(acc, id, %{name: name, arguments: args})
+          end)
+
+        ask_in_flight = Enum.into(ask_calls, %{}, fn %{id: id} -> {id, :awaiting_permission} end)
+        {%{data | pending_permission_requests: pending}, ask_in_flight}
+      else
+        Enum.each(ask_calls, fn %{id: id, name: name} ->
+          result =
+            ToolResult.new(
+              tool_call_id: id,
+              tool_name: name,
+              content:
+                "Permission required for #{name} but session is non-interactive; denied by policy.",
+              is_error: true
+            )
+
+          Process.send(parent, {:tool_done, id, result}, [])
+
+          :telemetry.execute(
+            [:tau, :permissions, :decision],
+            %{system_time: System.system_time()},
+            %{
+              session_id: data.id,
+              tool_call_id: id,
+              tool_name: name,
+              decision: :deny_non_interactive
+            }
+          )
+        end)
+
+        ask_in_flight = Enum.into(ask_calls, %{}, fn %{id: id} -> {id, :denied} end)
+        {data, ask_in_flight}
+      end
+
+    if data.interactive? and ask_calls != [] do
+      allow_batch =
+        Enum.map(allowed, fn %{id: id, name: name, arguments: args} ->
+          {id, name, args}
+        end)
+
+      initial_in_flight =
+        ask_in_flight
+        |> Map.merge(Enum.into(gated, %{}, fn %{id: id} -> {id, :denied} end))
+        |> Map.merge(Enum.into(whitelisted_out, %{}, fn %{id: id} -> {id, :whitelist_filtered} end))
+        |> Map.merge(activated_in_flight)
+
+      Tau.Session.transition(data.id, data, :awaiting_permission)
+
+      {:next_state, :awaiting_permission,
+       %{
+         data
+         | tools_in_flight: initial_in_flight,
+           tool_dispatcher: nil,
+           permission_dispatch_batch: allow_batch,
+           permission_pending_results: [],
+           provider_task: nil,
+           assembler: nil,
+           stream_ref: nil,
+           provider_span_ref: nil,
+           tool_loop_call_lookups: Map.merge(data.tool_loop_call_lookups, call_lookups)
+       }}
+    else
+      {_hook_denied, parallel_calls} =
+        Enum.reduce(
+          allowed,
+          {[], []},
+          fn %{id: id, name: name, arguments: args}, {denied, kept} ->
+            case Tau.Hooks.Dispatcher.run(
+                   :pre_tool_use,
+                   Tau.Session.hook_payload(data, :pre_tool_use, %{
+                     tool_name: name,
+                     tool_call_id: id,
+                     tool_input: args
+                   })
+                 ) do
+              {:halt, reason} ->
+                result =
+                  ToolResult.new(
+                    tool_call_id: id,
+                    tool_name: name,
+                    content: "Hook blocked: #{inspect(reason)}",
+                    is_error: true
+                  )
+
+                Process.send(parent, {:tool_done, id, result}, [])
+                {[id | denied], kept}
+
+              {:deny, reason} ->
+                result =
+                  ToolResult.new(
+                    tool_call_id: id,
+                    tool_name: name,
+                    content: "Hook denied: #{reason}",
+                    is_error: true
+                  )
+
+                Process.send(parent, {:tool_done, id, result}, [])
+                {[id | denied], kept}
+
+              {:cont, payload} ->
+                rewritten_args = Map.get(payload, :tool_input, args)
+                {denied, [{id, name, rewritten_args} | kept]}
+            end
+          end
+        )
+
+      parallel_calls = Enum.reverse(parallel_calls)
+
+      call_lookups =
+        Enum.reduce(parallel_calls, call_lookups, fn {id, name, args}, acc ->
+          Map.put(acc, id, {name, tool_args_hash(args)})
+        end)
+
+      dispatcher_pid =
+        case parallel_calls do
+          [] -> nil
+          _ -> spawn_parallel_dispatcher(parallel_calls, data, parent)
+        end
+
+      real_tasks = Enum.into(parallel_calls, %{}, fn {id, _n, _a} -> {id, :running} end)
+
+      initial_in_flight =
+        real_tasks
+        |> Map.merge(ask_in_flight)
+        |> Map.merge(Enum.into(gated, %{}, fn %{id: id} -> {id, :denied} end))
+        |> Map.merge(Enum.into(whitelisted_out, %{}, fn %{id: id} -> {id, :whitelist_filtered} end))
+        |> Map.merge(activated_in_flight)
+
+      Tau.Session.transition(data.id, data, :tool_executing)
+
+      {:next_state, :tool_executing,
+       %{
+         data
+         | tools_in_flight: initial_in_flight,
+           tool_dispatcher: dispatcher_pid,
+           provider_task: nil,
+           assembler: nil,
+           stream_ref: nil,
+           provider_span_ref: nil,
+           tool_loop_call_lookups: Map.merge(data.tool_loop_call_lookups, call_lookups)
+       }}
+    end
+  end
+
+  @doc """
+  Called when the last pending permission request resolves.
+
+  Emits accumulated instant-resolve results (`permission_pending_results`),
+  runs `:pre_tool_use` hooks on the approved batch, and either dispatches the
+  parallel batch (transitioning to `:tool_executing`) or re-invokes
+  `:start_provider` directly when no approved calls remain.
+  """
+  @spec finish_permission_round(Tau.Session.Data.t()) :: :gen_statem.event_handler_result()
+  def finish_permission_round(data) do
+    parent = self()
+
+    tools_in_flight_after =
+      Map.reject(data.tools_in_flight, fn {_id, status} -> status == :awaiting_permission end)
+
+    data =
+      Enum.reduce(
+        Enum.reverse(data.permission_pending_results),
+        %{data | tools_in_flight: tools_in_flight_after},
+        fn {call_id, result_msg}, acc ->
+          {_lookup, call_lookups_rest} = Map.pop(acc.tool_loop_call_lookups, call_id)
+
+          acc =
+            acc
+            |> Tau.Session.append_message(result_msg)
+            |> Tau.Session.Journal.persist(
+              "tool_result",
+              Tau.Session.Journal.tool_result_to_data(result_msg)
+            )
+            |> Map.put(:tool_loop_call_lookups, call_lookups_rest)
+
+          Tau.Session.broadcast(acc.id, %Events.ToolEnd{
+            session_id: acc.id,
+            tool_call_id: call_id,
+            result: result_msg
+          })
+
+          acc
+        end
+      )
+
+    batch = Enum.reverse(data.permission_dispatch_batch)
+
+    data = %{
+      data
+      | pending_permission_requests: %{},
+        permission_dispatch_batch: [],
+        permission_pending_results: []
+    }
+
+    {hook_denied_results, parallel_calls} =
+      Enum.reduce(
+        batch,
+        {[], []},
+        fn {id, name, args}, {denied_acc, kept} ->
+          case Tau.Hooks.Dispatcher.run(
+                 :pre_tool_use,
+                 Tau.Session.hook_payload(data, :pre_tool_use, %{
+                   tool_name: name,
+                   tool_call_id: id,
+                   tool_input: args
+                 })
+               ) do
+            {:halt, reason} ->
+              result =
+                ToolResult.new(
+                  tool_call_id: id,
+                  tool_name: name,
+                  content: "Hook blocked: #{inspect(reason)}",
+                  is_error: true
+                )
+
+              {[{id, result} | denied_acc], kept}
+
+            {:deny, reason} ->
+              result =
+                ToolResult.new(
+                  tool_call_id: id,
+                  tool_name: name,
+                  content: "Hook denied: #{reason}",
+                  is_error: true
+                )
+
+              {[{id, result} | denied_acc], kept}
+
+            {:cont, payload} ->
+              rewritten_args = Map.get(payload, :tool_input, args)
+              {denied_acc, [{id, name, rewritten_args} | kept]}
+          end
+        end
+      )
+
+    parallel_calls = Enum.reverse(parallel_calls)
+
+    call_lookups =
+      Enum.reduce(parallel_calls, data.tool_loop_call_lookups, fn {id, name, args}, acc ->
+        Map.put(acc, id, {name, tool_args_hash(args)})
+      end)
+
+    data =
+      Enum.reduce(
+        hook_denied_results,
+        %{data | tool_loop_call_lookups: call_lookups},
+        fn {call_id, result_msg}, acc ->
+          {_lookup, call_lookups_rest} = Map.pop(acc.tool_loop_call_lookups, call_id)
+
+          acc =
+            acc
+            |> Tau.Session.append_message(result_msg)
+            |> Tau.Session.Journal.persist(
+              "tool_result",
+              Tau.Session.Journal.tool_result_to_data(result_msg)
+            )
+            |> Map.put(:tool_loop_call_lookups, call_lookups_rest)
+
+          Tau.Session.broadcast(acc.id, %Events.ToolEnd{
+            session_id: acc.id,
+            tool_call_id: call_id,
+            result: result_msg
+          })
+
+          acc
+        end
+      )
+
+    if parallel_calls == [] do
+      Tau.Session.handle_event(
+        :internal,
+        :start_provider,
+        :provider_streaming,
+        %{data | tools_in_flight: %{}, tool_dispatcher: nil}
+      )
+    else
+      dispatcher_pid = spawn_parallel_dispatcher(parallel_calls, data, parent)
+      running = Enum.into(parallel_calls, %{}, fn {id, _n, _a} -> {id, :running} end)
+
+      {:next_state, :tool_executing,
+       %{data | tools_in_flight: running, tool_dispatcher: dispatcher_pid}}
+    end
+  end
+
+  @doc """
+  Split tool calls into `{filtered_out, kept}` based on `tools_whitelist`.
+
+  `:all` is the no-op (everything kept). A list keeps only calls whose `name`
+  is in the list. Ordering is preserved.
+  """
+  @spec split_tools_whitelist(list(), :all | list()) :: {list(), list()}
+  def split_tools_whitelist(tool_calls, :all), do: {[], tool_calls}
+
+  def split_tools_whitelist(tool_calls, list) when is_list(list) do
+    Enum.split_with(tool_calls, fn %{name: name} -> name not in list end)
+  end
+
+  @doc """
+  Return the effective whitelist size for telemetry.
+  """
+  @spec whitelist_size(:all | list()) :: :all | non_neg_integer()
+  def whitelist_size(:all), do: :all
+  def whitelist_size(list) when is_list(list), do: length(list)
+
+  @doc """
+  Compute a SHA-256 hash of tool arguments in canonical form.
+
+  Canonical form: keys sorted recursively, encoded with `Jason.encode!/1`.
+  Falls back to `inspect/1` if Jason cannot encode the arguments (D-035
+  try/rescue site — preserved as-is).
+  """
+  @spec tool_args_hash(map() | nil) :: String.t()
+  def tool_args_hash(args) do
+    canonical =
+      try do
+        Jason.encode!(canonicalize_for_hash(args || %{}))
+      rescue
+        _ -> inspect(args, limit: :infinity, printable_limit: :infinity)
+      end
+
+    :crypto.hash(:sha256, canonical) |> Base.encode16(case: :lower)
+  end
+
+  @doc """
+  Recursively sort map keys and normalise key type to string for hashing.
+  """
+  @spec canonicalize_for_hash(term()) :: term()
+  def canonicalize_for_hash(%{} = m) do
+    m
+    |> Enum.map(fn {k, v} -> {to_string(k), canonicalize_for_hash(v)} end)
+    |> Enum.sort_by(fn {k, _} -> k end)
+    |> Enum.into(%{})
+  end
+
+  def canonicalize_for_hash(list) when is_list(list),
+    do: Enum.map(list, &canonicalize_for_hash/1)
+
+  def canonicalize_for_hash(other), do: other
+
+  @doc """
+  Evaluate whether the tool-loop brake threshold has been reached.
+
+  Returns `{:continue, data}` for normal flow or `{:brake, data}` when the
+  threshold is reached. A successful (non-error) result clears the whole brake
+  table for the turn — evidence the model has un-wedged.
+  """
+  @spec maybe_apply_tool_loop_brake(Tau.Session.Data.t(), term(), struct()) ::
+          {:continue, Tau.Session.Data.t()} | {:brake, Tau.Session.Data.t()}
+  def maybe_apply_tool_loop_brake(data, nil, _result_msg), do: {:continue, data}
+
+  def maybe_apply_tool_loop_brake(data, _lookup, %ToolResult{is_error: false}),
+    do: {:continue, reset_tool_loop_state(data)}
+
+  def maybe_apply_tool_loop_brake(data, {name, args_hash}, %ToolResult{
+        is_error: true,
+        content: error_text
+      }) do
+    key = {name, args_hash}
+    error_str = to_string(error_text || "")
+    prev = Map.get(data.tool_loop_state, key)
+
+    cell =
+      case prev do
+        %{count: c, error: ^error_str} -> %{count: c + 1, error: error_str}
+        _ -> %{count: 1, error: error_str}
+      end
+
+    state2 = Map.put(data.tool_loop_state, key, cell)
+    data2 = %{data | tool_loop_state: state2}
+
+    if cell.count >= data2.tool_loop_brake_threshold do
+      {:brake, data2}
+    else
+      {:continue, data2}
+    end
+  end
+
+  @doc """
+  Clear the per-turn brake table.
+
+  Called on a successful tool dispatch to signal the model has un-wedged.
+  """
+  @spec reset_tool_loop_state(Tau.Session.Data.t()) :: Tau.Session.Data.t()
+  def reset_tool_loop_state(data), do: %{data | tool_loop_state: %{}}
+
+  @doc """
+  Synthesise the tool-loop-brake escalation notice and abort the turn.
+
+  Broadcasts `%SystemNotice{}`, appends an `%Assistant{stop_reason:
+  :tool_loop_aborted}` message, and transitions to `:awaiting_user`.
+  """
+  @spec emit_tool_loop_brake_abort(Tau.Session.Data.t(), map()) ::
+          :gen_statem.event_handler_result()
+  def emit_tool_loop_brake_abort(data, tools) do
+    {{name, args_hash}, %{count: count, error: error_str}} =
+      Enum.max_by(data.tool_loop_state, fn {_k, %{count: c}} -> c end)
+
+    notice_text =
+      "Tool '#{name}' has been called with identical arguments #{count}x in a row, " <>
+        "each time rejected with: '#{error_str}'. Halting this turn."
+
+    :telemetry.execute(
+      [:tau, :session, :tool_loop_brake],
+      %{count: count},
+      %{
+        session_id: data.id,
+        tool_name: name,
+        args_hash: args_hash,
+        error: error_str
+      }
+    )
+
+    Tau.Session.broadcast(data.id, %Events.SystemNotice{session_id: data.id, text: notice_text})
+
+    abort_msg =
+      Assistant.new(
+        stop_reason: :tool_loop_aborted,
+        content: [%{type: :text, text: notice_text}]
+      )
+
+    data =
+      data
+      |> Tau.Session.append_message(abort_msg)
+      |> Tau.Session.Journal.persist(
+        "assistant_message",
+        Tau.Session.Journal.message_to_data(abort_msg)
+      )
+
+    Tau.Session.broadcast(data.id, %Events.MessageEnd{session_id: data.id, message: abort_msg})
+
+    next_data = %{
+      data
+      | provider_task: nil,
+        assembler: nil,
+        cancel_flag: nil,
+        stream_ref: nil,
+        provider_span_ref: nil,
+        tools_in_flight: tools,
+        tool_dispatcher: nil,
+        tool_iterations: 0,
+        tool_loop_state: %{},
+        tool_loop_call_lookups: %{},
+        provider_retry_state: %{count: 0}
+    }
+
+    actions =
+      if :queue.is_empty(next_data.followup_queue),
+        do: [],
+        else: [{:next_event, :internal, :drain_followups}]
+
+    {:next_state, :awaiting_user, next_data, actions}
+  end
+
+  @doc """
+  Format the deny reason for a permission-denied tool call.
+
+  When an active skill is in effect and the tool is not on its `allowed_tools`
+  list, the denial is attributed to the skill; otherwise it came from a
+  rule-set deny rule.
+  """
+  @spec deny_reason(String.t(), struct() | nil) :: String.t()
+  def deny_reason(name, %Tau.Skill{name: skill_name, allowed_tools: list})
+      when is_list(list) and list != [] do
+    if name in list do
+      "Permission denied: #{name} blocked by deny rule"
+    else
+      "Tool '#{name}' not on active skill '#{skill_name}' allowed_tools whitelist"
+    end
+  end
+
+  def deny_reason(name, _active_skill),
+    do: "Permission denied: #{name} blocked by deny rule"
+
+  @doc """
+  Lookup and execute a tool by name, handling validation errors and unknown tools.
+
+  Returns a `%ToolResult{}` — never raises.
+  """
+  @spec run_tool(String.t(), String.t(), map() | nil, Tau.Session.Data.t()) :: struct()
+  def run_tool(name, call_id, args, data) do
+    started = System.monotonic_time(:millisecond)
+
+    case Tau.Tool.lookup(name) do
+      {:ok, mod} ->
+        case Tau.Tool.Validator.validate(mod, args) do
+          :ok ->
+            run_tool_validated(name, call_id, args, data, mod, started)
+
+          {:error, errors} ->
+            summary = Tau.Tool.Validator.format_errors(errors)
+
+            :telemetry.execute(
+              [:tau, :tool, :validate, :error],
+              %{system_time: System.system_time()},
+              %{tool: name, tool_call_id: call_id, errors: summary}
+            )
+
+            ToolResult.new(
+              tool_call_id: call_id,
+              tool_name: name,
+              content: "Invalid arguments for tool #{name}: #{summary}",
+              is_error: true
+            )
+        end
+
+      :error ->
+        ToolResult.new(
+          tool_call_id: call_id,
+          tool_name: name,
+          content: "Unknown tool: #{name}",
+          is_error: true
+        )
+    end
+  end
+
+  @doc """
+  Execute a validated tool, wrapping in `try/rescue` (D-035 site — preserved).
+
+  Emits `[:tau, :tool, :execute, :start]` / `[:tau, :tool, :execute, :stop]` pair
+  and `[:tau, :tool, :execute, :exception]` on raise. Returns a `%ToolResult{}`.
+  """
+  @spec run_tool_validated(
+          String.t(),
+          String.t(),
+          map() | nil,
+          Tau.Session.Data.t(),
+          module(),
+          integer()
+        ) :: struct()
+  def run_tool_validated(name, call_id, args, data, mod, started) do
+    ctx =
+      Tau.Tool.Context.new(
+        tool_call_id: call_id,
+        session_id: data.id,
+        cwd: data.cwd,
+        emit: fn payload ->
+          Tau.Session.broadcast(data.id, %Events.ToolUpdate{
+            session_id: data.id,
+            tool_call_id: call_id,
+            payload: payload
+          })
+
+          :ok
+        end
+      )
+
+    :telemetry.execute(
+      [:tau, :tool, :execute, :start],
+      %{system_time: System.system_time()},
+      %{tool: name, tool_call_id: call_id}
+    )
+
+    result =
+      try do
+        case mod.execute(args || %{}, ctx) do
+          {:ok, %Tau.Tool.Result{} = r} ->
+            ToolResult.new(
+              tool_call_id: call_id,
+              tool_name: name,
+              content: r.content,
+              details: r.details,
+              is_error: r.is_error
+            )
+
+          {:error, reason} ->
+            ToolResult.new(
+              tool_call_id: call_id,
+              tool_name: name,
+              content: "Tool error: #{inspect(reason)}",
+              is_error: true
+            )
+        end
+      rescue
+        e ->
+          :telemetry.execute(
+            [:tau, :tool, :execute, :exception],
+            %{duration: System.monotonic_time(:millisecond) - started},
+            %{tool: name, tool_call_id: call_id, error: Exception.message(e)}
+          )
+
+          ToolResult.new(
+            tool_call_id: call_id,
+            tool_name: name,
+            content: "Tool exception: #{Exception.message(e)}",
+            is_error: true
+          )
+      end
+
+    :telemetry.execute(
+      [:tau, :tool, :execute, :stop],
+      %{duration: System.monotonic_time(:millisecond) - started},
+      %{tool: name, tool_call_id: call_id, is_error: result.is_error}
+    )
+
+    result
+  end
+
+  @doc """
+  Spawn the parallel tool dispatcher under `Tau.Tools.TaskSupervisor`.
+
+  A single iterator process drives the `async_stream_nolink` pipeline; crashes
+  surface as `{:exit, reason}` and are synthesised into `is_error: true`
+  ToolResults so the FSM never loses a tool_call → tool_result correspondence.
+  Returns the dispatcher `pid`.
+  """
+  @spec spawn_parallel_dispatcher(list(), Tau.Session.Data.t(), pid()) :: pid()
+  def spawn_parallel_dispatcher(parallel_calls, data, parent) do
+    {:ok, pid} =
+      Task.Supervisor.start_child(Tau.Tools.TaskSupervisor, fn ->
+        Enum.each(parallel_calls, fn {id, name, args} ->
+          Tau.Session.broadcast(data.id, %Events.ToolStart{
+            session_id: data.id,
+            tool_call_id: id,
+            name: name,
+            arguments: args
+          })
+        end)
+
+        Tau.Tools.TaskSupervisor
+        |> Task.Supervisor.async_stream_nolink(
+          parallel_calls,
+          fn {id, name, args} -> run_tool(name, id, args, data) end,
+          max_concurrency: System.schedulers_online(),
+          timeout: :infinity,
+          on_timeout: :kill_task,
+          ordered: true
+        )
+        |> Stream.zip(parallel_calls)
+        |> Enum.each(fn {stream_result, {id, name, _args}} ->
+          result =
+            case stream_result do
+              {:ok, %ToolResult{} = r} ->
+                r
+
+              {:exit, reason} ->
+                ToolResult.new(
+                  tool_call_id: id,
+                  tool_name: name,
+                  content: "Tool task crashed: #{inspect(reason)}",
+                  is_error: true
+                )
+            end
+
+          post_event = if result.is_error, do: :post_tool_use_failure, else: :post_tool_use
+
+          result =
+            case Tau.Hooks.Dispatcher.run(
+                   post_event,
+                   Tau.Session.hook_payload(data, post_event, %{
+                     tool_name: name,
+                     tool_call_id: id,
+                     result: result
+                   })
+                 ) do
+              {:cont, %{result: rewritten}} when is_struct(rewritten, ToolResult) -> rewritten
+              _ -> result
+            end
+
+          Process.send(parent, {:tool_done, id, result}, [])
+        end)
+      end)
+
+    pid
+  end
+
+  # --- FSM clause handlers ---------------------------------------------------
+
+  @doc """
+  Handle `{:tool_done, call_id, result_msg}` info in `:tool_executing`.
+
+  Appends the result, checks the tool-loop brake, and either aborts the turn
+  (brake fired) or starts the next provider call (all tools done) or keeps
+  waiting (more in-flight).
+  """
+  @spec handle_tool_done(String.t(), struct(), Tau.Session.Data.t()) ::
+          :gen_statem.event_handler_result()
+  def handle_tool_done(call_id, result_msg, data) do
+    tools = Map.delete(data.tools_in_flight, call_id)
+
+    {lookup, call_lookups_rest} = Map.pop(data.tool_loop_call_lookups, call_id)
+
+    data =
+      data
+      |> Tau.Session.append_message(result_msg)
+      |> Tau.Session.Journal.persist(
+        "tool_result",
+        Tau.Session.Journal.tool_result_to_data(result_msg)
+      )
+      |> Map.put(:tool_loop_call_lookups, call_lookups_rest)
+
+    Tau.Session.broadcast(data.id, %Events.ToolEnd{
+      session_id: data.id,
+      tool_call_id: call_id,
+      result: result_msg
+    })
+
+    case maybe_apply_tool_loop_brake(data, lookup, result_msg) do
+      {:brake, data} ->
+        emit_tool_loop_brake_abort(data, tools)
+
+      {:continue, data} ->
+        if map_size(tools) == 0 do
+          data = Tau.Session.Queue.drain_steering_queue_one(data)
+
+          Tau.Session.handle_event(
+            :internal,
+            :start_provider,
+            :provider_streaming,
+            %{data | tools_in_flight: tools, tool_dispatcher: nil}
+          )
+        else
+          {:keep_state, %{data | tools_in_flight: tools}}
+        end
+    end
+  end
+
+  @doc """
+  Handle `{:tool_done, call_id, result_msg}` info in `:awaiting_permission`.
+
+  Pre-resolved items (deny-rule, whitelist-filtered, skill-activated) arrive
+  via `{:tool_done}`. They are processed (append, persist, broadcast) but do
+  NOT trigger the post-round transition — that fires only when
+  `pending_permission_requests` is empty.
+  """
+  @spec handle_tool_done_awaiting_permission(String.t(), struct(), Tau.Session.Data.t()) ::
+          :gen_statem.event_handler_result()
+  def handle_tool_done_awaiting_permission(call_id, result_msg, data) do
+    case Map.get(data.tools_in_flight, call_id) do
+      :awaiting_permission ->
+        require Logger
+
+        Logger.warning(
+          "Unexpected {:tool_done} for :awaiting_permission sentinel #{inspect(call_id)}; ignoring"
+        )
+
+        {:keep_state, data}
+
+      nil ->
+        {:keep_state, data}
+
+      _status ->
+        tools = Map.delete(data.tools_in_flight, call_id)
+        {_lookup, call_lookups_rest} = Map.pop(data.tool_loop_call_lookups, call_id)
+
+        data =
+          data
+          |> Tau.Session.append_message(result_msg)
+          |> Tau.Session.Journal.persist(
+            "tool_result",
+            Tau.Session.Journal.tool_result_to_data(result_msg)
+          )
+          |> Map.put(:tool_loop_call_lookups, call_lookups_rest)
+          |> Map.put(:tools_in_flight, tools)
+
+        Tau.Session.broadcast(data.id, %Events.ToolEnd{
+          session_id: data.id,
+          tool_call_id: call_id,
+          result: result_msg
+        })
+
+        {:keep_state, data}
+    end
+  end
+
+  @doc """
+  Handle `{:permission_decision, tool_call_id, :allow_once}` cast in
+  `:awaiting_permission`.
+
+  Adds the call to the dispatch batch; if the last pending, runs
+  `finish_permission_round/1`.
+  """
+  @spec handle_permission_allow_once(String.t(), Tau.Session.Data.t()) ::
+          :gen_statem.event_handler_result()
+  def handle_permission_allow_once(tool_call_id, data) do
+    case Map.pop(data.pending_permission_requests, tool_call_id) do
+      {nil, _} ->
+        require Logger
+
+        Logger.debug(
+          "permission_decision :allow_once for unknown tool_call_id #{inspect(tool_call_id)}"
+        )
+
+        :telemetry.execute(
+          [:tau, :permissions, :stale_decision],
+          %{system_time: System.system_time()},
+          %{session_id: data.id, tool_call_id: tool_call_id, verdict: :allow_once}
+        )
+
+        {:keep_state, data}
+
+      {%{name: name, arguments: args}, remaining} ->
+        :telemetry.execute(
+          [:tau, :permissions, :decision],
+          %{system_time: System.system_time()},
+          %{
+            session_id: data.id,
+            tool_call_id: tool_call_id,
+            tool_name: name,
+            decision: :allow_once
+          }
+        )
+
+        batch = [{tool_call_id, name, args} | data.permission_dispatch_batch]
+        data = %{data | pending_permission_requests: remaining, permission_dispatch_batch: batch}
+
+        if map_size(remaining) == 0 do
+          finish_permission_round(data)
+        else
+          {:keep_state, data}
+        end
+    end
+  end
+
+  @doc """
+  Handle `{:permission_decision, tool_call_id, :deny_once}` cast in
+  `:awaiting_permission`.
+
+  Synthesises an `is_error` ToolResult accumulated in `permission_pending_results`;
+  if the last pending, calls `finish_permission_round/1`.
+  """
+  @spec handle_permission_deny_once(String.t(), Tau.Session.Data.t()) ::
+          :gen_statem.event_handler_result()
+  def handle_permission_deny_once(tool_call_id, data) do
+    case Map.pop(data.pending_permission_requests, tool_call_id) do
+      {nil, _} ->
+        require Logger
+
+        Logger.debug(
+          "permission_decision :deny_once for unknown tool_call_id #{inspect(tool_call_id)}"
+        )
+
+        :telemetry.execute(
+          [:tau, :permissions, :stale_decision],
+          %{system_time: System.system_time()},
+          %{session_id: data.id, tool_call_id: tool_call_id, verdict: :deny_once}
+        )
+
+        {:keep_state, data}
+
+      {%{name: name}, remaining} ->
+        result =
+          ToolResult.new(
+            tool_call_id: tool_call_id,
+            tool_name: name,
+            content: "Permission denied: #{name} denied by user.",
+            is_error: true
+          )
+
+        :telemetry.execute(
+          [:tau, :permissions, :decision],
+          %{system_time: System.system_time()},
+          %{
+            session_id: data.id,
+            tool_call_id: tool_call_id,
+            tool_name: name,
+            decision: :deny_once
+          }
+        )
+
+        pending_results = [{tool_call_id, result} | data.permission_pending_results]
+
+        data = %{
+          data
+          | pending_permission_requests: remaining,
+            permission_pending_results: pending_results
+        }
+
+        if map_size(remaining) == 0 do
+          finish_permission_round(data)
+        else
+          {:keep_state, data}
+        end
+    end
+  end
+
+  @doc """
+  Handle a stale/unknown `{:permission_decision, tool_call_id, verdict}` in
+  `:awaiting_permission` (D-090 logged no-op).
+  """
+  @spec handle_permission_stale(String.t(), term(), Tau.Session.Data.t()) ::
+          :gen_statem.event_handler_result()
+  def handle_permission_stale(tool_call_id, verdict, data) do
+    require Logger
+
+    Logger.debug(
+      "permission_decision #{inspect(verdict)} for unknown/stale tool_call_id #{inspect(tool_call_id)}"
+    )
+
+    :telemetry.execute(
+      [:tau, :permissions, :stale_decision],
+      %{system_time: System.system_time()},
+      %{session_id: data.id, tool_call_id: tool_call_id, verdict: verdict}
+    )
+
+    {:keep_state, data}
+  end
+
+  @doc """
+  Handle a `{:permission_decision, ...}` cast outside `:awaiting_permission`
+  (D-090 logged no-op — stale decision after state transition).
+  """
+  @spec handle_permission_outside_state(String.t(), term(), Tau.Session.Data.t()) ::
+          :gen_statem.event_handler_result()
+  def handle_permission_outside_state(tool_call_id, verdict, data) do
+    require Logger
+
+    Logger.debug(
+      "permission_decision #{inspect(verdict)} for #{inspect(tool_call_id)} outside :awaiting_permission (state ignored)"
+    )
+
+    :telemetry.execute(
+      [:tau, :permissions, :stale_decision],
+      %{system_time: System.system_time()},
+      %{session_id: data.id, tool_call_id: tool_call_id, verdict: verdict}
+    )
+
+    {:keep_state, data}
+  end
+end

--- a/test/tau/session/compaction_property_test.exs
+++ b/test/tau/session/compaction_property_test.exs
@@ -1,0 +1,43 @@
+defmodule Tau.Session.CompactionPropertyTest do
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  @moduletag :property
+
+  alias Tau.Session.Compaction
+
+  defp make_data(failures \\ 0) do
+    %{
+      id: "test-session",
+      messages: [],
+      compaction_failures: failures,
+      provider: Tau.Providers.Replay,
+      model: "replay"
+    }
+  end
+
+  property "emit_cache_usage does not crash on any integer inputs" do
+    check all(
+            read <- integer(0..1_000_000),
+            write <- integer(0..1_000_000)
+          ) do
+      data = make_data()
+      usage = %{cache_read: read, cache_write: write}
+      assert :ok = Compaction.emit_cache_usage(data, usage)
+    end
+  end
+
+  property "emit_cache_usage treats nil values as 0" do
+    check all(_ <- constant(nil)) do
+      data = make_data()
+      assert :ok = Compaction.emit_cache_usage(data, %{cache_read: nil, cache_write: nil})
+    end
+  end
+
+  property "emit_cache_usage handles missing keys gracefully" do
+    check all(_ <- constant(nil)) do
+      data = make_data()
+      assert :ok = Compaction.emit_cache_usage(data, %{})
+    end
+  end
+end

--- a/test/tau/session/model_swap_property_test.exs
+++ b/test/tau/session/model_swap_property_test.exs
@@ -1,0 +1,80 @@
+defmodule Tau.Session.ModelSwapPropertyTest do
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  @moduletag :property
+
+  alias Tau.Session.ModelSwap
+
+  defp make_data(model \\ "claude-3-opus") do
+    %{
+      id: "test-session",
+      model: model,
+      provider: Tau.Providers.Replay,
+      persist_handle: nil,
+      persistence: nil
+    }
+  end
+
+  property "swap_model accepts any non-blank binary" do
+    check all(model <- string(:printable, min_length: 1)) do
+      trimmed = String.trim(model)
+
+      if trimmed != "" do
+        data = make_data()
+        assert {:ok, updated, _old} = ModelSwap.swap_model(data, model)
+        assert updated.model == model
+      else
+        data = make_data()
+        assert {:error, :invalid_model} = ModelSwap.swap_model(data, model)
+      end
+    end
+  end
+
+  property "swap_model rejects nil" do
+    check all(_ <- constant(nil)) do
+      assert {:error, :invalid_model} = ModelSwap.swap_model(make_data(), nil)
+    end
+  end
+
+  property "swap_model rejects empty string" do
+    check all(_ <- constant(nil)) do
+      assert {:error, :invalid_model} = ModelSwap.swap_model(make_data(), "")
+    end
+  end
+
+  property "swap_model rejects whitespace-only strings" do
+    whitespace = [" ", "\t", "\n"]
+
+    check all(ws_parts <- list_of(member_of(whitespace), min_length: 1)) do
+      spaces = Enum.join(ws_parts)
+      assert {:error, :invalid_model} = ModelSwap.swap_model(make_data(), spaces)
+    end
+  end
+
+  property "swap_model is idempotent — swapping to current model succeeds" do
+    check all(model <- string(:alphanumeric, min_length: 1)) do
+      data = make_data(model)
+      assert {:ok, updated, ^model} = ModelSwap.swap_model(data, model)
+      assert updated.model == model
+    end
+  end
+
+  property "maybe_replace returns data unchanged when value is nil" do
+    check all(key <- atom(:alphanumeric)) do
+      data = %{a: 1, b: 2}
+      assert ModelSwap.maybe_replace(data, key, nil) == data
+    end
+  end
+
+  property "maybe_replace sets key when value is non-nil" do
+    check all(
+            key <- atom(:alphanumeric),
+            value <- integer()
+          ) do
+      data = %{}
+      result = ModelSwap.maybe_replace(data, key, value)
+      assert Map.get(result, key) == value
+    end
+  end
+end

--- a/test/tau/session/provider_turn_property_test.exs
+++ b/test/tau/session/provider_turn_property_test.exs
@@ -1,0 +1,61 @@
+defmodule Tau.Session.ProviderTurnPropertyTest do
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  @moduledoc false
+
+  @moduletag :property
+
+  alias Tau.Session.ProviderTurn
+
+  defp provider_generator do
+    member_of([Tau.Providers.Anthropic, Tau.Providers.Replay])
+  end
+
+  property "describe_provider_error returns a binary for any reason" do
+    check all(reason <- one_of([atom(:alphanumeric), string(:printable), integer()])) do
+      result = ProviderTurn.describe_provider_error(reason)
+      assert is_binary(result)
+    end
+  end
+
+  property "describe_provider_error returns non-empty string for known atoms" do
+    known = [
+      :missing_api_key,
+      :oauth_expired,
+      :oauth_missing_scope,
+      :oauth_malformed,
+      :circuit_open
+    ]
+
+    check all(atom <- member_of(known)) do
+      result = ProviderTurn.describe_provider_error(atom)
+      assert is_binary(result) and result != ""
+    end
+  end
+
+  property "lookup_fallback_chain returns a list for any atom" do
+    check all(provider <- provider_generator()) do
+      chain = ProviderTurn.lookup_fallback_chain(provider)
+      assert is_list(chain)
+    end
+  end
+
+  property "maybe_replace returns data unchanged when value is nil" do
+    check all(key <- atom(:alphanumeric)) do
+      data = %{some: :value}
+      assert ProviderTurn.maybe_replace(data, key, nil) == data
+    end
+  end
+
+  property "maybe_replace sets the key when value is non-nil" do
+    check all(
+            key <- atom(:alphanumeric),
+            value <- integer()
+          ) do
+      data = %{}
+      result = ProviderTurn.maybe_replace(data, key, value)
+      assert Map.get(result, key) == value
+    end
+  end
+end

--- a/test/tau/session/queue_property_test.exs
+++ b/test/tau/session/queue_property_test.exs
@@ -1,0 +1,92 @@
+defmodule Tau.Session.QueuePropertyTest do
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  @moduletag :property
+
+  alias Tau.Session.Queue
+
+  defp make_data(steering_queue, followup_queue) do
+    %{
+      id: "test-session",
+      steering_queue: steering_queue,
+      followup_queue: followup_queue,
+      messages: [],
+      persistence: nil,
+      persist_handle: nil
+    }
+  end
+
+  defp msg_generator do
+    gen all(text <- string(:alphanumeric, min_length: 1)) do
+      %Tau.Message.User{content: text, metadata: %{}, timestamp: DateTime.utc_now()}
+    end
+  end
+
+  property "steering_queue FIFO order is preserved across enqueue/dequeue" do
+    check all(msgs <- list_of(msg_generator(), min_length: 1)) do
+      q =
+        Enum.reduce(msgs, :queue.new(), fn msg, acc ->
+          :queue.in(msg, acc)
+        end)
+
+      dequeued =
+        Enum.reduce(msgs, {[], q}, fn _msg, {acc, queue} ->
+          {{:value, v}, rest} = :queue.out(queue)
+          {acc ++ [v], rest}
+        end)
+        |> elem(0)
+
+      assert dequeued == msgs
+    end
+  end
+
+  property "enqueue respects the 32-entry hard cap" do
+    check all(msgs <- list_of(msg_generator(), length: 35)) do
+      data = make_data(:queue.new(), :queue.new())
+
+      final_data =
+        Enum.reduce(msgs, data, fn msg, acc ->
+          case Queue.enqueue(acc, msg, :steering, :awaiting_user) do
+            {:keep_state, updated} -> updated
+            {:keep_state_and_data, _} -> acc
+          end
+        end)
+
+      assert :queue.len(final_data.steering_queue) <= 32
+    end
+  end
+
+  property "enqueue followup respects the 32-entry hard cap" do
+    check all(msgs <- list_of(msg_generator(), length: 35)) do
+      data = make_data(:queue.new(), :queue.new())
+
+      final_data =
+        Enum.reduce(msgs, data, fn msg, acc ->
+          case Queue.enqueue(acc, msg, :followup, :provider_streaming) do
+            {:keep_state, updated} -> updated
+            {:keep_state_and_data, _} -> acc
+          end
+        end)
+
+      assert :queue.len(final_data.followup_queue) <= 32
+    end
+  end
+
+  property "enqueue preserves FIFO order up to cap" do
+    check all(msgs <- list_of(msg_generator(), min_length: 1, max_length: 30)) do
+      data = make_data(:queue.new(), :queue.new())
+
+      final_data =
+        Enum.reduce(msgs, data, fn msg, acc ->
+          case Queue.enqueue(acc, msg, :steering, :awaiting_user) do
+            {:keep_state, updated} -> updated
+            {:keep_state_and_data, _} -> acc
+          end
+        end)
+
+      queued = :queue.to_list(final_data.steering_queue)
+      assert queued == Enum.take(msgs, 32)
+    end
+  end
+end

--- a/test/tau/session/tool_dispatch_property_test.exs
+++ b/test/tau/session/tool_dispatch_property_test.exs
@@ -1,0 +1,141 @@
+defmodule Tau.Session.ToolDispatchPropertyTest do
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  @moduletag :property
+
+  alias Tau.Session.ToolDispatch
+
+  defp tool_name_generator do
+    string(:alphanumeric, min_length: 1, max_length: 32)
+  end
+
+  defp args_generator do
+    map_of(string(:alphanumeric, min_length: 1, max_length: 16), integer())
+  end
+
+  property "tool_args_hash is deterministic for the same arguments" do
+    check all(args <- args_generator()) do
+      h1 = ToolDispatch.tool_args_hash(args)
+      h2 = ToolDispatch.tool_args_hash(args)
+      assert h1 == h2
+    end
+  end
+
+  property "tool_args_hash is the same regardless of map key insertion order" do
+    check all(
+            keys <- uniq_list_of(string(:alphanumeric, min_length: 1), min_length: 1),
+            vals <- list_of(integer(), length: length(keys))
+          ) do
+      pairs = Enum.zip(keys, vals)
+      args1 = Enum.into(pairs, %{})
+      args2 = Enum.into(Enum.reverse(pairs), %{})
+      assert ToolDispatch.tool_args_hash(args1) == ToolDispatch.tool_args_hash(args2)
+    end
+  end
+
+  property "tool_args_hash returns a 64-char hex string" do
+    check all(args <- args_generator()) do
+      hash = ToolDispatch.tool_args_hash(args)
+      assert is_binary(hash)
+      assert String.length(hash) == 64
+      assert hash =~ ~r/^[0-9a-f]+$/
+    end
+  end
+
+  property "tool_args_hash handles nil args" do
+    check all(_ <- constant(nil)) do
+      hash = ToolDispatch.tool_args_hash(nil)
+      assert String.length(hash) == 64
+    end
+  end
+
+  defp tool_call_generator do
+    gen all(name <- tool_name_generator()) do
+      %{name: name, id: "id_#{name}", arguments: %{}}
+    end
+  end
+
+  property "split_tools_whitelist with :all returns empty filtered list" do
+    check all(calls <- list_of(tool_call_generator())) do
+      {filtered, kept} = ToolDispatch.split_tools_whitelist(calls, :all)
+      assert filtered == []
+      assert kept == calls
+    end
+  end
+
+  property "split_tools_whitelist with explicit list partitions correctly" do
+    check all(
+            allowed <- list_of(tool_name_generator(), min_length: 1),
+            calls <- list_of(tool_call_generator(), min_length: 0, max_length: 10)
+          ) do
+      {filtered, kept} = ToolDispatch.split_tools_whitelist(calls, allowed)
+      assert Enum.all?(filtered, fn %{name: n} -> n not in allowed end)
+      assert Enum.all?(kept, fn %{name: n} -> n in allowed end)
+      assert length(filtered) + length(kept) == length(calls)
+    end
+  end
+
+  property "maybe_apply_tool_loop_brake does not brake on successful result" do
+    check all(
+            name <- tool_name_generator(),
+            hash <- string(:alphanumeric, length: 64)
+          ) do
+      data = %{
+        tool_loop_state: %{{name, hash} => %{count: 10, error: "err"}},
+        tool_loop_brake_threshold: 3
+      }
+
+      result = %Tau.Message.ToolResult{
+        tool_call_id: "id",
+        tool_name: name,
+        content: "ok",
+        is_error: false,
+        timestamp: DateTime.utc_now()
+      }
+
+      assert {:continue, updated} =
+               ToolDispatch.maybe_apply_tool_loop_brake(data, {name, hash}, result)
+
+      assert updated.tool_loop_state == %{}
+    end
+  end
+
+  property "maybe_apply_tool_loop_brake increments counter for repeated errors" do
+    check all(
+            name <- tool_name_generator(),
+            hash <- string(:alphanumeric, length: 64),
+            error_text <- string(:printable, min_length: 1)
+          ) do
+      key = {name, hash}
+
+      data = %{
+        tool_loop_state: %{},
+        tool_loop_brake_threshold: 5
+      }
+
+      result = %Tau.Message.ToolResult{
+        tool_call_id: "id",
+        tool_name: name,
+        content: error_text,
+        is_error: true,
+        timestamp: DateTime.utc_now()
+      }
+
+      {tag1, data1} = ToolDispatch.maybe_apply_tool_loop_brake(data, {name, hash}, result)
+      assert tag1 == :continue
+      assert get_in(data1, [:tool_loop_state, key, :count]) == 1
+
+      {tag2, data2} = ToolDispatch.maybe_apply_tool_loop_brake(data1, {name, hash}, result)
+      assert tag2 == :continue
+      assert get_in(data2, [:tool_loop_state, key, :count]) == 2
+    end
+  end
+
+  property "whitelist_size returns :all for :all and length for lists" do
+    check all(list <- list_of(tool_name_generator())) do
+      assert ToolDispatch.whitelist_size(:all) == :all
+      assert ToolDispatch.whitelist_size(list) == length(list)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Splits `lib/tau/session.ex` (5,139 LOC at branch point) into 10 focused sub-modules under `lib/tau/session/`, reducing `session.ex` to 2,306 LOC (target: ≤2,500).

## Sub-modules

| Module | Responsibility |
|--------|---------------|
| `Tau.Session.Data` | FSM state struct and constructor |
| `Tau.Session.ProviderTurn` | Provider streaming, fallback chain, circuit-breaker gate |
| `Tau.Session.ToolDispatch` | Tool execution pool, permission gate, tool-loop brake |
| `Tau.Session.Compaction` | Context-window compaction, cache-usage telemetry |
| `Tau.Session.CodingAgentTurn` | Coding-agent streaming path, workspace lifecycle |
| `Tau.Session.SkillActivation` | Model/slash skill activation, tool-spec assembly |
| `Tau.Session.ModelSwap` | `/model` swap, provider reconfiguration |
| `Tau.Session.Queue` | Steering + followup queue helpers |
| `Tau.Session.Journal` | `persist_event/3`, JSONL helpers |
| `Tau.Session.SlashCommand` | Slash-command classification |

## Approach

- FSM clause bodies in `Tau.Session` converted to one-line delegations; source order preserved (load-bearing for `:gen_statem` clause matching).
- `broadcast/2` and `transition/3` remain `def` with `@doc false` in `Tau.Session` so sub-modules can call them.
- Sub-modules are pure function modules (no GenServer).
- Property tests added for `ProviderTurn`, `ToolDispatch`, `Compaction`, `ModelSwap`, and `Queue`.

## Gate results

- `mix compile --warnings-as-errors`: exit 0
- `mix format --check-formatted`: exit 0  
- `mix test --seed 0`: 1,401 tests, 145 properties, 0 failures
- `mix dialyzer`: exit 0 (pre-existing `lib/tau/tui/render/markdown.ex` warning unchanged)

## SPECs in scope

Touches `lib/tau/session.ex` → in scope of SPEC-USER-TURN, SPEC-PERMISSION-PROMPTS, SPEC-CODING-AGENT. This PR is a pure refactor: no FSM behaviour, state transitions, or boundary contracts change. No AC-N advances; no new constraints surfaced.