### PR TITLE
fix(gate,memory): restore main green — async File.cd! race + Gate 5.3 no-production-delta N/A (#417, #423)

### DIFF
--- a/lib/mix/gate/mutation.ex
+++ b/lib/mix/gate/mutation.ex
@@ -21,9 +21,11 @@ defmodule Mix.Gate.Mutation do
 
   Returns:
   - `:ok` — ≥1 gating test fails against the reverted tree (suite is discriminating).
-  - `:not_applicable` — every declared gating-test path lives in a Mix project
-    whose nearest-ancestor `mix.exs` is absent at `base_ref` (PR-created project;
-    no pre-implementer code to mutate).
+  - `:not_applicable` — either (a) every declared gating-test path lives in a Mix
+    project whose nearest-ancestor `mix.exs` is absent at `base_ref` (PR-created
+    project; no pre-implementer code to mutate), or (b) the PR's entire diff lies
+    within the declared gating-test paths (no production delta outside those
+    paths — test-only or docs-only change; nothing to mutate).
   - `{:error, :all_passed}` — all gating tests pass against the reverted tree
     (vacuous suite).
   - `{:error, {:runner_crashed, detail}}` — `mix test` exited without producing
@@ -109,19 +111,42 @@ defmodule Mix.Gate.Mutation do
   end
 
   defp mutation_check_in(gating_test_paths, base_ref, repo_dir) do
-    gating_snapshots = snapshot_files(gating_test_paths, repo_dir)
-
     {all_files_str, 0} = System.cmd("git", ["ls-files"], cd: repo_dir)
     all_files = all_files_str |> String.split("\n", trim: true)
 
     paths_to_revert = all_files -- gating_test_paths
 
-    try do
-      revert_to_base(paths_to_revert, base_ref, repo_dir)
-      restore_snapshots(gating_snapshots, repo_dir)
-      run_gating_tests(gating_test_paths, repo_dir)
-    after
-      restore_head(all_files, repo_dir)
+    if no_production_delta?(paths_to_revert, base_ref, repo_dir) do
+      :not_applicable
+    else
+      gating_snapshots = snapshot_files(gating_test_paths, repo_dir)
+
+      try do
+        revert_to_base(paths_to_revert, base_ref, repo_dir)
+        restore_snapshots(gating_snapshots, repo_dir)
+        run_gating_tests(gating_test_paths, repo_dir)
+      after
+        restore_head(all_files, repo_dir)
+      end
+    end
+  end
+
+  # Returns true iff none of the non-gating paths differ from base_ref — i.e.
+  # the PR's entire diff lies within the gating-test path set (test-only change).
+  # Uses `git diff --quiet base_ref -- <paths>` which exits 0 when there is no
+  # diff, non-zero when there is one. An empty paths_to_revert list trivially has
+  # no production delta.
+  defp no_production_delta?([], _base_ref, _repo_dir), do: true
+
+  defp no_production_delta?(paths_to_revert, base_ref, repo_dir) do
+    case System.cmd(
+           "git",
+           ["diff", "--quiet", base_ref, "--" | paths_to_revert],
+           cd: repo_dir,
+           stderr_to_stdout: true
+         ) do
+      {_, 0} -> true
+      _ -> false
     end
   end
 

--- a/lib/mix/gate/mutation.ex
+++ b/lib/mix/gate/mutation.ex
@@ -23,9 +23,10 @@ defmodule Mix.Gate.Mutation do
   - `:ok` — ≥1 gating test fails against the reverted tree (suite is discriminating).
   - `:not_applicable` — either (a) every declared gating-test path lives in a Mix
     project whose nearest-ancestor `mix.exs` is absent at `base_ref` (PR-created
-    project; no pre-implementer code to mutate), or (b) the PR's entire diff lies
-    within the declared gating-test paths (no production delta outside those
-    paths — test-only or docs-only change; nothing to mutate).
+    project; no pre-implementer code to mutate), or (b) `git diff --name-only
+    base_ref HEAD` reports no changed paths outside the declared gating-test paths
+    (no production delta — test-only, docs-only, or delete-only change where the
+    deleted files are all within the gating-test set; nothing to mutate).
   - `{:error, :all_passed}` — all gating tests pass against the reverted tree
     (vacuous suite).
   - `{:error, {:runner_crashed, detail}}` — `mix test` exited without producing
@@ -116,7 +117,7 @@ defmodule Mix.Gate.Mutation do
 
     paths_to_revert = all_files -- gating_test_paths
 
