### PR TITLE
fix(memory): restore test suite — async File.cd! CWD race (#417)

### DIFF
--- a/test/mix/gate/mutation_safety_test.exs
+++ b/test/mix/gate/mutation_safety_test.exs
@@ -8,7 +8,7 @@ defmodule Mix.Gate.MutationSafetyTest do
   safety contract that closes the partial-revert gap noted in
   `.code_audit/00-synthesis.md` §9 finding #14.
   """
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
 
   alias Mix.Gate.Mutation
 

--- a/test/tau/factory/gate_precision_test.exs
+++ b/test/tau/factory/gate_precision_test.exs
@@ -9,7 +9,7 @@ defmodule Tau.Factory.GatePrecisionTest do
   AC-1, AC-3, AC-6 are meta-ACs (CI/inspection-verified) and are out of
   this file's scope.
   """
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
 
   alias Mix.Gate.AcLinkage
   alias Mix.Gate.Mutation

--- a/test/tau/factory/gate_test.exs
+++ b/test/tau/factory/gate_test.exs
@@ -10,7 +10,7 @@ defmodule Tau.Factory.GateTest do
 
   Each test references the AC it gates (AC-1 / AC-2 / AC-3).
   """
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
 
   alias Mix.Gate.AcLinkage
   alias Mix.Gate.Masking


### PR DESCRIPTION
Restores `main` to green (#417). The four bypassed-gate merges (#411–#414) left `main` red; the visible symptom was `mix test` aborting with a `MatchError {:error, :enoent}` at `ParallelCompiler.require_file/2` in `test/tau/memory/migrations_test.exs` (a bystander).

**Root cause:** three gate tests call `File.cd!` (VM-global CWD). In Elixir 1.18, `mix test` runs `ParallelCompiler` concurrently with already-running async tests; the compiler `Path.expand`s relative test paths against the OS CWD. While a gate test held the CWD inside a temp dir, a concurrent compile resolved another test's path against the wrong dir → file-not-found → MatchError, aborting the suite.

**Fix:** `async: true` → `async: false` in `test/tau/factory/gate_test.exs`, `test/tau/factory/gate_precision_test.exs`, `test/mix/gate/mutation_safety_test.exs`. These run in ExUnit's sync phase (no concurrent async tests), so the VM-global `File.cd!` can no longer race. No assertions removed or weakened; test-only, 3 insertions / 3 deletions.

**Gate (both PASS):**
- **critic (Opus-class judgement):** the race is *eliminated*, not reduced; no other async `File.cd!` callers remain; CI cost negligible.
- **reviewer:** `mix test` → `1403 tests, 0 failures` on 3 consecutive runs; `mix compile --warnings-as-errors` clean; diff is purely the `async` flips.

**Follow-up (not blocking):** `Mix.Gate.Mutation.mutation_check/2` resolves the repo via OS CWD, forcing the `File.cd!` wrappers — a re-trigger surface. Make it take an explicit repo path and drop `File.cd!` from tests; folds into the SPEC-FACTORY-GATE rewrite (#418).

Closes #417.

🤖 Generated with [Claude Code](https://claude.com/claude-code)