-    if no_production_delta?(paths_to_revert, base_ref, repo_dir) do
+    if no_production_delta?(gating_test_paths, base_ref, repo_dir) do
       :not_applicable
     else
       gating_snapshots = snapshot_files(gating_test_paths, repo_dir)
@@ -131,22 +132,30 @@ defmodule Mix.Gate.Mutation do
     end
   end
 
-  # Returns true iff none of the non-gating paths differ from base_ref — i.e.
-  # the PR's entire diff lies within the gating-test path set (test-only change).
-  # Uses `git diff --quiet base_ref -- <paths>` which exits 0 when there is no
-  # diff, non-zero when there is one. An empty paths_to_revert list trivially has
-  # no production delta.
-  defp no_production_delta?([], _base_ref, _repo_dir), do: true
-
-  defp no_production_delta?(paths_to_revert, base_ref, repo_dir) do
+  # Returns true iff the PR's entire diff (base_ref → HEAD) lies within the
+  # declared gating-test paths — i.e. no production delta outside those paths.
+  #
+  # Uses `git diff --name-only base_ref HEAD` which reports ALL changed paths
+  # regardless of whether they are additions, modifications, deletions, or
+  # renames (unlike `git ls-files`, which only lists files present at HEAD and
+  # therefore silently omits deleted production files). If the set of changed
+  # paths minus the gating-test paths is empty, there is no production delta.
+  defp no_production_delta?(gating_test_paths, base_ref, repo_dir) do
     case System.cmd(
            "git",
-           ["diff", "--quiet", base_ref, "--" | paths_to_revert],
+           ["diff", "--name-only", base_ref, "HEAD"],
            cd: repo_dir,
            stderr_to_stdout: true
          ) do
-      {_, 0} -> true
-      _ -> false
+      {output, 0} ->
+        changed = output |> String.split("\n", trim: true)
+        production_changed = changed -- gating_test_paths
+        production_changed == []
+
+      _ ->
+        # If the diff command fails (e.g. invalid base_ref), assume there IS a
+        # production delta so we don't silently skip the mutation check.
+        false
     end
   end
 

--- a/lib/mix/tasks/tau.gate.mutation.ex
+++ b/lib/mix/tasks/tau.gate.mutation.ex
@@ -25,7 +25,7 @@ defmodule Mix.Tasks.Tau.Gate.Mutation do
 
   | code | meaning |
   |------|---------|
-  | 0    | ≥1 gating test failed against the reverted tree (discriminating); OR N/A (project-creation PR — no pre-implementer code to mutate) |
+  | 0    | ≥1 gating test failed against the reverted tree (discriminating); OR N/A (project-creation PR, or test-only/docs-only change — no production delta to mutate) |
   | 1    | all gating tests passed against the reverted tree (vacuous suite) |
   | 2    | usage error |
   | 3    | test runner crashed — gate could not evaluate (compile error or process crash) |
@@ -47,7 +47,7 @@ defmodule Mix.Tasks.Tau.Gate.Mutation do
 
           :not_applicable ->
             Mix.shell().info(
-              "tau.gate.mutation: N/A — project-creation PR; no pre-implementer production code to mutate"
+              "tau.gate.mutation: N/A — no production delta outside gating-test paths; mutation check not applicable"
             )
 
           {:error, :all_passed} ->

--- a/test/mix/gate/mutation_safety_test.exs
+++ b/test/mix/gate/mutation_safety_test.exs
@@ -8,7 +8,7 @@ defmodule Mix.Gate.MutationSafetyTest do
   safety contract that closes the partial-revert gap noted in
   `.code_audit/00-synthesis.md` §9 finding #14.
   """
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
 
   alias Mix.Gate.Mutation
 

--- a/test/mix/gate/mutation_safety_test.exs
+++ b/test/mix/gate/mutation_safety_test.exs
@@ -1,12 +1,17 @@
 defmodule Mix.Gate.MutationSafetyTest do
   @moduledoc """
-  Safety tests for the `try/after` restore guarantee in `Mix.Gate.Mutation`.
+  Safety tests for the `try/after` restore guarantee in `Mix.Gate.Mutation`
+  and the no-production-delta `:not_applicable` exemption.
 
   Verifies that `mutation_check_in` restores the working tree to its HEAD
   state unconditionally — covering both normal completion and scenarios where
   the working tree is modified before the check runs. This exercises the
   safety contract that closes the partial-revert gap noted in
   `.code_audit/00-synthesis.md` §9 finding #14.
+
+  Also verifies Gate 5.3 returns `:not_applicable` when the PR's entire diff
+  lies within the declared gating-test paths (test-only / docs-only change),
+  fixing the false FAIL reported in issue #423.
   """
   use ExUnit.Case, async: false
 
@@ -104,5 +109,63 @@ defmodule Mix.Gate.MutationSafetyTest do
 
     assert restored == head_prod_content,
            "expected HEAD content after restore, got: #{inspect(restored)}"
+  end
+
+  # Test for issue #423: Gate 5.3 must return :not_applicable (exit 0) when
+  # the PR's entire diff lies within the declared gating-test paths — i.e.
+  # a test-only or docs-only change with no production delta.
+  #
+  # Scenario: base commit has lib/widget.ex unchanged; HEAD only adds a new
+  # gating test file. The only change between base_ref and HEAD is the gating
+  # test itself. Reverting everything outside gating-test paths reverts nothing
+  # — no production delta to mutate.
+  test "returns :not_applicable when PR has no production delta outside gating-test paths (#423)",
+       %{tmp_dir: tmp_dir} do
+    # Build a fresh isolated repo inside tmp_dir/test_only_repo so it does
+    # not share git history with the outer setup repo.
+    repo = Path.join(tmp_dir, "test_only_repo")
+    File.mkdir_p!(Path.join(repo, "lib"))
+    File.mkdir_p!(Path.join(repo, "test"))
+    run = fn args -> {_, 0} = System.cmd("git", args, cd: repo) end
+
+    run.(["init", "-q"])
+    run.(["config", "user.email", "test@example.com"])
+    run.(["config", "user.name", "Test"])
+
+    # base commit: production file only (no gating test yet)
+    prod = Path.join(repo, "lib/widget.ex")
+    File.write!(prod, "defmodule Widget do\n  def run, do: :value\nend\n")
+    run.(["add", "-A"])
+    run.(["commit", "-q", "-m", "base"])
+    {base_ref, 0} = System.cmd("git", ["rev-parse", "HEAD"], cd: repo)
+    base_ref = String.trim(base_ref)
+
+    # HEAD commit: production file UNCHANGED; only a new gating test added.
+    # This simulates a test-only PR where the implementer already shipped the
+    # production code and this PR only adds the gating test.
+    gating = Path.join(repo, "test/widget_gate_test.exs")
+
+    File.write!(gating, """
+    defmodule WidgetGateTest do
+      use ExUnit.Case
+      test "widget returns expected value" do
+        assert Widget.run() == :value
+      end
+    end
+    """)
+
+    run.(["add", "-A"])
+    run.(["commit", "-q", "-m", "add gating test only"])
+
+    # Run mutation check with the gating test as the only declared path.
+    # The production file (lib/widget.ex) is identical at base_ref and HEAD,
+    # so there is no production delta to revert — gate must return :not_applicable.
+    result =
+      File.cd!(repo, fn ->
+        Mutation.mutation_check(["test/widget_gate_test.exs"], base_ref)
+      end)
+
+    assert result == :not_applicable,
+           "expected :not_applicable for test-only PR (no production delta), got: #{inspect(result)}"
   end
 end

--- a/test/mix/gate/mutation_safety_test.exs
+++ b/test/mix/gate/mutation_safety_test.exs
@@ -111,6 +111,72 @@ defmodule Mix.Gate.MutationSafetyTest do
            "expected HEAD content after restore, got: #{inspect(restored)}"
   end
 
+  # f-3 positive-control: a real production delta must NOT return :not_applicable.
+  # Guards against a no_production_delta?/3 that wrongly returns true unconditionally.
+  test "does NOT return :not_applicable when production file is changed (positive-control f-3)",
+       %{tmp_dir: tmp_dir, base_ref: base_ref} do
+    # The outer setup repo already has lib/widget.ex changed base→HEAD.
+    # mutation_check must NOT short-circuit; it runs the real check.
+    result =
+      File.cd!(tmp_dir, fn ->
+        Mutation.mutation_check(["test/widget_gate_test.exs"], base_ref)
+      end)
+
+    assert result != :not_applicable,
+           "expected non-:not_applicable when production file differs base→HEAD, got: #{inspect(result)}"
+  end
+
+  # f-1 delete-only case: a production file deleted in HEAD (vs base) is a
+  # production delta — must NOT return :not_applicable.
+  # Verifies no_production_delta?/3 uses git diff --name-only (which reports
+  # deletions) rather than git ls-files (which only lists HEAD-present files).
+  test "does NOT return :not_applicable when production file is deleted in HEAD (f-1 delete-only)",
+       %{tmp_dir: tmp_dir} do
+    repo = Path.join(tmp_dir, "delete_repo")
+    File.mkdir_p!(Path.join(repo, "lib"))
+    File.mkdir_p!(Path.join(repo, "test"))
+    run = fn args -> {_, 0} = System.cmd("git", args, cd: repo) end
+
+    run.(["init", "-q"])
+    run.(["config", "user.email", "test@example.com"])
+    run.(["config", "user.name", "Test"])
+
+    # base commit: production file exists
+    prod = Path.join(repo, "lib/widget.ex")
+    File.write!(prod, "defmodule Widget do\n  def run, do: :value\nend\n")
+    run.(["add", "-A"])
+    run.(["commit", "-q", "-m", "base"])
+    {base_ref, 0} = System.cmd("git", ["rev-parse", "HEAD"], cd: repo)
+    base_ref = String.trim(base_ref)
+
+    # HEAD commit: production file DELETED; gating test added
+    File.rm!(prod)
+
+    gating = Path.join(repo, "test/widget_gate_test.exs")
+
+    File.write!(gating, """
+    defmodule WidgetGateTest do
+      use ExUnit.Case
+      test "placeholder — production file deleted" do
+        assert true
+      end
+    end
+    """)
+
+    run.(["add", "-A"])
+    run.(["commit", "-q", "-m", "delete prod, add gating test"])
+
+    # Production file was deleted in HEAD — that IS a production delta.
+    # Gate 5.3 must NOT return :not_applicable.
+    result =
+      File.cd!(repo, fn ->
+        Mutation.mutation_check(["test/widget_gate_test.exs"], base_ref)
+      end)
+
+    assert result != :not_applicable,
+           "expected non-:not_applicable for delete-only production change, got: #{inspect(result)}"
+  end
+
   # Test for issue #423: Gate 5.3 must return :not_applicable (exit 0) when
   # the PR's entire diff lies within the declared gating-test paths — i.e.
   # a test-only or docs-only change with no production delta.

--- a/test/tau/factory/gate_precision_test.exs
+++ b/test/tau/factory/gate_precision_test.exs
@@ -9,7 +9,7 @@ defmodule Tau.Factory.GatePrecisionTest do
   AC-1, AC-3, AC-6 are meta-ACs (CI/inspection-verified) and are out of
   this file's scope.
   """
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
 
   alias Mix.Gate.AcLinkage
   alias Mix.Gate.Mutation

--- a/test/tau/factory/gate_test.exs
+++ b/test/tau/factory/gate_test.exs
@@ -10,7 +10,7 @@ defmodule Tau.Factory.GateTest do
 
   Each test references the AC it gates (AC-1 / AC-2 / AC-3).
   """
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
 
   alias Mix.Gate.AcLinkage
   alias Mix.Gate.Masking


### PR DESCRIPTION
Restores `main` to a STABLE green by consolidating two interdependent fixes that must land together (the async fix stabilizes the suite; the gate fix makes the mutation-check pass legitimately).

## Changes
1. **#417 — async `File.cd!` cwd race:** `async: true`→`async: false` on the three gate tests that call `File.cd!` (VM-global cwd). Eliminates the intermittent `{:error, :enoent}` parallel-compile abort that left `main` red.
2. **#423 — Gate 5.3 false FAIL on no-production-delta PRs:** adds a `:not_applicable` exemption when a PR's entire diff lies within the declared gating-test paths (mirrors the existing project-creation N/A path). Closes the spurious "vacuous suite" FAIL on test-only / docs PRs.
3. **f-1:** detect deletions — `no_production_delta?` now uses `git diff --name-only <base> HEAD` (catches D/R/T) instead of `git ls-files`, closing a silent delete-only false-N/A hole found in review.
4. **f-3:** positive-control + delete-only tests guarding the exemption.

## Gate — both Opus, both PASS
- **critic:** walked every `git diff` status (A/M/D/R/T/copy/mode) — detection is complete, **no silent false-`:not_applicable`**; **no new bypass** (the only exploit path is the pre-existing #383/#418 declared-path boundary); `async: false` is the correct mechanism for the process-global-cwd race.
- **reviewer:** `mix test` → `1406 tests, 0 failures` on **3 consecutive runs** (race gone, no parallel-compile aborts); diff is 5 in-scope files, **no weakened/removed assertions**; f-1 fail-before/pass-after proven; `mix compile --warnings-as-errors` clean.

## Follow-ups (tracked, non-blocking)
- #424 (f-2) — surface the N/A verdict into the critic review set; tighten under SPEC-FACTORY-GATE (#418).
- f-1 delete-only test is baseline-non-binding (the shared codepath is bound by the f-3 positive-control) — strengthen or relabel; track with #424.

Closes #417, #423. Supersedes #422.

🤖 Generated with [Claude Code](https://claude.com/claude-code)