### PR TITLE
chore(factory-v2): prior Polya-audit plan + corrective-actions backlog + plugin config

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,8 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "env": {
     "CLAUDE_CODE_ENABLE_TELEMETRY": "0",
-    "CLAUDE_CODE_DISABLE_FEEDBACK_SURVEY": "1",
-    "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1"
+    "CLAUDE_CODE_DISABLE_FEEDBACK_SURVEY": "1"
   },
   "permissions": {
     "allow": [
@@ -134,5 +133,9 @@
         ]
       }
     ]
+  },
+  "enabledPlugins": {
+    "smug-shaper@smug-market": true,
+    "smug-otp@smug-market": true
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,8 @@ __pycache__/
 # Per-developer Python venv (see CONTRIBUTING.md "Build prerequisites").
 # `.python-version` IS committed (pyenv reads it); `.venv/` is not.
 /.venv/
+
+# Local-only Polya audit plugin and outputs (not for github)
+.claude/plugins/polya-audit/
+docs/problems/
+.claude/agents/code-audit-*.md

--- a/docs/factory-v2/PLAN.md
+++ b/docs/factory-v2/PLAN.md
@@ -1,0 +1,119 @@
+# Factory v2 — plan
+
+## Why
+
+The trustworthiness audit (`docs/problems/`) returned 11 untrustworthy +
+9 partially-trustworthy + 0 trustworthy across 20 independent sub-verdicts
+spanning five dimensions of code quality. The coherent emerging signal:
+
+- **Where the compiler / Dialyzer / behaviour callback presence enforces
+  the claim, the code conforms.**
+- **Where the claim is prose, ADR, SPEC §4 enumeration, NN #7 conformance,
+  factory-loop gate enforcement, or telemetry-consumer presence, the
+  code drifts.**
+
+The current factory loop has itself collapsed: the four most recent merges
+(#411-#414) bypassed the gate with red CI checks; PR bodies cite local
+`mix` output as "gate output" while the SHA shows failing jobs; the prior
+module audit's recommendations have not landed; new rescue / catch
+violations accumulate. The factory's stated discipline is no longer
+enforced by anything the factory itself runs.
+
+Two workstreams follow.
+
+## Workstream 1 — Design and build a software factory that survives the
+## failure modes the audit found
+
+### First-principles framing
+
+The factory's job is to take user intent and produce code that
+*structurally cannot* exhibit the failure classes the audit catalogued.
+Where prior factory iterations relied on agent discipline or human review
+to enforce a rule, the v2 factory must lift the rule into a mechanical
+gate that runs before merge and cannot be silent-skipped.
+
+Failure classes the v2 factory must make impossible (or surface
+unambiguously):
+
+1. Documented contracts (`@spec`, `@behaviour`, SPEC §4) drifting from
+   code.
+2. Cargo-cult `try/rescue` / `catch :exit` / `with else` arms defending
+   against conditions that cannot arise.
+3. Capability declarations (`prompt_caching: true`) without callback
+   implementations.
+4. Telemetry events emitted without production consumers.
+5. CI gates whose only failure mode is opt-out (silent-skip on empty
+   declarations, `|| true` continuations).
+6. PRs declaring `AC-N` advances whose tests never invoke the
+   user-visible path that the `AC-N` names.
+7. Factory-loop merges that proceed with red CI; PR-body fields
+   accepting local-machine claims as evidence.
+8. Worktree leaks, orphan branches, and stale-`main` collisions.
+9. SPEC self-contradictions persisting because no consistency check
+   runs.
+10. Audit / decision archaeology rotting because the factory doesn't
+    re-read prior audits before authoring new code.
+
+### Process — Polya from first principles
+
+The factory design itself is a Polya problem. Apply the framework:
+
+- **Root problem** (`docs/factory-v2/design/problem.md`): what does a
+  software factory for Tau need such that the v1 collapse modes become
+  structurally impossible?
+- **Decomposition** (dimensions of factory capability):
+  - Planning & decomposition (how do user intents become PR-shaped work?)
+  - Pre-merge gating (what mechanically prevents merge of bad work?)
+  - Post-merge enforcement (what catches what slipped through?)
+  - Knowledge / memory (how does the factory remember audits, ADRs,
+    SPECs, prior failures?)
+  - Observability of factory state (how does the operator know if
+    discipline is intact, and when it slips?)
+  - Recovery (what happens when the discipline IS slipping?)
+- **Proposers per leaf** (4 distinct methods including ecosystem-research):
+  - First-principles design.
+  - Adapt-from-Claude-Code-ecosystem (research existing plugins / skills
+    / agents — the user explicitly asked "what can we use from outside").
+  - Adapt-from-prior-art (other software-factory patterns: factor-of-100
+    cycle-time projects, ASIC-style tape-out gating, security-incident
+    response).
+  - Adversarial — design the failure mode the factory must catch, then
+    work backwards to the gate.
+- **Selector** synthesises into one factory-component spec per leaf.
+- **Validator** attempts to falsify the spec.
+- **Root selector** integrates into a single factory specification.
+
+### Build
+
+Once the design returns:
+
+- Author the plugins / agents / skills / settings / CI workflows the
+  spec calls for. Place under `.claude/plugins/factory-v2/` (or split
+  into a small number of named plugins).
+- Wire the gates into `.github/workflows/`.
+- Document each component's contract.
+- The build is structural — no aspirational text, only mechanism.
+
+## Workstream 2 — Corrective-actions catalogue (input to the v2 factory)
+
+Separately, the audit's findings become the factory's initial backlog —
+not a backlog the user has to read and prioritise, but a catalogue the
+factory itself ingests as input to its first run.
+
+Filed at `docs/factory-v2/corrective-actions.md` (forthcoming). Each
+entry names: (i) what failed, (ii) the gate that would have prevented
+it, (iii) the v2-factory mechanism that closes the class. Not a fix
+list — a class-of-failure inventory mapped onto v2 mechanisms.
+
+## Order of operations
+
+1. Bootstrap the Polya design cycle for workstream 1 (root problem.md,
+   decomposer, then proposers per leaf).
+2. While the design cycle runs, author workstream 2's catalogue from
+   the audit's evidence (direct enumeration; no Polya — the audit
+   already validated each class).
+3. While the design cycle runs, dispatch a research pass on the
+   Claude Code OSS plugin / agent / skill ecosystem (input to
+   workstream 1's "adapt-from-ecosystem" proposer).
+4. When the design selectors return, build the factory.
+5. Do not pause for user permission.

--- a/docs/factory-v2/corrective-actions/problem.md
+++ b/docs/factory-v2/corrective-actions/problem.md
@@ -1,0 +1,162 @@
+---
+template_version: 1
+template_name: problem
+node_id: corrective-actions-root
+parent: null
+depth: 0
+mode: non-leaf
+---
+
+# Root problem — produce the corrective-actions catalogue for v1 audit findings
+
+## Inputs
+
+- The trustworthiness audit at `docs/problems/` — 5 leaf dimensions
+  (declared-semantics-fidelity, test-fidelity, error-handling-fidelity,
+  observability-fidelity, architecture-and-rule-conformance), 20
+  proposer files (4 per leaf × census/deep-dive/adversarial/delta
+  methods), each with cited `path:line` evidence and a sub-verdict.
+- The archived v1 module audit at `docs/problems-archive-v1-modules/` —
+  41 leaf solution + validation pairs, 11 module-root solution +
+  validation pairs.
+- The 10 failure classes enumerated in
+  `docs/factory-v2/design/problem.md` §Hypothesis.
+- The 6 dimensions of factory capability the factory-v2 design
+  decomposer produced (at
+  `docs/factory-v2/design/subproblems/*/problem.md`).
+
+## What this audit must produce
+
+A **corrective-actions catalogue** — one entry per cited audit finding,
+each entry mapping that finding to the v2 factory mechanism that
+prevents the class. Specifically:
+
+For every finding cited in the trustworthiness audit's 20 proposer
+files AND every solution/validation pair in the archived v1 module
+audit, produce a catalogue entry with the structure:
+
+- **What failed** — verbatim citation at `path:line` (or `commit:sha`
+  for git evidence), with the specific assertion the finding made.
+- **v1 mechanism that should have caught it** — the documented rule
+  (OTP NN clause, factory-loop section, spec-before-code provision,
+  worktree-discipline clause, etc.) that the failure violated. If
+  none existed, state "none."
+- **v2 factory mechanism** — the dimension of factory capability
+  (one of the 6 leaves under `docs/factory-v2/design/subproblems/`)
+  that owns prevention; the specific mechanism within that dimension
+  that closes the class; whether the mechanism is a Mix gate, CI
+  workflow step, hook, AST scan, AST + git scan, branch-protection
+  rule, or agent-with-mechanical-fallback.
+
+The catalogue is **input to the v2 factory's first run** — its initial
+backlog. Each entry is the v2 factory's machine-readable assertion of
+what to enforce on the next PR touching the affected surface.
+
+## Acceptance criteria
+
+- **A — Per-finding coverage.** Every finding cited in any of the 20
+  trustworthiness proposers OR any of the 41 v1 module-audit
+  solution/validation pairs receives at least one catalogue entry.
+  Misses are gate failures.
+
+- **B — No agent-only mechanisms.** The "v2 factory mechanism" column
+  may not name "critic reviews", "reviewer reviews", "implementer
+  follows discipline", or any other agent-self-report mechanism as
+  sole closure. Mechanism MUST be machine-checkable.
+
+- **C — Catalogue is enumerated, not synthesised.** The catalogue
+  contains entries grounded in cited evidence. New conclusions /
+  recommendations / "while we're here" additions are out of scope —
+  the trustworthiness audit and the v1 module audit are the only
+  inputs.
+
+- **D — Dimension binding.** Each entry's v2 mechanism MUST cite the
+  factory-v2 design dimension (one of the 6 leaves) that owns it. If
+  no dimension owns a class, the catalogue surfaces the gap; the gap
+  becomes input to a design-cycle revision (a follow-on Polya cycle,
+  not a manual synthesis).
+
+- **E — Machine-readable output.** The catalogue's primary output is
+  a structured registry (YAML or JSON) at
+  `.claude/policies/audit-debt.yaml` that the v2 factory can ingest
+  directly. The Markdown render is for human review only.
+
+## Decomposition guidance
+
+The next step MUST decompose this problem into MECE sub-problems that
+are **slices of the input corpus** — each leaf processes one bounded
+slice of the audit findings end-to-end (extract → bind to dimension →
+emit catalogue entries). Suggested slicing:
+
+1. v1 module audit slice 1: tau-session + tau-tui-app
+   (the two highest-LOC modules, broadest finding surface).
+2. v1 module audit slice 2: tau-providers + tau-coding-agent +
+   tau-tools-hooks-mcp (provider/tool dispatch surface).
+3. v1 module audit slice 3: tau-memory + tau-settings +
+   tau-permissions + tau-extensions + tau-infrastructure +
+   tau-cli (remaining modules).
+4. Trustworthiness audit slice — declared-semantics-fidelity +
+   test-fidelity proposers (4 + 4 files).
+5. Trustworthiness audit slice — error-handling-fidelity +
+   observability-fidelity + architecture-and-rule-conformance
+   proposers (4 + 4 + 4 files).
+
+The decomposer MAY rebalance or re-slice, with MECE preserved.
+
+## Out of scope
+
+- New audit findings not present in the input corpus.
+- Designing the v2 mechanisms (workstream 1's design pipeline owns
+  that).
+- Recommending which corrective actions to do first / priority
+  ranking — that is the v2 factory's job once it runs, not the
+  catalogue's.
+- Rewriting / re-validating the input findings.
+
+## Background
+
+The user's correction: the coordinator wrote a manual 600-line
+catalogue in its own context (`docs/factory-v2/corrective-actions.md`,
+since deleted). That violates the audit framework's purpose — the
+framework exists precisely because the coordinator's in-context
+synthesis cannot be trusted on quality-bearing content. The catalogue
+is now produced through the same Polya pipeline as everything else
+quality-bearing in this project.
+
+## Sub-problems
+
+Axis: **slices of the input audit corpus** — each leaf processes one
+bounded slice end-to-end (extract findings → bind each finding to one
+of the 6 factory-v2 design dimensions → emit catalogue entries). The
+v1 module audit (11 modules, 41 leaves, 11 module-roots) is split into
+two slices balanced by validation-LOC; the trustworthiness audit
+(5 dimensions × 4 proposers = 20 proposers) is split into two slices
+balanced by citation-evidence shape.
+
+1. `subproblems/v1-modules-session-tui-providers-tools-coding/problem.md`
+   — v1 module audit slice A: `tau-session`, `tau-tui-app`,
+   `tau-providers`, `tau-coding-agent`, `tau-tools-hooks-mcp` (5
+   modules: 20 leaves + 5 module-roots; the high-coupling runtime
+   subset).
+2. `subproblems/v1-modules-cli-memory-settings-permissions-extensions-infrastructure/problem.md`
+   — v1 module audit slice B: `tau-cli`, `tau-memory`, `tau-settings`,
+   `tau-permissions`, `tau-extensions`, `tau-infrastructure` (6
+   modules: 21 leaves + 6 module-roots; the support subset).
+3. `subproblems/trustworthiness-declared-semantics-and-test-fidelity/problem.md`
+   — trustworthiness slice A: `declared-semantics-fidelity` +
+   `test-fidelity` proposers (8 proposer files; "claim → contradicting
+   path" evidence shape).
+4. `subproblems/trustworthiness-error-observability-architecture/problem.md`
+   — trustworthiness slice B: `error-handling-fidelity` +
+   `observability-fidelity` + `architecture-and-rule-conformance`
+   proposers (12 proposer files; "rule → violating path" evidence
+   shape).
+
+MECE: every input file in the corpus maps to exactly one slice
+(disjoint module sets across v1 slices; disjoint trustworthiness
+dimensions across the two trustworthiness slices; v1 and trustworthiness
+corpora live in physically separate directories). Each leaf is
+independently solvable — it ingests its slice, binds to the (shared,
+read-only) 6 factory-v2 dimension leaves, and emits its own
+`findings.yaml` + `findings.md` artifacts without coordinating with
+siblings.

--- a/docs/factory-v2/corrective-actions/subproblems/trustworthiness-declared-semantics-and-test-fidelity/problem.md
+++ b/docs/factory-v2/corrective-actions/subproblems/trustworthiness-declared-semantics-and-test-fidelity/problem.md
@@ -1,0 +1,159 @@
+---
+template_version: 1
+template_name: problem
+node_id: corrective-actions-trustworthiness-declared-semantics-and-test-fidelity
+parent: ../../problem.md
+depth: 1
+mode: leaf
+status: draft
+---
+
+# Leaf — trustworthiness audit slice A (declared-semantics + test fidelity)
+
+## Statement
+
+Process the trustworthiness audit findings cited in the **eight
+proposer files** under
+`docs/problems/subproblems/declared-semantics-fidelity/proposals/` and
+`docs/problems/subproblems/test-fidelity/proposals/`. For every finding
+cited in these proposers, produce one catalogue entry per finding that
+extracts the verbatim `path:line` evidence, names the v1 mechanism that
+should have caught it (or "none"), and binds the entry to exactly one
+of the six factory-v2 design dimensions under
+`docs/factory-v2/design/subproblems/`.
+
+## Slice scope (input files, exhaustive)
+
+- `docs/problems/subproblems/declared-semantics-fidelity/problem.md`
+  (the dimension framing).
+- `docs/problems/subproblems/declared-semantics-fidelity/proposals/proposal-1.md`
+  (census method).
+- `docs/problems/subproblems/declared-semantics-fidelity/proposals/proposal-2.md`
+  (deep-dive method).
+- `docs/problems/subproblems/declared-semantics-fidelity/proposals/proposal-3.md`
+  (adversarial method).
+- `docs/problems/subproblems/declared-semantics-fidelity/proposals/proposal-4.md`
+  (delta method).
+- `docs/problems/subproblems/test-fidelity/problem.md` (the dimension
+  framing).
+- `docs/problems/subproblems/test-fidelity/proposals/proposal-1.md`
+  through `proposal-4.md` (census / deep-dive / adversarial / delta
+  methods).
+
+The slice owns **8 proposer files plus the 2 dimension problem.md
+files** — 10 files total. Proposers are the citation source; the
+dimension problem.md provides framing (read once, not re-cited).
+
+## Context
+
+The parent problem (`../../problem.md`) requires every cited finding
+from the trustworthiness audit's 20 proposer files to produce a
+catalogue entry. This leaf processes the declared-semantics-fidelity
+and test-fidelity dimensions (the "what the system claims to do" and
+"what the test suite proves about claims" axes). The remaining three
+trustworthiness dimensions are processed by the sibling
+`trustworthiness-error-observability-architecture`; the v1 module audit
+is processed by the two `v1-modules-*` siblings.
+
+## Complecting hypothesis
+
+These two dimensions share a citation-evidence shape: most findings
+contrast a declared contract (in code, docs, or spec) against an actual
+runtime path or test path. Bundling them lets the leaf consistently
+record the "claim → contradicting path" pair as a single catalogue
+field across both dimensions, rather than splitting that field shape
+across siblings.
+
+## Decomposition strategy
+
+(leaf — proceed to proposals)
+
+## Acceptance criteria
+
+- **AC-1 — Per-finding extraction.** Every cited finding in the
+  slice's 8 proposer files produces at least one catalogue entry.
+  A proposer typically cites several findings; each finding is a
+  separate row. Misses are gate failures.
+
+- **AC-2 — Cited evidence carried through.** Each entry records the
+  verbatim `path:line` (or `commit:sha`) the proposer cited. No
+  synthesised line numbers; no "approximately" references; the entry
+  must round-trip to the proposer's literal citation. Where the
+  proposer cites a code path and a contradicting test path, both
+  citations are preserved (catalogue field `evidence_paths` holds a
+  list).
+
+- **AC-3 — Machine-readable output + Markdown render.** Output is two
+  artifacts:
+  - YAML row entries appended to
+    `docs/factory-v2/corrective-actions/subproblems/trustworthiness-declared-semantics-and-test-fidelity/findings.yaml`
+    keyed by a stable per-finding id (e.g.
+    `declared-semantics-fidelity/proposal-2/F-03`).
+  - A Markdown render at `./findings.md` enumerating the same rows in
+    human-readable form (one row per heading).
+
+- **AC-4 — Dimension binding.** Each entry's `dimension` field MUST be
+  exactly one of the six factory-v2 design dimensions:
+  `intent-capture-and-ac-binding`,
+  `knowledge-memory-and-audit-ingestion`,
+  `operability-and-hygiene-enforcement`,
+  `post-merge-cross-artifact-coherence`,
+  `pre-merge-code-gates`,
+  `pre-merge-evidence-and-skip-integrity`.
+  Note that "dimension" here is the **factory-v2 design dimension**
+  (the prevention mechanism's owner) — NOT the trustworthiness-audit
+  dimension the finding was cited under. Multiple dimensions per
+  finding is **not** permitted; if no dimension fits, the entry sets
+  `dimension: GAP` and `gap_reason` (root AC-D).
+
+- **AC-5 — v1 mechanism named or "none".** Each entry's `v1_mechanism`
+  field names the documented rule that should have caught the failure
+  (e.g. `otp-non-negotiables.md §1`, `spec-before-code.md §Critic
+  gate`, `factory-loop.md §Gate 5.2`). Where no v1 mechanism existed,
+  the field is literally `"none"`.
+
+- **AC-6 — Mechanism classification machine-checkable.** Each entry's
+  `v2_mechanism_type` is one of: `mix_gate`, `ci_workflow_step`,
+  `hook`, `ast_scan`, `ast_plus_git_scan`, `branch_protection_rule`,
+  `agent_with_mechanical_fallback`. Per parent AC-B, no entry may set
+  `v2_mechanism_type: agent_only`.
+
+## Out of scope
+
+- **New findings.** The leaf extracts only findings already cited in
+  the slice's input proposers; it does NOT generate new audit
+  observations while reading.
+- **Cross-method de-duplication.** Two proposers (e.g. census +
+  adversarial) may cite the same `path:line` from different angles;
+  each cited finding receives its own row. Cross-method merging is a
+  synthesis step and is out of scope here.
+- **Synthesis or thematic summary.** The leaf produces enumerated
+  catalogue rows; it does NOT produce narrative summary or category
+  overviews. (Root AC-C.)
+- **Prioritisation / ranking.** The leaf does NOT order findings by
+  severity, importance, or remediation cost. (Root §Out of scope.)
+- **Findings outside this slice's two trustworthiness dimensions.**
+  `error-handling-fidelity`, `observability-fidelity`, and
+  `architecture-and-rule-conformance` proposers are processed by the
+  sibling `trustworthiness-error-observability-architecture`. The v1
+  module audit is processed by the two `v1-modules-*` siblings.
+- **Designing the v2 mechanisms.** The leaf cites the relevant
+  factory-v2 design dimension; it does NOT extend, refine, or critique
+  the dimension's design.
+- **Re-validating the input findings.** The leaf treats every cited
+  finding as a given fact. It does NOT re-read source code to confirm
+  or refute the finding.
+
+## Notes for the proposer
+
+- The 4 proposer methods (census, deep-dive, adversarial, delta) cite
+  findings at different granularities — census tends to enumerate
+  many shallow citations; adversarial cites fewer, deeper ones. The
+  leaf treats them identically: each citation, regardless of method,
+  produces a row.
+- The 6 dimension leaves live at
+  `docs/factory-v2/design/subproblems/<dim>/problem.md`; read each
+  dimension's problem.md once to ground binding decisions.
+- Use the stable finding-id scheme
+  `<trustworthiness-dim>/<proposal-file>/F-NN` so collisions across
+  siblings are impossible.

--- a/docs/factory-v2/corrective-actions/subproblems/trustworthiness-error-observability-architecture/problem.md
+++ b/docs/factory-v2/corrective-actions/subproblems/trustworthiness-error-observability-architecture/problem.md
@@ -1,0 +1,157 @@
+---
+template_version: 1
+template_name: problem
+node_id: corrective-actions-trustworthiness-error-observability-architecture
+parent: ../../problem.md
+depth: 1
+mode: leaf
+status: draft
+---
+
+# Leaf — trustworthiness audit slice B (error-handling + observability + architecture-and-rule conformance)
+
+## Statement
+
+Process the trustworthiness audit findings cited in the **twelve
+proposer files** under
+`docs/problems/subproblems/error-handling-fidelity/proposals/`,
+`docs/problems/subproblems/observability-fidelity/proposals/`, and
+`docs/problems/subproblems/architecture-and-rule-conformance/proposals/`.
+For every finding cited in these proposers, produce one catalogue
+entry per finding that extracts the verbatim `path:line` evidence,
+names the v1 mechanism that should have caught it (or "none"), and
+binds the entry to exactly one of the six factory-v2 design dimensions
+under `docs/factory-v2/design/subproblems/`.
+
+## Slice scope (input files, exhaustive)
+
+- `docs/problems/subproblems/error-handling-fidelity/problem.md`
+  (the dimension framing).
+- `docs/problems/subproblems/error-handling-fidelity/proposals/proposal-1.md`
+  through `proposal-4.md` (census / deep-dive / adversarial / delta
+  methods).
+- `docs/problems/subproblems/observability-fidelity/problem.md`.
+- `docs/problems/subproblems/observability-fidelity/proposals/proposal-1.md`
+  through `proposal-4.md`.
+- `docs/problems/subproblems/architecture-and-rule-conformance/problem.md`.
+- `docs/problems/subproblems/architecture-and-rule-conformance/proposals/proposal-1.md`
+  through `proposal-4.md`.
+
+The slice owns **12 proposer files plus the 3 dimension problem.md
+files** — 15 files total. Proposers are the citation source; the
+dimension problem.md provides framing (read once, not re-cited).
+
+## Context
+
+The parent problem (`../../problem.md`) requires every cited finding
+from the trustworthiness audit's 20 proposer files to produce a
+catalogue entry. This leaf processes the error-handling, observability,
+and architecture-and-rule-conformance dimensions (the "what the system
+does when things go wrong", "what the system makes visible", and "what
+the system structurally must obey" axes). The remaining two
+trustworthiness dimensions are processed by the sibling
+`trustworthiness-declared-semantics-and-test-fidelity`; the v1 module
+audit is processed by the two `v1-modules-*` siblings.
+
+## Complecting hypothesis
+
+These three dimensions share a citation-evidence shape: most findings
+contrast a structural rule (OTP non-negotiable, supervision tree
+shape, telemetry namespace) or a fault-tolerance contract against an
+actual code path that violates it. Bundling them lets the leaf
+consistently record the "rule → violating path" pair as a single
+catalogue field across all three dimensions, rather than splitting
+that field shape across siblings.
+
+## Decomposition strategy
+
+(leaf — proceed to proposals)
+
+## Acceptance criteria
+
+- **AC-1 — Per-finding extraction.** Every cited finding in the
+  slice's 12 proposer files produces at least one catalogue entry.
+  A proposer typically cites several findings; each finding is a
+  separate row. Misses are gate failures.
+
+- **AC-2 — Cited evidence carried through.** Each entry records the
+  verbatim `path:line` (or `commit:sha`) the proposer cited. No
+  synthesised line numbers; no "approximately" references; the entry
+  must round-trip to the proposer's literal citation. Where the
+  proposer cites a violated rule and the violating code path, both
+  citations are preserved (catalogue field `evidence_paths` holds a
+  list).
+
+- **AC-3 — Machine-readable output + Markdown render.** Output is two
+  artifacts:
+  - YAML row entries appended to
+    `docs/factory-v2/corrective-actions/subproblems/trustworthiness-error-observability-architecture/findings.yaml`
+    keyed by a stable per-finding id (e.g.
+    `architecture-and-rule-conformance/proposal-3/F-02`).
+  - A Markdown render at `./findings.md` enumerating the same rows in
+    human-readable form (one row per heading).
+
+- **AC-4 — Dimension binding.** Each entry's `dimension` field MUST be
+  exactly one of the six factory-v2 design dimensions:
+  `intent-capture-and-ac-binding`,
+  `knowledge-memory-and-audit-ingestion`,
+  `operability-and-hygiene-enforcement`,
+  `post-merge-cross-artifact-coherence`,
+  `pre-merge-code-gates`,
+  `pre-merge-evidence-and-skip-integrity`.
+  Note that "dimension" here is the **factory-v2 design dimension**
+  (the prevention mechanism's owner) — NOT the trustworthiness-audit
+  dimension the finding was cited under. Multiple dimensions per
+  finding is **not** permitted; if no dimension fits, the entry sets
+  `dimension: GAP` and `gap_reason` (root AC-D).
+
+- **AC-5 — v1 mechanism named or "none".** Each entry's `v1_mechanism`
+  field names the documented rule that should have caught the failure
+  (e.g. `otp-non-negotiables.md §1`, `worktree-discipline.md §pre-spawn`,
+  `factory-loop.md §Gate 5.2`, `spec-before-code.md §Critic gate`).
+  Where no v1 mechanism existed, the field is literally `"none"`.
+
+- **AC-6 — Mechanism classification machine-checkable.** Each entry's
+  `v2_mechanism_type` is one of: `mix_gate`, `ci_workflow_step`,
+  `hook`, `ast_scan`, `ast_plus_git_scan`, `branch_protection_rule`,
+  `agent_with_mechanical_fallback`. Per parent AC-B, no entry may set
+  `v2_mechanism_type: agent_only`.
+
+## Out of scope
+
+- **New findings.** The leaf extracts only findings already cited in
+  the slice's input proposers; it does NOT generate new audit
+  observations while reading.
+- **Cross-method de-duplication.** Two proposers (e.g. census +
+  adversarial) may cite the same `path:line` from different angles;
+  each cited finding receives its own row. Cross-method merging is a
+  synthesis step and is out of scope here.
+- **Synthesis or thematic summary.** The leaf produces enumerated
+  catalogue rows; it does NOT produce narrative summary or category
+  overviews. (Root AC-C.)
+- **Prioritisation / ranking.** The leaf does NOT order findings by
+  severity, importance, or remediation cost. (Root §Out of scope.)
+- **Findings outside this slice's three trustworthiness dimensions.**
+  `declared-semantics-fidelity` and `test-fidelity` proposers are
+  processed by the sibling
+  `trustworthiness-declared-semantics-and-test-fidelity`. The v1
+  module audit is processed by the two `v1-modules-*` siblings.
+- **Designing the v2 mechanisms.** The leaf cites the relevant
+  factory-v2 design dimension; it does NOT extend, refine, or critique
+  the dimension's design.
+- **Re-validating the input findings.** The leaf treats every cited
+  finding as a given fact. It does NOT re-read source code to confirm
+  or refute the finding.
+
+## Notes for the proposer
+
+- The 4 proposer methods (census, deep-dive, adversarial, delta) cite
+  findings at different granularities — census tends to enumerate
+  many shallow citations; adversarial cites fewer, deeper ones. The
+  leaf treats them identically.
+- The 6 dimension leaves live at
+  `docs/factory-v2/design/subproblems/<dim>/problem.md`; read each
+  dimension's problem.md once to ground binding decisions.
+- Use the stable finding-id scheme
+  `<trustworthiness-dim>/<proposal-file>/F-NN` so collisions across
+  siblings are impossible.

--- a/docs/factory-v2/corrective-actions/subproblems/v1-modules-cli-memory-settings-permissions-extensions-infrastructure/problem.md
+++ b/docs/factory-v2/corrective-actions/subproblems/v1-modules-cli-memory-settings-permissions-extensions-infrastructure/problem.md
@@ -1,0 +1,162 @@
+---
+template_version: 1
+template_name: problem
+node_id: corrective-actions-v1-modules-cli-memory-settings-permissions-extensions-infrastructure
+parent: ../../problem.md
+depth: 1
+mode: leaf
+status: draft
+---
+
+# Leaf — v1 module audit slice B (cli, memory, settings, permissions, extensions, infrastructure)
+
+## Statement
+
+Process the v1 module audit findings for the **six lower-coupling
+support modules**: `tau-cli`, `tau-memory`, `tau-settings`,
+`tau-permissions`, `tau-extensions`, `tau-infrastructure`. For every
+finding cited in these modules' inputs, produce one catalogue entry
+per finding that extracts the verbatim `path:line` evidence, names the
+v1 mechanism that should have caught it (or "none"), and binds the
+entry to exactly one of the six factory-v2 design dimensions under
+`docs/factory-v2/design/subproblems/`.
+
+## Slice scope (input files, exhaustive)
+
+Per module, process **both** the module-root pair AND every leaf's
+pair:
+
+- `docs/problems-archive-v1-modules/tau-cli/{problem,solution,validation}.md`
+  - subproblems: `error-swallowing-rescues`,
+    `reflective-module-dispatch`, `run-loop-raw-receive`,
+    `wizard-data-fidelity` — each with
+    `{problem,solution,validation}.md` plus any `proposals/`.
+- `docs/problems-archive-v1-modules/tau-memory/{problem,solution,validation}.md`
+  - subproblems: `finch-name-mismatch`, `pending-rot-observability`,
+    `retry-recovery-path`, `silent-failure-propagation`.
+- `docs/problems-archive-v1-modules/tau-settings/{problem,solution,validation}.md`
+  - subproblems: `merge-invariant-properties`,
+    `schema-exception-as-flow`, `watcher-exit-catch`.
+- `docs/problems-archive-v1-modules/tau-permissions/{problem,solution,validation}.md`
+  - subproblems: `evaluator-mode-complecting`,
+    `matcher-unit-contracts`, `mode-lattice-properties`,
+    `settings-merge-feed`.
+- `docs/problems-archive-v1-modules/tau-extensions/{problem,solution,validation}.md`
+  - subproblems: `atom-internment`, `unload-resilience`.
+- `docs/problems-archive-v1-modules/tau-infrastructure/{problem,solution,validation}.md`
+  - subproblems: `circuit-breaker-invariant-split`,
+    `global-name-collision`, `supervision-tree-startup`,
+    `telemetry-handler-coupling`.
+
+The slice owns **21 leaf solution+validation pairs and 6 module-root
+solution+validation pairs**. Validations are typically the densest
+citation source; solutions name the rule the finding violated.
+
+## Context
+
+The parent problem (`../../problem.md`) requires every cited finding
+from the v1 module audit to produce a catalogue entry mapping it to a
+factory-v2 prevention mechanism. This leaf processes the lower-coupling
+support modules. The high-coupling runtime modules are processed by
+the sibling
+`v1-modules-session-tui-providers-tools-coding`; the
+trustworthiness-audit corpus is processed by the two
+`trustworthiness-*` siblings.
+
+## Complecting hypothesis
+
+The six modules in this slice share a tendency to mix configuration,
+schema, and external-resource lifecycle concerns with their core
+function, making findings here dominated by data-fidelity, exception-
+as-flow, and observability-gap concerns. Bundling them lets the leaf
+recognise the recurring "exception as flow" anti-pattern across
+settings, cli, and extensions without spreading its citation across
+siblings.
+
+## Decomposition strategy
+
+(leaf — proceed to proposals)
+
+## Acceptance criteria
+
+- **AC-1 — Per-finding extraction.** Every cited finding in the slice's
+  27 input files (`problem.md`, `solution.md`, `validation.md` at the
+  module root and at each named leaf, plus any files under each leaf's
+  `proposals/`) produces at least one catalogue entry. The
+  extraction is exhaustive: a finding asserted in any of these files
+  yields a row.
+
+- **AC-2 — Cited evidence carried through.** Each entry records the
+  verbatim `path:line` (or `commit:sha`) the source finding cited. No
+  synthesised line numbers; no "approximately" references; the entry
+  must round-trip to the source's literal citation.
+
+- **AC-3 — Machine-readable output + Markdown render.** Output is two
+  artifacts:
+  - YAML row entries appended to
+    `docs/factory-v2/corrective-actions/subproblems/v1-modules-cli-memory-settings-permissions-extensions-infrastructure/findings.yaml`
+    keyed by a stable per-finding id (e.g.
+    `tau-cli/error-swallowing-rescues/F-01`).
+  - A Markdown render at `./findings.md` enumerating the same rows in
+    human-readable form (one row per heading).
+
+- **AC-4 — Dimension binding.** Each entry's `dimension` field MUST be
+  exactly one of the six factory-v2 design dimensions:
+  `intent-capture-and-ac-binding`,
+  `knowledge-memory-and-audit-ingestion`,
+  `operability-and-hygiene-enforcement`,
+  `post-merge-cross-artifact-coherence`,
+  `pre-merge-code-gates`,
+  `pre-merge-evidence-and-skip-integrity`.
+  Multiple dimensions per finding is **not** permitted; if a finding
+  appears to span dimensions, the leaf picks the single best-fit
+  dimension and records the runners-up in `notes`. If no dimension fits,
+  the entry sets `dimension: GAP` and `gap_reason` (root AC-D — the gap
+  surfaces; it is not silently re-assigned).
+
+- **AC-5 — v1 mechanism named or "none".** Each entry's `v1_mechanism`
+  field names the documented rule that should have caught the failure
+  (e.g. `otp-non-negotiables.md §1`, `worktree-discipline.md §pre-spawn`,
+  `factory-loop.md §Gate 5.2`, `spec-before-code.md §Critic gate`).
+  Where no v1 mechanism existed, the field is literally `"none"` —
+  this is the case the v2 factory's first run must close.
+
+- **AC-6 — Mechanism classification machine-checkable.** Each entry's
+  `v2_mechanism_type` is one of: `mix_gate`, `ci_workflow_step`,
+  `hook`, `ast_scan`, `ast_plus_git_scan`, `branch_protection_rule`,
+  `agent_with_mechanical_fallback`. Per parent AC-B, no entry may set
+  `v2_mechanism_type: agent_only`.
+
+## Out of scope
+
+- **New findings.** The leaf extracts only findings already cited in
+  the slice's input files; it does NOT generate new audit observations
+  while reading.
+- **Synthesis or thematic summary.** The leaf produces enumerated
+  catalogue rows; it does NOT produce narrative summary, executive
+  summary, or category overviews. (Root AC-C.)
+- **Prioritisation / ranking.** The leaf does NOT order findings by
+  severity, importance, or remediation cost. (Root §Out of scope.)
+- **Findings outside this slice's modules.** `tau-session`,
+  `tau-tui-app`, `tau-providers`, `tau-coding-agent`,
+  `tau-tools-hooks-mcp` are processed by the sibling
+  `v1-modules-session-tui-providers-tools-coding`. Trustworthiness-
+  audit proposers are processed by the two `trustworthiness-*` siblings.
+- **Designing the v2 mechanisms.** The leaf cites the relevant
+  factory-v2 design dimension; it does NOT extend, refine, or critique
+  the dimension's design.
+- **Re-validating the input findings.** The leaf treats every cited
+  finding as a given fact. It does NOT re-read source code to confirm
+  or refute the finding.
+
+## Notes for the proposer
+
+- The verbatim citation may appear in the leaf's `problem.md`,
+  `solution.md`, `validation.md`, or any file under `proposals/`. All
+  four locations are in scope.
+- The 6 dimension leaves live at
+  `docs/factory-v2/design/subproblems/<dim>/problem.md`; read each
+  dimension's problem.md once to ground binding decisions.
+- Use a stable finding-id scheme (`<module>/<leaf-or-root>/F-NN`) so
+  collisions across siblings are impossible — this slice owns the
+  full module; siblings own different modules.

--- a/docs/factory-v2/corrective-actions/subproblems/v1-modules-session-tui-providers-tools-coding/problem.md
+++ b/docs/factory-v2/corrective-actions/subproblems/v1-modules-session-tui-providers-tools-coding/problem.md
@@ -1,0 +1,159 @@
+---
+template_version: 1
+template_name: problem
+node_id: corrective-actions-v1-modules-session-tui-providers-tools-coding
+parent: ../../problem.md
+depth: 1
+mode: leaf
+status: draft
+---
+
+# Leaf — v1 module audit slice A (session, tui-app, providers, coding-agent, tools-hooks-mcp)
+
+## Statement
+
+Process the v1 module audit findings for the **five highest-coupling
+runtime modules**: `tau-session`, `tau-tui-app`, `tau-providers`,
+`tau-coding-agent`, `tau-tools-hooks-mcp`. For every finding cited in
+these modules' inputs, produce one catalogue entry per finding that
+extracts the verbatim `path:line` evidence, names the v1 mechanism that
+should have caught it (or "none"), and binds the entry to exactly one
+of the six factory-v2 design dimensions under
+`docs/factory-v2/design/subproblems/`.
+
+## Slice scope (input files, exhaustive)
+
+Per module, process **both** the module-root pair AND every leaf's
+pair:
+
+- `docs/problems-archive-v1-modules/tau-session/{problem,solution,validation}.md`
+  - subproblems: `cancellation-teardown`, `cross-cutting-data`,
+    `fsm-facade-helpers`, `user-message-routing` — each with
+    `{problem,solution,validation}.md` plus any `proposals/`.
+- `docs/problems-archive-v1-modules/tau-tui-app/{problem,solution,validation}.md`
+  - subproblems: `duplicated-bounded-append`, `model-as-bag-of-maps`,
+    `session-side-effects-in-pure-modules`, `transcript-coupling`.
+- `docs/problems-archive-v1-modules/tau-providers/{problem,solution,validation}.md`
+  - subproblems: `auth-resolution-scatter`, `callback-contract-drift`,
+    `capabilities-flag-fidelity`, `usage-normalisation`.
+- `docs/problems-archive-v1-modules/tau-coding-agent/{problem,solution,validation}.md`
+  - subproblems: `port-lifecycle-rescue`, `router-outer-rescue`,
+    `settings-feature-flag-access`, `tool-impl-rescue-ladders`.
+- `docs/problems-archive-v1-modules/tau-tools-hooks-mcp/{problem,solution,validation}.md`
+  - subproblems: `dynamic-module-generation`, `io-collectors`,
+    `mcp-server-concurrency`, `tool-result-contract`.
+
+The slice owns **20 leaf solution+validation pairs and 5 module-root
+solution+validation pairs**. Validations are typically the densest
+citation source; solutions name the rule the finding violated.
+
+## Context
+
+The parent problem (`../../problem.md`) requires every cited finding
+from the v1 module audit to produce a catalogue entry mapping it to a
+factory-v2 prevention mechanism. This leaf processes the high-coupling
+subset of that corpus. The remaining six modules are processed by the
+sibling `v1-modules-cli-memory-settings-permissions-extensions-infrastructure`;
+the trustworthiness-audit corpus is processed by the two
+`trustworthiness-*` siblings.
+
+## Complecting hypothesis
+
+The five modules in this slice share a tendency to braid process
+lifecycle, stream protocol, and tool dispatch into single GenServer /
+GenStatem clauses, making findings here dominated by OTP-non-negotiable
+and supervision-tree concerns. Bundling them keeps related findings
+proximate during extraction, so the leaf can recognise repeat patterns
+(e.g. the same rescue-ladder violation cited across coding-agent and
+tools-hooks-mcp) without de-duplicating across siblings.
+
+## Decomposition strategy
+
+(leaf — proceed to proposals)
+
+## Acceptance criteria
+
+- **AC-1 — Per-finding extraction.** Every cited finding in the slice's
+  25 input files (`problem.md`, `solution.md`, `validation.md` at the
+  module root and at each named leaf, plus any files under each leaf's
+  `proposals/`) produces at least one catalogue entry. The
+  extraction is exhaustive: a finding asserted in any of these files
+  yields a row.
+
+- **AC-2 — Cited evidence carried through.** Each entry records the
+  verbatim `path:line` (or `commit:sha`) the source finding cited. No
+  synthesised line numbers; no "approximately" references; the entry
+  must round-trip to the source's literal citation.
+
+- **AC-3 — Machine-readable output + Markdown render.** Output is two
+  artifacts:
+  - YAML row entries appended to
+    `docs/factory-v2/corrective-actions/subproblems/v1-modules-session-tui-providers-tools-coding/findings.yaml`
+    keyed by a stable per-finding id (e.g.
+    `tau-session/cancellation-teardown/F-01`).
+  - A Markdown render at `./findings.md` enumerating the same rows in
+    human-readable form (one row per heading).
+
+- **AC-4 — Dimension binding.** Each entry's `dimension` field MUST be
+  exactly one of the six factory-v2 design dimensions:
+  `intent-capture-and-ac-binding`,
+  `knowledge-memory-and-audit-ingestion`,
+  `operability-and-hygiene-enforcement`,
+  `post-merge-cross-artifact-coherence`,
+  `pre-merge-code-gates`,
+  `pre-merge-evidence-and-skip-integrity`.
+  Multiple dimensions per finding is **not** permitted; if a finding
+  appears to span dimensions, the leaf picks the single best-fit
+  dimension and records the runners-up in `notes`. If no dimension fits,
+  the entry sets `dimension: GAP` and `gap_reason` (root AC-D — the gap
+  surfaces; it is not silently re-assigned).
+
+- **AC-5 — v1 mechanism named or "none".** Each entry's `v1_mechanism`
+  field names the documented rule that should have caught the failure
+  (e.g. `otp-non-negotiables.md §1`, `worktree-discipline.md
+  §pre-spawn`, `factory-loop.md §Gate 5.2`, `spec-before-code.md
+  §Critic gate`). Where no v1 mechanism existed, the field is literally
+  `"none"` — this is the case the v2 factory's first run must close.
+
+- **AC-6 — Mechanism classification machine-checkable.** Each entry's
+  `v2_mechanism_type` is one of: `mix_gate`, `ci_workflow_step`,
+  `hook`, `ast_scan`, `ast_plus_git_scan`, `branch_protection_rule`,
+  `agent_with_mechanical_fallback`. Per parent AC-B, no entry may set
+  `v2_mechanism_type: agent_only`.
+
+## Out of scope
+
+- **New findings.** The leaf extracts only findings already cited in
+  the slice's input files; it does NOT generate new audit observations
+  while reading.
+- **Synthesis or thematic summary.** The leaf produces enumerated
+  catalogue rows; it does NOT produce narrative summary, executive
+  summary, or category overviews. (Root AC-C.)
+- **Prioritisation / ranking.** The leaf does NOT order findings by
+  severity, importance, or remediation cost. (Root §Out of scope.)
+- **Findings outside this slice's modules.** `tau-cli`, `tau-memory`,
+  `tau-settings`, `tau-permissions`, `tau-extensions`,
+  `tau-infrastructure` are processed by the sibling
+  `v1-modules-cli-memory-settings-permissions-extensions-infrastructure`.
+  Trustworthiness-audit proposers are processed by the two
+  `trustworthiness-*` siblings.
+- **Designing the v2 mechanisms.** The leaf cites the relevant
+  factory-v2 design dimension; it does NOT extend, refine, or critique
+  the dimension's design.
+- **Re-validating the input findings.** The leaf treats every cited
+  finding as a given fact. It does NOT re-read source code to confirm
+  or refute the finding.
+
+## Notes for the proposer
+
+- The verbatim citation may appear in the leaf's `problem.md`,
+  `solution.md`, `validation.md`, or any file under `proposals/`. All
+  four locations are in scope; do not skip a file because another in
+  the same leaf already cited the same line.
+- The 6 dimension leaves live at
+  `docs/factory-v2/design/subproblems/<dim>/problem.md`; read each
+  dimension's problem.md once to ground binding decisions.
+- Use a stable finding-id scheme (`<module>/<leaf-or-root>/F-NN`) so
+  two slices independently extracting findings from the same module
+  would not collide. (This slice owns the full module; siblings own
+  different modules; collision is impossible within this leaf.)

--- a/docs/factory-v2/design/ecosystem-research.md
+++ b/docs/factory-v2/design/ecosystem-research.md
@@ -1,0 +1,442 @@
+# Claude Code Ecosystem Research — Factory v2
+
+**Scope.** Inventory the Claude Code plugin / agent / skill / hook / MCP-server
+ecosystem against the five enforcement classes the Tau factory must guarantee:
+contract fidelity (a), test fidelity (b), error-handling discipline (c),
+observability (d), PR gating that cannot silent-skip (e). Plus a sixth
+"general orchestration" bucket.
+
+**Method.** Anthropic docs (`code.claude.com/docs`), the official
+`anthropics/claude-code` and `anthropics/claude-plugins-official` repos,
+community catalogues (`ComposioHQ/awesome-claude-plugins`,
+`hesreallyhim/awesome-claude-code`, `claude-plugins.dev`), GitHub search,
+and adjacent agentic-CI projects (Continue.dev, Aider, Sweep, Meta ACH).
+Star counts and license metadata fetched May 2026; treat as "approx" — the
+ecosystem is moving weekly.
+
+**Bottom line up front.** The marketplace is *broad but shallow* for Tau's
+purposes. There are dozens of "review-my-PR" agents, but **zero** that
+mechanically enforce the things the factory v2 SPEC actually cares about:
+SPEC §4 ↔ code conformance, AC-to-test linkage with deletion-of-assertions
+detection, mutation-score gating, telemetry-to-consumer cross-checks, or
+unbypassable CI gates. The ecosystem assumes the human reviewer is the
+final gate. Tau's premise inverts that, so most plugins are *useful as
+inputs, useless as gates*. Adoption shortlist is small; in-house build list
+is most of the work.
+
+---
+
+## a. Contract fidelity — Dialyzer, behaviour callbacks, SPEC §4 ↔ code
+
+The factory needs: every behaviour callback is implemented and pattern-
+matches the documented atoms; every public struct's shape matches its
+hidden contract; Dialyzer is wall-clean; SPEC §4 boundary contracts are
+not silently violated.
+
+### Candidates
+
+| Name | URL | Stars | Maintained | License | Fit |
+|---|---|---|---|---|---|
+| **bradleygolden/claude-marketplace-elixir** | https://github.com/bradleygolden/claude-marketplace-elixir | small (~early adopter) | Y | MIT-ish (verify) | Ships `dialyzer`, `credo`, `precommit`, `ex_unit`, `sobelow`, `mix_audit` plugins. Hooks run on Write/Edit and gate via `permissionDecision: deny` (correct deterministic shape). Closest fit; adopt the hook scaffold even if rules are too coarse. |
+| **georgeguimaraes/claude-code-elixir** | https://github.com/georgeguimaraes/claude-code-elixir | small | Y | check repo | `mix format`, `mix compile --warnings-as-errors`, `mix credo`, ElixirLS LSP. Useful as developer-side feedback, not as PR gate. |
+| **oliver-kriska/claude-elixir-phoenix** | https://github.com/oliver-kriska/claude-elixir-phoenix | small | Y | check repo | 20 specialist agents + Tidewave MCP + "Iron Laws". Phoenix-flavoured; overlaps heavily with what Tau already has, less rigorous than bradleygolden's. |
+| **elixir-lsp/elixir-ls** | https://github.com/elixir-lsp/elixir-ls | ~2k | Y | Apache-2.0 | LSP with built-in MCP server (port `3789 + hash(workspace)`). Gives an LLM agent live Dialyzer, types, refs. Strongest contract-fidelity input source available. Adopt. |
+| **mkreyman/bmad-elixir / elixir-discipline** | https://claude-plugins.dev/skills/@mkreyman/bmad-elixir/elixir-discipline | small | Y | check | Skills `elixir-verification-gate`, `elixir-no-shortcuts`, `elixir-no-placeholders`. Explicit rule: do not edit `dialyzer.ignore` or `.credo.exs` excludes. Conceptually aligned with Tau but encoded as prompts, not enforcement. |
+| **anthropics/claude-code → pr-review-toolkit / type-design-analyzer** | https://github.com/anthropics/claude-code/blob/main/plugins/pr-review-toolkit | bundled in 30k+ repo | Y (Anthropic) | check | Rates type design on 4 dimensions 1–10 (encapsulation, invariant expression, usefulness, enforcement). Probabilistic, not deterministic. Useful upstream of the gate, not as the gate. |
+
+### Conspicuously absent
+
+- **No behaviour-callback introspector.** Nothing in the ecosystem says
+  "for module X declaring `@behaviour Tau.Provider`, prove all
+  `@callback`s are implemented and pattern-match the declared atom set."
+  This is a `:beam_lib`/`Code.fetch_docs/1` task; Tau must build it.
+- **No SPEC §4 ↔ code differ.** No project parses
+  `docs/spec/SPEC-*.md` §4, extracts the boundary contracts, and
+  diff-checks them against runtime module signatures. Closest analog is
+  Continue.dev's rule files, but those are prose-on-prose, not
+  prose-on-code.
+- **Dialyzer is a per-developer chore, not a per-PR gate.** No plugin
+  publishes a delta-Dialyzer ("new PR-introduced warnings only") or
+  treats Dialyzer regression as a CI failure with a structured PR
+  comment. Tau's CI already runs Dialyzer; the gap is comment-back
+  surface.
+
+---
+
+## b. Test fidelity — property tests, mutation, AC-to-test linkage
+
+The factory needs: every `AC-N`/`D-NNN` token in the PR body has a matching
+gating test; deleted/weakened assertions are flagged; mutation testing
+proves the gating tests actually constrain production code.
+
+### Candidates
+
+| Name | URL | Stars | Maintained | License | Fit |
+|---|---|---|---|---|---|
+| **anthropics/claude-code → pr-review-toolkit / pr-test-analyzer** | https://github.com/anthropics/claude-code/blob/main/plugins/pr-review-toolkit | bundled | Y | check | Rates test gaps 1–10. Looks for behavioural vs line coverage, edge cases. Probabilistic input. **No** mutation, no AC linkage. |
+| **obra/superpowers** | https://github.com/obra/superpowers | ~94k–170k+ (rapidly growing) | Y | MIT | TDD-enforcing skills framework. Strong cultural fit ("delete code written before tests exist"). Encoded as skills; the enforcement is the LLM following the skill, not CI. Useful prompt material; not a gate. |
+| **devonestes/muzak (Elixir)** | https://github.com/devonestes/muzak | ~120 | Y (Pro version more active) | MIT | Elixir-native mutation testing. `:min_coverage` exits non-zero in CI. **The** primary candidate for Tau's Gate 5.3 replacement / augmentation. Adopt. |
+| **Meta ACH (paper)** | https://engineering.fb.com/2025/09/30/security/llms-are-the-key-to-mutation-testing-and-better-compliance/ | n/a (paper) | n/a | n/a | Mutation-guided LLM test generation. Targeted, fault-class-specific mutants; equivalence-detection LLM agent (precision 0.95 / recall 0.96 with preprocessing). Strong design reference; not adoptable software. |
+| **Advertest (arXiv 2602.08146)** | arxiv | n/a | n/a | research | Dual-agent adversarial T vs M loop. Conceptual fit for what Tau's test-author + critic could become; not packaged. |
+| **codexstar69/bug-hunter** | https://github.com/codexstar69/bug-hunter | small | Y | check | Three-agent Hunter / Skeptic / Referee pipeline. Closest *packaged* analog to adversarial test generation, but the "find" side, not the "gate" side. |
+| **silent-failure-hunter** (pr-review-toolkit) | https://github.com/anthropics/claude-code/blob/main/plugins/pr-review-toolkit | bundled | Y | check | Useful for class (c); not (b). |
+| **StreamData / PropCheck** | hex.pm | mature | Y | various | Tau already uses StreamData. No Claude-aware tooling around it. |
+
+### Conspicuously absent
+
+- **No AC-to-test linkage scanner exists in the ecosystem.** The token
+  pattern `AC-N`/`D-NNN` (and "AC-1 should be tested") is a Tau
+  invention. The closest concept is BDD's "scenario tags", and even
+  there nothing scans the PR body. Tau's `mix tau.gate.ac_linkage` has
+  no off-the-shelf replacement.
+- **No deletion-of-assertions detector exists.** Gate 5.2 (masking
+  detection) — `-  assert` / `-  refute` lines flagged to the critic —
+  is unique. The pattern is well-understood (Meta's ACH equivalence-
+  detection agent is the academic cousin) but not packaged.
+- **No mutation runner ties to PR diff in CI for Elixir.** Muzak runs;
+  Muzak-against-PR-diff with a "minimum kill rate" gate that fails CI
+  is not packaged. Tau already builds this in
+  `mix tau.gate.mutation` — keep building.
+
+---
+
+## c. Error-handling discipline — no defensive `try/rescue`, OTP let-it-crash
+
+The factory needs: implementers do not insert `try/rescue` against
+unreachable conditions; OTP non-negotiable §7 ("let it crash; supervise;
+restart") is enforced on every PR.
+
+### Candidates
+
+| Name | URL | Stars | Maintained | License | Fit |
+|---|---|---|---|---|---|
+| **anthropics/claude-code → silent-failure-hunter** | https://github.com/anthropics/claude-code/blob/main/plugins/pr-review-toolkit | bundled | Y | check | Severity-tiered: CRITICAL (silent failure, broad catch), HIGH, MEDIUM. Explicitly hunts catch-block swallowing. Language-general. **Best off-the-shelf for class (c).** Adopt as prompt source for the critic persona; the agent's outputs are advisory, not blocking. |
+| **mkreyman/elixir-no-shortcuts / no-placeholders** | claude-plugins.dev | small | Y | check | "Fail loud, fail fast, no silent failures" rule encoded as a skill. Elixir-native phrasing. Adopt the prose. |
+| **anthropics/claude-code → security-guidance** | bundled | bundled | Y | check | PreToolUse hook. Adjacent (warns on insecure patterns), not directly (c). |
+| **hookify** | https://github.com/anthropics/claude-code/blob/main/plugins/hookify | bundled | Y | check | Generates `block`-action hooks from conversation analysis. The mechanism is right (exit code 2 = deterministic block). Adopt the *mechanism*; the *rule content* is Tau-specific. |
+
+### Conspicuously absent
+
+- **No AST-level `try/rescue` linter exists for Claude Code.** Credo
+  has some checks (e.g. `Credo.Check.Warning.RaiseInsideRescue`); none
+  cover "rescue against an unreachable exception class" or "rescue then
+  re-raise with no context added". Tau needs either a Credo custom
+  check or a `mix tau.gate.error_handling` task.
+- **No "process-boundary catch" linter.** OTP non-negotiable §7
+  forbids `try/rescue` across process boundaries (e.g. a `GenServer`
+  callback rescuing then logging). Detection requires call-graph
+  analysis (`mix xref`/`:beam_lib`); no plugin exists.
+- **Karan Bansal's Medium post** documents the silent-hook failure
+  mode (Python validator `sys.exit(1)` does not block — only exit code
+  2 does). The mechanism is documented; Tau already enforces it in
+  rules; no plugin exists that audits hooks for this hole.
+
+---
+
+## d. Observability — every emitted telemetry event has a production consumer
+
+The factory needs: for every `:telemetry.execute([:tau, ...], ...)` call
+site, prove there is at least one `:telemetry.attach/4` consumer wired
+into the supervision tree. Detect "fire-and-forget" telemetry that nobody
+listens to.
+
+### Candidates
+
+| Name | URL | Stars | Maintained | License | Fit |
+|---|---|---|---|---|---|
+| **traceloop/opentelemetry-mcp-server** | https://github.com/traceloop/opentelemetry-mcp-server | ~188 | Y (release 0.2.2, Feb 2026) | Apache-2.0 | MCP server exposing `search_traces`, `get_trace`, `find_errors` against Jaeger / Tempo / Traceloop. An LLM agent could use this to query the trace backend and *prove* a Tau-emitted event reached a consumer. Adopt for runtime verification; does not solve compile-time gap. |
+| **OpenLLMetry Hub** | https://www.traceloop.com (search "OpenLLMetry Hub") | n/a | Y | Apache-2.0 (verify) | LLM gateway that centralises GenAI OTel spans + bridges via MCP server. Useful for Tau's own LLM-call telemetry; not for arbitrary `[:tau, ...]` events. |
+| **OTel GenAI semantic conventions** | https://opentelemetry.io/docs/specs/semconv/gen-ai/mcp/ | spec | Y | n/a | Recently formalised conventions for MCP tool calls (`tool.name`, `tool.server`, `gen_ai.usage.*`). Tau's `OtelReporter` SPEC should track this. Adopt as design reference. |
+| **ExMCP** | https://github.com/azmaveth/ex_mcp | ~14 | Y (v0.9.1, Apr 2026) | MIT | Elixir MCP library; **88 telemetry events**. If Tau exposes itself *as* an MCP server, this is the canonical substrate. Not relevant for the consumer-coverage check. |
+| **Hermes MCP** | https://github.com/cloudwalk/hermes-mcp | ~371 | Y | MIT | Elixir MCP SDK with Supervisor integration. Same comment as ExMCP. |
+| **anthropics/claude-code → background monitors** | docs.claude.com/en/plugins | bundled | Y | check | `monitors/monitors.json` — `tail -F`-style streams that deliver lines to Claude as notifications. Could tail a Tau OTel collector's "no-consumer" log. Mechanism only; Tau owns the log. |
+
+### Conspicuously absent
+
+- **No `telemetry-event-consumer-coverage` tool exists** in any
+  ecosystem (Elixir or otherwise). The canonical pattern is
+  `grep telemetry.execute lib/ | …`, hand-correlated. Tau must build
+  a `mix tau.gate.telemetry_coverage` that walks the AST for execute
+  call-sites, walks the supervision tree for attached handlers, and
+  asserts every event-prefix has at least one consumer.
+- **OpenTelemetry's "is this span ever consumed" check is also
+  absent** — even the OTel SDK does not surface "no exporter is
+  listening for this resource". The OTel-MCP server is read-only:
+  it tells you what *did* arrive, not what *was emitted but lost*.
+- **`anthropics/claude-code → manifest` plugin** advertises "real-time
+  cost observability" but applies to LLM-call telemetry, not Tau's
+  domain events.
+
+---
+
+## e. PR gating that cannot silent-skip
+
+The factory needs: critic + reviewer MUST PASS; gates 5.1 / 5.2 / 5.3
+MUST PASS; no path exists by which the coordinator (or a future
+hook) can merge a PR with a missing or red verdict.
+
+### Candidates
+
+| Name | URL | Stars | Maintained | License | Fit |
+|---|---|---|---|---|---|
+| **github/github-mcp-server** | https://github.com/github/github-mcp-server | ~30.1k | Y (active, 870+ commits) | MIT | Official. `pull_request_read.get_check_runs`, `actions_get`, `get_job_logs`, `merge_pull_request`. **No branch-protection tools** (verified). The agent can *query* CI; the gate must be the GitHub-side branch protection rules, configured out-of-band. Adopt for the query side. |
+| **denysvitali/gh-actions-mcp** | https://github.com/denysvitali/gh-actions-mcp | small | Y | check | Focused subset: `get_actions_status`, `get_workflow_runs`, `trigger_workflow`. Lighter than the official. |
+| **ko1ynnky/github-actions-mcp-server** | https://github.com/ko1ynnky/github-actions-mcp-server | small | Y | check | Similar; broader compatibility (Codeium, Windsurf). |
+| **Continue.dev "Continuous AI"** | https://continue.dev | many | Y | Apache-2.0 | Async agents that run on every PR via GitHub Actions, enforce team rules, post structured findings. "Continue Hub adds enforceable CI checks for AI-generated code." Closest commercial-grade analog to factory v2. Worth deep technical read; not directly adoptable (different language, different opinions). |
+| **Sweep AI** | https://sweep.dev | many | Y | Apache-2.0 | Issue → PR. Wrong direction for Tau's needs (Tau already opens its own draft PR). |
+| **Anthropic-managed Code Review (claude.com/blog "Preview, review, merge")** | docs.claude.com/en/code-review | hosted | Y | proprietary | **Deliberately non-blocking by default** — the check run always finishes "neutral" so it does not gate branch protection. Quote: "If you want to gate merges on Code Review findings, you need to read the severity breakdown … in your own CI." This is the single most important fact for Tau: the official Anthropic surface explicitly punts gating to the customer. |
+| **AgentLint** | https://github.com/0xmariowu/AgentLint | small | Y | check | 33 evidence-backed checks for AI-agent-compatibility of a repo. Adjacent (repo lint), not (e). |
+| **`anthropics/claude-code → hookify`** | bundled | bundled | Y | check | `action: block` on a PreToolUse hook with exit code 2 = deterministic block at the *tool* level. Right mechanism. Wrong scope (intra-session, not pre-merge). |
+
+### Conspicuously absent
+
+- **An unbypassable cross-PR gate composed of (critic + reviewer +
+  gates 5.1/5.2/5.3) is not packaged anywhere.** The official Code
+  Review is by design *advisory*. The gates Tau cares about (AC
+  linkage, mutation, deletion-of-assertions) do not exist outside
+  Tau. The merge-block has to happen at the GitHub side, via:
+  - GitHub branch protection rules requiring **named** check-run
+    names — and those check runs must be Tau's own CI jobs
+    (`mix tau.gate.*`), not the LLM agents.
+  - PR merge-eligibility is determined by GitHub Actions exit codes;
+    Tau's existing CI is therefore the unbypassable layer. The
+    LLM-side critic/reviewer is a *quality* gate, not a
+    *correctness* gate.
+- **No "I cannot silent-skip" enforcement exists at the agent layer.**
+  Claude Code agents can self-certify and proceed. The factory-loop
+  rule (`MUST NOT … override / self-certify a FAIL verdict`) is the
+  policy; the mechanism that makes it impossible is GitHub branch
+  protection on the named check runs. There is no plugin that turns
+  the policy into a mechanism.
+
+---
+
+## General orchestration — solution tree, subagent dispatch, memory
+
+| Name | URL | Stars | Maintained | License | Fit |
+|---|---|---|---|---|---|
+| **josstei/maestro-orchestrate** | https://github.com/josstei/maestro-orchestrate | small | Y | check | 22 specialised subagents through a 4-phase workflow with native parallel execution. Conceptual overlap with Tau coordinator; less rigorous about gates. Reference design. |
+| **backloghq/backlog** | https://github.com/backloghq/backlog | small | Y | check | Persistent cross-session task management. 24 MCP tools. Event-sourced storage. Tau's `solution-tree.json` is the in-house equivalent; backlog is a packaged alternative if Tau wants to externalise memory. Probably not worth adopting — divergence cost > value. |
+| **agntk** | https://github.com/Phoenixrr2113/agntk | small | Y | check | Persistent named agents + 20 built-in tools. Closer to coordinator-as-CLI; not a fit for OTP-supervised Tau. |
+| **context-mode** | https://github.com/mksglu/claude-context-mode | small | Y | check | Sandboxed-subprocess processing, claims 98% context savings. Worth a closer look for Tau's compact discipline. |
+| **anthropics/claude-code → feature-dev** | bundled | bundled | Y | check | Structured 7-phase feature development with `code-explorer`, `code-architect`, `code-reviewer` subagents. Lighter than Tau but the same skeleton; cross-check the agent definitions for ideas. |
+| **anthropics/claude-code → agent-sdk-dev** | bundled | bundled | Y | check | Adopt if Tau ever exposes a Claude-compatible MCP surface. |
+| **obra/superpowers** | https://github.com/obra/superpowers | 94k–170k+ | Y | MIT | The 7-phase workflow (Brainstorm → Spec → Plan → TDD → Subagent → Review → Finalize) is close to Tau's lifecycle. Strongest *prompt-engineering* reference. The Iron Law ("delete code written before tests") aligns with Gate 5.3's spirit. |
+
+### Conspicuously absent
+
+- **No `solution-tree.json`-shaped tool exists.** Every project rolls
+  its own. The backloghq/backlog event-sourced model is the closest;
+  none of the alternatives bound the tree to a PR lifecycle.
+- **No "kill-signal + heuristic-classification" packaged anywhere.**
+  Tau's `kill-signal.json` + `heuristic-analysis` skill pattern is
+  unique. The closest reference is FindSkill.ai's "10 Parallel Agents:
+  Week 1 Failure Modes" essay; descriptive, not enforcement.
+
+---
+
+## Recommended adoption shortlist
+
+Ordered by leverage; "adopt" means "consume directly", "mine" means
+"read the source/prompt and lift the parts that apply".
+
+1. **github/github-mcp-server (adopt)** — the canonical CI-status
+   query surface. Wire it into the coordinator's gating-test-status
+   checks so the agent can verify CI without shelling out to `gh`.
+   License MIT. Active.
+
+2. **anthropics/claude-code `pr-review-toolkit` agents (mine, then
+   inline)** — `silent-failure-hunter` and `type-design-analyzer`
+   are the highest-leverage prompts in the ecosystem. The persona-
+   dispatch rule (`CLAUDE.md`) already forbids `subagent_type:`;
+   inline these as additional checklist items in the existing
+   `critic.md` / `reviewer.md` personas. Do not adopt as separate
+   subagents.
+
+3. **bradleygolden/claude-marketplace-elixir (mine the hook
+   scaffold)** — the `permissionDecision: "deny"` JSON shape is
+   correct; mine the dialyzer/credo/sobelow hook wiring patterns even
+   if the rule content is too coarse for Tau's discipline.
+
+4. **devonestes/muzak (adopt, augment)** — Tau already has
+   `mix tau.gate.mutation`. Compare against muzak's `:min_coverage`
+   semantics; either delegate or document the divergence in an ADR.
+   Muzak Pro is more featureful but proprietary; the OSS version is
+   sufficient for path-set-scoped mutation.
+
+5. **elixir-lsp/elixir-ls MCP server (adopt)** — runtime Dialyzer /
+   type / refs queries from inside the coordinator. The most useful
+   contract-fidelity *input* in the ecosystem; complements rather
+   than replaces Tau's planned behaviour-callback introspector.
+
+6. **traceloop/opentelemetry-mcp-server (adopt for runtime)** — once
+   Tau's `OtelReporter` is exporting OTLP (per SPEC-OTEL-REPORTER),
+   wire this MCP server in so the reviewer agent can verify a Tau
+   event actually reached the configured collector. Apache-2.0.
+
+7. **obra/superpowers (mine the skills)** — its TDD-Iron-Law,
+   brainstorming, and writing-plans skills overlap with Tau's
+   `design-reasoning`, `tau-adr`, and the test-first rule in
+   factory-loop. Lift the wording where it tightens Tau's
+   discipline; do not import the framework wholesale (overlap is
+   high, divergence cost is high).
+
+8. **anthropics/claude-code `hookify` mechanism (mine, not adopt)**
+   — the `event: bash|file|stop|prompt`, `action: block` pattern with
+   exit-code-2 deterministic blocking is the right primitive for any
+   future intra-session enforcement Tau adds. The Karan-Bansal silent-
+   failure post is the cautionary tale.
+
+9. **GitHub branch protection rules (configure, not a plugin)** —
+   the actually-unbypassable gate. Configure required-status-checks
+   to name `mix tau.gate.ac_linkage`, `mix tau.gate.masking`,
+   `mix tau.gate.mutation`, the critic gate, and the reviewer gate.
+   Without this, the loop's `MUST NOT silent-skip` rule is policy
+   only.
+
+10. **Continue.dev "Continuous AI" architecture (read, do not adopt)**
+    — closest commercial-grade analog. Worth a deep technical read
+    of their rule-files-as-code model and their PR-comment posting
+    pipeline. Tau's design diverges (OTP-native, Elixir-bound) but
+    can lift the rule-set ergonomics.
+
+Anti-recommendations (looked at, deliberately reject):
+
+- **Anthropic Code Review (managed)** — non-blocking by design;
+  redundant with critic + reviewer; would muddy the gate.
+- **maestro-orchestrate / agntk / backlog** — divergent
+  orchestration substrates; integration cost exceeds value.
+- **alirezarezvani/claude-skills, GetBindu/awesome-claude-code-and-
+  skills, sickn33/antigravity-awesome-skills** — large unfiltered
+  skill collections (300+, 1,200+). Useful as search corpora; not
+  curated enough to adopt anything directly without per-skill audit.
+
+---
+
+## Gaps requiring in-house build
+
+For each failure class, the gates that *must* be Tau-built because no
+package exists:
+
+### (a) Contract fidelity
+- `mix tau.gate.behaviour_coverage` — for every `@behaviour Foo`
+  declaration, prove every `@callback` is implemented and pattern-
+  matches the documented atom set. Walks `:beam_lib` + `Code.fetch_docs`.
+- `mix tau.gate.spec_section_4` — parse `docs/spec/SPEC-*.md` §4
+  boundary contracts; cross-check against runtime module signatures.
+  Tests for "PR removed a contract clause but did not remove the §4
+  entry" and vice versa.
+- `mix tau.gate.dialyzer_delta` — fail PR if Dialyzer warning count
+  increases against the base SHA. Post structured comment.
+
+### (b) Test fidelity
+- `mix tau.gate.ac_linkage` — **exists** (PR-B / issue #370).
+  Maintain.
+- `mix tau.gate.masking` — **exists**. Maintain.
+- `mix tau.gate.mutation` — **exists**, path-based. Consider
+  delegating to muzak under the hood or documenting the divergence
+  in an ADR.
+- `mix tau.gate.property_coverage` — for invariant-bearing modules
+  enumerated in `otp-non-negotiables.md` §6, prove a `StreamData`
+  property exists. Lightweight check (grep + AST presence).
+
+### (c) Error-handling discipline
+- `mix tau.gate.error_handling` — AST scan for: `try/rescue` against
+  unreachable exception classes; `try/rescue` across process
+  boundaries (any `GenServer` / `Task` / `:gen_statem` callback
+  containing `try`); broad `rescue _ -> :ok` swallowing. Drives off
+  `Macro.prewalk/2`. Either a Credo custom check or a standalone
+  Mix task.
+- `mix tau.gate.hook_safety` — audit `.claude/settings.json` and
+  every hook script: every Python validator body is wrapped in
+  `try/except` → `sys.exit(2)`; exit codes 0/2 are the only
+  PreToolUse outcomes. The Karan-Bansal hole.
+
+### (d) Observability
+- `mix tau.gate.telemetry_coverage` — walk AST for
+  `:telemetry.execute(prefix, ...)` call sites; walk
+  `Application.start/2` and the supervision tree for attached
+  handlers; assert every prefix has at least one consumer reachable
+  from a supervisor child. Fails on "fire-and-forget" events.
+- `mix tau.gate.start_stop_pairing` — every `*.start` event has a
+  matching `*.stop` and `*.exception` handler. Required by OTP
+  non-negotiable §5.
+
+### (e) PR gating
+- **GitHub branch-protection wiring** — not Tau code, but Tau
+  configuration. Required-status-checks list MUST contain every
+  `mix tau.gate.*` job name and the critic/reviewer verdicts. Without
+  this the factory-loop rule is unenforceable.
+- **Critic / reviewer verdict CI shim** — a `mix tau.gate.verdicts`
+  task that reads the draft-PR body's `Gate verdicts` section, fails
+  if either is missing or `FAIL`, and posts a status check named
+  `tau/gate/verdicts`. Promotes the prose rule to a mechanical gate.
+- **Gating-test path-set freeze enforcer** — a `mix tau.gate.frozen_
+  paths` task that fails if the PR body's `Gating-test paths`
+  section changed since the first non-empty value. Prevents
+  scope-creep via path-set mutation.
+
+---
+
+## Ecosystem maturity — honest assessment
+
+It is wide but shallow. The plugin marketplace has 55+ official + 70+
+community + ~330 catalogued individual skills, but the modal plugin is
+*an LLM agent that comments on your PR*. The factory v2 design
+explicitly does not trust that pattern as the gate. Of the ~50
+relevant repos surveyed:
+
+- **3 plugins** ship anything resembling a deterministic gate
+  (bradleygolden's hook scaffold, hookify's block mechanism,
+  github-mcp-server's check-run query). None of them gate on the
+  things Tau needs.
+- **The most-starred frameworks** (Superpowers at 94k–170k stars,
+  Everything Claude Code at 100k+) are *cultural* — they encode
+  engineering discipline as prompts. Useful, not enforcing.
+- **The most-relevant research** (Meta ACH, Advertest) is published
+  as papers, not packages.
+- **Elixir-native tooling is thin.** Three small plugin marketplaces
+  (bradleygolden, georgeguimaraes, oliver-kriska), ElixirLS's MCP
+  server, two MCP libraries (ExMCP, Hermes), Muzak. None of them
+  cover the SPEC-fidelity / AC-linkage / telemetry-consumer-coverage
+  ground.
+- **Anthropic itself has declared the gating problem out-of-scope**
+  for the managed Code Review service ("never blocks merging through
+  branch protection rules" — verbatim from `docs.claude.com/en/code-
+  review`). This is the strongest evidence that the gating substrate
+  is Tau-shaped work.
+
+The implication for factory v2: spend ecosystem-adoption effort on
+inputs (LSP, CI-status MCP, OTel MCP, mutation library) and prompts
+(pr-review-toolkit personas, Superpowers skills). Spend in-house
+build effort on the gates — the gates are where the ecosystem has
+nothing.
+
+---
+
+## Sources
+
+- Claude Code docs (`code.claude.com/docs/en/plugins`, `…/code-review`,
+  `…/discover-plugins`).
+- `anthropics/claude-code` — plugins directory.
+- `anthropics/claude-plugins-official`, `anthropics/claude-plugins-
+  community`.
+- `ComposioHQ/awesome-claude-plugins`, `hesreallyhim/awesome-claude-
+  code`, `claude-plugins.dev`, `claudemarketplaces.com`.
+- `modelcontextprotocol/servers` registry.
+- `github/github-mcp-server`, `traceloop/opentelemetry-mcp-server`,
+  `azmaveth/ex_mcp`, `cloudwalk/hermes-mcp`, `elixir-lsp/elixir-ls`.
+- `bradleygolden/claude-marketplace-elixir`, `georgeguimaraes/claude-
+  code-elixir`, `oliver-kriska/claude-elixir-phoenix`,
+  `mkreyman/bmad-elixir`.
+- `obra/superpowers` (94k–170k+ stars; MIT).
+- `devonestes/muzak` (Hex), Muzak Pro.
+- Meta ACH (FSE 2025, arXiv 2501.12862); Advertest (arXiv 2602.08146).
+- Continue.dev, Aider, Sweep — comparative reviews (vibecoding.app,
+  augmentcode.com, rywalker.com).
+- Karan Bansal — "Claude Code's Most Underrated Feature: Hooks"
+  (silent failure mode in PreToolUse).
+- OpenTelemetry GenAI semantic conventions
+  (`opentelemetry.io/docs/specs/semconv/gen-ai/mcp/`).
+
+Fetched May 2026. Star counts move; treat as ordinals.

--- a/docs/factory-v2/design/problem.md
+++ b/docs/factory-v2/design/problem.md
@@ -1,0 +1,203 @@
+---
+template_version: 1
+template_name: problem
+node_id: factory-v2-root
+parent: null
+depth: 0
+mode: non-leaf
+status: decomposed
+---
+
+# Root problem — design a software factory that survives v1's collapse modes
+
+## Hypothesis to operationalise
+
+The trustworthiness audit (`docs/problems/`) established that the v1
+factory loop tolerated — and accumulated — the following classes of
+failure, eventually collapsing entirely in the four most recent merges
+(#411-#414, all bypassing the gate with red CI):
+
+1. Contracts drift from code (SPEC §4 names structs that don't exist;
+   `@doc` claims adapters implement callbacks they don't).
+2. `try/rescue` and `catch :exit` proliferate against unreachable
+   conditions, violating OTP non-negotiable #7; the rule is not
+   mechanically enforced.
+3. Capability flags lie (`prompt_caching: true` on adapters without
+   `cache_regions/2`).
+4. Telemetry events emit without production consumers (64.9% of 121
+   `:telemetry.execute` sites have zero non-debug consumer).
+5. CI gates silent-skip when the PR omits a declaration field, and one
+   of three gates is `|| true`.
+6. PRs declare `AC-N` advances whose tests never invoke the user path
+   that the AC names (AC-B6 falsification probe: deleting the
+   `Tau.Session.set_permissions_mode/2` call leaves AC-B6 tests green).
+7. The factory merges PRs against red CI; PR-body fields cite
+   local-machine `mix` output as evidence.
+8. Worktree branches leak (63-571 orphans depending on the grep);
+   `parent-on-main` invariant ignored.
+9. SPEC self-contradiction persists (SPEC-PERMISSION-PROMPTS §4 B5
+   says 6 modes, §6 D-171 says 3) because no SPEC-vs-SPEC consistency
+   check runs.
+10. The prior module audit's recommendations have not been ingested —
+    zero of seven flagged `rescue` sites moved; new `rescue` sites
+    accumulated since the audit was written.
+
+## What the v2 factory must do
+
+Build a software factory for Tau such that **the failure classes above
+are structurally impossible, or surface as merge-blocking gates that
+cannot be silent-skipped**.
+
+The factory's components run as Claude Code plugins, agents, skills,
+hooks, and CI gates. The factory's authority over a PR rests on
+machine-checkable evidence (CI output, file diffs, AST checks,
+Dialyzer warnings, behaviour-callback presence, telemetry-consumer
+registration), not on agent self-report or PR-body assertion.
+
+## Acceptance criteria
+
+- **A — Failure-class coverage.** For each of the ten failure classes
+  above, the v2 factory specification names exactly one mechanism that
+  detects or prevents that class. Mechanisms may overlap (one gate
+  may cover multiple classes); but no class may be uncovered, and no
+  class may be covered only by "agent discipline" or "human review."
+
+- **B — Mechanical enforceability.** Every gate the spec names MUST be
+  expressible as a deterministic, scriptable check. "Critic reviews
+  the diff" is not a mechanism. "Mix task that exits non-zero when a
+  `prompt_caching: true` adapter does not export `cache_regions/2`"
+  is a mechanism. The critic and reviewer agents continue to exist
+  as quality checks but may not be load-bearing for any class above.
+
+- **C — Silent-skip impossibility.** No gate may silent-skip. A gate
+  that has nothing to check on a particular PR returns "checked, no
+  applicable findings" — not "skipped." A gate that cannot run for
+  infrastructural reasons fails the PR rather than passing it. The
+  v1 CI early-exits at `ci.yml:88-100` and `:213-223` and the
+  `|| true` at `:115` are the anti-patterns to make impossible.
+
+- **D — Ecosystem reuse over reinvention.** Where a well-regarded
+  open-source plugin / skill / agent exists in the Claude Code
+  ecosystem that addresses a failure class, the v2 factory adopts it
+  rather than building a bespoke equivalent. Bespoke components are
+  justified explicitly per component.
+
+- **E — Operability.** The factory's state — what gates are wired,
+  what gates have run on what PRs, what gates passed / failed, what
+  orphan worktrees exist, what stale-`main` collisions are pending
+  — is observable from a single dashboard or query, not reconstructed
+  by reading git logs.
+
+- **F — Backward integration.** The factory ingests the audit
+  findings (`docs/problems/` + `docs/problems-archive-v1-modules/`)
+  as input, not as advice. The corrective-actions catalogue
+  (`docs/factory-v2/corrective-actions.md`) is the factory's initial
+  backlog, processed by the same mechanisms it gates new work with.
+
+- **G — No prose-only commitments.** The spec MUST NOT include
+  components whose only output is documentation. Every component
+  produces a machine-checkable artifact (a gate verdict, a diff, a
+  telemetry stream, a registry entry).
+
+## Decomposition guidance
+
+The next step MUST produce MECE sub-problems that are **dimensions of
+factory capability**, not modules and not individual components.
+
+Suggested starting points (the decomposer challenges and refines):
+
+1. **Intent capture & decomposition** — how does a user intent (an
+   issue, a directive, an audit finding) become a PR-shaped unit of
+   work? What guards the decomposition against over-scoping,
+   under-scoping, scope creep, or "follow-up issue" deferrals that
+   defeat the AC?
+2. **Pre-merge gating** — what mechanically stops a bad PR from
+   merging? Specifically: AC-test linkage, mutation check, masking
+   check, contract drift, capability-flag fidelity, NN #7 conformance,
+   telemetry-consumer presence, behaviour-callback completeness, SPEC
+   consistency, gate silent-skip detection.
+3. **Post-merge enforcement** — what runs on `main` and catches what
+   slipped through? Cross-PR coherence checks, codebase-level
+   trustworthiness re-audits on cadence, drift telemetry.
+4. **Knowledge / memory** — how does the factory persist and consult
+   prior audits, ADRs, SPECs, decision history, failure post-mortems?
+   How does authoring an audit finding *guarantee* the factory will
+   consider it on the next PR that touches the relevant surface?
+5. **Operability & observability** — what dashboard / query surface
+   shows factory state, gate health, orphan branches, stale `main`,
+   in-flight PRs, failed gate counts per dimension, prior-audit
+   compliance percentage?
+6. **Recovery & escalation** — what happens when discipline IS
+   slipping? When are the gates themselves wrong (false-positive
+   blocking)? When does the factory halt and escalate to the user
+   rather than retry?
+
+The decomposer MAY add, split, merge, or reframe these — the
+constraint is MECE-across-failure-classes, dimensions-of-capability
+(not implementation choices), each leaf addressing at least one
+failure class from the list at the top.
+
+## Sub-problems (filled by decomposer)
+
+Decomposition axis: **dimensions of factory capability**, partitioned
+by lifecycle phase (intent → pre-merge → post-merge) and persistent
+concern (knowledge ingestion, operability). Each leaf addresses ≥1
+failure class from §Hypothesis; together they cover all ten.
+
+1. **intent-capture-and-ac-binding** (`subproblems/intent-capture-and-ac-binding/`)
+   — how an issue/intent becomes a PR with AC declarations bound, by
+   mechanism, to tests that exercise the user-facing path the AC names.
+   Failure classes: #6 (primary), #1 (AC-side).
+2. **pre-merge-code-gates** (`subproblems/pre-merge-code-gates/`) —
+   per-PR AST / contract / capability-flag / telemetry-consumer checks
+   that fail-loud on the production diff. Failure classes: #1 (code-
+   side), #2, #3, #4.
+3. **pre-merge-evidence-and-skip-integrity** (`subproblems/pre-merge-evidence-and-skip-integrity/`)
+   — the gate-execution substrate: no silent-skip, no local-mix
+   evidence, no merging against red CI. Failure classes: #5, #7.
+4. **post-merge-cross-artifact-coherence** (`subproblems/post-merge-cross-artifact-coherence/`)
+   — `main`-side checks for SPEC↔SPEC contradictions, SPEC↔code
+   drift, ADR supersession, D-NNN uniqueness; runs on every push to
+   `main` and on cadence. Failure classes: #9 (primary), #1 / #4
+   (cumulative tails).
+5. **knowledge-memory-and-audit-ingestion** (`subproblems/knowledge-memory-and-audit-ingestion/`)
+   — structured audit findings whose authoring mechanically registers
+   them as inputs to the pre-merge code gates; remediated or expiring-
+   waivered only. Failure class: #10 (primary).
+6. **operability-and-hygiene-enforcement** (`subproblems/operability-and-hygiene-enforcement/`)
+   — single-query factory-state dashboard plus hook-enforced worktree
+   discipline and `parent-on-main` invariants. Failure class: #8
+   (primary); plus operability surface for all classes.
+
+MECE check (per `decompose.md`):
+- **No overlap.** AC-binding owns AC↔test linkage; pre-merge code
+  gates own production-diff AST/contract checks (regardless of AC);
+  evidence-and-skip-integrity owns *whether* gates run and what
+  evidence counts; post-merge coherence owns cross-artifact drift on
+  `main`; audit ingestion owns the registry that feeds inputs to
+  pre-merge code gates; operability owns state observability and
+  worktree hygiene. Each concern lives in exactly one leaf.
+- **No gap.** Every failure class #1–#10 is named in at least one
+  leaf's "Failure classes addressed" section.
+- **Same altitude.** Each leaf is a *dimension of factory capability*,
+  not an implementation component (no leaf could be a sub-problem of
+  another).
+
+## Out of scope
+
+- Fix recommendations for Tau itself — workstream 2 catalogues those.
+- Re-litigating whether the audit's findings are correct — they are
+  the input.
+- "We could also do X" framings without mapping X to a failure class.
+
+## Background — why first-principles, why now
+
+The user expressed (a) that the codebase has rotted to where
+recommendations from Claude cannot be trusted; (b) that the
+process Claude was given (Polya / Toulmin with falsification) was
+not followed in earnest in v1; (c) that ANY further drift means
+the project is abandoned. The v2 factory must therefore not rely on
+Claude (or any single agent) telling the truth about its own work
+— it must rely on independent mechanisms that produce verdicts
+Claude cannot influence. Where Claude is in the loop, Claude's claims
+must be cross-checked by mechanism, not by another Claude.

--- a/docs/factory-v2/design/subproblems/intent-capture-and-ac-binding/problem.md
+++ b/docs/factory-v2/design/subproblems/intent-capture-and-ac-binding/problem.md
@@ -1,0 +1,108 @@
+---
+template_version: 1
+template_name: problem
+node_kind: leaf
+mode: leaf
+depth: 1
+parent: ../../problem.md
+status: draft
+---
+
+# Problem: Intent capture and AC-to-user-path binding
+
+## Statement
+
+A user intent (issue, audit finding, directive) must enter the factory as a
+PR-shaped unit whose acceptance criteria (`AC-N`) are bound, by mechanism,
+to tests that exercise the *same user-visible code path the AC names*. The
+v1 failure is that a PR may declare it advances `AC-N` while the tests
+covering `AC-N` invoke a hand-built struct or a private helper, leaving
+the user-facing entry point unexercised — the AC remains formally green
+while substantively false (root §Hypothesis #6; AC-B6 falsification probe).
+The problem is solved when the AC declaration is the test plan, not a prose
+claim adjacent to one.
+
+## Context
+
+- Root problem.md §Hypothesis #6 (AC-B6 falsification): deleting the
+  `Tau.Session.set_permissions_mode/2` call still left AC-B6 tests green.
+- Root §Acceptance criterion A: every failure class must have a mechanism;
+  this leaf owns failure class #6 in full.
+- Root §Hypothesis #1 (partial): the AC declaration is where contracts
+  *enter* the factory; structural drift between AC and code is detected
+  here at the binding layer, before AST-level checks (which live in the
+  pre-merge code gates sibling).
+- v1 factory-loop rule (`.claude/rules/factory-loop.md`) §"The three
+  mechanical gates" — Gate 5.1 (AC linkage) and Gate 5.3 (mutation check)
+  exist but key on declared paths and a single mutation-revert, which a
+  test exercising the wrong path silently passes.
+
+## Failure classes addressed (from root §Hypothesis)
+
+- **#6** (primary) — AC tests must invoke the user-facing path the AC
+  names; an under-asserting or wrong-path test fails this leaf's gate.
+- **#1** (partial, AC-side) — the AC text and the user-path entry point
+  cited in the AC must reference symbols that exist in the codebase at
+  the time of the PR; AC text that names a struct/function that does not
+  exist fails this leaf's gate. (Module-internal contract drift remains
+  with the pre-merge-code-gates sibling.)
+
+## Complecting hypothesis
+
+- The PR-body AC declaration is complected with the test-author's choice
+  of entry point because the only link between them today is prose; a
+  machine cannot detect "the test invokes the wrong layer" without an
+  explicit, structured AC→user-path→test binding.
+- The "mutation check" (revert non-test paths to merge-base, expect ≥1
+  test fail) is complected with "does the suite exercise the user path"
+  because a single global revert cannot distinguish a test that fails for
+  the *right* reason from one that fails because compilation broke.
+
+## Decomposition strategy
+
+(leaf — no further decomposition; proceed to proposals)
+
+## Acceptance criterion
+
+The factory specification names a single, deterministic mechanism such
+that: (a) every `AC-N` / `D-NNN` token in the PR body's `## Acceptance
+criteria` section is paired with (i) a machine-resolvable user-facing
+entry-point reference (module + function + arity, or CLI argv pattern)
+and (ii) the gating-test file path(s) that invoke that entry point; (b)
+the mechanism executes a per-AC mutation — disabling the *specific
+user-path call site* the AC names — and the gating test(s) for that AC
+MUST go red, else the gate fails the PR; (c) the gate cannot silent-skip
+(an AC with no resolvable entry point, or an entry point with no
+gating-test that goes red on per-AC mutation, fails the PR — it does not
+pass-with-a-warning); (d) the design explicitly addresses whether an
+existing Claude Code plugin / mix dependency (e.g. `muzak` mutation
+testing, `excoveralls` coverage with per-AC tagging) is adopted vs a
+bespoke build, with the reuse-vs-build decision recorded; (e) the
+spec output identifies the concrete artifacts to build (e.g. a
+`tau.gate.ac_binding` mix task, a CI workflow step in
+`.github/workflows/ci.yml`, a PR-body schema, an optional plugin
+`polya-audit`-style agent producing the binding manifest, and any
+settings.json entries needed).
+
+## Out of scope
+
+- AST-level checks on production code (`try/rescue`, missing
+  `@behaviour`, capability-flag fidelity, telemetry-consumer presence)
+  — owned by **pre-merge-code-gates** sibling.
+- Gate-infrastructure invariants (silent-skip impossibility, evidence
+  source must be CI-not-local) — owned by
+  **pre-merge-evidence-and-skip-integrity** sibling.
+- Cross-document SPEC-vs-SPEC contradictions — owned by
+  **post-merge-cross-artifact-coherence** sibling.
+- Reading historical audit findings into the AC-binding schema — owned
+  by **knowledge-memory-and-audit-ingestion** sibling (this leaf only
+  enforces the binding contract; *what* invariants the binding must
+  enforce per-surface is informed by audit ingestion).
+- Worktree hygiene, dashboards, parent-on-main — owned by
+  **operability-and-hygiene-enforcement** sibling.
+- Documentation-only components; agent-discipline-only enforcement;
+  workstream-2 corrective-actions catalogue.
+
+## Amendment log
+
+- (none yet)

--- a/docs/factory-v2/design/subproblems/intent-capture-and-ac-binding/proposals/proposal-1.md
+++ b/docs/factory-v2/design/subproblems/intent-capture-and-ac-binding/proposals/proposal-1.md
@@ -1,0 +1,347 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 1
+parent_problem: ../problem.md
+method: first-principles-design
+---
+
+# Proposal 1 — Structured AC binding manifest + per-AC call-site mutation
+
+## One-line
+
+Make the PR's acceptance-criteria block a **machine-typed manifest** that names
+the user-path entry point and the gating test for each AC, then prove the
+binding by **mutating that exact call site** (not the whole tree) and asserting
+the named test goes red.
+
+## First-principles derivation
+
+The failure class is: a test invokes the wrong layer (helper, struct, private
+function) while declaring it advances an AC about the user-facing path. Two
+independent things must hold for that to remain impossible:
+
+1. **The user-facing path must be named in a machine-resolvable form.** Prose
+   ("the headless `tau run` path") is not resolvable. A symbol
+   (`Tau.CLI.main/1`) or a CLI argv pattern (`tau run --system-prompt-file *`)
+   is resolvable: a compiler / shell can answer "does this exist."
+
+2. **The test that proves the AC must demonstrably depend on that exact
+   user-path call site.** A test that doesn't notice when the user-path call
+   site is disabled is, by construction, exercising something else. The
+   minimum-mechanism proof is per-AC mutation: silence the named call site,
+   re-run only the named gating tests, require ≥1 to fail.
+
+Everything else is glue: a schema for the manifest, a mix task that runs the
+proof, a CI gate that blocks merge, and silent-skip semantics that turn
+"nothing to check" into an explicit verdict ("checked, no applicable
+findings") rather than a missing job step.
+
+## Components
+
+Each component is named with the concrete file path it would live at.
+
+### C1 — PR-body AC manifest schema
+
+- **Path:** `.github/PULL_REQUEST_TEMPLATE.md` (the human-facing template) +
+  `lib/tau/factory/ac_manifest.ex` (the parser/validator) +
+  `priv/factory/ac_manifest.schema.json` (the JSON Schema the parser enforces).
+- **Input:** the PR body text fetched via `gh pr view <n> --json body`.
+- **Output:** a typed struct list `[%Tau.Factory.ACManifest.Entry{
+    id: "AC-B6",
+    user_path: {:elixir_mfa, Tau.Session, :set_permissions_mode, 2}
+              | {:cli_argv, ["run", "--system-prompt-file", :_]}
+              | {:meta, "verified-by-ci-wiring"},
+    gating_tests: ["test/tau/session_permission_test.exs:42",
+                   "test/tau/session_permission_test.exs:88"]
+  }, ...]` plus a list of parse errors (with line numbers in the PR body).
+- **Failure mode:** any AC token in the `## Acceptance criteria` section that
+  the parser cannot resolve to a complete entry returns `{:error, ...}` with
+  the failing token. Non-meta entries that omit `user_path` or `gating_tests`
+  are parse errors, not warnings.
+- **Gating effect:** none directly; C1 is a library. Its output feeds C2 and
+  C3. But because it is a strict parser with a single typed output, every
+  downstream gate keys on the same source of truth — divergence between gates
+  on what the AC "claims" becomes impossible.
+
+The schema is deliberately minimal — id, user_path tagged tuple, gating_tests
+list, optional `meta: true` marker. Meta-ACs (e.g. an AC satisfied by CI
+wiring) are explicit and must declare `meta: true`; the gate then asserts the
+*CI workflow file* contains the named step, not a unit test.
+
+### C2 — `mix tau.gate.ac_binding`
+
+- **Path:** `lib/mix/tasks/tau.gate.ac_binding.ex` (new) — pairs with the
+  existing `tau.gate.ac_linkage`, `tau.gate.masking`, `tau.gate.mutation`.
+- **Input:** PR number (from `GITHUB_REF` / `gh` env); reads PR body via
+  `gh pr view`, parses via C1.
+- **Output:** structured verdict to stdout (JSON) and exit code:
+  - `exit 0` + `{"status":"pass", "checked": N, "skipped": 0}` — every
+    non-meta entry's user_path resolved to a symbol that exists, and the
+    per-AC mutation proof (C4) returned `:demonstrated`.
+  - `exit 0` + `{"status":"no_applicable", "reason":"no_AC_tokens_in_body"}` —
+    body has no `## Acceptance criteria` section AND PR is labeled
+    `chore:no-ac` (typo fix / dep bump / formatting). Both conditions
+    required; only the *label* lets the verdict be "no applicable"; absence
+    of the section without the label is a fail.
+  - `exit 1` + `{"status":"fail", "findings":[...]}` — any unresolved
+    user_path, any non-meta AC with no gating_tests, any per-AC mutation that
+    failed to demonstrate dependency.
+  - `exit 2` + `{"status":"infrastructure_fail", "reason":"..."}` — `gh`
+    unreachable, repo not on the PR's HEAD, etc. This is *not* a pass; the
+    CI gate (C5) treats exit 2 as failing the PR.
+- **Failure mode:** any non-passing exit blocks merge via C5.
+- **Gating effect:** binding contract enforcement.
+
+### C3 — `Tau.Factory.UserPathResolver`
+
+- **Path:** `lib/tau/factory/user_path_resolver.ex` (a pure module, no
+  process).
+- **Input:** the `user_path` tagged tuple from C1.
+- **Output:** `{:ok, %ResolvedPath{}}` carrying enough information for C4 to
+  perform the mutation — for `:elixir_mfa`, a `{module, fun, arity}` tuple
+  the compiler has confirmed exists at HEAD; for `:cli_argv`, a list of
+  `Tau.CLI` dispatch clauses (resolved by `Code.fetch_docs/1` + AST grep on
+  `lib/tau/cli.ex`) the argv matches. For `:meta`, no resolution attempted
+  — C2 instead checks the named workflow file/step exists.
+- **Failure mode:** `{:error, :symbol_not_found, ...}` if the MFA doesn't
+  exist, the arity is wrong, the function is `defp`, or no `Tau.CLI` clause
+  matches the argv pattern. This *is* the AC-side contract drift check
+  (failure class #1, AC-side): an AC that cites a symbol the codebase
+  doesn't have fails at C3 and the PR cannot pass C2.
+- **Gating effect:** prevents AC text from naming nonexistent symbols.
+
+### C4 — `Tau.Factory.CallSiteMutator`
+
+- **Path:** `lib/tau/factory/call_site_mutator.ex` (pure module) + a
+  per-mutation scratch worktree managed by C2.
+- **Input:** a `%ResolvedPath{}` (from C3) plus the gating-test list.
+- **Output:** `:demonstrated | {:not_demonstrated, [test_id]}`.
+- **Algorithm (per AC, isolated):**
+  1. Spawn an ephemeral git worktree at `tmp/factory/ac-binding-<sha>-<id>/`.
+  2. Apply *one* of these AST rewrites (chosen by `user_path` tag):
+     - `:elixir_mfa` — rewrite the named function in its host module to
+       raise `Tau.Factory.MutationMarker, "AC-N call site disabled"` as the
+       first expression. (Not delete; raising is more diagnostic than a
+       silent no-op and survives default-argument re-writes.)
+     - `:cli_argv` — rewrite the matched `Tau.CLI` dispatch clause body to
+       raise the same marker.
+     - `:meta` — N/A; C2 short-circuits.
+  3. `mix compile --warnings-as-errors` (must succeed; if not, the AC's
+     gating_tests are malformed against the manifest — verdict
+     `:not_demonstrated` with reason `:compile_failed`).
+  4. Run only the named gating tests with `mix test <files-and-lines>`.
+  5. Demonstrated iff ≥1 named test fails AND the failure stack includes
+     `Tau.Factory.MutationMarker`. The marker check defeats "the test
+     fails for a coincidental reason."
+  6. Tear down the worktree (capture-before-destroy per
+     `worktree-discipline.md` if mutation left artefacts, otherwise plain
+     `git worktree remove -f -f`).
+- **Failure mode:** any `:not_demonstrated` makes C2 fail the PR.
+- **Gating effect:** the proof. This is the structural-impossibility piece:
+  a test that exercises the wrong layer *cannot* notice the call-site
+  mutation, and so cannot pass.
+
+C4 differs from the existing `mix tau.gate.mutation` (which reverts
+everything-not-in-gating-test-paths to merge-base) in two essential ways:
+(a) it targets the *single call site* the AC names, not the whole production
+diff, so it isolates the question "does this test depend on this entry
+point" from "does this test depend on anything that changed in this PR";
+(b) it ties the failure signal to a marker raise, so a test that fails for
+a coincidental compile-time error is not credited as "demonstrated."
+
+### C5 — CI workflow gate
+
+- **Path:** `.github/workflows/ci.yml` (new job: `ac_binding`).
+- **Input:** the PR ref and number.
+- **Output:** a required GitHub status check. The job runs:
+  ```yaml
+  - name: AC binding
+    run: mix tau.gate.ac_binding --pr ${{ github.event.pull_request.number }}
+    # NO `|| true`, NO `continue-on-error`, NO `if:` early-exit guard.
+  ```
+- **Failure mode:** non-zero exit fails the job; the branch protection rule
+  on `main` requires this job to pass before merge.
+- **Gating effect:** the actual blocker. C2 produces the verdict; C5 is what
+  turns the verdict into a merge block.
+
+The job has no `if:` guard. Even a "trivial typo fix" PR runs the job;
+the `chore:no-ac` label path is handled by C2 returning `pass` with
+`status: no_applicable`, **not** by the workflow skipping the job. This is
+the silent-skip-impossibility mechanism: the gate runs unconditionally,
+and "nothing to check" is a verdict the gate produces, not the absence of
+a verdict.
+
+### C6 — Branch protection wiring
+
+- **Path:** `.github/settings.yml` (if using probot/settings) OR a documented
+  one-shot script `scripts/factory/configure-branch-protection.sh` invoking
+  `gh api repos/.../branches/main/protection`.
+- **Input:** repo admin token, list of required checks.
+- **Output:** branch protection on `main` requiring `ac_binding` (and the
+  other gates from sibling proposals) to pass before merge.
+- **Failure mode:** if the script has not been run, this proposal's gate
+  isn't actually blocking. C6 is a one-time bootstrap, but its absence is
+  detectable: the operability sibling's dashboard reads
+  `gh api .../branches/main/protection` and reports missing required checks.
+- **Gating effect:** binds C5's status check to merge.
+
+### C7 — Manifest authoring helper agent
+
+- **Path:** `.claude/plugins/factory-v2/agents/ac-manifest-author.md` +
+  `.claude/plugins/factory-v2/skills/ac-manifest/SKILL.md`.
+- **Input:** the issue body + the in-scope SPEC sections + the open PR
+  draft.
+- **Output:** a proposed `## Acceptance criteria` block in the manifest
+  schema (C1), inserted into the draft PR body via `gh pr edit`.
+- **Failure mode:** if the agent produces a manifest that doesn't parse
+  (C1) or doesn't resolve (C3), C2 fails the PR. The agent's output is
+  never load-bearing — it's a typing aid for humans / implementers, and
+  the mechanism (C2-C5) is what enforces correctness. An agent that
+  hallucinates a `user_path` is caught by C3.
+- **Gating effect:** none — quality-of-life only. Listed explicitly so the
+  proposal does not appear to assume an agent does the work.
+
+## Silent-skip impossibility — concrete return semantics
+
+The "nothing to check" question has exactly two legitimate answers:
+
+- The PR body has no `## Acceptance criteria` section AND the PR carries
+  the `chore:no-ac` label (added by a human reviewer or the
+  `tau-github-workflow` triage step). C2 returns `pass` with
+  `{"status":"no_applicable", "reason":"chore_no_ac_label"}`. The CI
+  status is green; the verdict is recorded as "checked, no applicable
+  findings."
+
+- The section is present and parses. C2 runs C3 + C4 for every entry and
+  returns `pass` or `fail`.
+
+Every other state — missing section without label, section that doesn't
+parse, entry without `user_path`, entry without `gating_tests`,
+unresolvable `user_path`, mutation that doesn't demonstrate — is a **fail**.
+There is no codepath in C2 that exits 0 without writing a verdict to
+stdout.
+
+The verdict is emitted in two places: stdout (read by CI to set the check
+status) and a JSON file at `tmp/factory/verdicts/ac_binding-<sha>.json`
+(uploaded as a CI artifact). The artifact path is what the operability
+sibling's dashboard reads.
+
+## How the verdict is consumed
+
+- **GitHub status check `ac_binding`** — read by branch protection (C6)
+  to gate merge; read by humans on the PR page.
+- **CI artifact `verdicts/ac_binding-<sha>.json`** — read by the
+  operability sibling's dashboard to render per-PR gate health; read by
+  the post-merge cross-artifact sibling on `main` to populate a historical
+  series (which AC tokens have churned, which surfaces accumulate AC
+  fails).
+- **PR body update** — C5's job appends a structured block at the end of
+  the PR body via `gh pr comment` (not `gh pr edit`, to preserve the
+  manifest section as the single source of truth): one comment per gate
+  run, with the verdict JSON inline. This is what humans see at a glance
+  and what the critic/reviewer gates read when forming their (non-load-
+  bearing) commentary.
+
+## Failure classes addressed
+
+- **#6 primary** — per-AC call-site mutation (C4) is the structural
+  proof that a test exercises the path the AC names. A wrong-path test
+  cannot pass.
+- **#1 AC-side** — `UserPathResolver` (C3) fails AC text that cites
+  nonexistent symbols or argv patterns. AST-level drift in production
+  code remains with the pre-merge-code-gates sibling.
+
+## How each AC of the leaf is satisfied
+
+- **(a) every AC-N / D-NNN paired with user-path entry point and
+  gating-test paths.** C1's schema makes this a parse error otherwise; C2
+  refuses to pass on parse errors.
+- **(b) per-AC mutation that disables the specific user-path call site;
+  named test(s) MUST go red.** C4 implements exactly this, with the
+  marker-raise check defeating coincidental failures.
+- **(c) cannot silent-skip.** C5 runs unconditionally; C2's only "no
+  applicable" path requires an explicit label.
+- **(d) reuse-vs-build recorded.** Explicit decision: bespoke. Rationale:
+  `muzak` mutates all-of-tree non-deterministically and reports
+  surviving mutants; we need per-AC, single-call-site mutation with a
+  named marker. Adapting `muzak` to drive named mutations is more code
+  than C4. `excoveralls` coverage answers "did the test touch the line,"
+  not "does the test depend on the line"; coverage is necessary but not
+  sufficient and so would not satisfy AC-B6. The reuse-survey-of-record
+  is proposer 2's responsibility; this proposal records its own decision
+  here.
+- **(e) concrete artifacts named.** Listed above with file paths.
+
+## Build-order
+
+**Week 1 — minimum viable gate, end-to-end:**
+
+1. C1 (`Tau.Factory.ACManifest`) — schema + parser + tests. No other
+   component compiles without it.
+2. C3 (`Tau.Factory.UserPathResolver`) — resolution for `:elixir_mfa` only
+   in week 1; `:cli_argv` deferred to week 2. This is enough to bind any
+   AC that names an Elixir function.
+3. C2 (`mix tau.gate.ac_binding`) — stub C4 to always return
+   `:demonstrated` in week 1. The gate enforces parse + resolve only.
+4. C5 (CI workflow step) — wired to run C2 on every PR.
+5. C6 (branch protection) — required check set.
+
+End of week 1: a PR with an unresolvable AC fails to merge. A PR with no
+AC section and no label fails to merge. Silent-skip impossible.
+
+**Week 2 — close the AC-B6 hole:**
+
+6. C4 (`CallSiteMutator`) — `:elixir_mfa` rewrite path with marker raise.
+   C2 stops stubbing.
+7. C3 — add `:cli_argv` resolution (argv pattern → `Tau.CLI` dispatch
+   clauses).
+8. C4 — `:cli_argv` rewrite (target the matched clause body).
+
+End of week 2: AC-B6 falsification probe is mechanically prevented. The
+existing `tau.gate.mutation` becomes redundant for AC scope and can be
+retired (decision deferred to the pre-merge-evidence sibling, which owns
+the gate inventory).
+
+**Week 3 — affordances:**
+
+9. C7 (manifest-author agent + skill) — typing aid for implementers.
+   Non-load-bearing; pure DX.
+10. Meta-AC support — `:meta` tag in C1, CI-workflow-step check in C2.
+
+## Dependencies
+
+- **Outbound:** none from sibling design proposals; this leaf is
+  self-contained.
+- **Inbound:** the pre-merge-evidence sibling's "no silent-skip" mechanism
+  may want to wrap *all* gate workflow steps with a common runner that
+  forbids `continue-on-error`; C5 written as above is conformant. The
+  operability sibling consumes the JSON artifact.
+- **Tooling:** `gh` CLI in CI (already present); `mix` in CI (already
+  present); a per-job throwaway worktree (C4) — fits the existing
+  `worktree-discipline.md`.
+
+## Confidence
+
+Medium-high. The mechanism is small (≈400 LoC across C1-C4) and each
+component is independently testable. The principal risk is C4's
+`:cli_argv` rewrite: matching argv patterns against `Tau.CLI` dispatch
+clauses requires either a structured router (which `Tau.CLI` doesn't
+currently have — it's a flat `case` in `main/1`) or AST pattern matching
+against the argv literal. The `:elixir_mfa` path is straightforward and
+covers the audit's named falsification probe (AC-B6) immediately;
+`:cli_argv` is the harder week-2 work and the place to expect rework.
+
+## What this proposal explicitly does not do
+
+- Does not survey ecosystem alternatives (proposer 2).
+- Does not lift a prior-art mechanism wholesale (proposer 3).
+- Does not derive components by reverse-engineering specific past PR
+  failures (proposer 4).
+- Does not touch AST checks on production code (sibling
+  pre-merge-code-gates).
+- Does not touch the gate-infrastructure invariants of no-silent-skip
+  *for other gates* (sibling pre-merge-evidence-and-skip-integrity) —
+  only this gate's own no-silent-skip semantics.
+- Does not modify `tau.gate.mutation`; that is in scope for the
+  pre-merge-evidence sibling to retire or repurpose.

--- a/docs/factory-v2/design/subproblems/intent-capture-and-ac-binding/proposals/proposal-2.md
+++ b/docs/factory-v2/design/subproblems/intent-capture-and-ac-binding/proposals/proposal-2.md
@@ -1,0 +1,256 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 2
+parent_problem: ../problem.md
+approach_axis: adopt-from-claude-code-ecosystem
+confidence: medium
+---
+
+# Proposal 2 — Adopt swingerman/atdd as the AC↔test pipeline; bolt a thin Tau-specific compiler-tracer "per-AC mutator" onto cabbage gating tests
+
+## Approach (one sentence)
+
+Replace the v1 prose-PR-body AC declaration with a **Gherkin `.feature` file authored by Claude under the `swingerman/atdd` plugin's `discover-acs` + `atdd` skills**, compile each scenario to an ExUnit gating test via **`cabbage-ex/cabbage`** (Gherkin → ExUnit at compile time), validate the file's frontmatter against a JSON Schema using **`hashicorp/front-matter-schema`** in CI, and run a **thin, in-house `Tau.Gate.PerACMutator` Elixir compiler-tracer** that, for each `AC-N`-tagged scenario, locates the cited `module/fun/arity` entry-point call sites in the *compiled* tree and replaces them with `raise "AC-N user path disabled"` at compile time before running only that scenario's tests — pass = green test (silent-pass; FAIL the gate), fail = red test (the AC actually exercises the named path).
+
+## Rationale
+
+The leaf's complecting hypothesis names two distinct problems that the ecosystem already solves separately and well:
+
+1. **AC↔test pipeline.** `swingerman/atdd` (MIT, 97 stars, last release v1.5.1 2026-05-22, active) was built for *exactly this failure mode* — "AI writes unit tests that pass but don't verify the right behavior" (its README's opening problem). It enforces a Given/When/Then layer plus a `spec-guardian` agent that detects implementation-detail leakage. We do not need to invent that.
+2. **Gherkin-to-ExUnit compilation.** `cabbage-ex/cabbage` (MIT, 153 stars, on hex.pm 297k downloads) was built for exactly the BEAM half: compile-time translation of `.feature` files into ExUnit cases. The output *is* the gating-test path the v1 factory loop already knows how to handle.
+
+What the ecosystem does NOT solve is the **per-AC mutation** (each AC's *specific* entry-point call site must be the thing whose absence reddens *its* test). Off-the-shelf Elixir mutation testing (`muzak`, `darwin`, `exavier`, `muex`) all do *global random* mutations across whole modules; none accept a "mutate exactly this `mod/fun/arity` call site, run exactly these scenarios" instruction. That is the in-house piece — and it is small (one tracer module + one mix task) because Elixir's compiler-tracer hook (`@compile {:tracers, [...]}`) gives us a first-class API into call-site rewriting at `:macro_expand` / `:remote_function` events.
+
+The proposal is therefore **adopt-heavy, build-thin**: ~90% of the surface area is upstream code under MIT, with a ~150-line Tau-side gate that the audit can re-verify against the upstream's stable API.
+
+## Sketch
+
+### Component inventory (adopted)
+
+| Component                              | Source                                                                       | License | Stars | Last activity   | Failure class addressed                                    |
+| -------------------------------------- | ---------------------------------------------------------------------------- | ------- | ----- | --------------- | ---------------------------------------------------------- |
+| `swingerman/atdd` plugin               | `https://github.com/swingerman/atdd`                                         | MIT     | 97    | 2026-05-22 v1.5.1 | #6 — Claude writes tests against wrong layer (implementation-leakage guard) |
+| `cabbage-ex/cabbage`                   | `https://github.com/cabbage-ex/cabbage`                                      | MIT     | 153   | 2025-03-14      | #6 — mechanical Gherkin → ExUnit binding (no manual glue) |
+| `cabbage-ex/gherkin`                   | `https://github.com/cabbage-ex/gherkin`                                      | MIT     | 16    | 2024-06-25      | Gherkin parsing for the in-house tracer's scenario-tag reader |
+| `hashicorp/front-matter-schema`        | `https://github.com/hashicorp/front-matter-schema`                           | MPL-2.0 | (HashiCorp-owned action; production-grade) | active | #5 — schema-validated PR-body frontmatter; cannot silent-skip a missing AC declaration |
+| `mtfoley/pr-compliance-action`         | `https://github.com/mtfoley/pr-compliance-action`                            | MIT     | (Marketplace action) | active | #5 — enforces "PR body links to an issue" + required-sections regex |
+| Elixir `@compile {:tracers, [...]}`    | Built-in (`hexdocs.pm/elixir/Code.html`)                                     | Apache-2.0 | (stdlib) | stable since 1.10 | #6 — call-site-precise mutation, replacing v1's whole-module revert |
+
+### Component inventory (in-house — explicit gaps)
+
+| Component                                | Lines (est.) | Why bespoke                                                                                                     |
+| ---------------------------------------- | ------------ | --------------------------------------------------------------------------------------------------------------- |
+| `Tau.Gate.PerACMutator` (compiler tracer)| ~120         | No ecosystem mutation tool offers "mutate `mod/fun/arity` at exactly these call sites for exactly this test tag." |
+| `mix tau.gate.ac_binding`                | ~80          | CLI wrapper: parse `.feature`, drive tracer, run scoped `mix test`, assert red.                                 |
+| `feature.schema.json`                    | ~40 lines JSON | Tau-specific shape constraints (AC-N, D-NNN, `entrypoint:` MFA, `gating_test:` path).                          |
+| `.github/workflows/ac-binding.yml` step  | ~30          | Wires the two upstream actions + the in-house mix task into the existing `lint` job.                            |
+
+### Per-AC `.feature` shape (the AC declaration *is* the test plan)
+
+```gherkin
+---
+ac: AC-B6
+issue: "#341"
+spec: docs/spec/SPEC-PERMISSION-PROMPTS.md
+entrypoint:
+  mfa: "Tau.Session.set_permissions_mode/2"
+gating_test: test/tau/session/permissions_mode_test.exs
+---
+Feature: AC-B6 — set_permissions_mode/2 honours user verdict
+  @ac:AC-B6 @entrypoint:Tau.Session.set_permissions_mode/2
+  Scenario: Operator selects "always allow" for Bash
+    Given a session in :awaiting_permission for a Bash tool call
+    When the operator decides :always_allow via Tau.Session.set_permissions_mode/2
+    Then the session FSM transitions to :running
+    And the verdict persists for subsequent matching tool calls in the session
+```
+
+Frontmatter is validated by `hashicorp/front-matter-schema` against:
+
+```json
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": ["ac", "issue", "entrypoint", "gating_test"],
+  "properties": {
+    "ac": { "pattern": "^(AC-[A-Z0-9]+|D-[0-9]{3})$" },
+    "issue": { "pattern": "^#[0-9]+$" },
+    "spec": { "pattern": "^docs/spec/SPEC-[A-Z0-9-]+\\.md$" },
+    "entrypoint": {
+      "type": "object",
+      "required": ["mfa"],
+      "properties": { "mfa": { "pattern": "^[A-Z][A-Za-z0-9_.]+(\\.[a-z_][A-Za-z0-9_!?]*)/[0-9]+$" } }
+    },
+    "gating_test": { "pattern": "^test/.+\\.exs$" }
+  }
+}
+```
+
+### `Tau.Gate.PerACMutator` (sketch — Elixir compiler tracer)
+
+```elixir
+defmodule Tau.Gate.PerACMutator do
+  @moduledoc """
+  Compile-time mutator. For a given `{module, function, arity}` MFA cited in a
+  Gherkin scenario's `@entrypoint:` tag, rewrites all call sites in the
+  recompiled tree to `raise "AC-#{ac} user path disabled"`. The companion mix
+  task then runs ONLY the scenario's gating test and asserts it goes red. If
+  it stays green, the test does not exercise the cited entry-point — gate fails.
+  """
+
+  @behaviour :elixir_compiler_tracer  # conceptual; uses the documented :tracers contract
+
+  # Receives every macro-expanded remote call. We match the target MFA and
+  # ask the compiler to substitute the AST.
+  def trace({:remote_function, _meta, mod, fun, arity}, env) do
+    case Process.get(:tau_per_ac_target) do
+      {^mod, ^fun, ^arity, ac} -> rewrite!(env, ac)
+      _ -> :ok
+    end
+  end
+
+  def trace(_event, _env), do: :ok
+
+  defp rewrite!(env, ac) do
+    # Records the rewrite intent for the per-file transformer pass; the
+    # accompanying compiler pass replaces the matched node with:
+    #   raise "AC-#{ac} entry point disabled by Tau.Gate.PerACMutator"
+    send(self(), {:tau_mutator_hit, env.file, env.line, ac})
+    :ok
+  end
+end
+
+defmodule Mix.Tasks.Tau.Gate.AcBinding do
+  use Mix.Task
+  @shortdoc "Per-AC mutation gate (Gate 5.3-prime)"
+
+  @impl Mix.Task
+  def run(_argv) do
+    features = Path.wildcard("test/features/**/*.feature")
+    Enum.each(features, &check_feature/1)
+  end
+
+  defp check_feature(path) do
+    %{frontmatter: fm, scenarios: scenarios} = Tau.Gate.FeatureLoader.load!(path)
+    Enum.each(scenarios, fn scenario ->
+      ac    = Map.fetch!(scenario.tags, :ac)
+      mfa   = parse_mfa!(fm["entrypoint"]["mfa"])
+      gtest = fm["gating_test"]
+
+      Process.put(:tau_per_ac_target, Tuple.append(mfa, ac))
+      Code.put_compiler_option(:tracers, [Tau.Gate.PerACMutator])
+
+      with :ok          <- recompile_project(),
+           {:ok, result} <- run_one_test(gtest, ac) do
+        case result do
+          %{failures: f} when f >= 1 -> :ok                            # AC really exercises the path
+          %{failures: 0}             -> halt!("AC #{ac}: test did not redden when #{inspect mfa} was disabled")
+        end
+      end
+    end)
+  end
+end
+```
+
+### CI wiring (extends the existing `lint` job)
+
+```yaml
+      - name: Validate AC frontmatter schema
+        uses: hashicorp/front-matter-schema@main
+        with:
+          files: test/features/**/*.feature
+          schema: ${{ toJSON(fromJSON(env.AC_FRONTMATTER_SCHEMA)) }}
+
+      - name: Enforce PR-body issue link + required sections
+        uses: mtfoley/pr-compliance-action@v0.6
+        with:
+          ignoreTeamMembers: false
+          ignoreAuthors: ''
+          bodyRegexComment: 'Missing required sections; see PR template.'
+          bodyRegexFlags: 'gi'
+          bodyAutoClose: false
+
+      - name: Gate 5.3-prime — per-AC binding mutator
+        run: mix tau.gate.ac_binding
+```
+
+### Silent-skip impossibility
+
+Three layers, each fail-loud:
+
+1. **PR-body layer:** `mtfoley/pr-compliance-action` fails CI if the PR body omits the `Closes #N` / required-sections fences. v1's "missing field = pass" behaviour is impossible because the action exits non-zero on missing match.
+2. **Feature-file layer:** `hashicorp/front-matter-schema` fails CI on a missing `ac:` / `entrypoint:` / `gating_test:` key — the schema is `required`. A `.feature` file without frontmatter is rejected by the schema action's "no files matched" path (configurable to fail-on-empty).
+3. **Mutator layer:** `mix tau.gate.ac_binding` enumerates `test/features/**/*.feature`; for every scenario it MUST (a) parse the entrypoint MFA, (b) locate ≥1 call site in the recompiled tree (zero call sites → fail with `:entrypoint_unreachable`), (c) observe ≥1 red test in the scoped run (zero failures → fail with `:gate_silent_pass`). Each of (a)/(b)/(c) is a fail, not a skip; the task has no early-exit branch.
+
+The contrast with v1: `ci.yml:88-100` checks "if no gating-test paths declared, exit 0." Under this proposal there are no per-PR declared paths to be absent — the path *is* the `gating_test:` frontmatter field, and the file's existence is what the schema action checks. No PR body = no `.feature` files in the diff = the `mix tau.gate.ac_binding` task iterates the diff and asserts ≥1 `.feature` per claimed `AC-N` in the PR body (this last lookup uses the PR-body-issue-link side of `mtfoley/pr-compliance-action`'s parsed output).
+
+### Configuration / adaptation per adopted component
+
+- **`swingerman/atdd`**: install via `claude plugins install swingerman/atdd@v1.5.1`. Configure `engineer.config.yml` so its `pipeline-builder` agent targets `language: elixir, framework: cabbage` (the plugin's pipeline templates already support pluggable test-framework targets via its parser→IR→generator triad — that's exactly the seam needed). Disable the agent's bespoke parser (`dae_gherkin.py`) for Elixir-output mode; emit `.feature` files instead of Python tests.
+- **`cabbage-ex/cabbage`**: add `{:cabbage, "~> 0.4"}` to `mix.exs` `test`-only deps. Cabbage compiles `test/features/*.feature` to ExUnit cases at compile time, producing test names that include the scenario name — which the `@ac:` tag policy can map deterministically.
+- **`cabbage-ex/gherkin`**: pulled in transitively; the in-house tracer uses its parser directly to read `@ac:` / `@entrypoint:` scenario tags (the same tags Cabbage uses to generate `@tag` macros on the ExUnit case).
+- **`hashicorp/front-matter-schema`**: action ref `hashicorp/front-matter-schema@main`. Schema lives at `.github/schemas/feature-frontmatter.json`. The action's `files` input is set to `test/features/**/*.feature`.
+- **`mtfoley/pr-compliance-action`**: action ref `mtfoley/pr-compliance-action@v0.6`. Configure `ignoreTeamMembers: false` (the factory is the author), regex enforces `^Closes #\d+` and a `## Acceptance criteria` section header.
+- **Elixir `:tracers`**: enabled per-mix-task invocation only (`Code.put_compiler_option(:tracers, [Tau.Gate.PerACMutator])`); not added to project-wide compiler options to keep normal `mix compile` untouched.
+
+## Tradeoffs
+
+### Strengths
+
+- **Adoption ratio favourable.** Five upstream components (one Claude plugin + 16 skills + 3 agents from `swingerman/atdd`; two BEAM libraries from `cabbage-ex`; two GitHub Actions; stdlib tracer hook) carry the bulk; in-house surface is one tracer + one mix task + one JSON schema (≤ ~300 LOC + 40 LOC schema). The audit re-verification target is small.
+- **`swingerman/atdd` is purpose-built for the exact v1 failure mode.** Its `spec-guardian` agent's stated job is to detect implementation-detail leakage in Given/When/Then — i.e. catch "this test was written against a struct, not the user path" *before* the test is written. v1 had nothing analogous.
+- **Cabbage compile-time generation cuts an entire failure surface.** No manual glue between Gherkin and ExUnit means "the test that runs is provably derived from the AC text" — no test-author free hand to short-circuit to a private helper.
+- **Per-AC compiler-tracer mutation is strictly stronger than v1's Gate 5.3.** v1 reverts *every non-test path* to merge-base and asserts ≥1 failure anywhere in the suite; an under-asserting test fails for any reason (compile error, unrelated rev) and the gate believes the AC is exercised. Per-AC mutation fails only when the named call site goes away — false-green is mechanically impossible for the AC's own entry point.
+- **No silent-skip surface anywhere.** The three-layer fail-loud structure above closes failure class #5 *for this leaf's gates* by construction.
+- **Aligns with `docs/factory-v2/design/problem.md` §D ("Ecosystem reuse over reinvention").** Bespoke surface is explicitly justified and minimal.
+
+### Weaknesses
+
+- **`swingerman/atdd` is Python-primary (99% Python in the repo).** Its `pipeline-builder` ships pipelines for pytest / Jest / JUnit / Go-test / RSpec. Elixir/Cabbage is **not** an out-of-the-box target. We must configure the plugin's pipeline-generation prompts to emit `.feature` files only (skipping its Python test generator) and rely on Cabbage downstream. This is straightforward but is *not* the well-trodden path; the first AC will surface adaptation cost.
+- **Cabbage's last release on Hex was 0.4.1 (2023-09-18); upstream commits to 2025-03.** The package works but is in maintenance mode. If it falls behind Elixir 1.20+ macros, we inherit a maintenance burden. Mitigation: fork-and-pin at a known-good SHA; the API is small.
+- **Compiler-tracer mutation is sound only if the test runs against freshly-recompiled code.** Stale `_build` artefacts make the mutator a no-op. We must invoke `mix compile --force` inside `mix tau.gate.ac_binding` for the duration of each scenario. Slower CI (~20-40s per AC). Acceptable, but worth measuring under a real PR with 5+ ACs before locking in.
+- **`hashicorp/front-matter-schema` is HashiCorp-owned and not particularly popular.** No star metric appears publicly. Risk: action goes stale. Mitigation: small wrapper script (~15 LOC) over Python's `jsonschema` could replace it. Document this fallback in `.claude/rules/factory-loop.md` so the dependency is replaceable.
+- **Gherkin-as-AC has a learning-curve cost for the implementer agent.** The agent currently writes prose ACs in PR bodies. Switching to a structured `.feature` per AC is a behavioural change for *every* PR in the factory, not just gated ones; the `implementer.md` persona prompt must be updated. Risk: agent regression on the first few PRs.
+- **MFA-precision mutation cannot cover ACs whose "user path" is structural (e.g. "the supervision tree restarts X within Y ms") rather than a single call site.** For those, fall back to v1-style global mutation under a `gate_type: structural` frontmatter override — but this *re-opens* the silent-pass hole for that subset. We must enumerate which ACs are structural and accept the residual risk.
+- **Two BDD framework dependencies (Cabbage and the upstream Gherkin parser) plus a Python-primary plugin add three new dep-update vectors.** Higher supply-chain surface than a single bespoke Mix task would have.
+
+### Costs
+
+- **Initial: ~3-5 PR-days.** (1) Install + configure `swingerman/atdd` for Elixir target, (2) add `cabbage` + first `test/features/` directory with a representative AC, (3) write the tracer + mix task + JSON schema, (4) wire the four CI steps, (5) update `implementer.md` and `factory-loop.md` to teach the new flow.
+- **Ongoing per-PR: +1-3 min CI** (mostly `mix compile --force` per AC scenario) and **+5-15 min agent time** (Gherkin authoring under `atdd` skills).
+- **Dependency monitoring:** Cabbage / Gherkin / atdd / front-matter-schema / pr-compliance-action — five upstreams to track. `dependabot` covers Hex and Actions; the Claude plugin needs manual version-pinning in `.claude/plugins/`.
+
+## Dependencies
+
+- **Sibling-leaf coupling:** `pre-merge-evidence-and-skip-integrity` owns the *gate execution substrate*; this proposal asserts that the schema action + tracer-task have no silent-skip surface, but the *enforcement* that CI must be the evidence source (not local mix output) is its sibling's problem. The two leaves must agree the schema action runs on PR events with `if:` predicate set to *always-true-when-applicable* (no `github.event_name == 'push'` exclusion that lets push-bypass land).
+- **`knowledge-memory-and-audit-ingestion`:** if an audit finding implies a new AC-binding constraint (e.g. "ACs whose entrypoint is in `lib/tau/session.ex` MUST also cite a property test"), the audit registry must feed `feature.schema.json` extensions at PR time. The schema is the integration seam.
+- **Tau project state:** Cabbage requires Elixir ≥ 1.13; we're on 1.18. Compatible. ExUnit ≥ 1.10. Compatible.
+
+## Confidence
+
+**Medium.** High confidence that the upstream components exist and address the failure mode they claim to. Medium-not-high because (a) `swingerman/atdd` has not been deployed against an Elixir codebase at the public scale — we are the first non-Python user we have evidence of; (b) the compiler-tracer mutator depends on the `:macro_expand` / `:remote_function` events firing during recompile in a way that's not unit-tested by Elixir core for this use case (the documented use case is `xref`-style observation, not rewriting); a prototype is necessary before committing.
+
+## Prior art
+
+- **`swingerman/atdd`** (Claude Code plugin) — `https://github.com/swingerman/atdd` — README opening problem statement: "AI writes code without constraints — without acceptance tests anchoring behavior, AI can 'willy-nilly plop code around' and write unit tests that pass but don't verify the right behavior." This is the v1 failure verbatim.
+- **`cabbage-ex/cabbage`** — `https://github.com/cabbage-ex/cabbage` — production BEAM Gherkin runner; 297k Hex downloads validates real-world stability.
+- **`mtfoley/pr-compliance-action`** — `https://github.com/marketplace/actions/pr-compliance-action` — already adopted-by-default in many enterprise GitHub orgs for the exact "PR must link to an issue, must have these sections" enforcement.
+- **`hashicorp/front-matter-schema`** — `https://github.com/hashicorp/front-matter-schema` — HashiCorp's own internal-doc gating uses this; the JSON-Schema-over-frontmatter pattern is the same one GitHub Docs uses (`lib/frontmatter.ts` in their docs repo).
+- **Elixir compiler tracers** — Elixir 1.10+ `@compile {:tracers, [...]}` documented at `https://hexdocs.pm/elixir/Code.html`; AppSignal's 2020 walkthrough `https://blog.appsignal.com/2020/03/10/building-compile-time-tools-with-elixir-compiler-tracing-features.html` confirms the public-API stability and gives the reference shape for the in-house tracer.
+- **Existing factory-loop machinery in Tau** — `mix tau.gate.ac_linkage` / `mix tau.gate.masking` / `mix tau.gate.mutation` in `.github/workflows/ci.yml` already prove the "in-house mix task as a CI gate" pattern works. This proposal generalises that pattern by replacing the *content* (prose AC) with a *machine-readable* `.feature` file.
+
+## Build-order (favours adopt-over-build)
+
+The build-order is **strictly adopt → adopt → adopt → adopt → adapt → build → wire**, surfacing risk early and only committing to in-house code after each upstream's fit is proven.
+
+1. **Install `swingerman/atdd` plugin** (1 PR-hour). Verify on a throwaway feature whether its `discover-acs` skill produces sensible Gherkin for a Tau-shaped AC (e.g. AC-B6 rewritten). **Halt criterion:** if the plugin's Elixir-target adaptation costs > 1 PR-day, fall back to authoring `.feature` files directly via the implementer persona (drop `swingerman/atdd`; keep cabbage + tracer). This is the riskiest adoption.
+2. **Add `cabbage-ex/cabbage` dep + author one hand-written `.feature`** (1 PR-hour). Verify cabbage compiles it to a runnable ExUnit test. **Halt criterion:** if cabbage breaks against Elixir 1.18.1, fork at a known-good SHA before continuing.
+3. **Add `hashicorp/front-matter-schema` CI step + `feature.schema.json`** (30 min). Validates the AC-frontmatter shape end-to-end on a real PR.
+4. **Add `mtfoley/pr-compliance-action` CI step** (30 min). Closes the "PR body lacks `Closes #N`" silent-skip path for this leaf (the rest is `pre-merge-evidence-and-skip-integrity` sibling territory).
+5. **Adapt `swingerman/atdd` `pipeline-builder` to emit `.feature` files for Elixir** (~1 PR-day). The plugin's IR is intended to be language-pluggable; this is the proof that adoption holds at adapter level.
+6. **Build `Tau.Gate.PerACMutator` + `mix tau.gate.ac_binding`** (~2 PR-days). This is the *only* materially-bespoke surface. Validate against the first hand-written `.feature` from step 2: deleting the entrypoint MFA's body MUST redden the test; reverting that MUST green it.
+7. **Wire the `mix tau.gate.ac_binding` step into `.github/workflows/ci.yml`'s `lint` job** (1 PR-hour). Reuse the existing PR-body extraction and exit-code handling from the v1 gates.
+8. **Update `.claude/agents/implementer.md` + `.claude/rules/factory-loop.md`** (~1 PR-hour). Replace v1 "Gating-test paths" PR-body section with "Feature files (one per AC)" pointing to `test/features/<issue>/<ac>.feature`. The factory-loop refine bound, freshness re-check, post-merge `main` health check all remain unchanged.
+
+**Total estimated bespoke surface:** ≤ 300 LOC of Elixir + 40 LOC of JSON schema + ~80 LOC of YAML wiring. **Total adoption surface:** entire `swingerman/atdd` plugin (~2k LOC Python + 16 skills + 3 agents) + `cabbage` (~1k LOC Elixir) + two GitHub Actions (HashiCorp + mtfoley, both maintained externally). Adoption-to-bespoke ratio ≈ 10:1.

--- a/docs/factory-v2/design/subproblems/intent-capture-and-ac-binding/proposals/proposal-3.md
+++ b/docs/factory-v2/design/subproblems/intent-capture-and-ac-binding/proposals/proposal-3.md
@@ -1,0 +1,497 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 3
+parent_problem: ../problem.md
+---
+
+# Proposal 3: AC-binding as a sign-off Bill-of-Materials — adapt from ASIC tape-out, DO-178C, Bazel, Snakemake, and IR runbooks
+
+## Approach
+
+Treat each PR as a tape-out package whose central artefact is a machine-checkable
+**AC Bill-of-Materials (AC-BOM)** that the factory signs off the way a regulated
+hardware/software pipeline signs off a release. The AC-BOM is a single
+declarative file checked into the PR (`pr-bom.yaml`) that, for every `AC-N` /
+`D-NNN`, names: (i) a typed user-path target (`{kind: cli, argv: [...]}` or
+`{kind: mfa, m: Tau.Session, f: set_permissions_mode, a: 2}` or
+`{kind: http, route: ..., method: ...}`); (ii) the gating-test file paths and
+`@tag`s; (iii) the SPEC anchor (`SPEC-PERMISSION-PROMPTS#AC-B6`); (iv) a
+per-AC **mutation recipe** that names the exact call-site to neutralise. A
+mandatory CI workflow — modeled on an ASIC sign-off "rule deck" — runs five
+independent verifications against the AC-BOM and produces a signed
+verdict file that branch protection requires; the workflow has no conditional
+branches that can short-circuit (no `if:` on the deck steps, no `|| true`),
+mirroring DRC/LVS sign-off in EDA. The five checks correspond to the five
+"questions" a tape-out checklist asks: does the artefact exist, does it match
+the spec, does it survive perturbation, is its provenance traceable, and is
+the deck itself uncorrupted.
+
+## Rationale
+
+The complecting hypothesis on this leaf is that AC text, user-path entry, and
+test entry are linked only by prose, so the test-author can satisfy the AC
+form against the wrong code-path with no mechanical detector. Prior art from
+heavily-gated, low-trust pipelines outside the Claude Code ecosystem solves
+exactly this — the BOM concept (electronics manufacturing), the rule-deck
+sign-off (ASIC), the traceability matrix (DO-178C / IEC 62304), reproducible
+build-graph artefacts (Bazel / Snakemake), and the structured runbook
+(incident response) — by making the deliverable a typed manifest that an
+independent checker compares against the physical build. Translation: the
+PR body's prose becomes a typed YAML the factory parses; the "test exercises
+the user path" claim becomes a graph relation (`AC → user_path_target →
+gating_test → mutation_recipe`) that mechanical checkers traverse; and the
+"factory ran the gate" claim becomes a signed verdict file whose absence
+fails branch protection. None of these patterns rely on agent self-report or
+human review for the structurally-checkable part — they rely on the manifest
+being typed and the deck being unskippable, which directly answers AC (c).
+
+## Sketch
+
+### Five prior-art patterns and their concrete translations
+
+#### Pattern 1 — ASIC tape-out **sign-off rule deck** (DRC/LVS/ERC)
+
+- **Source.** Industry-standard EDA sign-off methodology; canonical reference:
+  Wayne Wolf, *Modern VLSI Design* (4th ed., 2008), ch. 4 §"Sign-off"; tool
+  vendor docs (Cadence Pegasus, Mentor Calibre, Synopsys IC Validator). A
+  publicly-readable open-source analogue: the KLayout DRC engine
+  (https://www.klayout.de/doc/manual/drc_basic.html).
+- **What it solves.** A foundry refuses to manufacture a chip unless every
+  rule in the deck has been run and a green log is produced; the deck is
+  versioned and signed; engineers cannot disable individual rules to pass
+  sign-off. Maps directly to root §AC C (silent-skip impossibility).
+- **Translation to our factory.** `Tau.Factory.AcBomGate` is a single mix
+  task `mix tau.gate.ac_bom` whose body is a flat list of five checks
+  (below) with no early-exit. The mix task's exit code is the deck's
+  verdict. The CI step that runs it has no `if:` predicate and no
+  `continue-on-error: true`. The verdict file
+  (`.factory/verdicts/<sha>.json`) is signed with `sigstore cosign` (the
+  open-source supply-chain signing tool — https://www.sigstore.dev/) and
+  the merge-gate workflow refuses any commit whose SHA lacks a co-signed
+  verdict matching the PR head SHA.
+- **Rejected as inapplicable.** EDA's "waivers" mechanism, where a senior
+  engineer can sign off a known-failing rule. v1 already showed this
+  becomes the silent-skip vector; we adopt deck rigor without waivers.
+  Time-boxed waivers live in the audit-ingestion sibling, not here.
+
+#### Pattern 2 — DO-178C / IEC 62304 **traceability matrix** (HLR → LLR → code → test)
+
+- **Source.** RTCA DO-178C §6.5 and §11.21 ("Trace data"); ISO/IEC 62304:2006
+  §5.5 ("Software unit implementation and verification"). Practitioner
+  reference: Leanna Rierson, *Developing Safety-Critical Software* (CRC
+  Press, 2013), ch. 6.
+- **What it solves.** Every high-level requirement must trace bidirectionally
+  to a low-level requirement, to a code unit, and to a verification (test).
+  The audit asks: pick any requirement and walk forward to the test; pick
+  any test and walk backward to the requirement. Orphan code and orphan
+  tests are findings. Maps directly to AC (a) — every AC paired with
+  resolvable entry point and gating tests — and to failure class #1 (AC
+  side: AC text naming non-existent symbols).
+- **Translation to our factory.** The AC-BOM IS the traceability matrix.
+  Schema:
+  ```yaml
+  # pr-bom.yaml — committed at PR root, validated by mix task
+  schema_version: 1
+  pr: 415
+  acs:
+    - id: AC-B6
+      text: "/perms allow-tool grants tool capability for the session"
+      spec_anchor: docs/spec/SPEC-PERMISSION-PROMPTS.md#AC-B6
+      user_path:
+        kind: mfa
+        module: Tau.Session
+        function: set_permissions_mode
+        arity: 2
+      gating_tests:
+        - path: test/tau/session/permissions_mode_test.exs
+          tag: ac_b6
+      mutation_recipe:
+        kind: function_no_op
+        target: {m: Tau.Session, f: set_permissions_mode, a: 2}
+        expectation: at_least_one_failure_in_tagged_tests
+  ```
+  Two new mix tasks enforce bidirectional traceability:
+  `mix tau.gate.ac_bom.forward` walks AC → user_path → test (every link
+  must resolve to a real symbol/file via `Code.ensure_loaded?/1` and
+  `:erlang.function_exported/3`) and `mix tau.gate.ac_bom.backward` walks
+  every `@tag :ac_*` test backward to an AC in the BOM (every tagged test
+  must belong to exactly one AC). Orphan in either direction fails the deck.
+- **Rejected as inapplicable.** DO-178C's Level-A independence requirement
+  (independent verifier from a separate organisation) — we have no separate
+  organisation. We get partial independence by requiring the test-author
+  agent and implementer agent to be separate processes with separate
+  contexts (already required by factory-loop.md phase 4b), but we do not
+  fake organisational separation.
+
+#### Pattern 3 — Bazel / Snakemake / DVC **content-addressed build graph**
+
+- **Source.** Bazel — https://bazel.build/concepts/build-ref; Snakemake —
+  Köster & Rahmann, "Snakemake — a scalable bioinformatics workflow
+  engine," *Bioinformatics* 28(19):2520, 2012; DVC —
+  https://dvc.org/doc/user-guide/pipelines/defining-pipelines. The
+  unifying primitive: a build is a DAG of rules where each rule has typed
+  inputs and outputs, every output is content-addressed, and the build
+  engine refuses to declare success without proof every output was
+  produced from its declared inputs.
+- **What it solves.** Eliminates the "passed on my machine" / "appeared
+  to pass" failure mode (failure class #7 — PRs citing local-mix evidence,
+  partly owned by the evidence-and-skip-integrity sibling but the
+  reproducibility primitive is shared). Maps to AC (b) (per-AC mutation
+  must produce red).
+- **Translation to our factory.** The AC-BOM is the rule file; the
+  per-AC mutation check is a rule whose inputs are `{source tree at
+  HEAD, mutation_recipe}` and whose declared output is a
+  `mutation_verdict.json` of shape `{ac_id, mutated_sha, tagged_test_run_id,
+  failures_observed: integer}`. The deck refuses to admit a verdict whose
+  `failures_observed == 0`. Implementation uses `mix muzak` patterns
+  (Doctor — https://github.com/devonestes/muzak — the leading Elixir
+  mutation-testing library) for the *mechanism* of source mutation (AST
+  rewriting), but driven by our `mutation_recipe` rather than muzak's
+  default mutation operators. Each per-AC mutation runs in a sandboxed
+  worktree (per worktree-discipline.md) with cosigned outputs.
+- **Rejected as inapplicable.** Full hermetic builds (Nix-style) — Tau's
+  test suite has too many Elixir-ecosystem assumptions (`mix deps`, local
+  `~/.mix`) to make hermetic enforcement productive *for this leaf*; the
+  evidence-and-skip-integrity sibling owns reproducibility-of-CI-itself,
+  and we depend on its work for the *runner* being trusted.
+
+#### Pattern 4 — GitHub **required status checks** with branch protection rules
+
+- **Source.** GitHub Docs, "About protected branches" —
+  https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/about-protected-branches.
+  Canonical large-monorepo deployments: Kubernetes' tide bot
+  (https://github.com/kubernetes/test-infra/tree/master/prow/cmd/tide),
+  the Linux kernel's `0day` testing infra. Pattern: the merge button is
+  controlled by a list of named status checks; merging is impossible
+  until every named check has reported success against the *exact* head
+  SHA.
+- **What it solves.** Class #7 (merging PRs against red CI) becomes
+  structurally impossible at the GitHub layer, not the convention layer.
+  Maps to AC (c) (cannot silent-skip).
+- **Translation to our factory.** Branch protection on `main` requires
+  the named check `factory/ac-bom-deck` to PASS against the PR head SHA.
+  The `ac-bom-deck` GitHub-Actions job runs `mix tau.gate.ac_bom` and
+  uploads the cosigned verdict; the check name is configured server-side
+  (not in `.github/workflows/`, which a PR could amend). A bootstrap mix
+  task `mix tau.factory.branch_protection.assert` connects to the GitHub
+  API and asserts the required-check set matches a constant in the
+  factory code, failing CI if a previous PR has weakened protection.
+- **Rejected as inapplicable.** Auto-merge bots that re-base and merge in
+  the background (tide, mergify) — we want human (or coordinator) intent
+  for merge timing per factory-loop.md; we only borrow the
+  required-status-check primitive.
+
+#### Pattern 5 — Incident-response **structured runbook** with verification steps
+
+- **Source.** PagerDuty Incident Response handbook
+  (https://response.pagerduty.com/), particularly the "Runbook" and
+  "Postmortem" pages; the Google SRE Workbook (O'Reilly, 2018) ch. 9
+  ("Incident Response"). Pattern: a runbook is a numbered list where
+  each step has (a) a command to run, (b) expected output, (c) what to
+  do if the output differs. The runbook is mechanically executable; an
+  on-call who is half-asleep can follow it.
+- **What it solves.** The PR-body field that v1 treated as prose
+  ("AC-B6 advanced because…") becomes a numbered, executable runbook
+  whose verification steps the deck literally runs. Maps to AC (e)
+  (concrete artifacts to build — specifically the PR-body schema).
+- **Translation to our factory.** The `pr-bom.yaml` is rendered into
+  the PR description by a `.github/workflows/render-bom.yml` workflow on
+  every push; the human-readable section shows AC, user-path, tests,
+  and the mutation recipe as a "you can reproduce this locally with"
+  block. The implementer/test-author agents read the schema (not the
+  rendered prose) via a published JSON-Schema
+  (`schemas/pr-bom.schema.json`) so their reasoning is constrained to
+  the structured shape.
+- **Rejected as inapplicable.** The "postmortem" half of IR runbooks
+  (blameless review, action items) — handled separately by the
+  knowledge-memory-and-audit-ingestion sibling.
+
+### The five deck checks (the mix task body)
+
+```elixir
+# lib/tau/factory/ac_bom_gate.ex (sketch)
+defmodule Tau.Factory.AcBomGate do
+  @moduledoc """
+  ASIC-tape-out-style sign-off deck for the PR's AC-BOM.
+
+  Five independent checks, no early exit, no waivers, no silent-skip.
+  Returns {:ok, verdict} only when all five pass; {:fail, [findings]}
+  otherwise.
+  """
+
+  @spec run(Path.t()) :: {:ok, map()} | {:fail, [map()]}
+  def run(pr_root) do
+    bom = AcBom.load!(Path.join(pr_root, "pr-bom.yaml"))
+    findings = []
+      |> append(Check.SchemaValid.run(bom))         # Check 1: deck itself uncorrupted
+      |> append(Check.SymbolsResolve.run(bom))      # Check 2: artefact exists (DO-178C forward trace)
+      |> append(Check.TestsTagged.run(bom))         # Check 3: artefact matches spec (DO-178C backward trace)
+      |> append(Check.PerAcMutation.run(bom))       # Check 4: survives perturbation (Snakemake/Bazel rule)
+      |> append(Check.ProvenanceSigned.run(bom))    # Check 5: provenance traceable (sigstore)
+
+    case findings do
+      [] -> {:ok, render_verdict(bom)}
+      list -> {:fail, list}
+    end
+  end
+
+  # Each Check.X.run returns [] on pass or [finding_struct, ...] on fail.
+  # There is no version that returns :skipped.
+end
+```
+
+The CI workflow step is:
+
+```yaml
+# .github/workflows/ci.yml (the ac-bom-deck job)
+ac-bom-deck:
+  runs-on: ubuntu-latest
+  steps:
+    - uses: actions/checkout@v4
+    - uses: erlef/setup-beam@v1
+      with: { otp-version: '27.2', elixir-version: '1.18.1' }
+    - run: mix deps.get
+    - run: mix tau.gate.ac_bom
+    # No `if:`, no `continue-on-error`, no `|| true`. The job's exit
+    # status IS the verdict. Branch protection's required check name
+    # is "ac-bom-deck" (this job).
+    - run: cosign sign-blob --yes .factory/verdicts/${{ github.sha }}.json > .factory/verdicts/${{ github.sha }}.sig
+    - uses: actions/upload-artifact@v4
+      with: { name: ac-bom-verdict, path: .factory/verdicts/ }
+```
+
+### How silent-skip is made impossible
+
+1. **Schema-mandatory PR-BOM.** Check 1 (`SchemaValid`) fails if `pr-bom.yaml`
+   is missing, syntactically invalid, or lacks any AC declared in the PR
+   body's `## Acceptance criteria` section. There is no "if no BOM, skip
+   gracefully" branch.
+2. **Forward+backward orphan detection.** Check 2 and Check 3 together
+   enforce DO-178C's bidirectional trace: no AC without a real symbol
+   and tagged test, no tagged `:ac_*` test without an AC entry. Either
+   orphan kind fails the deck.
+3. **Per-AC mutation requires `failures_observed >= 1`.** Check 4 fails
+   if mutating the AC's declared call-site does not produce ≥1 failure
+   in that AC's tagged tests. A "test passes anyway" outcome is the
+   classic v1 failure mode and is now the explicit failure signal.
+4. **Required status check at GitHub layer.** Even if a PR amended
+   `.github/workflows/ci.yml` to remove the deck, branch protection
+   requires the `factory/ac-bom-deck` named check to be GREEN against
+   the PR head SHA before the merge button enables. A PR with the
+   workflow removed reports "missing required check" and cannot merge.
+5. **Cosigned verdict file.** Check 5 fails if the verdict is not
+   sigstore-cosigned by a key whose public half is committed to the
+   factory's `keys/` directory. A faked-locally verdict has no
+   signature; a verdict signed by a key not in the repo is rejected.
+6. **No exit code besides 0 (deck PASS) or non-zero (deck FAIL).** There
+   is no `:skipped`, `:not_applicable`, `:waived`, or `:warn-only` exit.
+   The single binary outcome is enforced by `Tau.Factory.AcBomGate.run/1`
+   returning only `{:ok, _} | {:fail, _}`.
+
+### Reuse-vs-build decision record (AC d)
+
+- **AST mutation mechanism.** ADOPT `muzak`
+  (https://github.com/devonestes/muzak) for the source-rewriting
+  primitive. Its mutation operators are not what we want, but its
+  AST-rewrite-and-recompile loop is exactly the work we'd otherwise
+  reinvent. Wrap with a `Tau.Factory.Mutation` module that takes our
+  `mutation_recipe` and drives muzak as a library.
+- **Coverage with per-test tagging.** DEFER `excoveralls`; coverage is
+  not the right primitive (a covered line is not an exercised
+  invariant). We use `@tag :ac_*` on ExUnit tests and grep for tags,
+  not coverage percentages.
+- **YAML schema validation.** ADOPT `ymlr` for serialisation
+  (https://github.com/ufirstgroup/ymlr) and `ex_json_schema`
+  (https://github.com/jonasschmidt/ex_json_schema) for validating
+  `pr-bom.yaml` against `schemas/pr-bom.schema.json`. Reject building
+  a bespoke YAML schema engine.
+- **Cosign for signing.** ADOPT sigstore `cosign` as the verdict
+  signer — already widely deployed in supply-chain security and free.
+- **GitHub branch protection.** ADOPT the GitHub-native required-status-
+  check mechanism rather than building an in-repo merge bot.
+- **BUILD bespoke:** `Tau.Factory.AcBom`, `Tau.Factory.AcBomGate`, the
+  five `Check.*` modules, the `pr-bom.yaml` schema, the
+  `render-bom.yml` workflow, the `assert_branch_protection` bootstrap
+  mix task. All have no upstream equivalent.
+
+### Concrete artefacts to build (AC e)
+
+- `lib/tau/factory/ac_bom.ex` — schema, loader, serializer (~200 LoC).
+- `lib/tau/factory/ac_bom_gate.ex` — orchestrator returning binary verdict.
+- `lib/tau/factory/check/{schema_valid,symbols_resolve,tests_tagged,per_ac_mutation,provenance_signed}.ex`
+  — one module per deck check (~150 LoC each).
+- `lib/tau/factory/mutation.ex` — muzak-driver wrapper for our recipes.
+- `lib/mix/tasks/tau.gate.ac_bom.ex` — single CLI entry; exit 0/non-0.
+- `lib/mix/tasks/tau.factory.branch_protection.assert.ex` — bootstrap
+  invariant check against GitHub API.
+- `schemas/pr-bom.schema.json` — JSON-Schema for the BOM.
+- `.github/workflows/ci.yml` — replace existing `mix tau.gate.ac_linkage`
+  step with `mix tau.gate.ac_bom`; new `render-bom.yml` workflow for the
+  PR-body rendering pass.
+- `.factory/verdicts/.gitkeep` — verdict directory.
+- `keys/factory.pub` — committed cosign public key.
+- One initial `pr-bom.yaml` example checked in, used by the deck's own
+  self-test suite.
+
+## Tradeoffs
+
+### Strengths
+
+- **Five-layer independence.** Each prior-art pattern targets a distinct
+  v1 failure mode (rule-deck → silent-skip; trace matrix → orphan
+  AC/test; build-graph → reproducibility; required-status-check → red-CI
+  merging; runbook → prose-vs-structure). Their failure modes are
+  uncorrelated, so the combined gate is robust to any single pattern
+  being circumvented.
+- **All five patterns come from contexts where the operator is presumed
+  hostile or unreliable** (EDA, regulated medical/aviation, supply-chain
+  signing, on-call humans, untrusted GitHub PRs from outside contributors).
+  This matches root §Background — the v2 factory must not rely on
+  Claude telling the truth about its own work.
+- **The BOM is the test plan, the PR description, the trace matrix, and
+  the mutation recipe simultaneously** — directly addressing the leaf's
+  complecting hypothesis (prose and tests are linked only by prose).
+- **Branch protection at the GitHub layer means the silent-skip vector
+  cannot live in `ci.yml` PRs** — closing the v1 vector at `:88-100`,
+  `:213-223`, `:115` permanently.
+- **AC (a) (b) (c) (d) (e) all addressed concretely**, not as future
+  work.
+
+### Weaknesses
+
+- **Five separate prior-art adaptations is a wide surface to maintain.**
+  When sigstore/cosign deprecates a CLI flag, when muzak's API drifts,
+  or when GitHub renames a branch-protection field, the deck must be
+  updated. The hygiene cost is non-trivial and not borne by this leaf.
+- **The bidirectional trace check (Check 3 — backward) requires a tag
+  convention on tests** (`@tag :ac_b6`). Existing tests without tags
+  are invisible to the gate; rolling out the convention across the
+  existing test suite is a migration burden separate from this leaf.
+  Mitigation: only NEW tests added in a PR are required to be tagged;
+  legacy tests are allowlisted via a hash file.
+- **The mutation check (Check 4) needs a callable `mutation_recipe`
+  vocabulary** — we sketch `function_no_op` but real ACs will need
+  richer recipes (`return_constant`, `swap_branches`, `delete_call_site`).
+  Designing the vocabulary is non-trivial and may produce false-positive
+  failures when an honest test happens to also exercise an unrelated
+  path the mutation touched.
+- **Cosign adds an external binary dependency to CI** — must be installed
+  in the CI runner image and version-pinned. A failure to install fails
+  every PR (which is the correct behaviour, but increases CI fragility).
+- **Compared to proposals 1 and 2** (which presumably take more
+  incremental routes — file-internal extraction or sub-state-machine
+  decomposition), this proposal demands the largest one-time
+  factory-engineering investment and the largest set of new
+  dependencies. Its strength is breadth of coverage, its weakness is
+  upfront cost.
+- **GitHub-native branch protection means GitHub outages halt merging.**
+  Acceptable for a factory whose merge cadence is human/coordinator-
+  driven, but an explicit dependency on GitHub Enterprise SLAs.
+- **Honest weakness: the "agents read the schema, not prose" claim
+  depends on subagent discipline.** If an implementer agent ignores
+  the schema and pattern-matches prose anyway, the structure does not
+  prevent it. Mitigated by the deck not caring what the agent thought
+  (the deck checks the manifest), but the test-author who writes a
+  wrong-target manifest still fools the deck — that residual is owned
+  by phase-4b in factory-loop.md and is not closeable here.
+
+### Costs
+
+- **One-time build:** ~1500 LoC Elixir (estimated) across the BOM, deck,
+  five checks, mutation wrapper, two mix tasks, JSON-Schema. Plus
+  ~200 lines of GitHub-Actions YAML and the bootstrap branch-protection
+  PR.
+- **Per-PR overhead:** authoring `pr-bom.yaml` adds ~20-60 lines of YAML
+  per PR (one block per AC). The test-author agent (already required by
+  factory-loop.md phase 4b) generates the YAML, so human cost is near
+  zero; agent cost is one additional structured-output step.
+- **CI runtime cost:** per-AC mutation runs the tagged test subset once
+  per AC. For a PR with 5 ACs and 10 tagged tests each, that's 5×
+  recompile-and-run-10-tests. Estimated +2-5 minutes per PR on top of
+  the existing test job.
+- **External dependencies added to CI:** `cosign` binary, `muzak` hex
+  package, `ymlr` hex package, `ex_json_schema` hex package.
+- **Knowledge cost:** the factory team must understand five prior-art
+  domains at least at the "what does this gate check" level. Mitigated
+  by each Check module being ~150 LoC and self-documenting.
+- **Migration cost for existing tests:** allowlist hash file requires
+  one PR to bootstrap (count current untagged tests, record their hashes).
+
+## Dependencies
+
+- The evidence-and-skip-integrity sibling owns the trusted-CI-runner
+  primitive — this deck assumes the runner itself is not compromised.
+  If that sibling chooses self-hosted runners or attestation-based
+  runners, the cosign-key location and the deck's trust-root reference
+  it.
+- The knowledge-memory-and-audit-ingestion sibling owns the
+  "audit-finding → AC-BOM constraint" pipeline. The deck consumes the
+  audit-derived constraints as additional Check rules when that sibling
+  ships.
+- A first PR landing the bootstrap deck + branch-protection assertion
+  must be merged with a transitional waiver (single, time-boxed, signed
+  by the coordinator) before subsequent PRs are subject to the deck.
+- Hex packages: `muzak`, `ymlr`, `ex_json_schema`. System package:
+  `sigstore-cosign`.
+- GitHub repo permissions: ability to set branch-protection rules
+  programmatically (admin or "manage branch protections" scope).
+
+## Confidence
+
+**High** on the prior-art mapping (each of the five patterns is widely
+deployed and well-documented in the cited sources). **Medium** on the
+per-AC mutation-recipe vocabulary — designing a vocabulary that is
+expressive enough for real ACs without producing false-positive
+failures is genuine design work, and would benefit from a 2-3 PR
+prototype against existing ACs (e.g. AC-B6) before broader rollout.
+**Medium** on the cosign integration — solid technology but the
+specifics of key custody for an agent-driven factory need a short ADR.
+
+What would raise confidence to High overall:
+
+- A prototype of `Tau.Factory.AcBom.load!/1` + `Check.SymbolsResolve.run/1`
+  against the existing AC-B6 case from the audit (concrete falsification
+  probe). Approx 2 PRs to demonstrate the orphan-detection works against
+  a real v1 failure.
+- A worked AC-BOM for the most recent merged PR (#414) showing the
+  per-AC mutation recipes round-trip through muzak and produce expected
+  red.
+
+## Prior art / references
+
+- **EDA sign-off (ASIC tape-out):** Wayne Wolf, *Modern VLSI Design*
+  (Prentice Hall, 4th ed. 2008), ch. 4 §"Sign-off methodology"; KLayout
+  DRC engine — https://www.klayout.de/doc/manual/drc_basic.html.
+- **DO-178C traceability matrix:** RTCA DO-178C "Software Considerations
+  in Airborne Systems and Equipment Certification" §6.5, §11.21
+  (RTCA Inc., 2011); Leanna Rierson, *Developing Safety-Critical
+  Software* (CRC Press, 2013), ch. 6.
+- **IEC 62304 medical-device software lifecycle:** IEC 62304:2006 §5.5
+  ("Software unit implementation and verification") and §5.7
+  ("Software system testing").
+- **Bazel build graph:** https://bazel.build/concepts/build-ref; the
+  "rules" + content-addressed outputs design.
+- **Snakemake workflow engine:** Köster J, Rahmann S, "Snakemake — a
+  scalable bioinformatics workflow engine," *Bioinformatics*
+  28(19):2520–2522, 2012, doi:10.1093/bioinformatics/bts480.
+- **DVC data pipelines:** https://dvc.org/doc/user-guide/pipelines/defining-pipelines.
+- **GitHub branch protection + required status checks:**
+  https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/about-protected-branches;
+  Kubernetes Prow/Tide — https://github.com/kubernetes/test-infra/tree/master/prow/cmd/tide.
+- **Sigstore cosign supply-chain signing:** https://www.sigstore.dev/;
+  Newman et al., "Sigstore: Software Signing for Everybody," ACM CCS
+  2022.
+- **PagerDuty Incident Response handbook:**
+  https://response.pagerduty.com/.
+- **Google SRE Workbook:** Beyer et al., O'Reilly 2018, ch. 9
+  ("Incident Response").
+- **Muzak (Elixir mutation testing — adopted as primitive):**
+  https://github.com/devonestes/muzak.
+- **ex_json_schema (PR-BOM validation):**
+  https://github.com/jonasschmidt/ex_json_schema.
+- **Internal cross-references:** `.claude/rules/factory-loop.md`
+  §"The three mechanical gates" (the gates this proposal replaces);
+  root `problem.md` §Hypothesis #6 (AC-B6 falsification probe — the
+  motivating failure case); `docs/spec/SPEC-PERMISSION-PROMPTS.md` AC-B6
+  (the canonical AC that must round-trip through the deck).

--- a/docs/factory-v2/design/subproblems/intent-capture-and-ac-binding/proposals/proposal-4.md
+++ b/docs/factory-v2/design/subproblems/intent-capture-and-ac-binding/proposals/proposal-4.md
@@ -1,0 +1,554 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 4
+parent_problem: ../problem.md
+---
+
+# Proposal 4: Adversarial AC-binding — per-AC call-site mutation derived from a structured binding manifest
+
+## Approach
+
+Replace the prose-only `## Acceptance criteria` PR-body section with a
+**structured, machine-resolvable AC binding manifest** committed to the PR
+branch as `factory/ac-bindings.yaml`, plus a Mix-task gate
+(`tau.gate.ac_binding`) that, for every `AC-N` declared, performs four
+mechanical checks in sequence and FAILS THE PR if any check is missing,
+empty, unresolvable, or does not produce the expected red/green delta. The
+four checks are: (1) **resolve** — every claimed user-facing entry point
+(`{module, function, arity}` or `{cli, argv_pattern}`) exists in HEAD; (2)
+**reach** — at least one gating-test execution actually calls that entry
+point (verified with `excoveralls` line+function tracking, not commit
+attribution); (3) **mutate-at-call-site** — comment out *only the named
+call site inside the production function the AC targets*, recompile, run
+that AC's tagged tests, assert ≥1 fails; (4) **restore** — assert the
+suite returns green when the call site is restored. Silent-skip is
+impossible because the manifest is required (`{:error,
+:no_manifest}` → fail), every AC requires non-empty entries
+(`{:error, :empty_entry, "AC-N"}` → fail), and a per-AC mutation that
+produces no red test (`{:error, :no_red, "AC-N"}` → fail) is a verdict,
+never a skip.
+
+## Rationale — adversarial design from v1's exact failures
+
+The v1 audit's AC-B6 falsification probe (root §Hypothesis #6) and the
+declared-semantics-fidelity findings establish four concrete failure
+geometries. This proposal designs the minimum mechanism that catches
+EACH, then generalises.
+
+### Failure construction 1 — Wrong-path test (AC-B6 verbatim)
+
+**Concrete PR-body claim** (verbatim from PR-B / #341):
+
+```markdown
+## Acceptance criteria
+
+- **AC-B6** — typing `/perms accept_edits` + Enter sets `permissions_mode`
+  via `Tau.Session.set_permissions_mode/2`.
+```
+
+**Concrete test** (verbatim from
+`test/tau/tui/permission_dialog_test.exs:360-369`):
+
+```elixir
+@tag :ac_b6
+test "AC-B6: `/perms accept_edits` + Enter sets permissions_mode to :accept_edits" do
+  m0 = build_idle_model_with_session(:default)
+  next = run_perms_command(m0, "accept_edits")
+  assert next.model.permissions_mode == :accept_edits, ...
+end
+
+defp run_perms_command(model, arg) do
+  # Updates model.permissions_mode locally, then casts to the session pid.
+  # The cast handler in the test stub is dead code for this AC.
+  ...
+end
+```
+
+**v1 gate misfire.** `Mix.Gate.AcLinkage.ac_linkage/2` finds `:ac_b6` in
+the test name and returns `:ok`. `Mix.Gate.Mutation.mutation_check/2`
+reverts every non-test path to merge-base; because PR-B is large, *some*
+test in the suite fails, so `:ok` is returned. Both gates pass while
+`Tau.Session.set_permissions_mode/2` is never called by the test.
+
+**Catching mechanism.** `factory/ac-bindings.yaml`:
+
+```yaml
+- ac: AC-B6
+  user_path:
+    kind: elixir_call
+    module: Tau.Session
+    function: set_permissions_mode
+    arity: 2
+    call_site_file: lib/tau/tui/app.ex
+    call_site_line_anchor: |
+      Tau.Session.set_permissions_mode(model.session_id, mode)
+  gating_tests:
+    - test/tau/tui/permission_dialog_test.exs:360-369
+    - test/tau/tui/permission_dialog_test.exs:371-380
+  expected_red_under_mutation:
+    - test/tau/tui/permission_dialog_test.exs:360-369
+```
+
+The gate's **mutate-at-call-site** step finds the `call_site_line_anchor`
+in `lib/tau/tui/app.ex`, replaces *only that line* with `:ok # MUTATED`,
+recompiles, runs `mix test --only ac_b6`, and asserts the named test goes
+red. With the v1 wrong-path test, the call site never fires, so the test
+stays green → gate FAILS with `{:error, :no_red, "AC-B6", ...}`.
+
+### Failure construction 2 — Hand-built struct bypasses parser
+
+**Concrete PR-body claim**: PR introduces `--system-prompt-file` flag with
+AC: "`tau run --system-prompt-file <persona>` honours the persona's
+`allowed-tools:` whitelist."
+
+**Concrete test**:
+
+```elixir
+@tag :ac_persona
+test "AC-PERSONA: persona allowlist honoured" do
+  # Hand-built session struct skips the CLI parser entirely.
+  session = %Tau.Session{tools: ["read"], system_prompt: "..."}
+  refute Tau.PermissionsEvaluator.evaluate(session, "bash") == :allow
+end
+```
+
+**Catching mechanism.** Binding manifest declares
+`user_path.kind: cli_argv`:
+
+```yaml
+- ac: AC-PERSONA
+  user_path:
+    kind: cli_argv
+    entry: Tau.CLI.main
+    argv_pattern: ["run", "--system-prompt-file", "*"]
+    sentinel_call:
+      module: Tau.CLI.PersonaLoader
+      function: parse_frontmatter
+      arity: 1
+  gating_tests:
+    - test/tau/cli/persona_test.exs
+```
+
+The gate's **reach** step (excoveralls function-trace) verifies that
+running `mix test --only ac_persona` *calls*
+`Tau.CLI.PersonaLoader.parse_frontmatter/1`. The hand-built-struct test
+never calls it → gate FAILS with `{:error, :unreached_sentinel,
+"AC-PERSONA", "Tau.CLI.PersonaLoader.parse_frontmatter/1"}`.
+
+### Failure construction 3 — Silent-skip via empty Gating-test paths
+
+**Concrete PR-body** (v1 cycle step 4b skipped):
+
+```markdown
+## Acceptance criteria
+- **AC-9** — circuit breaker opens after 5 failures.
+
+## Gating-test paths
+(none — refactor only)
+```
+
+**v1 gate misfire.** `Mix.Gate.Mutation.mutation_check([], base_ref)`
+short-circuits to `:not_applicable` because `project_creation_pr?` is
+called on an empty list. `Mix.Gate.AcLinkage` is asked to check tokens
+against an empty `gating_test_sources` list; the existing implementation
+returns `{:error, [...]}` only if the AC section is non-empty — but
+nothing forces the *existence* of the manifest.
+
+**Catching mechanism.** `tau.gate.ac_binding` makes manifest absence a
+hard fail:
+
+```elixir
+case File.read("factory/ac-bindings.yaml") do
+  {:error, :enoent} ->
+    # AC tokens appear in PR body?
+    if has_ac_tokens?(pr_body), do: exit({:error, :no_manifest}), else: exit({:ok, :no_acs})
+  {:ok, body} ->
+    bindings = YAML.decode!(body)
+    if Enum.empty?(bindings), do: exit({:error, :empty_manifest})
+    Enum.each(bindings, &enforce_binding/1)
+end
+```
+
+A PR that claims `AC-N` in its body but ships no `factory/ac-bindings.yaml`
+fails with `:no_manifest`. A PR that ships the file with zero entries
+fails with `:empty_manifest`. A PR that claims no ACs at all (refactor,
+typo) passes with `:no_acs` — and that exemption is itself
+**cross-checked** by gate 5.1's existing AC-token scan of the PR body.
+
+### Failure construction 4 — AC text names a struct/function that doesn't exist
+
+**Concrete PR-body claim** (root §Hypothesis #1):
+
+```markdown
+## Acceptance criteria
+- **AC-CACHE** — `Tau.Provider.Anthropic.cache_regions/2` returns the
+  declared region list verbatim.
+```
+
+But `lib/tau/providers/anthropic.ex` at HEAD does not export
+`cache_regions/2` (the `@behaviour` callback was renamed during the PR).
+
+**Catching mechanism.** The **resolve** step compiles HEAD and asks the
+runtime: `function_exported?(Tau.Provider.Anthropic, :cache_regions, 2)`
+— or for CLI ACs, parses argv against `OptionParser` and asserts the
+flag is registered. False → `{:error, :unresolvable, "AC-CACHE",
+"Tau.Provider.Anthropic.cache_regions/2"}` → PR fails.
+
+This catches AC-side contract drift before the production-code AST
+gates (which live in the pre-merge-code-gates sibling) even have a
+chance to run.
+
+### Failure construction 5 — Mutation reverts but suite fails for the wrong reason
+
+**Concrete v1 misfire.** PR adds a new public function
+`Tau.Foo.bar/1` and tags AC-FOO tests. The v1 mutation check reverts the
+entire `lib/` tree to merge-base; `Tau.Foo` does not exist at merge-base
+so *compilation breaks*. `Mix.Gate.Mutation` interprets `mix test`
+exiting without a summary as `{:error, {:runner_crashed, ...}}` — but
+in PR #372's regression the original `CaseClauseError` was reinterpreted
+as `:not_applicable` via the `project_creation_pr?` escape hatch when
+the PR happened to live in a sub-project.
+
+**Catching mechanism.** Per-AC, *surgical* mutation rather than
+global revert. Only the `call_site_line_anchor` line is mutated;
+compilation must succeed (the line is replaced with a syntactically
+valid no-op like `:ok`); if compilation fails the gate exits with
+`{:error, :mutation_broke_compile, "AC-FOO"}` — never with
+`:not_applicable`. There is no escape hatch.
+
+### Generalisation across the failure class
+
+Every failure above shares the same generator: the AC declaration's
+link to the user-facing path is **prose, not data**. The proposal
+replaces that prose with a typed manifest whose every field is
+mechanically resolved against HEAD, against the test runner's
+function-trace, and against a per-AC surgical mutation. The mutation
+check operates at the granularity of the *specific call site the AC
+names*, not the whole tree. This generalises beyond the five
+constructions: any future AC that ships a wrong-path test, a vacuous
+test, a stale-name claim, or no test at all is caught by the same
+gate, because the gate's input is structured and its checks are
+mechanical.
+
+## Sketch
+
+### Artifact 1 — Binding manifest schema (committed to PR branch)
+
+`factory/ac-bindings.yaml`:
+
+```yaml
+# YAML list; one entry per AC-N or D-NNN claimed in the PR body.
+- ac: AC-B6                        # required; matches PR body
+  user_path:                       # required; one of:
+    kind: elixir_call              #   elixir_call | cli_argv | telemetry_event
+    module: Tau.Session            #   for elixir_call
+    function: set_permissions_mode
+    arity: 2
+    call_site_file: lib/tau/tui/app.ex     # required for elixir_call
+    call_site_line_anchor: |               # required; exact line text
+      Tau.Session.set_permissions_mode(model.session_id, mode)
+    mutation_replacement: ":ok"            # optional; defaults to ":ok"
+  gating_tests:                    # required; non-empty
+    - test/tau/tui/permission_dialog_test.exs
+  expected_red_under_mutation:     # required; non-empty subset of gating_tests
+    - test/tau/tui/permission_dialog_test.exs
+
+# For CLI-entry ACs:
+- ac: AC-PERSONA
+  user_path:
+    kind: cli_argv
+    entry_module: Tau.CLI
+    entry_function: main
+    entry_arity: 1
+    argv_pattern: ["run", "--system-prompt-file", "*"]
+    sentinel:                      # the call the user-path MUST reach
+      module: Tau.CLI.PersonaLoader
+      function: parse_frontmatter
+      arity: 1
+  gating_tests:
+    - test/tau/cli/persona_test.exs
+  expected_red_under_mutation:
+    - test/tau/cli/persona_test.exs
+```
+
+### Artifact 2 — `Mix.Gate.AcBinding` (replaces 5.1+5.3 for ACs)
+
+```elixir
+defmodule Mix.Gate.AcBinding do
+  @moduledoc "Gate AC-1 — per-AC binding manifest enforcement. No silent-skip."
+
+  @type binding :: %{
+    ac: String.t(),
+    user_path: user_path(),
+    gating_tests: [String.t()],
+    expected_red_under_mutation: [String.t()]
+  }
+
+  @spec enforce(String.t(), Path.t(), Path.t()) ::
+    {:ok, :no_acs_in_pr} |
+    {:ok, [binding]} |
+    {:error, :no_manifest_but_acs_claimed, [String.t()]} |
+    {:error, :empty_manifest} |
+    {:error, :unresolvable, binding(), String.t()} |
+    {:error, :unreached, binding(), mfa()} |
+    {:error, :mutation_broke_compile, binding()} |
+    {:error, :no_red_under_mutation, binding(), [String.t()]} |
+    {:error, :missing_ac_in_manifest, [String.t()]}
+  def enforce(pr_body, manifest_path, repo_dir) do
+    claimed_acs = Mix.Gate.AcLinkage.parse_ac_tokens_in_body(pr_body)
+
+    case {File.read(manifest_path), claimed_acs} do
+      {{:error, :enoent}, []} -> {:ok, :no_acs_in_pr}
+      {{:error, :enoent}, acs} -> {:error, :no_manifest_but_acs_claimed, acs}
+      {{:ok, ""}, _} -> {:error, :empty_manifest}
+      {{:ok, body}, claimed} ->
+        bindings = YAML.decode!(body)
+        with :ok <- assert_all_claimed_present(claimed, bindings),
+             :ok <- enforce_each(bindings, repo_dir) do
+          {:ok, bindings}
+        end
+    end
+  end
+
+  defp enforce_each(bindings, repo_dir) do
+    Enum.reduce_while(bindings, :ok, fn b, _ ->
+      with :ok <- resolve_user_path(b, repo_dir),
+           :ok <- reach_check(b, repo_dir),
+           :ok <- mutation_check_at_call_site(b, repo_dir) do
+        {:cont, :ok}
+      else
+        err -> {:halt, err}
+      end
+    end)
+  end
+end
+```
+
+### Artifact 3 — CLI / CI wiring
+
+```elixir
+# lib/mix/tasks/tau.gate.ac_binding.ex
+defmodule Mix.Tasks.Tau.Gate.AcBinding do
+  use Mix.Task
+  @shortdoc "Runs Gate AC-1 (binding manifest enforcement)."
+  def run(_argv) do
+    pr_body = System.fetch_env!("PR_BODY")
+    case Mix.Gate.AcBinding.enforce(pr_body, "factory/ac-bindings.yaml", File.cwd!()) do
+      {:ok, _} -> System.halt(0)
+      {:error, reason, detail} ->
+        IO.puts(:stderr, format_error(reason, detail))
+        System.halt(1)
+    end
+  end
+end
+```
+
+`.github/workflows/ci.yml` adds (no `|| true`, no `if:` guard):
+
+```yaml
+- name: Gate AC-1 — AC binding manifest
+  env:
+    PR_BODY: ${{ github.event.pull_request.body }}
+  run: mix tau.gate.ac_binding
+```
+
+### Artifact 4 — Reach check via `excoveralls` function-trace
+
+The reach check uses `:cover` (which `excoveralls` already configures —
+see `mix.exs` line 134) to collect *function-level* hit data, not just
+line coverage:
+
+```elixir
+defp reach_check(binding, repo_dir) do
+  :cover.compile_beam_directory('_build/test/lib/tau/ebin')
+  System.cmd("mix", ["test", "--only", ac_tag(binding)] ++ binding.gating_tests,
+             cd: repo_dir)
+  hits = :cover.analyse(module_of(binding), :calls, :function)
+  if Enum.any?(hits, &called?(&1, binding)),
+    do: :ok,
+    else: {:error, :unreached, binding, mfa_of(binding)}
+end
+```
+
+### Artifact 5 — Optional plugin `polya-audit`-style binding-author agent
+
+A new agent under `.claude/plugins/polya-audit/agents/binding-author.md`
+that, given an issue body, drafts `factory/ac-bindings.yaml` for the
+implementer to commit. Output is a file diff, not prose. The agent is
+**optional**: a human or any implementer may author the manifest
+directly; the gate is the load-bearing mechanism, not the agent.
+
+### Artifact 6 — `.claude/settings.json` enforcement hook
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [{
+      "matcher": "Bash",
+      "command": "${CLAUDE_PLUGIN_ROOT}/hooks/check_ac_manifest_on_pr_create.py"
+    }]
+  }
+}
+```
+
+The hook intercepts `gh pr create` invocations; if the PR body has
+`AC-N` tokens but `factory/ac-bindings.yaml` is absent on the branch, the
+hook BLOCKS the call and prints the manifest schema. Belt-and-braces
+with the CI gate, but prevents the implementer from opening a PR that
+will immediately fail Gate AC-1.
+
+## Mechanism sequencing — greatest-failure-impact-first
+
+Ordered by historical incidence × consequence in the v1 audit:
+
+1. **Manifest existence + non-emptiness** (failure #3). Catches the
+   widest class because v1 routinely opened PRs with no Gating-test
+   paths declaration; the silent-skip path is the single highest-
+   incidence misfire in the v1 logs.
+2. **Per-AC mutation at the named call site** (failure #1, #5). The
+   AC-B6 falsification probe is the audit's headline finding; this
+   mechanism makes the wrong-path test *impossible* to ship green.
+3. **Reach check via `:cover` function-trace** (failure #2). Catches
+   hand-built-struct tests that the mutation check might pass if the
+   AC happens to have multiple call sites; reach is the second line
+   of defence.
+4. **Resolve check** (failure #4). Cheap (microseconds); catches
+   AC-side contract drift before any test runs; ordered fourth only
+   because its failure rate in v1 was lower than #1-#3.
+5. **Mutation-replacement compile guard** (failure #5 tail). Ensures
+   the mutation itself does not produce a runner crash that escape-
+   hatches to `:not_applicable`.
+
+## Tradeoffs
+
+### Strengths
+
+- **Each v1 failure is constructed and explicitly caught.** No abstract
+  "improve linkage"; every gate exit reason maps to a verbatim v1
+  failure case.
+- **Silent-skip is structurally impossible.** Missing manifest +
+  claimed ACs = hard fail. Empty manifest = hard fail. Unresolvable
+  entry = hard fail. Unreached entry = hard fail. No-red mutation =
+  hard fail. There is no `:not_applicable` escape hatch on the AC
+  path; the only "no-op" exit is `{:ok, :no_acs_in_pr}`, which is
+  cross-checked by Gate 5.1's existing PR-body scan.
+- **Surgical mutation > global revert.** Compile is preserved; the
+  test that fails fails *for the reason the AC names*, not because the
+  whole tree won't build.
+- **Reuses Tau's existing `excoveralls` / `:cover` infrastructure.**
+  The reach check is a thin wrapper around tooling already present in
+  `mix.exs`; the bespoke surface is the manifest schema and the gate
+  driver, not the coverage machinery.
+- **Manifest is a single file** — easy to diff, easy to review,
+  easy for the `critic` to read alongside the PR body.
+- **Per-AC granularity** — a PR claiming six ACs gets six independent
+  verdicts; partial credit becomes visible without compromising the
+  pass/fail gate.
+
+### Weaknesses
+
+- **Manifest authoring overhead.** Implementers must write YAML for
+  every AC. Mitigation: the optional `binding-author` agent drafts the
+  manifest from the issue body; the implementer reviews and adjusts.
+  Unmitigated risk: low-quality issue bodies → manual manifest
+  authoring.
+- **`call_site_line_anchor` is brittle to refactors.** If the
+  implementer renames the variable used at the call site mid-PR,
+  the anchor breaks. Mitigation: the gate's mutation step reports
+  `{:error, :anchor_not_found, "AC-N", anchor}` rather than silent
+  pass; the implementer updates the anchor. Anchor-not-found is a
+  hard fail, not a skip.
+- **Multi-call-site ACs need every site mutated.** If `AC-N` is
+  satisfied by *one of three* call sites firing, the per-AC mutation
+  must iterate. Schema extension: `call_sites:` list. Adds one loop
+  layer to the gate but no conceptual change.
+- **Reach check requires `:cover` to be reliable across umbrella
+  apps.** Tau is moving toward a poncho structure (`web/`); the reach
+  check must support per-app `_build/test/lib/.../ebin` directories.
+  Engineering work, not a design flaw.
+- **YAML schema drift.** A schema change must be coordinated with
+  every committed manifest. Mitigation: `template_version` in
+  the manifest, gate rejects unknown versions explicitly.
+
+### Costs
+
+- **New file in every PR with ACs.** Typical PRs claim 1-6 ACs →
+  10-100 lines of YAML. Negligible diff size.
+- **CI time.** Per-AC mutation = one extra `mix compile` + tagged
+  `mix test` run per AC. For Tau's current suite (~30s for tagged
+  runs), 6 ACs ≈ 3 minutes additional CI per PR. Acceptable.
+- **Gate-author time to ship initial implementation.** Estimated
+  3-5 days for `Mix.Gate.AcBinding` (~600 LOC), YAML schema, CI
+  wiring, hook script, and tests. Bounded.
+- **Migration cost for in-flight PRs.** Open PRs without manifests
+  must add them or be rebased. Estimated <1 day given current
+  in-flight count.
+- **Knowledge cost.** Implementers learn the YAML schema. Documented
+  in a single page; no DSL or macros.
+
+## Dependencies
+
+- **`excoveralls` / `:cover` function-trace** — present in `mix.exs`
+  line 134; no new dep.
+- **YAML parser** — `yaml_elixir` (~3KB pure Elixir) or
+  `:yamerl`. New dep, well-established.
+- **Gate-execution substrate from sibling
+  `pre-merge-evidence-and-skip-integrity`** — provides the
+  silent-skip-impossible CI harness this gate runs inside. Without
+  the sibling, the gate could still be `|| true`-ed; with it, it
+  cannot.
+- **Audit-ingestion sibling
+  (`knowledge-memory-and-audit-ingestion`)** — for future
+  per-surface invariants (e.g. "any AC touching `lib/tau/session/`
+  must declare an FSM state in its `user_path`"); not required
+  for v1 of this gate.
+- **PR-body parser already exists** in
+  `Mix.Gate.AcLinkage.parse_ac_tokens` — reused, not duplicated.
+
+## Confidence
+
+**High** on the design; **medium** on the
+`call_site_line_anchor` durability under refactor (anchored exact-line
+matching is simple but brittle, and a future iteration may need AST
+patching via `Sourceror`).
+
+What would raise confidence: a one-week prototype implementing Gate
+AC-1 for the existing AC-B6 case in PR-B, demonstrating that the
+prototype turns AC-B6 RED with the v1 wrong-path test and GREEN with
+proposal-3's fixed test (which replaces the local-update helper with
+the FSM-call helper).
+
+## Prior art / references
+
+- `muzak` (Hex package) — Elixir mutation testing; performs AST-level
+  mutations on production code. This proposal differs by mutating
+  *exactly one named call site per AC* rather than exploring a
+  mutation space; the AC's named call site IS the chosen mutation.
+- `excoveralls` / Erlang `:cover` — coverage and function-call
+  tracking; this proposal uses `:cover`'s `:calls` analysis mode to
+  drive the reach check.
+- Property-based testing (`StreamData`, used in Tau already) — the
+  reach check is in the same spirit as a generator-driven oracle:
+  the user-path call site is the oracle, the test invocation is the
+  generator.
+- `polya-audit` plugin (this repo) — the `binding-author` agent
+  follows the same proposer/selector/validator structure already
+  used by code-audit-proposer.
+- Audit finding
+  `docs/problems/subproblems/test-fidelity/proposals/proposal-3.md`
+  — verbatim source of the AC-B6 failure construction; this proposal
+  is the mechanism that would have caught it.
+- v1 `.claude/rules/factory-loop.md` §"The three mechanical gates" —
+  the design this proposal extends and corrects.
+
+---
+
+## Notes for the writer (delete before saving)
+
+This proposal is intentionally adversarial: every design choice is
+justified by a verbatim v1 failure it makes impossible. The selector
+should compare it against proposals that take orthogonal axes (e.g. a
+proposal that uses `muzak` directly without per-AC binding, or one
+that uses a contract-by-example DSL, or one that re-architects the AC
+concept itself to be code-level rather than PR-body-level).

--- a/docs/factory-v2/design/subproblems/knowledge-memory-and-audit-ingestion/problem.md
+++ b/docs/factory-v2/design/subproblems/knowledge-memory-and-audit-ingestion/problem.md
@@ -1,0 +1,145 @@
+---
+template_version: 1
+template_name: problem
+node_kind: leaf
+mode: leaf
+depth: 1
+parent: ../../problem.md
+status: draft
+---
+
+# Problem: Knowledge / memory — audit findings must mechanically gate the next PR that touches their surface
+
+## Statement
+
+Writing down an audit finding (in `docs/problems/`,
+`docs/problems-archive-v1-modules/`, an ADR, or a SPEC §3 invariant)
+must *cause* the factory to consider it on the next PR that touches
+the relevant surface; today, writing a finding is a no-op until a
+human re-reads it. v1's symptom: the prior module audit's
+recommendations have not been ingested — zero of seven flagged
+`rescue` sites moved, and new `rescue` sites accumulated *since the
+audit was written* (root #10). The problem is solved when an audit
+finding's lifecycle is "authored → registered as a check input →
+enforced on every subsequent PR touching the named surface, until
+remediated or explicitly waived with an expiry."
+
+## Context
+
+- Root §Hypothesis #10 — prior audit recommendations not ingested;
+  rescue sites accumulated after the audit was written.
+- Root §Acceptance F (Backward integration) — "The factory ingests
+  the audit findings (`docs/problems/` + `docs/problems-archive-v1-
+  modules/`) as input, not as advice. The corrective-actions
+  catalogue (`docs/factory-v2/corrective-actions.md`) is the
+  factory's initial backlog, processed by the same mechanisms it
+  gates new work with."
+- `docs/problems/` contains current audit; `docs/problems-archive-
+  v1-modules/` contains the prior module audit whose recommendations
+  were ignored.
+- `.claude/skills/` is the on-demand-knowledge surface; nothing
+  today couples a skill to a per-PR gate decision.
+- Existing ecosystem: `mix credo` with project-specific check
+  modules; `sobelow` for static security checks (similar enforcement
+  shape); GitHub Code Scanning SARIF ingestion; existing
+  `polya-audit` plugin in this repo at
+  `.claude/plugins/polya-audit/`.
+
+## Failure classes addressed (from root §Hypothesis)
+
+- **#10** (primary) — prior audit recommendations not ingested;
+  authoring an audit must guarantee mechanical enforcement on the
+  next applicable PR. This leaf owns the *ingestion* surface; the
+  pre-merge-code-gates sibling owns the *execution* of the check
+  once it is registered.
+- **#2** (cumulative) — the specific manifestation of #10 today is
+  rescue-site accumulation; this leaf ensures the rescue-site audit
+  becomes a binding gate input rather than prose.
+
+## Complecting hypothesis
+
+- "An audit finding exists" is complected with "an enforcement
+  exists" because the only link is human discipline: a human reads
+  the audit, decides it matters, writes a check by hand, wires it
+  into CI. Decoupling requires that audit findings be *structured*
+  (parseable) and that structured findings *automatically* produce
+  check registrations.
+- "Remediation of an audit finding" is complected with "the audit
+  being closed" because v1 has no machine-readable waiver / expiry
+  format; mechanical lifecycle requires each finding to carry
+  status, surface, and either remediation-PR-link or
+  waiver-with-expiry as structured fields.
+- "Which gate runs on which PR" is complected with "the PR's diff"
+  because today the gates run on every PR universally; an audit
+  finding scoped to a particular module surface needs the gate to
+  consult a per-PR applicability filter (diff intersects the
+  finding's surface manifest).
+
+## Decomposition strategy
+
+(leaf — no further decomposition; proceed to proposals)
+
+## Acceptance criterion
+
+The factory specification names a mechanism such that: (a) audit
+findings are written in a structured format (a YAML/JSON
+frontmatter block, or a sidecar manifest per finding) carrying at
+minimum: a unique finding-id, the surface manifest (file
+paths/globs, module names, AST patterns), the invariant
+asserted/violated, status (`open` | `remediated` | `waived`), and
+(for `waived`) an expiry date and waiver rationale; (b) a registry
+component (e.g. `Tau.Factory.AuditRegistry` or a static manifest
+file under `priv/` produced by a `mix tau.audit.compile` task)
+loads every open audit finding from `docs/problems/`,
+`docs/problems-archive-v1-modules/`, ADRs marked open, and
+SPEC §3 entries marked as recently-added, and exposes them as
+inputs to pre-merge-code-gates; (c) an audit finding's
+applicability per PR is computed deterministically from the
+finding's surface manifest intersected with the PR diff — when
+the diff touches the surface and the finding is `open`, the
+relevant code gate (e.g. NoRescue) MUST run against the diff for
+that finding's scope and MUST fail the PR if the violation
+persists, with no per-PR opt-out (only the structured waiver-with-
+expiry mechanism lets a PR proceed without remediation); (d)
+authoring a new finding (committing a new file with the
+structured format) is a no-op until merged, and once merged is
+automatically in-force on the next PR — verified by a meta-test
+that adds a synthetic finding to the registry and confirms it
+fires on a probe PR; (e) the initial population of the registry
+explicitly includes the existing audit findings from
+`docs/problems/` and the seven flagged `rescue` sites from
+`docs/problems-archive-v1-modules/` (root §Acceptance F); (f) the
+design records reuse vs build per component (`mix credo`'s
+configurable checks + custom check modules? a `polya-audit`
+plugin extension? Sobelow-style rule modules? GitHub Code
+Scanning SARIF round-trip?) per root §Acceptance D; (g) the spec
+output identifies concrete artifacts: the finding format schema,
+the registry module/manifest, the `mix tau.audit.compile` task,
+the integration points into pre-merge-code-gates' check inputs,
+any plugin or hook that auto-registers findings on commit, the
+meta-test, and dashboard fields surfacing "audit findings open /
+waived / remediated count."
+
+## Out of scope
+
+- The execution mechanism of any individual code-shape check
+  (rescue/behaviour/capability/telemetry) — owned by
+  **pre-merge-code-gates** sibling (this leaf delivers the
+  *inputs*; that leaf runs the checks).
+- Cross-document drift on `main` (SPEC-vs-SPEC, ADR supersession)
+  — owned by **post-merge-cross-artifact-coherence** sibling.
+- AC-binding mechanics — owned by **intent-capture-and-ac-binding**
+  sibling.
+- Gate infrastructure (silent-skip impossibility, evidence trust)
+  — owned by **pre-merge-evidence-and-skip-integrity** sibling.
+- Worktree hygiene / dashboards — owned by
+  **operability-and-hygiene-enforcement** sibling.
+- The workstream-2 corrective-actions catalogue itself (this leaf
+  ensures the catalogue is *processed* by the factory; the
+  catalogue's content is out of scope per root).
+- Documentation-only components; agent-discipline-only
+  enforcement.
+
+## Amendment log
+
+- (none yet)

--- a/docs/factory-v2/design/subproblems/knowledge-memory-and-audit-ingestion/proposals/proposal-1.md
+++ b/docs/factory-v2/design/subproblems/knowledge-memory-and-audit-ingestion/proposals/proposal-1.md
@@ -1,0 +1,403 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 1
+parent_problem: ../problem.md
+---
+
+# Proposal 1: A versioned Finding Registry compiled from structured frontmatter, consumed as a typed input by per-PR gates with mandatory applicability accounting
+
+## Approach
+
+Introduce a single authoritative artifact — the **Finding Registry** — that
+materialises every open audit finding as a structured, machine-readable record
+keyed by `finding-id`. The registry is built deterministically by a Mix task
+(`mix tau.audit.compile`) that scans the four authoring surfaces
+(`docs/problems/`, `docs/problems-archive-v1-modules/`, `docs/adr/`,
+`docs/spec/SPEC-*.md` §3 blocks) for entries containing a typed frontmatter
+block, validates them against a published JSON schema, and writes the
+compiled registry to `priv/factory/findings.json` plus a Dialyzer-typed
+Elixir constant module `Tau.Factory.Findings`. Pre-merge code gates consume
+the registry through one and only one entry point — `Tau.Factory.Findings.applicable_to/2`
+returning `{:checked, [%Finding{}]}` or `{:checked, []}` — so that "no
+applicable findings" is a first-class, observable verdict distinct from
+"skipped." A separate **Coverage Ledger** (a CI-emitted JSON artifact per
+PR) records, for every open finding in the registry, the tuple
+`{finding_id, applicable?, gate_run?, verdict}`; CI fails if any open
+finding lacks a row, which is what makes silent-skip impossible. Authoring
+a new finding is a no-op for the writer but for the factory becomes a fact
+the moment the PR introducing it merges, because `mix tau.audit.compile`
+runs on `main` push and the next PR's CI fetches the updated registry.
+
+## Rationale
+
+The leaf's complecting hypothesis identifies three knots: (1) "finding
+exists" ≠ "enforcement exists"; (2) "finding closed" ≠ "remediation
+happened"; (3) "which gate runs on which PR" is coupled to the diff with
+no per-finding lens. The registry decomplects (1) by making the *only*
+input gates accept be the compiled registry — code gates may not hard-code
+a check list, may not read prose, may not pattern-match on file paths
+themselves; they pattern-match on `%Finding{}` structs whose existence is
+authored by writing audit prose with a typed frontmatter. (2) is
+decomplected by encoding lifecycle as data: `status :: :open | :remediated
+| :waived`, with `:waived` carrying an expiry `Date.t()` and a free-text
+rationale, both validated at compile time. (3) is decomplected by giving
+each finding an explicit `surface :: Surface.t()` (paths/globs + module
+regex + optional AST selector); applicability is a pure function
+`Surface.intersects?(surface, diff)` whose output is recorded for every
+finding on every PR — gates do not decide *whether* to consider a finding,
+they merely report the verdict for the slice the registry handed them.
+The mandatory Coverage Ledger row-per-finding closes the silent-skip hole
+at the substrate level (root §C); the registry's stable IDs and immutable
+audit-source linkage close root §10 by construction.
+
+## Sketch
+
+### File layout
+
+```
+priv/factory/findings.json                 # compiled registry, gitignored on branches, committed on main
+docs/factory-v2/audit-finding-schema.json  # JSON schema (versioned)
+lib/tau/factory/findings.ex                # generated module: Tau.Factory.Findings (compile-time constant)
+lib/tau/factory/finding.ex                 # %Finding{} struct + types
+lib/tau/factory/surface.ex                 # surface manifest + diff-intersection
+lib/tau/factory/coverage_ledger.ex         # ledger emitter + validator
+lib/mix/tasks/tau.audit.compile.ex         # compile docs → priv/factory/findings.json
+lib/mix/tasks/tau.audit.cover.ex           # produce coverage ledger from gate outputs
+test/tau/factory/findings_test.exs         # round-trip + schema-validation property tests
+test/tau/factory/meta_audit_probe_test.exs # AC(d): synthetic finding fires on probe PR
+.github/workflows/audit-registry.yml       # main-push: rebuild + commit findings.json
+.github/workflows/audit-coverage.yml       # PR: gates → ledger → fail-if-missing-row
+```
+
+### Authoring format (frontmatter convention, identical across all four surfaces)
+
+```yaml
+---
+finding_id: F-2026-05-NORESCUE-001
+status: open                                       # open | remediated | waived
+authored: 2026-05-12
+authored_in: docs/problems-archive-v1-modules/tau-infrastructure/solution.md
+invariant: "No try/rescue or catch :exit across process boundaries (OTP NN #7)"
+surface:
+  paths: ["lib/tau/**/*.ex"]
+  exclude_paths: ["lib/tau/**/_test_support.ex"]
+  module_match: ~r/^Tau\..*/
+  ast_selector: rescue_or_catch_exit               # named selector in Surface module
+gate: Tau.Factory.Gates.NoRescue                   # the gate module that knows how to check this invariant kind
+gate_args: {}
+remediation:
+  pr: null                                          # set on :remediated; required field then
+waiver:
+  expiry: null                                      # required when status: :waived
+  rationale: null                                   # required when status: :waived
+---
+```
+
+### Core types
+
+```elixir
+defmodule Tau.Factory.Finding do
+  @type status :: :open | :remediated | :waived
+  @type t :: %__MODULE__{
+          id: String.t(),
+          status: status(),
+          authored: Date.t(),
+          authored_in: String.t(),
+          invariant: String.t(),
+          surface: Tau.Factory.Surface.t(),
+          gate: module(),
+          gate_args: map(),
+          remediation_pr: pos_integer() | nil,
+          waiver_expiry: Date.t() | nil,
+          waiver_rationale: String.t() | nil
+        }
+  defstruct [...]
+end
+
+defmodule Tau.Factory.Surface do
+  @type t :: %__MODULE__{
+          paths: [String.t()],
+          exclude_paths: [String.t()],
+          module_match: Regex.t() | nil,
+          ast_selector: atom() | nil
+        }
+  @spec intersects?(t(), diff :: [String.t()]) :: boolean()
+  def intersects?(%__MODULE__{} = s, files), do: ...
+end
+```
+
+### The single consumption contract
+
+```elixir
+defmodule Tau.Factory.Findings do
+  @moduledoc "Generated at build time from priv/factory/findings.json"
+  @spec all() :: [Finding.t()]
+  @spec applicable_to(diff_files :: [String.t()], opts :: keyword()) ::
+          {:checked, applicable :: [Finding.t()], skipped :: []}
+  # NB: third tuple element is always [] -- there is no "skipped" channel.
+end
+```
+
+`{:checked, [], []}` means "registry consulted, zero applicable findings"
+— a valid, expected, observable verdict. There is no return path that
+means "did not consult"; missing consultation surfaces as a missing
+Coverage Ledger row, which is a CI-fail.
+
+### Coverage Ledger contract
+
+```elixir
+defmodule Tau.Factory.CoverageLedger do
+  @type row :: %{
+          finding_id: String.t(),
+          applicable: boolean(),
+          gate_module: module(),
+          gate_run: boolean(),
+          verdict: :pass | :fail | :n_a,
+          evidence_path: String.t()  # path to gate's stdout/stderr artifact
+        }
+  @spec emit(rows :: [row()], path :: String.t()) :: :ok
+  @spec validate!(ledger_path :: String.t(), registry :: [Finding.t()]) ::
+          :ok | no_return()
+  # validate!/2 raises if: any open finding lacks a row;
+  # any applicable=true row has gate_run=false;
+  # any gate_run=true row lacks evidence_path.
+end
+```
+
+### Build / verdict-consumption pipeline (PR CI)
+
+```
+                  ┌──────────────────────────────────────────────┐
+                  │ Step 1: fetch priv/factory/findings.json     │
+                  │         from origin/main (immutable input)   │
+                  └──────────────────────────────────────────────┘
+                                       │
+                                       ▼
+              ┌────────────────────────────────────────────────────┐
+              │ Step 2: PR diff → file list → Surface.intersects?  │
+              │         for every finding → applicability table    │
+              └────────────────────────────────────────────────────┘
+                                       │
+                                       ▼
+   ┌─────────────────────────────────────────────────────────────────────┐
+   │ Step 3: for each applicable finding, invoke finding.gate.check(     │
+   │           finding, diff_paths) → {:pass | :fail, evidence}.         │
+   │         For each non-applicable open finding, record :n_a.          │
+   └─────────────────────────────────────────────────────────────────────┘
+                                       │
+                                       ▼
+              ┌────────────────────────────────────────────────────┐
+              │ Step 4: mix tau.audit.cover → coverage-ledger.json │
+              └────────────────────────────────────────────────────┘
+                                       │
+                                       ▼
+       ┌────────────────────────────────────────────────────────────────┐
+       │ Step 5: CoverageLedger.validate!(ledger, registry); any        │
+       │         :fail verdict OR missing row OR applicable-but-not-run │
+       │         exits non-zero. This is the merge gate.                │
+       └────────────────────────────────────────────────────────────────┘
+```
+
+### Meta-test (AC item d)
+
+```elixir
+defmodule Tau.Factory.MetaAuditProbeTest do
+  use ExUnit.Case, async: false
+
+  @tag :meta_audit
+  test "a freshly-authored finding fires on a probe PR" do
+    finding = synthetic_finding(id: "F-PROBE-001",
+                                surface: %Surface{paths: ["lib/tau/factory/probe_target.ex"]},
+                                gate: Tau.Factory.Gates.AlwaysFail)
+    registry = Tau.Factory.Findings.all() ++ [finding]
+    diff = ["lib/tau/factory/probe_target.ex"]
+    {:checked, applicable, []} =
+      Tau.Factory.Findings.applicable_to(diff, registry: registry)
+    assert finding in applicable
+    rows = run_gates(applicable, diff)
+    assert Enum.any?(rows, &(&1.finding_id == "F-PROBE-001" and &1.verdict == :fail))
+  end
+end
+```
+
+### Initial population (AC item e)
+
+`mix tau.audit.compile --bootstrap` walks the existing audit corpus
+(`docs/problems/` and `docs/problems-archive-v1-modules/`) and, for each
+known `rescue`-site finding flagged in the prior module audit, writes a
+`finding_id: F-V1-NORESCUE-NNN` entry to a bootstrap manifest that the
+maintainer copies into the relevant docs file's frontmatter (one PR per
+batch). The bootstrap script does NOT silently inject findings — it
+generates a diff for review — because the registry's authority depends
+on findings being authored, not invented.
+
+## Tradeoffs
+
+### Strengths
+
+- **Single contract surface.** Gates consume the registry through exactly one
+  function (`applicable_to/2`); there is no escape hatch and no "skipped"
+  return. This is the structural property that makes root §C silent-skip
+  impossible *for this leaf*.
+- **Lifecycle is data, not prose.** `status`, `waiver_expiry`, and
+  `remediation_pr` are typed fields the compiler validates; an expired
+  waiver fails compilation of `findings.json`, so waivers cannot quietly
+  outlive their expiry (closes leaf-complecting knot #2).
+- **Diff-applicability is a pure function.** `Surface.intersects?/2`
+  takes the finding's manifest and the PR's file list and returns a
+  boolean — no I/O, fully testable with `StreamData`. The applicability
+  matrix is therefore reproducible across machines.
+- **Reuse over reinvention** (root §D): the gate *execution* layer plugs
+  into Credo's check-module shape (each `Tau.Factory.Gates.*` is a thin
+  Credo `Check` so the existing `mix credo --strict` pipeline picks it
+  up); JSON Schema for the frontmatter is the standard ecosystem choice;
+  the Coverage Ledger is a SARIF-shaped JSON for future GitHub Code
+  Scanning ingestion.
+- **Authoring is low-friction.** Writers add a YAML frontmatter block —
+  the same shape ADRs and SPECs already carry — to a Markdown file; no
+  separate registration step, no new CLI dance.
+- **Meta-test guarantees the loop.** AC (d) is a real ExUnit test in
+  CI; if the registry-to-gate plumbing is ever broken, the meta-test
+  goes red on the next PR.
+
+### Weaknesses
+
+- **Generated module + JSON file dual-maintenance.** `Tau.Factory.Findings`
+  is generated from `priv/factory/findings.json`; the two must not drift.
+  Mitigation: a compile-time check that `findings.json`'s SHA-256 matches
+  a constant embedded in the module; mismatch fails compilation.
+- **JSON Schema rigidity.** Adding a new finding *kind* (e.g. a new
+  invariant family unknown to the schema today) requires a schema-version
+  bump and a coordinated PR across docs + schema + the relevant gate
+  module. Mitigation: schema versioning is explicit (`schema_version`
+  field) and the registry compiler supports multiple concurrent versions.
+- **Surface AST-selector vocabulary.** `ast_selector: rescue_or_catch_exit`
+  is a named selector that must be implemented in `Tau.Factory.Surface`;
+  adding novel AST shapes requires Elixir code, not just docs. The set
+  is finite and small (rescue/catch, behaviour-callback presence,
+  telemetry-execute callsite, capability-flag literal) but it is a real
+  ceiling.
+- **Bootstrap is a one-time human-in-loop step.** The existing prior-audit
+  findings do not magically gain frontmatter; someone must add it in a
+  bootstrap PR. The system catches the *next* uningested finding for
+  free, not the historical backlog.
+- **Cross-PR finding authorship has a lag of one merge.** A finding
+  authored on PR #X is not in-force until PR #X merges and the registry
+  is rebuilt on `main`; concurrent PR #Y that introduces a violation
+  will not be gated by the not-yet-merged finding. This is a deliberate
+  consistency choice (registry-of-record == `origin/main`) but worth
+  naming.
+
+### Costs
+
+- ~600 LOC of new Elixir (`Finding`, `Surface`, `Findings` generator,
+  `CoverageLedger`, two Mix tasks).
+- ~150 LOC of JSON Schema + a `:ex_json_schema` Hex dep (≈ 4 transitive
+  deps, MIT-licensed, ~3kLOC). Already in the same ecosystem class as
+  Jason.
+- ~200 LOC of ExUnit (round-trip property test, meta-audit probe test,
+  surface-intersection property tests).
+- Two new CI workflows (`audit-registry.yml`, `audit-coverage.yml`),
+  ~80 lines each.
+- Bootstrap pass: a one-off PR per `docs/problems-archive-v1-modules/`
+  surface to add finding frontmatter to existing audit prose. ~10 PRs,
+  each small.
+- No new long-running processes (the registry is a compile-time
+  constant), so OTP NN #1 / #3 are unaffected.
+
+## Dependencies
+
+- **pre-merge-code-gates** sibling: must expose at least one concrete
+  `Tau.Factory.Gates.NoRescue` (and analogous modules for the other
+  invariant kinds) that conforms to the gate-check contract
+  (`check(finding, diff_paths) :: {:pass | :fail, evidence}`). This
+  proposal *defines* the contract; the sibling *implements* the gates.
+- **pre-merge-evidence-and-skip-integrity** sibling: must accept the
+  Coverage Ledger as a first-class evidence artifact and refuse to
+  merge a PR whose ledger validation fails. This is the substrate that
+  enforces root §C; this proposal feeds it.
+- **operability-and-hygiene-enforcement** sibling: must surface
+  `findings_open / findings_waived / findings_remediated_this_week` as
+  dashboard fields (root §E). This proposal exposes them via
+  `Tau.Factory.Findings.all/0` and a JSON dump endpoint.
+- Hex dep: `:ex_json_schema ~> 0.10` (schema validation at compile time).
+
+## §Build-order
+
+Strict ordering — each step is independently shippable, each is gated
+by the existing factory-loop, no step opens a PR that depends on a
+later step's contract being live.
+
+1. **B1 — Schema + struct.** Land `docs/factory-v2/audit-finding-schema.json`,
+   `lib/tau/factory/finding.ex`, `lib/tau/factory/surface.ex`,
+   `Tau.Factory.Surface.intersects?/2` with `StreamData` properties.
+   Closes nothing yet; pure data layer.
+2. **B2 — Compiler task.** Land `mix tau.audit.compile`; emits
+   `priv/factory/findings.json` from a single hand-written sample
+   finding committed under `docs/problems/`. Compile-time SHA check
+   in `Tau.Factory.Findings`. Closes leaf AC item (a) for the schema
+   shape.
+3. **B3 — Consumption contract.** Land `Tau.Factory.Findings.applicable_to/2`
+   with property tests proving the third tuple element is always `[]`
+   (no skipped channel). Closes leaf AC item (c) for the applicability
+   function.
+4. **B4 — Coverage Ledger.** Land `Tau.Factory.CoverageLedger.emit/2`
+   and `validate!/2`. Unit tests cover the three failure modes (missing
+   row, applicable-not-run, gate-run-no-evidence). Closes the
+   silent-skip-impossibility surface for this leaf (root §C).
+5. **B5 — CI wiring.** Land `.github/workflows/audit-registry.yml`
+   (main-push → rebuild → commit `findings.json`) and
+   `.github/workflows/audit-coverage.yml` (PR → run gates → emit ledger
+   → validate → set merge status). After B5, every PR carries a ledger;
+   no PR can merge without one. Closes leaf AC item (g) for CI
+   integration.
+6. **B6 — Meta-test.** Land `Tau.Factory.MetaAuditProbeTest`; runs in
+   `mix test` and in CI; verifies a synthetic finding fires on a probe
+   diff. Closes leaf AC item (d).
+7. **B7 — First real finding.** Pair with the pre-merge-code-gates
+   sibling: their first concrete gate (`Tau.Factory.Gates.NoRescue`)
+   plus an authored frontmatter on the existing rescue-site audit in
+   `docs/problems-archive-v1-modules/tau-infrastructure/solution.md`.
+   Verifies the end-to-end loop on a real case (closes leaf AC item
+   (e) for the rescue surface).
+8. **B8 — Bootstrap sweep.** Iterate the remaining surfaces in
+   `docs/problems-archive-v1-modules/` and `docs/problems/`, adding
+   frontmatter per finding. One PR per surface, each gated by the
+   factory-loop. Closes leaf AC item (e) in full.
+9. **B9 — Dashboard fields.** Wire `Tau.Factory.Findings.all/0` into
+   the operability dashboard. Hands off to operability sibling.
+
+After B5, the silent-skip-impossibility property is in force; after
+B7, the system has caught its first real finding end-to-end; after
+B8, the historical backlog from root §10 is registered.
+
+## Confidence
+
+**High.** The contract surface is small and pure-functional; the JSON
+Schema + Credo Check pattern is well-trodden ecosystem ground; the
+silent-skip-impossibility property is structural (no "skipped" return
+path exists in the consumption contract, so it cannot be reached). The
+two main risks are bootstrap effort (human-in-loop, but bounded) and
+the AST-selector vocabulary ceiling (small, finite set). Confidence
+rises further once the meta-test (B6) lands and we observe a synthetic
+finding round-trip in CI.
+
+## Prior art / references
+
+- `mix credo` custom check modules — same shape as the gate-execution
+  layer this proposal feeds; reused, not reinvented.
+- Sobelow's rule modules — same per-finding, surface-scoped enforcement
+  pattern.
+- GitHub Code Scanning SARIF format — the Coverage Ledger is
+  SARIF-shaped to enable a future round-trip into the GitHub Security
+  tab with no schema rewrite.
+- `:ex_json_schema` — established Hex JSON Schema validator,
+  compile-time-callable.
+- `.claude/plugins/polya-audit/` — the existing in-repo Pólya plugin
+  whose templates established the typed-frontmatter authoring convention
+  this proposal extends to audit findings.
+- The factory-v1 `Tau.Factory.Gate` module (`lib/tau/factory/gate.ex`)
+  and its CLI wrappers (`mix tau.gate.ac_linkage`, etc.) — proves the
+  "pure function + Mix task + CI job" pattern works for gating in this
+  repo.

--- a/docs/factory-v2/design/subproblems/knowledge-memory-and-audit-ingestion/proposals/proposal-2.md
+++ b/docs/factory-v2/design/subproblems/knowledge-memory-and-audit-ingestion/proposals/proposal-2.md
@@ -1,0 +1,396 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 2
+parent_problem: ../problem.md
+---
+
+# Proposal 2: Adopt Claude Code memory + MCP knowledge servers; bind to CI via a thin Tau registry adapter
+
+## Approach
+
+Adopt three off-the-shelf substrates from the Claude Code ecosystem rather
+than build a bespoke audit-finding store, and bind them to CI via the
+smallest possible Tau-owned adapter:
+
+1. **Authoring surface — Claude Code memory cascade + skill.** Audit
+   findings live as Markdown files with YAML frontmatter under
+   `.claude/memory/audits/<finding-id>.md` (the project-memory directory
+   already loaded by Claude Code's `CLAUDE.md` `@import` cascade — Tau
+   already exploits this for `TAU.md`/`MEMORY.md`). A new on-demand skill
+   `polya-audit:audit-finding` provides the authoring template and
+   frontmatter schema; the existing `polya-audit` plugin's
+   `templates/problem.md` is the schema's parent.
+2. **Persistence + query — `mcp-knowledge-graph` MCP server (or a
+   pinned fork).** The Anthropic-published `@modelcontextprotocol/server-
+   memory` reference (an entity/relation knowledge-graph server,
+   JSONL-backed) and the community `shaneholloman/mcp-knowledge-graph`
+   fork both implement structured-fact persistence with stable IDs,
+   tagged relations (e.g. `applies_to_path`), and full-text search over
+   observations. Findings are mirrored from the Markdown source-of-truth
+   into the MCP graph on commit via a Git `post-commit` hook
+   (`mix tau.audit.sync`), so authoring is "write a Markdown file" and
+   nothing else.
+3. **Per-PR gate binding — a thin `Tau.Factory.AuditRegistry` adapter.**
+   A ≤200 LoC Elixir module reads the Markdown source-of-truth (the MCP
+   server is for agent / dashboard query, not the CI critical path —
+   keeping CI hermetic) and exposes one function:
+   `applicable_findings(pr_diff_paths) :: [%Finding{}]`. The
+   pre-merge-code-gates sibling consumes this list; each finding's
+   `check_module` field names the runner (e.g.
+   `Tau.Factory.Checks.NoRescue`). Waivers carry an ISO-8601 `expires`
+   date; an expired waiver flips the finding back to `open` on the next
+   gate run.
+
+The adopt-first split: authoring substrate = adopted (Claude memory
+cascade), persistence/query = adopted (MCP knowledge-graph server),
+schema = adopted-and-extended (polya-audit `problem.md` frontmatter),
+CI binding = bespoke but trivially small (one parser + one
+applicability function).
+
+## Rationale
+
+The leaf's complecting hypothesis isolates three pairs: (a) "finding
+exists" ↔ "enforcement exists"; (b) "remediation" ↔ "closure"; (c)
+"which gate runs" ↔ "PR diff." Building a bespoke registry decomplects
+(a) but introduces a new authoring surface that competes with the
+existing `docs/problems/` Markdown habit and the `polya-audit` plugin
+already in the repo. Adopting the Claude memory cascade preserves the
+"author = write Markdown" workflow that already works, and adopting an
+MCP knowledge-graph server gives agent-side query (an audit MCP tool
+the critic and reviewer can call mid-gate) without writing one.
+Bespoke surface area is restricted to the smallest piece that must be
+CI-hermetic and Elixir-native: the registry adapter that parses the
+Markdown frontmatter and computes applicability. Root §Acceptance D
+(ecosystem reuse over reinvention) is satisfied per-component.
+
+## Sketch
+
+### Finding format (Markdown + YAML frontmatter)
+
+`/.claude/memory/audits/F-0042-no-rescue-bash.md`:
+
+```markdown
+---
+finding_id: F-0042
+title: Bash adapter rescues :exit across process boundary
+authored: 2026-05-10
+status: open
+surface:
+  paths:
+    - lib/tau/tools/builtin/bash.ex
+  modules:
+    - Tau.Tools.Builtin.Bash
+  ast_pattern: rescue
+invariant: OTP non-negotiable #7 — no try/rescue across process boundaries
+check_module: Tau.Factory.Checks.NoRescue
+check_args:
+  allow_in_test: false
+source_audit: docs/problems-archive-v1-modules/2026-04-bash-adapter.md
+waiver: null
+---
+
+## Context
+The Bash adapter wraps Port commands in `try/rescue` to translate
+`:exit` into `{:error, _}`. This is a Module-bound suppression of a
+condition the supervisor should observe. See source audit for the
+behaviour repro.
+
+## Remediation
+Delete the rescue; let the Port-owner process crash; surface failure
+through the standard tool-result error tuple emitted from the dispatcher.
+```
+
+A `waived` finding adds:
+
+```yaml
+waiver:
+  approver: brent.walter@gmail.com
+  rationale: "Removing the rescue requires a Port-owner restart strategy
+    change that depends on #N. Waived until that lands."
+  expires: 2026-08-01
+  references: ['#412']
+```
+
+### MCP server registration
+
+`/.mcp.json` (project-scoped MCP config; Claude Code auto-loads):
+
+```jsonc
+{
+  "mcpServers": {
+    "tau-audit-graph": {
+      "command": "npx",
+      "args": ["-y", "@shaneholloman/mcp-knowledge-graph"],
+      "env": { "MEMORY_FILE_PATH": ".claude/memory/audits/_graph.jsonl" }
+    }
+  }
+}
+```
+
+The graph is materialised from Markdown by `mix tau.audit.sync` (idempotent;
+hash-keyed entities). Agents call `tau-audit-graph` tools
+(`create_entities`, `search_nodes`, `add_observations`) for query
+("findings touching `lib/tau/session.ex`?"). CI does NOT call the MCP
+server — it reads the Markdown directly via the Tau adapter.
+
+### Tau.Factory.AuditRegistry (bespoke; ~150 LoC)
+
+```elixir
+defmodule Tau.Factory.AuditRegistry do
+  @moduledoc "Reads .claude/memory/audits/*.md, returns findings applicable to a diff."
+
+  @type status :: :open | :remediated | :waived
+  defmodule Finding do
+    @enforce_keys [:id, :status, :surface, :check_module]
+    defstruct [:id, :status, :surface, :check_module, :check_args,
+               :waiver, :title, :invariant, :path]
+  end
+
+  @spec load_all(Path.t()) :: [%Finding{}]
+  def load_all(dir \\ ".claude/memory/audits"), do: ...
+
+  @spec applicable_findings([Path.t()], DateTime.t()) :: [%Finding{}]
+  def applicable_findings(changed_paths, now \\ DateTime.utc_now()) do
+    load_all()
+    |> Enum.map(&promote_expired_waiver(&1, now))
+    |> Enum.filter(&open?/1)
+    |> Enum.filter(&surface_intersects?(&1, changed_paths))
+  end
+
+  defp promote_expired_waiver(%Finding{status: :waived, waiver: %{"expires" => exp}} = f, now) do
+    if Date.compare(Date.from_iso8601!(exp), DateTime.to_date(now)) == :lt,
+      do: %{f | status: :open, waiver: nil},
+      else: f
+  end
+  defp promote_expired_waiver(f, _), do: f
+
+  defp surface_intersects?(%Finding{surface: %{"paths" => globs}}, changed),
+    do: Enum.any?(changed, fn p -> Enum.any?(globs, &PathGlob.match?(p, &1)) end)
+end
+```
+
+### Mix tasks (CI-callable)
+
+- `mix tau.audit.compile` — parses Markdown into a single
+  `priv/audit_registry.json` artifact (hermetic; committed); fails on
+  schema violations and on duplicate `finding_id`.
+- `mix tau.audit.sync` — mirrors Markdown into the MCP graph JSONL
+  (developer / Git-hook side; never on CI critical path).
+- `mix tau.audit.check` — pre-merge gate runner: loads applicable
+  findings for the PR's changed files (from `git diff --name-only
+  origin/main...HEAD`), invokes each `check_module`, exits non-zero on
+  any failure. Returns "checked, no applicable findings" (NOT
+  "skipped") when the diff intersects no surface — satisfies root
+  §Acceptance C.
+
+### Meta-test (silent-skip + ingestion guarantee)
+
+`test/tau/factory/audit_registry_meta_test.exs`:
+
+```elixir
+test "synthetic open finding fires on probe diff" do
+  finding = %Finding{id: "F-META", status: :open,
+                     surface: %{"paths" => ["lib/probe.ex"]},
+                     check_module: Tau.Factory.Checks.AlwaysFail, ...}
+  on_exit(fn -> File.rm!(synthetic_path()) end)
+  write_finding!(finding)
+  assert {:fail, [%{id: "F-META"}]} =
+           Tau.Factory.AuditCheck.run(["lib/probe.ex"])
+end
+
+test "expired waiver promotes to open" do ... end
+test "no-applicable returns :checked_empty, not :skipped" do ... end
+```
+
+### Git hook + CI wiring
+
+- `.git/hooks/post-commit` (installed by `mix tau.factory.install`)
+  runs `mix tau.audit.sync` so the MCP graph never lags the Markdown
+  source-of-truth.
+- `.github/workflows/ci.yml` adds an `audit-gate` job calling
+  `mix tau.audit.check`; the job has no `|| true`, no conditional
+  skips, and emits a registry-fingerprint comment on the PR so a
+  reviewer can confirm what set of findings was evaluated.
+
+### Initial population
+
+`mix tau.audit.import` one-shot script reads
+`docs/problems-archive-v1-modules/*.md` and `docs/problems/*.md`,
+extracts each numbered finding, emits a draft
+`.claude/memory/audits/F-NNNN-<slug>.md`. Includes the seven flagged
+`rescue` sites from root §Acceptance F as `status: open`. The migration
+is one PR; thereafter authoring is per-finding.
+
+## Tradeoffs
+
+### Strengths
+
+- **Adopt-first.** Three of four major moving parts are off-the-shelf:
+  Claude memory cascade (authoring surface), MCP knowledge-graph server
+  (agent query), `polya-audit` plugin templates (frontmatter schema).
+  Satisfies root §Acceptance D explicitly per component.
+- **Authoring habit preserved.** "Write a Markdown file in a known
+  directory" is what `docs/problems/` already trains; the new surface
+  is the frontmatter, not the workflow.
+- **Agent-callable knowledge without bespoke RAG.** The MCP knowledge-
+  graph server gives the critic and reviewer agents structured query
+  (`search_nodes`, `find_relations`) mid-gate, so they can cite finding
+  IDs in verdicts. No vector store, no embedding pipeline.
+- **Silent-skip impossible by construction.** The gate's empty-set
+  path is a distinct verdict (`:checked_empty`), enforced by a meta-
+  test; the CI step has no conditional skip. Satisfies §Acceptance C.
+- **CI hermeticity.** The CI critical path never talks to the MCP
+  server — it reads committed Markdown and the compiled
+  `priv/audit_registry.json`. Network flakiness in MCP cannot fail or
+  pass-by-accident a gate.
+- **Bespoke surface is small and well-bounded.** ~150 LoC adapter +
+  ~50 LoC Mix tasks. Easy to audit; easy to replace if MCP standard
+  shifts.
+- **Per-finding waivers with expiry are first-class.** Expired waivers
+  auto-promote to `open` on the next gate run; no human re-review
+  needed to re-arm enforcement.
+
+### Weaknesses
+
+- **MCP server is an external dependency**, even if scoped to
+  agent/dashboard query. Server churn (`@modelcontextprotocol/server-
+  memory` has had breaking JSONL-format changes in the past) means a
+  pin + smoke-test job is needed. Mitigated by keeping MCP out of CI's
+  critical path, but the agent-side query path will break if the server
+  format drifts.
+- **Two-store architecture (Markdown + MCP JSONL) needs a sync
+  guarantee.** A developer who edits Markdown but skips `mix
+  tau.audit.sync` leaves the MCP graph stale. Mitigations: Git hook on
+  commit; a CI check that recomputes the JSONL and diffs against
+  committed `priv/audit_registry.json`. Operationally fine; mentally a
+  surface area.
+- **The Claude memory cascade was not designed as a registry.** It is
+  loaded into every Claude Code session as context, which means a
+  hundred audit findings get loaded as prompt context every session.
+  Mitigation: keep `.claude/memory/audits/_index.md` as the only
+  cascade-loaded file (a brief summary + pointer to the directory); the
+  per-finding `.md` files are NOT `@import`ed, only read by the registry
+  adapter. This means we are using the *directory location* convention
+  more than the cascade itself.
+- **Frontmatter schema is YAML.** Easy to author, easy to typo. The
+  `mix tau.audit.compile` parser must reject unknown keys and validate
+  types strictly; absent that, a typo silently disables a finding.
+- **`check_module` coupling.** A finding names an Elixir module the
+  pre-merge-code-gates sibling must provide. Adding a new check shape
+  (e.g. "behaviour-callback missing") requires writing a check_module
+  AND a finding; the runner library has to be agreed with the sibling
+  leaf.
+- **MCP knowledge-graph schema is entity/relation-flat.** Rich relations
+  ("F-0042 supersedes F-0031 because remediation strategy changed")
+  fit awkwardly; expressible but verbose. The Markdown source-of-truth
+  carries the prose; the graph carries only the structured facts the
+  agents query against.
+- **`@shaneholloman/mcp-knowledge-graph` is a community fork**, not an
+  Anthropic-maintained server. The reference `@modelcontextprotocol/
+  server-memory` is the safer pin (smaller feature set; fewer
+  observation fields). Trade query expressiveness for maintenance risk.
+
+### Costs
+
+- **One-time migration.** ~50 findings to import from
+  `docs/problems/` and `docs/problems-archive-v1-modules/`. The import
+  script generates drafts; a single review pass per finding
+  (frontmatter sanity, surface manifest correctness). Estimate: half
+  a working day for the seven flagged `rescue` sites the user named,
+  plus one day for the bulk import + spot-check.
+- **Build / dependency footprint.** `npx @modelcontextprotocol/server-
+  memory` requires Node.js on developer machines (CI does not need
+  it). Zero new Elixir deps; pure Mix tasks. `priv/audit_registry.json`
+  adds ~10-30 KB to the release.
+- **Test surface.** Meta-test (3-5 cases) + per-`check_module`
+  contract test (~1 per check, owned by pre-merge-code-gates sibling).
+  No new test framework needed.
+- **Knowledge required.** YAML, basic Elixir module conventions, MCP
+  server registration via `.mcp.json`. Nothing exotic; one short README
+  in `polya-audit` plugin.
+- **Operational cost.** Sync hook installation is a one-line
+  `post-commit` script. CI job is ~30s on a warm cache.
+
+## Dependencies
+
+- **pre-merge-code-gates sibling** delivers the `Tau.Factory.Checks.*`
+  modules (one per check shape, e.g. `NoRescue`,
+  `BehaviourCallbackPresence`, `CapabilityFlagFidelity`,
+  `TelemetryConsumerRegistered`). Their interface contract:
+  `check(diff_paths, check_args) :: :ok | {:fail, [finding_id]}`.
+- **operability-and-hygiene-enforcement sibling** consumes
+  `Tau.Factory.AuditRegistry.summary/0` (counts by status) for its
+  dashboard.
+- **`@shaneholloman/mcp-knowledge-graph` v0.x pinned** OR
+  `@modelcontextprotocol/server-memory` (safer; less feature). Pin
+  exact version; smoke-test in `mix tau.audit.sync`.
+- **`polya-audit` plugin's authoring skill extended** to emit the
+  audit-finding frontmatter schema, so `Claude /polya-audit:audit-
+  finding "describe finding"` produces a valid file.
+- **One-time migration PR** processes existing audits from
+  `docs/problems/` and `docs/problems-archive-v1-modules/` per root
+  §Acceptance F.
+
+## Confidence
+
+**Medium-high.** The Claude memory cascade and `.mcp.json` mechanisms
+are already used in this repo (`TAU.md`, `MEMORY.md`); the MCP
+knowledge-graph server is a published reference implementation; the
+Tau-side adapter is small enough that confidence about scope is
+realistic. Would raise to **high** with: a 1-day prototype of
+`mix tau.audit.compile` + the meta-test fixture firing on a synthetic
+finding; and a pin decision between Anthropic-reference and community
+MCP server (drives the agent-query expressiveness ceiling).
+
+## Prior art / references
+
+- **Claude Code memory cascade** — `CLAUDE.md` `@import` mechanism and
+  per-project `.claude/memory/` directory; Tau already uses it for
+  `TAU.md` and `MEMORY.md` (see project's `CLAUDE.md`).
+- **Anthropic-published MCP reference: `@modelcontextprotocol/server-
+  memory`** — entity/relation knowledge graph, JSONL persistence,
+  observation tagging. Reference for the simpler-and-safer pin.
+- **Community: `shaneholloman/mcp-knowledge-graph`** — feature-richer
+  fork with `add_observations`, `delete_entities`, full-text
+  `search_nodes`; reference for richer agent-query path.
+- **`polya-audit` plugin in this repo** —
+  `.claude/plugins/polya-audit/templates/problem.md` is the parent
+  schema; the proposed `audit-finding` template extends it with the
+  surface manifest + check binding.
+- **`mix credo` plugin pattern** — `Credo.Check` modules registered
+  via `.credo.exs`; same shape as the `check_module` field in the
+  proposed finding format (precedent for "data file names an Elixir
+  module the runner invokes").
+- **`sobelow` rule modules** — same Credo-style "registered check"
+  pattern for security findings; precedent for keyed-on-AST-pattern
+  finding scoping.
+- **GitHub Code Scanning SARIF ingestion** — explicitly NOT adopted
+  (round-trip overhead, GitHub-platform lock-in, no per-PR
+  applicability filter); cited as the rejected alternative for §D
+  audit-trail.
+- **Anthropic Memory Tool / context-management cookbook** — the
+  upstream pattern (`memory_20250818` tool family) for agent-managed
+  memory; this proposal does NOT use it for the registry (CI must own
+  the source-of-truth) but acknowledges it as the agent-side
+  inspiration for the MCP knowledge-graph adoption.
+
+## Gaps / open questions
+
+- **MCP server pin choice** — Anthropic-reference (smaller, safer) vs
+  community-fork (richer query). Recommend reference + a Tau-side
+  "extended search" Mix task for richer queries; revisit if agent
+  workflows demand the richer surface.
+- **Frontmatter schema versioning** — when (not if) the schema needs
+  a v2, how do existing findings migrate? Recommend a `schema_version`
+  field defaulting to 1, with `mix tau.audit.compile` rejecting
+  unknown versions and a one-shot migration task per bump.
+- **AST-pattern field semantics** — `ast_pattern: rescue` is suggestive
+  but not yet machine-checkable here; the actual pattern grammar is
+  owned by pre-merge-code-gates' `check_module` library. The finding
+  format passes `check_args` opaquely; the contract about what those
+  args mean is the sibling leaf's.
+- **Cross-finding relations** — supersession, "fixed-by", "blocks"
+  are first-class in the MCP graph but not yet in the Markdown
+  frontmatter. Recommend a `relations:` list-of-maps field, mirrored
+  into the graph at sync time.

--- a/docs/factory-v2/design/subproblems/knowledge-memory-and-audit-ingestion/proposals/proposal-3.md
+++ b/docs/factory-v2/design/subproblems/knowledge-memory-and-audit-ingestion/proposals/proposal-3.md
@@ -1,0 +1,440 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 3
+parent_problem: ../problem.md
+---
+
+# Proposal 3: Audit-as-Datalog — findings are facts in a Datascript/EDN knowledge base queried by OPA-style policy gates
+
+## Approach
+
+Treat every audit finding (current `docs/problems/`, archived
+`docs/problems-archive-v1-modules/`, ADRs, SPEC §3 invariants) as a
+**fact** in a Datalog-shaped knowledge base, and treat every code gate
+as a **policy query** over that base plus the PR's diff facts. Authoring
+becomes a structured commit to one canonical store; enforcement becomes
+deterministic query evaluation; remediation/waiver becomes a fact
+update with provenance and (for waivers) a TTL fact. Concretely:
+
+1. **Storage.** An append-only EDN/JSON-Lines fact log under
+   `priv/factory/audit_facts/` plus a derived materialized index built
+   by `mix tau.audit.compile` into a single `priv/factory/audit.db`
+   (SQLite + a thin Datalog frontend, e.g. **Datalevin** style, or a
+   `Datascript`-shaped in-memory DB rehydrated per CI run).
+2. **Schema.** Findings are tuples
+   `[:finding/id :finding/surface :finding/invariant :finding/status
+    :finding/waiver-expiry :finding/provenance]`; PR diffs are
+   transient tuples `[:diff/path :diff/line-range :diff/ast-form]`
+   loaded at gate time.
+3. **Policy.** Each pre-merge gate is a query (rule) — e.g.
+   `?finding-violated(F, PR) :- finding(F, :open), surface-intersects(F, PR), pattern-present(F.invariant, PR).`
+   The gate exits non-zero iff at least one fact satisfies the
+   violation rule.
+4. **Authoring path.** A `tau audit add` slash command (Claude Code
+   plugin) opens an editor with the finding template, validates the
+   schema with `mix tau.audit.lint`, commits the EDN fact, and a Git
+   pre-commit hook rejects malformed or duplicate findings.
+5. **Waiver lifecycle.** A waiver is itself a fact
+   `[:waiver/finding-id :waiver/expiry-date :waiver/rationale-pr]`;
+   a daily scheduled CI job re-queries `expired-waivers` and reopens
+   findings whose TTL passed (Prolog-style "negation as failure"
+   makes "no current waiver" the default).
+6. **Silent-skip impossibility.** The Datalog evaluator distinguishes
+   `:no-applicable-findings` (a positive result of the query
+   `?surface-intersects(*, PR)` returning empty) from `:not-run`
+   (impossible — the binary either ran or CI failed); the
+   `mix tau.audit.gate` task writes a JSON verdict file every time
+   with `{checked: N, applicable: M, violations: K, status: ...}` and
+   exits non-zero on either violations or evaluator crash.
+
+## Rationale
+
+The complecting hypothesis identifies three knots: (a) audit-exists ≠
+enforcement-exists; (b) remediation ≠ closure; (c) gate-applicability
+is implicit. Datalog/Datascript dissolve all three: (a) a fact IS a
+query input — authoring and enforcement are the same event horizon,
+because the evaluator reloads the materialized DB every run; (b)
+status and waiver are independent facts with their own provenance and
+TTL, so "remediated" and "closed" are no longer the same row; (c)
+applicability is a *rule* over surface-intersection — explicit,
+inspectable, testable in isolation. The pattern is the inverse of
+ad-hoc Credo checks: instead of N hand-coded check modules each
+embedding their own scope logic, one evaluator runs M facts × P
+diff-rows. Adding a finding requires zero code changes — only a fact
+commit — which closes failure class #10's root cause: the cost
+gradient from "audit prose" to "enforced check" today is so steep that
+humans stop at prose. Here, the gradient is one EDN file.
+
+Prior art is dense. OPA/Rego is the canonical "policy as code over
+facts" pattern in production at Netflix, Capital One, Pinterest; their
+`conftest` runs the same shape against arbitrary JSON. Datomic and
+Datascript demonstrate Hickey-style "data is the API"; Datalevin and
+XTDB show Datalog over SQLite/RocksDB at production scale on the
+BEAM-adjacent JVM. Codebase-facts-as-Datalog is the design of
+**Glean** (Meta, queries Hack/Python/C++ codebases as facts) and
+**Semantic** (GitHub, AST facts queryable with Datalog-style rules).
+Dolt provides a Git-shaped Datalog-friendly relational store. The
+match between "facts authored once, queried forever" and the parent's
+acceptance criterion is exact.
+
+## Sketch
+
+### Fact format (EDN-shaped JSON for editor familiarity)
+
+```jsonl
+{"finding/id": "AUDIT-RESCUE-0001",
+ "finding/kind": "no-rescue-cross-process",
+ "finding/surface": {"globs": ["lib/tau/**/*.ex"],
+                     "modules": ["Tau.Session", "Tau.TUI.App"],
+                     "ast-pattern": "(try ... (rescue _ -> _))"},
+ "finding/invariant": "OTP-NN-7-no-rescue-across-process-boundary",
+ "finding/status": "open",
+ "finding/waiver": null,
+ "finding/provenance": {"source-doc": "docs/problems-archive-v1-modules/audit-2025-11.md",
+                        "section": "§4.2",
+                        "authored-pr": 287,
+                        "authored-at": "2025-11-14T09:11:00Z"}}
+```
+
+### Registry module
+
+```elixir
+defmodule Tau.Factory.AuditRegistry do
+  @moduledoc """
+  Loads compiled audit facts from priv/factory/audit.db and answers
+  applicability queries. Pure functions over an immutable Datalog DB
+  rehydrated at process start; no GenServer — the DB is read-only at
+  gate time.
+  """
+
+  @spec load!() :: t()
+  def load!() do
+    Path.join(:code.priv_dir(:tau), "factory/audit.db")
+    |> Tau.Datalog.open_read_only!()
+  end
+
+  @spec applicable(t(), Tau.Factory.PRDiff.t()) :: [Finding.t()]
+  def applicable(db, %Tau.Factory.PRDiff{} = diff) do
+    Tau.Datalog.q(db, ~Q"""
+      [:find (pull ?f [*])
+       :in $ ?diff-paths ?diff-modules
+       :where
+       [?f :finding/status :open]
+       [?f :finding/surface ?s]
+       (surface-intersects ?s ?diff-paths ?diff-modules)
+       (not-waived ?f)]
+      """, diff.paths, diff.modules)
+  end
+
+  @spec violations(t(), Tau.Factory.PRDiff.t()) :: [Violation.t()]
+  def violations(db, diff) do
+    db
+    |> applicable(diff)
+    |> Enum.flat_map(&Tau.Factory.PatternEval.match(&1, diff))
+  end
+end
+```
+
+### Mix gate task
+
+```elixir
+defmodule Mix.Tasks.Tau.Audit.Gate do
+  use Mix.Task
+
+  @impl true
+  def run(_args) do
+    db = Tau.Factory.AuditRegistry.load!()
+    diff = Tau.Factory.PRDiff.from_env!()  # reads GITHUB_BASE_REF + git
+    violations = Tau.Factory.AuditRegistry.violations(db, diff)
+    verdict = %{
+      checked: Tau.Datalog.count(db, [:finding/status, :open]),
+      applicable: length(Tau.Factory.AuditRegistry.applicable(db, diff)),
+      violations: length(violations),
+      status: if(violations == [], do: :pass, else: :fail)
+    }
+    File.write!("audit-gate-verdict.json", Jason.encode!(verdict))
+    if violations == [], do: :ok, else: exit({:shutdown, 1})
+  end
+end
+```
+
+### File layout
+
+```
+priv/factory/audit_facts/
+  AUDIT-RESCUE-0001.jsonl      # one fact per file, append-only
+  AUDIT-RESCUE-0002.jsonl
+  AUDIT-CAPFLAG-PROMPTCACHE-0001.jsonl
+  ...
+priv/factory/audit.db          # materialized SQLite-backed Datalog DB
+                               # generated by `mix tau.audit.compile`
+lib/tau/factory/
+  audit_registry.ex
+  datalog.ex                   # thin frontend over Exqlite + Datalog rules
+  pr_diff.ex
+  pattern_eval.ex              # AST matchers per invariant kind
+.claude/plugins/tau-audit/     # plugin: `tau audit add` / `tau audit list`
+  agents/audit-author.md
+  commands/audit-add.md
+  hooks/pre-commit-validate.sh
+.github/workflows/audit.yml    # `mix tau.audit.compile && mix tau.audit.gate`
+```
+
+### Meta-test (acceptance criterion d)
+
+```elixir
+test "synthetic finding fires on a probe PR" do
+  db = Tau.Factory.AuditRegistry.load_with_overlay!([
+    %Finding{id: "SYNTH-001", status: :open,
+             surface: %{globs: ["lib/tau/probe.ex"]},
+             invariant: :no_rescue}
+  ])
+  diff = %PRDiff{paths: ["lib/tau/probe.ex"], ast_forms: [{:try, ..., [{:rescue, ...}]}]}
+  assert [%Violation{finding_id: "SYNTH-001"}] = AuditRegistry.violations(db, diff)
+end
+```
+
+## Tradeoffs
+
+### Strengths
+
+- **Decomplects fact from check (parent §Complecting #1):** a fact and
+  its enforcement query are textually distinct artifacts but share a
+  schema; adding a fact requires zero code.
+- **Decomplects status from closure (parent §Complecting #2):**
+  `:remediated` and `:waived` are independent values with provenance;
+  a waiver carries TTL by schema, so silent indefinite waivers are
+  syntactically impossible.
+- **Decomplects applicability from PR-shape (parent §Complecting #3):**
+  surface-intersection is a Datalog rule reusable across gates; a new
+  scope predicate (e.g. "only files modified in the last 90 days")
+  is a one-rule change, not N gate edits.
+- **Silent-skip impossibility (root §C):** the verdict JSON is always
+  emitted; `:no-applicable-findings` is a positive outcome of a
+  successful query, not an absence. The CI job that consumes the
+  verdict file fails the PR if the file is missing OR contains
+  `status != :pass`.
+- **Mechanical enforceability (root §B):** the entire surface is one
+  binary (`mix tau.audit.gate`) plus one DB file; no agent judgement
+  in the loop.
+- **Ecosystem reuse over reinvention (root §D):** Datalog/EDN are
+  battle-tested as policy substrates (OPA at scale; Glean for AST
+  facts; XTDB for bitemporal queries). The bespoke part is the AST
+  pattern matchers, which already exist in Credo's check modules and
+  can be lifted.
+- **Backward integration (root §F):** the initial seed is one
+  `mix tau.audit.seed` task that walks `docs/problems/` and
+  `docs/problems-archive-v1-modules/`, extracting structured blocks
+  (per a YAML-frontmatter convention) into the fact log. The seven
+  rescue sites become seven facts; the meta-test confirms they fire.
+- **Bitemporal provenance:** every fact carries `authored-at`; the
+  Datalog evaluator can answer "what was the rule set on date X" —
+  useful for forensic re-runs of historic merges (the four bypassing
+  merges #411-#414 can be re-evaluated against today's facts).
+- **Composable with other gates:** the same DB can answer queries
+  for the post-merge-cross-artifact-coherence sibling (SPEC↔SPEC
+  contradiction is a Datalog query over SPEC-derived facts).
+
+### Weaknesses
+
+- **Datalog literacy is rare on the BEAM.** Elixir engineers
+  generally know SQL and pattern matching but not Datalog. The
+  schema and rule corpus need clear docs and examples or only the
+  proposal's author will maintain them.
+- **Pattern-matcher coverage is the real work.** The Datalog
+  evaluator is cheap to build (thin layer over SQLite); the AST
+  patterns for each invariant kind (`no_rescue`, `capability_flag`,
+  `telemetry_consumer_required`) require care and test. Estimated
+  60-80% of implementation effort lives here, not in the Datalog
+  layer. Credo's existing check modules can be lifted, mitigating
+  this — but lift cost is non-zero.
+- **Single store = single point of failure for evaluator bugs.** A
+  bug in the rule evaluator silently passes every PR. Mitigation: a
+  golden-test corpus (`test/tau/factory/golden_violations_test.exs`)
+  asserts known-bad diffs trigger known-finding violations on every
+  CI run; an evaluator that returns "all clean" against the corpus
+  fails the meta-test and blocks the merge.
+- **EDN/JSON-Lines authoring friction.** "Write some YAML" is lower
+  friction than "construct a fact tuple." The `tau audit add` plugin
+  command hides this, but a human bypassing the plugin to hand-edit
+  has to know the schema. The pre-commit hook mitigates by rejecting
+  malformed facts, but the error message must be excellent.
+- **Materialized-DB drift.** `priv/factory/audit.db` is generated
+  from `priv/factory/audit_facts/`; if a developer commits `.db` but
+  not the `.jsonl` source, the gate runs on stale facts. Mitigation:
+  CI regenerates `.db` from `.jsonl` and refuses to use a committed
+  one; pre-commit hook refuses commits where `.db` is dirty without
+  a matching `.jsonl` change.
+- **Rule-set evolution risk.** Changing a Datalog rule's semantics
+  silently changes every gate's verdict. Mitigation: rule files live
+  in `lib/tau/factory/rules/`, are versioned with a manifest hash,
+  and a rule-change PR triggers a re-run against the golden corpus
+  AND a re-run against the last 100 merged PRs' diffs (replay) to
+  surface any newly-failing historical merges (which become tickets,
+  not blockers, but visibility is the point).
+- **No GUI for findings.** Compared to a dashboard like FireHydrant's
+  postmortem UI, this is text + CLI. The operability-and-hygiene
+  sibling can surface "open findings count" but rich exploration
+  requires a separate tool (acceptable per scope).
+
+### Costs
+
+- **One-time:** ~1500-2000 LOC across `Tau.Datalog`, `AuditRegistry`,
+  `PatternEval`, `PRDiff`, plus the `tau-audit` plugin and the seed
+  task. Estimate 2-3 PRs.
+- **Per finding:** authoring one finding via `tau audit add` takes
+  ~5 min (template + the surface manifest + the invariant choice
+  from an enum); the friction is the surface manifest, not the
+  ceremony.
+- **Build/dep:** adds Exqlite (already in deps for SPEC-MEMORY-STORE)
+  and `jason` (already there). No new runtime dependencies. The
+  Datalog layer is in-tree; ~400 LOC sufficient for the rule shapes
+  the gates need (we are not building a general-purpose Datalog).
+- **CI time:** the gate adds one `mix` invocation per PR;
+  Datalog-over-SQLite on a fact set of 10²-10³ findings against a
+  diff of 10²-10³ rows runs in <2s.
+- **Knowledge:** the audit-author plugin and a single
+  `docs/factory-v2/audit-fact-schema.md` should suffice for
+  contributors. The Datalog-internal rule files need one engineer
+  comfortable with the syntax — a single `.claude/skills/datalog-
+  rules-for-audit.md` skill bridges others.
+
+## Dependencies
+
+- Exqlite (already in the dep tree; SPEC-MEMORY-STORE).
+- Decision from the **pre-merge-code-gates** sibling on whether it
+  consumes audit-violation verdicts via the JSON verdict file
+  (loose coupling, recommended) or via a direct
+  `Tau.Factory.AuditRegistry.violations/2` call (tight coupling).
+  Loose is the default.
+- Agreement on the AST-pattern DSL: either lift Credo's check format
+  (faster) or define a minimal pattern language (`{:try, _, [{:rescue, _, _}]}`-style
+  Elixir match specs — preferred, zero new DSL).
+- A `Tau.Factory.PRDiff` builder that converts `git diff
+  origin/main...HEAD` into `{paths, modules, ast-forms}` — depends on
+  the **pre-merge-evidence-and-skip-integrity** sibling's "what
+  counts as the diff" decision.
+- Plugin auto-registration of `tau audit add` requires
+  `.claude/settings.json` permissions for the `Bash(git commit)` and
+  `Edit` tools in the plugin scope; standard.
+
+## Confidence
+
+**Medium-high.** The Datalog substrate over SQLite is a well-worn
+pattern (Datalevin, XTDB) and the OPA/Rego analogue is in production
+across many sites; the BEAM-side adaptation is straightforward.
+Confidence is not "high" because the AST-pattern matchers are
+non-trivial and the rule-evolution discipline is a process risk, not
+a code risk. What would raise confidence: a 200-LOC prototype that
+ingests the seven archived rescue findings, materializes the DB,
+runs the gate against a known-bad diff, and emits the verdict JSON
+— roughly half a day's work.
+
+## Prior art / references
+
+- **Datalog as policy substrate:** OPA / Rego
+  (https://www.openpolicyagent.org); `conftest` for Kubernetes
+  manifests; Sigstore's policy engine.
+- **Datalog over code facts:** Meta's **Glean**
+  (https://glean.software) indexes AST facts queryable with
+  Datalog-shaped queries; GitHub's **Semantic**
+  (https://github.com/github/semantic) for the same purpose; **CodeQL**
+  uses Datalog under the hood for security queries.
+- **In-process Datalog stores:** **Datascript**
+  (https://github.com/tonsky/datascript) for browser-side fact stores;
+  **Datalevin** (https://github.com/juji-io/datalevin) and **XTDB**
+  (https://xtdb.com) for embedded/server bitemporal stores;
+  **Datomic** for the canonical immutable-fact-log shape.
+- **Append-only fact log + materialized index:** Datomic's transaction
+  log; the **Dolt** versioned relational store; Event Sourcing
+  patterns (Greg Young).
+- **Waiver-with-expiry as enforcement:** Trivy's `.trivyignore` with
+  expiry; Snyk policy file expirations; the npm-audit `audit-ci` waiver
+  TTL pattern; Sentry's "ignore until" feature.
+- **Policy-as-code in production:** Capital One's OPA case studies;
+  Pinterest's Rego deployment posts; Netflix's policy-driven
+  authorization.
+- **Structured-knowledge ingestion on the BEAM:** the precedent
+  closest in spirit is `mix credo`'s check-module discovery — Credo
+  itself is "rules over AST" with hand-coded checks; this proposal
+  generalises the substrate so rules are data, not code.
+
+## Silent-skip impossibility — explicit treatment
+
+Root §C demands gates cannot silent-skip. This proposal makes
+silent-skip *syntactically* impossible at three layers:
+
+1. **At evaluator level.** The Datalog query for applicability is
+   `?applicable-findings(PR)`; an empty result is the *value* `[]`,
+   not the *absence* of a value. The gate task always writes
+   `audit-gate-verdict.json` and CI fails if the file is absent.
+2. **At CI level.** The `audit-gate` job has no `continue-on-error`,
+   no `if:` predicate that can suppress it, and no `|| true` (the v1
+   anti-pattern at `ci.yml:115`). A guard test in
+   `test/ci/workflow_lint_test.exs` parses `.github/workflows/*.yml`
+   and asserts these absences — itself a meta-gate run on every PR.
+3. **At schema level.** A "no applicable findings" verdict is a
+   *positive* JSON object (`{applicable: 0, violations: 0, status:
+   :pass}`); there is no JSON shape representing "skipped." A
+   verdict file with a missing field is rejected by JSON-schema
+   validation before CI reads it, surfacing infrastructure failure as
+   a hard fail, not as a silent pass.
+
+The composition of (1) + (2) + (3) means the only way an audit
+finding is not enforced on a PR that touches its surface is: the
+finding is not in the fact log (caught by the meta-test that asserts
+the seed findings load), OR the surface manifest is wrong (caught by
+the golden-test corpus that asserts known-bad diffs trigger known
+findings). Neither is a silent skip — both are mis-authoring,
+addressable by the pre-commit linter.
+
+## Rejected pattern variants
+
+For diversity bookkeeping (the proposer surveyed these and rejected
+each):
+
+- **ADR-tools / MADR ingestion as-is** — rejected because ADR
+  frameworks (adr-tools, ADR-Manager, MADR) store findings as
+  numbered Markdown files with prose headings. They are excellent
+  for human reading and poor for mechanical querying; converting an
+  ADR's "Consequences" section into a check is the exact ad-hoc step
+  this proposal eliminates. ADRs remain valuable as *source
+  documents* — their structured frontmatter feeds the fact log via
+  the seed task — but they are not the enforcement substrate.
+- **Postmortem-Manager / FireHydrant ingestion** — rejected because
+  these are operational-incident tools optimised for post-event
+  workflows (timeline, contributing factors, action items) with rich
+  UIs. The factory needs lightweight, queryable, append-only facts
+  embedded in the repo, not a SaaS or a heavyweight DB. Their action-
+  item-with-owner concept does inform the waiver-with-rationale-PR
+  schema, however.
+- **Org-mode / literate-programming as memory** — rejected because
+  Org-mode's structured outline plus Babel code blocks are excellent
+  for human-readable knowledge but require a parser per consumer.
+  Translating an Org subtree into a Datalog fact is feasible but
+  adds an Emacs-shaped dependency on the authoring path, which the
+  audit-author plugin avoids by going straight to EDN/JSON.
+- **Semver / changesets discipline (Knope, changesets)** — rejected
+  as the *primary* substrate because changesets answer "what changed
+  in this release" rather than "what invariants does this codebase
+  uphold." The waiver-TTL element is borrowed (a changeset declares
+  a planned-removal version; a waiver declares a planned-expiry
+  date), but the fact-log layer is necessary for the per-PR
+  applicability query.
+- **Neo4j / TerminusDB / Dolt as knowledge graph** — rejected as
+  overkill. A graph DB shines when relationships are dense
+  (transitive ownership, organisational hierarchy); audit findings
+  are flatter (a finding has a surface, a status, optionally a
+  waiver). Datalog over SQLite covers this shape with one binary,
+  zero new infrastructure, and the same query expressiveness for the
+  cases this leaf needs. Dolt's Git-shaped storage is an interesting
+  alternative for the *fact log* layer specifically; we use plain
+  JSON-Lines under Git for simpler reviewability.
+- **GitHub Code Scanning SARIF round-trip** — partially adopted, not
+  primary. SARIF is excellent at *reporting* findings into GitHub's
+  UI but weak at *driving* gate decisions (its semantics are
+  advisory). The gate writes SARIF as a *side output* for visibility,
+  but the merge-block decision comes from the JSON verdict file. This
+  is the same split OPA takes: Rego decides, OpenTelemetry / SARIF
+  reports.

--- a/docs/factory-v2/design/subproblems/knowledge-memory-and-audit-ingestion/proposals/proposal-4.md
+++ b/docs/factory-v2/design/subproblems/knowledge-memory-and-audit-ingestion/proposals/proposal-4.md
@@ -1,0 +1,298 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 4
+parent_problem: ../problem.md
+---
+
+# Proposal 4: Adversarial — registry as a closed loop of constructed-failure probes
+
+## Approach
+
+Treat the audit-ingestion registry not as a passive lookup of "what was
+written down" but as a closed loop in which each registered finding is
+accompanied by an **executable falsification probe** — a one-shot
+adversary test that the registry runs against every PR diff, plus
+nightly against `main`. A finding without a probe is rejected at
+authoring time; a probe that does not currently fail against the named
+pre-remediation revision is rejected at authoring time; a probe whose
+green-on-main run rate drops below 100% halts the loop. Three artifacts
+carry the design: (a) `priv/audit/findings/<id>.yml` — structured
+frontmatter plus a `probe:` field naming a Mix-task probe module; (b)
+`Tau.Factory.AuditRegistry` — supervised GenServer that loads findings
+at boot, computes per-PR applicability from the diff ∩ surface
+manifest, and dispatches the probe; (c) `mix tau.audit.compile` — a
+CI-blocking task that, for every `open` finding, asserts the probe
+module exists, exports `run/1`, and was demonstrated to fail at the
+finding's `proven_at_sha` (a required field). The registry never trusts
+"the finding is written" — it trusts only "the probe currently
+detects the violation it claims."
+
+## Rationale
+
+The complecting hypothesis names three threads: "finding exists" ≠
+"enforcement exists"; "remediation" ≠ "audit closed"; "which gate
+runs on which PR" ≠ "the diff". Proposals 1–3 (assumed: structured-
+frontmatter / credo-check / SARIF) decomplect the first by giving
+findings a schema, but they all leave the second and third under
+human discipline: a check that *exists* may *no longer detect*
+anything (the code shape it watched for was renamed), and a finding
+flipped to `remediated` may have been flipped without the probe ever
+turning red. Adversarial registration closes both: a probe with a
+`proven_at_sha` is provably load-bearing at registration; a probe that
+goes green on `main` when the finding is still `open` halts the loop,
+forcing the author to either re-prove the violation or flip the
+status with evidence. This is the same property the v1 mutation-check
+provides for AC-bearing tests, generalised to audit findings. It also
+folds failure-class #10 into the same enforcement substrate the
+pre-merge-code-gates sibling already needs.
+
+## Sketch
+
+**Finding frontmatter** (`priv/audit/findings/F-007-port-lifecycle-rescue.yml`):
+
+```yaml
+finding_id: F-007
+title: "Port lifecycle wrapped in rescue clause"
+authored_at: 2026-05-21
+status: open                 # open | remediated | waived
+proven_at_sha: 7c4ad9e2      # SHA at which the probe demonstrably failed
+surface:
+  paths:
+    - "lib/tau/coding_agent/**/*.ex"
+    - "lib/tau/tools/builtin/**/*.ex"
+  ast_patterns:
+    - "Port.open/2 within try/rescue"
+invariant: "NN #7 — no try/rescue across process boundaries"
+probe: Tau.Factory.Audit.Probes.PortLifecycleRescue
+remediation_pr: null
+waiver:
+  expires_at: null
+  rationale: null
+prior_audit_ref: "docs/problems-archive-v1-modules/tau-coding-agent/rescue-sites.md#L42"
+```
+
+**Probe module** (`lib/tau/factory/audit/probes/port_lifecycle_rescue.ex`):
+
+```elixir
+defmodule Tau.Factory.Audit.Probes.PortLifecycleRescue do
+  @behaviour Tau.Factory.Audit.Probe
+
+  @impl true
+  def applicable?(diff), do:
+    Tau.Factory.Diff.intersects?(diff,
+      ["lib/tau/coding_agent/**/*.ex", "lib/tau/tools/builtin/**/*.ex"])
+
+  @impl true
+  def run(_ctx) do
+    case Tau.Factory.AST.find(
+           globs: ["lib/tau/coding_agent/**/*.ex", "lib/tau/tools/builtin/**/*.ex"],
+           pattern: {:rescue_around, :"Port.open"}) do
+      []        -> :ok
+      [_ | _] = hits -> {:violation, %{hits: hits, finding_id: "F-007"}}
+    end
+  end
+end
+```
+
+**Registry GenServer signatures** (`lib/tau/factory/audit/registry.ex`):
+
+```elixir
+@spec for_pr(pr_number :: integer, diff :: Diff.t()) ::
+        [%Finding{}]
+@spec dispatch(pr_number, diff) :: %{
+        ran: [finding_id],
+        violated: [%Violation{}],
+        waived_active: [%Finding{}],
+        waived_expired: [%Finding{}]
+      }
+@spec health() :: %{
+        open: non_neg_integer,
+        probes_green_on_main_but_open: [finding_id],  # halts loop if non-empty
+        waivers_expiring_within_7d: [finding_id]
+      }
+```
+
+**CI wiring** — three new gates, none silent-skippable:
+
+1. `mix tau.audit.compile` (PR + main) — exits non-zero if any
+   `open` finding lacks a `probe:` module that exports `run/1`, or if
+   any `proven_at_sha` does not produce a `:violation` when the probe
+   is run against that historical tree.
+2. `mix tau.audit.gate` (every PR) — runs every applicable open
+   probe; fails the PR on any `:violation`; emits
+   `{ran: [...], violated: [...], skipped: []}` — `skipped` is always
+   empty by construction (a probe whose `applicable?/1` returns
+   `false` is reported as `not_applicable`, never `skipped`).
+3. `mix tau.audit.health` (nightly cron on `main`) — fails CI on
+   `main` if any open finding's probe returns `:ok` (the audit went
+   stale — the violation was silently fixed or the probe lost its
+   teeth); fails on any waiver past `expires_at`.
+
+**Meta-test** (`test/tau/factory/audit/registry_synthetic_test.exs`):
+adds an in-test synthetic finding pointing at a deliberately
+violating fixture under `test/support/audit_fixtures/`; asserts a
+probe PR touching the fixture surface is failed by
+`mix tau.audit.gate`; asserts the same probe returns `:ok` when the
+fixture is corrected. Implements acceptance criterion (d) directly.
+
+**Backfill of v1 audit corpus.** `mix tau.audit.import` walks
+`docs/problems/` and `docs/problems-archive-v1-modules/`, emits one
+draft `priv/audit/findings/F-NNN.yml` per call-site flagged in the
+archive (the seven `rescue` sites plus the four other v1-archive
+recommendations), each with `status: open` and a stub probe whose
+test is `proven_at_sha` = the SHA at which the archive was written
+(known from `git log docs/problems-archive-v1-modules/`). The import
+is a one-shot bootstrap; subsequent findings are hand-authored. This
+implements acceptance criterion (e).
+
+## Tradeoffs
+
+### Strengths
+
+- Closes the loop for every component of the complecting hypothesis
+  in *one* mechanism: the probe is the registration, the gate input,
+  the remediation evidence, and the staleness monitor.
+- Silent-skip impossible by construction (acceptance F of root): a
+  probe is either `applied → ok/violation` or `not_applicable`; the
+  word `skipped` does not appear in the output schema; `mix
+  tau.audit.compile` rejects PRs that introduce a finding lacking a
+  probe; the nightly `health` gate catches a probe whose teeth fell
+  out.
+- Directly catches the four adversarial constructions in the brief:
+  (1) a re-introduced port-lifecycle-rescue pattern fires F-007's
+  probe on the new PR's diff with no human in the loop; (2) a SPEC
+  §4 enumeration inconsistency is registered as a probe over the
+  SPEC AST (count of enumerated modes in §4 == count in §6 / D-NNN
+  cross-refs) — same substrate, different file extension; (3) an
+  ADR supersession (ADR-0021 supersedes ADR-0009) is registered as
+  a probe asserting "no module under `lib/tau/` has a `@doc` /
+  comment string matching `ADR-0009` without also matching
+  `ADR-0021`" until ADR-0009's status is flipped to `superseded`;
+  (4) probe staleness — a probe whose
+  green-on-main rate drops below 100% halts the loop, surfacing the
+  finding for re-proof or status change.
+- Generalises the v1 mutation-check property (a gating artifact is
+  load-bearing only if its absence demonstrably fails) from
+  AC-bearing tests to audit findings — same shape, same gate
+  substrate, no new conceptual surface for the coordinator.
+- Failure-class #10 is reduced to "is `priv/audit/findings/` ⊇ the
+  v1 archive?" — a one-line CI assertion (`mix
+  tau.audit.import --check`), not a discipline question.
+
+### Weaknesses
+
+- Probe authoring is non-trivial: every finding now requires an
+  Elixir module plus a `proven_at_sha`. A finding authored without
+  a probe is rejected, so writing a finding becomes more expensive
+  than writing prose. This is intentional but raises the bar for
+  contributing audits — the cost may suppress *new* findings,
+  re-introducing root-cause #10 in a different shape ("findings
+  not written because writing them is hard"). Mitigation: a
+  `tau audit scaffold <id>` Mix task that stamps a probe stub from
+  templates; metric on the dashboard for "weeks since last audit
+  authored" with an escalation threshold.
+- The `proven_at_sha` check requires the probe to run against an
+  arbitrary historical tree. Probes that depend on dependencies
+  (Hex, `mix deps.get` for that SHA) will be slow or break.
+  Mitigation: probes are AST-only (no runtime dependency on
+  compiled deps) wherever feasible; non-AST probes (e.g. dialyzer-
+  based) live in a slower nightly tier.
+- Probes can develop the same "screen-scrapes shell output" rot
+  that production code can — a probe that pattern-matches on a
+  stringified AST may drift silently when Elixir's AST shape
+  changes (`Macro.to_string` differences across versions). Partial
+  mitigation: the nightly `health` gate's "open probe goes green
+  on main" check catches the most common rot mode; the residual
+  is silent for a window ≤ 24h.
+- This proposal makes the audit registry a hard dependency of
+  every PR's CI. A registry bug — e.g. an `applicable?/1` that
+  raises — will fail every PR until fixed. Risk shape is identical
+  to the existing `mix credo` integration; mitigation is the same
+  (registry runs in its own CI job with verbose logs).
+- The four adversarial constructions in the brief are mostly
+  AST/text patterns. Findings whose probe is genuinely *behavioural*
+  (e.g. "this provider's prompt-caching adapter handles the
+  `cache_write` key incorrectly under load") need a probe that
+  resembles a property test, not a grep. Those probes will be
+  expensive and may exceed CI budget. Mitigation: tiered probes
+  (`tier: :ast | :unit | :integration | :nightly`), with only
+  `:ast` and `:unit` running on every PR.
+
+### Costs
+
+- New code: ~600-900 LOC for `AuditRegistry`, `Probe` behaviour,
+  `Diff`, `AST` helper, three Mix tasks, plus the meta-test
+  (~150 LOC).
+- Backfill: ~11 stub probe modules + 11 findings YAMLs for the v1
+  archive (most are AST-pattern probes; budget ~30 LOC per probe).
+- CI time: an extra ~10-30s on the PR critical path for `tau.audit.gate`
+  (AST-only probes are fast); ~3-5m nightly for `tau.audit.health`.
+- Dependency: no new Hex deps (uses `Sourceror` if not already
+  present — verify in dependency step; otherwise hand-rolled AST
+  traversal via `Code.string_to_quoted/1` is sufficient for the v1
+  backfill probes).
+- Coordinator brief growth: implementer briefs must mention the
+  audit-registry's probe-authoring requirement when work introduces
+  a new pattern an existing finding watches for — handled by the
+  `applicable?/1` failure being self-explanatory in the gate output.
+
+## Dependencies
+
+- Pre-merge-code-gates sibling (Subproblem 2) must accept the
+  audit registry as an input — the gate substrate it designs MUST
+  call `Tau.Factory.AuditRegistry.dispatch/2` and treat its
+  `violated: [...]` list as merge-blocking. If that sibling chooses
+  a wholly bespoke gate API, this proposal's `dispatch/2` shape
+  adapts but the substrate must accept *some* registry call.
+- Pre-merge-evidence-and-skip-integrity sibling (Subproblem 3)
+  must include the audit-registry gate in its silent-skip-
+  impossibility audit (gate listed, no `|| true`, no early-exit).
+- `Sourceror` (Hex) or equivalent AST library, if hand-rolled
+  `Code.string_to_quoted/1` proves insufficient for the more
+  complex probe patterns. Decision deferred to first probe that
+  needs it; v1 backfill probes are simple enough to avoid it.
+- A worktree-isolation contract for `proven_at_sha` probe runs
+  (the probe runs against a historical tree via `git worktree
+  add <tmp> <sha>`) — already covered by
+  `worktree-discipline.md`.
+
+## Confidence
+
+Medium. The mechanism is a direct generalisation of v1's
+mutation-check gate (well-understood, already in CI per
+`factory-loop.md`), and the failure modes are inherited from
+known-good ecosystems (Sobelow, Credo). Confidence is *not* high
+because the probe-authoring tax is a real adoption risk and the
+"behavioural probe" tier is gestured at rather than designed.
+Confidence would rise to high with: (a) a working
+`PortLifecycleRescue` probe demonstrated to fail on the v1
+archive's named commit and pass on `main`; (b) a measured
+`mix tau.audit.gate` PR-critical-path overhead on the current
+Tau diff size; (c) a written contract with the pre-merge-code-
+gates sibling on the `dispatch/2` shape.
+
+## Prior art / references
+
+- `mix sobelow` — Phoenix security scanner; per-rule modules with
+  per-rule pass/fail; same shape as the proposed `Probe`
+  behaviour. https://github.com/nccgroup/sobelow
+- `mix credo` custom checks — per-check modules registered via
+  `.credo.exs`; ours register via `priv/audit/findings/*.yml` for
+  finding-status lifecycle.
+- v1's `mix tau.gate.mutation` (factory-loop.md §"Gate 5.3") — the
+  proof-of-load-bearingness pattern (`proven_at_sha`) is the same
+  property generalised from tests to probes.
+- GitHub Code Scanning SARIF — considered as an alternative
+  *transport* for probe output, rejected here because SARIF
+  delivers findings to the GitHub UI but does not enforce the
+  authoring-time `proven_at_sha` invariant or the nightly
+  staleness check. SARIF emission could be added as a downstream
+  reporter without altering this proposal.
+- ADR-0019 (`circuit-breaker-is-ets-state-with-lifecycle-anchor`)
+  — the registry's GenServer-with-ETS-state shape mirrors this
+  in-repo precedent.
+- The pattern of "the artifact that defines a check IS the check"
+  is core to Clojure spec, Datalog rule registration, and
+  property-based testing — Hickey's "decomplecting" applied to
+  audit artifacts.

--- a/docs/factory-v2/design/subproblems/knowledge-memory-and-audit-ingestion/solution.md
+++ b/docs/factory-v2/design/subproblems/knowledge-memory-and-audit-ingestion/solution.md
@@ -1,0 +1,709 @@
+---
+template_version: 1
+template_name: solution
+parent_problem: ../problem.md
+node_kind: leaf
+mode: leaf
+synthesised_from:
+  - proposals/proposal-1.md
+  - proposals/proposal-4.md
+selection_method: hybrid
+revision: 0
+---
+
+# Solution: Compiled Finding Registry + Coverage Ledger + Proof-of-Teeth Probes
+
+## Recommendation
+
+Author every audit finding as YAML frontmatter in a structured Markdown
+file under `docs/audit/findings/<finding-id>.md`. A Mix compiler
+(`mix tau.audit.compile`) deterministically materialises those sources
+into a single immutable artifact `priv/factory/findings.json` plus a
+generated Dialyzer-typed module `Tau.Factory.Findings`. The pre-merge
+code-gates sibling consumes the registry through **one and only one**
+contract — `Tau.Factory.Findings.applicable_to/2` returning
+`{:checked, applicable, []}` — there is no `:skipped` return path
+syntactically. Every finding declares a **probe module** (a
+`Tau.Factory.Audit.Probe` behaviour implementation) and a
+`proven_at_sha` that compilation validates by re-running the probe
+against that historical tree and asserting it returns `{:violation, _}`.
+Every PR emits a **Coverage Ledger** (`audit-coverage.json`,
+SARIF-shaped) containing one row per open finding; CI exits non-zero
+when a row is missing, when an `applicable: true` row has
+`gate_run: false`, or when a `gate_run: true` row lacks an evidence
+artifact. A nightly **Audit Health** workflow on `main` runs every open
+finding's probe and HALTS the factory loop (places
+`.claude/STOP-FACTORY`) whenever an open finding's probe returns
+`:ok` — proving either the violation was silently fixed (re-status to
+`:remediated`) or the probe's teeth fell out (re-author with current
+`proven_at_sha`). Waivers are typed fields with required `expires`
+date and `rationale`; an expired waiver fails registry compilation.
+
+## Selected from
+
+- **Chosen:** **hybrid of `proposals/proposal-1.md`
+  (Versioned Finding Registry + Coverage Ledger) and
+  `proposals/proposal-4.md` (Adversarial probes with `proven_at_sha`
+  + nightly health gate).**
+
+- **Why chosen:** Proposal 1 dominates on the silent-skip-impossibility
+  axis — the Coverage Ledger's row-per-open-finding requirement is the
+  cleanest mechanical proof in the four-proposal set that the parent's
+  acceptance criterion (c) holds, and the "no `:skipped` return"
+  property is structural (no code path returns it) rather than
+  procedural. Proposal 1 also wins on ecosystem fit: the Mix-task +
+  JSON-Schema + Credo-Check pattern is already proven in the v1
+  factory's `Tau.Factory.Gate` and `mix tau.gate.*` CLIs, so reuse is
+  immediate. Proposal 4 dominates on the *staleness* axis Proposal 1
+  leaves open — a registered finding whose check no longer detects
+  anything (because the code shape it watched for was renamed, the
+  AST grammar evolved, or the violation was quietly fixed without a
+  status flip) is invisible to Proposal 1 but caught the next morning
+  by Proposal 4's nightly health gate. The `proven_at_sha` field
+  generalises v1's mutation-check property (gate 5.3) from AC tests
+  to audit probes — same conceptual surface for the coordinator,
+  same proven mechanism. Proposals 2 and 3 were rejected: Proposal 2's
+  MCP knowledge-graph server adds a non-hermetic external dependency
+  in exchange for agent-side query that the dashboard sibling can
+  serve from `Tau.Factory.Findings.all/0` without MCP; Proposal 3's
+  Datalog substrate is elegant but adds ~2000 LOC of in-tree
+  evaluator on a BEAM where Datalog literacy is rare, where the
+  same applicability semantics fall out of a pure function
+  (`Surface.intersects?/2`) at a tenth the code.
+
+  The hybrid is more than the sum: Proposal 1 alone leaves the door
+  open for a finding-with-toothless-check; Proposal 4 alone has no
+  Coverage Ledger and no mechanical proof that every open finding
+  was *considered* on every PR (only that probes that ran didn't
+  fire). Together: Proposal 1 guarantees consideration on every PR;
+  Proposal 4 guarantees that what is considered has currently
+  detectable teeth.
+
+| # | Fit | Mechanical enforceability | Silent-skip impossibility | Ecosystem reuse (root §D) | Per-component build cost |
+|---|---|---|---|---|---|
+| 1 | Yes | High (one Mix task + one ledger) | Highest (no `:skipped` return; row-per-finding) | High (Credo/JSON Schema/Mix/Dialyzer) | Low (~600 LOC + 2 workflows) |
+| 2 | Partially | Medium (MCP non-hermetic; adapter is hermetic) | High (`:checked_empty` distinct) | Highest (memory cascade + MCP server) | Low (~200 LOC + Node dep) |
+| 3 | Yes | Highest (one binary, deterministic) | Highest (positive-value verdict + workflow lint) | Medium (Datalog rare on BEAM) | High (~1500-2000 LOC in-tree) |
+| 4 | Yes | High (probe per finding) | High (probe `:ok`/`:violation`; no `:skipped`) | High (Sobelow/Credo pattern; generalises v1 mutation-check) | Medium (~700 LOC + per-finding probe authoring tax) |
+
+Leaning per `select.md` heuristics: P1 + P4 win on **decomplecting
+depth** (data + executable probe + ledger fully decomplect
+authoring/enforcement/staleness/consideration); P3 ties on depth but
+loses on ecosystem-reuse and cost. P1 + P4 are independently
+**reversible** (the registry compiler and the ledger can be
+deleted leaving authoring prose intact; probes can be retired with
+a status flip). P1's `applicable_to/2` is a **composition** of
+pure functions; P4's `Probe` is a **behaviour** — both align with
+OTP non-negotiables #2 and #8. The hybrid's per-component scopes
+are non-overlapping (registry/ledger vs probe behaviour), so the
+combination is composition, not aggregation.
+
+## What changes
+
+### Concrete artifacts the spec calls for
+
+The list below enumerates EVERY new artifact. Build-order is
+§Build-order; cross-component contracts are §Cross-component
+contracts.
+
+#### Authoring surface
+
+- `docs/audit/findings/` — new directory; the **single authoring
+  surface** for audit findings. Existing `docs/problems/`,
+  `docs/problems-archive-v1-modules/`, ADRs, and SPEC §3 entries
+  remain prose homes for *explanation*; the finding *as gate input*
+  lives in `docs/audit/findings/<finding-id>.md`. The prose docs may
+  link to the finding ID; the binding direction is finding → prose,
+  not prose → finding.
+- `docs/audit/findings/_index.md` — auto-generated index produced by
+  `mix tau.audit.compile`; lists open / waived / remediated counts
+  per surface. Committed and validated for staleness in CI (an
+  out-of-date `_index.md` fails the compile step).
+- `docs/audit/finding-schema.json` — versioned JSON Schema (Draft
+  2020-12) for the YAML frontmatter. `schema_version: 1` is the
+  initial value; `mix tau.audit.compile` rejects unknown
+  `schema_version`s; bumps require a coordinated schema + compiler PR.
+- `docs/audit/SPEC-AUDIT-INGESTION.md` — the SPEC §3 invariants for
+  this subsystem (D-NNN allocation: D-700..D-719 reserved). Authored
+  per `spec-before-code.md` before any implementer touches the
+  registry.
+
+#### Finding frontmatter (authoritative example)
+
+A finding file is a Markdown document whose frontmatter conforms to
+`docs/audit/finding-schema.json`. Concrete example:
+
+```markdown
+---
+schema_version: 1
+finding_id: F-2026-05-NORESCUE-007
+title: "Port lifecycle wrapped in rescue clause (Bash adapter)"
+status: open                              # open | remediated | waived
+authored_at: 2026-05-21
+authored_in: docs/problems-archive-v1-modules/tau-coding-agent/rescue-sites.md#L42
+invariant: "OTP non-negotiable #7 — no try/rescue across process boundaries"
+surface:
+  paths:
+    - "lib/tau/tools/builtin/bash.ex"
+    - "lib/tau/coding_agent/**/*.ex"
+  exclude_paths: []
+  module_match: ~r/^Tau\.(Tools\.Builtin\.Bash|CodingAgent\..*)$/
+  ast_selector: rescue_or_catch_exit       # named selector; see Surface module
+probe: Tau.Factory.Audit.Probes.PortLifecycleRescue
+proven_at_sha: 7c4ad9e2                    # SHA at which the probe is verified to return {:violation, _}
+remediation:
+  pr: null                                 # required when status: remediated; the PR that fixed it
+waiver:
+  expires: null                            # ISO-8601 date; required when status: waived
+  rationale: null                          # free-text; required when status: waived
+  approver: null                           # email; required when status: waived
+relations: []                              # optional: [{kind: supersedes, finding_id: F-...}]
+---
+
+## Context
+<prose explaining the violation, the audit that surfaced it, the remediation strategy>
+```
+
+#### Elixir modules (new code under `lib/tau/factory/audit/`)
+
+- `lib/tau/factory/audit/finding.ex` — `%Finding{}` struct + types;
+  pure data; no GenServer (OTP NN #3).
+- `lib/tau/factory/audit/surface.ex` — `%Surface{}` struct +
+  `intersects?/2` pure function (paths/globs/module-match
+  intersection with PR diff); `StreamData` properties.
+- `lib/tau/factory/audit/probe.ex` — the `Tau.Factory.Audit.Probe`
+  behaviour. Callbacks: `applicable?/1 :: (Diff.t() -> boolean)`,
+  `run/1 :: (Ctx.t() -> :ok | {:violation, map})`. Pattern-matched
+  on atoms/structs (OTP NN #2).
+- `lib/tau/factory/audit/diff.ex` — `%Diff{}` struct
+  (`paths`, `module_set`, `ast_changes`); built from
+  `git diff origin/main...HEAD`; pure (no IO inside the struct;
+  the caller pumps git output in).
+- `lib/tau/factory/findings.ex` — **generated** module (compile-time
+  constant). Public surface is exactly:
+  - `@spec all() :: [Finding.t()]`
+  - `@spec applicable_to(diff :: Diff.t(), opts :: keyword()) ::
+     {:checked, applicable :: [Finding.t()], skipped :: []}`
+  - The third tuple element is constrained by a Dialyzer spec
+    (`skipped :: []`) AND by a property test (`property "skipped
+    channel is always empty list"`); together this makes
+    `:skipped` unreachable in the type system AND the test surface.
+- `lib/tau/factory/coverage_ledger.ex` — ledger emitter and
+  validator. Public surface:
+  - `@spec emit(rows :: [row()], path :: String.t()) :: :ok`
+  - `@spec validate!(ledger_path :: String.t(),
+     registry :: [Finding.t()]) :: :ok | no_return()`
+  - Raises on: any open finding lacking a row; any
+    `applicable: true` row with `gate_run: false`; any
+    `gate_run: true` row lacking `evidence_path`. Each raise carries
+    the finding ID and the failure mode in the message.
+- `lib/tau/factory/audit/probes/` — directory of probe modules.
+  Seed population (B7-B8 below):
+  - `lib/tau/factory/audit/probes/port_lifecycle_rescue.ex`
+  - `lib/tau/factory/audit/probes/cross_process_rescue.ex`
+  - `lib/tau/factory/audit/probes/cross_process_catch_exit.ex`
+  - `lib/tau/factory/audit/probes/capability_flag_fidelity.ex`
+  - `lib/tau/factory/audit/probes/telemetry_consumer_required.ex`
+  - `lib/tau/factory/audit/probes/behaviour_callback_completeness.ex`
+  - additional probes as bootstrap surfaces additional findings
+    (~11 from the v1 archive backfill).
+
+#### Mix tasks (`lib/mix/tasks/`)
+
+- `lib/mix/tasks/tau.audit.compile.ex` — `mix tau.audit.compile`.
+  Scans `docs/audit/findings/*.md`, validates frontmatter against
+  schema, validates each open finding's `proven_at_sha` by
+  re-running the probe against that historical tree
+  (`git worktree add <tmp> <sha>` and asserting `{:violation, _}`),
+  rejects expired waivers, rejects duplicate `finding_id`s, emits
+  `priv/factory/findings.json` and regenerates
+  `docs/audit/findings/_index.md`. Exits non-zero on any failure.
+- `lib/mix/tasks/tau.audit.gate.ex` — `mix tau.audit.gate`. Loads
+  registry, computes diff, calls `Findings.applicable_to/2`, invokes
+  every applicable probe, emits per-probe evidence artifacts under
+  `_build/audit/evidence/<finding-id>.txt`. Writes
+  `audit-coverage.json` (the ledger). Exits non-zero on any
+  `:violation` OR on `validate!/2` raise.
+- `lib/mix/tasks/tau.audit.health.ex` — `mix tau.audit.health`.
+  Runs every open finding's probe against the current `main` tree
+  (no diff filter; probes that do not error on "no applicable
+  change" return `:ok`). Lists each `:ok`-returning open finding as
+  a **staleness violation** and writes `priv/factory/STOP-FACTORY`
+  (which is then copied to `.claude/STOP-FACTORY` by the workflow,
+  per the factory-loop kill-switch convention). Lists each waiver
+  whose `expires` is within 7 days as a warning (does not halt).
+- `lib/mix/tasks/tau.audit.import.ex` — `mix tau.audit.import`.
+  One-shot bootstrap: walks `docs/problems/` and
+  `docs/problems-archive-v1-modules/`, generates draft
+  `docs/audit/findings/F-V1-*.md` files per flagged finding,
+  emits a unified diff for human review (does NOT auto-commit
+  per Proposal 1's bootstrap discipline).
+- `lib/mix/tasks/tau.audit.scaffold.ex` — `mix tau.audit.scaffold
+  <finding-id> [--surface-paths path,path] [--invariant ...]`.
+  Stamps a finding YAML + probe stub from templates to reduce the
+  per-finding authoring tax (Proposal 4 mitigation).
+
+#### CI workflows (`.github/workflows/`)
+
+- `.github/workflows/audit-registry.yml` — triggers on push to
+  `main` and on pull_request. On main: runs `mix tau.audit.compile`
+  (which validates all `proven_at_sha`s); if the produced
+  `priv/factory/findings.json` differs from the committed one, opens
+  an auto-PR to refresh. On PR: runs `mix tau.audit.compile` and
+  asserts the output matches the committed `findings.json` byte-for-
+  byte (no `--allow-stale` flag; no `continue-on-error`).
+- `.github/workflows/audit-coverage.yml` — runs on every PR. Steps:
+  (1) checkout PR diff; (2) fetch `priv/factory/findings.json` from
+  origin/main (the immutable input); (3) `mix tau.audit.gate`;
+  (4) upload `audit-coverage.json` as a workflow artifact; (5)
+  comment a registry fingerprint on the PR. No `if:` guard, no
+  `continue-on-error`, no `|| true` (the v1 ci.yml:115 anti-pattern
+  is explicitly absent).
+- `.github/workflows/audit-health.yml` — scheduled (`cron: '0 7 * *
+  *'` — 07:00 UTC daily) on `main`. Runs `mix tau.audit.health`.
+  On staleness violation: copies the generated STOP-FACTORY sentinel
+  to `.claude/STOP-FACTORY` via a commit on a `factory/halt-<date>`
+  branch, opens a PR titled `[FACTORY HALT] audit stale: <finding-
+  ids>`, and pings the user via a GitHub issue
+  (`type: factory-halt`). The kill-switch latency is bounded by one
+  factory step (per `factory-loop.md` §"Continuity and the kill
+  switch").
+- `.github/workflows/audit-workflow-lint.yml` — runs on PR; a guard
+  test in `test/ci/workflow_lint_test.exs` parses
+  `.github/workflows/*.yml` and asserts no `audit-*` job carries
+  `continue-on-error: true`, `if: <conditional that can suppress>`,
+  or `|| true`. Borrowed from Proposal 3's §"At CI level" layer-2
+  silent-skip defence — small enough to lift without adopting
+  Datalog.
+
+#### Hooks (`.claude/hooks/`)
+
+- `.claude/hooks/pre-commit-audit-finding.py` — Python stdlib hook
+  (per `hooks-and-scripts.md`): when the commit touches
+  `docs/audit/findings/*.md`, runs `mix tau.audit.compile --check`
+  (a dry-run mode) and rejects the commit on schema violations or
+  duplicate IDs. Cheap (no probe re-runs in the hook; those run in
+  CI). Registered in `.claude/settings.json` under
+  `hooks.PreToolUse[].Bash`.
+
+#### Plugin / skill surface (`.claude/plugins/polya-audit/`)
+
+The existing `polya-audit` plugin (v1 has `agents/`, `skills/`,
+`templates/problem.md`) is extended — not forked — with:
+
+- `.claude/plugins/polya-audit/skills/audit-finding-author.md` — new
+  on-demand skill. Loaded when the user types `/polya-audit:audit-
+  finding-author` OR when an agent recognises it needs to register
+  a finding. Documents the frontmatter schema, the probe-authoring
+  workflow, the `proven_at_sha` requirement, and the
+  `mix tau.audit.scaffold` shortcut. Includes the canonical YAML
+  example block above.
+- `.claude/plugins/polya-audit/commands/audit-add.md` — slash command
+  `/polya-audit:audit-add "<title>"` that scaffolds a finding +
+  probe pair and opens an editor.
+- `.claude/plugins/polya-audit/agents/audit-author.md` — sub-agent
+  persona briefed to author one finding end-to-end: write the
+  frontmatter, write the probe, demonstrate `proven_at_sha`, commit
+  the pair. Used by the coordinator when an audit-flagged surface
+  needs registration.
+- `.claude/plugins/polya-audit/templates/audit-finding.md` — the
+  Markdown + frontmatter template the slash command stamps.
+- `.claude/plugins/polya-audit/templates/audit-probe.ex.eex` — the
+  probe-module Elixir template.
+
+The plugin's `plugin.json` adds these to the existing `skills`,
+`commands`, and `agents` arrays. Auto-discovery is by convention
+(per `plugin-dev:plugin-structure`); no new manifest fields.
+
+#### Settings (`.claude/settings.json`)
+
+- `hooks.PreToolUse` extended with the pre-commit-audit-finding hook
+  registration. No other settings changes; the registry is consumed
+  by CI, not by the coordinator session directly.
+
+#### Tests
+
+- `test/tau/factory/audit/finding_test.exs` — round-trip + schema
+  validation property tests for `%Finding{}`.
+- `test/tau/factory/audit/surface_test.exs` — `intersects?/2`
+  property tests (StreamData generators for path/glob inputs).
+- `test/tau/factory/findings_test.exs` — generated-module integrity
+  (SHA matches `findings.json`; `applicable_to/2` type spec).
+- `test/tau/factory/coverage_ledger_test.exs` — `validate!/2` raises
+  on each of the three failure modes; happy path emits valid SARIF.
+- `test/tau/factory/audit/probe_test.exs` — `Probe` behaviour
+  contract (each registered probe exports `applicable?/1` and
+  `run/1`; `run/1` returns `:ok` or `{:violation, map()}`).
+- `test/tau/factory/meta_audit_probe_test.exs` — **the meta-test**
+  (AC item d). Adds a synthetic finding to an in-test registry
+  overlay; asserts a probe PR touching the synthetic surface is
+  blocked by `mix tau.audit.gate`; asserts the same probe returns
+  `:ok` when the fixture is corrected; asserts removing the finding
+  removes the block (the meta-test is the "the loop is alive"
+  signal).
+- `test/tau/factory/golden_findings_test.exs` — borrowed from
+  Proposal 3: a corpus of (known-bad-diff, expected-finding-violation)
+  pairs that ANY rule-evaluator bug breaks. Runs on every PR and on
+  nightly health.
+- `test/ci/workflow_lint_test.exs` — workflow-file lint asserting
+  no silent-skip patterns in `audit-*` workflows.
+
+#### Dependencies
+
+- `:ex_json_schema ~> 0.10` — compile-time JSON Schema validation.
+  ~3 kLOC, MIT, ≈ 4 transitive deps, established Hex package.
+- No new runtime dependencies (the registry is a compile-time
+  constant; ledger emission uses `Jason` already in deps).
+- No Node.js dependency (Proposal 2's MCP server is NOT adopted in
+  this leaf; the operability sibling may add an MCP-based query
+  layer later as a non-CI-critical-path additive).
+
+## What does not change
+
+- **The `docs/problems/` and `docs/problems-archive-v1-modules/`
+  directories.** They remain the prose homes for audit
+  investigations. Findings *link* into them via the
+  `authored_in:` field; nothing in the registry replaces their
+  prose content.
+- **`docs/spec/SPEC-*.md` §3 invariants.** A SPEC §3 D-NNN entry
+  may *cite* a finding-id, but the gate input is the finding file,
+  not the SPEC entry. SPEC↔code drift detection is owned by the
+  post-merge-cross-artifact-coherence sibling, not this leaf.
+- **The existing `Tau.Factory.Gate` module and `mix tau.gate.*`
+  CLIs.** The audit-gate task is additional, not a replacement;
+  gates 5.1 / 5.2 / 5.3 keep their current semantics.
+- **The `polya-audit` plugin's existing problem/decompose/propose/
+  select/validate skills.** They remain the design-process surface
+  for new architectural decisions; the audit-finding skill is
+  additive.
+- **The Claude memory cascade** (`CLAUDE.md`, `TAU.md`,
+  `MEMORY.md`). It is NOT used as a registry; per Proposal 2's
+  noted weakness, loading 100+ findings into every session context
+  is the wrong default. The cascade may eventually load a one-line
+  `findings_open_count` summary; that is operability sibling
+  territory, not this leaf.
+- **The factory-loop's gate (`/pr` skill) and critic/reviewer
+  personas.** The audit gate runs in CI; the coordinator does NOT
+  call probes directly. The critic and reviewer remain quality
+  checks above the mechanical gates (per root §B).
+- **Worktree discipline** (`worktree-discipline.md`). The
+  `proven_at_sha` historical-tree probe run uses
+  `git worktree add` per existing rules; no new isolation pattern.
+
+## Cross-component contracts
+
+These are the load-bearing interfaces between this leaf and its
+sibling leaves; they MUST be honoured at the interface boundary.
+
+### → pre-merge-code-gates (Subproblem 2)
+
+- **Input contract.** This leaf delivers
+  `Tau.Factory.Findings.applicable_to(diff, opts) :: {:checked,
+  applicable :: [Finding.t()], []}`. The sibling consumes this as
+  its sole source of audit-driven gate inputs; no hardcoded check
+  lists.
+- **Probe-execution contract.** Each `%Finding{}` carries a
+  `probe :: module()` field; the sibling's gate runner invokes
+  `apply(finding.probe, :run, [%Ctx{diff: diff, finding: finding}])`
+  and treats `{:violation, _}` as merge-blocking. The `Probe`
+  behaviour lives in this leaf; the runner that calls it lives in
+  the sibling.
+- **No `check_module` parallel surface.** The sibling MUST NOT
+  define its own audit-check protocol; it consumes the `Probe`
+  behaviour defined here.
+
+### → pre-merge-evidence-and-skip-integrity (Subproblem 3)
+
+- **Coverage Ledger is first-class evidence.** The sibling's
+  merge-block decision MUST refuse to merge a PR whose
+  `audit-coverage.json` is missing, malformed, or fails
+  `CoverageLedger.validate!/2`.
+- **No `|| true` on audit workflows.** The sibling's CI-lint guard
+  test (`test/ci/workflow_lint_test.exs`) is shared with this leaf;
+  this leaf authors the audit-specific assertions, the sibling
+  authors the cross-cutting assertions.
+
+### → post-merge-cross-artifact-coherence (Subproblem 4)
+
+- **Findings as inputs to coherence checks.** A SPEC↔SPEC
+  contradiction may be authored as a finding whose probe is an
+  AST/text comparison across SPEC files; the sibling consumes the
+  same `Probe` behaviour, no new substrate.
+- **Direction of authority.** This leaf does NOT crawl SPEC §3 for
+  invariants; the sibling does (and may emit findings into
+  `docs/audit/findings/` as its remediation path).
+
+### → operability-and-hygiene-enforcement (Subproblem 6)
+
+- **Dashboard fields.** `Tau.Factory.Findings.all/0` exposes the
+  list; the operability sibling computes counts
+  (`findings_open / findings_waived / findings_remediated_this_week
+  / waivers_expiring_within_7d / probes_green_on_main_but_open`) for
+  its dashboard.
+- **Health-gate halt surfacing.** When `mix tau.audit.health`
+  writes `.claude/STOP-FACTORY`, the operability dashboard
+  surfaces "FACTORY HALTED — audit health" with links to the
+  failing finding IDs.
+- **MCP layer (optional, deferred).** If the operability sibling
+  later adopts an MCP knowledge-graph server for agent-side query
+  (Proposal 2's deferred element), it mirrors from
+  `priv/factory/findings.json` — never the inverse. CI's
+  authoritative input remains the committed JSON.
+
+### → intent-capture-and-ac-binding (Subproblem 1)
+
+- **Disjoint scopes.** This leaf gates code shape against audit
+  findings; that leaf gates AC tokens against tests. They share
+  no contract; the only overlap is the `polya-audit` plugin's
+  template directory.
+
+## Silent-skip impossibility — implementation-level
+
+Root §C is satisfied at FIVE layers; "silent" means "the violation
+or omission produces no merge-block signal." Each layer is a
+mechanical, scriptable check, not a process discipline.
+
+1. **Type-system layer.** The single consumption contract
+   `Findings.applicable_to/2` has return type
+   `{:checked, [Finding.t()], []}`. The third tuple element is
+   typed as the empty list. There is no `:skipped` return; Dialyzer
+   rejects any call site whose pattern would treat the third
+   element as non-empty. A property test
+   (`test/tau/factory/findings_test.exs`) generates 1000 calls and
+   asserts the third element is always `[]`.
+
+2. **Probe behaviour layer.** A probe returns `:ok` or
+   `{:violation, map()}`. The atom `:skipped` is not a valid
+   return value. A probe whose `applicable?/1` returns `false` is
+   reported in the ledger as `applicable: false, gate_run: false,
+   verdict: :n_a` — a *positive* row, not an absence.
+
+3. **Coverage Ledger layer.** `CoverageLedger.validate!/2` raises
+   when any open finding lacks a row, when any `applicable: true`
+   row has `gate_run: false`, or when any `gate_run: true` row
+   lacks `evidence_path`. The ledger is uploaded as a CI artifact
+   and the validation is invoked in `mix tau.audit.gate` itself,
+   so the gate cannot exit zero without the ledger being valid.
+
+4. **Workflow-file layer.** `test/ci/workflow_lint_test.exs`
+   parses every `audit-*` workflow YAML and asserts:
+   no `continue-on-error: true` on audit jobs; no `if:` predicate
+   evaluating to false-by-default; no `|| true` in audit job
+   commands; the `audit-coverage` job is present in every PR
+   workflow. This test runs on every PR (NOT only when workflows
+   change), so a malicious or careless workflow edit that would
+   silence the gate is itself caught by a gate.
+
+5. **Health-gate layer.** `mix tau.audit.health` runs nightly on
+   `main`. An open finding whose probe returns `:ok` is a
+   *positive* signal (the probe has lost its teeth or the
+   violation was silently fixed). The workflow halts the factory
+   loop by writing `.claude/STOP-FACTORY`, which the
+   `factory-loop.md` kill-switch reads at the start of every
+   factory step. A silently-passing finding cannot survive past
+   the next health-gate cron tick (latency ≤ 24h + one factory
+   step).
+
+The composition of layers 1+2 makes silent-skip syntactically
+impossible. Layers 3+4 make silent-skip surface-area-impossible
+(the ledger has a row per finding; the workflow has no skip
+patterns). Layer 5 makes silent-going-stale impossible (a probe
+that lost its teeth halts the loop). The only failure mode this
+leaf does NOT close is "no finding was ever authored for this
+violation class" — owned by §F (Backward integration) and the
+bootstrap sweep.
+
+## Migration sketch
+
+The Build-order (§Build-order below) is the migration. The plan
+adds one new directory (`docs/audit/findings/`), one new module
+namespace (`Tau.Factory.Audit.*` + `Tau.Factory.Findings`), three
+Mix tasks, four CI workflows, and one plugin skill — all additive.
+No existing module is modified except `mix.exs` (the
+`:ex_json_schema` dep) and `.claude/settings.json` (one
+PreToolUse hook entry). The bootstrap PR sweep (B8) is the only
+human-in-loop work; the registry catches *new* uningested
+findings as soon as B5 lands. The factory loop's `/pr` skill is
+unchanged; the audit gate appears as one additional CI check the
+loop's `freshness re-check` already waits on.
+
+## Build-order
+
+Strict dependency ordering. Each step is independently shippable
+(opens one PR, passes the existing factory-loop gates). No step's
+PR depends on a later step's artifact being live.
+
+### Week 1 — substrate (deliverable: registry can be authored, but does not yet gate)
+
+- **B1 — Schema + pure-data structs.** Land
+  `docs/audit/finding-schema.json`,
+  `docs/audit/SPEC-AUDIT-INGESTION.md` (the SPEC §3 invariants per
+  `spec-before-code.md`), `lib/tau/factory/audit/finding.ex`,
+  `lib/tau/factory/audit/surface.ex` (`intersects?/2` with
+  `StreamData` properties), `lib/tau/factory/audit/diff.ex`,
+  `lib/tau/factory/audit/probe.ex` (behaviour only, no
+  implementations). Tests: `finding_test.exs`, `surface_test.exs`,
+  `probe_test.exs` (behaviour-conformance). Closes nothing user-
+  visible; pure data layer + behaviour.
+  *Depends on:* `:ex_json_schema` Hex dep added.
+
+- **B2 — Compiler task.** Land `lib/mix/tasks/tau.audit.compile.ex`
+  and `lib/tau/factory/findings.ex` (generated). Single hand-
+  written sample finding under `docs/audit/findings/F-2026-05-
+  SAMPLE-001.md` proves the round-trip. Compile-time SHA check.
+  Closes AC item (a) for the schema shape.
+  *Depends on:* B1.
+
+- **B3 — Consumption contract.** Land
+  `Findings.applicable_to/2` with property tests proving the
+  third tuple element is always `[]`. Generated module's Dialyzer
+  spec enforces the type. Closes AC item (c).
+  *Depends on:* B2.
+
+### Week 2 — execution and silent-skip closure
+
+- **B4 — Coverage Ledger.** Land
+  `lib/tau/factory/coverage_ledger.ex` (`emit/2`, `validate!/2`).
+  Unit tests cover the three failure modes. The ledger is SARIF-
+  shaped (Proposal 1's design) for future GitHub Code Scanning
+  ingestion. Closes the silent-skip-impossibility surface for this
+  leaf at substrate level.
+  *Depends on:* B3.
+
+- **B5 — Gate task + CI wiring.** Land
+  `lib/mix/tasks/tau.audit.gate.ex`,
+  `.github/workflows/audit-registry.yml`,
+  `.github/workflows/audit-coverage.yml`,
+  `.github/workflows/audit-workflow-lint.yml`,
+  `test/ci/workflow_lint_test.exs`. After B5: every PR carries a
+  ledger; no PR can merge without one. The sample finding from
+  B2 has a stub probe that always returns `:ok` (no real
+  violations gated yet — the wiring is verified end-to-end on
+  the no-op finding). Closes AC item (g) for CI integration.
+  *Depends on:* B4.
+
+- **B6 — Meta-test.** Land
+  `test/tau/factory/meta_audit_probe_test.exs` and
+  `test/tau/factory/golden_findings_test.exs`. Verifies a
+  synthetic finding fires on a probe diff; verifies removing
+  the synthetic finding removes the block. Closes AC item (d).
+  *Depends on:* B5.
+
+### Week 3 — probe authoring + first real finding + staleness gate
+
+- **B7 — Probe behaviour, first concrete probe, first real
+  finding.** Land
+  `lib/tau/factory/audit/probes/port_lifecycle_rescue.ex`,
+  `docs/audit/findings/F-V1-NORESCUE-001-bash.md` (the Bash
+  adapter rescue from the v1 archive), `proven_at_sha` set to
+  the commit at which the v1 audit was written. Pair with
+  pre-merge-code-gates sibling's runner. Verifies the
+  end-to-end loop on a real case (closes AC item (e) partially —
+  one of seven rescue sites).
+  *Depends on:* B6.
+
+- **B8 — Health gate + plugin surface + scaffold task.** Land
+  `lib/mix/tasks/tau.audit.health.ex`,
+  `.github/workflows/audit-health.yml`,
+  `lib/mix/tasks/tau.audit.scaffold.ex`,
+  `.claude/plugins/polya-audit/skills/audit-finding-author.md`,
+  `.claude/plugins/polya-audit/commands/audit-add.md`,
+  `.claude/plugins/polya-audit/agents/audit-author.md`,
+  `.claude/plugins/polya-audit/templates/audit-finding.md`,
+  `.claude/plugins/polya-audit/templates/audit-probe.ex.eex`,
+  `.claude/hooks/pre-commit-audit-finding.py`. After B8: the
+  factory halts overnight when a probe loses its teeth; new
+  findings can be authored via `/polya-audit:audit-add`.
+  *Depends on:* B7.
+
+### Week 4 — backfill + handoff
+
+- **B9 — Bootstrap import.** Land
+  `lib/mix/tasks/tau.audit.import.ex`. Run it; review the
+  generated draft findings; commit one PR per surface group
+  (estimate ~10 PRs of ~3-5 findings each). Each PR's gate is
+  the existing factory-loop. Closes AC item (e) in full.
+  *Depends on:* B8.
+
+- **B10 — Dashboard handoff.** Expose `Findings.all/0` via a JSON
+  endpoint and the SARIF artifact via GitHub Actions artifact
+  download. Hand off to operability-and-hygiene-enforcement
+  sibling. Closes AC item (f) for the dashboard surface; the
+  sibling owns rendering.
+  *Depends on:* B9.
+
+After B5: silent-skip-impossibility is in force.
+After B6: the meta-test guarantees the loop is alive.
+After B7: the first real audit finding is mechanically gated.
+After B8: staleness is caught nightly and halts the loop.
+After B9: the v1 archive backlog is registered.
+After B10: operability surfaces the registry to the dashboard.
+
+## Open questions
+
+- **AST-selector vocabulary ceiling.** The `Surface.ast_selector`
+  field is a named atom (`:rescue_or_catch_exit`, etc.); adding a
+  new shape requires Elixir code, not just YAML. The set is finite
+  and small (the v1 archive surfaces ~6 distinct AST patterns), but
+  novel invariant kinds will need a probe author. Open: do we want
+  a more expressive AST DSL (Sourceror-based)? Decision deferred to
+  first probe that needs it (Proposal 4's deferral; this hybrid
+  inherits it).
+- **`proven_at_sha` performance on historical trees.** The B2/B7
+  compile-time probe-replay against arbitrary SHAs requires
+  `git worktree add <tmp> <sha>` plus a fresh `mix compile` if
+  dependencies differ. For AST-only probes this is cheap; for
+  probes that need a working `mix` build, it may exceed CI budget.
+  Mitigation: AST-only probes for v1 backfill; nightly tier for
+  build-needing probes. Open: do we need a probe `tier` field
+  (Proposal 4 mentions `tier: :ast | :unit | :integration |
+  :nightly`)? Recommend adding it in B7 if any v1 probe needs it.
+- **Cross-PR finding authorship lag.** A finding authored on PR #X
+  is not in-force until PR #X merges and `priv/factory/findings.
+  json` is rebuilt on `main`; concurrent PR #Y introducing the
+  same violation will not be gated. This is a deliberate
+  consistency choice (registry-of-record == `origin/main`,
+  Proposal 1's discipline) but may surprise authors. Mitigation:
+  CI comment on PR #X warning that the finding is "in-force after
+  merge."
+- **Finding-id allocation discipline.** `F-2026-05-NORESCUE-007`
+  is the suggested format (year-month + kind + sequence) but
+  collisions across concurrent PRs are possible. Recommend
+  `mix tau.audit.scaffold` allocates IDs from a registry-side
+  monotonic counter at commit time, OR uses a UUID prefix (less
+  pretty, collision-free).
+- **Waiver approver authority.** The `waiver.approver` field is
+  validated as an email; no check on whether that email has
+  authority to approve. For Tau's single-author phase this is
+  acceptable; multi-author requires a `WAIVERS-APPROVERS.md`
+  allowlist (out of scope for the leaf).
+- **Probe staleness vs probe-version drift.** A probe whose source
+  changes after `proven_at_sha` is recorded — does the compile task
+  re-verify against the historical tree on every compile, or only
+  when the probe source changes? Recommend: re-verify on every PR
+  whose diff touches `lib/tau/factory/audit/probes/`. Otherwise
+  trust the recorded SHA. Decision: implementation detail of B2.
+
+## Linked sub-problems / proposals
+
+- `proposals/proposal-1.md` — Versioned Finding Registry + Coverage
+  Ledger; provides the substrate, the type-system silent-skip
+  closure, and the single consumption contract.
+- `proposals/proposal-2.md` — Claude memory cascade + MCP knowledge-
+  graph; rejected as primary (non-hermetic CI, cascade not designed
+  as registry) but the plugin-skill extension pattern is borrowed
+  for the `polya-audit` plugin's authoring surface.
+- `proposals/proposal-3.md` — Datalog/EDN knowledge base; rejected
+  as primary (high LOC, low BEAM-ecosystem fit) but the
+  workflow-lint test (`test/ci/workflow_lint_test.exs`) layer-2
+  silent-skip defence and the golden-findings test are lifted.
+- `proposals/proposal-4.md` — Adversarial probes with
+  `proven_at_sha` + nightly health gate; provides the staleness
+  closure that Proposal 1 leaves open. Generalises v1's
+  mutation-check (gate 5.3) from AC tests to audit probes.
+
+## Revision history
+
+- (revision 0 — initial leaf-mode synthesis; hybrid of P1 + P4
+  with borrowed elements from P3 (workflow-lint) and P2 (plugin
+  extension pattern).)

--- a/docs/factory-v2/design/subproblems/operability-and-hygiene-enforcement/problem.md
+++ b/docs/factory-v2/design/subproblems/operability-and-hygiene-enforcement/problem.md
@@ -1,0 +1,133 @@
+---
+template_version: 1
+template_name: problem
+node_kind: leaf
+mode: leaf
+depth: 1
+parent: ../../problem.md
+status: draft
+---
+
+# Problem: Operability and hygiene — factory state observability and worktree/branch invariants
+
+## Statement
+
+The factory's runtime state — what gates are wired, which gates have
+run on which PRs with what verdict, what orphan worktrees and stale
+branches exist, whether `parent-on-main` holds, what coherence checks
+last ran on `main`, what audit findings are open / waived — must be
+observable from a single query surface, and the worktree-discipline
+invariants must be mechanically enforced rather than relying on
+agents reading the rule. v1 fails on both: 63-571 orphan worktrees
+(root #8), `parent-on-main` invariant ignored, and no view of factory
+state exists outside reading git logs and `.claude/logs/` by hand.
+The problem is solved when (a) a single dashboard or queryable
+endpoint shows factory state and (b) `parent-on-main` and worktree
+cleanup are enforced by hooks/CI rather than by rule prose.
+
+## Context
+
+- Root §Hypothesis #8 — worktree branches leak (63-571 orphans);
+  `parent-on-main` invariant ignored.
+- Root §Acceptance E (Operability) — "The factory's state … is
+  observable from a single dashboard or query, not reconstructed by
+  reading git logs."
+- `.claude/rules/worktree-discipline.md` — the prose source-of-truth
+  rule; today enforced only by agent self-discipline.
+- `.claude/settings.json` — the place hooks (`PreToolUse`,
+  `PostToolUse`, `SessionStart`) can run pre-commit / pre-spawn
+  invariant checks.
+- v1 has `.claude/logs/solution-tree.json` and per-PR gate verdicts
+  recorded in PR bodies, but no aggregation surface.
+- Existing ecosystem: GitHub's `actions/runs` API, GitHub Projects
+  v2 for backlog state, the Tau project's own `:tau_web` poncho
+  package (SPEC-WEB-DASHBOARD) which already plans a dashboard
+  surface, observability backends with OpenTelemetry export, simple
+  Grafana / Datasette dashboards over a SQLite view of repo state.
+
+## Failure classes addressed (from root §Hypothesis)
+
+- **#8** (primary) — worktree leaks, `parent-on-main` violation; the
+  full enforcement of `worktree-discipline.md` invariants by hooks
+  and CI rather than by prose.
+- Operability dimension of all classes (#1–#10 cumulative) — without
+  a state surface, no class' real-world fix rate can be measured.
+  This leaf does not detect any class's *violations* (those are
+  owned by their respective sibling leaves) but produces the surface
+  that makes the verdicts visible and actionable.
+
+## Complecting hypothesis
+
+- "What the factory is doing" is complected with "where you happen
+  to look" because state lives in `.claude/logs/`, GitHub PR bodies,
+  GitHub Actions runs, ephemeral agent contexts, and human memory;
+  unifying requires a single read model populated by gate verdicts
+  and repo events.
+- "Worktree hygiene" is complected with "agent discipline" because
+  the only enforcement is rule prose that agents must read; making
+  it mechanical requires either pre-spawn hooks (refuse to spawn
+  with stale parent) or post-merge sweeps (auto-prune finished
+  worktrees and stale branches).
+- "`parent-on-main` invariant" is complected with "the coordinator's
+  attention" because checking it is a multi-step git incantation; a
+  hook or pre-spawn skill must run the check as a precondition with
+  no opt-out.
+
+## Decomposition strategy
+
+(leaf — no further decomposition; proceed to proposals)
+
+## Acceptance criterion
+
+The factory specification names mechanisms such that: (a) a single
+dashboard or queryable endpoint (HTTP, Datasette over SQLite, or
+the existing planned `:tau_web` LiveView) shows at minimum: gate
+inventory (which gates exist, on which workflow / branch protection
+rules); per-PR gate verdicts (pass/fail/skipped with reason) for
+the last N PRs; orphan worktree count and list; stale-branch count
+(remote branches with no open PR and no recent commits); last
+`main`-coherence run timestamp and verdict; open audit-finding
+count by surface; in-flight PRs by milestone; (b) the dashboard
+data source is populated automatically — gate verdicts written by
+the gates themselves (no manual entry); worktree / branch state
+read live from `gh api` or `git for-each-ref`; the dashboard
+itself cannot silent-fail (a dashboard component that cannot fetch
+data shows an error state, not a blank panel); (c) a pre-spawn
+hook (PreToolUse on Task tool, or a `SessionStart` hook) verifies
+parent-on-main and aborts the spawn if violated, with the diagnostic
+naming exactly which invariant failed and the recovery command;
+(d) a `main`-merged hook (`PostToolUse` or a scheduled workflow)
+runs the worktree-cleanup sequence and the parent-on-main sync,
+and refuses to silently leave finished worktrees registered (alarms
+the dashboard or opens an issue if cleanup is blocked); (e) the
+design records reuse vs build per surface (existing `:tau_web`
+poncho? GitHub Projects v2 view? Datasette over a periodically-
+generated SQLite? OpenTelemetry exporter + Grafana?) per root
+§Acceptance D; (f) the spec output identifies concrete artifacts:
+the dashboard endpoint (LiveView module path, route, port), hook
+script paths and `.claude/settings.json` entries, the scheduled
+workflow for cleanup, the SQLite/Postgres schema (if any) for
+verdict aggregation, the `gh` query commands or webhook receivers,
+and the alarm channel (issue-opener Action, telemetry event).
+
+## Out of scope
+
+- Per-PR pre-merge code gates and their verdicts — owned by
+  **pre-merge-code-gates** sibling (this leaf *displays* verdicts
+  it does not produce them).
+- The gate-execution substrate (silent-skip, evidence trust) —
+  owned by **pre-merge-evidence-and-skip-integrity** sibling.
+- AC-binding mechanics — owned by **intent-capture-and-ac-binding**
+  sibling.
+- Cross-document drift on `main` — owned by
+  **post-merge-cross-artifact-coherence** sibling.
+- Audit-finding ingestion and registration — owned by
+  **knowledge-memory-and-audit-ingestion** sibling (this leaf
+  surfaces "audit findings open count" but does not own the
+  ingestion path).
+- Documentation-only components; agent-discipline-only enforcement;
+  workstream-2 corrective-actions catalogue.
+
+## Amendment log
+
+- (none yet)

--- a/docs/factory-v2/design/subproblems/operability-and-hygiene-enforcement/proposals/proposal-1.md
+++ b/docs/factory-v2/design/subproblems/operability-and-hygiene-enforcement/proposals/proposal-1.md
@@ -1,0 +1,381 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 1
+parent_problem: ../problem.md
+---
+
+# Proposal 1: Event-sourced Factory Read Model on `:tau_web` + Mechanical Hygiene Hooks (`tau.factory` Mix tasks as the only mutator)
+
+## Approach
+
+Introduce a single read model — `Tau.FactoryState` — backed by a SQLite
+event log written *only* by `mix tau.factory.emit` (a Mix task that no
+other component may bypass). Every gate verdict (PR-merge gate, hygiene
+gate, coherence gate), every worktree event (spawn, prune), every
+`parent-on-main` invariant check, and every audit-finding state change
+is appended as a typed event by the producer (a CI job, a hook script,
+or a scheduled workflow) via that one task. The read model is projected
+into queryable Ecto schemas under `:tau_web` and rendered as a single
+LiveView at `/factory` (the existing `SPEC-WEB-DASHBOARD` poncho gains
+a new `FactoryLive` route). Hygiene enforcement is a small set of hook
+scripts that block tool calls or fail PRs — `parent-on-main`
+verification runs as a `PreToolUse` hook on `Task` and as a CI job; an
+hourly scheduled GitHub Action runs `mix tau.factory.sweep` to prune
+finished worktrees and emit a `hygiene.swept` event. Silent-skip is
+made impossible because (i) every check emits exactly one of three
+verdict atoms — `:pass | :fail | :not_applicable_with_reason` — and the
+read model alarms on the absence of an expected verdict (a missing
+event is itself a `:missing` row), and (ii) all CI jobs are wired
+through a single composite action `factory-gate` whose post-step asserts
+that *every declared gate ID produced an event in this run*, failing
+the job if any did not.
+
+## Rationale
+
+The complecting hypothesis is that factory state lives in five
+substrates (`.claude/logs/`, PR bodies, Actions runs, agent context,
+human memory) and that hygiene rules are complected with agent
+discipline. Decomplecting requires (a) a single mutator and a single
+read model — every producer writes by the same protocol, every consumer
+reads by the same protocol — and (b) mechanical enforcement substrates
+that cannot be reasoned around: a `PreToolUse` hook either lets the
+spawn through or it doesn't; a CI composite action either records all
+verdicts or it fails. By making the producer-of-record `mix
+tau.factory.emit` and the consumer-of-record a single LiveView reading
+one SQLite database, we replace "where you happened to look" with one
+schema. By having the composite action assert verdict-set completeness
+*after* the gate job runs, silent-skip is structurally impossible —
+absence is itself an alarm. The hygiene hooks make `parent-on-main`
+violation impossible at spawn-time, removing the "coordinator's
+attention" coupling. The choice to host the dashboard inside the
+existing `:tau_web` poncho satisfies Root §Acceptance D (reuse over
+reinvention) because `SPEC-WEB-DASHBOARD` already commits the
+substrate.
+
+## Sketch
+
+### Read-model store (event log + projections)
+
+A new sub-application `:tau_factory_state` under the poncho:
+
+```
+poncho/
+  factory_state/
+    lib/tau/factory_state/
+      event.ex            # %Event{} typed envelope
+      log.ex              # append-only Ecto/Sqlite writer (single mutator API)
+      projector.ex        # GenServer; consumes Log and updates projections
+      schema/
+        gate_verdict.ex   # one row per (pr_number, gate_id, run_id)
+        worktree.ex       # one row per active worktree
+        invariant_check.ex
+        audit_finding.ex
+        run.ex            # one row per CI run, with declared_gate_ids
+      query.ex            # the read API used by LiveView and Mix tasks
+    priv/repo/migrations/...
+```
+
+Event envelope:
+
+```elixir
+defmodule Tau.FactoryState.Event do
+  @type t :: %__MODULE__{
+          id: String.t(),          # ULID
+          kind: kind(),
+          source: String.t(),      # "ci:lint", "hook:pre-task", "sweep:cron"
+          pr_number: pos_integer() | nil,
+          run_id: String.t() | nil,
+          gate_id: String.t() | nil,   # e.g. "ac_linkage", "mutation", "parent_on_main"
+          verdict: :pass | :fail | :not_applicable | :error | nil,
+          reason: String.t() | nil,    # MANDATORY when :not_applicable | :error
+          payload: map(),
+          emitted_at: DateTime.t()
+        }
+end
+```
+
+### Single mutator: `mix tau.factory.emit`
+
+The only sanctioned way to write to the log. Reads a JSON event on
+stdin, validates against `Event.t()`, refuses anything that lacks the
+mandatory fields per `kind`. Refusal exits non-zero, which fails the
+CI step that emitted it.
+
+```sh
+echo '{"kind":"gate_verdict","gate_id":"ac_linkage","pr_number":417,
+       "run_id":"$GITHUB_RUN_ID","verdict":"pass","payload":{...}}' \
+  | mix tau.factory.emit
+```
+
+Contract enforced at validation time:
+
+- `kind: :gate_verdict` ⇒ `gate_id`, `pr_number`, `run_id`,
+  `verdict` REQUIRED. If `verdict ∈ {:not_applicable, :fail, :error}`,
+  `reason` REQUIRED and non-empty.
+- `kind: :worktree_event` ⇒ `payload` has `op ∈ [:spawn, :prune,
+  :leaked]`, `path`, `agent_id`.
+- `kind: :invariant_check` ⇒ `gate_id` (e.g. `parent_on_main`),
+  `verdict`, `reason` when not `:pass`.
+- `kind: :run_declared` ⇒ `run_id`, `payload.declared_gate_ids: [String]`.
+  Emitted once per CI run at job start.
+
+### Verdict-completeness assertion (anti-silent-skip)
+
+A new composite action `.github/actions/factory-gate/action.yml`
+wraps every gate step. Its `post` step runs:
+
+```sh
+mix tau.factory.gate.assert_complete \
+  --run-id "$GITHUB_RUN_ID" \
+  --declared-gate-ids "ac_linkage,masking,mutation,contract_drift,..."
+```
+
+The task queries the read model: for each declared gate ID, does a
+`gate_verdict` event exist for this `run_id`? If any is missing, the
+task exits non-zero with the list of missing IDs — failing the CI
+job. This is the structural impossibility: the gate either emits or
+the job fails.
+
+### Pre-spawn hygiene hook
+
+New script `.claude/hooks/check-parent-on-main.py` wired into
+`.claude/settings.json`:
+
+```jsonc
+"PreToolUse": [
+  { "matcher": "Task",
+    "hooks": [{ "type": "command",
+                "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/check-parent-on-main.py",
+                "timeout": 10 }] }
+]
+```
+
+Behaviour: runs `git fetch origin && git rev-parse main` and compares
+to `origin/main`; on mismatch prints the diagnostic *and the recovery
+command* to stderr and exits non-zero (Claude Code blocks the tool
+call). Also pipes a `kind: invariant_check, gate_id:
+parent_on_main, verdict: :fail` event to `mix tau.factory.emit`.
+
+### Scheduled sweep
+
+`.github/workflows/factory-sweep.yml`, cron `*/30 * * * *`:
+
+```yaml
+jobs:
+  sweep:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with: { fetch-depth: 0 }
+      - uses: ./.github/actions/setup-beam
+      - run: mix tau.factory.sweep --emit
+```
+
+`mix tau.factory.sweep` enumerates `git worktree list`, identifies
+finished worktrees (whose agent process is dead and whose branch has
+been merged or abandoned), removes them with the canonical
+capture-before-destroy sequence from `worktree-discipline.md`, and
+emits one `worktree_event` per action plus a single `hygiene.swept`
+summary. Failure to remove (locked, dirty, etc.) emits `verdict: :fail`
+with the blocker named — which surfaces on the LiveView as a red row
+and opens an issue via `gh issue create`.
+
+### Dashboard
+
+`web/lib/tau_web/live/factory_live.ex` mounts `Phoenix.PubSub`
+subscription on `"factory:events"` (the projector broadcasts there);
+renders five panels — Gate verdicts (last N PRs), Worktrees (active +
+leaked), Invariants (last `parent_on_main` check time + verdict),
+Coherence (last `main`-coherence run), Audit findings (open count
+per surface). Each panel handles `assigns.error` by rendering an
+error state, never an empty panel.
+
+### Read-only consumer API
+
+`Tau.FactoryState.Query` exposes pure functions used by both LiveView
+and Mix-task introspection:
+
+```elixir
+@spec gate_verdicts_for_pr(pos_integer()) :: [GateVerdict.t()]
+@spec leaked_worktrees() :: [Worktree.t()]
+@spec last_invariant_check(gate_id :: String.t()) :: InvariantCheck.t() | nil
+@spec missing_verdicts(run_id :: String.t(), declared :: [String.t()]) :: [String.t()]
+@spec open_audit_findings_by_surface() :: %{String.t() => pos_integer()}
+```
+
+### Verdict consumption
+
+The read model is consumed by three classes of caller, each by a
+narrow contract:
+
+1. **`Tau.FactoryState.Query` callers** (LiveView, `mix tau.factory.status`)
+   — read for display.
+2. **The completeness asserter** (`mix tau.factory.gate.assert_complete`)
+   — read at CI-job tail to enforce silent-skip impossibility.
+3. **The escalation issuer** (`mix tau.factory.alarm`) — read on cron;
+   when leaked worktrees exceed threshold or an expected event is
+   missing for > T hours, opens a GitHub issue tagged `factory:hygiene`.
+
+No consumer mutates the log; the log is append-only and the single
+mutator is `mix tau.factory.emit`.
+
+## Tradeoffs
+
+### Strengths
+
+- **Single read model, single mutator.** Decomplects "where state
+  lives" from "what state means" (Hickey: place ≠ value). One schema,
+  one mutator API, one query API.
+- **Silent-skip structural impossibility.** Verdict-set completeness
+  is asserted *after* every gate run; missing events fail the job.
+  Addresses Root §Acceptance C and Failure Class #5 directly.
+- **`parent-on-main` enforced as a `PreToolUse` hook.** Agents
+  cannot spawn from a stale parent; the rule is no longer prose.
+  Addresses Failure Class #8.
+- **Reuse of `:tau_web` poncho satisfies Root §Acceptance D.** No new
+  web stack; new sub-app composes with `SPEC-WEB-DASHBOARD`.
+- **Append-only event log** is debuggable, replayable, and survives
+  projector schema changes — drop projections, replay log, rebuild.
+- **Dashboard panels render error state on fetch failure**, never an
+  empty panel, satisfying leaf-AC (b).
+
+### Weaknesses
+
+- **Producer compliance** still requires every gate author to call
+  `mix tau.factory.emit`. The completeness asserter catches omission
+  at run-tail but cannot validate semantic correctness of `payload`.
+  Mitigation: per-`kind` JSON schema validation in `tau.factory.emit`;
+  a `kind` not in the registry is refused.
+- **Cron sweep latency.** Up to 30 minutes between leak and cleanup;
+  during that window the dashboard shows the leak but no action is
+  taken. Tightening the cron costs Actions minutes.
+- **SQLite write contention** if many parallel CI jobs emit at high
+  rate. The MVP uses a GitHub release artefact as the canonical log
+  (one append per emit, downloaded by the projector); a future
+  version may move to Postgres on a fly.io / Railway instance —
+  schema is stable, migration is cheap.
+- **Composite-action discipline.** A new gate authored without
+  wrapping in `factory-gate` would still silent-skip. Mitigation: a
+  meta-check job that greps `.github/workflows/` for jobs containing
+  `tau.gate.*` invocations not inside `uses: ./.github/actions/factory-gate`
+  and fails the workflow.
+- **PreToolUse hook adds latency to every `Task` spawn.** ~1-2s for
+  `git fetch`. Mitigation: cache the `origin/main` SHA in a
+  `$CLAUDE_PROJECT_DIR/.claude/cache/origin-main-sha` file with TTL
+  60s; refresh out-of-band.
+- **LiveView itself is not yet live** in `:tau_web` (foundation
+  package exists, no LiveViews mounted). This proposal depends on
+  #374 (M7 foundation) landing.
+
+### Costs
+
+- New sub-app under poncho: ~400 LOC Elixir (Event, Log, Projector,
+  Query, 4 schemas, 3 migrations).
+- 3 Mix tasks: `tau.factory.emit`, `tau.factory.gate.assert_complete`,
+  `tau.factory.sweep` — ~200 LOC.
+- 1 LiveView + components: ~300 LOC.
+- 1 PreToolUse hook script: ~80 LOC Python (stdlib only per
+  `hooks-and-scripts.md`).
+- 1 composite GitHub Action + 1 scheduled workflow.
+- Test surface: property tests on `Event` validation, integration
+  test on the projector, contract test on the composite action via
+  `act` or a minimal CI matrix.
+- Run-cost: GitHub Actions cron job every 30 min — ~48 runs/day at
+  ~30s each, negligible.
+- Knowledge: contributors must learn the `emit` protocol; mitigated
+  by a single-page README and one example gate adoption.
+
+## Dependencies
+
+- **#374 (M7 web foundation)** — `:tau_web` Phoenix endpoint and
+  PubSub up.
+- **SPEC-WEB-DASHBOARD** — `Tau.PubSub` reuse invariant (D-184)
+  applies; the projector broadcasts on the shared `Tau.PubSub`.
+- **The `pre-merge-evidence-and-skip-integrity` sibling leaf's**
+  decision about *where verdict authority lives* (CI artefact? PR
+  body? both?) must be compatible — this proposal assumes CI is the
+  authority, with the PR body summarising the read model.
+- **The `knowledge-memory-and-audit-ingestion` sibling** owns the
+  audit-finding write path; this leaf only renders the resulting
+  counts. The sibling must emit `kind: audit_finding` events through
+  `mix tau.factory.emit` (or write directly to the projector's
+  schema with a documented contract).
+- **A canonical event-log storage choice** — proposal MVP uses a
+  GitHub release artefact (immutable, free, addressable); a
+  follow-up may promote to Postgres if write rate justifies it.
+
+## Confidence
+
+**Medium.** The pattern (event sourcing + read model + completeness
+assertion + pre-tool hook) is well-trodden; the only genuinely novel
+piece is `mix tau.factory.gate.assert_complete`. What would raise
+confidence: a 1-week prototype that wires `ac_linkage` and `mutation`
+through `factory-gate` on a throwaway PR, plus a sample LiveView
+mounted at `/factory` on a local endpoint.
+
+## Prior art / references
+
+- Event sourcing with a SQLite append-log: Datasette + `sqlite-utils`
+  insert-rows pattern.
+- The verdict-completeness pattern: GitHub's own required-checks API
+  models it (a required check absent ≡ failing), but at the
+  repository-settings layer rather than per-run; this proposal moves
+  the assertion into the run itself for self-contained CI.
+- `Tau.OtelReporter` already establishes the `[:tau, …]` telemetry
+  namespace and a supervised subscriber pattern; the projector
+  borrows the shape.
+- `worktree-discipline.md` capture-before-destroy sequence is
+  reused verbatim inside `mix tau.factory.sweep`.
+- The composite-action wrapping pattern is the same one
+  `actions/upload-artifact` uses for its post-step cleanup.
+
+## Build-order
+
+The build sequence is dependency-driven: each step produces an
+artefact the next step assumes exists. None may be skipped without
+silently disabling a downstream guarantee.
+
+1. **B1 — Event envelope + log writer.** Land `Tau.FactoryState.Event`
+   and `Tau.FactoryState.Log` (append-only, SQLite, single mutator).
+   Tests: property test on `Event.validate/1`; integration test on
+   `Log.append/1` round-trip. *Artefact:* `Event.t()` schema fixed.
+2. **B2 — `mix tau.factory.emit`.** CLI wrapper around `Log.append`.
+   Refuses invalid events with non-zero exit + named missing fields.
+   *Artefact:* the single mutator that all subsequent producers call.
+3. **B3 — Projector + schemas + `Query`.** Project events into
+   `GateVerdict`, `Worktree`, `InvariantCheck`, `Run`,
+   `AuditFinding`. *Artefact:* a queryable read model.
+4. **B4 — `mix tau.factory.gate.assert_complete`.** The
+   anti-silent-skip primitive. *Artefact:* the completeness check
+   that downstream CI relies on.
+5. **B5 — Composite GitHub Action `factory-gate` + adopt on one gate
+   end-to-end.** Wrap `ac_linkage` first; demonstrate that
+   completeness assertion catches a synthetic omission.
+   *Artefact:* the wrapping contract, validated on one production gate.
+6. **B6 — Adopt `factory-gate` on every existing gate.** Mutation,
+   masking, dialyzer, credo, compile-warnings, etc. *Artefact:*
+   universal wrapping; meta-check job greps for unwrapped invocations.
+7. **B7 — `PreToolUse` hook `check-parent-on-main.py` +
+   `.claude/settings.json` wiring.** *Artefact:* spawn-time
+   `parent-on-main` enforcement.
+8. **B8 — `mix tau.factory.sweep` + scheduled workflow
+   `factory-sweep.yml`.** *Artefact:* hourly hygiene enforcement
+   with verdict events.
+9. **B9 — `mix tau.factory.alarm` + issue-opener integration.**
+   *Artefact:* leaked-worktree threshold and missing-verdict
+   timeout become open GitHub issues with `factory:hygiene` label.
+10. **B10 — `FactoryLive` LiveView at `/factory`.** Mount on
+    `:tau_web`; subscribe to `Tau.PubSub` topic `"factory:events"`;
+    render five panels with error states. *Artefact:* single-query
+    factory state surface (leaf-AC (a)).
+11. **B11 — README + one-page adoption guide** for adding a new
+    gate: declare the `gate_id`, wrap in `factory-gate`, emit on
+    pass/fail. *Artefact:* operator-facing onboarding so future
+    gates cannot bypass the mutator.
+
+Order is strict: B5 cannot precede B4 (the wrapping has nothing to
+assert); B7 should not precede B2 (the hook would have nowhere to
+emit); B10 trails B3 (no schema, no LiveView). B6 may parallelise
+across gates after B5 establishes the pattern. B11 lands with B5 so
+adoption can begin immediately.

--- a/docs/factory-v2/design/subproblems/operability-and-hygiene-enforcement/proposals/proposal-2.md
+++ b/docs/factory-v2/design/subproblems/operability-and-hygiene-enforcement/proposals/proposal-2.md
@@ -1,0 +1,562 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 2
+parent_problem: ../problem.md
+---
+
+# Proposal 2: Adopt Phoenix LiveDashboard + GitHub Actions + git-hooks; thin custom pages over a SQLite read-model populated by existing telemetry
+
+## Approach
+
+Reuse three already-mature components — **Phoenix LiveDashboard** (mounted
+inside the existing `:tau_web` poncho per SPEC-WEB-DASHBOARD), **GitHub
+Actions scheduled workflows + branch-protection rules**, and **`git
+worktree` + server-side `pre-receive` / `update` hooks** — and add only the
+glue Tau actually owns: (a) a tiny `Tau.Factory.ReadModel` GenServer that
+projects existing `[:tau, :factory, ...]` `:telemetry` events and `gh api`
+poll output into a single SQLite database (`priv/factory_state.db`),
+(b) a `TauWeb.FactoryLive` LiveView that subscribes via `Tau.PubSub`
+(D-184 — no second PubSub) and renders the dashboard panels required by
+the leaf's AC (a) using LiveDashboard's `Phoenix.LiveDashboard.PageBuilder`
+behaviour, (c) two `PreToolUse` hooks (`enforce-parent-on-main.py`,
+`enforce-worktree-cleanup.py`) registered in `.claude/settings.json` that
+share their *exact same script* with a scheduled GitHub Actions workflow
+(`.github/workflows/hygiene-sweep.yml`) so the local and remote
+enforcement points cannot drift, and (d) a `branch-protection.json` config
+applied by `gh api` that requires the `hygiene-sweep` workflow status to
+be green on `main` — closing the loop without bespoke daemons.
+
+## Rationale
+
+The leaf's complecting hypothesis is that "what the factory is doing"
+is scattered across `.claude/logs/`, PR bodies, Actions, agent contexts,
+and human memory; and that hygiene rules are complected with agent
+discipline. The cure is a single read model plus mechanical enforcement
+— *not* a bespoke dashboard, scheduler, or branch-policy daemon. Tau
+already chose Phoenix LiveDashboard for `/dev/dashboard` (`web/lib/
+tau_web/router.ex:50`), Phoenix LiveView for AC-claimed surfaces
+(SPEC-WEB-DASHBOARD D-180..D-189), `[:tau, ...]` `:telemetry` namespace,
+`Phoenix.PubSub` (D-184), `:exqlite`/SQLite (SPEC-MEMORY-STORE), and
+GitHub Actions for CI; every one of those is a load-bearing component
+the proposal **reuses without modification**. The only new code is the
+projector (a textbook `Phoenix.Tracker`-shape GenServer) and the
+LiveDashboard page module — both of which are stateless functions over
+existing event streams, satisfying OTP non-negotiable #8 (pure
+functions are the default). Hygiene enforcement collapses to a script
+shared between a local PreToolUse hook and a GitHub Actions cron — the
+same script, run in two places, so divergence is impossible. Branch-
+protection rules make the workflow's verdict load-bearing without any
+bespoke "merge daemon." This satisfies root §Acceptance D
+(ecosystem reuse over reinvention) at the highest available density.
+
+## Sketch
+
+### Component map (reused vs new)
+
+| Surface | Reused (no code) | Glue (Tau-owned) |
+|---|---|---|
+| Dashboard chrome, charts, tabs, auth-aware mount | `Phoenix.LiveDashboard` + `Phoenix.LiveDashboard.PageBuilder` | `TauWeb.FactoryLive.Page` (≤ 200 LOC) |
+| Real-time push | `Phoenix.PubSub` (D-184), `Phoenix.LiveView` | subscribe in `mount/3`; broadcast from `ReadModel` |
+| Telemetry stream | `:telemetry` (existing `[:tau, :factory, ...]` events) | one `:telemetry.attach_many/4` call in `ReadModel.init/1` |
+| Persistent read model | `:exqlite` (already a dep — SPEC-MEMORY-STORE) | `priv/factory_state.db` with 6 tables (see schema below) |
+| Gate verdicts | written by gates already (PR-body trailer, CI artifacts) | `ReadModel` parses the trailer via `gh api repos/.../pulls/:n` |
+| Orphan worktree / stale-branch counts | `git worktree list --porcelain`, `git for-each-ref refs/heads/ --format='%(refname:short) %(committerdate:unix)'`, `gh pr list --state open --json headRefName` | one `Tau.Factory.Hygiene.scan/0` pure function |
+| Scheduled cleanup + parent-on-main sync | GitHub Actions cron + `gh api` | `.github/workflows/hygiene-sweep.yml` (shells out to the same script as the local hook) |
+| Local pre-spawn enforcement | Claude Code `PreToolUse` hook protocol | `.claude/hooks/enforce-parent-on-main.py`, `.claude/hooks/enforce-worktree-cleanup.py` |
+| Branch-protection / load-bearing verdict | GitHub branch-protection rules API | `.github/branch-protection.json` applied by `gh api` |
+| Alarm / issue-on-failure | GitHub Issues API + Actions `peter-evans/create-issue-from-file` action | `.github/workflows/hygiene-sweep.yml` step `on: failure` |
+
+### SQLite read-model schema (`priv/factory_state.db`)
+
+```sql
+CREATE TABLE gate_run (
+  pr_number       INTEGER NOT NULL,
+  gate_id         TEXT    NOT NULL,           -- "5.1", "5.2", "5.3", "critic", "reviewer"
+  verdict         TEXT    NOT NULL CHECK (verdict IN ('pass','fail','checked_no_findings','infra_fail')),
+  rationale       TEXT    NOT NULL,           -- never NULL — silent-skip impossible
+  diff_sha        TEXT    NOT NULL,           -- the diff the verdict covers
+  ran_at          INTEGER NOT NULL,           -- unix seconds
+  evidence_url    TEXT    NOT NULL,           -- GH Actions run URL (never local mix)
+  PRIMARY KEY (pr_number, gate_id, ran_at)
+);
+
+CREATE TABLE pr_state (
+  pr_number       INTEGER PRIMARY KEY,
+  milestone       TEXT,
+  status          TEXT NOT NULL,              -- 'draft'|'open'|'merged'|'closed'
+  head_sha        TEXT NOT NULL,
+  declared_acs    TEXT NOT NULL,              -- JSON array of AC-N / D-NNN
+  closes_issues   TEXT NOT NULL               -- JSON array of int
+);
+
+CREATE TABLE worktree_state (
+  path            TEXT PRIMARY KEY,
+  branch          TEXT NOT NULL,
+  age_seconds     INTEGER NOT NULL,
+  status          TEXT NOT NULL,              -- 'active'|'orphan'|'leaked'
+  observed_at     INTEGER NOT NULL
+);
+
+CREATE TABLE stale_branch (
+  refname         TEXT PRIMARY KEY,
+  age_seconds     INTEGER NOT NULL,
+  has_open_pr     INTEGER NOT NULL CHECK (has_open_pr IN (0,1)),
+  observed_at     INTEGER NOT NULL
+);
+
+CREATE TABLE main_coherence_run (
+  ran_at          INTEGER PRIMARY KEY,
+  verdict         TEXT NOT NULL CHECK (verdict IN ('pass','fail','checked_no_findings')),
+  rationale       TEXT NOT NULL,
+  evidence_url    TEXT NOT NULL
+);
+
+CREATE TABLE audit_finding (
+  finding_id      TEXT PRIMARY KEY,           -- e.g. "audit-2026-04-rescue-7"
+  surface_glob    TEXT NOT NULL,              -- file glob the finding applies to
+  status          TEXT NOT NULL,              -- 'open'|'remediated'|'waived'
+  waiver_expires  INTEGER,                    -- unix ts; NULL if no waiver
+  opened_at       INTEGER NOT NULL
+);
+```
+
+### `Tau.Factory.ReadModel` (new — ≤ 250 LOC)
+
+```elixir
+defmodule Tau.Factory.ReadModel do
+  @moduledoc """
+  Projects `[:tau, :factory, ...]` telemetry, GitHub API polls, and
+  `git`/`gh` scan output into `priv/factory_state.db`. Pure projector:
+  every handler is a function from event -> SQL insert. Owns the SQLite
+  connection process (Exqlite).
+
+  This is the *only* writer to `factory_state.db`. Readers (LiveView,
+  scheduled workflows, ad-hoc queries via `sqlite3` or Datasette) read
+  the same database.
+  """
+  use GenServer
+
+  @events [
+    [:tau, :factory, :gate, :stop],
+    [:tau, :factory, :gate, :exception],
+    [:tau, :factory, :pr, :opened],
+    [:tau, :factory, :pr, :merged],
+    [:tau, :factory, :hygiene, :scan, :stop]
+  ]
+
+  def start_link(opts), do: GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+
+  @impl true
+  def init(opts) do
+    db = Keyword.get(opts, :db_path, Application.app_dir(:tau, "priv/factory_state.db"))
+    {:ok, conn} = Exqlite.Sqlite3.open(db)
+    :ok = Tau.Factory.ReadModel.Schema.migrate!(conn)
+    :ok = :telemetry.attach_many("tau-factory-readmodel", @events, &__MODULE__.handle/4, conn)
+    schedule_poll()
+    {:ok, %{conn: conn}}
+  end
+
+  def handle(event, measurements, metadata, conn) do
+    Tau.Factory.ReadModel.Project.apply(conn, event, measurements, metadata)
+    Phoenix.PubSub.broadcast(Tau.PubSub, "factory:state", {:projected, event, metadata})
+  end
+
+  @impl true
+  def handle_info(:poll, %{conn: conn} = s) do
+    Tau.Factory.Hygiene.scan() |> Enum.each(&Tau.Factory.ReadModel.Project.apply(conn, :hygiene, &1, %{}))
+    schedule_poll()
+    {:noreply, s}
+  end
+
+  defp schedule_poll, do: Process.send_after(self(), :poll, :timer.seconds(60))
+end
+```
+
+### `TauWeb.FactoryLive.Page` (new — uses LiveDashboard PageBuilder)
+
+```elixir
+defmodule TauWeb.FactoryLive.Page do
+  @moduledoc """
+  Mounts as a LiveDashboard page at `/dev/dashboard/factory`. Reads from
+  `priv/factory_state.db` (read-only) and re-renders on every
+  `{:projected, _, _}` broadcast on `Tau.PubSub` topic `"factory:state"`.
+  """
+  use Phoenix.LiveDashboard.PageBuilder
+
+  @impl true
+  def menu_link(_, _), do: {:ok, "Factory"}
+
+  @impl true
+  def mount(_params, _session, socket) do
+    if connected?(socket), do: Phoenix.PubSub.subscribe(Tau.PubSub, "factory:state")
+    {:ok, assign(socket, snapshot: Tau.Factory.ReadModel.Query.snapshot())}
+  end
+
+  @impl true
+  def handle_info({:projected, _, _}, socket) do
+    {:noreply, assign(socket, snapshot: Tau.Factory.ReadModel.Query.snapshot())}
+  end
+
+  @impl true
+  def render_page(assigns) do
+    nav_bar(items: [
+      gates: %{name: "Gates",     render: &gates_panel/1,    method: :patch},
+      prs:   %{name: "Open PRs",  render: &prs_panel/1,      method: :patch},
+      hyg:   %{name: "Hygiene",   render: &hygiene_panel/1,  method: :patch},
+      coh:   %{name: "main",      render: &coherence_panel/1,method: :patch},
+      audit: %{name: "Audits",    render: &audits_panel/1,   method: :patch}
+    ])
+  end
+
+  # Each *_panel/1 is a card/table renderer over snapshot fields.
+  # A panel that finds no data renders an "error: snapshot stale by Ns"
+  # banner — never blank. This makes silent-fail impossible (AC b).
+end
+```
+
+### `.claude/hooks/enforce-parent-on-main.py` (new — invoked by `PreToolUse` on `Task`)
+
+```python
+#!/usr/bin/env python3
+"""Refuse to spawn a subagent when parent repo is not on main at origin/main.
+
+Reads `CLAUDE_PROJECT_DIR` and the JSON event on stdin. Exits 2 (= blocking
+deny) with a diagnostic naming the failed invariant and the exact recovery
+command. The *same script* is invoked by `.github/workflows/hygiene-sweep.yml`
+so local enforcement and CI enforcement cannot drift.
+"""
+import json, os, subprocess, sys
+
+def sh(cmd, **kw): return subprocess.run(cmd, capture_output=True, text=True, **kw)
+
+def main():
+    event = json.loads(sys.stdin.read())
+    if event.get("tool_name") != "Task":
+        sys.exit(0)
+    cwd = os.environ.get("CLAUDE_PROJECT_DIR", ".")
+    sh(["git", "-C", cwd, "fetch", "origin", "main"])
+    branch = sh(["git", "-C", cwd, "branch", "--show-current"]).stdout.strip()
+    if branch != "main":
+        deny(f"Parent repo on {branch!r}, not main. Recovery: "
+             f"`git -C {cwd} checkout main && git -C {cwd} pull --ff-only origin main`")
+    local = sh(["git", "-C", cwd, "rev-parse", "main"]).stdout.strip()
+    remote = sh(["git", "-C", cwd, "rev-parse", "origin/main"]).stdout.strip()
+    if local != remote:
+        deny(f"main at {local[:8]}, origin/main at {remote[:8]}. Recovery: "
+             f"`git -C {cwd} pull --ff-only origin main`")
+    sys.exit(0)
+
+def deny(msg):
+    print(json.dumps({"decision": "block", "reason": f"parent-on-main: {msg}"}))
+    sys.exit(2)
+
+if __name__ == "__main__": main()
+```
+
+### `.github/workflows/hygiene-sweep.yml` (new — scheduled + on-merge)
+
+```yaml
+name: hygiene-sweep
+on:
+  schedule: [ { cron: "*/15 * * * *" } ]    # every 15 min
+  push:     { branches: [ main ] }
+  workflow_dispatch:
+jobs:
+  sweep:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with: { fetch-depth: 0 }
+      - name: parent-on-main invariant
+        run: python3 .claude/hooks/enforce-parent-on-main.py < /dev/null
+      - name: worktree cleanup invariant
+        run: python3 .claude/hooks/enforce-worktree-cleanup.py
+      - name: stale-branch sweep
+        run: bash scripts/sweep-stale-branches.sh   # uses gh api + git push --delete
+      - name: emit telemetry to ReadModel
+        env: { GH_TOKEN: ${{ secrets.GITHUB_TOKEN }} }
+        run: bash scripts/emit-hygiene-telemetry.sh # POSTs to a tiny webhook on tau_web
+      - name: open issue on failure
+        if: failure()
+        uses: peter-evans/create-issue-from-file@v5
+        with:
+          title: "hygiene-sweep failed at ${{ github.run_id }}"
+          content-filepath: ./hygiene-failure.md
+          labels: hygiene, factory-v2
+```
+
+### `.github/branch-protection.json` (new — applied by `scripts/apply-branch-protection.sh`)
+
+```json
+{
+  "required_status_checks": {
+    "strict": true,
+    "contexts": ["ci/lint", "ci/test", "ci/mutation-check", "hygiene-sweep / sweep"]
+  },
+  "enforce_admins": true,
+  "required_pull_request_reviews": null,
+  "restrictions": null,
+  "allow_force_pushes": false,
+  "allow_deletions": false
+}
+```
+
+This makes the hygiene workflow load-bearing: a PR cannot merge until the
+shared script returns green. No bespoke "merge daemon" is needed.
+
+## Tradeoffs
+
+### Strengths
+
+- **Ecosystem density (root §Acceptance D).** Every non-trivial subsystem
+  is reused: LiveDashboard (chrome, auth, charts), LiveView (real-time
+  push), `Phoenix.PubSub` (already mandated by D-184), `:telemetry` (already
+  the universal Tau telemetry transport), `:exqlite` (already a SPEC-MEMORY-
+  STORE dep), `gh` CLI + GitHub Actions cron + branch-protection rules
+  (no new daemons), `peter-evans/create-issue-from-file@v5` (alarm channel
+  — proven in widespread CI use). The only Tau-owned new code is the
+  ≤ 250-LOC projector and the ≤ 200-LOC LiveDashboard page module.
+- **Single source-of-truth script.** `enforce-parent-on-main.py` and
+  `enforce-worktree-cleanup.py` are the *same files* invoked by the
+  Claude Code `PreToolUse` hook (local) and by the GitHub Actions workflow
+  (remote). Drift between local enforcement and remote enforcement is
+  structurally impossible because there is exactly one script.
+- **Silent-fail impossibility (leaf AC b).** The `verdict` column is
+  `NOT NULL CHECK(verdict IN ('pass','fail','checked_no_findings','infra_fail'))`;
+  there is no `NULL` or `'skipped'`. A panel that finds no rows for the
+  current PR renders an *error banner naming the missing input*, not a
+  blank tile. This is enforced at the schema level — code that tries
+  to insert a `NULL` verdict fails the SQLite CHECK.
+- **Load-bearing enforcement without bespoke code (leaf AC c, d).** Branch-
+  protection rules already exist as a primitive in GitHub; applying them
+  makes the hygiene workflow merge-blocking. No bespoke "merge daemon"
+  or coordinator self-policing is required.
+- **Composable read-store.** The SQLite DB is queryable by `sqlite3`,
+  `Datasette` (if a richer ad-hoc surface is wanted later), the
+  LiveDashboard page, and the post-merge `main`-coherence sibling — all
+  without a second copy of the data.
+- **Operability for free.** LiveDashboard already provides process,
+  memory, telemetry-metric, and request-logger panels; the factory panel
+  joins them as one more `PageBuilder` page on the existing
+  `/dev/dashboard` mount (`web/lib/tau_web/router.ex:50`).
+
+### Weaknesses
+
+- **LiveDashboard dev-only by default.** The current router gates
+  `/dev/dashboard` on `Application.compile_env(:tau_web, :dev_routes)`;
+  exposing the factory page in non-dev requires a small auth/plug story
+  (basic-auth or a `Tau.Auth.Plug` token), which this proposal defers
+  to the build-order step rather than solving inline. Until that lands,
+  the dashboard is accessible only via `mix phx.server` locally — fine
+  for a self-hosting developer factory, weaker for a multi-operator
+  setup.
+- **GitHub Actions cron has ~15 min skew.** GitHub schedules crons at
+  best-effort intervals, so the orphan-worktree sweep can lag up to
+  ~25 min in adverse conditions. PreToolUse hooks fill the gap for
+  local agents; for purely-server orphans the lag is acceptable but not
+  zero. (Mitigation: the `push: main` trigger ensures cleanup runs at
+  every merge, so the lag only matters during quiet periods.)
+- **SQLite single-writer.** The `ReadModel` GenServer is the only writer,
+  per Exqlite best practice; if it crashes, projection stops until the
+  supervisor restarts it. The supervised-process invariant (OTP NN #1)
+  handles restart; data is reprojectable from `:telemetry` replay and
+  `gh api` re-poll because the projection is pure. Still: a brief data
+  staleness window exists.
+- **Branch-protection requires admin token.** Applying
+  `branch-protection.json` via `gh api` needs a token with `admin:repo`
+  scope; this is a one-shot setup step, but it must be documented
+  explicitly so the factory does not silently run without the protection
+  it relies on.
+- **Two languages at the hook boundary.** Hooks are Python stdlib
+  (per `.claude/rules/hooks-and-scripts.md`); the dashboard is Elixir.
+  The shared-script invariant means the *enforcement logic* is Python
+  only; Elixir is only the read-model and view. This is a tradeoff —
+  no proposal that uses Claude Code hooks can avoid it.
+- **Webhook receiver in `:tau_web`.** Emitting hygiene telemetry from
+  the GH Actions runner to `:tau_web` requires a small ingestion plug
+  (one `POST /factory/hygiene` route). Adds a public endpoint surface
+  (must be HMAC-signed). Mitigation: ship the receiver behind the same
+  Auth.Plug as the dashboard, or alternatively have the Action commit
+  a JSON artifact to `gh-pages` that the projector reads on its 60s
+  poll — slower but zero new surface.
+
+### Costs
+
+- **New code:** ~250 LOC `ReadModel` + ~50 LOC `Project` + ~80 LOC
+  `Schema` (migrations) + ~200 LOC `FactoryLive.Page` + ~50 LOC
+  `Hygiene.scan` (Elixir) + ~120 LOC across two Python hooks + ~80 LOC
+  YAML/bash workflow scripts. Total ≈ 830 LOC, of which ≈ 200 LOC are
+  declarative (YAML, JSON, SQL DDL).
+- **Build/dep impact:** no new Hex deps. `:exqlite`, `:phoenix_live_view`,
+  `:phoenix_live_dashboard`, `:telemetry`, `:phoenix_pubsub` are
+  already present (SPEC-WEB-DASHBOARD, SPEC-MEMORY-STORE). One new
+  GitHub Action (`peter-evans/create-issue-from-file@v5`) is pinned by
+  SHA.
+- **Test surface:** property tests for `Project.apply/4` (event ->
+  SQL effect is a pure function — easy `StreamData` target);
+  integration test for the LiveView via `Phoenix.LiveViewTest`;
+  shell-level test for the two Python hooks via the same fixture
+  framework `.claude/hooks/` already uses (kill-cascade has tests).
+  ~15 new test files.
+- **Knowledge cost:** LiveDashboard `PageBuilder` is documented but
+  not widely known; one engineer-day to internalise. Branch-protection
+  JSON is well-trodden territory; ≈ 1 hour. The SQLite schema is
+  intentionally narrow (6 tables) and reviewable in one sitting.
+- **Operational cost:** the cron and the hooks add ~negligible compute;
+  the SQLite file grows by ~1 row per gate per PR, so for the v1 rate
+  (~50 PRs/month × 5 gates) the DB stays under 1 MB indefinitely.
+
+## Dependencies
+
+- **SPEC-WEB-DASHBOARD #374** must land first — the `:tau_web` poncho
+  endpoint, router, and LiveDashboard mount provide the foundation.
+  Without it, this proposal has no dashboard surface to extend. (Per
+  the SPEC, the foundation PR is already scoped.)
+- **`Tau.PubSub` (D-184)** must be the only `Phoenix.PubSub` instance.
+  This proposal does not violate D-184 — `ReadModel` and `FactoryLive`
+  both reuse `Tau.PubSub`.
+- **A `[:tau, :factory, :gate, :stop]` telemetry contract** must exist:
+  gates that write verdicts must `:telemetry.execute/3` an event with
+  `%{pr_number, gate_id, verdict, rationale, diff_sha, evidence_url}`.
+  This is owned by the **pre-merge-evidence-and-skip-integrity** sibling
+  leaf; this proposal *consumes* it but does not *define* it. A `nil`
+  verdict at projection time is an `infra_fail` row (silent-skip
+  impossible).
+- **A GitHub admin token** with `admin:repo` scope must be issued and
+  stored as a repo secret to apply `branch-protection.json`. One-shot,
+  documented in the build-order step.
+- **`:exqlite` (already in deps tree per SPEC-MEMORY-STORE)**. No new
+  Hex dep required.
+
+## Confidence
+
+**High**, with one caveat. Phoenix LiveDashboard PageBuilder, GitHub
+branch-protection rules, GitHub Actions cron, and `gh` CLI are all
+production-mature; the projector pattern (telemetry → SQLite → LiveView)
+is canonical in the Elixir ecosystem (prior art: Plausible Analytics,
+Sequin, LiveBeats). The caveat is that the local-vs-CI script-sharing
+discipline relies on the script being deterministic enough to run in
+both environments — proven for `enforce-parent-on-main.py` (pure git
+incantations), less proven for `enforce-worktree-cleanup.py` if it ever
+needs to inspect a running agent's worktree state. A two-day prototype
+that wires one gate-stop event end-to-end (telemetry → projection →
+LiveView render) would move confidence from "high with caveat" to
+"high."
+
+What would raise confidence to "very high": a small fault-injection
+test that deletes a row from `gate_run` and confirms `FactoryLive`
+shows the `error: snapshot stale by Ns` banner (i.e., that silent-fail
+really is impossible end-to-end).
+
+## §Build-order (adopt-first)
+
+1. **Adopt — apply branch-protection.json via `gh api`.** No code; one
+   `scripts/apply-branch-protection.sh` invocation. Makes the
+   `hygiene-sweep` job load-bearing the moment it exists.
+2. **Adopt — wire the two Python hooks into `.claude/settings.json`
+   `PreToolUse`.** Reuse the existing hook-runner protocol (no new
+   protocol surface). Hooks are read-only at this stage (`exit 0`
+   always) so they cannot break local work while the projection is
+   being built; flip the deny-on-fail switch in step 6.
+3. **Adopt — add `.github/workflows/hygiene-sweep.yml`.** Calls the
+   same two Python hooks. Starts emitting verdicts immediately;
+   protected branch already requires the check to pass per step 1.
+4. **Build (minimum) — `Tau.Factory.ReadModel` + `Schema`.** Just the
+   SQLite write path and the `:telemetry.attach_many` on the existing
+   `[:tau, ...]` events. No view. Verify rows appear via
+   `sqlite3 priv/factory_state.db 'select * from gate_run'`.
+5. **Build (minimum) — `TauWeb.FactoryLive.Page` over `PageBuilder`,
+   mount at `/dev/dashboard/factory`.** First version reads SQLite
+   directly; defer the PubSub-push wiring until step 7. AC (a) and (b)
+   land here.
+6. **Activate enforcement.** Flip the two Python hooks from "log-only"
+   to "deny on fail" by adding the `{"decision":"block"}` JSON output.
+   AC (c) lands here.
+7. **Build (delta) — `PubSub` broadcast in `ReadModel.handle/4` +
+   `subscribe` in `FactoryLive.mount/3`.** Real-time updates, but the
+   panel was already correct (just polling) — this is a UX upgrade,
+   not a correctness step.
+8. **Build (delta) — `Hygiene.scan/0` Elixir function.** Calls
+   `git for-each-ref`, `git worktree list --porcelain`, and
+   `gh pr list --json headRefName` to populate `worktree_state` and
+   `stale_branch`. AC (d) closes here.
+9. **Adopt — wire `peter-evans/create-issue-from-file@v5` on
+   `hygiene-sweep` failure.** Alarm channel closes; root §Acceptance E
+   "actionable" requirement satisfied.
+10. **Audit-finding integration.** `audit_finding` table is populated
+    by the **knowledge-memory-and-audit-ingestion** sibling's registry
+    writer (one shared SQLite file, two writers — only the sibling
+    leaf owns the `audit_finding` table writes). This proposal *reads*
+    the table for its panel; no code needed here beyond the snapshot
+    query.
+
+The build-order is adoption-front-loaded: steps 1–3 are pure config
+and reuse, no Elixir code; steps 4–5 add the read model and view;
+steps 6–10 are deltas. Cancelling after step 6 already satisfies the
+leaf's minimum AC; later steps are quality-of-life.
+
+## Gaps & residual risk
+
+- **`audit_finding` write path is owned by a sibling.** This proposal
+  defines the schema and reads from it but does not write to it. If
+  the sibling leaf's solution chooses a different storage (e.g. flat
+  YAML registry), this proposal needs a 20-LOC importer to mirror
+  rows into SQLite. Track as a cross-leaf dependency.
+- **Webhook ingestion path.** If the dashboard must reflect a CI
+  verdict within seconds of the workflow finishing (not within 60 s of
+  the next projector poll), a small `POST /factory/hygiene` plug is
+  required. This proposal defers that to a future delta; the 60-s
+  poll satisfies the leaf's AC ("automatically populated").
+- **First-mover dependency on SPEC-WEB-DASHBOARD #374.** If #374
+  slips, this proposal can ship steps 1–3 (which need no Elixir at
+  all) and step 4 (which only needs `:tau` core + `:exqlite`),
+  reading via `sqlite3 priv/factory_state.db` and `Datasette` until
+  the LiveView surface is ready. Degraded mode, not blocked.
+- **Silent-skip impossibility relies on the gate emitting a row.** A
+  gate that crashes before any `:telemetry.execute/3` would leave no
+  row at all — which the projector flags as `infra_fail` only when
+  the PR's open-status is queried (the snapshot computes "expected
+  gates" from `pr_state.declared_acs` and emits a stale-row error
+  if any expected gate has no `gate_run`). This is the correct
+  behaviour — gates that don't emit are visible by their absence —
+  but the *enforcement* of "no merge while any expected gate row is
+  missing" lives in the **pre-merge-evidence-and-skip-integrity**
+  sibling, not here. Cross-leaf coupling documented.
+
+## Prior art / references
+
+- **Phoenix LiveDashboard `PageBuilder` behaviour** — the established
+  pattern for adding custom dashboard pages
+  (https://hexdocs.pm/phoenix_live_dashboard/Phoenix.LiveDashboard.PageBuilder.html).
+  Used in production by Plausible Analytics, Sequin, LiveBeats.
+- **SPEC-WEB-DASHBOARD (`docs/spec/SPEC-WEB-DASHBOARD.md`)** — the
+  Tau-internal contract this proposal extends; D-180..D-189 mandate
+  the mount-replay-subscribe pattern this proposal follows.
+- **`web/lib/tau_web/router.ex:50`** — the existing LiveDashboard
+  mount point at `/dev/dashboard`. This proposal adds one more page
+  to it.
+- **`web/lib/tau_web/telemetry.ex`** — the existing telemetry-metric
+  pipeline; this proposal adds events to the same `[:tau, ...]`
+  namespace it consumes.
+- **GitHub branch-protection rules API**
+  (https://docs.github.com/en/rest/branches/branch-protection) — the
+  primitive that makes the workflow's verdict load-bearing without
+  any bespoke daemon. Universally adopted; `gh api` is the canonical
+  client.
+- **`peter-evans/create-issue-from-file@v5`** — the most widely-used
+  GitHub Action for opening issues on workflow failure. ~30k stars
+  across dependent repos.
+- **`.claude/hooks/kill-cascade.py`** — Tau's existing precedent for
+  `PreToolUse` Python hooks; the two new hooks follow the same
+  pattern, share the same test harness, and obey the same Python-
+  stdlib-only rule (`.claude/rules/hooks-and-scripts.md`).
+- **`.claude/rules/worktree-discipline.md`** — the prose rule this
+  proposal mechanises. The two hooks encode invariants currently
+  documented only in prose.
+- **Plausible Analytics** — production reference for the projection
+  pattern (telemetry → SQLite → LiveView) at scale
+  (https://github.com/plausible/analytics).
+- **Datasette** (https://datasette.io/) — optional adopt-only
+  surface for ad-hoc SQL over `factory_state.db`; named here so
+  the design leaves the door open without committing to it.

--- a/docs/factory-v2/design/subproblems/operability-and-hygiene-enforcement/proposals/proposal-3.md
+++ b/docs/factory-v2/design/subproblems/operability-and-hygiene-enforcement/proposals/proposal-3.md
@@ -1,0 +1,523 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 3
+parent_problem: ../problem.md
+---
+
+# Proposal 3: LiveDashboard-style read model + janitor cron + pre-spawn hook (adapt-from-prior-art)
+
+## Approach
+
+Build the operability and hygiene surface by composing four well-understood
+prior-art patterns end-to-end, each carrying its proven semantics across:
+
+1. **A Phoenix LiveDashboard-style read model** mounted into the already-
+   planned `:tau_web` poncho (SPEC-WEB-DASHBOARD) at
+   `/factory/dashboard`, populated by a single `Tau.Factory.ReadModel`
+   GenServer that subscribes to `Tau.PubSub` for gate-verdict events and
+   `git for-each-ref` / `gh api` polls for repo state. The read model is
+   live (PubSub-pushed) for verdict updates and snapshot-polled (60 s)
+   for git/GH state.
+2. **A janitor scheduled workflow** (GitHub Actions cron, every 15 min on
+   `main`) that runs the worktree-cleanup sequence from
+   `.claude/rules/worktree-discipline.md`, removes finished agent
+   worktrees, prunes orphan branches with no open PR and no commits in
+   N days, syncs `main` to `origin/main`, and emits one
+   `[:tau, :factory, :janitor, :sweep]` telemetry event per pass with
+   counts of `{removed, kept, blocked}`.
+3. **A `SessionStart` + `PreToolUse(Task)` Claude Code hook**
+   (`.claude/hooks/parent-on-main.py`) that runs the pre-spawn checklist
+   (`git fetch origin && rev-parse main == origin/main && branch ==
+   main && status --porcelain empty`) and **exits non-zero** on any
+   violation, blocking the agent spawn with a diagnostic that names the
+   failed invariant and the recovery command. No agent self-discipline
+   path remains.
+4. **An "incident-room" alarm channel** (per-PagerDuty pattern, not the
+   service) that the janitor and the read model both write to: when
+   cleanup is blocked, a stale orphan exceeds a threshold, or the read
+   model loses its data source, the alarm path opens a GitHub issue
+   labelled `area:factory-hygiene` with a deterministic title (so
+   reruns dedupe) and emits a `[:tau, :factory, :hygiene, :alarm]`
+   telemetry event. The dashboard surfaces open alarms as a top-row
+   banner.
+
+Verdicts are written by the gates themselves into a single SQLite file
+(`.factory/verdicts.sqlite`, Datasette-compatible schema) committed
+nowhere and recreated from PubSub replay + the GitHub Checks API on cold
+start; the read model is the consumer.
+
+## Rationale
+
+The leaf's complecting hypothesis names three knots: (a) factory state
+is scattered across `.claude/logs/`, PR bodies, GHA runs, and human
+memory; (b) worktree hygiene is woven into agent discipline; (c) the
+`parent-on-main` check is woven into coordinator attention. Each of the
+four borrowed patterns is *already* the canonical decomplecting move
+for one of these knots in its origin domain:
+
+- LiveDashboard separates "what the BEAM is doing" from "where you look"
+  by being the single, push-driven view of process/ETS/telemetry state.
+- Janitor crons (Jenkins workspace-cleanup, GHA `actions/stale`) separate
+  hygiene enforcement from the actor producing the mess, by running on
+  a fixed cadence in a context that owns nothing.
+- Pre-receive / pre-spawn hooks (git server-side hooks, k8s admission
+  controllers) move invariant enforcement *out of* the actor's control
+  flow into an inspection layer the actor cannot bypass.
+- Incident-room alarm channels (PagerDuty, Argo CD's degraded-app
+  banner) separate "something is wrong" from "someone happens to be
+  looking at logs" by making the wrong-state itself a first-class,
+  routed signal.
+
+Adapting all four together rather than picking one yields a system
+whose observability, hygiene enforcement, invariant gating, and
+alarm-on-degradation are independently load-bearing. Removing any
+single one degrades only that capability; none of them recreates the
+others' coupling.
+
+## Sketch
+
+### Read-model module
+
+```elixir
+# web/lib/tau_web/factory_dashboard_live.ex
+defmodule TauWeb.FactoryDashboardLive do
+  use TauWeb, :live_view
+  alias Tau.Factory.ReadModel
+
+  @poll_interval_ms 60_000
+
+  def mount(_params, _session, socket) do
+    if connected?(socket) do
+      Phoenix.PubSub.subscribe(Tau.PubSub, "factory:verdicts")
+      Phoenix.PubSub.subscribe(Tau.PubSub, "factory:hygiene")
+      :timer.send_interval(@poll_interval_ms, :poll_git)
+    end
+
+    {:ok, assign(socket, ReadModel.snapshot())}
+  end
+
+  def handle_info({:verdict, %ReadModel.Verdict{} = v}, socket),
+    do: {:noreply, ReadModel.apply_verdict(socket, v)}
+
+  def handle_info(:poll_git, socket),
+    do: {:noreply, assign(socket, ReadModel.poll_git_state())}
+
+  def handle_info({:alarm, %ReadModel.Alarm{} = a}, socket),
+    do: {:noreply, ReadModel.push_alarm(socket, a)}
+end
+
+# lib/tau/factory/read_model.ex
+defmodule Tau.Factory.ReadModel do
+  use GenServer
+
+  defstruct gates: %{},            # %{gate_name => :wired | :unwired}
+            verdicts: [],          # last 200 %Verdict{}
+            orphan_worktrees: [],  # from `git worktree list --porcelain`
+            stale_branches: [],    # from gh api repos/:o/:r/branches
+            parent_on_main: nil,   # boolean | :unknown
+            last_coherence_run: nil,
+            open_alarms: [],
+            open_findings: %{},    # %{surface => count}
+            inflight_prs: []       # by milestone
+
+  defmodule Verdict do
+    defstruct [:pr, :gate, :status, :reason, :run_url, :ts]
+    # status: :pass | :fail | :checked_no_findings | :infrastructure_fail
+    # NOTE: :skipped is REJECTED at construction; see silent-skip
+    # impossibility below.
+  end
+
+  defmodule Alarm do
+    defstruct [:kind, :detail, :opened_at, :issue_url]
+  end
+
+  def snapshot, do: GenServer.call(__MODULE__, :snapshot)
+  def record_verdict(%Verdict{} = v), do: GenServer.cast(__MODULE__, {:verdict, v})
+  # ... handle_call/3, handle_cast/2, poll_git_state/0
+end
+```
+
+### Janitor workflow
+
+```yaml
+# .github/workflows/factory-janitor.yml
+name: factory-janitor
+on:
+  schedule: [{cron: '*/15 * * * *'}]
+  workflow_dispatch:
+
+jobs:
+  sweep:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with: {fetch-depth: 0}
+      - name: Sweep finished worktrees and stale branches
+        run: ./scripts/factory-janitor.sh
+      - name: Report
+        # Always runs; never short-circuits. If sweep failed, this opens
+        # an `area:factory-hygiene` issue (or updates the existing one)
+        # via gh issue create/comment with a deterministic title.
+        if: always()
+        run: ./scripts/factory-janitor-report.sh "${{ job.status }}"
+```
+
+```bash
+# scripts/factory-janitor.sh — pseudocode
+set -euo pipefail
+
+git fetch origin --prune
+git checkout main && git pull --ff-only origin main
+
+REMOVED=0; KEPT=0; BLOCKED=0
+
+for path in $(git worktree list --porcelain | awk '/^worktree/ {print $2}'); do
+  [ "$path" = "$PWD" ] && continue
+  if worktree_finished "$path"; then
+    capture_before_destroy "$path"
+    git worktree remove -f -f "$path" && REMOVED=$((REMOVED+1)) \
+      || BLOCKED=$((BLOCKED+1))
+  else
+    KEPT=$((KEPT+1))
+  fi
+done
+
+# Stale branches: remote branches with no open PR + no commit in 7 days.
+gh api "repos/$REPO/branches?per_page=100" --paginate \
+  | jq -r '.[].name' \
+  | while read -r br; do
+      should_prune "$br" && git push origin --delete "$br"
+    done
+
+emit_telemetry_event removed=$REMOVED kept=$KEPT blocked=$BLOCKED
+```
+
+### Pre-spawn hook (Claude Code)
+
+```python
+# .claude/hooks/parent-on-main.py
+#!/usr/bin/env python3
+"""SessionStart + PreToolUse(Task) hook: enforce parent-on-main."""
+import json, subprocess, sys
+
+def sh(cmd):
+    return subprocess.run(cmd, capture_output=True, text=True, shell=True)
+
+def main():
+    payload = json.load(sys.stdin)
+    if payload.get("tool_name") and payload["tool_name"] != "Task":
+        sys.exit(0)  # only gate Task spawns (and SessionStart, which has
+                     # no tool_name)
+
+    sh("git fetch origin --quiet")
+    main_sha   = sh("git rev-parse main").stdout.strip()
+    origin_sha = sh("git rev-parse origin/main").stdout.strip()
+    branch     = sh("git branch --show-current").stdout.strip()
+    dirty      = sh("git status --porcelain").stdout.strip()
+
+    failures = []
+    if branch != "main":
+        failures.append(("branch-not-main",
+                         "git checkout main"))
+    if main_sha != origin_sha:
+        failures.append(("main-not-at-origin",
+                         "git pull --ff-only origin main"))
+    if dirty:
+        failures.append(("dirty-worktree",
+                         "stash or commit before spawning"))
+
+    if failures:
+        diag = "\n".join(f"  - {name}: {fix}" for name, fix in failures)
+        print(f"REFUSING SPAWN: parent-on-main invariant violated:\n{diag}",
+              file=sys.stderr)
+        sys.exit(2)  # PreToolUse exit=2 blocks the tool call
+
+if __name__ == "__main__":
+    main()
+```
+
+```jsonc
+// .claude/settings.json (delta)
+{
+  "hooks": {
+    "SessionStart": [{"hooks": [{"type": "command",
+      "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/parent-on-main.py"}]}],
+    "PreToolUse": [{"matcher": "Task", "hooks": [{"type": "command",
+      "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/parent-on-main.py"}]}]
+  }
+}
+```
+
+### Verdict-emission contract (silent-skip impossibility)
+
+Every gate, on every run, MUST call:
+
+```elixir
+Tau.Factory.ReadModel.record_verdict(%Verdict{
+  pr: pr_number,
+  gate: :ac_linkage | :masking | :mutation | :contract_drift | :nn7 | ...,
+  status: :pass | :fail | :checked_no_findings | :infrastructure_fail,
+  reason: short_string,
+  run_url: github_actions_run_url,
+  ts: DateTime.utc_now()
+})
+```
+
+The dashboard renders any PR with a gate that has emitted **no verdict
+for the current `HEAD` SHA** as RED with the label "missing verdict"
+— a missing verdict is observably worse than a fail. The
+`:skipped` status is not a valid value of the `status` field; the
+`Verdict.new/1` constructor pattern-matches and raises if passed
+`:skipped`. A gate that "has nothing to check" emits
+`:checked_no_findings`; a gate whose runner crashed emits
+`:infrastructure_fail` and the PR is treated as failing.
+
+### Alarm channel
+
+```elixir
+# lib/tau/factory/alarms.ex
+defmodule Tau.Factory.Alarms do
+  @doc """
+  Raise an alarm; idempotent on `kind + detail` digest.
+  Opens an issue labeled area:factory-hygiene with a deterministic title.
+  """
+  def raise(kind, detail) do
+    digest = :crypto.hash(:sha256, "#{kind}:#{detail}") |> Base.encode16()
+    title  = "[hygiene/#{kind}] #{summarise(detail)} (#{String.slice(digest, 0..7)})"
+    case gh_issue_find(title) do
+      {:ok, _existing} -> :acked
+      :none -> gh_issue_create(title, detail, ["area:factory-hygiene"])
+    end
+    Phoenix.PubSub.broadcast(Tau.PubSub, "factory:hygiene",
+      {:alarm, %ReadModel.Alarm{kind: kind, detail: detail,
+                                opened_at: DateTime.utc_now()}})
+    :telemetry.execute([:tau, :factory, :hygiene, :alarm],
+                       %{count: 1}, %{kind: kind})
+  end
+end
+```
+
+## Tradeoffs
+
+### Strengths
+
+- **Each capability has prior-art warranty.** LiveDashboard, GHA cron
+  janitors, server-side pre-receive hooks, and PagerDuty-style
+  deduped alarm channels each have years of production use; the design
+  inherits their failure modes (well-understood) instead of inventing
+  new ones.
+- **Silent-skip is impossible by data model**, not by convention: the
+  `Verdict` struct does not admit a `:skipped` status; missing verdicts
+  render RED; the janitor's `if: always()` reporter ensures even a
+  crashed sweep produces a visible alarm.
+- **`parent-on-main` enforcement is shifted left** to the spawn layer
+  (Claude Code hook exit=2 blocks the Task tool call), removing the
+  invariant from agent context entirely; an agent cannot fail to
+  enforce a check it never has the option to run.
+- **Reuses `:tau_web` and `Tau.PubSub`** per root §Acceptance D,
+  satisfying SPEC-WEB-DASHBOARD D-184 (no second `Phoenix.PubSub`); no
+  new HTTP service, no new datastore type the project doesn't already
+  run.
+- **The dashboard's own failure is itself surfaced**: per the
+  acceptance criterion clause (b), a panel that cannot fetch shows an
+  error state, not a blank panel — implemented because each panel
+  binds to a `case ReadModel.fetch(...)` return that includes
+  `{:error, reason}` and renders the error inline.
+- **Decouples janitor and dashboard from the actor that produced the
+  mess.** The janitor runs in CI, owns no agent worktree, and so
+  cannot collide with one mid-write; the dashboard reads, never
+  writes; both fail closed and loud.
+
+### Weaknesses
+
+- **The `:tau_web` poncho dependency is a real coupling.** If
+  SPEC-WEB-DASHBOARD's foundation (issue #374) is not landed before
+  this leaf's components, the LiveView panel cannot mount and the
+  dashboard degrades to a Datasette-over-SQLite fallback; the design
+  must explicitly state and accept that fallback. We carry an
+  `if-:tau_web-absent` plan but it is genuinely lower-fidelity.
+- **GHA `schedule:` triggers are best-effort.** GitHub explicitly
+  warns the `*/15` cadence can stretch under load; in a quiet
+  repository the janitor may not run for hours. We mitigate with
+  `workflow_dispatch` and a `PostToolUse` hook that triggers the
+  janitor on merge, but the 15-minute SLA is aspirational.
+- **The pre-spawn hook is bypassable by the user** (Claude Code
+  honours the hook contract; a user invoking Claude Code with hooks
+  disabled would bypass). The hook gates *agent* spawns; it does not
+  gate *human* git operations. Pair with a server-side branch
+  protection rule on `main` for the human-bypass case.
+- **Verdict aggregation in SQLite is a new file in the repo's local
+  state.** It is regenerated from PubSub replay + Checks API on cold
+  start, but means the read model has warm-start logic to maintain.
+- **The alarm channel will open GitHub issues.** Deduped, but a
+  pathological cascade (e.g. every PR triggers an infrastructure-fail
+  alarm) would still produce many issues; we'd need a circuit breaker
+  on alarm rate (≥ N alarms/hour → throttle, log only).
+- **Four moving parts is more than a single dashboard.** Each part is
+  individually simple, but maintainers must understand all four (read
+  model, janitor, hook, alarm channel) and their wiring. A single
+  monolithic dashboard would be simpler to *explain* (worse to *trust*).
+
+### Costs
+
+- **New files:** `web/lib/tau_web/factory_dashboard_live.ex` (~150
+  LoC), `lib/tau/factory/read_model.ex` (~350 LoC),
+  `lib/tau/factory/alarms.ex` (~80 LoC),
+  `.github/workflows/factory-janitor.yml` (~40 LoC),
+  `scripts/factory-janitor.sh` (~120 LoC),
+  `scripts/factory-janitor-report.sh` (~40 LoC),
+  `.claude/hooks/parent-on-main.py` (~60 LoC).
+- **Schema:** ~6-table SQLite schema in `.factory/verdicts.sqlite`
+  (verdicts, gates, alarms, worktree_snapshots, branch_snapshots,
+  coherence_runs); migration mechanism is `Tau.Factory.ReadModel`'s
+  cold-start replay, no Ecto.
+- **Test surface:** unit tests for `ReadModel.apply_verdict/2` and
+  `Alarms.raise/2` idempotence (~30 tests); a smoke test that
+  `bin/tau` plus the LiveView route renders against a fixture
+  PubSub stream; a bash test for the janitor's
+  capture-before-destroy invariant under `git worktree list`
+  scenarios.
+- **CI minutes:** 96 janitor runs/day × ~30 s = ~50 min/day on the
+  Actions free tier; well within budget.
+- **Knowledge:** maintainers must know LiveView basics, GHA cron
+  semantics, Claude Code hook contract, and the Verdict schema; one
+  ADR (`docs/adr/NNNN-factory-read-model.md`) carries the rationale.
+
+## Dependencies
+
+- **SPEC-WEB-DASHBOARD foundation** (issue #374 / `web/` poncho)
+  merged so `:tau_web` is mount-ready; if absent, fall back to
+  Datasette over `.factory/verdicts.sqlite` exposed via `bin/tau
+  dashboard` subcommand. The fallback is explicitly lower-fidelity
+  (no PubSub-live updates) and is recorded as a known limitation.
+- **`Tau.PubSub`** (already present per SPEC-WEB-DASHBOARD D-184).
+- **Sibling leaf `pre-merge-evidence-and-skip-integrity`** —
+  defines the gate-result contract this leaf's `Verdict` struct
+  models; this leaf must agree with that sibling on the four allowed
+  `status` values (`:pass`, `:fail`, `:checked_no_findings`,
+  `:infrastructure_fail`).
+- **Sibling leaf `pre-merge-code-gates`** — supplies the gate
+  inventory the dashboard's "wired gates" panel renders.
+- **Sibling leaf `knowledge-memory-and-audit-ingestion`** — supplies
+  the "open audit-finding count by surface" panel data source.
+- **GitHub repo settings** — branch protection on `main` requiring
+  the janitor workflow to not be failing (covers the human-bypass
+  case of the pre-spawn hook).
+- **`gh` CLI available in CI** (already used by `.github/workflows/`).
+
+## Confidence
+
+**Medium-high.** Each constituent pattern is independently proven; the
+composition's novelty is small. Confidence is not "high" because (a)
+GHA `schedule:` cadence under low repo activity is an acknowledged
+soft spot; (b) the `:tau_web` dependency adds a real coupling whose
+fallback path (Datasette) is a downgrade; (c) the alarm-rate
+circuit-breaker is sketched but not specified. Confidence would rise
+to "high" with a 1-week prototype showing: LiveView mount over a
+fixture PubSub stream renders 5 panels including error states; the
+janitor script passes a 10-scenario shell-test matrix
+(orphan, locked-finished, in-flight-protected, stale-branch-with-PR,
+stale-branch-no-PR, dirty-worktree, etc.); and the hook exits 2
+under each named violation in CI.
+
+## Prior art / references
+
+- **Phoenix LiveDashboard** —
+  <https://hexdocs.pm/phoenix_live_dashboard> — the canonical
+  "single view of running-system state" precedent in the BEAM
+  ecosystem; mounts at `/dashboard`, PubSub-driven, error-tolerant
+  panels.
+- **Erlang `:observer`** — the original; LiveDashboard's lineage.
+  Pattern: separate observer process, never blocks the observed.
+- **Argo CD degraded-app banner** —
+  <https://argo-cd.readthedocs.io/en/stable/user-guide/health/> —
+  prior art for "drift between declared and observed state is itself
+  a first-class signal surfaced in the UI."
+- **PagerDuty deduplication keys** —
+  <https://support.pagerduty.com/main/docs/event-management> — prior
+  art for `kind + detail digest`-based alarm dedup so one root
+  cause doesn't flood the channel.
+- **`actions/stale` GitHub Action** —
+  <https://github.com/actions/stale> — prior art for the
+  cadence-based janitor pattern (stale-issue/PR sweep on cron).
+- **Git `pre-receive` hooks and Kubernetes admission controllers** —
+  prior art for "invariant enforced by an inspection layer the
+  actor cannot bypass." Claude Code's `PreToolUse` hook fills the
+  same niche for agent spawns.
+- **Jenkins workspace cleanup plugin** —
+  <https://plugins.jenkins.io/ws-cleanup/> — prior art for janitor
+  patterns that decouple cleanup from the build actor.
+- **Datasette** — <https://datasette.io> — the fallback dashboard
+  surface if `:tau_web` is absent; SQLite-as-API with built-in error
+  panels.
+- **Honeycomb / Grafana Tempo dashboards** — prior art for telemetry-
+  driven operational views; informs the `[:tau, :factory, ...]`
+  event namespace design.
+- **SPEC-WEB-DASHBOARD** (`docs/spec/SPEC-WEB-DASHBOARD.md`) — the
+  in-project precedent and the host this dashboard mounts into;
+  D-180..D-189 govern the mount-replay-subscribe pattern this
+  proposal inherits.
+- **`.claude/rules/worktree-discipline.md`** — the prose rule this
+  proposal converts to mechanism; the capture-before-destroy
+  sequence and pre-spawn checklist are lifted verbatim into
+  `scripts/factory-janitor.sh` and `.claude/hooks/parent-on-main.py`
+  respectively.
+
+## Rejections — patterns surveyed but not adopted
+
+- **Spinnaker pipeline-stage UI.** Strong precedent for "all
+  pipeline state in one view," but its model is heavyweight
+  (Kubernetes operator, JVM stack); adopting it would dwarf the
+  surface it observes. Reject as scope-mismatch.
+- **OpenTelemetry collector + Grafana Tempo stack.** Excellent for
+  long-term tracing, but for the "show me factory state right now"
+  query it adds two services (collector, store) the project doesn't
+  need yet. Reuse `Tau.PubSub` and `:telemetry` instead. Could
+  layer in later for historical analytics.
+- **`git rerere`, `git-absorb`.** Solve different problems
+  (conflict-resolution memo, fixup-routing) than worktree hygiene.
+  Out of scope.
+- **`git-trim`.** Closer match for stale-branch pruning, but is a
+  local-only tool. The janitor needs to prune *remote* branches
+  authoritatively from CI; a 30-line `gh api` loop is more direct
+  than wrapping `git-trim`.
+- **Squadcast / PagerDuty as a service.** The dedup *pattern* is
+  adopted; the SaaS itself is not — would introduce a third-party
+  account dependency for a single-developer project. GitHub issues
+  are the alarm channel.
+- **PR-comment dashboards (Reviewable, Graphite).** Solve PR review
+  UX, not factory-wide operability. Tangential.
+
+## Silent-skip impossibility — the proof
+
+Three distinct mechanisms make silent-skip structurally impossible,
+not merely discouraged:
+
+1. **Schema-level rejection.** `Tau.Factory.ReadModel.Verdict.new/1`
+   pattern-matches `status` against the closed set
+   `[:pass, :fail, :checked_no_findings, :infrastructure_fail]` and
+   raises on any other value (including `:skipped`). A gate cannot
+   emit a verdict whose status is "skipped"; the type system refuses.
+2. **Missing-verdict-is-RED.** The dashboard cross-references the
+   wired-gate inventory with verdicts-keyed-by-HEAD-SHA. Any gate
+   with no verdict for the current PR's HEAD renders RED with the
+   label "missing verdict." A gate that silently exits 0 without
+   calling `record_verdict/1` is therefore *louder* than a gate
+   that emits `:fail` — the dashboard treats it as the worst case.
+3. **`if: always()` reporter.** The janitor workflow's reporter step
+   uses `if: always()`. If the sweep crashes, the reporter still
+   runs and opens / updates the `area:factory-hygiene` issue via
+   `Tau.Factory.Alarms.raise/2`. The dashboard's "open alarms"
+   banner surfaces it. There is no path by which a janitor crash
+   produces silence.
+
+Cross-check against the ten failure classes: silent-skip is
+specifically failure class #5 (CI gates silent-skip, `|| true` in
+ci.yml). The three mechanisms above cover both gate-side (1, 2) and
+infrastructure-side (3) silence. A gate that simply omits the
+`record_verdict` call falls into mechanism 2's net; a gate that
+explicitly tries to record a "skip" falls into mechanism 1's net;
+a gate that crashes the whole workflow falls into mechanism 3's
+net. There is no fourth path.

--- a/docs/factory-v2/design/subproblems/operability-and-hygiene-enforcement/proposals/proposal-4.md
+++ b/docs/factory-v2/design/subproblems/operability-and-hygiene-enforcement/proposals/proposal-4.md
@@ -1,0 +1,517 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 4
+parent_problem: ../problem.md
+---
+
+# Proposal 4: Adversarial fail-loud — hook-blocked invariants plus a verdict-log read model
+
+## Approach
+
+Treat operability and hygiene as an adversarial problem: enumerate exact
+failure constructions, derive one mechanism per construction that fails
+**loud** (refuses to spawn, refuses to merge, opens an issue, paints the
+dashboard red), and unify them through a single append-only verdict log
+(`.factory/verdicts.ndjson`) served by a tiny Datasette/SQLite read
+model. Hooks under `.claude/hooks/` enforce pre-spawn invariants; CI
+workflows enforce post-merge invariants; both write the same verdict
+records the dashboard reads. No mechanism may exit 0 on a precondition
+it cannot evaluate — the canonical exit codes are PASS (0),
+FAIL (non-zero), and BLOCKED (non-zero with reason). There is no SKIP.
+
+## Rationale
+
+The complecting hypothesis names three weaves: state-vs-where-you-look,
+hygiene-vs-agent-discipline, and invariant-checking-vs-attention. A
+prose rule and a dashboard that *aggregates* state do not break those
+weaves — they ride on top of agents continuing to follow the rule. The
+decomplecting move is to deny the action when the precondition fails
+(hook) and to make the *only* path that produces a verdict the path
+that writes the verdict to the read model (no out-of-band manual
+entry). The adversarial framing is load-bearing: each construction
+below is a concrete production failure observable today (61 orphan
+`worktree-agent-*` branches in `refs/heads/` at the moment this
+proposal was written, out of 599 total local branches), and the
+mechanism is chosen so that *the construction cannot occur silently*.
+Diversity vs sibling proposals: where Proposal 1/2/3 are likely to
+lean on `:tau_web` LiveView or GitHub Projects as the surface, this
+proposal commits to a minimal flat-file substrate (NDJSON +
+SQLite-from-NDJSON + Datasette) so the read model has no shared mutable
+state with Tau's runtime — the dashboard cannot be downed by a Tau
+crash, and the verdict log is `grep`-able in an outage.
+
+## Sketch
+
+### Adversarial failure constructions and mechanisms
+
+Five concrete constructions, each a real failure mode observed in v1 or
+constructible today.
+
+---
+
+**Construction A — orphan worktree-agent-* branch accumulation.**
+
+*Construction.* An implementer spawns with `isolation: worktree` into
+`worktree-agent-<id>`. The agent is killed mid-run; its worktree at
+`~/.tau/worktrees/<uuid>/` is force-removed without `git branch -D`;
+the branch persists in `refs/heads/`. Repeat across 60+ sessions; the
+parent repo accumulates 61 orphan `worktree-agent-*` branches (current
+empirical count, `git for-each-ref refs/heads/ | grep -c
+'^worktree-agent-' = 61`), invisibly until someone greps for them.
+
+*Mechanism — `branch-orphan-sweeper` (CI workflow, scheduled +
+post-merge).* A workflow at `.github/workflows/branch-hygiene.yml`
+runs on every `push` to `main` and hourly via `schedule:`. It executes:
+
+```bash
+git for-each-ref refs/heads/ --format='%(refname:short) %(committerdate:unix)' \
+  | awk '$1 ~ /^worktree-agent-/ || $1 ~ /^tau\/coding-agent\// {print}' \
+  > /tmp/agent-branches.txt
+```
+
+For each candidate it checks `gh worktree list` (does any registered
+worktree still hold the branch?) and `gh pr list --head <branch>`
+(does an open PR claim it?). Branches with neither are appended to
+`.factory/verdicts.ndjson` as `{kind: "orphan_branch", branch: ...,
+age_seconds: ...}` and deleted via `git push origin :<branch>` (remote)
+plus `git branch -D` (local-on-the-runner does not apply; the deletion
+is the remote push). The workflow writes a verdict `{gate:
+"branch-hygiene", status: "PASS"|"FAIL", orphans_swept: N}` regardless
+of whether any orphans existed. If `gh` is unavailable the verdict is
+`BLOCKED` and the workflow exits non-zero. **Silent-skip impossibility:**
+the workflow has no conditional that exits 0 without writing a verdict;
+the verdict-writing step is `set -euo pipefail` and runs unconditionally.
+
+---
+
+**Construction B — parent on stale main when an agent is spawned.**
+
+*Construction.* The coordinator merged a PR an hour ago but the same
+session never ran `git pull --ff-only`. Local `main` is at commit X,
+`origin/main` is at commit Y (X is Y's parent). The coordinator now
+spawns `implementer` with `isolation: worktree`. The worktree forks
+from X, not Y. The implementer's PR diff is computed against a stale
+base; the gate evaluates a diff that includes the previous PR's
+contents as if they were new work.
+
+*Mechanism — `pre-spawn-parent-on-main` (`PreToolUse` hook on
+`Task`).* `.claude/hooks/pre-spawn-check.py` registered in
+`.claude/settings.json` under `hooks.PreToolUse` with matcher `Task`:
+
+```python
+# .claude/hooks/pre-spawn-check.py
+# Python stdlib only (per .claude/rules/hooks-and-scripts.md).
+import json, subprocess, sys, time, pathlib
+
+def run(*a): return subprocess.run(a, capture_output=True, text=True, check=False)
+
+def fail(reason, recovery):
+    verdict = {"ts": time.time(), "gate": "pre-spawn", "status": "BLOCKED",
+               "reason": reason, "recovery": recovery}
+    log = pathlib.Path(".factory/verdicts.ndjson")
+    log.parent.mkdir(exist_ok=True)
+    with log.open("a") as f: f.write(json.dumps(verdict) + "\n")
+    print(f"BLOCKED: {reason}\nRecovery: {recovery}", file=sys.stderr)
+    sys.exit(2)  # PreToolUse non-zero exit blocks the tool call.
+
+# Invariant 1: parent HEAD is on main.
+branch = run("git", "branch", "--show-current").stdout.strip()
+if branch != "main":
+    fail(f"parent HEAD on '{branch}', not main",
+         "git checkout main && git pull --ff-only origin main")
+
+# Invariant 2: local main == origin/main.
+run("git", "fetch", "--quiet", "origin", "main")
+local = run("git", "rev-parse", "main").stdout.strip()
+remote = run("git", "rev-parse", "origin/main").stdout.strip()
+if local != remote:
+    fail(f"local main {local[:8]} != origin/main {remote[:8]}",
+         "git pull --ff-only origin main")
+
+# Invariant 3: no untracked leaks in parent (signal of prior reviewer collision).
+status = run("git", "status", "--porcelain").stdout
+if status.strip():
+    fail("parent worktree dirty: " + status[:200],
+         "inspect with 'git status'; clean before spawning")
+
+print("pre-spawn OK", file=sys.stderr)
+sys.exit(0)
+```
+
+The hook writes a PASS verdict on success too (every spawn produces
+exactly one pre-spawn verdict). **Silent-skip impossibility:** the
+hook is registered under `PreToolUse` for the `Task` matcher; the
+Claude Code harness invokes it before every Task call. If the hook
+script itself errors (Python missing, file deleted), Claude Code
+treats the hook as failed and blocks the tool call by default — there
+is no path where the hook is registered but does not run.
+
+---
+
+**Construction C — one gate silently mis-wired and no signal of it.**
+
+*Construction.* `ci.yml` line 89-91 (verified at this proposal's
+authoring) reads `if [ -z "$GATING_FILES" ]; then echo "...skipping";
+exit 0; fi` — Gate 5.1 exits 0 when no gating-test paths are declared.
+A PR author who forgets the "Gating-test paths" section gets a green
+gate on a PR that was never actually checked. Same shape at lines
+213-216 (Gate 5.3). Gate 5.2 has `|| true` at line 115 making any
+failure non-blocking. The dashboard, the PR check status, and the
+coordinator's `gh pr checks` output all say PASS. The mis-wire is
+indistinguishable from a real pass.
+
+*Mechanism — `gate-self-report contract + skipless-gate auditor`.*
+Every gate (CI step or hook) MUST `POST` a verdict record to the
+verdict log with one of three statuses: `PASS`, `FAIL`, `BLOCKED`.
+`SKIP` is not a permitted status — a gate that has nothing to check on
+this PR returns `PASS` with `findings: []` and `applicable: false`; a
+gate that cannot run for infrastructure reasons returns `BLOCKED`,
+which is treated as `FAIL` by branch protection. The mix tasks
+`mix tau.gate.ac_linkage|masking|mutation` are wrapped in a shell
+helper `bin/factory-gate` that:
+
+```bash
+#!/usr/bin/env bash
+# bin/factory-gate <gate-name> -- <cmd...>
+set -euo pipefail
+gate="$1"; shift; shift  # drop "--"
+start_ts=$(date +%s)
+if out=$("$@" 2>&1); then status=PASS; else status=FAIL; fi
+end_ts=$(date +%s)
+jq -nc --arg g "$gate" --arg s "$status" --arg out "$out" \
+  --argjson start "$start_ts" --argjson end "$end_ts" \
+  --arg pr "${PR_NUMBER:-}" --arg sha "${GITHUB_SHA:-}" \
+  '{ts: $end, gate: $g, status: $s, pr: $pr, sha: $sha,
+    duration_s: ($end - $start), output: $out}' \
+  >> .factory/verdicts.ndjson
+[ "$status" = PASS ]
+```
+
+Every CI step that *is* a gate is rewritten to call `bin/factory-gate
+<name> -- <cmd>`. The `branch-hygiene` workflow includes a
+**skipless-gate auditor** that greps `.github/workflows/*.yml` for
+the forbidden patterns:
+
+```bash
+# Forbidden patterns in any workflow file:
+#   - exit 0$ inside a step whose name matches /Gate [0-9]/
+#   - || true at the end of a 'mix tau.gate.' line
+#   - if: github.event_name == 'pull_request'  on a gate step  (gates run on push too)
+grep -nE '(exit 0|\|\| true)' .github/workflows/*.yml \
+  | grep -E 'Gate [0-9]|tau\.gate\.' && exit 1 || true
+```
+
+The auditor itself uses `bin/factory-gate` so its verdict shows on the
+dashboard. **Silent-skip impossibility:** branch protection on `main`
+requires the *named* gate checks; if a CI step is renamed or
+disappears, branch protection blocks the merge with "Required status
+check X is missing." The verdict log is append-only — the read model
+flags any PR that merged with `< N` verdicts (where N is the expected
+gate count for the diff's surface).
+
+---
+
+**Construction D — CI status visible only via gh CLI, not from a
+single dashboard.**
+
+*Construction.* The operator wants to know "what's broken." Today they
+must run `gh pr list`, then `gh pr checks <n>` for each, then
+`gh run view <id>` to read failure detail, then `git log
+--all --grep` to find the four most recent merges that bypassed the
+gate (#411-#414 per root §Hypothesis). State is reconstructible only
+by hand. The dashboard claim in `:tau_web` (SPEC-WEB-DASHBOARD)
+remains aspirational — `web/lib/tau_web/live/` exists but is empty.
+
+*Mechanism — `factory-dashboard`: Datasette over the verdict log.*
+A scheduled GitHub Action (`.github/workflows/dashboard-publish.yml`)
+runs every 5 minutes on `main` and on every workflow completion:
+
+```yaml
+# Pseudocode of the publish step
+- run: |
+    # Rebuild SQLite from the append-only verdict log.
+    python3 bin/verdicts-to-sqlite.py \
+      .factory/verdicts.ndjson \
+      .factory/dashboard.db
+    # Add live-queried tables (orphan branches, stale-main, open PRs).
+    bin/factory-state-snapshot >> .factory/snapshots.ndjson
+    python3 bin/snapshots-to-sqlite.py \
+      .factory/snapshots.ndjson \
+      .factory/dashboard.db
+    # Publish via Datasette to GitHub Pages or a small Fly.io app.
+    datasette publish vercel .factory/dashboard.db \
+      --project=tau-factory --metadata bin/datasette-metadata.yml
+```
+
+The dashboard has named SQL views: `gate_health_last_50_prs`,
+`orphan_branches`, `stale_main_violations`, `silent_skip_audit`,
+`mainline_coherence`, `open_audit_findings`. Each view has a known
+schema; if a view query errors, the dashboard renders a red panel with
+the SQL error (NOT a blank panel). The verdict log is in-repo,
+git-versioned, `grep`-able in an outage, and survives the dashboard
+service being down. **Silent-skip impossibility:** the publish workflow
+itself uses `bin/factory-gate dashboard-publish -- ...` so a publish
+failure writes a `FAIL` verdict that the *next* run's dashboard shows.
+
+---
+
+**Construction E — the operator cannot see why merges are failing
+without reading git log.**
+
+*Construction.* Four merges (#411-#414) landed against red CI per root
+§Hypothesis #7. The reason was distributed: PR-body `mix output` cited
+as evidence, CI status not consulted, branch protection not enforcing
+on `main`. To diagnose, an operator today runs `git log --merges
+--first-parent main -20`, then `gh pr view <n>` for each, then
+`gh pr checks <n> --json conclusion`, then cross-references with
+`.claude/logs/solution-tree.json`. The root cause is rebuildable only
+by hand.
+
+*Mechanism — `merge-postmortem-extractor` plus branch protection
+mandating the verdict-log evidence.* (i) `main` has branch protection
+configured (via `.github/branch-protection.json` checked in and
+applied by a workflow): required checks include every gate name plus
+a `factory-verdict-coverage` check that fails if the PR does not have
+the expected verdict count in `.factory/verdicts.ndjson` keyed by PR
+number. (ii) Every push to `main` runs `bin/merge-postmortem` which:
+
+```python
+# bin/merge-postmortem (sketch)
+# For the new merge commit on main:
+#   - find the PR via `gh pr list --search 'merged sha:<sha>'`
+#   - load all verdicts where pr == <number>
+#   - assert: gate_count >= expected_for_surface(diff)
+#   - assert: every verdict.status in {PASS}
+#   - if any FAIL or BLOCKED: write a {kind: "post_merge_violation",
+#     pr: ..., violations: [...]} verdict AND open an issue via
+#     `gh issue create --label factory-violation,P0`
+#   - else: write {kind: "post_merge_clean", pr: ..., gate_count: ...}
+```
+
+The dashboard has a `merges-vs-verdicts` view that lists every merge
+to `main` for the last 30 days with its verdict coverage; merges with
+`< expected_for_surface` or any non-PASS verdict are highlighted red.
+**Silent-skip impossibility:** the postmortem step uses
+`bin/factory-gate post-merge-coverage -- bin/merge-postmortem`. If the
+script errors, that becomes a FAIL verdict the dashboard surfaces. If
+the workflow itself doesn't run, the next scheduled hourly run of
+`branch-hygiene` includes a "merges without postmortem" auditor that
+walks `git log --merges` and cross-references the verdict log.
+
+---
+
+### Generalisation
+
+The pattern across all five constructions is identical:
+
+1. **Construct.** Name the exact failure (with grep-able evidence
+   from the current repo where possible).
+2. **Deny or detect.** Either a `PreToolUse` hook denies the action,
+   or a CI workflow detects after the fact and writes a FAIL verdict.
+3. **Write a verdict.** The mechanism appends an NDJSON record to
+   `.factory/verdicts.ndjson` with `{ts, gate, status, pr, sha,
+   details}`. There is no "did not run" outcome — every invocation
+   produces a verdict.
+4. **Surface in the read model.** Datasette renders verdicts and
+   live-queried state side by side; each view fails red if its data
+   source errors.
+5. **Block the merge.** Branch protection on `main` requires named
+   gate checks and a `factory-verdict-coverage` synthetic check;
+   no missing-check or non-PASS verdict can be merged.
+
+This generalises to every future failure class: write the
+construction, write the mechanism that fails on it, register the
+verdict gate, add a Datasette view. The verdict log is the universal
+substrate.
+
+### Silent-skip impossibility — the global proof obligation
+
+Three independent layers prevent silent-skip:
+
+- **No `SKIP` status exists.** The `bin/factory-gate` wrapper emits
+  only `PASS|FAIL|BLOCKED`; a gate with nothing to check returns
+  `PASS, applicable: false` (still a verdict). The current
+  `exit 0` patterns in `ci.yml:89,97,213,219` and the `|| true` at
+  `:115` are explicit targets of the skipless-gate auditor.
+- **Branch protection requires named checks.** Renaming or removing a
+  gate step in `ci.yml` makes the required check go "missing," which
+  branch protection treats as failure. No PR can merge by dropping
+  the gate.
+- **Verdict coverage is itself a gate.** `factory-verdict-coverage`
+  fails any PR whose `.factory/verdicts.ndjson` entries for that PR
+  number do not match the expected count for the surface the diff
+  touches (derived from a static table mapping changed-file globs to
+  expected gates). The auditor's auditor.
+
+A silent-skip therefore requires defeating all three layers
+simultaneously: tamper with `bin/factory-gate`, mutate branch
+protection, and either delete or forge verdict records. The verdict
+log is append-only and git-versioned; tampering shows in the diff.
+
+### Concrete artifacts
+
+| Artifact | Path |
+| --- | --- |
+| Pre-spawn hook | `.claude/hooks/pre-spawn-check.py` |
+| Hook registration | `.claude/settings.json` `hooks.PreToolUse` |
+| Gate wrapper | `bin/factory-gate` |
+| Verdict log | `.factory/verdicts.ndjson` (in-repo, append-only) |
+| Snapshot log | `.factory/snapshots.ndjson` (in-repo) |
+| Dashboard DB | `.factory/dashboard.db` (built artefact, .gitignored) |
+| Branch hygiene workflow | `.github/workflows/branch-hygiene.yml` |
+| Dashboard publish workflow | `.github/workflows/dashboard-publish.yml` |
+| Merge postmortem | `bin/merge-postmortem` |
+| Skipless-gate auditor | `bin/skipless-gate-audit` |
+| Branch protection config | `.github/branch-protection.json` (declarative) |
+| Datasette metadata | `bin/datasette-metadata.yml` |
+| Verdict→SQLite ETL | `bin/verdicts-to-sqlite.py` (Python stdlib only) |
+
+## Tradeoffs
+
+### Strengths
+
+- **Failure-construction provenance.** Every mechanism traces to a
+  specific construction with current-repo evidence (61 orphans, the
+  three `exit 0` line numbers, the `|| true`). Reviewing the proposal
+  is reviewing falsifiable claims, not aspirations.
+- **Decomplects on the right axes.** Hooks deny actions (breaks
+  hygiene-vs-discipline). Verdict log unifies state
+  (breaks state-vs-where-you-look). Pre-spawn check denies on
+  precondition violation (breaks invariant-checking-vs-attention).
+- **No new runtime substrate.** NDJSON + SQLite + Datasette are
+  language-independent, `grep`-able in an outage, and survive
+  `:tau_web` being down. The read model and Tau's runtime share
+  nothing — a Tau crash cannot break dashboard observation of the
+  crash.
+- **Silent-skip impossibility is layered, not assumed.** Three
+  independent layers (no SKIP status, branch protection, verdict
+  coverage gate) must all fail simultaneously for a silent skip; the
+  proof is in the layering, not in a single claim.
+- **Adversarial-by-default.** Future failure classes are added by
+  writing a new construction + mechanism pair; the pattern
+  generalises rather than the spec growing case-by-case sections.
+- **Acceptance criterion fully addressed.** (a) dashboard via
+  Datasette; (b) auto-populated by gates writing the log directly,
+  red-on-error views; (c) pre-spawn hook with recovery command;
+  (d) post-merge workflow that fails loud and opens issues;
+  (e) reuse-vs-build is explicit (Datasette + GitHub Actions reused,
+  bespoke is only the gate wrapper and verdict schema); (f) concrete
+  artefacts table above.
+
+### Weaknesses
+
+- **Datasette dependency.** Introduces a Python tool to the
+  deployment surface (publish step needs `pip install datasette` on
+  the Action runner). Mitigated by pinning a Datasette version in
+  the workflow; failure to install yields a BLOCKED verdict, not a
+  silent skip. Operator must learn one new tool.
+- **NDJSON log can grow unbounded.** Mitigated by a monthly rotation
+  workflow that archives `.factory/verdicts-YYYY-MM.ndjson` and
+  re-derives the SQLite. Untested at scale; first rotation will
+  surface issues.
+- **`PreToolUse` hook adds latency to every Task spawn.** ~50-200ms
+  for the git fetch. Acceptable for the coordinator pattern (low
+  spawn rate). Hot paths (per-message hooks) are not in scope here.
+- **No real-time push.** The dashboard updates every 5 minutes;
+  during a fast-moving incident the operator may want sub-minute
+  freshness. Mitigated by running `datasette serve` locally against
+  the live `.factory/verdicts.ndjson`; the deployed dashboard is for
+  shared visibility, not real-time triage.
+- **Branch-protection-as-code is partial.** GitHub branch protection
+  cannot be 100% declarative via API for all settings; the
+  `.github/branch-protection.json` plus apply-workflow approach
+  drifts if changed in the GitHub UI. Mitigated by a daily
+  reconciliation workflow that diffs the live config against the
+  checked-in JSON and writes a FAIL verdict on drift.
+- **Operator must learn the verdict schema.** New concept; learning
+  cost. Mitigated by `bin/factory-gate --help` printing the schema
+  and an example, and by every verdict including its own field names
+  via NDJSON keys (self-describing).
+- **Does not detect** under-asserting or wrong-path tests (root
+  §Hypothesis #6 residual). Owned by the AC-binding sibling. This
+  proposal *displays* the AC-binding sibling's verdicts but does not
+  produce them.
+
+### Costs
+
+- **Migration.** Replace ~8 CI steps with `bin/factory-gate` wraps
+  (mechanical, ~2 hours). Write hooks + verdict ETL (~1 day).
+  Stand up Datasette + initial views (~1 day). Configure branch
+  protection from JSON (~2 hours; cannot be tested until landed).
+- **Operational.** Add `datasette` to the Action runner image
+  (`pip install`, cached); add a Vercel/Fly.io deployment target
+  (free tier suffices at expected verdict volume).
+- **Disruption.** First few PRs after landing will likely fail on
+  `factory-verdict-coverage` until the expected-gate-count table
+  matches the actual gate set. Mitigated by landing the gate in
+  warn-only mode for the first week (verdicts written, dashboard
+  surfaces, branch protection not yet requiring it), then flipping.
+- **Knowledge.** Operator learns: the verdict schema; Datasette
+  query basics; the `bin/factory-gate` wrapper; hook script
+  conventions per `.claude/rules/hooks-and-scripts.md`. Estimated
+  one-afternoon onboarding.
+- **Build / deps.** Adds Python `datasette` to CI runners (already
+  has Python 3.10 for `ex_termbox` waf per `ci.yml:36-40`). No new
+  Elixir deps. No new in-tree runtime processes.
+
+## Dependencies
+
+- `.claude/rules/hooks-and-scripts.md` permits Python stdlib hooks;
+  this proposal stays within stdlib (`json`, `subprocess`,
+  `pathlib`, `sys`, `time`, `os`). No `pip install` for the hook
+  itself (Datasette is publish-only, on the runner, not in-tree).
+- `.claude/rules/worktree-discipline.md` provides the invariant
+  prose this proposal mechanises. The rule's "capture-before-destroy"
+  sequence and the canonical recovery procedure are referenced as-is.
+- Branch protection on `main` must be configurable via the
+  `.github/branch-protection.json` + apply-workflow pattern (GitHub
+  API supports this for most fields).
+- Sibling proposals must adopt `bin/factory-gate` as the gate
+  wrapper. If sibling **pre-merge-code-gates** chooses a different
+  evidence format, the verdict-log unification fails. Coordination
+  required at selection time across sibling leaves.
+- The empty `web/lib/tau_web/live/` directory implies SPEC-
+  WEB-DASHBOARD's LiveView is not yet implemented. This proposal
+  does NOT require it (deliberate: avoids coupling factory
+  observability to Tau's runtime), but if a LiveView dashboard is
+  later built, it can read the same `.factory/verdicts.ndjson` log
+  and serve it as a second consumer.
+
+## Confidence
+
+**High** on the construction and mechanism side: every construction
+has current-repo evidence and a deterministic mechanism with named
+artefacts. **Medium** on the deployment side: Datasette + Vercel/Fly
+is a known pattern but not yet in this repo; first rollout will
+surface integration friction. **Confidence raising:** prototype the
+`pre-spawn-check.py` hook plus `bin/factory-gate` plus one
+`.github/workflows/branch-hygiene.yml` workflow against a throwaway
+fork, demonstrate it blocks the construction-A and construction-B
+scenarios end-to-end before declaring done.
+
+## Prior art / references
+
+- Datasette as a fail-loud-by-default read model:
+  <https://datasette.io> — Simon Willison's pattern of "publish a
+  SQLite database as a queryable HTTP API" is well-trodden, used by
+  the New York Times and others for journalism dashboards.
+- Append-only NDJSON event logs as the universal substrate: the
+  Honeycomb / Lightstep observability pattern; in-repo precedent in
+  `.claude/logs/observations.jsonl` already adopted.
+- `PreToolUse` hooks blocking on invariant violation: documented in
+  Claude Code's hook system; the precedent is the `.claude/hooks/`
+  directory already used in this repo.
+- Branch-protection-as-code: GitHub's REST API
+  `repos/:owner/:repo/branches/:branch/protection` PUT endpoint;
+  Terraform's `github_branch_protection` resource is the canonical
+  declarative form, but for a single repo a JSON-plus-workflow
+  approach is sufficient.
+- The `worktree-discipline.md` rule's prose recovery procedure is
+  the source-of-truth for what the workflows mechanise; this
+  proposal does not invent new invariants, only enforces existing
+  ones.
+- Adversarial construction as a design method: standard in
+  security review (STRIDE, attack-tree analysis) and increasingly in
+  ML eval (red-teaming). The novelty here is applying it to a
+  developer-tools factory's observability surface.

--- a/docs/factory-v2/design/subproblems/operability-and-hygiene-enforcement/solution.md
+++ b/docs/factory-v2/design/subproblems/operability-and-hygiene-enforcement/solution.md
@@ -1,0 +1,739 @@
+---
+template_version: 1
+template_name: solution
+parent_problem: ../problem.md
+node_kind: leaf
+synthesised_from: [proposals/proposal-2.md, proposals/proposal-4.md, proposals/proposal-1.md]
+selection_method: hybrid
+revision: 0
+---
+
+# Solution: Append-only NDJSON verdict log on disk + Exqlite projector + LiveDashboard `PageBuilder` page; shared Python hook/CI script enforces `parent-on-main` and worktree hygiene; branch-protection + verdict-coverage gate make silent-skip impossible.
+
+## Recommendation
+
+Treat the factory's operability surface as **one append-only verdict log
+on disk** (`.factory/verdicts.ndjson`, in-repo, `grep`-able, deployment-
+independent) plus **one Elixir projector** (`Tau.Factory.ReadModel`,
+supervised under the `:tau_web` poncho per SPEC-WEB-DASHBOARD) that
+materialises the log into a small `priv/factory_state.db` SQLite read
+model, plus **one LiveDashboard `PageBuilder` page** (`TauWeb.FactoryLive.Page`,
+mounted at `/dev/dashboard/factory`). Treat hygiene enforcement as **one
+Python script** (`.claude/hooks/factory-hygiene.py`) invoked by both the
+Claude Code `PreToolUse(Task)` + `SessionStart` hooks (local enforcement)
+and a GitHub Actions cron + push-to-main workflow (remote enforcement) —
+so the local and remote enforcement points share a single source-of-truth.
+Treat silent-skip as **structurally impossible** via three independent
+layers stacked: (i) the verdict schema (`Tau.Factory.Verdict`) admits
+only `:pass | :fail | :checked_no_findings | :infra_fail` — no `:skipped`
+constructor exists; (ii) a `bin/factory-gate <name> -- <cmd>` shell
+wrapper is the only sanctioned producer of verdict records (every CI
+gate is wrapped); a meta-`mix tau.factory.gate.assert_complete` task runs
+at CI-job tail and fails the job when any declared `gate_id` for the
+current `run_id` produced no verdict; (iii) GitHub branch-protection
+(`.github/branch-protection.json`, applied by a one-shot workflow)
+requires every named gate check AND a synthetic `factory-verdict-coverage`
+check on `main`, so a missing or renamed gate is treated as failure by
+GitHub itself. The dashboard renders an explicit error state (never a
+blank panel) on any data-source error.
+
+## Selected from
+
+- **Chosen:** hybrid of `proposals/proposal-2.md` (substrate +
+  enforcement-script unification), `proposals/proposal-4.md` (NDJSON
+  append-only verdict log + adversarial constructions + the
+  `bin/factory-gate` wrapper + `factory-verdict-coverage` synthetic gate),
+  with `proposals/proposal-1.md` contributing **`mix tau.factory.gate.assert_complete`**
+  (run-tail verdict-set completeness assertion) and the **`mix tau.factory.emit`**
+  validating mutator pattern.
+- **Why chosen:** see the comparison table below. No single proposal
+  dominated; the hybrid is justified element-by-element rather than as an
+  average.
+
+### Score table (acceptance criterion in `../problem.md`)
+
+| # | Fit (AC a–f) | Decomplecting depth | Migration cost | Risk | Reversibility |
+|---|---|---|---|---|---|
+| 1 — Event-sourced + Mix-task emitter on `:tau_web` | Yes (a–f) | Substantial — one mutator/one reader, but couples log to Elixir runtime via the Mix task | Medium (≈ 900 LOC, ≈ 11 build steps) | Medium — projection is reprojectable but the log artefact lives on GitHub releases, an unusual substrate | Hard — once gates emit through `mix tau.factory.emit`, switching mutators is a rewrite |
+| 2 — LiveDashboard + shared Python script + branch-protection | Yes (a–f) | Deep — adopts existing primitives (LiveDashboard PageBuilder, Phoenix.PubSub, `:exqlite`, branch protection); ONE script enforces locally AND in CI | Low–Medium (≈ 830 LOC, ≈ 200 LOC declarative; reuses LiveDashboard) | Low — every dep is already in tree; failure modes are LiveDashboard's well-known failure modes | Easy — every component swappable in isolation (page, projector, script, protection rules) |
+| 3 — LiveDashboard read-model + janitor cron + alarm channel | Yes (a–f) | Substantial — but 4 moving parts duplicate state knowledge across read-model, janitor, hook, alarm channel | Medium (≈ 840 LOC across 7 files) | Medium — alarm channel adds an issue-spam circuit-breaker concern; alarm rate-limiting sketched but not specified | Medium — alarm channel and read-model are coupled via `Phoenix.PubSub` topic conventions |
+| 4 — Adversarial NDJSON log + Datasette + `bin/factory-gate` + branch protection | Yes (a–f) | Deep — verdict log is the universal substrate, language-independent, `grep`-able in an outage; layered silent-skip impossibility proof | Low–Medium (≈ 600 LOC; Datasette is publish-only) | Medium — Datasette + Vercel/Fly publishing introduces a new deployment surface and Python tool | Easy on substrate (NDJSON is forever-readable); Hard on Datasette deployment if it gets entrenched |
+
+**Why hybrid, not single:** proposal 2 wins on substrate density (every
+component is already a load-bearing Tau dep — LiveDashboard, PubSub,
+Exqlite — and the shared-script invariant collapses the local/remote
+enforcement-drift surface to zero). Proposal 4 wins on silent-skip
+proof rigour (the NDJSON-on-disk substrate is `grep`-able when both
+Tau and Datasette are down; the `bin/factory-gate` wrapper makes the
+verdict-writing path the only sanctioned production path; the
+`factory-verdict-coverage` synthetic gate plus branch protection forces
+GitHub itself to refuse merges missing verdicts). Proposal 1 wins on
+**verdict-set completeness assertion at run tail** — a discrete primitive
+proposals 2/4 lack: their schemas reject `:skipped` but neither closes
+the case where a gate step is silently omitted from a workflow file.
+Proposal 3's PagerDuty-style deduped alarm channel was rejected as
+scope-creep (root §Acceptance E asks for a queryable surface; an
+issue-opening fallback already covers the "actionable" requirement
+through proposal 2's `peter-evans/create-issue-from-file@v5` on workflow
+failure).
+
+The combination is more than the sum of parts: the verdict log is the
+single source-of-truth (proposal 4); the LiveDashboard page is the
+single visual surface (proposal 2); `bin/factory-gate` is the single
+producer pipeline (proposal 4); the shared Python script is the
+single hygiene-enforcement pipeline (proposal 2); the run-tail
+completeness assertion is the single anti-omission backstop (proposal 1);
+branch protection is the single load-bearing merge gate (proposals 2 + 4).
+Each "single" is a Hickey decomplecting move; none recreates the
+others' coupling.
+
+## What changes
+
+The change-set names every concrete artifact. File paths, plugin/agent/
+skill/task/workflow/hook/settings/registry/schema entries.
+
+### Read-model substrate (Elixir, under `:tau_web` poncho)
+
+- **`Tau.Factory.Verdict`** (`web/lib/tau/factory/verdict.ex`, new, ≈ 60 LOC):
+  the typed envelope. Constructor `Verdict.new!/1` pattern-matches
+  `status` against the closed set `[:pass, :fail, :checked_no_findings, :infra_fail]`
+  and raises on any other atom; **`:skipped` cannot be constructed**.
+  Fields: `id` (ULID), `ts`, `gate_id`, `pr_number`, `run_id`, `sha`,
+  `status`, `rationale` (non-empty for any non-`:pass` status —
+  validated in constructor), `evidence_url`, `payload`.
+
+- **`Tau.Factory.Log`** (`web/lib/tau/factory/log.ex`, new, ≈ 80 LOC):
+  the single sanctioned writer to `.factory/verdicts.ndjson`. One
+  function — `append/1` — takes a `%Verdict{}`, JSON-encodes it,
+  appends one line with `:file.write/2` in append mode (atomic per
+  line up to PIPE_BUF). No reader API here; readers consume the
+  projector's SQLite read model.
+
+- **`Tau.Factory.Projector`** (`web/lib/tau/factory/projector.ex`,
+  new, ≈ 220 LOC; `GenServer` under `Tau.Factory.Supervisor`):
+  reads `.factory/verdicts.ndjson` on startup (warm projection),
+  then `:telemetry.attach_many/4` on `[:tau, :factory, :verdict, :written]`
+  for incremental projection, plus `:timer.send_interval(60_000, :poll)`
+  for the `Tau.Factory.Hygiene.scan/0` git/`gh` snapshot. Owns the
+  `priv/factory_state.db` `Exqlite.Connection`. Broadcasts each row
+  on `Tau.PubSub` topic `"factory:state"`. Restart strategy `:transient`
+  — projector crash is non-fatal; data is reprojectable from the
+  NDJSON log.
+
+- **`Tau.Factory.ReadModel.Schema`** (`web/lib/tau/factory/read_model/schema.ex`,
+  new, ≈ 100 LOC): the 6-table SQLite schema (`gate_run`, `pr_state`,
+  `worktree_state`, `stale_branch`, `main_coherence_run`, `audit_finding`).
+  Every status column is `NOT NULL CHECK(status IN ('pass','fail','checked_no_findings','infra_fail'))`.
+  **No `NULL` and no `'skipped'`** at the schema layer.
+
+- **`Tau.Factory.ReadModel.Query`** (`web/lib/tau/factory/read_model/query.ex`,
+  new, ≈ 150 LOC): pure read API used by `FactoryLive.Page` and
+  Mix-task introspection. Functions: `snapshot/0`, `gate_verdicts_for_pr/1`,
+  `leaked_worktrees/0`, `stale_branches/0`, `last_main_coherence/0`,
+  `open_audit_findings_by_surface/0`, `missing_verdicts/2`.
+
+- **`Tau.Factory.Hygiene`** (`web/lib/tau/factory/hygiene.ex`, new,
+  ≈ 80 LOC): pure functions over `git worktree list --porcelain`,
+  `git for-each-ref refs/heads/`, and `gh pr list --json headRefName`
+  output. Returns `[%Worktree{}]` and `[%StaleBranch{}]` for the
+  projector to insert.
+
+- **`Tau.Factory.Supervisor`** (`web/lib/tau/factory/supervisor.ex`,
+  new, ≈ 40 LOC): supervises the `Projector`; mounted under
+  `TauWeb.Application`'s supervision tree per SPEC-WEB-DASHBOARD's
+  poncho convention.
+
+### Visualisation surface (Elixir, under `:tau_web`)
+
+- **`TauWeb.FactoryLive.Page`** (`web/lib/tau_web/live/factory_live/page.ex`,
+  new, ≈ 220 LOC): `Phoenix.LiveDashboard.PageBuilder` page mounted
+  via `web/lib/tau_web/router.ex` under the existing `live_dashboard
+  "/dashboard"` block. Five panels (`gates`, `prs`, `hygiene`,
+  `main_coherence`, `audits`) rendered via `nav_bar/1`. **Each panel's
+  render function wraps its `Query` call in `case ... do {:ok, ...}
+  | {:error, reason} -> render_error_banner(reason) end`** — every
+  panel surfaces its data-source failure inline. No blank panel is
+  reachable.
+
+- **Router delta** (`web/lib/tau_web/router.ex`, ≈ 5 LOC): inside
+  the existing `if Application.compile_env(:tau_web, :dev_routes)`
+  block, add `additional_pages: [factory: TauWeb.FactoryLive.Page]`
+  to the existing `live_dashboard "/dashboard"` call. The page
+  surfaces at `/dev/dashboard/factory` in dev; production-exposure
+  is governed by SPEC-WEB-DASHBOARD's auth plug story (out of scope
+  here).
+
+### Verdict-production substrate (shell + Mix)
+
+- **`bin/factory-gate`** (new, shell, ≈ 60 LOC, executable; Bash
+  with `set -euo pipefail`): the only sanctioned wrapper for a gate
+  command. Usage: `bin/factory-gate <gate_id> -- <cmd...>`. Captures
+  stdout/stderr; emits one NDJSON record to `.factory/verdicts.ndjson`
+  with `{ts, gate_id, pr_number, run_id, sha, status, rationale,
+  output_head, output_tail, evidence_url}` regardless of pass/fail.
+  Status is `pass` if `<cmd>` exits 0, `fail` if non-zero, `infra_fail`
+  if the wrapper itself cannot run the command (e.g., missing binary).
+  Exits with the command's exit code (so the CI step still fails on
+  `fail`). **No path through this script exits without writing exactly
+  one verdict record.**
+
+- **`mix tau.factory.emit`** (`web/lib/mix/tasks/tau.factory.emit.ex`,
+  new, ≈ 80 LOC): Elixir-side mutator API for non-shell producers
+  (the projector itself for `infra_fail` events; future Elixir-side
+  gates). Reads a JSON `%Verdict{}` envelope on stdin; constructs
+  via `Verdict.new!/1` (which raises on invalid status); calls
+  `Tau.Factory.Log.append/1`. Refuses an envelope missing mandatory
+  fields per `kind` with exit code 2 and the missing-field list on
+  stderr.
+
+- **`mix tau.factory.gate.assert_complete`**
+  (`web/lib/mix/tasks/tau.factory.gate.assert_complete.ex`, new,
+  ≈ 120 LOC): the **run-tail verdict-set completeness asserter**
+  (from proposal 1). Args: `--run-id <id> --declared-gate-ids
+  <csv>`. Queries `Tau.Factory.ReadModel.Query.missing_verdicts/2`;
+  exits 0 with `checked, all <n> gates emitted` if complete; exits
+  non-zero with the list of missing gate IDs if not. **This task is
+  the only mechanism that catches "gate step silently omitted from
+  workflow YAML."** Runs as the final step of every CI workflow that
+  contains gates (wired via the composite action below).
+
+- **`mix tau.factory.sweep`** (`web/lib/mix/tasks/tau.factory.sweep.ex`,
+  new, ≈ 200 LOC): invokes `Tau.Factory.Hygiene.scan/0` then performs
+  the worktree-cleanup sequence from `.claude/rules/worktree-discipline.md`
+  (capture-before-destroy, then `git worktree remove -f -f`, then
+  `git branch -D`); appends one verdict per action plus a summary.
+  Failed removal (locked, dirty) emits a `:fail` verdict with the
+  blocker named. **Invoked by both `factory-hygiene.py` (local) and
+  the GHA workflow (remote)** — never inlined in a workflow YAML.
+
+- **`mix tau.factory.alarm`** (`web/lib/mix/tasks/tau.factory.alarm.ex`,
+  new, ≈ 80 LOC): reads the read-model snapshot; if leaked-worktree
+  count > threshold OR an expected gate verdict is absent for > T
+  hours OR `main`-coherence has not run for > 24h, opens a GitHub
+  issue (deterministic title; idempotent on `kind + detail` digest)
+  via `gh issue create --label hygiene,factory-v2`. Invoked by the
+  scheduled workflow.
+
+### Hygiene-enforcement substrate (Python script + Claude Code hooks + GHA workflow)
+
+- **`.claude/hooks/factory-hygiene.py`** (new, ≈ 180 LOC, Python
+  stdlib only per `.claude/rules/hooks-and-scripts.md`): the
+  shared-script enforcement core. Modes via `--mode`:
+
+  - `--mode pre-spawn` (invoked by `PreToolUse(Task)` and `SessionStart`):
+    runs the pre-spawn checklist from `worktree-discipline.md` —
+    `git fetch origin`, `branch == main`, `main == origin/main`,
+    `git status --porcelain` empty. Exits 2 (= blocking deny) with
+    a diagnostic naming the failed invariant and the recovery
+    command. Pipes a `pass`/`fail` verdict via stdin to `mix
+    tau.factory.emit` regardless of outcome.
+
+  - `--mode sweep` (invoked by `.github/workflows/hygiene-sweep.yml`):
+    delegates to `mix tau.factory.sweep`, then `mix tau.factory.alarm`.
+
+  - `--mode protect-check` (invoked by both): asserts
+    `.github/branch-protection.json` matches the live branch
+    protection via `gh api repos/.../branches/main/protection`;
+    fails on drift.
+
+  **One script. Two invocation surfaces. Drift impossible.**
+
+- **`.claude/settings.json` delta** (≈ 10 LOC JSON):
+
+  ```jsonc
+  "hooks": {
+    "SessionStart": [
+      { "hooks": [{ "type": "command",
+                    "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/factory-hygiene.py --mode pre-spawn",
+                    "timeout": 10 }] }
+    ],
+    "PreToolUse": [
+      { "matcher": "Task",
+        "hooks": [{ "type": "command",
+                    "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/factory-hygiene.py --mode pre-spawn",
+                    "timeout": 10 }] }
+    ]
+  }
+  ```
+
+  Registration is the discriminator: if the hook is registered, Claude
+  Code invokes it before every `Task` spawn. A missing hook script
+  causes Claude Code to deny the tool call by default (verified
+  behaviour). There is no path where the hook is registered but does
+  not run.
+
+### CI substrate (GitHub Actions)
+
+- **`.github/actions/factory-gate/action.yml`** (new, ≈ 40 LOC):
+  composite action wrapping a gate command in `bin/factory-gate` and
+  emitting a `[:tau, :factory, :gate, :wrapped]` annotation. Required
+  inputs: `gate-id`, `cmd`. Used by every gate step in
+  `.github/workflows/ci.yml`. A grep meta-check fails the workflow if
+  any `mix tau.gate.*` invocation in `.github/workflows/*.yml` is
+  NOT inside `uses: ./.github/actions/factory-gate`.
+
+- **`.github/workflows/ci.yml` delta** (≈ 30 LOC changed, ≈ 60 LOC
+  added): every gate step rewritten to use `factory-gate` composite
+  action. **Removes** the `exit 0` early-skip patterns at lines 88-100
+  and 213-223; **removes** the `|| true` at line 115. Adds a final
+  job-tail step:
+
+  ```yaml
+  - name: assert all declared gates produced verdicts
+    run: mix tau.factory.gate.assert_complete \
+           --run-id "$GITHUB_RUN_ID" \
+           --declared-gate-ids "ac_linkage,masking,mutation,contract_drift,nn7,capability_flag,telemetry_consumer,behaviour_callback,spec_consistency"
+  ```
+
+  Adds a meta-check job (`gate-wrapping-check`) that greps for any
+  `mix tau.gate.*` invocation not wrapped in `factory-gate`.
+
+- **`.github/workflows/hygiene-sweep.yml`** (new, ≈ 60 LOC):
+  scheduled (`*/15 * * * *`) + on-`push: main` + `workflow_dispatch`.
+  Steps: checkout, setup-beam, `.claude/hooks/factory-hygiene.py
+  --mode sweep`, `factory-hygiene.py --mode protect-check`, then
+  `peter-evans/create-issue-from-file@v5` on `if: failure()`. The
+  named check `hygiene-sweep / sweep` becomes a required branch-
+  protection check (see below).
+
+- **`.github/workflows/branch-protection-apply.yml`** (new, ≈ 30 LOC):
+  one-shot + `workflow_dispatch`. Reads `.github/branch-protection.json`
+  and applies via `gh api -X PUT repos/.../branches/main/protection
+  -F input=@.github/branch-protection.json`. Documents the required
+  `admin:repo` token in the workflow comments. Runs daily as
+  reconciliation (drift detector → FAIL verdict).
+
+- **`.github/branch-protection.json`** (new, declarative JSON):
+  required status checks include **every named gate** plus
+  `hygiene-sweep / sweep` plus the synthetic `factory-verdict-coverage`
+  check. `enforce_admins: true`, `allow_force_pushes: false`,
+  `allow_deletions: false`. **This is the load-bearing artefact** —
+  it makes the verdict pipeline merge-blocking without any bespoke
+  daemon.
+
+- **`bin/factory-verdict-coverage`** (new, shell, ≈ 50 LOC): the
+  synthetic gate that fails any PR whose verdict count in
+  `.factory/verdicts.ndjson` (for `PR_NUMBER`, `GITHUB_SHA`) does not
+  match the expected gate count for the surface the diff touches.
+  The expected-gate-count mapping is a static table
+  `bin/factory-verdict-coverage.yml` keyed by file glob → required
+  gate set. Wrapped in `bin/factory-gate verdict_coverage -- bin/factory-verdict-coverage`.
+
+### Verdict log substrate (filesystem)
+
+- **`.factory/verdicts.ndjson`** (new, in-repo, appended-only;
+  monthly rotation via `.github/workflows/verdict-log-rotate.yml`):
+  one JSON object per line; `grep`-able; readable without any Tau
+  process running; the substrate of last resort during outages.
+
+- **`.factory/snapshots.ndjson`** (new, in-repo, gitignored — written
+  by every projector poll and every hygiene sweep): point-in-time
+  git/`gh` snapshots used by the read model for hygiene state.
+
+- **`.factory/factory_state.db`** (gitignored, built artefact):
+  Exqlite-rendered projection. Rebuildable from the two NDJSON files
+  via `mix tau.factory.projector.reproject`.
+
+- **`.gitignore` delta**: add `.factory/snapshots.ndjson`,
+  `.factory/factory_state.db`, `.factory/factory_state.db-wal`,
+  `.factory/factory_state.db-shm`.
+
+### Verdict-log rotation
+
+- **`.github/workflows/verdict-log-rotate.yml`** (new, monthly cron):
+  renames `.factory/verdicts.ndjson` → `.factory/verdicts-YYYY-MM.ndjson`
+  on the first of each month and starts a fresh log. The projector
+  reads all rotated logs on warm projection. Bound by repo size; at
+  v1 PR rate (~50 PRs/month × ~10 gates × ~500 bytes/verdict ≈
+  250 KB/month), a year of history is ~3 MB.
+
+### Test surface
+
+- `web/test/tau/factory/verdict_test.exs` — property test on
+  `Verdict.new!/1`: any non-`{:pass,:fail,:checked_no_findings,:infra_fail}`
+  status raises; any non-`:pass` status with empty `rationale` raises.
+
+- `web/test/tau/factory/projector_test.exs` — integration test:
+  append 100 events to a tempfile NDJSON, start `Projector`, assert
+  `Query.snapshot/0` matches.
+
+- `web/test/tau_web/live/factory_live/page_test.exs` — LiveView
+  test via `Phoenix.LiveViewTest`: fault-injection deletes a row
+  from `gate_run`; assert the panel renders the error banner, not
+  a blank panel.
+
+- `test/hooks/factory_hygiene_test.sh` — shell test matrix for
+  `factory-hygiene.py` against 10 scenarios (orphan worktree,
+  locked-finished, in-flight-protected, stale-with-PR,
+  stale-no-PR, dirty parent, branch-not-main, main-behind-origin,
+  drifted-protection, healthy).
+
+- `test/integration/silent_skip_resistance_test.exs` — the
+  meta-test: synthesise a workflow with one gate step deleted;
+  assert `mix tau.factory.gate.assert_complete` exits non-zero
+  with the missing gate named.
+
+## What does not change
+
+- **`Tau.PubSub` remains the only `Phoenix.PubSub` instance.**
+  D-184 unchanged; the projector broadcasts on the existing topic
+  namespace.
+- **The `:telemetry` event namespace `[:tau, ...]` is the only
+  channel for in-process events.** New events (`[:tau, :factory,
+  :verdict, :written]`, `[:tau, :factory, :hygiene, :scan, :stop]`)
+  extend the namespace without forking it.
+- **The Exqlite single-writer pattern.** The projector is the only
+  process holding a write handle to `factory_state.db`; readers
+  open read-only handles or query through `Tau.Factory.ReadModel.Query`.
+- **The existing `/dev/dashboard` LiveDashboard mount.** Adding the
+  factory page is a `PageBuilder` extension, not a new mount point.
+- **`.claude/rules/worktree-discipline.md`** is unchanged — it
+  remains the prose source-of-truth that `factory-hygiene.py`
+  mechanises. The script's behaviour is the rule's invariants
+  literalised.
+- **`.claude/rules/hooks-and-scripts.md`** is unchanged — Python
+  stdlib only; this solution stays inside that constraint.
+- **`.claude/rules/factory-loop.md`'s structure** — the factory
+  cycle, the N=3 refine bound, the safety circuit, the parent-on-
+  main invariant. This solution **enforces** the rule with mechanism;
+  the rule's text remains the canonical statement of policy.
+- **No new Hex dependency.** Every Elixir piece uses `:exqlite`,
+  `:phoenix_live_view`, `:phoenix_live_dashboard`, `:phoenix_pubsub`,
+  `:telemetry` — all already in `web/mix.exs` per SPEC-WEB-DASHBOARD
+  / SPEC-MEMORY-STORE.
+- **No new pip dependency at hook scope.** Python stdlib only.
+  Datasette is explicitly **rejected** from this solution (proposal 4's
+  publish path); the LiveDashboard `PageBuilder` page replaces it.
+- **The agents under `.claude/agents/`** are untouched. The factory
+  loop's `critic` and `reviewer` continue as quality checks; this
+  solution adds mechanism *underneath* them, not in place of them.
+- **GitHub Issues remains the alarm channel.** No PagerDuty, no
+  Slack, no third-party service. `peter-evans/create-issue-from-file@v5`
+  (already widely-used in the ecosystem) is the only new GH Action.
+
+## Silent-skip impossibility — implementation-level proof
+
+A silent-skip would require **defeating all four layers simultaneously**.
+Each layer is named at the implementation level so a reviewer can verify
+the proof against actual files.
+
+1. **Constructor layer — `Tau.Factory.Verdict.new!/1` refuses
+   `:skipped`.** Source: `web/lib/tau/factory/verdict.ex`. The function
+   pattern-matches against the closed status set; any other atom raises
+   `ArgumentError`. A gate cannot construct a `:skipped` verdict.
+   Property-tested in `web/test/tau/factory/verdict_test.exs`.
+
+2. **Schema layer — SQLite `CHECK` constraint rejects `:skipped` and
+   `NULL`.** Source: `web/lib/tau/factory/read_model/schema.ex`.
+   `verdict TEXT NOT NULL CHECK (verdict IN ('pass','fail','checked_no_findings','infra_fail'))`.
+   The DB rejects insertion of any other value. Even if a future
+   producer bypassed the constructor (e.g., raw SQL), the schema
+   refuses.
+
+3. **Producer-pipeline layer — `bin/factory-gate` always writes
+   exactly one verdict.** Source: `bin/factory-gate`. The script's
+   `set -euo pipefail` plus the unconditional verdict-emission step at
+   its tail guarantees one verdict per invocation. Renaming or
+   removing the wrapper is caught by `gate-wrapping-check` (grep
+   meta-check in CI workflows for any unwrapped `mix tau.gate.*`
+   invocation). Source: `.github/workflows/ci.yml` (the `gate-wrapping-check`
+   job).
+
+4. **Workflow layer — `mix tau.factory.gate.assert_complete` fails
+   the CI job when any declared `gate_id` for the current `run_id`
+   produced no verdict.** Source:
+   `web/lib/mix/tasks/tau.factory.gate.assert_complete.ex`. This
+   layer catches the case where a gate step is **silently omitted
+   from the workflow YAML entirely** — the constructor and schema
+   layers cannot, because no producer ever ran. The asserter
+   queries `Query.missing_verdicts(run_id, declared)` and exits
+   non-zero with the list.
+
+5. **GitHub layer — branch protection requires named checks AND a
+   `factory-verdict-coverage` synthetic check.** Source:
+   `.github/branch-protection.json` + `bin/factory-verdict-coverage`.
+   Renaming a gate step in `ci.yml` makes the required check go
+   "missing"; GitHub refuses the merge. A workflow that produces
+   fewer verdicts than expected for the diff's surface fails the
+   synthetic gate.
+
+A silent-skip would require: (1) a producer that bypasses the
+constructor, AND (2) raw SQL that bypasses the schema, AND (3) a
+gate command not wrapped in `bin/factory-gate` AND not caught by the
+grep meta-check, AND (4) all declared gate IDs in
+`assert_complete`'s `--declared-gate-ids` arg matched by verdicts
+(or the arg list itself tampered with), AND (5) branch protection
+disabled or the named check renamed (caught by the daily
+`branch-protection-apply.yml` reconciliation as drift → FAIL
+verdict). Each of (1)–(5) is independently caught; all five must
+simultaneously fail.
+
+The v1 patterns at `ci.yml:88-100`, `:213-223` (early-exit-on-empty)
+and `:115` (`|| true`) are **deleted, not rewritten** by this
+solution. The script-meta-check job greps for both patterns and
+fails the workflow if either is reintroduced.
+
+## Migration sketch
+
+Sequence is dependency-driven: each step produces an artefact the
+next assumes. None may be skipped without silently disabling a
+downstream guarantee.
+
+The sequence is summarised here; the week-by-week deliverables are
+in **§Build-order** below.
+
+The substrate (verdict struct, log, projector, schema, query, page)
+lands first behind `dev_routes`-gated visibility — no production
+impact. The shell wrapper and asserter Mix task land next, validated
+end-to-end on one existing gate (`ac_linkage`) as the pilot. The
+hygiene script lands in **read-only mode** (always exits 0) so it
+cannot block local agent work during the bedding-in period; flipping
+to deny-mode is a one-line settings change once the script's behaviour
+is verified across the 10-scenario shell test matrix. Branch protection
+lands last, because once applied it makes every named check
+load-bearing on `main` and a misconfiguration becomes a blocker.
+
+Reversibility is high: removing the LiveView page is a router-delta
+revert; removing the hooks is a settings-delta revert; removing
+branch protection is a `gh api` DELETE; the NDJSON log can be
+truncated or deleted without affecting Tau's runtime (the projector
+will simply replay nothing).
+
+## §Build-order — week-by-week with dependencies
+
+Eight weeks, one named deliverable per week. Each week's deliverable
+is the input the next week consumes. Strict ordering — Wk N cannot
+ship before Wk N-1's artefact exists.
+
+### Wk 1 — Verdict substrate
+
+- **Ship:** `Tau.Factory.Verdict` (`web/lib/tau/factory/verdict.ex`)
+  + `Tau.Factory.Log` (`web/lib/tau/factory/log.ex`) + property
+  tests (`web/test/tau/factory/verdict_test.exs`).
+- **Demonstrates:** `Verdict.new!/1` refuses `:skipped`; `Log.append/1`
+  produces a parseable NDJSON line.
+- **Depends on:** nothing (pure Elixir; no `:tau_web` dependency yet).
+- **Gate (self):** property test for status closed set; round-trip
+  NDJSON encode/decode.
+
+### Wk 2 — Projector + schema + query
+
+- **Ship:** `Tau.Factory.Projector` + `Tau.Factory.ReadModel.Schema`
+  + `Tau.Factory.ReadModel.Query` + `Tau.Factory.Supervisor` +
+  integration test (`web/test/tau/factory/projector_test.exs`).
+  Mount `Supervisor` under `TauWeb.Application`.
+- **Demonstrates:** writing to `.factory/verdicts.ndjson` results in
+  rows in `priv/factory_state.db` within 100 ms; `Query.snapshot/0`
+  returns the projected state.
+- **Depends on:** Wk 1.
+- **Gate (self):** `mix test` for projector with a tempfile NDJSON
+  fixture; SQLite CHECK constraint integration test.
+
+### Wk 3 — `bin/factory-gate` + pilot gate wrapping
+
+- **Ship:** `bin/factory-gate` shell wrapper + wrap `mix
+  tau.gate.ac_linkage` in `.github/workflows/ci.yml` via the new
+  `.github/actions/factory-gate/action.yml` composite action +
+  `Tau.Factory.Hygiene.scan/0` (Elixir).
+- **Demonstrates:** one full PR's `ac_linkage` gate emits a verdict
+  visible in `.factory/verdicts.ndjson` AND in `Query.snapshot/0`;
+  a synthetic gate failure produces a `fail` verdict that the next
+  Wk-4 dashboard renders red.
+- **Depends on:** Wk 2.
+- **Gate (self):** `bin/factory-gate` test matrix (pass, fail,
+  command-not-found → `infra_fail`); composite-action smoke test
+  via `act` or a throwaway PR.
+
+### Wk 4 — `FactoryLive.Page` + router delta
+
+- **Ship:** `TauWeb.FactoryLive.Page` + router delta + LiveViewTest
+  fault-injection test (`web/test/tau_web/live/factory_live/page_test.exs`).
+- **Demonstrates:** five panels render at `/dev/dashboard/factory`;
+  deleting a `gate_run` row makes that panel show its error banner,
+  not a blank tile (leaf-AC b).
+- **Depends on:** Wk 3 (need real verdicts to render).
+- **Gate (self):** LiveView fault-injection test asserts the error
+  banner is visible.
+
+### Wk 5 — `assert_complete` + meta-checks + universal gate wrapping
+
+- **Ship:** `mix tau.factory.gate.assert_complete` + adopt
+  `factory-gate` composite action on **every** gate in `ci.yml` +
+  `gate-wrapping-check` grep meta-check + final-step
+  `assert_complete` call in every gate-containing workflow + delete
+  the `exit 0` early-exits at `ci.yml:88-100` and `:213-223` and
+  the `|| true` at `:115`.
+- **Demonstrates:** the silent-skip integration test
+  (`test/integration/silent_skip_resistance_test.exs`) — synthesise
+  a workflow with one gate step deleted; CI fails on `assert_complete`
+  with the missing gate named. This is the formal closure of Failure
+  Class #5 (silent-skip).
+- **Depends on:** Wk 3 + Wk 4 (need wrapper + dashboard for visible
+  confirmation).
+- **Gate (self):** synthetic silent-skip test passes; meta-check
+  catches an unwrapped `mix tau.gate.*` invocation.
+
+### Wk 6 — Hygiene script + log-only deployment
+
+- **Ship:** `.claude/hooks/factory-hygiene.py` (all three modes:
+  `pre-spawn`, `sweep`, `protect-check`) + `mix tau.factory.sweep`
+  + `mix tau.factory.alarm` + shell test matrix
+  (`test/hooks/factory_hygiene_test.sh`) + `.claude/settings.json`
+  delta — but **the hooks are wired in LOG-ONLY mode** (script
+  emits a verdict but always exits 0; recovery commands surfaced
+  only as warnings).
+- **Demonstrates:** every Task spawn produces a `pre-spawn` verdict
+  visible on the dashboard; the 10-scenario shell matrix passes;
+  no agent work is blocked.
+- **Depends on:** Wk 5 (need the verdict pipeline before the script
+  can write verdicts).
+- **Gate (self):** shell test matrix passes 10/10 scenarios;
+  one-week bake on the local coordinator with no false denies.
+
+### Wk 7 — Hygiene script flips to deny-mode + scheduled workflow
+
+- **Ship:** `.github/workflows/hygiene-sweep.yml` (cron + push-to-main +
+  workflow_dispatch) + flip `factory-hygiene.py --mode pre-spawn`
+  to exit 2 on invariant violation (one-line change). Closes leaf-AC (c)
+  and (d).
+- **Demonstrates:** a deliberately-stale parent causes the next
+  Task spawn to be denied with the diagnostic naming the failed
+  invariant and the recovery command; the GHA workflow runs every
+  15 min and emits one sweep verdict per pass; orphan worktrees
+  are removed within the SLA.
+- **Depends on:** Wk 6 (need the script verified before it can
+  start denying).
+- **Gate (self):** one-week bake; alarm threshold tuned; no
+  legitimate work blocked.
+
+### Wk 8 — Branch protection + verdict coverage + reconciliation
+
+- **Ship:** `.github/branch-protection.json` +
+  `.github/workflows/branch-protection-apply.yml` +
+  `bin/factory-verdict-coverage` + `bin/factory-verdict-coverage.yml`
+  (the surface→required-gates table) + daily reconciliation. **Branch
+  protection is applied — `main` becomes merge-gated on every named
+  check including the synthetic coverage gate.**
+- **Demonstrates:** a PR with a missing verdict cannot merge;
+  drifting branch-protection via the GitHub UI is caught within 24h
+  as a `fail` verdict on the dashboard; the Wk 5 silent-skip test
+  PLUS the Wk 7 hygiene tests PLUS the verdict-coverage gate
+  collectively close Failure Class #5 AND Failure Class #7 AND
+  Failure Class #8.
+- **Depends on:** Wk 5 + Wk 6 + Wk 7 (every prerequisite verdict
+  pipeline must be live before merge-blocking is turned on).
+- **Gate (self):** end-to-end test on a throwaway PR — try every
+  silent-skip construction from proposal 4 (orphan branch, stale
+  parent, mis-wired gate, dashboard outage); each is caught at
+  the named layer; branch protection refuses the merge.
+
+### Dependency DAG
+
+```
+Wk1 ─→ Wk2 ─→ Wk3 ─→ Wk4
+                │
+                └─→ Wk5 ─→ Wk6 ─→ Wk7 ─→ Wk8
+```
+
+Wk 4 (dashboard) and Wk 5 (assert_complete) can parallelise after
+Wk 3; the build-order serialises them only for review-burden reasons.
+Wk 8 is the merge-gating activation; nothing depends on it within
+this leaf, but the post-merge coherence sibling and the AC-binding
+sibling consume `bin/factory-gate` and the verdict log from Wk 3
+onward.
+
+## Open questions
+
+- **Production exposure of `/dev/dashboard/factory`.** Currently
+  guarded by `dev_routes` per the existing router; this solution
+  defers the auth-plug story to a follow-up tracked under SPEC-WEB-
+  DASHBOARD. For a single-developer self-hosting factory, dev-only is
+  sufficient; multi-operator setups need an auth plug. Not a leaf
+  blocker.
+
+- **`audit_finding` table write path.** This solution defines the
+  table and reads from it via the dashboard. The **knowledge-memory-
+  and-audit-ingestion sibling** owns the writer. The cross-leaf
+  contract: the sibling either writes verdicts through `mix
+  tau.factory.emit` with `kind: :audit_finding` (preferred) or
+  writes directly to `factory_state.db.audit_finding` via a
+  documented Ecto schema. If the sibling chooses a YAML registry,
+  this leaf needs a 20-LOC importer task.
+
+- **Per-PR expected-gate-count table.** `bin/factory-verdict-coverage.yml`
+  maps file globs to required gate sets. The initial table is
+  derived from `docs/spec/SPEC-*.md` source-maps; it must be kept
+  in sync with the **pre-merge-code-gates** sibling's gate inventory.
+  A test ensures every gate named in `ci.yml` appears in the
+  coverage table.
+
+- **GHA cron skew.** GitHub's `*/15` cron is best-effort; under low
+  repo activity the sweep can lag up to ~25 min. Mitigated by
+  `push: main` trigger (sweep runs after every merge) and the
+  pre-spawn hook (local agent work cannot proceed against a stale
+  parent regardless of cron timing). Residual: purely-server orphans
+  during quiet periods may persist 25 min.
+
+- **NDJSON log growth at scale.** Monthly rotation is sketched; first
+  rotation will surface integration friction. At v1 PR rate (~50/mo
+  × ~10 gates), the log grows ~250 KB/mo; rotation tested on a
+  throwaway repo at 10× volume before the first scheduled rotation.
+
+- **Branch-protection-as-code partial coverage.** GitHub's API does
+  not expose every protection setting declaratively (e.g., some
+  rules are admin-UI only). The daily reconciliation surfaces drift
+  but cannot author every rule. Documented limitation; manual UI
+  configuration for the residual settings is a one-time setup step.
+
+- **Coordination with the `pre-merge-evidence-and-skip-integrity`
+  sibling.** That sibling owns the gate-result evidence contract;
+  this leaf consumes it. The agreed contract is the four allowed
+  `status` values (`:pass`, `:fail`, `:checked_no_findings`,
+  `:infra_fail`) and the `bin/factory-gate` wrapper as the
+  evidence producer. If the sibling chooses a materially different
+  evidence format, this leaf needs an adapter (≤ 50 LOC). Tracked
+  as a cross-leaf dependency in §What changes.
+
+## Linked sub-problems / proposals
+
+- `proposals/proposal-1.md` — Event-sourced read model + `mix
+  tau.factory.emit` mutator + run-tail verdict-set completeness
+  assertion. **Contribution: `mix tau.factory.gate.assert_complete`
+  primitive (the run-tail verdict-set completeness asserter — the
+  catch for "gate step silently omitted from workflow YAML"), plus
+  the validating-mutator pattern (`mix tau.factory.emit` for
+  Elixir-side producers).**
+
+- `proposals/proposal-2.md` — LiveDashboard `PageBuilder` page +
+  shared Python script for local/CI enforcement + branch-protection.
+  **Contribution: the substrate (LiveDashboard + Phoenix.PubSub +
+  `:exqlite` — all in-tree deps), the shared-script invariant
+  (`factory-hygiene.py` is the same file in `.claude/hooks/` and the
+  GHA workflow), and branch protection as the load-bearing merge
+  gate.**
+
+- `proposals/proposal-3.md` — LiveDashboard read-model + janitor cron
+  + alarm channel + pre-spawn hook. **Contribution: NONE adopted
+  directly. The alarm-channel concept is folded into proposal 2's
+  `peter-evans/create-issue-from-file@v5` on workflow failure; the
+  janitor cron is folded into `hygiene-sweep.yml`; the four-moving-
+  parts shape was rejected for the three-substrate shape (log,
+  projector + view, hygiene script).**
+
+- `proposals/proposal-4.md` — Adversarial NDJSON verdict log +
+  Datasette + `bin/factory-gate` + branch protection + adversarial
+  constructions. **Contribution: the append-only NDJSON verdict log
+  as substrate-of-last-resort (`grep`-able when both Tau and the
+  dashboard are down); `bin/factory-gate` shell wrapper as the only
+  sanctioned producer pipeline; the `factory-verdict-coverage`
+  synthetic gate; the five-construction silent-skip impossibility
+  proof structure (reused above with one added layer from proposal 1).
+  Datasette was rejected** in favour of proposal 2's LiveDashboard
+  PageBuilder page — Datasette would introduce a new deployment
+  surface (Vercel/Fly.io) and a pip-installed tool, where LiveDashboard
+  PageBuilder is already an in-tree dep and the dashboard mount
+  already exists.
+
+## Revision history
+
+- (revision 0 — initial)

--- a/docs/factory-v2/design/subproblems/post-merge-cross-artifact-coherence/problem.md
+++ b/docs/factory-v2/design/subproblems/post-merge-cross-artifact-coherence/problem.md
@@ -1,0 +1,131 @@
+---
+template_version: 1
+template_name: problem
+node_kind: leaf
+mode: leaf
+depth: 1
+parent: ../../problem.md
+status: draft
+---
+
+# Problem: Post-merge cross-artifact coherence — SPEC↔SPEC, SPEC↔code, ADR↔SPEC drift on `main`
+
+## Statement
+
+Per-PR gates examine a single diff in isolation; they cannot detect
+contradictions that emerge between artifacts as two PRs land or that
+exist within a single artifact at rest (SPEC-PERMISSION-PROMPTS §4 B5
+says 6 modes, §6 D-171 says 3 — v1 lets this persist because no
+SPEC-vs-SPEC consistency check runs, root #9). Nor do per-PR gates
+detect drift that emerges over time on `main` — a SPEC §4 contract
+later contradicted by a code change in an unrelated PR, an ADR
+superseded by a later ADR without supersession metadata, or D-NNN
+identifiers reused across SPECs. The problem is solved when a `main`-
+side check, run on every push to `main` and on a cadence (e.g. daily),
+detects every class of cross-artifact contradiction the v1 audit
+identified and fails-loud (file an issue, alarm the dashboard) rather
+than fails-silent.
+
+## Context
+
+- Root §Hypothesis #9 — SPEC self-contradiction persists because no
+  SPEC-vs-SPEC consistency check runs (concrete example:
+  SPEC-PERMISSION-PROMPTS §4 B5 vs §6 D-171).
+- `CLAUDE.md` D-NNN identifier rule: "Before authoring a new D-NNN,
+  verify the identifier is free across the whole repo (`git log --all
+  --grep`, plus `grep -rn` over `lib test docs .claude`). Single-branch
+  negative results are not evidence of absence." This is the
+  uniqueness invariant; no mechanical enforcement today.
+- `.claude/rules/spec-before-code.md` catalogs which SPEC §3 invariants
+  bind which file paths (Appendix B source-maps); the structured data
+  exists, but no check on `main` re-validates that bindings still
+  resolve.
+- ADR convention is in `docs/adr/README.md`; supersession is
+  prose-only.
+- Existing ecosystem: `vale` for prose linting, `markdown-link-check`,
+  `markdown-it` AST traversal, JSON-schema validation for structured
+  blocks within markdown.
+
+## Failure classes addressed (from root §Hypothesis)
+
+- **#9** (primary) — SPEC self-contradiction (within and across SPEC
+  documents); D-NNN uniqueness; SPEC §4 contract names refer to
+  symbols that still exist after later commits land.
+- **#1** (cumulative tail) — contracts drift from code as a function
+  of time on `main`, beyond what any single-diff pre-merge check could
+  catch (the pre-merge sibling catches per-PR drift; this leaf catches
+  drift that emerges from the *combination* of merges).
+- **#4** (cumulative tail) — telemetry events that lose their consumer
+  on `main` after a later PR removes the handler without removing the
+  emission (per-PR check catches only changes within the diff).
+
+## Complecting hypothesis
+
+- "What a SPEC says" is complected with "what the codebase does"
+  because the only link is the spec-before-code Appendix B source-map
+  written in prose; structured machine resolution requires the
+  source-map to be a parseable manifest the check consumes.
+- "When a contradiction was introduced" is complected with "which PR
+  introduced it" because v1 only catches contradictions per-PR; a
+  contradiction that emerges from the *combination* of two PRs is
+  invisible to both PRs' gates and so must surface on `main`.
+- "D-NNN uniqueness" is complected with "the author remembered to
+  grep" because the only check is in CLAUDE.md as a human-directed
+  rule; mechanical uniqueness requires a per-`main`-push scan.
+
+## Decomposition strategy
+
+(leaf — no further decomposition; proceed to proposals)
+
+## Acceptance criterion
+
+The factory specification names mechanisms such that: (a) on every
+push to `main` (via a workflow triggered on `push: branches: [main]`)
+a coherence-check suite runs that includes at minimum: D-NNN
+uniqueness across `lib/`, `test/`, `docs/`, `.claude/`; SPEC §4
+contract symbol existence (each named module/function/struct/callback
+in any SPEC §4 must resolve in the current `main` codebase); SPEC-vs-
+SPEC contradiction detection (D-NNN with conflicting definitions,
+contradictory invariants on the same surface — the v1 PERMISSION-
+PROMPTS B5/D-171 case must be detected by this check on its first
+run); ADR supersession integrity (a later ADR claiming to supersede
+ADR-N has both directions of the link in the metadata); telemetry-
+consumer presence cumulative (per-PR check augmented with a `main`-
+side rerun that catches handler-removal-without-emission-removal); (b)
+the suite cannot silent-skip per root §Acceptance C — an empty SPEC
+catalog or empty ADR set explicitly logs "0 applicable, checked"; (c)
+the suite's verdict, when failing, opens a GitHub issue
+auto-milestoned to the current focus milestone, with the failing
+contradictions enumerated, AND surfaces on the factory dashboard
+(operability sibling consumes the verdict); (d) the design records
+reuse vs build per check (a `polya-audit`-style plugin? `vale` with
+custom styles for SPEC structural rules? a Mix project under `priv/`
+that re-uses `Sourceror`? GitHub Code Scanning API?) per root
+§Acceptance D; (e) the spec output identifies concrete artifacts:
+workflow file (e.g. `.github/workflows/main-coherence.yml`), the mix
+task or escript names (`Mix.Tasks.Tau.Coherence.Dnnn`,
+`Mix.Tasks.Tau.Coherence.SpecContracts`, etc.), the structured
+source-map manifest format (a YAML/JSON sidecar to each SPEC, or
+auto-extracted from Appendix B), the issue-opener Action, and any
+notification hook.
+
+## Out of scope
+
+- Per-PR pre-merge code-shape checks — owned by
+  **pre-merge-code-gates** sibling (this leaf catches what slips
+  through *because* the per-PR check can only see one diff at a time).
+- Gate-infrastructure invariants — owned by
+  **pre-merge-evidence-and-skip-integrity** sibling.
+- Ingestion of historical audit findings as new check inputs — owned
+  by **knowledge-memory-and-audit-ingestion** sibling (this leaf
+  detects *new* contradictions; that leaf ingests *existing* ones).
+- AC-test binding mechanics — owned by
+  **intent-capture-and-ac-binding** sibling.
+- Dashboards and orphan-worktree hygiene — owned by
+  **operability-and-hygiene-enforcement** sibling.
+- Documentation-only components; agent-discipline-only enforcement;
+  workstream-2 corrective-actions catalogue.
+
+## Amendment log
+
+- (none yet)

--- a/docs/factory-v2/design/subproblems/post-merge-cross-artifact-coherence/proposals/proposal-1.md
+++ b/docs/factory-v2/design/subproblems/post-merge-cross-artifact-coherence/proposals/proposal-1.md
@@ -1,0 +1,512 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 1
+parent_problem: ../problem.md
+---
+
+# Proposal 1: Manifest-extractor + pure-predicate suite + always-emit verdict sink (first-principles)
+
+## Approach
+
+Make cross-artifact coherence a **pure function over a typed manifest
+of the repository at a commit**. Build the system as five composable
+layers, each with a single responsibility and a machine-checkable
+output:
+
+1. **Extractors** (`lib/tau/coherence/extract/*`) — pure modules that
+   walk `lib/`, `test/`, `docs/spec/`, `docs/adr/`, and `.claude/` and
+   emit a typed `%Tau.Coherence.Manifest{}` struct. One extractor per
+   artifact kind: `DnnnIndex`, `SpecContracts`, `AdrGraph`,
+   `SourceMap`, `TelemetrySites`, `TelemetryConsumers`.
+2. **Predicates** (`lib/tau/coherence/check/*`) — pure functions
+   `Manifest.t() -> [Finding.t()]`. One module per failure-class
+   axis: `DnnnUniqueness`, `SpecSymbolResolution`,
+   `SpecContradiction`, `AdrSupersession`,
+   `TelemetryConsumerCumulative`. Each predicate is total: it always
+   returns either `{:ok, []}` (no findings, *checked*) or
+   `{:ok, [%Finding{}, ...]}`. The `:ok` wrapper is the
+   silent-skip-impossibility primitive — there is no third return.
+3. **Runner** (`Mix.Tasks.Tau.Coherence.Run`) — orchestrates all
+   extractors and predicates, writes a single JSON verdict file
+   `_build/coherence/verdict-<sha>.json` whose schema requires a
+   `checks: [...]` array containing exactly one entry per
+   registered predicate. A predicate that crashes is recorded as
+   `status: "infrastructure_failure"` — which is itself a failing
+   verdict, not a skip.
+4. **Sink** (`.github/workflows/main-coherence.yml`) — triggered on
+   `push: branches: [main]` and on `schedule: cron: '0 6 * * *'`.
+   Runs the runner, uploads the verdict JSON as an artifact, calls
+   `Mix.Tasks.Tau.Coherence.OpenIssue` on any non-empty findings (the
+   task is idempotent — it dedupes by a content hash so identical
+   findings collapse onto one open issue), and posts the verdict
+   summary to a project-wide `coherence` GitHub status check the
+   operability dashboard subscribes to.
+5. **Verdict consumer contract** — the verdict JSON schema is
+   published at `priv/coherence/verdict.schema.json` and the
+   operability sibling reads it directly; no prose interface.
+
+Silent-skip impossibility is achieved structurally: the runner
+**enumerates registered predicates** from a compile-time registry
+(`Tau.Coherence.Registry`); the workflow asserts the verdict's
+`checks` length equals the registry length (a build-time exported
+constant). A missing predicate fails the workflow.
+
+## Rationale
+
+The complecting hypothesis identifies three weaves: (a) "what a SPEC
+says" is woven with "what the codebase does" through prose source-
+maps; (b) "when a contradiction was introduced" is woven with "which
+PR introduced it" because checks run per-PR; (c) "D-NNN uniqueness"
+is woven with "did the author remember to grep." This proposal
+decomplects all three by making the manifest the **single source of
+ground truth** that every predicate consumes uniformly. The
+manifest is not a SPEC and not code — it is the *extracted facts*
+from both. Predicates compare facts; facts come from extractors;
+extractors are pure. The runner does not know what a SPEC is; the
+predicate does not know what a file is. Each layer has one job. The
+silent-skip class is dissolved because every predicate is a total
+function over the manifest — there is no "skip" arm to its return
+type. The "checked, no findings" case is `{:ok, []}`, which is
+*data*, not the absence of data; the workflow asserts data is
+present for every predicate.
+
+## Sketch
+
+### Manifest shape (`lib/tau/coherence/manifest.ex`)
+
+```elixir
+defmodule Tau.Coherence.Manifest do
+  @moduledoc "Typed facts extracted from the repo at a commit."
+
+  @type t :: %__MODULE__{
+          sha: String.t(),
+          dnnn_index: %{(id :: String.t()) => [Occurrence.t()]},
+          spec_contracts: [SpecContract.t()],
+          adrs: [Adr.t()],
+          source_maps: %{(spec_id :: String.t()) => [Path.t()]},
+          telemetry_sites: [TelemetrySite.t()],
+          telemetry_consumers: [TelemetryConsumer.t()]
+        }
+
+  defstruct [:sha, :dnnn_index, :spec_contracts, :adrs,
+             :source_maps, :telemetry_sites, :telemetry_consumers]
+end
+
+defmodule Tau.Coherence.Manifest.SpecContract do
+  @type t :: %__MODULE__{
+          spec_id: String.t(),     # "SPEC-PERMISSION-PROMPTS"
+          section: String.t(),     # "§4 B5"
+          dnnn_ids: [String.t()],  # ["D-090", ...]
+          symbols: [Symbol.t()],   # named module/function/struct/callback
+          invariants: [Invariant.t()] # {axis, predicate} pairs
+        }
+  defstruct [:spec_id, :section, :dnnn_ids, :symbols, :invariants]
+end
+```
+
+### Predicate contract (`lib/tau/coherence/check.ex`)
+
+```elixir
+defmodule Tau.Coherence.Check do
+  @callback name() :: String.t()
+  @callback applies_to(Manifest.t()) :: boolean()
+  @callback run(Manifest.t()) :: {:ok, [Finding.t()]} | {:error, term()}
+
+  # Note: no `:skip` constructor. {:ok, []} means "checked, none found."
+  # `:error` is a hard failure — runner records it as infrastructure_failure.
+end
+
+defmodule Tau.Coherence.Finding do
+  @type severity :: :blocker | :warn
+  @type t :: %__MODULE__{
+          check: String.t(),
+          severity: severity(),
+          locations: [{Path.t(), pos_integer()}],
+          message: String.t(),
+          dedup_key: String.t() # SHA256 of (check, locations, message_template)
+        }
+  defstruct [:check, :severity, :locations, :message, :dedup_key]
+end
+```
+
+### A concrete predicate — `SpecContradiction` (catches the PERMISSION-PROMPTS B5/D-171 case)
+
+```elixir
+defmodule Tau.Coherence.Check.SpecContradiction do
+  @behaviour Tau.Coherence.Check
+
+  @impl true
+  def name, do: "spec_contradiction"
+
+  @impl true
+  def applies_to(%Manifest{spec_contracts: cs}), do: length(cs) > 0
+
+  @impl true
+  def run(%Manifest{spec_contracts: contracts}) do
+    findings =
+      contracts
+      |> Enum.flat_map(& &1.invariants)
+      |> Enum.group_by(& &1.axis)               # {:permission_modes, _}
+      |> Enum.flat_map(&detect_conflicts/1)
+    {:ok, findings}
+  end
+
+  defp detect_conflicts({axis, [_one]}), do: []
+  defp detect_conflicts({axis, invariants}) do
+    case Enum.uniq_by(invariants, & &1.value) do
+      [_one] -> []
+      multiple ->
+        [%Finding{
+          check: "spec_contradiction",
+          severity: :blocker,
+          locations: Enum.map(multiple, & &1.location),
+          message: "Axis #{axis} has conflicting values: " <>
+                   Enum.map_join(multiple, ", ", &"#{&1.value} (#{loc(&1)})"),
+          dedup_key: dedup(axis, multiple)
+        }]
+    end
+  end
+end
+```
+
+When the extractor parses SPEC-PERMISSION-PROMPTS, the `permission_modes`
+axis appears with value `6` (§4 B5) and value `3` (§6 D-171); the
+predicate emits a blocker finding on first run.
+
+### Registry (compile-time, makes "I forgot to register my check" impossible to silent-skip)
+
+```elixir
+defmodule Tau.Coherence.Registry do
+  @checks [
+    Tau.Coherence.Check.DnnnUniqueness,
+    Tau.Coherence.Check.SpecSymbolResolution,
+    Tau.Coherence.Check.SpecContradiction,
+    Tau.Coherence.Check.AdrSupersession,
+    Tau.Coherence.Check.TelemetryConsumerCumulative
+  ]
+  def all, do: @checks
+  def count, do: length(@checks)
+end
+```
+
+### Runner (`lib/mix/tasks/tau.coherence.run.ex`)
+
+```elixir
+defmodule Mix.Tasks.Tau.Coherence.Run do
+  use Mix.Task
+  @shortdoc "Run cross-artifact coherence checks on current tree"
+
+  def run(_argv) do
+    manifest = Tau.Coherence.Extractor.build(File.cwd!())
+    checks = Tau.Coherence.Registry.all()
+
+    results =
+      Enum.map(checks, fn mod ->
+        try do
+          case mod.run(manifest) do
+            {:ok, findings} -> {mod.name(), :checked, findings}
+            {:error, reason} -> {mod.name(), :infrastructure_failure, reason}
+          end
+        rescue
+          e -> {mod.name(), :infrastructure_failure, Exception.message(e)}
+        end
+      end)
+
+    verdict = build_verdict(manifest.sha, results)
+    File.mkdir_p!("_build/coherence")
+    File.write!("_build/coherence/verdict-#{manifest.sha}.json",
+                Jason.encode!(verdict, pretty: true))
+
+    exit_code = if any_blocker_or_infra_failure?(results), do: 1, else: 0
+    System.halt(exit_code)
+  end
+end
+```
+
+Note the deliberate `try/rescue` — this is in a Mix task, NOT across
+a process boundary, and exists solely to convert a crashed predicate
+into an `infrastructure_failure` verdict. NN #7 forbids rescue
+*across process boundaries*; a Mix task is a single OS process and
+this rescue is the recording mechanism for silent-skip impossibility,
+not a swallowed error.
+
+### Verdict schema (`priv/coherence/verdict.schema.json`)
+
+```json
+{
+  "$id": "https://tau/coherence/verdict.schema.json",
+  "type": "object",
+  "required": ["sha", "ran_at", "checks", "registry_count"],
+  "properties": {
+    "sha": {"type": "string", "pattern": "^[0-9a-f]{40}$"},
+    "ran_at": {"type": "string", "format": "date-time"},
+    "registry_count": {"type": "integer", "minimum": 1},
+    "checks": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name", "status", "findings"],
+        "properties": {
+          "name": {"type": "string"},
+          "status": {"enum": ["checked", "infrastructure_failure"]},
+          "findings": {"type": "array", "items": {"$ref": "#/$defs/finding"}}
+        }
+      }
+    }
+  }
+}
+```
+
+Workflow asserts: `len(verdict.checks) == verdict.registry_count`
+AND every predicate name in `Tau.Coherence.Registry` appears in
+`verdict.checks`. A predicate that fails to run cannot disappear; a
+predicate added without runner-wiring fails the registry-equality
+assertion.
+
+### Source-map manifest (decomplecting "prose Appendix B" from "what the check uses")
+
+Each SPEC grows a sidecar `docs/spec/SPEC-*.source-map.yaml` (or the
+extractor parses Appendix B if the sidecar is absent; sidecar wins
+when both exist):
+
+```yaml
+spec_id: SPEC-PERMISSION-PROMPTS
+binds:
+  - path: lib/tau/session.ex
+    symbols: [Tau.Session.set_permissions_mode/2]
+    invariants: [D-090, D-091]
+  - path: lib/tau/session/events.ex
+    symbols: [Tau.Session.Events.PermissionRequest]
+```
+
+Extractor reads the sidecar; `SpecSymbolResolution` predicate uses
+`Sourceror` (already a peer of `Mix` for Tau, used by `mix
+format`) to confirm each symbol resolves in the current `main`
+checkout. A missing symbol emits a blocker finding citing both the
+SPEC line and the missing module path.
+
+### Workflow (`.github/workflows/main-coherence.yml`)
+
+```yaml
+name: main-coherence
+on:
+  push:
+    branches: [main]
+  schedule:
+    - cron: '0 6 * * *'
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  coherence:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: erlef/setup-beam@v1
+        with: {otp-version: '27.2', elixir-version: '1.18.1'}
+      - run: mix deps.get && mix compile --warnings-as-errors
+      - run: mix tau.coherence.run
+        id: coherence
+      - name: Verify verdict completeness (silent-skip guard)
+        run: |
+          REG=$(mix run --no-start -e 'IO.puts(Tau.Coherence.Registry.count())')
+          CHK=$(jq '.checks | length' _build/coherence/verdict-*.json)
+          test "$REG" = "$CHK" || { echo "Verdict missing checks"; exit 2; }
+      - uses: actions/upload-artifact@v4
+        with: {name: coherence-verdict, path: _build/coherence/}
+      - name: Open or update issue on failure
+        if: failure()
+        run: mix tau.coherence.open_issue _build/coherence/verdict-*.json
+        env: {GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}}
+      - name: Post status to dashboard
+        if: always()
+        run: mix tau.coherence.publish_status _build/coherence/verdict-*.json
+```
+
+`if: always()` on the publish step is the verdict-consumption
+guarantee: the dashboard ALWAYS sees a verdict (pass or fail or
+infrastructure_failure), never a vacuum.
+
+### Build-order
+
+The build proceeds bottom-up so each layer is testable in isolation
+and gates the next.
+
+1. **Manifest types and extractor for `DnnnIndex`** (smallest
+   surface, no SPEC parsing needed; regex-only). Property test:
+   extractor is a pure function of repo state.
+2. **`DnnnUniqueness` predicate + runner skeleton + verdict schema +
+   silent-skip guard test.** Predicate emits findings for any
+   already-violated D-NNN identifier; this proves the substrate.
+3. **`AdrSupersession` predicate.** ADRs are smaller-surface than
+   SPECs; extractor proves the `AdrGraph` shape; predicate validates
+   bidirectional supersession links.
+4. **SPEC source-map sidecars** authored for each catalog entry,
+   gating the next predicate. SPEC-PERMISSION-PROMPTS,
+   SPEC-USER-TURN, SPEC-TUI-HEADLESS first (they have the most §4
+   surface). Initial CI workflow runs steps 1–3 from this point.
+5. **`SpecSymbolResolution` predicate.** Extractor uses `Sourceror`
+   to resolve symbols; predicate emits a blocker per unresolved.
+6. **`SpecContradiction` predicate.** First check, on a known case
+   (PERMISSION-PROMPTS B5/D-171), MUST emit a blocker; this is the
+   regression-fixture acceptance test.
+7. **`TelemetrySite` and `TelemetryConsumer` extractors** plus
+   `TelemetryConsumerCumulative` predicate. Reuses extractor work
+   from the pre-merge-code-gates sibling (its per-PR extractor and
+   this one share `Tau.Coherence.Extract.Telemetry`).
+8. **Issue-opener and dashboard publish tasks**
+   (`Mix.Tasks.Tau.Coherence.OpenIssue`,
+   `Mix.Tasks.Tau.Coherence.PublishStatus`). The opener dedupes by
+   `dedup_key`; the publisher writes to the operability sibling's
+   verdict ingest endpoint per its published contract.
+9. **`main-coherence.yml` wired on `push: branches: [main]` AND
+   `schedule: cron`**, with the silent-skip guard step. This is the
+   merge-blocking activation point for the workflow itself.
+10. **Backfill pass on current `main`** — run the suite against the
+    current HEAD, file issues for every finding (the
+    PERMISSION-PROMPTS contradiction surfaces here), close the
+    issues by remediation, *then* the steady-state guarantee holds.
+
+Each step is a single PR; each PR's AC declares the predicate(s) it
+adds and a regression-fixture test in `test/tau/coherence/` that
+proves the predicate emits the expected finding on a planted
+contradiction.
+
+## Tradeoffs
+
+### Strengths
+
+- **Silent-skip is structurally impossible**, not policy. The check
+  callback signature has no `:skip` arm. The runner records every
+  registered predicate, the verdict schema requires non-empty
+  `checks`, and the workflow asserts registry-count equality.
+  Removing a predicate from the runner without removing it from the
+  registry fails the workflow; adding one to the registry without
+  wiring also fails.
+- **Decomplects facts from predicates from execution from sink.**
+  Adding a new contradiction class is a single new predicate file
+  plus a registry entry — no workflow change, no schema change. Per
+  Hickey: simple = un-braided.
+- **Verdicts are typed data with a published JSON schema** — the
+  operability sibling consumes them by reading a file, not by parsing
+  prose; the dashboard contract is `priv/coherence/verdict.schema.json`,
+  which is version-controlled.
+- **Predicates are pure functions over the manifest** — property-
+  testable with `StreamData` against synthetic manifests, per Tau's
+  invariant-bearing-modules convention (OTP NN #6).
+- **Failure-class #9 caught on first run** by the regression-fixture
+  test: the PERMISSION-PROMPTS B5/D-171 contradiction surfaces as a
+  blocker finding when the suite is wired.
+- **D-NNN uniqueness mechanized**, dissolving the "did the author
+  grep" weave: extractor scans `lib/`, `test/`, `docs/`, `.claude/`
+  in one pass and the predicate emits a blocker per duplicate.
+
+### Weaknesses
+
+- **Manifest extraction is the bottleneck for correctness.** A SPEC
+  whose Appendix B is prose without a sidecar may extract incomplete
+  source-maps; the suite's coverage is bounded by extractor
+  completeness. Mitigation: sidecar requirement in
+  `spec-before-code.md` and a meta-predicate
+  `SourceMapPresence` that emits a finding for any SPEC missing a
+  sidecar (so the gap surfaces as a finding, not as silent partial
+  coverage). Still, a sidecar that lies about its bindings can't be
+  caught without symbol resolution — the next predicate does that,
+  so the gap closes on the second check, not the first.
+- **`SpecContradiction` predicate depends on an "axis" tag in the
+  extracted invariant**, which means SPEC authors must declare a
+  machine-readable axis identifier alongside each invariant (e.g.
+  `<!-- axis: permission_modes -->` in the SPEC source or in the
+  sidecar). Existing SPECs need a one-time annotation pass. Without
+  annotation the predicate cannot distinguish "same axis with
+  conflicting values" from "two unrelated values that happen to be
+  near each other."
+- **Backfill pass (Build-order step 10) may surface dozens of
+  findings on current `main`.** The factory cannot enforce "no
+  blocker findings on `main`" until the backfill is remediated;
+  there is a window where the daily-cadence run will fail every day.
+  Mitigation: the workflow opens *issues*, not auto-reverts;
+  remediation is incremental. The "fails-loud-rather-than-silent"
+  promise still holds.
+- **Telemetry consumer extraction has to model Phoenix.PubSub
+  handlers and `:telemetry.attach`-based handlers**; both forms
+  must be recognized. A non-standard handler registration (a custom
+  GenServer that subscribes via undocumented means) will be invisible
+  and produce a false-positive "no consumer" finding. Mitigation:
+  the predicate is `:warn` severity, not `:blocker`, until the
+  consumer-registration convention is canonicalized in the
+  pre-merge sibling.
+- **Daily cron may file duplicate issues** if dedup is implemented
+  naively. Dedup is by `dedup_key = SHA256(check, locations,
+  message_template)`; the opener consults open issues with the same
+  key first. Adds operational complexity.
+
+### Costs
+
+- **New code surface:** ~6 extractors (200 LOC each) + 5 predicates
+  (~150 LOC each) + manifest types + runner + opener + publisher =
+  roughly **2200 LOC of Elixir** plus ~400 LOC of test scaffolding,
+  spread across ~10 PRs in the Build-order.
+- **New dependencies:** `Sourceror` (Hex package, MIT-licensed; used
+  by `mix format` already, so no transitive impact on the build).
+  No new test deps — `ExUnit` + existing `StreamData`.
+- **SPEC sidecar authoring:** one ~50-line YAML file per SPEC in the
+  catalog; currently 11 SPECs → ~550 lines of curated YAML, written
+  by the SPEC author when authoring or amending a SPEC. Authored once
+  per SPEC; amended only when the SPEC's source-map changes.
+- **CI minutes:** one workflow per `push: branches: [main]` + one
+  per day; estimated 4-6 minutes per run. Negligible vs current
+  `lint` and `mutation-check` jobs.
+- **Storage:** verdict JSON ~10 KB per run, retained as an artifact
+  for 90 days = ~100 verdicts × 10 KB = 1 MB. Negligible.
+
+## Dependencies
+
+- **Pre-merge-code-gates sibling** publishes the
+  `Tau.Coherence.Extract.Telemetry` extractor (shared module) — if
+  it hasn't, this proposal builds it and that sibling consumes from
+  here. Either direction works; one author per module.
+- **Operability-and-hygiene-enforcement sibling** publishes a
+  verdict-ingest contract (a file path the dashboard polls, or an
+  HTTP endpoint the publisher posts to). Until that contract exists,
+  the publisher writes to `_build/coherence/published/` as a stub
+  and the operability sibling reads from there.
+- **`spec-before-code.md` rule update** — add "every SPEC in the
+  catalog MUST have a `SPEC-*.source-map.yaml` sidecar" as an
+  invariant. Without the rule update, the meta-predicate
+  `SourceMapPresence` is the only enforcement and SPEC authors may
+  not understand why the daily check is failing on new SPECs.
+- **Knowledge-memory-and-audit-ingestion sibling** writes structured
+  audit findings in the same `%Finding{}` shape this proposal
+  defines, so the dashboard can render both kinds uniformly — this
+  is a shared-type opportunity, not a hard dependency.
+
+## Confidence
+
+**High.** The substrate is composed of well-understood primitives:
+pure-function manifests, total predicates, JSON-schema-validated
+verdicts, and a GitHub Actions workflow with a registry-equality
+guard. The hardest design risk (silent-skip impossibility) is
+discharged by a typing argument: the callback signature lacks a skip
+arm and the verdict schema requires non-empty `checks`. The PERMISSION-
+PROMPTS B5/D-171 case is a concrete regression fixture that proves
+the substrate works on first run. What would lower confidence: a
+SPEC corpus too varied for the axis-tag convention to land cleanly
+on the first try — but the design lets the predicate emit findings
+incrementally as axes are tagged, with no all-or-nothing migration.
+
+## Prior art / references
+
+- **Sourceror** (`https://github.com/doorgan/sourceror`) — Elixir
+  AST traversal already used by `mix format`; relied on for symbol
+  resolution in `SpecSymbolResolution`.
+- **JSON-schema-validated CI verdicts** — pattern from
+  CodeQL/CodeScan SARIF format; same hardness against silent-skip.
+- **Tau's own `Tau.Factory.Gate`** (per `factory-loop.md`) — the
+  three mechanical gates already follow this pattern (pure function +
+  CLI wrapper + CI wire); this proposal extends the pattern to
+  `main`-side checks rather than per-PR.
+- **OTP behaviours** — predicates are behaviours (`@callback`); the
+  registry uses module pattern matching, consistent with OTP NN #2.

--- a/docs/factory-v2/design/subproblems/post-merge-cross-artifact-coherence/proposals/proposal-2.md
+++ b/docs/factory-v2/design/subproblems/post-merge-cross-artifact-coherence/proposals/proposal-2.md
@@ -1,0 +1,455 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 2
+parent_problem: ../problem.md
+---
+
+# Proposal 2: Scheduled `polya-audit` coherence-agent run on `main`, driven by a YAML rules-pack and a `validation.md → gh issue` adapter
+
+## Approach
+
+Adopt the in-repo `polya-audit` Claude Code plugin
+(`.claude/plugins/polya-audit/`) as the cross-artifact coherence engine.
+Run it as a **scheduled, non-interactive Claude Code subagent** invoked
+from a GitHub Actions workflow that triggers on (a) `push:
+branches: [main]` and (b) `schedule: cron '17 4 * * *'` (daily). The
+agent is the existing **`researcher`** + **`validator`** pair, but
+fronted by a new sub-skill `coherence-audit` (a sibling of
+`code-audit-polya`) whose `SKILL.md` loads a structured rules pack at
+`.claude/plugins/polya-audit/coherence-rules.yaml`. Each rule names a
+contradiction class (D-NNN uniqueness, SPEC §4 symbol resolution, ADR
+supersession integrity, telemetry-emit-without-consumer on `main`, SPEC
+↔ SPEC contradiction by D-NNN id, Appendix-B path liveness) and a
+deterministic detector (a Mix task, an AST grep, a JSON-Schema check, or
+— for the contradiction-by-meaning class — a Claude-call constrained to
+produce a typed `%CoherenceFinding{}` artifact). The agent's output is a
+`validation.md`-shaped artifact under
+`.code_audit/main-coherence/<run-id>/` whose findings a thin Elixir
+escript (`Mix.Tasks.Tau.Coherence.Report`) converts into one GitHub
+issue per finding class, milestoned to the current focus milestone,
+labelled `coherence`, and linked to the run-id directory. The workflow
+fails (exit non-zero) iff `findings_count > 0` OR
+`detectors_attempted < detectors_registered` — the second clause is the
+silent-skip guard.
+
+## Rationale
+
+The leaf's complecting hypothesis decomposes into three weaves: (a)
+"what a SPEC says" vs "what the code does" — linked only by prose
+Appendix-B; (b) "when a contradiction arose" vs "which PR introduced
+it" — invisible per-diff because the contradiction emerges from the
+*combination* of merges; (c) "D-NNN uniqueness" vs "the author
+remembered to grep". A *single-shot, on-`main`, rules-pack-driven
+agent* decomplects all three simultaneously: it sees the whole tree
+(not a diff), it has machine-readable Appendix-B (the rules pack is
+the manifest the leaf's acceptance criterion (e) calls for), and its
+detectors run uniformly regardless of who authored what. Reusing the
+already-present `polya-audit` agents (`researcher`, `validator`,
+`coordinator`) honours root §Acceptance D (ecosystem reuse over
+reinvention) and reduces new code to: one workflow file, one sub-skill
+directory, one YAML rules pack, one escript adapter. The `validator`'s
+Toulmin + falsification protocol gives every finding a documented
+backing claim — addressing root §Hypothesis directly: the coherence
+verdict is *not* "agent says so" but "rule R fired on artifact A at
+location L, with backing evidence B".
+
+## Sketch
+
+### File / module changes
+
+```
+.claude/plugins/polya-audit/skills/coherence-audit/SKILL.md      [NEW]
+.claude/plugins/polya-audit/skills/coherence-audit/rules.md      [NEW]
+.claude/plugins/polya-audit/coherence-rules.yaml                  [NEW]
+.github/workflows/main-coherence.yml                              [NEW]
+lib/mix/tasks/tau.coherence.report.ex                             [NEW]
+lib/mix/tasks/tau.coherence.dnnn.ex                               [NEW]
+lib/mix/tasks/tau.coherence.spec_contracts.ex                     [NEW]
+lib/mix/tasks/tau.coherence.adr_supersession.ex                   [NEW]
+lib/mix/tasks/tau.coherence.appendix_b_liveness.ex                [NEW]
+lib/mix/tasks/tau.coherence.telemetry_consumers.ex                [NEW]
+lib/tau/coherence/finding.ex                                      [NEW]
+lib/tau/coherence/rule.ex                                         [NEW]
+lib/tau/coherence/runner.ex                                       [NEW]
+test/tau/coherence/dnnn_test.exs                                  [NEW]
+test/tau/coherence/spec_contracts_test.exs                        [NEW]
+test/tau/coherence/runner_property_test.exs                       [NEW]
+docs/spec/SPEC-MAIN-COHERENCE.md                                  [NEW]
+```
+
+### Rules-pack schema (`coherence-rules.yaml`)
+
+```yaml
+version: 1
+rules:
+  - id: D-NNN-UNIQ
+    title: D-NNN identifiers are unique across lib/, test/, docs/, .claude/
+    detector:
+      kind: mix_task
+      task: tau.coherence.dnnn
+    fails_loud_on:
+      - duplicate_id
+      - id_in_code_not_in_spec
+    severity: error
+
+  - id: SPEC-S4-RESOLVE
+    title: Every SPEC §4 contract symbol resolves on main
+    detector:
+      kind: mix_task
+      task: tau.coherence.spec_contracts
+    inputs:
+      spec_glob: "docs/spec/SPEC-*.md"
+      section: "## 4"
+      symbol_extractor: erlang_module_callback_struct
+    severity: error
+
+  - id: SPEC-SPEC-CONTRA
+    title: No two SPECs contradict each other on a shared D-NNN
+    detector:
+      kind: agent_constrained
+      agent: validator
+      backing_required: true
+      output_shape: "Tau.Coherence.Finding"
+    severity: error
+
+  - id: ADR-SUPERSEDE
+    title: Supersession links are bidirectional
+    detector:
+      kind: mix_task
+      task: tau.coherence.adr_supersession
+    severity: error
+
+  - id: APPENDIX-B-LIVE
+    title: spec-before-code Appendix B paths exist and at least one symbol per file is mentioned in the SPEC body
+    detector:
+      kind: mix_task
+      task: tau.coherence.appendix_b_liveness
+    severity: error
+
+  - id: TELEMETRY-CONSUMER
+    title: Every :telemetry.execute on main has at least one non-debug consumer
+    detector:
+      kind: mix_task
+      task: tau.coherence.telemetry_consumers
+    severity: warn  # cumulative tail — root #4 already pre-merge-gated
+```
+
+### Module signatures
+
+```elixir
+defmodule Tau.Coherence.Finding do
+  @enforce_keys [:rule_id, :artifact, :location, :message, :backing]
+  defstruct [:rule_id, :artifact, :location, :message, :backing, severity: :error]
+  @type t :: %__MODULE__{
+          rule_id: String.t(),
+          artifact: String.t(),
+          location: String.t(),
+          message: String.t(),
+          backing: [%{kind: atom(), evidence: String.t()}],
+          severity: :error | :warn
+        }
+end
+
+defmodule Tau.Coherence.Runner do
+  @spec run(Path.t()) ::
+          {:ok, %{attempted: non_neg_integer(),
+                  registered: non_neg_integer(),
+                  findings: [Tau.Coherence.Finding.t()]}}
+          | {:error, {:silent_skip_detected, [String.t()]}}
+  def run(rules_yaml_path), do: ...
+end
+
+defmodule Mix.Tasks.Tau.Coherence.Report do
+  use Mix.Task
+  # exit codes:
+  # 0   — all detectors ran, zero findings
+  # 1   — findings present (any severity == :error)
+  # 2   — silent-skip detected (attempted < registered)
+  # 3   — rules.yaml unparseable
+  def run(argv), do: ...
+end
+```
+
+### Workflow (`.github/workflows/main-coherence.yml`)
+
+```yaml
+name: main-coherence
+on:
+  push:
+    branches: [main]
+  schedule:
+    - cron: '17 4 * * *'
+permissions:
+  contents: read
+  issues: write
+concurrency:
+  group: main-coherence
+  cancel-in-progress: false
+jobs:
+  coherence:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+        with: { fetch-depth: 0 }
+      - uses: erlef/setup-beam@v1
+        with: { otp-version: '27.2', elixir-version: '1.18.1' }
+      - run: mix deps.get --only test
+      - run: mix tau.coherence.report --rules .claude/plugins/polya-audit/coherence-rules.yaml --out .code_audit/main-coherence/${{ github.run_id }}/
+        id: cohere
+      - name: Open issues for findings
+        if: failure()
+        env: { GH_TOKEN: ${{ secrets.GITHUB_TOKEN }} }
+        run: |
+          set -euo pipefail
+          for f in .code_audit/main-coherence/${{ github.run_id }}/*.finding.json; do
+            gh issue create \
+              --label coherence \
+              --milestone "$(gh api repos/${{ github.repository }}/milestones --jq '.[] | select(.state=="open") | .title' | head -1)" \
+              --title "coherence: $(jq -r .rule_id $f) at $(jq -r .artifact $f):$(jq -r .location $f)" \
+              --body-file $f
+          done
+      - name: Silent-skip guard
+        if: steps.cohere.outputs.exit_code == '2'
+        run: |
+          echo "::error::Silent-skip detected: detectors_attempted < detectors_registered"
+          exit 2
+```
+
+### Agent invocation (used only for `SPEC-SPEC-CONTRA`)
+
+The `coherence-audit` sub-skill, when handed an `agent_constrained`
+rule, invokes the existing `polya-audit` `researcher` agent (already
+isolated, Read-only) with a typed output prompt that demands one JSON
+object per `Tau.Coherence.Finding` field; the runner rejects any output
+that does not parse, treating that as a detector failure (silent-skip
+class), not a "no findings" pass.
+
+## Tradeoffs
+
+### Strengths
+
+- **Maximises ecosystem reuse (acceptance D).** Reuses
+  `.claude/plugins/polya-audit/agents/researcher.md`,
+  `.../agents/validator.md`, and the entire `.../templates/` tree.
+  New code is bounded to ~5 Mix tasks (≤ 250 LOC each), 1 YAML pack,
+  1 workflow, 1 escript adapter, 1 SPEC. Estimated < 1.5 KLOC new
+  Elixir.
+- **Silent-skip impossibility is structural, not procedural.** Exit
+  code 2 means *the runner could not attempt a registered rule*; the
+  workflow surfaces this as a hard failure with `::error::` and a
+  distinct GitHub Check annotation. There is no `|| true`; there is
+  no path where `findings == 0` AND `attempted < registered` returns
+  green.
+- **`validator`'s Toulmin discipline is load-bearing.** Each finding
+  ships its backing evidence (file:line, AST node, grep hit). The
+  v1 PERMISSION-PROMPTS B5/D-171 case detects on first run: rule
+  `SPEC-SPEC-CONTRA` finds D-171 cited with two different cardinalities
+  (6 vs 3) and emits a `%Finding{}` with both backings.
+- **Cadence + push-trigger gives O(hours) detection of cumulative-tail
+  drift.** Root §Hypothesis #1 / #4 (the tails) are caught by daily
+  cron even when no PR touches the relevant surface.
+- **Rules pack is the manifest.** Acceptance criterion (a) requires a
+  "structured source-map manifest format" — the YAML rules pack with
+  per-rule `inputs.spec_glob` and `symbol_extractor` IS that manifest;
+  it lives next to the plugin that consumes it.
+
+### Weaknesses
+
+- **`SPEC-SPEC-CONTRA` rule is the one detector that depends on a
+  Claude call.** Even with strict output-schema enforcement, this
+  rule's recall is not deterministic across runs. Mitigation: the
+  runner pins the model + prompt + temperature, but a missed
+  contradiction will not be re-detected until the next cadence run,
+  and a hallucinated contradiction will spam issues until quashed.
+  The other five rules are pure-AST / pure-grep and deterministic.
+- **GitHub Actions cron jitter (≥ 15-minute documented variance) and
+  the lack of guaranteed exactly-once scheduling.** Two cron runs may
+  fire close together; the `concurrency` group prevents overlap but
+  may cause skipped runs. Detection latency floor is therefore ~15
+  minutes + run time, not "real time on push".
+- **Adds a new failure surface in the `gh issue create` step.** A
+  GitHub API outage produces a workflow failure that looks like a
+  coherence failure (post-`if: failure()` step never runs and findings
+  go undelivered). Distinguishing the two requires inspecting the
+  workflow step log, not the issue tracker. Partial mitigation:
+  upload findings as workflow artifact unconditionally.
+- **No fix-suggesting agent.** Findings open issues; they don't open
+  PRs. The leaf's acceptance does not require fixes, only detection;
+  the operability sibling consumes verdicts. But a high finding rate
+  will increase coordinator backlog management work.
+- **Cron-driven Claude invocation has a non-zero token cost per run**
+  (~5 K input + agent reasoning; estimated < $0.05/day at current
+  Sonnet pricing for the `SPEC-SPEC-CONTRA` rule only; pure-AST rules
+  use zero tokens). Annual cost ≤ $20 — accepted.
+
+### Costs
+
+- **New code:** ~1.5 KLOC Elixir + 1 YAML + 1 workflow + 1 SPEC
+  (~400 LOC).
+- **New deps:** `yaml_elixir` for rules-pack parsing (already a common
+  dep in the ecosystem; lightweight). `sourceror` for AST walks in
+  `tau.coherence.spec_contracts` and `tau.coherence.telemetry_consumers`
+  — already pulled transitively by `credo` (check `mix deps.tree`);
+  add explicit dep for safety.
+- **CI minutes:** estimated 6-12 min per main push or cron tick. Two
+  push-runs per day average + 1 cron = ~30 min/day, well within free
+  tier.
+- **Knowledge:** maintainer must understand the YAML rules-pack schema
+  + the `Tau.Coherence.Finding` shape. Both are documented in
+  `SPEC-MAIN-COHERENCE.md` (the SPEC is a deliverable of this proposal,
+  consistent with `spec-before-code.md`).
+
+## Dependencies
+
+- The `polya-audit` plugin remains at `.claude/plugins/polya-audit/`
+  (currently present; not removed by any in-flight work).
+- The operability sibling
+  (`subproblems/operability-and-hygiene-enforcement/`) consumes the
+  `.code_audit/main-coherence/<run-id>/*.finding.json` artifact for
+  the dashboard. This proposal produces them; the dashboard reads them.
+- The audit-ingestion sibling
+  (`subproblems/knowledge-memory-and-audit-ingestion/`) MAY reuse
+  `Tau.Coherence.Finding` as its finding shape — coordinate.
+- `mix tau.coherence.report` requires GitHub-Actions context to open
+  issues; locally it dumps JSON and prints the would-be-created issues
+  to stdout.
+
+## Confidence
+
+**Medium-high.** The pattern (scheduled GH Actions workflow + Mix task
++ thin agent wrapper) is well-trodden in the Elixir / Claude Code
+ecosystem; the unknown is recall on `SPEC-SPEC-CONTRA`. What would
+raise confidence: a one-day prototype of `tau.coherence.dnnn` +
+`tau.coherence.spec_contracts` run against current `main` — both
+should already produce ≥ 1 finding (D-171 cardinality contradiction,
+known SPEC §4 callbacks-that-no-longer-resolve). If those two
+deterministic rules light up on first run, the architecture is
+validated; the `SPEC-SPEC-CONTRA` agent-rule can be added in a follow-up.
+
+## Prior art / references
+
+- `.claude/plugins/polya-audit/` (this repo) — the in-repo Pólya-tree
+  audit plugin; `researcher` and `validator` agents have the exact
+  shape this proposal reuses.
+- `.code_audit/skills/code-audit-polya/validate.md` — the Toulmin +
+  falsification protocol that each finding's `backing` field
+  conforms to.
+- `.github/workflows/ci.yml:88-100, :115, :213-223` — the silent-skip
+  patterns this proposal's exit-code-2 guard makes structurally
+  impossible (root §Acceptance C anti-pattern).
+- `.claude/rules/spec-before-code.md` Appendix-B convention — the
+  current prose manifest the YAML rules pack supersedes for
+  machine-resolvable use.
+- `.claude/skills/loop/` — the `/loop` skill is Tau's existing
+  scheduled-driver primitive; the GitHub Actions cron is the
+  *production* equivalent of `/loop`'s local interval, chosen because
+  cron survives the operator's machine being off and because GH
+  Actions provides the secret + token context for `gh issue create`.
+- `docs/factory-v2/PLAN.md` Workstream-1 § "Adapt-from-Claude-Code-
+  ecosystem" — this proposal's directive.
+- GitHub Actions `schedule` event docs
+  (https://docs.github.com/actions/using-workflows/events-that-trigger-workflows#schedule)
+  — confirms ≥ 15-minute jitter caveat noted under Weaknesses.
+- `Sourceror` (https://hexdocs.pm/sourceror) — for AST walks; produces
+  source-position metadata used by `Finding.location`.
+
+## §Build-order (favouring adopt over invent)
+
+1. **(adopt)** Wire `.github/workflows/main-coherence.yml` to invoke
+   the existing `polya-audit` plugin's `researcher` agent in
+   read-only mode against a single hardcoded rule (`D-NNN-UNIQ`)
+   using a stub `coherence-rules.yaml`. Verify the workflow runs
+   green on `main`; verify silent-skip guard fires when the rule
+   list is empty. **Adopt-vs-invent: 95% adopt** (one new YAML
+   workflow + one stub Mix task that grep-and-counts D-NNNs).
+2. **(adopt)** Author `coherence-rules.yaml` with all six rules but
+   only wire the three deterministic Mix-task detectors
+   (`D-NNN-UNIQ`, `APPENDIX-B-LIVE`, `ADR-SUPERSEDE`). Reuses the
+   existing plugin's skill-loading machinery. **Adopt-vs-invent:
+   ~70%.**
+3. **(invent — minimum-viable)** Author the four Mix-task detectors
+   + `Tau.Coherence.Finding` + `Tau.Coherence.Runner` + SPEC. This
+   is the bulk of the new code, but each task is small and
+   independent. **Adopt-vs-invent: ~20%; Sourceror is the only
+   pulled dep doing meaningful work.**
+4. **(adopt)** Author `Mix.Tasks.Tau.Coherence.Report` as a thin
+   shim over `gh issue create` (no new HTTP client; subprocess gh).
+   **Adopt-vs-invent: 90% adopt** (the `gh` CLI is already in CI).
+5. **(adopt + minimum invent)** Add the `SPEC-SPEC-CONTRA`
+   agent-constrained rule last, after the deterministic rules are
+   green. Reuses the `validator` agent's existing schema-output
+   discipline; the new code is a JSON-schema validator over the
+   agent's output (≤ 80 LOC). **Adopt-vs-invent: 75% adopt.**
+6. **(adopt)** Add `TELEMETRY-CONSUMER` rule using the existing
+   pre-merge sibling's telemetry-consumer detector run in
+   cumulative-on-`main` mode. **Adopt-vs-invent: 100% adopt** if
+   the pre-merge sibling has shipped; trivial wrapper otherwise.
+
+Total new Elixir ≤ 1.5 KLOC, ≥ 70% reuse weight across the build
+order — satisfying root §Acceptance D.
+
+## §Gaps (honestly enumerated)
+
+- **G1 — `SPEC-SPEC-CONTRA` recall.** A subtle contradiction phrased
+  in differing prose between two SPECs may not be detected by the
+  Claude-call. Reduces strict-coverage of root §Hypothesis #9 to
+  "high-recall on D-NNN-keyed contradictions; medium-recall on
+  free-prose contradictions." Mitigation: the deterministic `D-NNN-
+  UNIQ` rule catches the v1 PERMISSION-PROMPTS B5/D-171 case
+  unconditionally because the contradiction surfaces on the D-NNN
+  identifier — Hypothesis #9's canonical example is covered
+  deterministically.
+- **G2 — Issue-noise.** A single misconfiguration may cause N
+  duplicate issues. Mitigation: `Mix.Tasks.Tau.Coherence.Report`
+  deduplicates by `(rule_id, artifact, location)` against open
+  `coherence`-labelled issues before creating, but the dedup is in
+  the new code, not in `gh` itself.
+- **G3 — Workflow failure ≠ coherence failure.** If GH Actions has
+  an outage during a run, the lack of an issue is indistinguishable
+  from "no findings". Mitigation: every run uploads the
+  `findings.json` artifact unconditionally so post-hoc inspection is
+  possible; the operability sibling's dashboard surfaces "last
+  successful coherence run timestamp" so stale-run states are
+  visible.
+- **G4 — Cron schedule drift.** GitHub Actions does not guarantee
+  cron precision; in practice runs may be skipped or delayed up to
+  ~30 minutes. Mitigation: the `push: branches: [main]` trigger
+  fires the same suite on every merge, so the cron is a backstop,
+  not the primary detection mode. Worst-case detection latency for
+  drift introduced by a non-`main`-touching event (e.g. a docs-only
+  merge that exposes a contradiction): ≤ next push to `main` OR
+  ≤ next cron tick.
+- **G5 — The plugin lives in `.claude/plugins/` (uncommitted-tooling-
+  area).** If a future plugin reorganisation moves it, the workflow
+  path breaks. Mitigation: pin the path in `SPEC-MAIN-COHERENCE.md`
+  Appendix-B and make plugin relocation a SPEC-amendment-requiring
+  event.
+
+## §Silent-skip impossibility (per leaf acceptance (b) and root §Acceptance C)
+
+The runner enforces three invariants in code:
+
+1. **Registered-but-unattempted is exit 2, not 0.** The rules pack
+   declares N rules; `Tau.Coherence.Runner.run/1` MUST instantiate a
+   detector for each. If `attempted < registered`, the runner returns
+   `{:error, {:silent_skip_detected, names}}` and the Mix task exits 2.
+   The workflow treats exit 2 as a hard `::error::` annotation
+   distinct from `exit 1` ("findings present").
+2. **Empty applicability is not skip.** A detector that finds 0
+   matches (e.g. `APPENDIX-B-LIVE` on a repo with no SPECs) explicitly
+   logs `{rule_id: ..., attempted: true, findings: 0, scope: empty}`.
+   The runner counts it as attempted.
+3. **No `|| true`, no `continue-on-error: true`.** The workflow has
+   neither; CI configurations adding either to the `mix
+   tau.coherence.report` step trip a separate `lint` job that greps
+   `.github/workflows/main-coherence.yml` for those tokens
+   (regression test exists at
+   `test/tau/coherence/workflow_format_test.exs`).
+
+The v1 anti-patterns at `ci.yml:88-100`, `:115`, `:213-223` are
+structurally impossible because the workflow has no per-rule
+conditional steps; one Mix task runs all rules, and the silent-skip
+guard is part of the Mix task's exit-code contract, not a YAML
+expression that can be deleted in a future edit.

--- a/docs/factory-v2/design/subproblems/post-merge-cross-artifact-coherence/proposals/proposal-3.md
+++ b/docs/factory-v2/design/subproblems/post-merge-cross-artifact-coherence/proposals/proposal-3.md
@@ -1,0 +1,437 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 3
+parent_problem: ../problem.md
+---
+
+# Proposal 3: Continuous Architectural Fitness Functions for cross-artifact coherence on `main`
+
+## Approach
+
+Adopt the **Continuous Architectural Fitness Function** discipline from
+Ford/Parsons/Kua (*Building Evolutionary Architectures*) and instantiate it
+as a `main`-side check suite under a new `priv/fitness/` Mix project that
+runs on every `push: branches: [main]` and on a daily `schedule` cron. Each
+**coherence invariant** is encoded as a *named fitness function* — a pure
+function that consumes the repository snapshot (a checked-out worktree at
+the post-merge SHA) and returns a `%Tau.Fitness.Verdict{}` (`:pass`,
+`:fail`, `:not_applicable` — never absent, never `:skipped`). The suite is
+modelled after **SonarQube's quality-gate baseline** (a versioned manifest
+of named conditions with required thresholds) and reports verdicts via the
+**OpenTelemetry post-deploy verification** pattern (every fitness function
+emits a `[:tau, :fitness, :function, :stop]` span; the dashboard reads the
+OTLP stream rather than parsing CI logs). On any `:fail` the suite opens a
+GitHub issue auto-milestoned to the focus milestone and tagged
+`area:coherence`, populated from a deterministic template that enumerates
+the contradicting artifacts; **Erlang/OTP system-tests' loud-failure
+discipline** is the cultural anchor — there is no "warning" verdict, only
+pass/fail/N-A. Adapted from **Sentry Release Health** and **canary analysis
+(Flagger/LaunchDarkly)**: each merge to `main` is treated as a "release";
+the suite is the release's automated post-deploy verification; a failing
+verdict marks `main` as **degraded** in the dashboard's release-health view
+and the factory-loop's pre-merge gate refuses to merge new PRs until the
+degradation is resolved or explicitly waived with an expiring `WAIVER`
+entry (CodeClimate-style technical-debt baseline).
+
+## Rationale
+
+The complecting hypothesis names three weaves: (a) "what a SPEC says" with
+"what the codebase does" via prose-only Appendix B; (b) "when a
+contradiction emerged" with "which PR introduced it"; (c) "D-NNN
+uniqueness" with "the author remembered to grep." Fitness functions
+**decomplect verdict from author intent**: the function runs unconditionally
+on `main`, against the post-merge artifact set, irrespective of who merged
+what when. SonarQube's baseline-manifest pattern decomplects "what is
+checked" from "what each check does" — a versioned `fitness.toml`
+enumerates every invariant, so a gate that has nothing to check returns
+`:not_applicable` against a named, audited entry rather than silently
+not-running (root §Acceptance C). OpenTelemetry post-deploy verification
+decomplects "verdict emission" from "verdict consumption" — the dashboard,
+the issue-opener, and the factory's pre-merge gate all subscribe to the
+same span stream rather than racing each other to parse CI artifacts.
+Sentry Release Health and Flagger canary analysis decomplect "merge
+happened" from "merge is healthy" — a merge that introduces a SPEC↔SPEC
+contradiction is a *degraded release*, not merely a closed PR, and the
+factory's downstream behaviour reflects that. The OTP system-test ethos
+decomplects "failure detected" from "human decides what to do" — the issue
+opens automatically, with structured evidence, not after a human review of
+a flaky-test report.
+
+## Sketch
+
+### Repository layout
+
+```
+priv/fitness/                          # new mini-Mix project (not part of main app)
+  mix.exs
+  lib/
+    tau/fitness.ex                     # entry point: load manifest, run suite, emit OTLP
+    tau/fitness/verdict.ex             # %Verdict{name, status, evidence, duration_ms}
+    tau/fitness/manifest.ex            # parse priv/fitness/fitness.toml
+    tau/fitness/runner.ex              # execute one fitness function; emit telemetry span
+    tau/fitness/reporter/issue.ex      # GitHub issue opener (uses `gh` CLI)
+    tau/fitness/reporter/otlp.ex       # OpenTelemetry exporter
+    tau/fitness/reporter/release.ex    # Sentry-style release-health write
+    tau/fitness/functions/
+      dnnn_uniqueness.ex               # FF-001
+      spec_contract_symbols.ex         # FF-002
+      spec_cross_contradiction.ex      # FF-003
+      adr_supersession_integrity.ex    # FF-004
+      telemetry_consumer_cumulative.ex # FF-005
+      appendix_b_path_resolution.ex    # FF-006
+  priv/
+    fitness.toml                       # baseline manifest (versioned)
+    waivers.toml                       # expiring-waiver registry (CodeClimate-style)
+  test/
+    tau/fitness/                       # property tests per FF + golden-cases for v1 bugs
+```
+
+### Behaviour and verdict shape
+
+```elixir
+defmodule Tau.Fitness.Function do
+  @moduledoc "Behaviour for one coherence invariant. Pure; deterministic; loud."
+  @callback id() :: String.t()                    # e.g. "FF-003"
+  @callback name() :: String.t()                  # human title
+  @callback applies?(repo_snapshot :: map()) :: boolean()
+  @callback evaluate(repo_snapshot :: map()) :: Tau.Fitness.Verdict.t()
+  # No silent-skip: applies?/1 false ==> verdict %{status: :not_applicable, evidence: reason}
+end
+
+defmodule Tau.Fitness.Verdict do
+  @enforce_keys [:function_id, :status, :evidence, :duration_ms]
+  defstruct [:function_id, :status, :evidence, :duration_ms, :sha, :emitted_at]
+  @type status :: :pass | :fail | :not_applicable
+  # NOTE: there is no :skipped, :warning, :unknown — those are bugs, not statuses.
+end
+```
+
+### Manifest (SonarQube-baseline pattern)
+
+```toml
+# priv/fitness/fitness.toml
+schema_version = 1
+
+[[function]]
+id = "FF-001"
+module = "Tau.Fitness.Functions.DnnnUniqueness"
+required = true
+description = "Every D-NNN identifier in lib/test/docs/.claude has one definition."
+
+[[function]]
+id = "FF-002"
+module = "Tau.Fitness.Functions.SpecContractSymbols"
+required = true
+description = "Every module/function/struct/callback named in any SPEC §4 resolves on main."
+
+[[function]]
+id = "FF-003"
+module = "Tau.Fitness.Functions.SpecCrossContradiction"
+required = true
+description = "No two SPEC entries make contradictory claims about the same surface (e.g. PERMISSION-PROMPTS §4 B5 vs §6 D-171)."
+
+[[function]]
+id = "FF-004"
+module = "Tau.Fitness.Functions.AdrSupersessionIntegrity"
+required = true
+description = "Every ADR claiming `supersedes: ADR-N` is matched by ADR-N having `superseded_by: ADR-M` (bidirectional)."
+
+[[function]]
+id = "FF-005"
+module = "Tau.Fitness.Functions.TelemetryConsumerCumulative"
+required = true
+description = "Every `:telemetry.execute/3` site in lib/ has ≥1 registered handler in lib/ (no consumer-removal-without-emission-removal)."
+
+[[function]]
+id = "FF-006"
+module = "Tau.Fitness.Functions.AppendixBPathResolution"
+required = true
+description = "Every file path named in any SPEC's Appendix B source-map exists on main."
+```
+
+### Workflow wiring
+
+```yaml
+# .github/workflows/main-coherence.yml
+name: main-coherence
+on:
+  push:
+    branches: [main]
+  schedule:
+    - cron: "0 7 * * *"        # daily 07:00 UTC drift sweep
+  workflow_dispatch:           # manual rerun
+jobs:
+  fitness:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with: { fetch-depth: 0 }
+      - uses: erlef/setup-beam@v1
+        with: { version-file: .tool-versions, version-type: strict }
+      - name: Run fitness suite
+        run: mix tau.fitness.run --manifest priv/fitness/fitness.toml --report otlp,issue,release
+        # Exit codes:
+        #   0 = all required functions :pass or :not_applicable
+        #   2 = at least one required function :fail
+        #   3 = infrastructure failure (manifest parse error, missing FF module, etc.)
+        # No `|| true`. No early-exit on empty inputs.
+      - name: Upload verdicts artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: fitness-verdicts
+          path: _build/fitness/verdicts.json
+```
+
+### Mix-task entry
+
+```elixir
+defmodule Mix.Tasks.Tau.Fitness.Run do
+  use Mix.Task
+  @shortdoc "Run the post-merge fitness suite against the current main."
+  def run(argv) do
+    {opts, _, _} = OptionParser.parse(argv,
+      strict: [manifest: :string, report: :string])
+    snapshot   = Tau.Fitness.Snapshot.capture(File.cwd!())
+    manifest   = Tau.Fitness.Manifest.load!(opts[:manifest])
+    verdicts   = Tau.Fitness.Runner.run_all(manifest, snapshot)
+    :ok        = Tau.Fitness.Reporter.dispatch(verdicts, parse_reports(opts[:report]))
+    exit_code  = Tau.Fitness.exit_code_for(verdicts)
+    System.halt(exit_code)
+  end
+end
+```
+
+### Silent-skip impossibility — mechanism
+
+Three reinforcing constraints make a silent skip structurally impossible:
+
+1. **Manifest is the source of truth.** `Runner.run_all/2` iterates the
+   manifest, not the filesystem. A function listed in `fitness.toml` but
+   whose module does not exist on `main` produces a `:fail` verdict with
+   evidence `{:missing_module, id}` — exit code 2. A function listed but
+   not `required` still runs; only its `required` flag governs exit-code
+   contribution.
+2. **No `:skipped` status exists.** `Verdict.status` is the type
+   `:pass | :fail | :not_applicable`. A function whose `applies?/1`
+   returns false MUST still produce a `:not_applicable` verdict with
+   evidence describing *why* (e.g. `{:no_spec_files_found, [...]}`). The
+   runner asserts every manifest entry produced exactly one verdict and
+   crashes (exit 3) if any are absent.
+3. **`mix.exs` of `priv/fitness/` has zero non-stdlib runtime deps.** The
+   suite cannot fail to install. The workflow has no conditional `if:` on
+   the `mix tau.fitness.run` step; it runs unconditionally on every
+   trigger. There is no `continue-on-error` and no `|| true`.
+
+### Concrete v1-bug repro test (golden case)
+
+```elixir
+# test/tau/fitness/functions/spec_cross_contradiction_test.exs
+defmodule Tau.Fitness.Functions.SpecCrossContradictionTest do
+  use ExUnit.Case, async: true
+  alias Tau.Fitness.Functions.SpecCrossContradiction, as: FF
+
+  test "detects PERMISSION-PROMPTS §4 B5 vs §6 D-171 mode-count contradiction" do
+    snapshot = Tau.Fitness.Snapshot.from_fixture("test/fixtures/permission_prompts_v1_bug")
+    verdict  = FF.evaluate(snapshot)
+    assert verdict.status == :fail
+    assert {:contradiction, "D-171", _details} in verdict.evidence
+  end
+end
+```
+
+If FF-003 ever returns `:pass` against the v1-bug fixture, the suite has
+regressed and CI fails before it even reaches `main`.
+
+### Waiver registry (CodeClimate technical-debt baseline)
+
+```toml
+# priv/fitness/waivers.toml
+# An expiring escape hatch. A waiver flips a specific (function_id, evidence_hash)
+# from :fail to :pass for a bounded window. Beyond expiry, the fail returns.
+[[waiver]]
+function_id    = "FF-005"
+evidence_hash  = "sha256:abc...123"
+reason         = "Issue #482 — telemetry handler removal lands in next PR"
+expires_at     = "2026-06-30T00:00:00Z"
+opened_by      = "brent.walter@gmail.com"
+```
+
+A waiver is granted only via PR (so it goes through the pre-merge gate
+suite). The fitness runner refuses to honour a waiver past `expires_at`.
+The dashboard surfaces active waivers and their countdown.
+
+## Tradeoffs
+
+### Strengths
+
+- **Direct fit to acceptance criterion (a).** Each named check in the
+  acceptance criterion maps 1:1 to a fitness function (FF-001..FF-006);
+  the manifest is the audit trail.
+- **Mechanically enforces acceptance criterion (c) silent-skip
+  impossibility.** Status enum has no `:skipped`; manifest-driven
+  iteration cannot silently drop a check; no `|| true` anywhere.
+- **Single span stream serves dashboard, issue-opener, factory-loop
+  pre-merge gate** (criterion d). OpenTelemetry decomplects verdict
+  emission from consumption — sibling **operability** subproblem consumes
+  the same stream without extra plumbing.
+- **Reuses ecosystem patterns** (criterion d): SonarQube baseline,
+  OpenTelemetry OTLP, CodeClimate waiver model, Sentry release-health,
+  Flagger canary halts. Bespoke surface limited to the FF modules
+  themselves, justified because no off-the-shelf check understands Tau's
+  `SPEC §4` / D-NNN / Appendix B conventions.
+- **Forward-compatible with audit ingestion** (sibling
+  **knowledge-memory-and-audit-ingestion**): a new audit finding becomes
+  a new entry in `fitness.toml` plus a new FF module — same shape, same
+  enforcement, same dashboard view.
+- **Failure → action is mechanical.** Sentry/Flagger pattern: a `:fail`
+  marks `main` degraded and the factory's pre-merge gate refuses new
+  merges until resolved or explicitly waived. No "follow-up issue"
+  deflection.
+- **Property-test friendly.** Each FF is a pure function over a
+  snapshot — ideal for StreamData property tests and golden fixtures.
+
+### Weaknesses
+
+- **Manifest can rot.** If `fitness.toml` is edited carelessly (a
+  required FF demoted to non-required, an FF removed), the suite weakens
+  without anyone noticing. Mitigation: a meta-FF (FF-000) that asserts
+  the manifest at HEAD is a superset of the manifest from the most
+  recent tagged release; manifest-shrinking requires an ADR. Cost: a new
+  enforcement surface to maintain.
+- **Waivers can become permanent debt** if no human watches the expiry.
+  Mitigation: the dashboard's release-health view highlights waivers in
+  their final 7 days red; the OperationsAndHygiene sibling owns
+  surfacing this. Risk remains: a waiver can be renewed indefinitely by
+  PR. Renewal requires re-justification, but enforcement is social.
+- **OpenTelemetry exporter complexity.** Adds an OTLP endpoint to the
+  factory's operational dependencies; offline / sandboxed CI runs need a
+  null exporter fallback. Cost: one more moving piece.
+- **GitHub-issue-opener is a side effect with a token.** The Action
+  needs `issues: write` and `GH_TOKEN`; misconfiguration silently
+  prevents issue creation. Mitigation: the OTLP span is the source of
+  truth; the issue is a notification. The reporter logs a structured
+  error when issue creation fails but does NOT change the verdict.
+- **`Tau.Fitness.Snapshot.capture/1` is non-trivial.** Parsing every
+  SPEC's §4 to extract "named symbols" is bespoke; brittle to SPEC
+  format drift. Mitigation: SPEC §4 is constrained to a fenced
+  block with declared schema (an upstream amendment to
+  `spec-before-code.md`) — but that amendment is a prerequisite, not a
+  given.
+- **Daily cron + per-push triggers means redundant runs.** Cost is
+  small (one CI minute), but noisy. Mitigation: dedupe on SHA in the
+  reporter.
+- **The fitness functions themselves are code that can have bugs.** An
+  FF that false-passes is invisible; an FF that false-fails wastes
+  cycles. Mitigation: each FF ships with a golden-fixture test
+  (positive: a v1 bug it must detect; negative: a `main` snapshot it
+  must pass against) and a StreamData property where applicable.
+
+### Costs
+
+- **New Mix project**: ~12 modules + manifest + waiver registry +
+  schemas + ~6 FF modules with tests each. Estimate: ~1500 LoC initial.
+- **New CI workflow**: `.github/workflows/main-coherence.yml` (~40
+  lines).
+- **New runtime dependency**: `opentelemetry_exporter` (+
+  `opentelemetry_api`, already in Tau for B3 — check). If absent, add.
+- **Operational cost**: OTLP collector endpoint (or a self-hosted
+  Jaeger / Tempo / SigNoz instance for the dashboard). Or a file-based
+  collector for the MVP, swappable later. Sibling **operability** owns
+  the receiving surface.
+- **One-off content cost**: SPEC §4 sections must be parseable. PR to
+  `spec-before-code.md` to add a fenced-block schema constraint —
+  modest amendment, one PR.
+- **Documentation**: ADR explaining the fitness-function model and the
+  manifest-evolution policy.
+- **Cadence**: ~1 CI minute per push + ~1 CI minute per day. Negligible
+  $.
+
+## Dependencies
+
+- **spec-before-code.md amendment**: SPEC §4 declares symbols in a
+  fenced block with a stable schema (so FF-002 can parse mechanically).
+  Estimate: one small PR.
+- **Sibling pre-merge-evidence-and-skip-integrity solution** must
+  guarantee CI's `mix tau.fitness.run` step is never wrapped in `|| true`
+  and the workflow has no `continue-on-error` — this proposal *assumes*
+  that invariant is enforced upstream of itself; without it, fitness
+  functions can be silently neutered at the workflow layer.
+- **Sibling operability-and-hygiene-enforcement** consumes the OTLP
+  stream and presents the dashboard view; that integration must exist
+  for criterion (c)'s "alarm the dashboard" half. If absent at v2
+  launch, the issue-opener half (criterion c first half) still works
+  standalone.
+- **Sibling knowledge-memory-and-audit-ingestion** writes its outputs
+  as new FF entries; needs an agreed shape (FF module + manifest entry).
+- **GitHub Actions secrets**: `GH_TOKEN` with `issues: write`,
+  `contents: read`, `actions: read`. Repository setting.
+- **Optional**: an OTLP collector. For the MVP, a JSON file under
+  `_build/fitness/verdicts.json` is sufficient; the dashboard reads it
+  via a Phoenix LiveView in the operability sibling.
+
+## Confidence
+
+**High** for the fitness-function-as-discipline core (Ford/Parsons/Kua's
+pattern is widely deployed in industry — ThoughtWorks Technology Radar
+elevated it to Adopt in 2018), the SonarQube baseline-manifest shape,
+and the loud-failure verdict enum (OTP system-test convention is
+boringly battle-tested). **Medium** for the OTLP-as-single-source-of-
+truth coupling — viable but introduces operational dependency on a
+collector; if rejected, a JSON-file fallback degrades the dashboard
+side without weakening the core gate. **Medium** for the SPEC §4
+parseability assumption — requires a small upstream amendment to
+`spec-before-code.md`; high-confidence achievable but not free.
+
+What would raise confidence to high across the board: a 1-day spike
+implementing FF-001 (D-NNN uniqueness) end-to-end against the current
+`main` and verifying it detects the known duplicates in the codebase
+(if any) while emitting an OTLP span the operability dashboard renders.
+
+## Prior art / references
+
+- **Ford, Parsons, Kua — *Building Evolutionary Architectures* (O'Reilly,
+  2017; 2nd ed. 2022)**: the canonical text on architectural fitness
+  functions. Chapter 2 defines the term; Chapter 5 covers
+  cross-component / "holistic" fitness functions, which is what this
+  leaf needs.
+- **ThoughtWorks Technology Radar (Vol. 19, Apr 2018)**: architectural
+  fitness functions elevated to "Adopt."
+- **SonarQube Quality Gates** —
+  <https://docs.sonarsource.com/sonarqube-server/latest/instance-administration/analysis-functions/quality-gates/>:
+  baseline-manifest model; "new code" vs "overall code" partition;
+  required/optional conditions; mandatory pass/fail emission.
+- **CodeClimate Maintainability + Technical Debt** —
+  <https://docs.codeclimate.com/docs/maintainability>: debt ratio as
+  baseline; the waiver-with-expiry pattern is adapted from CodeClimate's
+  issue snooze + reopening flow.
+- **Sentry Release Health** —
+  <https://docs.sentry.io/product/releases/health/>: a release is
+  "healthy / unhealthy / degraded" based on automated post-deploy
+  signals; halts deployment of subsequent releases under a degraded
+  state.
+- **OpenTelemetry "Post-Deploy Verification"** — Honeycomb, Lightstep,
+  Tempo, and the OTel community pattern of emitting deploy-marker
+  spans + automated verification spans on the same trace; consumers
+  subscribe rather than scrape logs.
+- **Erlang/OTP `common_test` and system-test discipline** —
+  Joe Armstrong's "let it crash" philosophy applied at the test
+  level: a system test that detects a regression *fails*; there is no
+  "warning" state. Adapted here as the no-`:warning`-status invariant.
+- **LaunchDarkly Release Guard / Flagger canary analysis** —
+  <https://docs.flagger.app/usage/metrics>: a canary analysis emits a
+  pass/fail decision after a defined window; the deployment proceeds
+  or rolls back automatically. Adapted as "degraded `main` blocks new
+  merges until resolved."
+- **GitHub's own ruleset / required-checks** —
+  <https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets>:
+  enforces that named required checks must pass before merge; the
+  `main-coherence` job is added to the required-check list, closing
+  the loop between fitness verdict and pre-merge gate (criterion d's
+  reuse — branch protection is GitHub-native, not bespoke).
+- **Project-internal**: existing `.github/workflows/ci.yml` and the
+  `mix tau.gate.ac_linkage` / `mix tau.gate.masking` / `mix
+  tau.gate.mutation` Mix tasks established by PR-B / issue #370 are
+  the *per-PR* precedent — the fitness suite is the *per-`main`*
+  generalisation of that same shape.

--- a/docs/factory-v2/design/subproblems/post-merge-cross-artifact-coherence/proposals/proposal-4.md
+++ b/docs/factory-v2/design/subproblems/post-merge-cross-artifact-coherence/proposals/proposal-4.md
@@ -1,0 +1,387 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 4
+parent_problem: ../problem.md
+---
+
+# Proposal 4: Adversarial main-side coherence — construct the joint-state failure, then build the trap for it
+
+## Approach
+
+Treat the coherence check not as a "lint the spec" task but as a property
+suite whose properties are derived **adversarially from constructed
+failures**: for each failure pattern that v1 demonstrably tolerated, write
+the smallest two-PR (or single-edit) construction that produces the bad
+joint state, then build the `main`-side check whose contract is "this exact
+joint state is impossible to reach without the check tripping." The check
+runs on every push to `main` and on a 24h cadence; on failure it opens a
+GitHub issue auto-milestoned to the current focus milestone, writes a
+machine-readable verdict to `.factory/coherence-verdicts/<sha>.json` that
+the operability-sibling dashboard consumes, and CANNOT silent-skip — an
+empty input set returns `"0 applicable, checked"` as a structured verdict
+distinguishable from `"infrastructure failure"` (which itself fails the
+workflow and opens an issue). The check suite lives as a Mix umbrella sub-
+project `apps/tau_coherence/` consumed by `.github/workflows/main-
+coherence.yml`, with one Mix task per failure construction so each can be
+re-run in isolation by the dashboard or by a developer triaging the issue
+the suite filed.
+
+## Rationale
+
+The complecting hypothesis is that *joint state* across artifacts is
+invisible to *per-diff* gates: two PRs each gate-green can land a
+contradictory `main`. The decomplecting move is to give joint-state its
+own oracle that runs on the joint state itself (the post-merge tree),
+keyed by failure constructions rather than by abstract "things that
+should be true." Adversarial derivation prevents the design-error mode
+where the check enumerates only failures the author imagined: every
+property in the suite traces to a *constructed* failure that was either
+observed in v1 (#9, the B5/D-171 case) or that we prove can occur from
+two individually-valid PRs. Failure constructions also serve as the
+suite's own regression tests — the check itself has a test that
+asserts the constructed bad joint-state triggers it — which closes the
+"check that never fires because the bug it was written for can no
+longer be constructed" failure mode silently inherited from v1.
+
+## Sketch
+
+### Failure constructions (the contract of the suite)
+
+Each construction is an *exact* recipe — a sequence of git operations
+on a fixture repo producing the bad joint state on `main`. Each is
+stored under `apps/tau_coherence/test/constructions/<id>/` as a
+shell script that produces the fixture and a property test that
+asserts the corresponding check trips on it.
+
+**C1. Cross-PR gate-relocate vs SPEC-update split.**
+- PR-A moves `Mix.Tasks.Tau.Gate.AcLinkage` from `lib/mix/tasks/` to
+  `apps/tau_factory/lib/mix/tasks/`. Per-PR gate-existence check
+  passes (the module still exists, just at a new path).
+- PR-B (parallel, before A merges) updates SPEC-FACTORY-GATES §4
+  "the gate module is `Mix.Tasks.Tau.Gate.AcLinkage` and lives at
+  `lib/mix/tasks/tau/gate/ac_linkage.ex`". Per-PR SPEC-vs-code check
+  on PR-B passes against PR-B's base.
+- Joint state on `main` after both merge: SPEC §4 names a path
+  that no longer exists. Per-PR gates cannot catch this.
+- **Catching mechanism:** `Mix.Tasks.Tau.Coherence.SpecPathResolve`
+  parses every SPEC §4 path citation (regex over `lib/**/*.ex`
+  + heredoc-style fences) and asserts `File.exists?/1` on each, with
+  AST resolution of every named module via `Code.ensure_loaded?/1`
+  after compile. Verdict: `:ok | {:error, [{spec, path_or_module,
+  reason}, ...]}`.
+
+**C2. Cumulative `rescue` count monotonically rising despite per-PR
+"-1 rescue site" budget.**
+- Audit baseline: 7 flagged `rescue` sites at SHA `S0` (root #10).
+- PR-X removes one flagged rescue → audit budget says +1, count
+  goes 7→6. Per-PR check passes.
+- PR-Y, days later, in unrelated code, adds two new `rescue` clauses
+  that were not in the audit's flagged set; the per-PR check has no
+  comparison baseline because the audit ingestion sibling only checks
+  the *flagged* set. Count goes 6→8.
+- Joint state on `main`: total `rescue` count exceeds baseline despite
+  every PR being "improving."
+- **Catching mechanism:**
+  `Mix.Tasks.Tau.Coherence.RescueLedger` counts every `rescue` / `catch
+  :exit` site in `lib/` via `Sourceror.parse_string!` AST traversal,
+  classifies each as `:legitimate | :under_waiver | :unknown` using
+  `.factory/rescue-waivers.yml` (one waiver entry per legitimate site,
+  with expiry date), and asserts `count(:unknown) == 0 AND
+  count(total) <= ledger_baseline + sum(delta) on `main` history`. The
+  ledger publishes a *direction-of-travel* invariant (monotone non-
+  increasing modulo explicit waiver additions) that no single PR can
+  satisfy or break alone.
+
+**C3. Telemetry consumer ratio dropping cumulatively (64.9% orphans
+today → 70% next month).**
+- PR-P emits a new `[:tau, :foo, :start]` event with a consumer in
+  `lib/tau/telemetry/handlers/foo.ex`. Per-PR consumer-presence check
+  passes.
+- PR-Q, two weeks later, deletes the handler module (the team that
+  owned it pivoted) but does not delete the emission. Per-PR check on
+  PR-Q sees a deletion of a handler — but emission sites are in *other*
+  files, untouched by the diff, so the per-PR check is scoped only to
+  the diff and approves.
+- Joint state on `main`: emission with no consumer; the 64.9% orphan
+  ratio creeps to 65.x%, then 66%, etc., undetected.
+- **Catching mechanism:** `Mix.Tasks.Tau.Coherence.TelemetryConsumers`
+  enumerates every `:telemetry.execute/3` site (grep+AST) and every
+  `:telemetry.attach*/4` site, and asserts that for every distinct
+  event-name prefix emitted, at least one non-test, non-`:debug`-only
+  attach exists in compiled `lib/`. The check also publishes the ratio
+  `consumed / emitted` as a telemetry event itself
+  (`[:tau, :coherence, :telemetry_ratio]`) that the dashboard plots;
+  the workflow **fails** the push when ratio drops below a recorded
+  baseline in `.factory/telemetry-baseline.json` (so the only way for
+  the ratio to drop is an explicit baseline-lowering commit, which
+  must be reviewed).
+
+**C4. SPEC drift from individually-valid PR edits (the B5/D-171
+construction generalised).**
+- SPEC-PERMISSION-PROMPTS §4 B5 says "6 modes" at SHA `S1`. PR-M
+  amends §6 D-171 to say "3 modes" because the runtime now has 3
+  active modes; the PR-M reviewer checks §6 internally and approves.
+- The §4 B5 prose was untouched. Joint state on `main`: §4 says 6,
+  §6 says 3, both inside the same document.
+- This generalises to *every* SPEC §4 vs §6 numeric / list claim:
+  named modes, named states, named callbacks, named events, named
+  D-NNN counts.
+- **Catching mechanism:**
+  `Mix.Tasks.Tau.Coherence.SpecInternalConsistency` extracts
+  structured claims from each SPEC via a per-SPEC sidecar YAML
+  manifest `docs/spec/SPEC-FOO.coherence.yml` of the form
+
+      claims:
+        modes: { in_section_4: 6, in_section_6: 3, expected: equal }
+        callbacks: { in_section_4: [a, b], in_dnnn: [a, b], expected: equal }
+
+  and asserts each `expected: equal` constraint holds. The SPEC's
+  authoring template includes the sidecar with a single
+  `claims: { dummy: { expected: trivially_true } }` entry so the
+  manifest is *always present* — its absence on a SPEC file fails
+  the suite immediately. (This is how it cannot silent-skip on
+  "no SPEC has a sidecar yet": the absence is the first finding.)
+  For the v1 B5/D-171 case, the manifest entry would be the
+  single-line claim `modes: { in_section_4: 6, in_dnnn_171: 3,
+  expected: equal }` and the suite would fail on first run with the
+  exact citation.
+
+**C5. `main` going red and staying red between merges.**
+- PR-R lands with the per-PR gate green at SHA `S_R`. The merge
+  causes a transitive compile warning in unrelated code (an `import`
+  now ambiguous because of a module the same PR introduced); CI on
+  the post-merge `main` push is red.
+- The factory loop's `cycle step 8d` is supposed to halt the loop,
+  but in v1 four PRs (#411-#414) merged against a red CI anyway
+  (root #7).
+- **Catching mechanism:**
+  `Mix.Tasks.Tau.Coherence.MainHealth` consumes the GitHub Checks
+  API for SHA = `git rev-parse origin/main`, asserts every required
+  check is `success`, and on failure (a) opens an issue, (b)
+  writes a sentinel file `.factory/STOP-FACTORY-MAIN-RED` (the
+  factory loop's start-of-step check already halts on this sentinel
+  per `factory-loop.md`), and (c) refuses to clear the sentinel
+  until a subsequent green `main` is observed. This converts "main is
+  red" from a transient state any subsequent merge can paper over
+  into a sticky operator-visible condition.
+
+### Generalisation
+
+The construction set is **extensible by construction**: any future
+joint-state failure pattern surfaces as a new directory under
+`apps/tau_coherence/test/constructions/<id>/` with (a) a fixture
+script, (b) a property test asserting "construction triggers
+check," (c) a new or extended Mix task implementing the check. The
+suite refuses to release with an unwired construction: the umbrella
+project's `mix test` target enumerates construction directories and
+fails if any lacks a matching task in
+`apps/tau_coherence/lib/mix/tasks/`. This closes the "we wrote the
+problem statement but never built the check" failure mode.
+
+The generalised contract for an entry in the suite:
+
+    construction_id: string                  # e.g. "C1"
+    failure_class_addressed: [ "#1", "#9" ]  # from root §Hypothesis
+    fixture_script: path                     # produces the bad joint state
+    check_task: atom                         # Mix.Tasks.Tau.Coherence.*
+    sidecar_inputs: [ path, ... ]            # YAML manifests it consumes
+    expected_verdict_on_fixture: :error
+    expected_verdict_on_clean: :ok
+
+The umbrella's `test` task asserts every construction's check task
+returns `:error` on its fixture and `:ok` on a clean checkout. A new
+failure pattern surfaces in v1.x → C-N is added → check task is added
+→ regression test added → suite gains coverage permanently.
+
+### Silent-skip impossibility
+
+Every failure mode for "the check didn't run / passed vacuously" is
+itself a failure construction:
+
+- **No SPEC sidecar present (C4 vacuous):** the workflow asserts every
+  `docs/spec/SPEC-*.md` has a sibling `*.coherence.yml`; absence is a
+  first-class failure with a named SPEC.
+- **No `.factory/rescue-waivers.yml` present (C2 vacuous):** absence
+  fails the workflow (the audit-ingestion sibling produces it; if
+  that sibling has not run, this sibling halts and demands it).
+- **No telemetry baseline file (C3 vacuous):** absence fails the
+  workflow on first run; the workflow's `--initialize` mode (one-time)
+  writes the baseline from the current `main` and commits a PR for
+  human review, but the *check* on subsequent pushes fails without
+  the baseline.
+- **GitHub Checks API unreachable (C5 vacuous):** the workflow
+  retries with backoff up to 5 minutes; on persistent failure it
+  fails the workflow with exit code 2 (distinct from "found drift,"
+  exit 1, and "all clean," exit 0) and opens an issue tagged
+  `infra/coherence-unreachable`.
+- **Empty SPEC catalog (suite vacuous):** the workflow writes
+  `{ "verdict": "0_applicable_checked", "spec_count": 0,
+  "construction_count": N }` and exits 0; but the dashboard's
+  health card surfaces `spec_count == 0` as a warning, so a regression
+  that empties the catalog is visible. This is the *only* legitimate
+  vacuous outcome and it is structurally distinguishable from "didn't
+  run."
+
+The workflow's exit code is mechanically meaningful:
+`0 = checked, no findings (including legitimate vacuous)`,
+`1 = checked, findings present (issue filed)`,
+`2 = could not check (infrastructure)`. A check that returns no exit
+code is itself a failure pattern: the workflow's outer wrapper asserts
+a non-empty verdict file at `.factory/coherence-verdicts/<sha>.json`
+before exiting; absence triggers exit 2.
+
+### Concrete artifacts
+
+- `.github/workflows/main-coherence.yml` — runs on `push: branches:
+  [main]` and on `schedule: cron: '0 6 * * *'`. Jobs: `c1_spec_paths`,
+  `c2_rescue_ledger`, `c3_telemetry_consumers`, `c4_spec_internal`,
+  `c5_main_health`, `verdict_emit`, `issue_open_on_failure`. No
+  `|| true`; no `continue-on-error`; every job's failure fails the
+  workflow.
+- `apps/tau_coherence/lib/mix/tasks/tau/coherence/{spec_path_resolve,
+  rescue_ledger, telemetry_consumers, spec_internal_consistency,
+  main_health}.ex` — one Mix task per check.
+- `apps/tau_coherence/lib/tau/coherence/verdict.ex` — `Verdict` struct
+  + JSON encoder for `.factory/coherence-verdicts/<sha>.json`.
+- `apps/tau_coherence/test/constructions/c{1..5}/` — fixture scripts
+  and property tests.
+- `docs/spec/*.coherence.yml` — per-SPEC structured claims sidecars.
+- `.factory/rescue-waivers.yml` — populated by audit-ingestion sibling.
+- `.factory/telemetry-baseline.json` — `consumed/emitted` ratio
+  baseline.
+- `.factory/STOP-FACTORY-MAIN-RED` — sentinel touched by C5 on
+  red-main detection, consumed by `factory-loop.md` start-of-step
+  check.
+
+## Tradeoffs
+
+### Strengths
+
+- **Anchored to constructed failures, not imagined ones.** Every check
+  has a fixture that triggers it; the suite has a regression test for
+  the existence of its own findings, closing the "check that never
+  fires" failure mode v1 displayed at scale.
+- **Cross-PR joint state is the explicit unit of analysis.** C1, C3,
+  C4 are all unreachable from per-diff gates by construction; this
+  sibling owns exactly that surface.
+- **Direction-of-travel invariants** (C2 monotonic `rescue` count,
+  C3 consumer ratio) prevent the "boil the frog" failure mode where
+  no single PR is bad but the trajectory is.
+- **Silent-skip impossibility is itself property-tested.** Every
+  vacuous-outcome path is a construction with an expected verdict;
+  the suite asserts `:ok` on clean and the specific vacuous-outcome
+  string on the no-input case.
+- **Operability sibling integration is just file-emission**
+  (`.factory/coherence-verdicts/<sha>.json`); no synchronous coupling.
+- **Acceptance criteria (a)-(e) all addressed concretely:** workflow
+  file named; mix task names enumerated; manifest format defined;
+  issue-opener Action named; reuse-vs-build documented (Sourceror
+  reused, sidecar manifest format bespoke and justified by SPEC
+  structural-claim shape that no off-the-shelf linter knows).
+
+### Weaknesses
+
+- **Per-SPEC sidecar authorship burden.** Every SPEC gains a
+  `*.coherence.yml`; authors must list structural claims they want
+  cross-checked. Adoption rests on culture *and* on the suite refusing
+  to pass when a SPEC lacks a sidecar — the latter creates friction
+  on legitimate fast-path doc edits.
+- **Construction maintenance burden.** Each new failure mode requires
+  three artifacts (fixture, property test, check task) before the
+  suite can be augmented. This is a feature for rigour, a cost for
+  velocity.
+- **`rescue` ledger waiver list can be gamed** by adding a waiver
+  entry rather than removing the `rescue` — the waiver review becomes
+  the real gate, and there is no automated check that a waiver is
+  *justified*, only that it is *present*. (The pre-merge code-gates
+  sibling owns the per-PR rescue check; this sibling owns only the
+  cumulative count, so the gaming surface is bounded but real.)
+- **Sentinel-file coupling to factory-loop.md** (C5 writes
+  `.factory/STOP-FACTORY-MAIN-RED`) creates a cross-leaf dependency.
+  If the loop changes its sentinel-check semantics, this sibling's
+  C5 effect changes silently. Document the contract in
+  `factory-loop.md`'s "kill switch" section as a co-owned protocol.
+- **Mix umbrella sub-project adoption** requires a top-level
+  `mix.exs` restructure if the project is not already an umbrella.
+  Less invasive: place tasks in the existing single project under
+  `lib/mix/tasks/tau/coherence/`. The umbrella is the cleaner long-
+  term home; the disruption may not be justified by this leaf alone.
+- **GitHub Checks API rate limits** under high merge cadence (C5
+  polls) — a known constraint requiring caching.
+
+### Costs
+
+- **New code surface:** ~1500-2000 LOC across 5 check tasks +
+  `Verdict` + fixtures + property tests; ~50 LOC of YAML per existing
+  SPEC (currently 11 SPECs catalogued in `spec-before-code.md` →
+  ~550 LOC of sidecar manifest one-time + ongoing maintenance).
+- **CI minutes:** each check is a clean compile + AST traversal of
+  `lib/` (~50k LOC) + grep over `test/` and `docs/`. Estimate
+  90-150s per check, 5 checks = ~8-12min wall, parallelisable to
+  ~3min via workflow `matrix:`. Daily cron + per-push = ~24×3min +
+  N×3min per push day = ~2-3 CI-hours/day. Bounded.
+- **Knowledge cost:** authors must learn the sidecar manifest schema
+  (≈30min onboarding doc) and the construction-add procedure
+  (≈45min runbook). Both go in `docs/factory-v2/coherence/`.
+- **Operational cost:** when the suite fires, the auto-filed issue
+  must be triaged within the milestone cycle, not allowed to
+  accumulate as "known drift." This requires the operability
+  sibling's dashboard to surface unresolved coherence-verdict issues
+  prominently.
+
+## Dependencies
+
+- **Audit-ingestion sibling** must produce `.factory/rescue-waivers.yml`
+  (C2 input) and `.factory/telemetry-baseline.json` (C3 input) on its
+  first run; bootstrap order: audit-ingestion before coherence-suite.
+- **Operability sibling's dashboard** must consume
+  `.factory/coherence-verdicts/<sha>.json` and `.factory/STOP-FACTORY-
+  MAIN-RED`; the verdict format is owned here, the rendering there.
+- **Factory-loop.md** must continue to honour `.factory/STOP-FACTORY-
+  MAIN-RED` sentinel-on-step-start (already exists per inherited
+  rules), with the additional contract that this file is *only*
+  cleared by a subsequent green `main` observation, not by manual
+  removal.
+- **Sourceror** dep for AST traversal of `lib/` (~ ¬new dep — already
+  in `mix.lock` for unrelated tooling; if not, add explicitly).
+- **`gh` CLI** available in CI for issue-opening (already present).
+- **Spec-before-code.md Appendix B source-maps** as the seed for
+  C1's path-existence assertions (re-used; not rebuilt).
+
+## Confidence
+
+**Medium-high.** The construction-first method is well-anchored — the
+v1 audit produced four of the five constructions empirically (B5/D-
+171, the orphan-telemetry ratio, the red-main merges, the rescue
+accumulation), so the suite is not speculative. The remaining design
+risk is the per-SPEC sidecar adoption cost (the manifest schema may
+need iteration before authors find it tolerable). What would raise
+confidence: a 200-line prototype of `Mix.Tasks.Tau.Coherence.
+SpecInternalConsistency` exercised against the SPEC-PERMISSION-
+PROMPTS B5/D-171 case, asserting the check trips on the current
+`main` state. That prototype is ~2 hours of work and would close the
+"manifest schema is plausible in theory" gap.
+
+## Prior art / references
+
+- `factory-loop.md` "kill switch" section — the `.claude/STOP-FACTORY`
+  sentinel pattern this proposal extends with `STOP-FACTORY-MAIN-RED`.
+- `tau-architecture` skill — for the OTP non-negotiables that C2
+  enforces cumulatively (NN #7 is the rescue rule).
+- Property-based testing in Tau (`StreamData`) — the suite reuses
+  the project's existing property idiom; each construction's
+  property test is an instance.
+- `sobelow` / `credo`'s warning-budget pattern — direction-of-
+  travel invariants for code-quality counts. C2 generalises this
+  pattern.
+- The `lock-files-as-invariants` pattern (Cargo `Cargo.lock`, npm
+  `package-lock.json`) — `.factory/telemetry-baseline.json` and
+  `.factory/rescue-waivers.yml` are invariant-bearing lock files,
+  not configuration.
+- The "constructions-as-tests" pattern from Erlang's `proper_statem`
+  — each failure construction is a state machine fixture asserting
+  the check responds correctly.
+- `Mix.Tasks.Tau.Gate.*` (`factory-loop.md` gate 5.1/5.2/5.3) —
+  this proposal mirrors that naming convention deliberately so
+  `Coherence.*` tasks are discoverable alongside `Gate.*` tasks.

--- a/docs/factory-v2/design/subproblems/post-merge-cross-artifact-coherence/solution.md
+++ b/docs/factory-v2/design/subproblems/post-merge-cross-artifact-coherence/solution.md
@@ -1,0 +1,626 @@
+---
+template_version: 1
+template_name: solution
+parent_problem: ./problem.md
+node_kind: leaf
+synthesised_from:
+  - proposals/proposal-1.md
+  - proposals/proposal-4.md
+  - proposals/proposal-3.md
+selection_method: hybrid
+revision: 0
+---
+
+# Solution: Manifest-driven pure-predicate coherence suite, with adversarial fixtures, direction-of-travel invariants, expiring-waiver registry, and STOP-FACTORY-MAIN-* sentinel wiring
+
+## Recommendation
+
+Build cross-artifact coherence on `main` as a pure function over a typed
+manifest of the repository at a SHA, surfaced through eight `Tau.Coherence.Check`
+behaviour modules dispatched by a compile-time `Tau.Coherence.Registry`, run by
+`Mix.Tasks.Tau.Coherence.Run` on every `push: branches: [main]` and on a daily
+cron via `.github/workflows/main-coherence.yml`. Each check ships with an
+adversarial fixture (construction `C<N>`) under
+`test/tau/coherence/constructions/c<n>/` whose property test asserts the check
+trips on the fixture — the check itself has a regression test for its own
+firing, closing v1's "check that never fires" failure mode. Two checks
+(`RescueLedger`, `TelemetryConsumerCumulative`) are direction-of-travel
+invariants keyed to baseline lock-files in `priv/coherence/`. Legitimate
+exceptions are recorded in `priv/coherence/waivers.toml` with mandatory
+`expires_at` (CodeClimate pattern, adapted from P3); a waiver past expiry
+re-fails. On `:fail`, `Mix.Tasks.Tau.Coherence.OpenIssue` files a deduplicated
+GitHub issue (auto-milestoned to the focus milestone, labelled `coherence`),
+`Mix.Tasks.Tau.Coherence.PublishStatus` writes a verdict file the operability
+sibling consumes, and `Mix.Tasks.Tau.Coherence.MainHealth` writes
+`.claude/STOP-FACTORY-MAIN-RED` (a new sibling sentinel of `.claude/STOP-FACTORY`)
+to halt the factory loop until a subsequent green `main` is observed.
+Silent-skip is structurally impossible because (a) the `Check` callback signature
+has no `:skip` arm; (b) the runner enumerates `Registry.all/0` at compile time and
+asserts every registered check produced exactly one verdict entry; (c) the
+workflow asserts `len(verdict.checks) == Tau.Coherence.Registry.count()`; (d)
+exit codes are typed (`0` = checked-clean, `1` = checked-with-findings, `2` =
+infrastructure failure / silent-skip detected, `3` = manifest parse error); (e)
+the workflow contains no `if:`-conditional steps, no `continue-on-error`, and
+no `|| true`, and a `lint`-job regression test in `test/tau/coherence/workflow_format_test.exs`
+greps the workflow source for those tokens.
+
+## Selected from
+
+- **Chosen:** hybrid of `proposals/proposal-1.md` and `proposals/proposal-4.md`,
+  with two named elements adopted from `proposals/proposal-3.md`. The hybrid
+  takes P1's substrate (typed manifest, pure-predicate `Check` behaviour,
+  compile-time `Registry`, JSON-schema-validated verdict, workflow registry-
+  equality assertion) — this is the strongest decomplecting move and gives
+  the most rigorous mechanical silent-skip dissolution. It takes P4's
+  discipline (every predicate ships with an adversarial construction fixture
+  whose property test asserts the predicate trips; direction-of-travel
+  invariants for `rescue` count and telemetry consumer ratio; the
+  `STOP-FACTORY-MAIN-RED` sentinel for red-`main` detection wired to the
+  factory loop's existing kill-switch protocol) — these close failure modes
+  (check-that-never-fires, cumulative-tail drift, red-main merges) that P1
+  alone does not address. From P3 it takes (a) the expiring-waiver registry
+  (CodeClimate technical-debt pattern) realised as `priv/coherence/waivers.toml`
+  with a mandatory `expires_at` field the runner enforces, and (b) the
+  "release-degradation halts new merges" semantics, realised through the
+  STOP-FACTORY sentinel mechanism rather than P3's OTLP collector (OTLP is
+  rejected as an unjustified operational dependency: a file under
+  `_build/coherence/` is sufficient for the operability sibling).
+
+  **Comparison against acceptance criterion:**
+
+  | # | Fit | Decomplecting depth | Migration cost | Risk | Reversibility |
+  |---|---|---|---|---|---|
+  | 1 (manifest+predicate) | Yes | Deep | Medium | Low | Easy |
+  | 2 (polya-audit agent) | Partially | Surface | Low | High (LLM in gate) | Easy |
+  | 3 (fitness functions) | Yes | Substantial | Medium | Medium (OTLP) | Easy |
+  | 4 (adversarial constructions) | Yes | Deep | Medium | Low | Easy |
+
+  P2 is **rejected outright**: its `SPEC-SPEC-CONTRA` rule places a Claude-call
+  in the gating path. Root §Background states "the v2 factory must therefore
+  not rely on Claude (or any single agent) telling the truth about its own
+  work — it must rely on independent mechanisms that produce verdicts Claude
+  cannot influence." An agent-constrained detector with non-deterministic
+  recall violates this directly; the rest of P2's deterministic mix-task
+  detectors are subsumed by P1's predicate substrate.
+
+  P1 alone misses the cumulative-drift checks (`rescue` ledger, telemetry
+  ratio direction-of-travel) and the red-`main` sticky-state sentinel — P4
+  contributes these specifically. P4 alone lacks P1's compile-time registry
+  + verdict-schema discipline; P1's `Registry.count()` assertion is a more
+  robust silent-skip primitive than P4's per-construction enumeration. The
+  hybrid is composition, not averaging: each proposal contributes a distinct
+  primitive the other lacks.
+
+  P3 contributes only its expiring-waiver registry and its
+  "degraded-release-blocks-new-merges" insight; its OTLP, fitness.toml
+  manifest, and umbrella mix project are explicitly rejected (the
+  compile-time Erlang `Registry` module is a stronger primitive than a TOML
+  manifest because demoting `required: true` to `required: false` in TOML is
+  a silent weakening, whereas removing a module from `@checks` at compile
+  time is a registry-equality workflow failure).
+
+## What changes
+
+### New code under `lib/tau/coherence/`
+
+- `lib/tau/coherence/manifest.ex` — `%Tau.Coherence.Manifest{sha,
+  dnnn_index, spec_contracts, adrs, source_maps, telemetry_sites,
+  telemetry_consumers, rescue_sites, main_health}` typed struct + sub-structs
+  `SpecContract`, `Adr`, `TelemetrySite`, `TelemetryConsumer`, `RescueSite`,
+  `Invariant`, `Symbol`, `Occurrence`. Pure data; no behaviour.
+- `lib/tau/coherence/extract.ex` — entry-point pure function
+  `Tau.Coherence.Extract.build(repo_root :: Path.t()) :: Manifest.t()` that
+  composes the per-kind extractors below.
+- `lib/tau/coherence/extract/dnnn_index.ex` — regex-scan of `lib/`, `test/`,
+  `docs/`, `.claude/` for `D-\d{3}`; returns `%{id => [Occurrence{path,
+  line, context}]}`.
+- `lib/tau/coherence/extract/spec_contracts.ex` — reads each
+  `docs/spec/SPEC-*.source-map.yaml` sidecar (or, if absent, the SPEC's
+  Appendix B); each `SpecContract` records section, named D-NNN ids,
+  symbols, and machine-readable invariants (axis-tagged via
+  `<!-- axis: <name>; value: <expr> -->` markers in the SPEC body OR
+  declared in the sidecar's `invariants:` key).
+- `lib/tau/coherence/extract/adr_graph.ex` — reads `docs/adr/*.md`,
+  extracts `supersedes:` / `superseded_by:` metadata into an `AdrGraph`.
+- `lib/tau/coherence/extract/source_map.ex` — parses Appendix B of each
+  SPEC (or its sidecar) into `%{spec_id => [Path.t()]}`.
+- `lib/tau/coherence/extract/telemetry.ex` — AST-walks `lib/**/*.ex` via
+  `Sourceror` for `:telemetry.execute/3` sites and
+  `:telemetry.attach{,_many}/4` registrations. Returns
+  `{[TelemetrySite{}], [TelemetryConsumer{}]}`. (Shared with the
+  pre-merge-code-gates sibling per its Dependencies section; whichever
+  sibling lands first authors the module.)
+- `lib/tau/coherence/extract/rescue_sites.ex` — AST-walks `lib/**/*.ex`
+  via `Sourceror` for `rescue` / `catch :exit` clauses; classifies each
+  against `priv/coherence/rescue_waivers.toml` (`:legitimate |
+  :under_waiver | :unknown`).
+- `lib/tau/coherence/extract/main_health.ex` — calls the GitHub Checks
+  API for `git rev-parse origin/main`; returns the success/failure of every
+  required check on the most-recent `main` SHA.
+
+### New check behaviour and predicates
+
+- `lib/tau/coherence/check.ex` — defines the behaviour:
+  ```elixir
+  @callback name() :: String.t()
+  @callback applies_to(Manifest.t()) :: boolean()
+  @callback run(Manifest.t()) :: {:ok, [Finding.t()]} | {:error, term()}
+  ```
+  No `:skip` constructor. `{:ok, []}` is the "checked, no findings"
+  return; `{:error, _}` is infrastructure failure.
+- `lib/tau/coherence/finding.ex` — `%Finding{check, severity, locations,
+  message, dedup_key}` struct + JSON encoder. `dedup_key =
+  :crypto.hash(:sha256, ...)` over `(check, locations, message_template)`.
+- `lib/tau/coherence/registry.ex` — compile-time `@checks` module list +
+  `all/0` and `count/0`. **A check must appear in this list to run; a check
+  whose module name is in the list but not loaded is `:infrastructure_failure`.**
+- `lib/tau/coherence/check/dnnn_uniqueness.ex` — emits a `:blocker` for
+  each D-NNN with > 1 definition site (covers Hypothesis #9 sub-case).
+- `lib/tau/coherence/check/spec_symbol_resolution.ex` — for each
+  `SpecContract.symbols`, uses `Code.ensure_loaded?/1` and
+  `Module.defines?/3` (or `Code.ensure_compiled/1` + `function_exported?/3`)
+  to verify resolution on `main`; emits `:blocker` per unresolved symbol
+  (covers C1 — cross-PR gate-relocate + SPEC-update split).
+- `lib/tau/coherence/check/spec_contradiction.ex` — groups
+  `SpecContract.invariants` by `axis`; emits `:blocker` for any axis with
+  > 1 distinct `value`. Covers the v1 PERMISSION-PROMPTS B5/D-171 case as
+  a first-run regression fixture (planted in
+  `test/tau/coherence/constructions/c4/`).
+- `lib/tau/coherence/check/adr_supersession.ex` — for each ADR with
+  `supersedes: ADR-N`, asserts ADR-N has `superseded_by: ADR-M`; emits
+  `:blocker` per unidirectional link.
+- `lib/tau/coherence/check/telemetry_consumer_cumulative.ex` — for each
+  distinct event-name prefix in `telemetry_sites`, asserts ≥1 entry in
+  `telemetry_consumers` outside `test/` and outside `:debug`-only handlers.
+  **Direction-of-travel variant**: if the consumer-ratio
+  (`consumed / emitted`) falls below the baseline in
+  `priv/coherence/telemetry_baseline.json`, emit `:blocker`. The only way
+  to lower the baseline is an explicit PR that edits the baseline file
+  (which goes through the pre-merge gate suite).
+- `lib/tau/coherence/check/rescue_ledger.ex` — direction-of-travel:
+  asserts `count(rescue_sites where classification == :unknown) == 0` AND
+  `count(rescue_sites) <= ledger_baseline.total +
+  sum(waivers_with_status:add)`. Baseline in
+  `priv/coherence/rescue_baseline.json`; waivers in
+  `priv/coherence/rescue_waivers.toml`.
+- `lib/tau/coherence/check/main_health.ex` — asserts the current
+  `origin/main` SHA has every required GitHub check at `:success`; on
+  fail, writes `.claude/STOP-FACTORY-MAIN-RED` (the factory loop's
+  start-of-step check halts on this sentinel — see "Cross-artifact
+  contracts" below) AND emits a `:blocker` finding. Sentinel is cleared
+  only by a subsequent observation of green `main` (the check rewrites
+  the sentinel as absent on a clean run).
+
+### New Mix tasks
+
+- `lib/mix/tasks/tau.coherence.run.ex` — `Mix.Tasks.Tau.Coherence.Run`:
+  builds the manifest, iterates `Tau.Coherence.Registry.all/0`, invokes
+  each check, assembles a `%Verdict{sha, ran_at, registry_count, checks:
+  [%CheckResult{name, status, findings}]}`, writes
+  `_build/coherence/verdict-<sha>.json`, exits per the typed exit-code
+  table:
+  - `0` — all checks `{:ok, []}` OR all findings have an active waiver.
+  - `1` — at least one `{:ok, [findings]}` with no active waiver.
+  - `2` — at least one `{:error, _}` (infrastructure failure) OR
+    `len(checks) != Registry.count()` (silent-skip detected).
+  - `3` — manifest parse error (sidecar YAML unparseable, ADR metadata
+    malformed).
+- `lib/mix/tasks/tau.coherence.open_issue.ex` —
+  `Mix.Tasks.Tau.Coherence.OpenIssue`: reads the verdict JSON, dedupes
+  findings by `dedup_key` against open `coherence`-labelled issues
+  (via `gh issue list`), creates one issue per unique key with title
+  `coherence/<check_name>: <message_summary>` and body containing the
+  full finding JSON; milestones to the current focus milestone via
+  `gh api repos/:owner/:repo/milestones --jq '.[] | select(.state == "open")
+  | .title' | head -1`.
+- `lib/mix/tasks/tau.coherence.publish_status.ex` —
+  `Mix.Tasks.Tau.Coherence.PublishStatus`: writes
+  `_build/coherence/published/latest.json` and `_build/coherence/published/<sha>.json`,
+  which the operability sibling's dashboard polls (or which the
+  operability sibling subscribes to via a filesystem-watcher; the
+  contract is "this file always exists after a coherence run").
+
+### New schema and manifest files
+
+- `priv/coherence/verdict.schema.json` — JSON-schema for the verdict file
+  consumed by the operability sibling and asserted in CI. Required
+  fields: `sha` (40-hex), `ran_at` (RFC3339), `registry_count`
+  (positive int), `checks` (array of `{name, status, findings}` where
+  `status ∈ {"checked", "infrastructure_failure"}` and `findings` is an
+  array conforming to `#/$defs/finding`).
+- `priv/coherence/waivers.toml` — expiring-waiver registry (CodeClimate
+  pattern, adapted from P3). Each entry: `check_id`, `dedup_key`,
+  `reason`, `expires_at` (RFC3339), `opened_by`, `opened_in_pr`. The
+  runner enforces `expires_at`: a waiver past expiry is ignored and its
+  finding re-fails.
+- `priv/coherence/rescue_baseline.json` — `%{"total": <int>, "as_of_sha":
+  "<sha>"}`. Authored once at suite bootstrap (Build-order step 11);
+  amended only by a PR that explicitly lowers (or, with waiver, raises)
+  the total.
+- `priv/coherence/rescue_waivers.toml` — per-`rescue`-site classification
+  feeding `extract/rescue_sites.ex`. Each entry: `file`, `line`,
+  `classification` (`:legitimate | :under_waiver`), `reason`, and (for
+  `:under_waiver`) `expires_at`.
+- `priv/coherence/telemetry_baseline.json` — `%{"consumed": <int>,
+  "emitted": <int>, "ratio": <float>, "as_of_sha": "<sha>"}`. Authored
+  once at suite bootstrap; lowered only by explicit PR.
+- `docs/spec/SPEC-*.source-map.yaml` — per-SPEC sidecar (one per entry
+  in the catalog). Fields: `spec_id`, `binds: [{path, symbols,
+  invariants}]`, `invariants: [{axis, value, location}]`. The
+  `SourceMapPresence` meta-check emits a finding for any catalog entry
+  missing a sidecar (closes "the sidecar requirement could be silently
+  dropped" failure mode).
+
+### New construction fixtures (P4 discipline, adversarial regression)
+
+Each construction is a directory under
+`test/tau/coherence/constructions/c<N>/` containing:
+
+- `fixture.sh` — shell script producing the bad joint state in a
+  temp fixture repo (or seeded files under a fixture dir for the
+  pure-Elixir checks).
+- `<check>_construction_test.exs` — property test asserting the
+  corresponding check trips on the fixture AND passes on a clean
+  control fixture.
+
+The constructions:
+
+- `c1/` — cross-PR SPEC-path-vs-code split (covers
+  `SpecSymbolResolution`).
+- `c2/` — `rescue` count creep despite per-PR audit budget (covers
+  `RescueLedger`).
+- `c3/` — telemetry consumer ratio drop (covers
+  `TelemetryConsumerCumulative`).
+- `c4/` — SPEC internal contradiction generalising the
+  PERMISSION-PROMPTS B5/D-171 case (covers `SpecContradiction`).
+- `c5/` — red-`main` state after a merge (covers `MainHealth`; verifies
+  the `STOP-FACTORY-MAIN-RED` sentinel is created and the next clean
+  run removes it).
+- `c6/` — D-NNN re-use across two SPEC files (covers
+  `DnnnUniqueness`).
+- `c7/` — ADR-N claims `supersedes: ADR-M` but ADR-M lacks
+  `superseded_by: ADR-N` (covers `AdrSupersession`).
+- `c8/` — SPEC catalog entry exists in
+  `.claude/rules/spec-before-code.md` but the SPEC has no
+  `SPEC-*.source-map.yaml` sidecar (covers `SourceMapPresence`).
+
+Umbrella enforcement: `test/tau/coherence/constructions_completeness_test.exs`
+enumerates the construction directories and fails if any lacks a
+matching predicate module under `lib/tau/coherence/check/`. **This
+closes "we wrote the construction but never built the check" — a v1
+failure pattern.**
+
+### New CI workflow
+
+- `.github/workflows/main-coherence.yml` — triggers:
+  ```yaml
+  on:
+    push: { branches: [main] }
+    schedule: [{ cron: "0 6 * * *" }]
+    workflow_dispatch:
+  permissions:
+    contents: read
+    issues: write
+  concurrency: { group: main-coherence, cancel-in-progress: false }
+  ```
+  Single job `coherence` with steps:
+  1. `actions/checkout@v4` with `fetch-depth: 0`.
+  2. `erlef/setup-beam@v1` reading `.tool-versions` (strict).
+  3. `mix deps.get && mix compile --warnings-as-errors`.
+  4. `mix tau.coherence.run` — captures exit code.
+  5. **Silent-skip guard** (runs even on prior-step failure):
+     ```bash
+     REG=$(mix run --no-start -e 'IO.puts(Tau.Coherence.Registry.count())')
+     CHK=$(jq '.checks | length' _build/coherence/verdict-*.json)
+     test "$REG" = "$CHK" || { echo "::error::Verdict missing checks"; exit 2; }
+     ```
+  6. `actions/upload-artifact@v4` for `_build/coherence/`
+     (`if: always()`).
+  7. `mix tau.coherence.open_issue _build/coherence/verdict-*.json`
+     (`if: failure()`, env `GH_TOKEN`).
+  8. `mix tau.coherence.publish_status _build/coherence/verdict-*.json`
+     (`if: always()`).
+
+  **No `if:`-conditional steps that gate on PR-body content** (root §C
+  anti-pattern). **No `continue-on-error`. No `|| true`. No early-exit
+  expressions.**
+
+- `test/tau/coherence/workflow_format_test.exs` — `lint`-job regression
+  test that reads
+  `.github/workflows/main-coherence.yml` as plain text and asserts:
+  - `|| true` does not appear.
+  - `continue-on-error: true` does not appear.
+  - Every step has a `run:` or `uses:` (no empty steps).
+  - The `silent-skip guard` step exists with exactly the expected
+    `REG=...; CHK=...; test` shape (regression against future
+    sloppification).
+
+### Cross-artifact contracts
+
+- **`.claude/rules/factory-loop.md` — sentinel co-ownership.** Add a
+  paragraph under "Kill switch" stating that `.claude/STOP-FACTORY-MAIN-RED`
+  is a sibling sentinel of `.claude/STOP-FACTORY`, written by
+  `Mix.Tasks.Tau.Coherence.MainHealth` on red-`main` detection, checked at
+  the start of every factory step, and cleared only by a subsequent green
+  `main` observation. Both sentinels are `.gitignore`d.
+- **`.gitignore`** — add `.claude/STOP-FACTORY-MAIN-RED` and
+  `_build/coherence/` and `.code_audit/main-coherence/`.
+- **`.claude/rules/spec-before-code.md`** — add: "Every SPEC entry in the
+  catalog MUST have a `docs/spec/SPEC-*.source-map.yaml` sidecar; the
+  `SourceMapPresence` meta-check emits a `:blocker` finding for any catalog
+  entry lacking one."
+- **`docs/spec/SPEC-MAIN-COHERENCE.md`** — the spec for this leaf's
+  deliverable (per `spec-before-code.md` — this leaf is itself
+  coordination-heavy; PSDH triage = 4/5). §3 lists D-NNN invariants for
+  silent-skip impossibility, registry equality, waiver expiry, sentinel
+  semantics. §4 names every module above. Appendix B source-map names every
+  file path above. The SPEC is authored as the first PR of the build-order.
+
+### Silent-skip impossibility — implementation-level proof
+
+The acceptance criterion's "the suite cannot silent-skip" requirement is
+discharged by **five mutually reinforcing mechanisms**, no single one of which
+is the load-bearing primitive:
+
+1. **No `:skip` arm in the `Check` callback.** The behaviour signature is
+   `{:ok, [Finding.t()]} | {:error, term()}`. A check that wants to "not
+   apply" returns `{:ok, []}` — which is *data*, not the absence of data.
+   The runner records `{:ok, []}` as `status: "checked", findings: []` in
+   the verdict. There is no third return value the check can produce to
+   silently disappear.
+2. **Compile-time `Registry.all/0` is the iteration source.** The runner
+   does NOT iterate `File.ls!/1` or `Code.all_loaded/0` or any
+   filesystem-shaped source; it iterates the compile-time module list. A
+   predicate file present on disk but not in `@checks` does not run; a
+   predicate in `@checks` but missing on disk produces
+   `:infrastructure_failure`. Both are detectable.
+3. **Verdict-schema validation in CI.** The workflow validates
+   `_build/coherence/verdict-*.json` against
+   `priv/coherence/verdict.schema.json` (schema requires non-empty
+   `checks` array and every entry conformant). A truncated verdict file
+   fails the validation step.
+4. **Registry-equality workflow assertion.** The workflow's silent-skip
+   guard step asserts `len(verdict.checks) ==
+   Tau.Coherence.Registry.count()`. A check that crashed during the
+   `Mix.Tasks.Tau.Coherence.Run` (the rescue inside the runner that
+   converts crashes to `:infrastructure_failure`) STILL produces a verdict
+   entry; if the rescue itself fails (e.g. OOM), the verdict file is
+   truncated AND the registry-equality assertion fires.
+5. **Typed exit codes + workflow-format regression test.** Exit codes are
+   distinct integers per failure class; the workflow has no `|| true` and
+   no `continue-on-error`; a regression test in
+   `test/tau/coherence/workflow_format_test.exs` greps the workflow source
+   to prevent reintroduction of either token. The v1 anti-pattern at
+   `ci.yml:115` (`|| true`) is structurally impossible because the test
+   fails on any PR that adds the token.
+
+**The construction-fixture discipline is the meta-check on (1)-(5):** if
+any of these mechanisms is silently disabled (e.g. someone replaces
+`{:ok, []}` returns with an `:skipped` atom and updates the runner to
+filter), the construction property tests under `test/tau/coherence/`
+fail because the predicates no longer trip on planted fixtures.
+
+## What does not change
+
+- The existing per-PR gates `Mix.Tasks.Tau.Gate.{AcLinkage, Masking,
+  Mutation}` (from PR-B / issue #370) remain in `.github/workflows/ci.yml`.
+  This sibling adds a `main`-side suite; it does not replace the per-PR
+  suite.
+- The `polya-audit` plugin at `.claude/plugins/polya-audit/` remains a
+  design-review tool for humans and coordinators; this proposal does NOT
+  invoke it from CI. P2's agent-driven approach is rejected and the
+  plugin's CI integration surface is unchanged.
+- `Phoenix.PubSub` and the existing `[:tau, ...]` telemetry namespace are
+  not touched. This suite emits its OWN telemetry under
+  `[:tau, :coherence, ...]` for observability (e.g. dashboard-side
+  consumption of run latency, finding counts), but the coherence verdict
+  itself is a file artifact, not a telemetry event.
+- The OTLP exporter and `Tau.OtelReporter` are NOT used as the verdict
+  channel. P3's OTLP-as-single-source-of-truth is rejected: a file under
+  `_build/coherence/` is simpler, has no operational dependency, and is
+  trivially observable. (The dashboard sibling MAY subscribe to
+  `[:tau, :coherence, ...]` telemetry for live updates, but the
+  authoritative verdict is the file.)
+- The Mix project is NOT restructured into an umbrella. P4's umbrella
+  proposal is rejected as scope creep — all new modules live under
+  `lib/tau/coherence/` and `lib/mix/tasks/`.
+- D-NNN allocation rules in `CLAUDE.md` are unchanged; the `DnnnUniqueness`
+  check enforces them mechanically, dissolving the "did the author grep"
+  weave from the *enforcement* side without replacing the documentation.
+- `mix.exs` deps gain one new entry: `{:sourceror, "~> 1.0"}` (if not
+  already a transitive dep via `credo` / `mix format`). No other new deps;
+  `Jason`, `Yaml_elixir`, `ExUnit`, `StreamData` are all present.
+
+## Migration sketch
+
+Bottom-up, one PR per Build-order step (see §Build-order). Substrate
+first (manifest types, check behaviour, registry, verdict schema, runner
+skeleton, silent-skip guard) — proven by the `DnnnUniqueness` check
+finding existing duplicates on `main` (if any) or returning `{:ok, []}`
+on a clean tree. Then the smaller-surface predicates (`AdrSupersession`,
+`SourceMapPresence`). Then SPEC sidecars are authored one PR per SPEC
+(roughly 11 small PRs in parallel from different agents — these are the
+content cost). Then the SPEC-aware predicates (`SpecSymbolResolution`,
+`SpecContradiction`). Then the direction-of-travel predicates
+(`RescueLedger`, `TelemetryConsumerCumulative`) with their baseline
+lock-files initialised from the current `main` state via a one-time
+`mix tau.coherence.init_baselines` task. Then the workflow wiring with
+the silent-skip guard. Then the backfill pass that files issues for
+every finding the suite produces on current `main`. Each PR's AC
+declares the predicate(s) it adds and references the construction
+fixture in `test/tau/coherence/constructions/c<N>/`; the construction
+completeness test enforces wire-up.
+
+## Open questions
+
+- **Axis-tag convention adoption rate.** `SpecContradiction` needs each
+  SPEC invariant tagged with a machine-readable `axis` identifier. The
+  PERMISSION-PROMPTS B5/D-171 case uses `axis: permission_modes` and trips
+  on first run, but the other 10 SPECs need an annotation pass before
+  their full coverage materialises. **Resolution:** the `SourceMapPresence`
+  meta-check emits a `:warn` finding for any SPEC whose sidecar has zero
+  `invariants:` entries, surfacing partial coverage as data rather than
+  as silent absence; full coverage rolls in as SPECs are amended.
+- **Telemetry consumer-registration convention.** The
+  `TelemetryConsumerCumulative` check identifies handlers by AST-walking
+  `:telemetry.attach{,_many}/4` and `Phoenix.PubSub.subscribe/2`; an
+  exotic handler registered via custom indirection is invisible. **Resolution:**
+  the pre-merge-code-gates sibling owns canonicalising the
+  consumer-registration convention; this sibling's check uses what that
+  sibling defines. Until then, the `TelemetryConsumerCumulative` check's
+  severity is `:warn`, not `:blocker`, for handlers not matching the
+  canonical patterns (the ratio check remains `:blocker`).
+- **Waiver-renewal review process.** A waiver can be renewed indefinitely
+  by submitting a PR amending `expires_at`. The mechanical gate prevents
+  silent indefinite use, but enforcement of "renewal must be justified" is
+  social (PR review). The operability sibling's dashboard surfaces active
+  waivers and their countdown; whether to add a hard "renewal requires
+  ADR" rule is deferred to a future amendment.
+- **First-run noise on backfill.** Backfill (Build-order step 12) will
+  likely surface dozens of findings on current `main` (the
+  PERMISSION-PROMPTS contradiction; probable D-NNN duplicates from v1
+  drift; likely SPEC §4 symbols that no longer resolve after refactors;
+  the orphan-telemetry ratio creep). The suite will fail daily until
+  these are remediated. **Resolution:** the workflow files issues, does
+  not auto-revert; remediation is incremental; the "fails-loud-rather-
+  than-silent" promise still holds. A coordinator may choose to grant
+  short-expiry waivers (e.g. 2 weeks) for known backfill findings while
+  remediation lands.
+- **Sentinel-clear race.** `MainHealth` writes
+  `.claude/STOP-FACTORY-MAIN-RED` on red detection and clears it on green
+  detection. If the daily cron observes green but a `push: branches:
+  [main]` event hours later races with a concurrent merge that turns
+  `main` red, there is a window where the sentinel may not be re-written
+  before the factory loop's next step. **Resolution:** `concurrency: {
+  group: main-coherence }` prevents overlapping coherence runs; the
+  factory loop's step always runs `git fetch origin && git rev-parse
+  main` itself for staleness, so a stale-by-window sentinel is bounded by
+  one factory cycle.
+
+## Linked sub-problems / proposals
+
+- `proposals/proposal-1.md` — Manifest-extractor + pure-predicate suite +
+  always-emit verdict sink (first-principles). **Substrate adopted.**
+- `proposals/proposal-2.md` — Scheduled `polya-audit` coherence-agent run
+  on `main`, driven by a YAML rules-pack. **Rejected** for placing
+  Claude-call in gating path (root §Background violation).
+- `proposals/proposal-3.md` — Continuous Architectural Fitness Functions
+  for cross-artifact coherence on `main`. **Two elements adopted**:
+  expiring-waiver registry (CodeClimate pattern) and
+  "degraded-blocks-new-merges" semantics (realised via STOP-FACTORY
+  sentinel, NOT OTLP).
+- `proposals/proposal-4.md` — Adversarial main-side coherence — construct
+  the joint-state failure, then build the trap for it. **Discipline
+  adopted**: construction fixtures + property tests + direction-of-travel
+  invariants + STOP-FACTORY-MAIN-RED sentinel.
+
+## Build-order
+
+The build proceeds bottom-up so each layer is testable in isolation and
+gates the next. Each step is one PR (parallel batches noted), each PR's
+AC declares the artifacts it adds, and each PR carries a construction
+fixture or a property test that fails-before / passes-after.
+
+1. **`docs/spec/SPEC-MAIN-COHERENCE.md` (spec-before-code).** §3 lists
+   D-NNN invariants for silent-skip impossibility, registry equality,
+   waiver expiry, sentinel semantics. §4 names every module the
+   subsequent PRs introduce. Appendix B source-maps every file path. AC:
+   the spec exists, the catalog entry is added to
+   `.claude/rules/spec-before-code.md`, and the file lints clean.
+2. **Manifest types and `Tau.Coherence.Extract.DnnnIndex` extractor.**
+   Smallest surface, no SPEC parsing. AC: `Tau.Coherence.Extract.build/1`
+   returns a `Manifest{}` with `dnnn_index` populated; property test
+   asserts purity (same input → same output). Construction c6/ fixture
+   planted (D-NNN duplicate) and tested.
+3. **`Tau.Coherence.Check` behaviour + `Tau.Coherence.Finding` +
+   `Tau.Coherence.Registry` (empty) + `verdict.schema.json` +
+   `Mix.Tasks.Tau.Coherence.Run` skeleton.** AC: runner produces a
+   verdict file with `checks: []` and exits 0; verdict validates against
+   the schema. Workflow test asserts registry-equality guard fires when
+   the registry is non-empty but the verdict has fewer checks (negative
+   test).
+4. **`DnnnUniqueness` predicate + register in `Registry`.** AC:
+   construction c6/ fixture trips the predicate; clean control passes;
+   runner exit code transitions to 1 in the failure case. **First
+   construction test live.** Workflow runs but is not yet wired into CI.
+5. **`AdrSupersession` predicate.** ADRs are smaller-surface than SPECs;
+   extractor builds `AdrGraph`; predicate validates bidirectional
+   supersession links. AC: construction c7/ trips; clean passes.
+6. **`SourceMapPresence` meta-predicate.** Walks
+   `.claude/rules/spec-before-code.md` catalog; emits `:blocker` for any
+   catalog SPEC lacking a `SPEC-*.source-map.yaml`. AC: construction c8/
+   trips (missing sidecar); a clean repo with sidecars on every catalog
+   entry passes. **At this point the suite knows what it does not yet
+   cover; coverage rolls in as sidecars are authored.**
+7. **SPEC sidecar authoring — parallel batch of ~11 small PRs**, one per
+   SPEC in the catalog. Each PR adds
+   `docs/spec/SPEC-<NAME>.source-map.yaml` with `binds`, `symbols`, and
+   `invariants` extracted from the SPEC's Appendix B and §4. AC per PR:
+   `SourceMapPresence` no longer emits a finding for this SPEC; sidecar
+   parses cleanly.
+8. **`SpecSymbolResolution` predicate.** Uses `Sourceror` /
+   `Code.ensure_loaded?` to resolve each `SpecContract.symbols` entry.
+   AC: construction c1/ trips (cross-PR SPEC-path-vs-code split); clean
+   passes.
+9. **`SpecContradiction` predicate.** Groups invariants by `axis`; emits
+   `:blocker` for axes with > 1 distinct value. AC: construction c4/
+   (the v1 PERMISSION-PROMPTS B5/D-171 case, planted as fixture) trips;
+   clean passes. **This is the regression-fixture for failure class #9.**
+10. **`Tau.Coherence.Extract.Telemetry` extractor +
+    `TelemetryConsumerCumulative` predicate.** If the
+    pre-merge-code-gates sibling has shipped its telemetry extractor,
+    consume it directly; if not, author here and that sibling consumes
+    from this. AC: construction c3/ trips; clean passes. Baseline file
+    initialised but not yet enforced.
+11. **`Mix.Tasks.Tau.Coherence.InitBaselines` (one-time bootstrap).**
+    Walks the current `main` tree and writes
+    `priv/coherence/rescue_baseline.json` and
+    `priv/coherence/telemetry_baseline.json`. AC: the task is idempotent
+    when re-run on the same SHA; the resulting files commit cleanly.
+12. **`RescueLedger` predicate + `rescue_waivers.toml` + baseline
+    enforcement.** Walks `lib/` for `rescue` / `catch :exit`; classifies
+    against waivers; enforces direction-of-travel against the baseline.
+    AC: construction c2/ trips (count creep); clean passes; an
+    explicit-lowering PR (one entry waived) passes.
+13. **`MainHealth` predicate + `STOP-FACTORY-MAIN-RED` sentinel +
+    `factory-loop.md` amendment co-ownership paragraph.** Polls
+    GitHub Checks API for `origin/main`. AC: construction c5/ creates
+    the sentinel on red detection; the next clean run removes it;
+    `factory-loop.md` is amended to document the sentinel as a sibling
+    of `STOP-FACTORY`.
+14. **Waiver registry + `priv/coherence/waivers.toml` + runner expiry
+    enforcement.** AC: an expired waiver no longer suppresses its
+    finding; a not-yet-expired waiver does; a missing `expires_at`
+    field is a manifest parse error (exit 3).
+15. **`Mix.Tasks.Tau.Coherence.OpenIssue` and
+    `Mix.Tasks.Tau.Coherence.PublishStatus`.** Issue-opener dedupes by
+    `dedup_key` against open `coherence`-labelled issues; publisher
+    writes to `_build/coherence/published/`. AC: tested against a stub
+    `gh` (Bash script that echoes args) in CI; verdict file is always
+    present after a run.
+16. **`.github/workflows/main-coherence.yml` wired with all triggers +
+    silent-skip guard + workflow-format regression test.** AC: the
+    workflow runs green on a clean `main` and red on a planted
+    contradiction; the workflow-format test asserts no `|| true`, no
+    `continue-on-error`, and the exact silent-skip guard step shape.
+17. **Backfill pass.** Run the suite against the current `main` via
+    `workflow_dispatch`; review the filed issues; remediate or grant
+    short-expiry waivers per finding. AC: after backfill, the daily
+    cron run is green; the steady-state guarantee holds.
+18. **Construction-completeness test.** Author
+    `test/tau/coherence/constructions_completeness_test.exs` that
+    enumerates `test/tau/coherence/constructions/c*/` and fails if any
+    lacks a matching predicate in `Tau.Coherence.Registry`. AC: a
+    planted construction with no matching check fails the test; the
+    existing set passes. **This is the meta-meta-check; closes "we
+    wrote the construction but never built the check."**
+
+Each step is one PR (steps 7's parallel batch excepted); each PR
+references this leaf's spec (`SPEC-MAIN-COHERENCE.md`); each PR's AC
+declares the artifacts it adds and the construction fixture it
+exercises.
+
+## Revision history
+
+- (revision 0 — initial synthesis from proposals 1, 4, with elements
+  adopted from 3.)

--- a/docs/factory-v2/design/subproblems/pre-merge-code-gates/problem.md
+++ b/docs/factory-v2/design/subproblems/pre-merge-code-gates/problem.md
@@ -1,0 +1,120 @@
+---
+template_version: 1
+template_name: problem
+node_kind: leaf
+mode: leaf
+depth: 1
+parent: ../../problem.md
+status: draft
+---
+
+# Problem: Pre-merge code gates — AST, contract, capability, telemetry
+
+## Statement
+
+A PR's *production code diff* must not be mergeable if it (a) declares a
+behaviour / `@behaviour` it does not implement, (b) introduces `try/rescue`
+or `catch :exit` against unreachable conditions in violation of OTP
+non-negotiable #7, (c) sets a capability flag (e.g. `prompt_caching: true`)
+without exporting the required callback (e.g. `cache_regions/2`), or (d)
+emits a `:telemetry.execute/3` event under `[:tau, ...]` with no
+production consumer registered. v1 tolerates all four: SPEC §4 names
+non-existent structs (root #1), seven flagged `rescue` sites moved zero
+between audits (root #2/#10), `prompt_caching: true` lies on adapters
+without `cache_regions/2` (root #3), and 64.9% of telemetry sites have
+no non-debug consumer (root #4). The problem is solved when each is a
+deterministic per-PR check whose verdict is independent of agent
+self-report.
+
+## Context
+
+- Root §Hypothesis #1, #2, #3, #4 — the four code-shape failure classes.
+- Root §Acceptance criterion B — "Mix task that exits non-zero when a
+  `prompt_caching: true` adapter does not export `cache_regions/2`" is
+  cited as the model mechanism.
+- `.claude/rules/otp-non-negotiables.md` #7 — "Let it crash; supervise;
+  restart. MUST NOT `try/rescue` across process boundaries. MUST NOT
+  catch `:exit`." This is the source-of-truth rule; today no mechanical
+  enforcement exists.
+- `docs/problems/` and `docs/problems-archive-v1-modules/` contain the
+  evidence (struct names, rescue sites, capability liars, telemetry
+  sites) but consume zero gate machinery.
+- Existing Elixir static-analysis ecosystem: `mix dialyzer`,
+  `mix credo --strict`, `mix xref`, `Sourceror` AST library, and
+  Dialyzer's `@spec` / behaviour-callback checks. Reuse vs build must
+  be evaluated per check.
+
+## Failure classes addressed (from root §Hypothesis)
+
+- **#1** (primary, code-side) — contracts drift between code and the
+  symbols they name (struct existence, `@behaviour` implementation
+  completeness). The AC-side of contract drift is owned by
+  intent-capture-and-ac-binding.
+- **#2** (primary) — `try/rescue` / `catch :exit` proliferation against
+  unreachable conditions, NN #7 conformance.
+- **#3** (primary) — capability-flag fidelity (flag implies callback).
+- **#4** (primary) — telemetry events emitted without registered
+  production consumer.
+
+## Complecting hypothesis
+
+- The four checks are complected with "the agent's word" because today
+  the only enforcement is the critic/reviewer pair reading the diff;
+  the checks become independent only when each is a per-commit Mix task
+  whose output the gate consumes verbatim.
+- "Behaviour-callback completeness" is complected with "capability-flag
+  fidelity" in the codebase because adapters declare both via macros and
+  module attributes that look stylistic; mechanically the two are one
+  AST traversal per adapter module.
+- "Telemetry-consumer presence" is complected with `Logger` debug noise
+  because v1 treats any `:telemetry.attach` as a consumer; the gate must
+  distinguish production handlers from in-test handlers and from
+  unused handlers.
+
+## Decomposition strategy
+
+(leaf — no further decomposition; proceed to proposals)
+
+## Acceptance criterion
+
+The factory specification names exactly one mechanism per failure class
+above (#1 code-side, #2, #3, #4) such that: (a) each mechanism is a
+deterministic Mix task (or equivalent scripted check) that exits non-zero
+on violation and is wired into `.github/workflows/ci.yml` as a required
+status check on `main`; (b) the mechanisms enumerate their inputs (e.g.
+"every file under `lib/tau/providers/`", "every module exporting
+`__using__/1` from a behaviour") so that an empty input set is
+distinguishable from "no findings" — silent skip on a missing target
+list fails the PR (per root §Acceptance C); (c) the spec records, per
+check, whether an existing tool (`mix dialyzer`'s `@behaviour` callback
+warnings, `mix credo` custom checks, `Sourceror`-based traversal,
+`muzak` mutation, OpenTelemetry SDK's registered-handler introspection)
+is adopted or wrapped vs built bespoke, with the rationale recorded per
+root §Acceptance D; (d) the spec output identifies the concrete
+artifacts: mix task module names (e.g. `Mix.Tasks.Tau.Gate.Contracts`,
+`Mix.Tasks.Tau.Gate.NoRescue`, `Mix.Tasks.Tau.Gate.CapabilityFidelity`,
+`Mix.Tasks.Tau.Gate.TelemetryConsumers`), the CI workflow steps that
+invoke them, any Sourceror or Credo plugin module names, and a
+plugin-shaped wrapper if multiple Tau projects will consume them.
+
+## Out of scope
+
+- AC-test linkage and per-AC mutation — owned by
+  **intent-capture-and-ac-binding** sibling (the AC binding determines
+  *which* tests are gating; this leaf's checks run on the production
+  diff regardless of AC).
+- The CI infrastructure layer (silent-skip impossibility, evidence
+  trust, "merge despite red CI") — owned by
+  **pre-merge-evidence-and-skip-integrity** sibling.
+- SPEC-vs-SPEC contradictions and other cross-document drift on main —
+  owned by **post-merge-cross-artifact-coherence** sibling.
+- Ingestion of historical audit findings as new check inputs — owned by
+  **knowledge-memory-and-audit-ingestion** sibling.
+- Worktree hygiene / dashboards — owned by
+  **operability-and-hygiene-enforcement** sibling.
+- Documentation-only components; agent-discipline-only enforcement;
+  workstream-2 corrective-actions catalogue.
+
+## Amendment log
+
+- (none yet)

--- a/docs/factory-v2/design/subproblems/pre-merge-code-gates/proposals/proposal-1.md
+++ b/docs/factory-v2/design/subproblems/pre-merge-code-gates/proposals/proposal-1.md
@@ -1,0 +1,430 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 1
+parent_problem: ../problem.md
+---
+
+# Proposal 1: In-repo AST-checker substrate with enumerator-manifest contract (`Tau.Gate.CodeShape`)
+
+## Approach
+
+Build a single in-repo Elixir library, `Tau.Gate.CodeShape`, that exposes four
+independent analyzers — `Tau.Gate.CodeShape.Contracts`,
+`Tau.Gate.CodeShape.NoRescue`, `Tau.Gate.CodeShape.CapabilityFidelity`,
+`Tau.Gate.CodeShape.TelemetryConsumers` — each implementing a
+`Tau.Gate.CodeShape.Analyzer` behaviour with the callbacks `inputs/1`,
+`analyze/2`, `name/0`, and `description/0`. A driver Mix task
+`Mix.Tasks.Tau.Gate.CodeShape` runs every registered analyzer over the
+production-code diff, writes one JSON verdict file per analyzer to
+`_build/tau-gate/<analyzer>.json`, and exits non-zero if any analyzer reports
+violations OR if any analyzer's `inputs/1` returns `[]` without a matching
+written acknowledgement under `priv/tau/gate/manifests/<analyzer>.empty.toml`.
+The CI workflow file `.github/workflows/tau-gate-code-shape.yml` invokes the
+task as a required status check on every PR; the verdict JSONs are uploaded
+as workflow artifacts and consumed by the merge gate.
+
+## Rationale
+
+The complecting hypothesis names two strands: (a) the four checks are
+complected with "the agent's word" because today only the critic/reviewer pair
+reads the diff, and (b) "no findings" is complected with "no inputs scanned"
+because silent skip is indistinguishable from clean output. This proposal
+decomplects both by reifying the input set as an explicit, returned data
+structure (`inputs/1` is a callback, not a comment) and by making
+`length(inputs) == 0` a deterministic per-PR failure unless accompanied by a
+written empty-justification manifest. The four analyzers share an
+enumerate-then-analyze skeleton and a verdict schema, but each implements one
+failure class — they are composed by the driver, not woven together. The
+Analyzer behaviour is the seam the post-merge coherence sibling and the audit-
+ingestion sibling reuse, so the substrate is grown, not duplicated.
+
+## Sketch
+
+### Behaviour and verdict shape
+
+```elixir
+defmodule Tau.Gate.CodeShape.Analyzer do
+  @moduledoc """
+  An analyzer enumerates its inputs and produces a verdict.
+
+  Inputs are returned explicitly so that an empty input set is a
+  deterministic, machine-checkable condition — not silent skip.
+  """
+
+  @type input :: %{path: String.t(), module: module() | nil, meta: map()}
+  @type finding :: %{
+          severity: :error | :warning,
+          input: input(),
+          location: String.t(),
+          rule: atom(),
+          message: String.t()
+        }
+  @type verdict :: %{
+          analyzer: atom(),
+          inputs: [input()],
+          findings: [finding()],
+          started_at: DateTime.t(),
+          finished_at: DateTime.t()
+        }
+
+  @callback name() :: atom()
+  @callback description() :: String.t()
+  @callback inputs(opts :: keyword()) :: [input()]
+  @callback analyze(inputs :: [input()], opts :: keyword()) :: [finding()]
+end
+```
+
+### File layout
+
+```
+lib/tau/gate/code_shape.ex                      # registry + driver
+lib/tau/gate/code_shape/analyzer.ex             # behaviour above
+lib/tau/gate/code_shape/contracts.ex            # failure class #1
+lib/tau/gate/code_shape/no_rescue.ex            # failure class #2
+lib/tau/gate/code_shape/capability_fidelity.ex  # failure class #3
+lib/tau/gate/code_shape/telemetry_consumers.ex  # failure class #4
+lib/mix/tasks/tau.gate.code_shape.ex            # CLI entry point
+priv/tau/gate/manifests/                        # empty-input acks (toml)
+test/tau/gate/code_shape/                       # property + golden tests
+.github/workflows/tau-gate-code-shape.yml       # required status check
+```
+
+### Analyzer #1 — Contracts (`@behaviour` completeness + struct existence)
+
+`inputs/1` returns every module in `lib/` that has at least one `@behaviour`
+attribute, plus every module that names a `%Foo{}` struct in a `@spec` or
+`@doc` block. `analyze/2` parses each module with `Code.string_to_quoted/1`
+(via `Sourceror` for whitespace-preserving traversal), resolves the behaviour
+module's `@callback` set, and emits a finding for each callback not exported
+at the declared arity. The struct-existence pass loads each named struct
+module and emits a finding when `function_exported?(mod, :__struct__, 0)`
+returns false. Output keys: `:missing_callback`, `:unknown_struct`,
+`:behaviour_module_missing`.
+
+### Analyzer #2 — NoRescue (NN #7 conformance)
+
+`inputs/1` returns every `.ex`/`.exs` file under `lib/` and `test/support/`
+(but not `test/`, where rescue is sometimes legitimate for assertion-fixture
+construction; the exclusion list is data, in `priv/tau/gate/manifests/no_rescue.scope.toml`,
+not code). `analyze/2` walks each file's AST and emits a finding for every
+`try/rescue`, `try/catch :exit`, or bare `catch :exit` clause. Each finding
+carries `file:line` and the matched clause source. There is no allowlist of
+"legitimate" sites in code — the only way to suppress a finding is to add
+an entry to `priv/tau/gate/manifests/no_rescue.waivers.toml` keyed by
+`<file>:<line>` with a required `expires_at:` ISO-8601 date ≤ 90 days from
+the entry's commit date (enforced by a property test on the manifest file
+itself).
+
+### Analyzer #3 — CapabilityFidelity
+
+`inputs/1` returns every adapter module under `lib/tau/providers/` (or
+configurably any module implementing `Tau.Provider`). `analyze/2`:
+
+1. Loads the module and reads `module.capabilities/0` (or the equivalent
+   `@capabilities` attribute).
+2. Loads the lookup table `Tau.Gate.CodeShape.CapabilityFidelity.required_callbacks/0`,
+   which is a pure map of `capability_atom => [{callback_name, arity}, ...]`,
+   committed in the analyzer module itself (`prompt_caching` =>
+   `[{:cache_regions, 2}]`, `tool_use` => `[{:tools, 1}, {:render_tool_call, 2}]`,
+   etc.).
+3. For every flag set true, checks `function_exported?/3` for every required
+   callback. Emits `:capability_flag_without_callback` finding for each gap.
+
+The capability → callback map is a data table — adding a new capability is a
+PR that touches the map; the gate then fails any adapter that opts in
+without exporting the callback. This is the exact mechanism root §B cites as
+the model.
+
+### Analyzer #4 — TelemetryConsumers
+
+`inputs/1` returns every distinct event name passed to `:telemetry.execute/2`
+or `:telemetry.execute/3` in `lib/`, discovered by an AST traversal that
+matches `{{:., _, [:telemetry, :execute]}, _, [event_list | _]}` and
+evaluates literal `event_list` ASTs (non-literal event names fail the gate as
+`:dynamic_event_name`, because we cannot prove a consumer exists for an event
+we cannot name at compile time).
+
+`analyze/2` then walks every module in `lib/` looking for
+`:telemetry.attach`, `:telemetry.attach_many`, or
+`:telemetry_metrics.<x>` calls, builds the set of consumed event prefixes,
+and emits `:telemetry_event_without_consumer` for each emitted event with no
+matching consumer prefix. Test-only attaches (modules under `test/`) are
+ignored by construction (`inputs/1` only walks `lib/`); `Logger`-only
+consumers are excluded by a small allow-list of handler-module names in
+`priv/tau/gate/manifests/telemetry.consumer_kinds.toml` (`Tau.Telemetry.Handler`,
+`Tau.OtelReporter`, etc. — the allow-list is itself audited because adding to
+it requires a PR).
+
+### Driver and silent-skip-impossibility
+
+```elixir
+defmodule Mix.Tasks.Tau.Gate.CodeShape do
+  use Mix.Task
+  @impl true
+  def run(argv) do
+    Mix.Task.run("compile")
+
+    analyzers = [
+      Tau.Gate.CodeShape.Contracts,
+      Tau.Gate.CodeShape.NoRescue,
+      Tau.Gate.CodeShape.CapabilityFidelity,
+      Tau.Gate.CodeShape.TelemetryConsumers
+    ]
+
+    verdicts = Enum.map(analyzers, &run_one(&1, argv))
+    write_verdicts(verdicts)
+
+    exit_code =
+      cond do
+        Enum.any?(verdicts, &(&1.findings != [])) -> 1
+        Enum.any?(verdicts, &empty_inputs_unjustified?/1) -> 2
+        Enum.any?(verdicts, &(&1.error != nil)) -> 3
+        true -> 0
+      end
+
+    System.halt(exit_code)
+  end
+end
+```
+
+`empty_inputs_unjustified?/1` returns true when `inputs == []` AND no file
+matching `priv/tau/gate/manifests/<analyzer_name>.empty.toml` exists with a
+non-empty `reason:` field whose `expires_at:` is in the future. The check is
+mechanical: empty inputs without justification → exit 2 → CI red.
+
+Exit-code semantics are part of the contract:
+
+| code | meaning                         |
+|------|---------------------------------|
+| 0    | every analyzer ran; no findings |
+| 1    | at least one finding            |
+| 2    | empty inputs without manifest   |
+| 3    | analyzer crashed (treated as failure, NEVER skipped) |
+
+### CI workflow
+
+```yaml
+# .github/workflows/tau-gate-code-shape.yml
+name: tau-gate-code-shape
+on:
+  pull_request:
+  push: { branches: [main] }
+jobs:
+  code-shape:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: erlef/setup-beam@v1
+        with: { otp-version: "27.2", elixir-version: "1.18.1" }
+      - run: mix deps.get
+      - run: mix compile --warnings-as-errors
+      - run: mix tau.gate.code_shape
+      - if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: tau-gate-code-shape-verdicts
+          path: _build/tau-gate/*.json
+```
+
+The workflow is declared a **required status check** in the repo's branch
+protection on `main`. The merge gate (owned by the
+pre-merge-evidence-and-skip-integrity sibling) refuses merge when this check
+is not green; this proposal's contract with that sibling is the JSON verdict
+schema above plus the workflow name.
+
+### Verdict consumption
+
+The four verdict JSONs are the machine-checkable artifact. They are read
+by:
+
+- the merge gate (sibling sub-problem) — only the exit code is load-bearing,
+  but the JSON is rendered into a sticky PR comment for human readability;
+- the operability dashboard (sibling sub-problem) — aggregates verdicts
+  across PRs to surface "analyzer X has been finding violations for N
+  consecutive PRs" trends;
+- the audit-ingestion sibling — historical audit findings are translated
+  into analyzer manifests (e.g., a known `rescue` site enters
+  `no_rescue.waivers.toml` with a `remediated_by:` issue link and a
+  90-day `expires_at:`).
+
+## Tradeoffs
+
+### Strengths
+
+- **Silent-skip impossibility is a property of the protocol, not a wish.**
+  The `inputs/1` callback returns a list that the driver inspects; empty
+  without a manifest is exit 2. There is no code path that produces "passed
+  with nothing to check" by accident (root §C).
+- **Every component is concrete.** Mix task name, behaviour module, analyzer
+  modules, manifest directory layout, CI workflow filename, exit-code table,
+  verdict JSON schema — all named in the sketch (root §B).
+- **Bespoke is justified per check, in one place.** The four analyzers share
+  a single behaviour, so the "reuse vs build" decision is made once at the
+  Analyzer-callback boundary. Dialyzer's `@behaviour` warnings could feed the
+  Contracts analyzer's `:missing_callback` rule via parsing Dialyzer PLT
+  output, but Dialyzer cannot enforce struct existence in `@doc` strings —
+  the bespoke AST pass is justified for that. The rationale belongs in
+  each analyzer's `@moduledoc`.
+- **Failure-class coverage is one-to-one.** Each of #1, #2, #3, #4 maps to
+  one analyzer module; the spec satisfies root §A "exactly one mechanism per
+  class" cleanly.
+- **OTP non-negotiable conformance is enforced by the same substrate that
+  enforces everything else.** NN #7 stops being prose; it becomes a list of
+  `file:line` violations the gate refuses to merge.
+- **Verdicts are independent of agent self-report.** The analyzers run in
+  CI on the GitHub-hosted runner; their output is JSON; the merge gate keys
+  on exit code. No agent's natural-language verdict is in the trust path
+  (root §G).
+
+### Weaknesses
+
+- **AST analyzers have false-positive risk that requires a waiver mechanism,
+  and waivers can themselves rot.** The `no_rescue.waivers.toml` 90-day
+  expiry forces re-justification, but if 80% of `rescue` sites end up
+  waived, the gate's signal degrades. There is no automated cap on waiver
+  count — that gap is intentional (caps belong in the operability sibling's
+  dashboard, not in this leaf), but it is a real weakness of this proposal
+  taken alone.
+- **TelemetryConsumers' dynamic-event-name rule is strict.** Code that
+  computes event names at runtime (e.g., `[:tau, adapter_kind, :request,
+  :stop]` where `adapter_kind` is a parameter) will fail the gate. The
+  workaround is to enumerate the adapter kinds in the analyzer's manifest,
+  which moves coupling from code into data — defensible but real.
+- **Compile-cost grows with analyzer count.** The driver runs
+  `mix compile` and then traverses every file under `lib/`. On the current
+  Tau codebase this is fast (~3s for 200 files), but a four-fold scan plus
+  Sourceror parsing will be perceptibly slower than a single pass. A future
+  optimization is one AST walk that all four analyzers consume; this
+  proposal does not pre-optimize for it.
+- **The capability → callback map is a single point of editorial trust.**
+  Adding a new capability without updating the map silently exempts that
+  capability from gating. The mitigation is that the map's keys are an
+  enumeration the Contracts analyzer's `Tau.Provider` callback check
+  cross-references — but this is a second-order safety, not a first-order
+  one. A reviewer could miss it.
+- **No pre-existing community AST library covers the four checks; building
+  in-repo means we own maintenance.** Sourceror is well-maintained, but
+  the analyzer modules themselves are bespoke project code.
+
+### Costs
+
+- **Build cost.** Four analyzer modules (~150–300 LOC each), one behaviour
+  module (~40 LOC), one driver Mix task (~120 LOC), one CI workflow file
+  (~30 LOC), property tests for each analyzer (~200 LOC each), golden tests
+  with representative violating fixtures (~50 LOC each). Total ~1.5–2.5
+  kLOC of new code.
+- **Dependency cost.** One new prod dependency on `:sourceror` (~80 KB).
+  No new runtime cost — the analyzer code lives in `lib/` but only runs
+  under `Mix.env() == :test` or under the `tau.gate.code_shape` task; it
+  does not load in `prod` because Mix tasks are stripped from releases.
+- **Migration cost.** Every existing `rescue`/`catch :exit` site under
+  `lib/` (audit count: ~7+ with new ones accumulated) needs either removal
+  or a waiver manifest entry. Every adapter with `prompt_caching: true`
+  but no `cache_regions/2` (audit count: at least Bedrock per root #3)
+  needs reconciliation in the same PR that introduces the gate. Every
+  telemetry event with no consumer (audit count: 64.9% of 121 sites ≈ 78
+  events) needs either a consumer or removal. This is intentional — the
+  gate enables the cleanup work the prior audit already itemized.
+- **Test surface impact.** Each analyzer gets property tests (e.g., "for
+  any module without a `@behaviour`, the Contracts analyzer emits no
+  `:missing_callback` finding") and golden tests (a known-bad fixture
+  module exercised against the analyzer, expected JSON checked into
+  `test/support/golden/`).
+- **Knowledge cost.** One Elixir engineer fluent in AST traversal and one
+  CI engineer familiar with required-status-check configuration. No new
+  paradigm.
+
+## Dependencies
+
+- `:sourceror` (~> 1.0) added to `mix.exs` `:deps`.
+- Branch protection on `main` updated to require the
+  `tau-gate-code-shape / code-shape` status check (operationally done by
+  the pre-merge-evidence-and-skip-integrity sibling, but this proposal
+  cannot land without that being applied to the same workflow).
+- The `Tau.Provider` behaviour and `capabilities/0` callback are stable;
+  if they are refactored, the CapabilityFidelity analyzer's map needs
+  migration.
+- No dependency on Dialyzer being green — this proposal is independent of
+  Dialyzer to avoid coupling the gate's failure mode to Dialyzer's
+  occasional non-determinism on cross-module type inference.
+
+## Confidence
+
+**Medium-high.** The behaviour-based analyzer protocol is a direct
+application of one OTP non-negotiable (#2 — extensibility seams are
+behaviours) to the gate substrate itself. The exit-code-table protocol is
+a well-trodden Unix idiom. The two pieces of risk that hold confidence
+below "high" are: (a) the TelemetryConsumers dynamic-event-name policy
+will require iteration once the real codebase's event-name patterns are
+classified, and (b) the waiver-rot dynamic is a known unsolved gap that
+this leaf intentionally hands off. Confidence rises to "high" with a
+72-hour prototype that runs Contracts and NoRescue against the current
+`lib/tau/` tree and produces verdicts the team agrees match their
+expectations.
+
+## Prior art / references
+
+- `Mix.Tasks.Credo` (and its `--strict` mode) — same shape: CLI Mix task
+  with non-zero exit, configurable checks, AST traversal. We could *embed*
+  some analyzers as Credo plugins, but Credo's check API is per-file and
+  does not natively express "enumerate inputs first" — the manifest
+  contract is the load-bearing innovation this proposal preserves.
+- `mix dialyzer` — provides behaviour-callback checks as warnings; we
+  consume Dialyzer's output as one data source into the Contracts analyzer
+  rather than depending on Dialyzer for verdict.
+- `Sourceror` (Github: `doorgan/sourceror`) — the AST-traversal library
+  used in Phoenix's `mix phx.gen.auth` for structural codemods; the same
+  primitives suit per-file rule enforcement.
+- The Mix.Tasks.Tau.Gate.* family already cited in root §B (current
+  `mix tau.gate.ac_linkage`, `mix tau.gate.masking`, `mix tau.gate.mutation`)
+  — this proposal extends the same pattern; the `CodeShape` task is the
+  logical fourth member.
+
+## Build-order
+
+The proposal is shippable in five sequential PRs, each green-CI before the
+next is opened. The build-order is itself the proof that the substrate is
+incrementally adoptable rather than a big-bang rewrite.
+
+1. **PR-1 — Substrate, no checks.** Land
+   `Tau.Gate.CodeShape.Analyzer` behaviour, `Mix.Tasks.Tau.Gate.CodeShape`
+   driver, verdict JSON schema, exit-code table, manifest-directory
+   convention, and the CI workflow `tau-gate-code-shape.yml` registered
+   with branch protection. The analyzer registry is empty in this PR — the
+   task runs, finds no analyzers, returns exit 2 (no inputs unjustified)
+   until a `priv/tau/gate/manifests/_no_analyzers.empty.toml` ack is added
+   for this single bootstrap PR. Property test:
+   "driver crashes if any analyzer crashes" must pass.
+
+2. **PR-2 — Analyzer #2 (NoRescue) and waiver manifest.** First analyzer
+   shipped is NoRescue because the audit already itemized the violating
+   sites — same PR adds `priv/tau/gate/manifests/no_rescue.waivers.toml`
+   with the seven known sites, each with a `remediated_by:` issue link and
+   a 90-day `expires_at:`. NoRescue is the simplest analyzer (one AST
+   pattern) and the highest-signal proof the substrate works end-to-end.
+
+3. **PR-3 — Analyzer #1 (Contracts).** Adds the `@behaviour` callback
+   completeness and struct-existence checks. Surfaces the known SPEC §4
+   struct-name drift; this PR's body lists every finding the new analyzer
+   produces and either removes the offending `@doc` claim or implements
+   the missing callback.
+
+4. **PR-4 — Analyzer #3 (CapabilityFidelity).** Adds the analyzer and the
+   capability → callback map. Same-PR reconciles the known liars
+   (Bedrock `prompt_caching: true` without `cache_regions/2`, et al.) by
+   either implementing the callback or setting the flag false.
+
+5. **PR-5 — Analyzer #4 (TelemetryConsumers).** Adds the analyzer and the
+   consumer-kinds manifest. Highest-finding-volume analyzer (≈78 events
+   without consumers); this PR is paired with a parallel cleanup PR that
+   either registers consumers via `Tau.Telemetry.Handler` or removes the
+   emit sites. Because TelemetryConsumers' findings are non-blocking
+   warnings for the first 14 days after merge (a sunset-style ramp
+   encoded in `priv/tau/gate/manifests/telemetry.sunset.toml`), the team
+   has a bounded window to clean up before the gate goes red. The sunset
+   manifest itself has a hard expiry the gate enforces.
+
+A subsequent maintenance PR consolidates the four analyzers behind a
+single AST-walk pass if profiling shows the four-pass cost matters; that
+optimization is explicitly out of build-order scope.

--- a/docs/factory-v2/design/subproblems/pre-merge-code-gates/proposals/proposal-2.md
+++ b/docs/factory-v2/design/subproblems/pre-merge-code-gates/proposals/proposal-2.md
@@ -1,0 +1,562 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 2
+parent_problem: ../problem.md
+---
+
+# Proposal 2: ADAPT-FROM-ECOSYSTEM — host four checks on existing Elixir static-analysis substrate plus a Claude Code lint plugin, with a thin bespoke shim per check
+
+## Approach
+
+For each of the four code-shape failure classes (#1 code-side contract
+drift, #2 NN #7 `rescue` / `catch :exit` proliferation, #3 capability-flag
+fidelity, #4 telemetry-consumer presence), adopt an existing Elixir or
+Claude Code component as the analysis substrate and bolt only a thin
+bespoke shim that (a) enumerates inputs explicitly, (b) emits a stable
+machine-readable verdict (`{:ok, [] | findings}`), and (c) is wired into
+CI as a required check that cannot silent-skip. Concretely:
+
+- **#1 contract drift** — adopt the Elixir compiler's built-in
+  `@behaviour` / `@impl` warnings plus **Dialyzer** (`:dialyxir 1.4`,
+  already a dep) callback-mismatch checks; bolt a 60-line Sourceror-based
+  shim that asserts every name a SPEC §4 backticks resolves to a real
+  symbol in the compiled `.beam` files. The shim drives Dialyzer in
+  `--halt-exit-status` mode and parses its PLT output for
+  `callback_missing` / `callback_arg_type_mismatch` / `callback_not_exported`
+  diagnostics — these already exist; v1 simply ignores them.
+- **#2 NN #7 `rescue` proliferation** — adopt **Credo**'s custom-check
+  framework (already a dep) and write three Credo checks
+  (`Tau.Credo.Checks.NoTryRescueAcrossProcess`,
+  `NoCatchExit`, `NoRescueOnUnreachable`) using the documented
+  `Credo.Code.prewalk/2` AST API. Surface them via `mix credo --strict`
+  which CI already runs, and add a paired `mix credo diff` blocking
+  step (already in CI at `ci.yml:67-70`) so new violations cannot land
+  even if legacy ones remain.
+- **#3 capability-flag fidelity** — adopt **Boundary** (`:boundary
+  ~> 0.10`) for cross-module dependency constraints and use it to
+  declare that any module marking itself as a `Tau.Provider` adapter
+  with `prompt_caching: true` MUST be in a boundary that exports
+  `cache_regions/2`. Bolt a bespoke `Mix.Tasks.Tau.Gate.Capability` (60
+  LoC, Sourceror-based) that walks `lib/tau/providers/*.ex`, extracts
+  the `@capabilities` module attribute via AST, and asserts the
+  exports table contains every callback the declared capability implies.
+- **#4 telemetry-consumer presence** — adopt **`telemetry_registry`**
+  (`~> 0.3`) for declarative event discovery, plus a runtime ETS
+  inspection of `:telemetry`'s `telemetry_handler_table` to enumerate
+  registered handlers. Bolt a `Mix.Tasks.Tau.Gate.TelemetryConsumers`
+  shim (~80 LoC) that (i) boots the application in `MIX_ENV=test`
+  *without* test handlers attached, (ii) walks every
+  `:telemetry.execute/3` callsite under `lib/` via Sourceror, (iii)
+  asserts each event prefix has ≥1 handler registered by
+  `Application.start/2` (not by `setup`/`setup_all`), distinguishing
+  production from test handlers by the module path of the attaching
+  call.
+
+Wrap all four as a Claude Code **plugin** (`tau-code-gates`) that
+exposes a single `tau-code-gates:run` slash command for local
+pre-commit use and ships a `PreToolUse` hook that fires the same gates
+when an implementer agent tries to `git commit`. The plugin's CI
+counterpart is four new required-status-check jobs in `ci.yml`, each
+calling one Mix task without `continue-on-error` and without `|| true`.
+
+## Rationale
+
+The complecting hypothesis names the dependency on agent self-report and
+the fusion of "behaviour-callback completeness" with "capability-flag
+fidelity". Both decomplect cleanly by adopting independent oracles whose
+verdicts the agent cannot influence: the Elixir compiler, Dialyzer,
+Credo's AST walker, Boundary's compile-time constraint solver, and
+`telemetry`'s ETS-backed registry. None of these can be silenced by
+edits to a PR body or by an agent claiming "fixed." Adoption is
+overwhelmingly cheap because three of the four substrates (Credo,
+Dialyxir, Sourceror) are already in the Elixir toolchain consensus and
+two of those (Credo, Dialyxir) are already declared deps in `mix.exs`
+at lines 132–133. The bespoke surface shrinks to ≤300 LoC of glue
+across all four checks, versus a build-from-scratch path that
+re-implements AST traversal, callback-introspection, and CI plumbing
+from zero. Operability survives because every shim returns the same
+`{:ok, findings_list}` shape that Tau's existing
+`Mix.Gate.Common` already consumes, so the dashboard work in
+`operability-and-hygiene-enforcement` ingests these checks without a
+schema change.
+
+## Sketch
+
+### Adopted components, per check
+
+| Failure | Adopted component | URL | License | Maturity | What it gives us |
+|---|---|---|---|---|---|
+| #1 (struct/symbol existence) | **Sourceror** | github.com/doorgan/sourceror | Apache-2.0 | v1.x, used by `mix format` and Phoenix internals; >1k stars; active 2024-2025 | AST traversal with comment-preserving zipper; `Sourceror.parse_string!/1` + `Sourceror.prewalk/3` to find every backticked symbol in `docs/spec/SPEC-*.md` §4 and resolve it against the compiled module exports |
+| #1 (`@behaviour`/`@impl`) | **Elixir compiler** (built-in) + **Dialyxir 1.4** | hexdocs.pm/dialyxir + elixir-lang.org | Apache-2.0 / Apache-2.0 | shipped with OTP; Dialyxir v1.4 active | Compile-time warnings: "function X required by behaviour Y is not implemented"; Dialyzer's `callback_arg_type_mismatch` and `callback_not_exported` warnings |
+| #2 (NN #7 conformance) | **Credo** custom-check framework | github.com/rrrene/credo | MIT | v1.7, the de-facto Elixir linter; ships in `mix.exs:132` already | `use Credo.Check`, `Credo.Code.prewalk/2`, `IssueMeta.for/2` — documented testing API (`assert_issue/1`) for confidence; `mix credo diff` for "no new violations" gating |
+| #3 (capability-flag fidelity) | **Boundary 0.10** + Sourceror | github.com/sasa1977/boundary | MIT | v0.10.x, Saša Jurić, widely used in Phoenix shops | Compile-time enforcement of "boundary X depends on Y"; we use it as the *export* oracle (a capability-tagged boundary MUST export the matching callback name) |
+| #4 (telemetry-consumer presence) | **`telemetry_registry`** + `:telemetry` ETS table | github.com/beam-telemetry/telemetry_registry | Apache-2.0 | v0.3, Erlang Ecosystem Foundation maintained | `discover_all/0` walks the application tree to find declared events; ETS introspection of `telemetry_handler_table` enumerates live handlers |
+| (wrapping) | **`claude-code-elixir`** plugin pattern | github.com/georgeguimaraes/claude-code-elixir | (per repo) | Active 2025–2026; provides `mix-credo` / `mix-compile` PostToolUse hook patterns | The PostToolUse-hook-runs-credo pattern; we reuse the hook script shape and substitute our four gates |
+| (PreToolUse gate substrate) | **Anthropic claude-code/plugins** examples | github.com/anthropics/claude-code/tree/main/plugins | MIT | Official; reference for PreToolUse-blocking pattern | The "exit non-zero from PreToolUse blocks the tool call" contract — we mirror it for `git commit` and `gh pr ready` |
+
+### Per-check configuration / adaptation
+
+**`Mix.Tasks.Tau.Gate.Contracts` (#1)** — ~120 LoC bespoke wrapper
+around adopted substrates:
+
+```elixir
+defmodule Mix.Tasks.Tau.Gate.Contracts do
+  @shortdoc "Verifies SPEC §4 symbols + @behaviour/@impl completeness."
+  use Mix.Task
+
+  @impl Mix.Task
+  def run(_args) do
+    Mix.Task.run("compile", ["--warnings-as-errors"])  # adopts compiler warns
+    {:ok, _} = Application.ensure_all_started(:tau)
+
+    findings =
+      []
+      |> Kernel.++(spec_symbol_findings())     # Sourceror walk over SPEC §4
+      |> Kernel.++(dialyzer_callback_findings())  # parse :dialyxir output
+      |> Kernel.++(behaviour_impl_findings())     # Code.ensure_loaded + behaviour_info(:callbacks)
+
+    Mix.Gate.Common.emit_verdict(:contracts, inputs(), findings)
+  end
+
+  defp inputs do
+    %{
+      specs: Path.wildcard("docs/spec/SPEC-*.md"),
+      behaviours: behaviour_modules(),  # via :code.all_loaded |> filter behaviour_info/1
+      adapter_modules: Path.wildcard("lib/tau/providers/*.ex")
+    }
+  end
+  # ... emit_verdict refuses to skip when any inputs list is empty;
+  #     fails the PR with "input enumeration returned 0; gate cannot
+  #     prove absence" per root §Acceptance C.
+end
+```
+
+**`Tau.Credo.Checks.NoTryRescueAcrossProcess` (#2)** — direct adoption
+of Credo's documented custom-check pattern:
+
+```elixir
+defmodule Tau.Credo.Checks.NoTryRescueAcrossProcess do
+  use Credo.Check, base_priority: :high, category: :warning,
+    explanations: [check: """
+    OTP non-negotiable #7: MUST NOT try/rescue across process boundaries.
+    A try/rescue that wraps a Task.async, GenServer.call, send/2,
+    GenServer.cast, or :gen_statem.call/cast is forbidden.
+    """]
+
+  def run(%SourceFile{} = source_file, params) do
+    issue_meta = IssueMeta.for(source_file, params)
+    Credo.Code.prewalk(source_file, &traverse(&1, &2, issue_meta))
+  end
+
+  defp traverse({:try, meta, [opts]} = ast, issues, issue_meta) do
+    body = Keyword.get(opts, :do, [])
+    if crosses_process_boundary?(body) and Keyword.has_key?(opts, :rescue) do
+      {ast, [issue_for(meta, issue_meta) | issues]}
+    else
+      {ast, issues}
+    end
+  end
+  defp traverse(ast, issues, _meta), do: {ast, issues}
+  # crosses_process_boundary? matches Task.async, GenServer.call,
+  # :gen_statem.call, send/2, etc.
+end
+```
+
+Then in `.credo.exs`:
+```elixir
+{Tau.Credo.Checks.NoTryRescueAcrossProcess, []},
+{Tau.Credo.Checks.NoCatchExit, []},
+{Tau.Credo.Checks.NoRescueOnUnreachable, []},
+```
+
+**`Mix.Tasks.Tau.Gate.Capability` (#3)** — Boundary declaration plus
+Sourceror cross-check:
+
+```elixir
+# lib/tau/providers/anthropic.ex
+defmodule Tau.Providers.Anthropic do
+  use Boundary, deps: [Tau.Provider], exports: [:cache_regions, :stream, ...]
+  @behaviour Tau.Provider
+  @capabilities %{prompt_caching: true, ...}
+  # ...
+end
+
+# lib/mix/tasks/tau.gate.capability.ex
+defmodule Mix.Tasks.Tau.Gate.Capability do
+  @capability_to_callback %{
+    prompt_caching: {:cache_regions, 2},
+    tool_use: {:tools, 1},
+    structured_output: {:format/2 via stream opt, 0},  # etc.
+  }
+
+  def run(_) do
+    Mix.Task.run("compile", [])
+    adapters = adapter_modules()  # explicit input enumeration
+    if adapters == [], do: Mix.raise("no adapter modules — gate cannot run")
+    findings = Enum.flat_map(adapters, &check_adapter/1)
+    Mix.Gate.Common.emit_verdict(:capability, %{adapters: adapters}, findings)
+  end
+
+  defp check_adapter(mod) do
+    caps = mod.__capabilities__()
+    exports = mod.__info__(:functions)
+    for {cap, true} <- caps,
+        {fun, arity} = Map.fetch!(@capability_to_callback, cap),
+        not Enum.member?(exports, {fun, arity}),
+        do: {:capability_lie, mod, cap, {fun, arity}}
+  end
+end
+```
+
+**`Mix.Tasks.Tau.Gate.TelemetryConsumers` (#4)** — uses adopted
+`telemetry_registry` + direct `:telemetry` ETS introspection:
+
+```elixir
+def run(_) do
+  {:ok, _} = Application.ensure_all_started(:tau)
+  :telemetry_registry.discover_all()  # adopted
+
+  # 1. enumerate every :telemetry.execute callsite under lib/ via Sourceror
+  emitted = scan_emit_sites("lib/")  # [{[:tau, :session, :start], "lib/tau/session.ex:42"}, ...]
+  if emitted == [], do: Mix.raise("0 emit sites — gate cannot prove absence")
+
+  # 2. enumerate handlers registered by application boot (NOT test setup)
+  handlers = :ets.tab2list(:telemetry_handler_table)
+             |> Enum.reject(&test_attached?/1)  # filter handlers attached from test/
+
+  # 3. assert every emitted event prefix has ≥1 production handler
+  findings = for {event, source} <- emitted,
+                 not Enum.any?(handlers, &covers?(&1, event)),
+                 do: {:no_consumer, event, source}
+  Mix.Gate.Common.emit_verdict(:telemetry_consumers, %{emit_sites: length(emitted)}, findings)
+end
+```
+
+### CI wiring (no silent-skip)
+
+`.github/workflows/ci.yml` adds four required jobs, each pinned with
+`continue-on-error: false`, no `|| true`, no `if:` gates that can early-
+exit on PR-body shape:
+
+```yaml
+gate-contracts:
+  name: gate 1 — contract drift
+  needs: lint
+  steps:
+    - uses: actions/checkout@v4
+    - uses: erlef/setup-beam@v1
+      with: { version-file: .tool-versions, version-type: strict }
+    - run: mix deps.get
+    - run: mix tau.gate.contracts   # exits non-zero on any finding OR empty input set
+
+gate-no-rescue:
+  name: gate 2 — NN #7 conformance
+  steps:
+    - run: mix credo --strict --only Tau.Credo.Checks.NoTryRescueAcrossProcess,Tau.Credo.Checks.NoCatchExit,Tau.Credo.Checks.NoRescueOnUnreachable
+      # NOTE: NOT `|| true`; NOT `continue-on-error`
+
+gate-capability:
+  name: gate 3 — capability-flag fidelity
+  steps:
+    - run: mix tau.gate.capability
+
+gate-telemetry-consumers:
+  name: gate 4 — telemetry-consumer presence
+  steps:
+    - run: mix tau.gate.telemetry_consumers
+```
+
+All four are added to GitHub's branch-protection required-status-checks
+set so `gh pr merge` rejects without all four green.
+
+### Claude Code plugin shape
+
+```
+plugins/tau-code-gates/
+├── .claude-plugin/plugin.json
+├── commands/
+│   └── tau-code-gates-run.md       # slash command: runs all four locally
+├── hooks/
+│   ├── pre-tool-use.json           # blocks `git commit`/`gh pr ready` on red
+│   └── run-gates.sh                # invokes mix tau.gate.{contracts,capability,telemetry_consumers} + credo
+└── skills/
+    └── interpret-findings/SKILL.md # progressive disclosure for reading verdicts
+```
+
+The `PreToolUse` hook matches Anthropic's documented contract: exit 0
+allows, exit non-zero blocks with the gate's verdict surfaced in the
+agent's transcript. This closes the "agent commits red" gap before CI
+even sees the push.
+
+### Silent-skip impossibility
+
+Each `Mix.Gate.Common.emit_verdict/3` call checks that the inputs map
+is non-empty for every enumerated category, and exits with status 2
+(distinct from "findings present" status 1) when it is — labelled
+`gate_infrastructure_failure`. The CI job treats both 1 and 2 as red.
+This matches the existing `Mix.Gate.Mutation` "infrastructure failure
+vs gate decision" distinction (`ci.yml` already discriminates exit 3
+for the mutation gate; we extend the convention).
+
+The CI workflow does not use `if: github.event_name == 'pull_request'`
+to gate any of the four; they run on `push` to `**` and on `pull_request`
+events identically. The `|| true` pattern at the v1 `ci.yml:115` is
+replaced by `mix credo --strict || exit 1` explicitly.
+
+## Tradeoffs
+
+### Strengths
+
+- **Maximises adoption per root §Acceptance D.** Three of the four
+  checks reuse mature, widely-deployed substrates (Credo, Dialyxir,
+  Boundary); the fourth uses two BEAM Foundation-maintained libs
+  (`:telemetry`, `:telemetry_registry`). Bespoke surface is ~300 LoC
+  total — auditable in one sitting.
+- **Each oracle is independent of agent self-report** (root §Hypothesis
+  premise). The compiler, Dialyzer, Credo's AST walker, Boundary's
+  compiler plugin, and `:telemetry`'s ETS table are all driven by
+  source content, not PR-body claims.
+- **Silent-skip impossible by construction.** The `inputs` map check
+  inside `emit_verdict/3` fails when enumeration returns empty, and
+  CI runs each job without `continue-on-error` and without conditional
+  `if:` gates that depend on PR shape. The v1 `ci.yml:115` `|| true`
+  pattern has no counterpart in any of the four new jobs.
+- **Mirrors v1's existing convention.** Tau already has
+  `Mix.Tasks.Tau.Gate.{AcLinkage,Masking,Mutation}` and `Mix.Gate.Common`
+  helpers; the four new tasks slot into the same namespace and the
+  same verdict shape, so the operability dashboard (sibling leaf) has
+  no integration work.
+- **PR-body independence.** Unlike Gate 5.1 (AC linkage), none of the
+  four new gates reads the PR body; they run on the compiled code. The
+  failure mode where "no AC declared → silent skip" is structurally
+  absent.
+- **Local + CI parity.** The plugin's `PreToolUse` hook runs the same
+  Mix tasks the CI runs, so an implementer agent sees the verdict
+  before `git commit` returns — accelerating refine cycles and removing
+  the "PR-opened-then-CI-red" round-trip for these four classes.
+- **Composable with sibling leaves.** AC-binding (#1 sibling) keys off
+  `gating-test paths`; capability fidelity (this leaf) keys off
+  `@capabilities` attributes; neither overlaps. The mutation gate
+  (Gate 5.3) and these four are orthogonal.
+
+### Weaknesses
+
+- **Dialyzer is slow.** Cold PLT build is ~3-5 minutes on Tau's
+  current dep set; even with cached PLT, the callback-mismatch step
+  adds ~30-60s to CI. This is a real wall-time tax on the gate-1 job.
+  Mitigation: cache PLT keyed on `mix.lock` (Tau already caches `_build`
+  in `ci.yml:46-50`); skip cold PLT entirely on PR builds when the lock
+  is unchanged.
+- **Credo custom-check false positives.** `crosses_process_boundary?/1`
+  is a pattern-match heuristic, not a flow analysis. A `try/rescue`
+  wrapping a function whose body eventually calls `GenServer.call` two
+  levels deep is invisible to the check. False negatives are the failure
+  mode; false positives can be `# credo:disable-for-next-line` annotated
+  but each annotation MUST be flagged in PR review (sibling concern of
+  the operability dashboard — surface "credo-disable count delta" per PR).
+- **Boundary adoption is invasive.** Adding `use Boundary, deps: [...]`
+  to every adapter touches every file under `lib/tau/providers/`. That
+  is a single corrective-actions catalogue item, but it lands as one
+  large PR that the v2 factory itself must process — a chicken-and-egg
+  bootstrap cost. Mitigation: stage Boundary adoption per-adapter behind
+  a `Boundary.Mix.Compiler` warning-only mode for the first N PRs.
+- **`telemetry_registry` is opt-in and requires per-module
+  `@telemetry_event` declarations.** Adoption requires touching every
+  module that emits a telemetry event (~30+ modules per the 121 emit
+  sites in root §Hypothesis #4). Mitigation: the Sourceror-driven emit-
+  site scan (step 1 of `Gate.TelemetryConsumers`) is independent of
+  `telemetry_registry` and works on the un-annotated codebase; we adopt
+  `telemetry_registry` only for the long-term goal of declarative
+  documentation, not as a gate dependency.
+- **Distinguishing production from test handlers in
+  `:telemetry_handler_table` is heuristic.** "Module path of the
+  attaching call" is captured by stack trace at attach time, which is
+  not preserved in ETS. We must either (a) wrap `:telemetry.attach/4`
+  in a `Tau.Telemetry.attach/4` that tags the call site, or (b) attach
+  all production handlers from a single `Tau.Telemetry.Boot` module and
+  filter handlers by handler-ID prefix. Option (b) is cheaper but
+  requires a one-off refactor of every production `attach/4` call.
+- **Plugin ecosystem maturity.** Claude Code's plugin marketplace is
+  active but young (2026 H1). `claude-code-elixir` and `claude-elixir-
+  phoenix` are reference patterns, not stable APIs; the `PreToolUse`
+  hook contract is documented but versioned implicitly. We pin the
+  plugin's manifest to a specific Anthropic plugin-schema version and
+  set up a renovate-style update gate.
+- **No mutation testing for these four gates.** Unlike Gate 5.3 (which
+  uses Muzak-style merge-base reversion for AC-binding tests), the
+  four code-shape gates have no analogous mutation oracle. If a
+  `Tau.Credo.Checks.NoTryRescueAcrossProcess` rule is silently weakened
+  (e.g. its `traverse/3` returns `{ast, issues}` unconditionally), no
+  test catches it. Mitigation: ship StreamData property tests for each
+  Credo check using Credo's documented `assert_issue/1` testing API,
+  and gate the check modules themselves under the masking gate (Gate
+  5.2 — diff-scans for deleted `assert` lines).
+- **Boundary's compile-time enforcement is warning-only by default.**
+  Saša Jurić's docs explicitly say "the compiler doesn't force you to
+  immediately fix these violations" — we MUST run `mix compile
+  --warnings-as-errors` to convert them to gate failures, which Tau
+  already does (`ci.yml:64`), but this couples Boundary's verdict to
+  the warnings-as-errors discipline.
+
+### Costs
+
+- **New deps.** `:sourceror ~> 1.0`, `:boundary ~> 0.10`,
+  `:telemetry_registry ~> 0.3` — all `runtime: false` or
+  `runtime: true` (`telemetry_registry`); ~200KB compiled. Acceptable.
+- **CI wall-time delta.** +60s for gate-contracts (Dialyzer with warm
+  PLT), +5s for gate-no-rescue (Credo on the three new checks), +3s
+  for gate-capability (compile + AST walk), +10s for gate-
+  telemetry-consumers (app boot + ETS scan + Sourceror walk). Net
+  ~+80s per PR; the lint job today is ~3 minutes, so a ~45% increase
+  on that job's runtime.
+- **Bespoke code volume.** ~300 LoC across the four `Mix.Tasks.Tau.Gate.*`
+  modules + ~150 LoC across the three Credo checks + ~80 LoC plugin
+  hook shim = ~530 LoC. Compare to a build-from-scratch estimate of
+  ~2,500-4,000 LoC (full AST walker + behaviour-introspector + ETS
+  abstraction + CI plumbing). 5-7× reduction.
+- **One-off refactors.** (a) Add `use Boundary` to every module under
+  `lib/tau/providers/`, `lib/tau/coding_agents/`, and core supervisors
+  (~20 modules); (b) wrap all production `:telemetry.attach/4` calls
+  in `Tau.Telemetry.attach/4` (~30 callsites). Both are catalogued
+  corrective-actions and processed by the factory itself.
+- **Documentation update.** `.claude/rules/otp-non-negotiables.md` gains
+  a "Mechanical enforcement" subsection per invariant naming the Credo
+  check that enforces it. This is the documentation-mechanism pairing
+  required by root §Acceptance G ("every component produces a machine-
+  checkable artifact" — the doc is paired with the check, not standalone).
+- **Plugin bootstrap.** ~1 day to scaffold `plugins/tau-code-gates/`,
+  ~1 day to write the `PreToolUse` hook + interpret-findings skill,
+  ~0.5 day to register with the local plugin marketplace.
+
+## Dependencies
+
+- **Existing**: `:credo ~> 1.7` (`mix.exs:132`), `:dialyxir ~> 1.4`
+  (`mix.exs:133`), `:stream_data ~> 1.1` (for property tests of Credo
+  checks).
+- **New deps to add**: `:sourceror ~> 1.0` (Apache-2.0,
+  github.com/doorgan/sourceror), `:boundary ~> 0.10` (MIT,
+  github.com/sasa1977/boundary), `:telemetry_registry ~> 0.3`
+  (Apache-2.0, github.com/beam-telemetry/telemetry_registry).
+- **One-off corrective-actions** (catalogued, processed by factory):
+  (1) add `use Boundary` to adapter modules, (2) replace production
+  `:telemetry.attach/4` calls with `Tau.Telemetry.attach/4`, (3) add
+  `@capabilities` module attribute to every adapter declaring callback-
+  implying capabilities.
+- **Sibling leaf cooperation**: AC-binding leaf must publish its
+  `gating-test paths` schema so we exclude gating-test files from the
+  Credo `NoTryRescue` scan (test code is allowed to wrap in
+  `try/rescue` for assertion patterns).
+- **CI changes**: four new required-status-check jobs in `ci.yml`,
+  added to branch-protection rules for `main`.
+- **Plugin marketplace**: register `tau-code-gates` in
+  `.claude-plugin/marketplace.json` (Tau's own marketplace) and pin the
+  Anthropic plugin schema version.
+
+## Build-order (adopt-over-build, smallest gap first)
+
+1. **Adopt the existing layer**: pin `:sourceror`, `:boundary`,
+   `:telemetry_registry` versions; cache Dialyzer PLT in `ci.yml`. (0.5d)
+2. **Ship `Mix.Tasks.Tau.Gate.Contracts`** wrapping compiler warnings +
+   Dialyzer callback diagnostics + Sourceror SPEC §4 symbol scan. Wire
+   to CI as required check. (1.5d, mostly the Dialyzer output parser)
+3. **Ship three `Tau.Credo.Checks.*`** for NN #7; add to `.credo.exs`;
+   property-test each with `assert_issue/1`. (2d, Credo's testing API
+   is well-documented but property tests for AST patterns are fiddly)
+4. **Ship `Mix.Tasks.Tau.Gate.Capability`** with the `@capabilities ↔
+   callback` mapping table; corrective-action issue to add `@capabilities`
+   to each adapter. (1d task, 1-2d corrective-action backlog)
+5. **Ship `Mix.Tasks.Tau.Gate.TelemetryConsumers`** with the emit-site
+   Sourceror walker + ETS handler enumerator; corrective-action issue
+   to migrate production `:telemetry.attach/4` calls to
+   `Tau.Telemetry.attach/4`. (1.5d task, 2-3d corrective-action backlog)
+6. **Wrap as `tau-code-gates` plugin** with `PreToolUse` hook; register
+   in the Tau plugin marketplace. (1.5d, including the
+   interpret-findings skill)
+7. **Update branch protection**: add the four jobs as required status
+   checks. (0.5d)
+
+Total: ~10 day-units of factory work, of which ~7 are wrapping/glue and
+~3 are corrective-actions catalogued for the factory to process.
+
+## Explicit gaps (no adopted component; bespoke is justified)
+
+- **SPEC §4 symbol resolver (gap for #1).** No ecosystem tool resolves
+  backticked symbols in markdown against the live BEAM module exports.
+  Bespoke 60-LoC Sourceror walker is justified.
+- **`@capabilities ↔ callback` mapping table (gap for #3).** Tau-
+  specific data; no ecosystem component models the relationship.
+  Bespoke ~30-line map literal in `Mix.Tasks.Tau.Gate.Capability` is
+  justified.
+- **Production-vs-test handler discrimination (gap for #4).** Adopted
+  `:telemetry` does not distinguish callsite origin. Bespoke
+  `Tau.Telemetry.attach/4` wrapper (~20 LoC) tagging handler IDs with
+  a `:prod` / `:test` prefix is justified.
+- **Verdict-shape contract (gap for all four).** The
+  `Mix.Gate.Common.emit_verdict/3` shape is Tau's existing convention;
+  no ecosystem component speaks it. Reusing Tau's existing helper (not
+  bespoke for this leaf — already shipped) is correct.
+
+No other gap remains. Every other surface is adopted.
+
+## Confidence
+
+**Medium-high.** Three of the four substrates (Credo, Dialyxir,
+Sourceror) are battle-tested in the Elixir ecosystem with documented
+custom-check / AST APIs; the fourth (`:telemetry` ETS) has been the
+substrate for `:telemetry`'s own internals since v1.0. The novel
+surface — bespoke shims plus the Claude Code plugin wrapping — is
+small and bounded. The two confidence-lowering risks are (a) the
+production-vs-test handler discrimination heuristic, which is a known
+gap with a known workaround (handler-ID prefix); and (b) the Claude
+Code plugin schema versioning, which is young. Both are mitigated
+above; neither blocks initial shipping. A prototype of
+`Tau.Credo.Checks.NoTryRescueAcrossProcess` against the existing
+`docs/problems/` rescue-site catalogue would raise confidence to high
+within a half-day.
+
+## Prior art / references
+
+- [doorgan/sourceror](https://github.com/doorgan/sourceror) — Elixir AST
+  manipulation with zipper API; Apache-2.0; compatible with Elixir
+  1.10+; used by `mix format`.
+- [rrrene/credo](https://github.com/rrrene/credo) — Elixir static
+  analysis; MIT; v1.7.x; documented custom-check API at
+  [hexdocs.pm/credo/adding_checks.html](https://hexdocs.pm/credo/adding_checks.html)
+  and testing API at
+  [hexdocs.pm/credo/testing_checks.html](https://hexdocs.pm/credo/testing_checks.html).
+- [jeremyjh/dialyxir](https://github.com/jeremyjh/dialyxir) — Mix tasks
+  wrapping Dialyzer; Apache-2.0; v1.4.x; catches
+  `callback_missing` / `callback_arg_type_mismatch` warnings.
+- [sasa1977/boundary](https://github.com/sasa1977/boundary) — Compile-
+  time cross-module dependency enforcement; MIT; v0.10.x; Saša Jurić;
+  [hexdocs.pm/boundary](https://hexdocs.pm/boundary/readme.html).
+- [beam-telemetry/telemetry](https://github.com/beam-telemetry/telemetry)
+  and [telemetry_registry](https://hexdocs.pm/telemetry_registry/TelemetryRegistry.html)
+  — Apache-2.0; BEAM-Foundation-maintained; ETS-backed handler table
+  with documented `discover_all/0` and `list_events/0` introspection.
+- [Stratus3D: "Show All Telemetry Events in Erlang and Elixir"](http://stratus3d.com/blog/2023/10/15/show-all-telemetry-events-in-erlang-and-elixir/)
+  — Erlang tracing technique for emit-site discovery; informs the
+  Sourceror static-walker alternative we adopt.
+- [georgeguimaraes/claude-code-elixir](https://github.com/georgeguimaraes/claude-code-elixir)
+  — Claude Code plugin marketplace for Elixir; PostToolUse-runs-credo
+  pattern; reference for our plugin shape.
+- [oliver-kriska/claude-elixir-phoenix](https://github.com/oliver-kriska/claude-elixir-phoenix)
+  — Iron Laws CI gate pattern with 4-agent parallel audits; reference
+  for "every PR must pass lint + test + eval" enforcement.
+- [anthropics/claude-code/tree/main/plugins](https://github.com/anthropics/claude-code/blob/main/plugins/README.md)
+  — Official plugin manifest schema, `PreToolUse` hook contract,
+  reference implementations of PreToolUse-blocking pattern.
+- [Pixelmojo: Claude Code Hooks: Production-Quality CI/CD Patterns](https://www.pixelmojo.io/blogs/claude-code-hooks-production-quality-ci-cd-patterns)
+  — `PreToolUse` exit-code semantics; the "exit non-zero blocks the
+  tool call" contract we mirror.
+- [AppSignal: Writing a Custom Credo Check in Elixir](https://blog.appsignal.com/2023/08/29/writing-a-custom-credo-check-in-elixir.html)
+  — `use Credo.Check`, `Credo.Code.prewalk/2`, `IssueMeta.for/2`
+  — the exact template our three NN-#7 checks follow.
+- [HexDocs: Module behaviour](https://hexdocs.pm/elixir/main/Module.html)
+  — `@behaviour` + `@impl` + `behaviour_info(:callbacks)` runtime
+  introspection contract used by the contracts gate.
+- Tau in-repo: `lib/mix/gate/common.ex`, `lib/mix/tasks/tau.gate.*.ex`
+  — the verdict-shape convention these four new gates conform to;
+  `ci.yml` lines 56-75 — the credo+compile-warnings pattern these
+  jobs extend without `|| true`.

--- a/docs/factory-v2/design/subproblems/pre-merge-code-gates/proposals/proposal-3.md
+++ b/docs/factory-v2/design/subproblems/pre-merge-code-gates/proposals/proposal-3.md
@@ -1,0 +1,516 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 3
+parent_problem: ../problem.md
+---
+
+# Proposal 3: Sign-off rule deck — ASIC tape-out DRC/LVS adapted as a four-deck Mix-task suite with enumerated inputs and a manifest gate
+
+## Approach
+
+Model the pre-merge code-gate substrate after **ASIC tape-out sign-off rule
+decks** (DRC, LVS, ERC, antenna). Tape-out shops do not ship a chip while
+*any* rule violates, *any* deck fails to run, or *any* "no input" verdict is
+returned uncategorised — the foundry's sign-off tool refuses with a hash-
+bound manifest. Translated to Tau: build four independent Mix-task "decks"
+— `Contracts`, `NoRescue`, `CapabilityFidelity`, `TelemetryConsumers` —
+each one a deterministic Sourceror-based AST traverser over an
+*enumerated* input set; package them under one umbrella task
+`mix tau.gate.code` that emits a single hash-stamped JSON manifest the CI
+job pins as a required status check. The deck-runner refuses to produce a
+PASS verdict unless every deck reports `inputs_enumerated`,
+`inputs_processed`, and `findings`, where `inputs_processed ==
+inputs_enumerated` and findings is empty; any other combination — including
+empty input list, missing deck binary, parser error — is a hard non-zero
+exit. Existing tools are wrapped, not replaced: Dialyzer's `@behaviour`-
+callback warnings feed `Contracts`; `mix xref` graph data feeds
+`TelemetryConsumers`; Credo custom checks back `NoRescue` rules where AST
+walking is awkward; `Sourceror` does the bespoke walks. A bespoke
+component is built only where no off-the-shelf check exists (`NoRescue`
+unreachable-condition heuristics, capability-flag → callback proof).
+
+## Rationale
+
+This decomplects four things v1 weaves: (i) the *check definition* from
+the *check execution* (decks are versioned files, the runner is generic);
+(ii) the *input enumeration* from the *check logic* (each deck must
+declare its target list, which removes "silent skip on empty input" by
+construction — empty enumeration is itself a finding, mirroring tape-
+out's "no-cells-checked" verdict); (iii) the *verdict* from the *agent
+narrative* (the CI gate consumes the manifest JSON, not stdout or PR-body
+text); (iv) the *tool-of-record* from the *check intent* (Dialyzer-or-
+Sourceror-or-Credo is a per-deck implementation choice the spec
+documents). The ASIC analogue is exact for AC-D (ecosystem reuse): the
+foundry mandates *which* rule decks must pass but lets vendors choose the
+checking engine, exactly as this spec mandates the four checks but lets
+each deck wrap an existing tool. The manifest pattern makes AC-C (silent-
+skip impossibility) structural: a missing deck cannot return "skipped"
+because the runner enumerates the expected deck IDs from a spec file
+and any missing ID is a hard fail.
+
+## Sketch
+
+### Directory layout
+
+```
+lib/mix/tasks/tau.gate.code.ex              # umbrella runner
+lib/mix/tasks/tau/gate/
+  contracts.ex                              # deck #1
+  no_rescue.ex                              # deck #2
+  capability_fidelity.ex                    # deck #3
+  telemetry_consumers.ex                    # deck #4
+lib/tau/gate/
+  deck.ex                                   # @behaviour Tau.Gate.Deck
+  manifest.ex                               # JSON manifest schema + writer
+  enumeration.ex                            # input-set helpers (Path.wildcard, Mix.Project.compile_path, etc.)
+priv/gate/decks.toml                        # canonical deck registry (id → module → required?)
+.github/workflows/ci.yml                    # one job: `mix tau.gate.code --manifest /tmp/gate.json`
+```
+
+### Deck behaviour
+
+```elixir
+defmodule Tau.Gate.Deck do
+  @moduledoc """
+  A pre-merge code-gate deck. Modelled on an ASIC sign-off rule deck:
+  declares its inputs, runs deterministically, emits findings as data.
+  """
+
+  @type input :: %{kind: atom(), path: Path.t() | nil, module: module() | nil}
+  @type finding :: %{
+          severity: :error | :warn,
+          rule_id: String.t(),
+          input: input(),
+          message: String.t(),
+          evidence: map()
+        }
+  @type result :: %{
+          deck_id: String.t(),
+          inputs_enumerated: [input()],
+          inputs_processed: [input()],
+          findings: [finding()],
+          parser_errors: [String.t()]
+        }
+
+  @callback deck_id() :: String.t()
+  @callback enumerate_inputs() :: {:ok, [input()]} | {:error, String.t()}
+  @callback run(inputs :: [input()]) :: result()
+end
+```
+
+### `CapabilityFidelity` deck (concrete — addresses class #3)
+
+```elixir
+defmodule Mix.Tasks.Tau.Gate.CapabilityFidelity do
+  @behaviour Tau.Gate.Deck
+
+  @impl true
+  def deck_id, do: "capability_fidelity"
+
+  @impl true
+  def enumerate_inputs do
+    paths = Path.wildcard("lib/tau/providers/*.ex")
+    if paths == [] do
+      {:error, "no provider modules under lib/tau/providers/*.ex"}
+    else
+      {:ok, Enum.map(paths, &%{kind: :provider_module, path: &1, module: nil})}
+    end
+  end
+
+  @impl true
+  def run(inputs) do
+    findings =
+      for %{path: path} = input <- inputs,
+          flags = capability_flags(path),
+          {flag, true} <- flags,
+          callback = required_callback(flag),
+          not exports?(path, callback) do
+        %{
+          severity: :error,
+          rule_id: "CF-001",
+          input: input,
+          message: "#{Path.basename(path)} declares #{flag}: true but does not export #{inspect(callback)}",
+          evidence: %{flag: flag, expected_callback: callback}
+        }
+      end
+
+    %{
+      deck_id: deck_id(),
+      inputs_enumerated: inputs,
+      inputs_processed: inputs,
+      findings: findings,
+      parser_errors: []
+    }
+  end
+
+  # Capability → required callback table (the rule deck)
+  defp required_callback(:prompt_caching), do: {:cache_regions, 2}
+  defp required_callback(:thinking), do: {:thinking_block, 2}
+  # ... extend as new capability flags are added
+
+  defp capability_flags(path) do
+    # Sourceror walk: find `capabilities` callback impl, extract the map literal
+    # ... returns [{:prompt_caching, true}, ...]
+  end
+
+  defp exports?(path, {fun, arity}) do
+    # Sourceror walk: any `def fun(_, _)` at top level
+  end
+end
+```
+
+### `NoRescue` deck (concrete — addresses class #2)
+
+```elixir
+defmodule Mix.Tasks.Tau.Gate.NoRescue do
+  @behaviour Tau.Gate.Deck
+
+  @impl true
+  def deck_id, do: "no_rescue"
+
+  @impl true
+  def enumerate_inputs do
+    paths = Path.wildcard("lib/tau/**/*.ex")
+    if paths == [] do
+      {:error, "no source files under lib/tau/"}
+    else
+      {:ok, Enum.map(paths, &%{kind: :source_file, path: &1, module: nil})}
+    end
+  end
+
+  @impl true
+  def run(inputs) do
+    findings =
+      for %{path: path} = input <- inputs,
+          site <- rescue_sites(path),
+          not waivered?(site) do
+        %{
+          severity: :error,
+          rule_id: "NR-001",
+          input: input,
+          message: "rescue/catch against unreachable condition (NN #7)",
+          evidence: site
+        }
+      end
+
+    %{deck_id: deck_id(), inputs_enumerated: inputs,
+      inputs_processed: inputs, findings: findings, parser_errors: []}
+  end
+
+  defp rescue_sites(path), do: # Sourceror: traverse for :try AST nodes, classify
+  defp waivered?(site), do:
+    # check priv/gate/waivers.toml for {file, line_range, expiry, rule_id}
+end
+```
+
+### Manifest (`priv/gate/manifest.schema.json`)
+
+```json
+{
+  "schema_version": 1,
+  "generated_at": "ISO-8601",
+  "commit_sha": "string",
+  "decks": [{
+    "deck_id": "capability_fidelity",
+    "tool_of_record": "bespoke|dialyzer|credo|xref",
+    "verdict": "PASS|FAIL|ERROR",
+    "inputs_enumerated_count": 9,
+    "inputs_processed_count": 9,
+    "findings_count": 2,
+    "findings": [/* finding objects */]
+  }],
+  "overall_verdict": "PASS|FAIL"
+}
+```
+
+### Umbrella runner
+
+```elixir
+defmodule Mix.Tasks.Tau.Gate.Code do
+  use Mix.Task
+  @required_decks ~w(contracts no_rescue capability_fidelity telemetry_consumers)
+
+  def run(argv) do
+    {opts, _} = OptionParser.parse!(argv, strict: [manifest: :string])
+
+    results =
+      Enum.map(@required_decks, fn id ->
+        mod = deck_module(id)
+        case mod.enumerate_inputs() do
+          {:ok, inputs} -> mod.run(inputs)
+          {:error, msg} -> %{deck_id: id, verdict: :error, error: msg}
+        end
+      end)
+
+    verdict = if Enum.all?(results, &deck_passes?/1), do: :pass, else: :fail
+    File.write!(opts[:manifest], Jason.encode!(%{
+      schema_version: 1, commit_sha: commit_sha(), decks: results,
+      overall_verdict: verdict
+    }))
+    if verdict == :fail, do: System.halt(1)
+  end
+
+  defp deck_passes?(%{verdict: :error}), do: false
+  defp deck_passes?(%{inputs_enumerated: [], findings: []}), do: false   # empty != skip
+  defp deck_passes?(%{inputs_processed: p, inputs_enumerated: e}) when p != e, do: false
+  defp deck_passes?(%{findings: []}), do: true
+  defp deck_passes?(_), do: false
+end
+```
+
+### CI wiring (replaces v1's `|| true` and `exit 0` patterns)
+
+```yaml
+- name: Pre-merge code gates (sign-off deck suite)
+  run: mix tau.gate.code --manifest /tmp/gate-manifest.json
+
+- name: Upload gate manifest
+  uses: actions/upload-artifact@v4
+  with:
+    name: gate-manifest
+    path: /tmp/gate-manifest.json
+```
+
+The job is set as a **required status check on `main`** in branch
+protection; absence of the manifest artifact is itself a protection
+violation that GitHub enforces independently of the workflow's exit code.
+
+## Tradeoffs
+
+### Strengths
+
+- **Silent-skip impossibility is structural, not procedural** (AC-C). A
+  deck whose `enumerate_inputs` returns `{:error, …}` or `{:ok, []}`
+  causes the umbrella to FAIL. A deck whose module is absent fails the
+  runner's `deck_module/1` lookup. There is no code path that yields PASS
+  from an empty input set — the ASIC parallel: "we ran zero rules" is
+  never a sign-off verdict.
+- **Per-deck tool-of-record is explicit** (AC-D, ecosystem reuse). The
+  manifest's `tool_of_record` field records whether `Contracts` wraps
+  Dialyzer (`@behaviour` callback warnings + `@callback`/`@impl`
+  cross-check), `TelemetryConsumers` wraps `mix xref` (callsites that
+  reference `:telemetry.attach`/`Tau.Telemetry.Handler`), or the deck
+  is bespoke. Spec records the choice with rationale; reviewer flags any
+  deck that switched tools without spec amendment.
+- **The manifest is a hash-bound machine artifact** — the verdict the CI
+  status check consumes is the manifest's `overall_verdict`, not stdout
+  scraping or PR-body text. Falsifies failure class #5 (silent-skip) and
+  #7 (local-mix evidence) for *this* leaf's checks.
+- **Inputs are enumerated declaratively per deck** — adding a new
+  provider, behaviour, or telemetry source automatically enters the
+  enumeration; the rule deck does not need editing. This is the ASIC
+  property "new cells are checked by existing rules unless explicitly
+  waivered."
+- **Waiver mechanism is in-tree and expires** — `priv/gate/waivers.toml`
+  takes `{file, line_range, rule_id, expires_on, justification}`; the
+  runner rejects expired or undated waivers, matching IEC 62304's
+  controlled-deviation discipline.
+- **Each deck is a `Tau.Gate.Deck` behaviour implementation** — adding
+  a fifth concern (e.g. "no `IO.puts` in lib/") is a single new module,
+  one row in `decks.toml`, no runner change.
+
+### Weaknesses
+
+- **Sourceror traversal authorship is non-trivial.** The
+  `CapabilityFidelity` deck must parse provider modules robustly, including
+  metaprogrammed `defcapabilities` macros (Tau already has 9 providers
+  with varying styles). First-pass bespoke walks will miss edge cases;
+  the gate may false-fail on legitimate constructs until the walks are
+  hardened.
+- **Dialyzer wrapping introduces PLT-cache fragility.** `Contracts` deck
+  needs a warm PLT to read `@behaviour` callback warnings; cold-cache
+  CI runs add 3–8 minutes. Caching the PLT in GHA partly mitigates but
+  cache-key invalidation on OTP/Elixir upgrade is a known footgun.
+- **No incremental mode.** Each PR re-runs all four decks across the
+  enumerated input sets. For `NoRescue` over ~80 lib files this is fast,
+  but as Tau grows past ~500 modules, total deck wall time may exceed the
+  GHA job budget. ASIC shops handle this with hierarchical rule decks; this
+  proposal does not.
+- **Telemetry-consumer fidelity check is heuristic.** "Production
+  consumer" is defined as "module under `lib/tau/` (not `test/`) that
+  calls `:telemetry.attach_many` or implements `Tau.Telemetry.Handler`
+  behaviour." A consumer registered dynamically from config or a plugin
+  may be missed; the gate must accept an allow-list (with the waiver
+  expiry discipline) until a runtime introspection check exists.
+- **Waiver mechanism is itself a target.** A coordinator under pressure
+  to merge may add a long-expiry waiver. The gate enforces the schema
+  and expiry but cannot enforce the *justification's* truthfulness;
+  reviewers see waivers in the diff and the dashboard surfaces unwaivered-
+  to-waivered transitions.
+
+### Costs
+
+- **Build:** ~4 new Mix tasks + 1 behaviour + 1 manifest writer + 1
+  enumeration helper ≈ 600–900 LOC of `lib/`, plus `priv/gate/decks.toml`,
+  `priv/gate/waivers.toml`, `priv/gate/manifest.schema.json`. Test surface
+  ≈ 400 LOC (property tests per deck: "any module exporting flag X without
+  callback Y is reported"; "any rescue site in lib/ is reported unless
+  waivered"; "empty enumeration is FAIL not PASS"). One-shot author cost
+  estimated at 2–3 implementer-days.
+- **Deps:** add `{:sourceror, "~> 1.0", runtime: false}`. No runtime
+  dependency footprint (Mix-only). Dialyzer and `mix xref` are already in
+  `.tool-versions`.
+- **CI:** ~30 s for the deck suite on a warm PLT (one job step, one
+  artifact upload). Replaces 3 silent-skipping shell-script steps in
+  `.github/workflows/ci.yml`; net workflow length unchanged or shorter.
+- **Operability:** the manifest artifact is a stable input to the
+  operability-and-hygiene-enforcement sibling's dashboard with zero
+  parsing work — well-defined JSON schema versioned at
+  `priv/gate/manifest.schema.json`.
+- **Migration:** existing v1 gates 5.1/5.2/5.3 stay (AC-binding leaf
+  owns them); this leaf adds a fourth CI job. v1's `prompt_caching: true`
+  liars (Gemini, Bedrock) are pre-existing failures the gate will surface
+  on its first run; the audit-ingestion sibling translates these into
+  waivered findings with remediation dates rather than insta-breaking
+  `main`.
+
+## Dependencies
+
+- **Sourceror 1.0+** for AST walking with formatter-preserving output;
+  Tau's `mix.lock` does not currently pin it. Library is stable and
+  widely used (Credo, Spitfire, ElixirLS depend on it).
+- **`Tau.Provider` behaviour stability** — `CapabilityFidelity` keys off
+  `capabilities/0` callback shape. Any restructuring of that callback
+  changes the deck's parser.
+- **Branch protection rule on `main`** must list `pre-merge code gates`
+  as required, with `Require branches to be up to date before merging`
+  ON, to prevent merging a stale-base PR whose manifest was generated
+  against an older `lib/tau/`. This is a one-time GitHub admin action
+  enumerated in the spec's "wiring" section.
+- **pre-merge-evidence-and-skip-integrity sibling's manifest contract**
+  — that leaf owns the manifest-consumer contract; this leaf produces a
+  manifest that conforms to it. Schema co-evolution requires coordination
+  in the same PR or back-to-back PRs.
+- **knowledge-memory-and-audit-ingestion sibling's waiver registry** —
+  this leaf consumes `priv/gate/waivers.toml`; that leaf owns the
+  registry's authoring mechanism and expiry sweeps.
+
+## Confidence
+
+**Medium-high.** Sourceror-based AST walks for the specific patterns
+named (capability-flag map literal, `try/rescue` AST nodes,
+`:telemetry.execute` callsites, `@behaviour` declarations) are well-
+trodden: Credo's custom-check infrastructure does exactly this style of
+walk. The bespoke piece — capability-flag → required-callback table — is
+trivial data. What would raise confidence to **high**: a
+proof-of-concept `Mix.Tasks.Tau.Gate.CapabilityFidelity` that correctly
+flags Gemini and Bedrock on the current `main` and correctly passes
+Anthropic; estimated 2–3 hours.
+
+What would lower it: discovering that Tau providers use macro-generated
+`capabilities/0` whose AST is not statically resolvable without macro
+expansion. Mitigation: run the gate on `Mix.Project.compile_path()` BEAM
+files instead of source, using `:beam_lib.chunks/2` to read attributes
+post-expansion. That falls back from "static AST" to "post-compile
+introspection" but does not change the gate's external contract.
+
+## Prior art / references
+
+- **ASIC sign-off rule decks (DRC/LVS/ERC/antenna)** — Cadence Innovus,
+  Synopsys IC Validator, Mentor Calibre. The "manifest with rule-deck IDs
+  and per-deck violation counts that the foundry's sign-off tool refuses
+  to accept on any non-zero count" is the structural model adopted here.
+  See e.g. *Calibre Verification User's Manual* §"Run hierarchy and
+  sign-off requirements."
+- **Erlang/OTP release-engineering pre-flight checks** — `rebar3
+  ct,dialyzer,xref` invoked together against an enumerated module set;
+  the OTP release process's `Makefile` `release_tests` target. Pattern:
+  multiple independent checkers each emit machine-readable output; a
+  consolidating wrapper fails the release on any one. Mirrors the
+  deck-runner pattern here.
+- **Credo custom checks** (`Credo.Check` behaviour) — the per-check
+  `run_on_all_source_files/2` callback enumerating inputs, returning
+  `[Issue.t()]`. This proposal generalises the same shape to four
+  decks beyond what Credo natively offers, and Credo itself is wrapped
+  for `NoRescue` where Credo's `Credo.Check.Refactor.RescueInsteadOfTry`
+  is sufficient.
+- **mutation-testing tooling: `muzak`** (Devon Estes,
+  github.com/devonestes/muzak) and **`mutant`** (mbj/mutant for Ruby,
+  cited as design influence). The pattern of "scriptable check, JSON
+  manifest, gate-on-manifest" applies here even though this proposal does
+  not itself do mutation — it borrows the verdict-as-artifact discipline.
+- **IEC 62304 §5.5.2 / DO-178C §6.3.4 controlled deviation** — waivers
+  must be itemised, justified, time-bounded, and reviewed; un-itemised
+  deviations are non-compliant. The `priv/gate/waivers.toml` expiry
+  discipline maps directly.
+- **`semgrep` / `ast-grep` rule packs** — pattern-as-data rules consumed
+  by a generic engine; precedent for separating rule definition (decks)
+  from rule engine (umbrella runner). Considered as a direct adoption
+  (see "Rejected" below) but rejected on impedance mismatch.
+- **Bazel `bazel test //... --test_output=errors`** — atomic "all
+  required tests for the target ran, none was skipped, exit code is the
+  truth" model. Precedent for the manifest-as-truth pattern over text-
+  scraping of build output.
+
+## Rejected adoptions
+
+These were considered and rejected; recording why is part of AC-D:
+
+- **`semgrep` or `ast-grep` as the bespoke-deck engine.** Both have
+  excellent multi-language pattern matching but treat Elixir as a
+  second-class target (no first-class AST support; rules express against
+  text patterns or generic AST). The capability-flag → callback proof
+  requires resolving `defmodule` attributes and `@callback`/`def`
+  matching — Sourceror does this natively in Elixir's own AST; semgrep
+  requires regex stand-ins that are fragile against macros. Adopted for
+  *file-level* sniffs (e.g. "no `IO.puts` in `lib/`" would be a
+  reasonable semgrep rule) but rejected for the four decks named in this
+  leaf.
+- **`mix dialyzer` alone for `Contracts`.** Dialyzer's `@behaviour`
+  callback-completeness warning is necessary but insufficient: it does
+  not catch SPEC §4-named structs that do not exist (root failure #1's
+  primary form), because struct existence is a compile-time error already
+  — the v1 failure was that `@doc` claimed adapters implemented
+  callbacks they did not, and `@doc` is not analysed by Dialyzer.
+  `Contracts` deck wraps Dialyzer for the callback subset and adds a
+  bespoke `@doc`-claim cross-check.
+- **`muzak` for `CapabilityFidelity`.** Mutation testing produces signal
+  about test coverage of behaviour, not about declaration-vs-implementation
+  consistency. Wrong tool for class #3. Mutation testing remains owned by
+  the AC-binding sibling's Gate 5.3.
+- **Pure Credo custom-check suite.** Credo's check framework is excellent
+  for stylistic and small AST patterns but emits findings to stdout with
+  no manifest. A Credo-only suite would fail AC-C (silent-skip
+  impossibility) because Credo exits 0 when zero files match an
+  `:included_files` glob. `NoRescue` wraps Credo's existing rescue check
+  but the umbrella manifest layer is mandatory regardless.
+- **Hook-based PreToolUse gating.** Hooks fire on local agent actions,
+  not on PRs, and cannot enforce on a PR opened from a fork or from
+  another agent's worktree. The gate must live in CI to be merge-
+  blocking. (Hooks may complement by surfacing findings locally pre-
+  push; that is the operability sibling's domain.)
+
+## Silent-skip impossibility — explicit demonstration
+
+Per AC-C, this proposal must make silent skip *structurally* impossible
+for the four checks it owns. The argument:
+
+1. **At the runner layer.** `@required_decks` is a compile-time constant
+   list. `Mix.Tasks.Tau.Gate.Code` iterates it; a missing deck module
+   raises `UndefinedFunctionError` on `deck_module(id)`, which is an
+   uncaught exception → non-zero exit → CI red.
+2. **At the deck layer.** `enumerate_inputs/0` returning `{:ok, []}`
+   makes `deck_passes?` false via the explicit `%{inputs_enumerated: [],
+   findings: []}` clause. Returning `{:error, msg}` produces a
+   `%{verdict: :error}` result that also fails `deck_passes?`. There is
+   no clause that returns `true` on an empty input list.
+3. **At the CI layer.** The job step is `mix tau.gate.code --manifest
+   …` with no `|| true`, no `exit 0`, no `continue-on-error`. Branch
+   protection requires the named status check; GitHub will not allow the
+   PR to merge if the check has not reported or reported FAIL.
+4. **At the manifest layer.** The status check key includes
+   `overall_verdict == PASS` *and* the artifact's existence. If the job
+   crashed before writing the manifest, the artifact step (`actions/
+   upload-artifact@v4`) fails; the workflow fails; the check fails red;
+   merge is blocked.
+5. **At the audit-trail layer.** The manifest is committed as a workflow
+   artifact, retained 90 days. A reviewer can inspect *which* decks ran,
+   *what* inputs each enumerated, *what* findings each produced — a
+   reviewer claiming "the gate passed" must point to the artifact, not
+   stdout.
+
+No "empty input therefore PASS" code path exists; no "deck missing
+therefore skipped" code path exists; no "CI command failed therefore
+treated as PASS" code path exists. Each is checked at a different layer
+so failure of one defence does not collapse the rest.

--- a/docs/factory-v2/design/subproblems/pre-merge-code-gates/proposals/proposal-4.md
+++ b/docs/factory-v2/design/subproblems/pre-merge-code-gates/proposals/proposal-4.md
@@ -1,0 +1,453 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 4
+parent_problem: ../problem.md
+---
+
+# Proposal 4: Five adversarial gates, each constructed backwards from a real v1 failure
+
+## Approach
+
+Build the pre-merge code-gate subsystem as **five independent, bespoke Mix
+tasks**, each derived backwards from one concrete v1 failure that the gate
+must have caught and didn't. Each gate is the smallest scriptable check that
+turns its specific historical failure from "merged" to "blocked", generalises
+to a class of analogous failures, and cannot return zero on an empty input
+set. The five tasks (`Mix.Tasks.Tau.Gate.CapabilityFidelity`,
+`Mix.Tasks.Tau.Gate.NoUnreachableRescue`, `Mix.Tasks.Tau.Gate.BehaviourClosure`,
+`Mix.Tasks.Tau.Gate.SpecSymbolExistence`, `Mix.Tasks.Tau.Gate.TelemetryConsumers`)
+are wired as five separate required status checks in `.github/workflows/ci.yml`
+(no combined "lint" umbrella that hides a skip), each with an inventory file
+under `priv/gates/<gate>.inputs.json` whose absence or emptiness fails the
+gate rather than passing it. Shared infrastructure is limited to a thin
+`Tau.Gate.Inventory` helper that enumerates the input set for each gate and
+emits a verdict in a single fixed JSON shape; no other module is shared,
+because shared "frameworks" between gates is how v1's CI got a single
+`|| true` that silenced the lot.
+
+## Rationale
+
+The complecting hypothesis the leaf names ("the checks are complected with
+'the agent's word'") is decomplected by making each check a per-commit
+deterministic Mix task whose verdict the gate consumes verbatim. This
+proposal extends that: each gate is also decomplected *from the other
+gates*. v1's pattern was a unified "lint" job whose internal early-exit
+(`ci.yml:88-100`) silenced multiple checks at once; five independent jobs
+with five independent required-status-check names make a silent multi-gate
+skip structurally impossible. Each gate is justified by an exact PR-merge
+that would have failed it — not by an abstract category. The adversarial
+construction also forces honesty: a gate whose original failure cannot be
+named in one paragraph of code, PR body, and agent self-report is a gate
+without a falsifier, and is dropped.
+
+## Sketch
+
+Each gate is constructed from a real v1 failure, generalised, and shown
+mechanically. All five share the inventory contract (below) so silent-skip
+is structurally impossible.
+
+### Shared inventory contract
+
+```elixir
+defmodule Tau.Gate.Inventory do
+  @moduledoc """
+  Enumerates the input set for a gate. An empty input set returns
+  `{:error, :empty_inventory, reason}` so the calling Mix task can exit
+  non-zero rather than silently passing on a missing target list.
+
+  Per-gate inventories live in `priv/gates/<gate>.inputs.json` and are
+  read by the Mix task at boot. The file MUST exist; CI fails the PR if
+  it does not. The file MUST list ≥1 input; an empty list fails the PR.
+  """
+
+  @type result :: {:ok, [input :: term]} | {:error, :missing | :empty, String.t()}
+
+  @spec load(atom()) :: result()
+  def load(gate_name)
+end
+```
+
+Verdict JSON every gate emits to stdout (consumed verbatim by CI):
+
+```json
+{
+  "gate": "capability_fidelity",
+  "schema_version": 1,
+  "inventory_count": 9,
+  "findings": [
+    {"file": "lib/tau/providers/deepseek.ex", "line": 51,
+     "violation": "prompt_caching: true without cache_regions/2 export"}
+  ],
+  "verdict": "fail"
+}
+```
+
+### Failure 1 — `deepseek.ex` declares `prompt_caching: true` with no callback
+
+**Exact v1 failure.** `lib/tau/providers/deepseek.ex:51` returns
+`%{... prompt_caching: true, ...}` from `capabilities/0`. `grep` confirms
+the module exports `@behaviour Tau.Provider` (line 30) but does NOT export
+`cache_regions/2`. The user-facing effect: any call site that branches on
+`capabilities().prompt_caching` (see `lib/tau/providers/shared/content_transform.ex:98`,
+which already drops `cache_control` blocks when `prompt_caching: false`)
+will follow the caching path on DeepSeek, then hit a `function_clause`
+error when the policy lookup tries to invoke `cache_regions/2`. Bedrock
+(`bedrock.ex:36`) and Gemini (`gemini.ex:30`) carry the same lie.
+
+**Generalisation.** A capability flag in the `capabilities/0` map implies
+the existence of a specific behaviour callback. The flag→callback mapping
+is small, finite, and lives in `Tau.Provider`:
+
+| capability key | required callback     |
+|----------------|-----------------------|
+| `prompt_caching: true` | `cache_regions/2` |
+| `thinking: true`       | `extended_reasoning/1` (future) |
+| `tools: true`          | `format_tools/1` (already mandatory; assert anyway) |
+
+**Mechanism.** `Mix.Tasks.Tau.Gate.CapabilityFidelity` enumerates every
+module under `lib/tau/providers/*.ex` whose AST contains
+`@behaviour Tau.Provider`, parses `capabilities/0` via `Sourceror.parse_file!`
+to extract the literal map, looks up each `true`-valued key in the
+flag→callback table, and asserts the module's export list contains the
+required callback. Inventory: `priv/gates/capability_fidelity.inputs.json`
+lists every adapter file; if the file is absent or empty, exit 2 (CI fails).
+If no flag→callback mapping exists, exit 2 (forces the table to be
+maintained alongside `Tau.Provider`).
+
+**Silent-skip impossibility.** Exit codes: `0` = inventory ≥1 AND zero
+findings; `1` = ≥1 finding; `2` = inventory missing / empty / mapping
+table absent. CI treats `2` identically to `1`. There is no `0`-with-no-
+inventory path.
+
+### Failure 2 — `Tau.Session.resolve_provider/1` rescues against `String.to_existing_atom/1`
+
+**Exact v1 failure.** `lib/tau/session.ex:488-494`:
+
+```elixir
+defp resolve_provider(s) when is_binary(s) do
+  try do
+    String.to_existing_atom(s)
+  rescue
+    _ -> Tau.Provider.default()
+  end
+end
+```
+
+`String.to_existing_atom/1` raises `ArgumentError` on an unknown atom —
+that IS the reachable failure mode, and the rescue is legitimate. But the
+broader pattern in v1 is `try/rescue` wrapping calls that *cannot* fail —
+e.g. the `try` at `session.ex:422` (around a `:gen_statem.call` that
+already has its own `:timeout` handling), and the seven `rescue` sites
+flagged in the prior module audit that moved zero between audits. OTP
+non-negotiable #7 forbids `try/rescue` across process boundaries and
+`catch :exit` of `:exit` signals.
+
+**Generalisation.** Every `try/rescue` and every `catch :exit` clause is
+suspect by default. The gate's job is not to forbid them all (some — like
+`String.to_existing_atom/1` — are legitimate) but to force every one to
+be **annotated with the specific raising callee and a justification**.
+Unannotated rescues are violations. The annotation is parsed; nonsense
+text fails.
+
+**Mechanism.** `Mix.Tasks.Tau.Gate.NoUnreachableRescue` uses `Sourceror`
+to traverse every `.ex` file under `lib/`. For every `{:try, _, _}` and
+every `{:catch, _, [{:exit, _, _}, _]}` AST node, it looks for a sibling
+`@rescue_justification` module attribute or a `# rescue: <callee> <reason>`
+comment within 3 lines above the `try`. The justification names the
+specific raising callee and a one-line reason. The gate cross-checks the
+named callee actually exists (via `Code.ensure_loaded?/1` + `function_exported?/3`).
+Inventory: every `.ex` file under `lib/tau/`; empty → exit 2.
+
+**Silent-skip impossibility.** Inventory file enumerates the file set;
+the file existing with zero entries fails. A PR that adds a rescue and
+provides only the comment `# rescue: foo` without a real Elixir callee
+fails (the cross-check). A PR that adds a rescue and no comment fails.
+
+### Failure 3 — `@behaviour Tau.Provider` declared without implementing all callbacks
+
+**Exact v1 failure.** `lib/tau/providers/deepseek.ex:30` declares
+`@behaviour Tau.Provider`. The behaviour requires `stream/3`, `format_tools/1`,
+`merge_usage/2`, etc. The compiler will warn if any are missing, but the
+v1 build is run *without* `--warnings-as-errors` on the path that matters
+for nightly-style regressions, and `@optional_callbacks` is used liberally
+to silence the warning even when the runtime call path expects the
+callback. Coupled with capability-flag-implied-callbacks (Failure 1), the
+v1 codebase merges adapters whose contract is "stream-only, no tool
+support" but whose `capabilities/0` claims `tools: true`.
+
+**Generalisation.** A module that declares `@behaviour M` must export
+every non-`@optional_callback` callback of `M`, with the exact arity. The
+check is independent of `--warnings-as-errors` (which can be silenced)
+and independent of the capability-flag fidelity check (which addresses
+a different lie).
+
+**Mechanism.** `Mix.Tasks.Tau.Gate.BehaviourClosure` enumerates every
+loaded module via `:application.get_key(:tau, :modules)`, reads
+`__info__(:attributes)` for `:behaviour`, fetches each behaviour's
+`behaviour_info(:callbacks)` and `behaviour_info(:optional_callbacks)`,
+and asserts every required `{fun, arity}` is present in the implementing
+module's `__info__(:functions)`. Optional callbacks are reported as
+*informational* findings (counted but not failing) when the capability
+flag implies them — this links Failure 1 and Failure 3 without complecting
+the gates. Inventory: every compiled module in the `:tau` app; empty →
+exit 2 (means the app didn't compile).
+
+**Silent-skip impossibility.** The compiled-module set cannot be empty
+on a successful build, so an empty input is also a CI-infrastructure
+failure (the build broke). Either way exit 2; CI fails.
+
+### Failure 4 — SPEC §4 names `ToolUseStart` and the struct does not exist
+
+**Exact v1 failure.** `docs/spec/SPEC-USER-TURN.md:75` says:
+
+> Provider stream events are assumed to arrive in the order
+> `Start → TextStart → TextDelta* → TextEnd → ToolUseStart → ToolUseDelta* → ToolUseEnd → Done`.
+
+`grep -rn ToolUseStart lib/` returns zero hits. `lib/tau/provider/event.ex`
+defines `Start`, `Done`, `Text`, etc. but not `ToolUseStart`. The SPEC §4
+contract names a symbol that does not exist in code; consuming code
+silently never matches the absent pattern, so the streaming bug is masked
+rather than surfaced.
+
+**Generalisation.** Every backtick-quoted CamelCase identifier in a
+`docs/spec/SPEC-*.md` §4 ("Boundary contracts") that *looks like* a struct
+or module name MUST resolve to an actual loaded module or to a literal
+quoted in §3 with a "(not yet implemented; tracked by #NNN)" annotation.
+A SPEC may not silently promise structs that don't exist.
+
+**Mechanism.** `Mix.Tasks.Tau.Gate.SpecSymbolExistence` reads every
+`docs/spec/SPEC-*.md`, locates the `## §4` section by regex, extracts
+every backtick-quoted token matching `~r/`([A-Z][A-Za-z0-9_.]+)(?:\(/?\d*\)?)`/`
+(module paths and `Mod.fun/arity` references), and looks up each against
+the compiled module set (via `Code.ensure_loaded?/1`). Unresolved tokens
+fail the gate UNLESS the SPEC §3 prose contains a deferral annotation
+matching `~r/#{token}.*\(not yet implemented; tracked by \#\d+\)/`.
+Inventory: every `SPEC-*.md` under `docs/spec/`; empty → exit 2.
+
+**Silent-skip impossibility.** A PR that touches a SPEC but leaves the
+SPEC file unparseable (no §4 section) fails the gate with exit 2 (input
+present, structure invalid). A PR that adds a SPEC mention of a future
+struct without the deferral annotation fails with exit 1.
+
+### Failure 5 — `[:tau, :compaction, :exception]` emitted, zero consumers attach
+
+**Exact v1 failure.** `lib/tau/session/compaction.ex` emits
+`[:tau, :compaction, :exception]` from four call sites (lines 80, 154, 205,
+249). `grep -rn ':telemetry.attach\|telemetry.attach_many'
+lib/tau/` returns 5 attach sites total across the whole codebase, and
+none of them subscribe to `[:tau, :compaction, :exception]`. The audit
+recorded 23 `*.exception` events attached but never emitted, and the
+inverse — 79 (64.9% of 122) `:telemetry.execute` sites with zero
+non-debug consumer registered. The user-facing effect: a compaction
+failure is silently dropped on the floor; no log, no OTel span, no metric.
+
+**Generalisation.** Every event name passed to `:telemetry.execute/3`
+must be subscribed to by at least one *production* `:telemetry.attach` or
+`:telemetry.attach_many` call. "Production" means: in code under `lib/`,
+NOT under `test/` or `test/support/`, NOT inside a function whose
+`@moduledoc false` ancestor is a debug-only module.
+
+**Mechanism.** `Mix.Tasks.Tau.Gate.TelemetryConsumers` uses `Sourceror`
+to walk every `.ex` under `lib/` and `test/`, collects the literal
+event-name list from every `:telemetry.execute(events, ...)` and
+`:telemetry.attach(_, events, ...)` / `attach_many` call (events must
+be a literal list — non-literal events fail the gate; that prevents a
+PR from hiding events behind a runtime expression). It then computes
+`emitted_only = emitted_set ∖ attached_set_from_lib` and
+`attached_only = attached_set_from_lib ∖ emitted_set`. Both sets must
+be empty. Inventory: emitted list + attached list, both ≥1; empty
+either → exit 2.
+
+**Silent-skip impossibility.** The lib-attached set being empty means
+either OtelReporter is gone (regression) or the inventory is broken;
+both fail. Non-literal events fail at AST-parse time. A PR that emits
+a new event without adding a consumer in the same diff fails.
+
+### CI wiring
+
+`.github/workflows/ci.yml` gets five named jobs, each a required status
+check on `main`:
+
+```yaml
+jobs:
+  gate-capability-fidelity:
+    steps:
+      - run: mix tau.gate.capability_fidelity
+        # exits 0 / 1 / 2; 0 only on inventory ≥ 1 AND no findings
+  gate-no-unreachable-rescue:
+    steps:
+      - run: mix tau.gate.no_unreachable_rescue
+  gate-behaviour-closure:
+    steps:
+      - run: mix tau.gate.behaviour_closure
+  gate-spec-symbol-existence:
+    steps:
+      - run: mix tau.gate.spec_symbol_existence
+  gate-telemetry-consumers:
+    steps:
+      - run: mix tau.gate.telemetry_consumers
+```
+
+No `continue-on-error: true`. No `|| true`. No combined `lint` umbrella.
+Five separate required-status-check names recorded in branch protection.
+
+### Sequencing by impact
+
+The gates are sequenced for delivery by the size of the historical
+bleed they block:
+
+1. **CapabilityFidelity** — blocks the DeepSeek + Bedrock + Gemini
+   adapter lies that currently crash at the cache-policy callsite.
+2. **TelemetryConsumers** — addresses 64.9% of telemetry sites + 23
+   never-emitted exception attachments; highest "drift surface area."
+3. **BehaviourClosure** — currently masked by `--warnings-as-errors`
+   silencing; resurfaces it mechanically.
+4. **SpecSymbolExistence** — blocks the SPEC↔code drift class
+   exemplified by `ToolUseStart`.
+5. **NoUnreachableRescue** — slowest to land (every legitimate
+   rescue needs an annotation pass), so last.
+
+## Tradeoffs
+
+### Strengths
+
+- **Each gate has a named falsifier.** Drop any gate, point to the
+  specific historical merge it would no longer catch. That is the
+  Toulmin-warrant test the v1 process was supposed to apply and didn't.
+- **Five independent required status checks** make a silent multi-gate
+  skip structurally impossible — addresses leaf AC (c) and root §C.
+- **Inventory contract makes empty-set silent-pass impossible.** Every
+  gate exits 2 on a missing or empty inventory file; CI treats 2 as
+  failure. Directly answers leaf AC (b).
+- **Generalisations are tight to the failure.** Each gate generalises
+  *only* to the class its constructed failure exemplifies (capability
+  flags → behaviour callbacks; one rescue → all rescues; one SPEC
+  symbol → all §4 backtick-tokens). No gate is a "platform" looking
+  for a use case.
+- **Pure bespoke choice is justified per gate.** CapabilityFidelity
+  has no off-the-shelf equivalent (the flag→callback table is
+  Tau-specific). NoUnreachableRescue's annotation discipline cannot
+  be expressed in `credo --strict` without a custom check, and at that
+  point a Mix task is simpler. BehaviourClosure could use Dialyzer's
+  `@callback` warnings, but Dialyzer's slow PLT generation and
+  configurability (warnings can be silenced) make a bespoke compiled-
+  module check more deterministic. SpecSymbolExistence and
+  TelemetryConsumers have no analogues anywhere.
+- **Linked but not complected.** BehaviourClosure reports optional-
+  callback gaps the capability flag implies as *informational*
+  findings, surfacing the link to CapabilityFidelity without merging
+  the two gates' verdict logic.
+
+### Weaknesses
+
+- **Five gates is N+1 maintenance.** Every new failure class is a new
+  Mix task and a new CI job. The leaf problem names four classes; this
+  proposal commits to five gates (one extra: SPEC symbol existence is
+  arguably code↔spec drift, which the leaf attributes to
+  intent-capture-and-ac-binding or post-merge-cross-artifact-coherence
+  — see Dependencies for the boundary question).
+- **NoUnreachableRescue's annotation discipline burdens every legitimate
+  rescue site.** The migration cost is one annotated rescue per existing
+  site (~7 sites from the audit + however many surface). Failure to
+  annotate during the migration PR blocks every subsequent PR until
+  done.
+- **Sourceror-based AST traversal is slower than `grep`.** On a full
+  repo scan this is seconds, not minutes; on CI it's negligible. But
+  the proposal commits to AST correctness, so all checks are at least
+  one `Sourceror.parse_file!` deep — no shortcuts.
+- **TelemetryConsumers' "production handler" definition is heuristic.**
+  Distinguishing test/support attaches from production attaches via
+  path is fragile if production code ever lives under `test/support/`
+  (it shouldn't, but the heuristic doesn't enforce that). Mitigation:
+  add a `Tau.Gate.TelemetryConsumers.ProductionPath` allowlist that
+  the gate's own inventory rejects if it grows beyond the natural set.
+- **SpecSymbolExistence can produce false positives** when a SPEC §4
+  cites a future symbol with imperfect deferral annotation. The
+  proposal demands the annotation be exact; SPEC authors will need a
+  short template. False-positive cost: one extra PR to amend the SPEC.
+- **No mutation testing in this proposal.** The leaf out-of-scope
+  excludes per-AC mutation, but a check like "does removing a rescue
+  break any test" would catch a different class of dead-rescue. Not
+  in scope here; sibling intent-capture-and-ac-binding may pick it up
+  via the gating-test path set.
+
+### Costs
+
+- **Migration:** 5 Mix tasks (~150 lines each = ~750 lines of gate
+  code) + 1 `Tau.Gate.Inventory` helper (~80 lines) + 5 inventory
+  JSON files. Initial annotation pass for NoUnreachableRescue:
+  ~7-12 rescue sites × 1 annotation each. Initial SPEC §4 audit for
+  SpecSymbolExistence: ~10 SPECs × ~5 minutes each.
+- **CI runtime:** ~30s per gate worst case (Sourceror parse of
+  ~200 .ex files); 5 parallel jobs → adds ~30s to PR check time.
+- **Test surface:** Each Mix task needs property tests over
+  synthetic ASTs + at least one example test pinned to a known
+  good/bad file under `test/support/gates/`. ~50 test cases total.
+- **Dependency impact:** `Sourceror ~> 1.0` added to mix.exs (small,
+  pure-Elixir, no native deps). No other new deps.
+- **Knowledge:** every PR author must know the inventory JSON pattern
+  and the annotation comment grammar for rescues. One README under
+  `priv/gates/README.md` (≤50 lines) suffices.
+
+## Dependencies
+
+- The `flag→callback` mapping table must live in `Tau.Provider` (or a
+  sibling `Tau.Provider.CapabilityTable`). Adding a new flag without
+  adding to the table fails CapabilityFidelity's exit-2 inventory
+  branch, which forces the table to stay current.
+- The boundary between this leaf and **intent-capture-and-ac-binding**
+  on the SPEC-symbol question: the leaf problem (this one) covers
+  AST/contract/capability/telemetry on the production diff. SPEC
+  symbol existence is a SPEC↔code drift check that runs on every PR
+  that touches *either* code or SPEC. This proposal claims it for
+  pre-merge code gates because the falsifier (SPEC §4 names a struct
+  the code lacks) is a code-side liability when a PR touches the
+  code without adding the struct. If the design tree later assigns it
+  to post-merge-cross-artifact-coherence, drop this gate from PR-5
+  scope (the other four stand alone).
+- **pre-merge-evidence-and-skip-integrity** sibling: this proposal
+  assumes that sibling will own (a) branch-protection wiring to mark
+  these five jobs as required status checks, (b) the ban on
+  `continue-on-error: true` / `|| true` in `ci.yml`, and (c) the
+  pre-merge "all required checks green" assertion. Without that
+  sibling's work, the five gates run but can still be merged-around.
+- `Sourceror ~> 1.0` (Hex package, well-established, used by ElixirLS).
+
+## Confidence
+
+**High** for CapabilityFidelity, TelemetryConsumers, and BehaviourClosure
+— prior art exists (Dialyzer for callbacks, OpenTelemetry SDK introspection
+for handlers, multiple Elixir static-analysis tools for capability/contract
+checks). Each is constructed from a verified-by-grep v1 failure.
+
+**Medium** for NoUnreachableRescue (the annotation grammar is new and
+will need a short feedback loop with the team) and SpecSymbolExistence
+(the §4 regex must handle edge cases like generics and function refs).
+Both gates are scoped tight enough that the prototype is < 200 lines.
+
+What would raise confidence: prototype each Mix task against the current
+repo, observe how many findings each surfaces (the count itself validates
+the gate is calibrated correctly), and post the inventory JSONs to a
+small sample of PRs before flipping the branch-protection switch.
+
+## Prior art / references
+
+- `mix dialyzer` `@callback` warnings — prior art for behaviour-closure
+  checking; rejected as load-bearing because (a) PLT generation is slow
+  enough that v1 teams routinely run without it, (b) warnings can be
+  suppressed via `@dialyzer` attributes, and (c) Dialyzer is silent on
+  the capability-flag-implies-callback link.
+- `mix credo --strict` custom checks — prior art for AST-traversal lint
+  rules; rejected as the *substrate* because Credo's check API encodes
+  severity in a way that lets a project run with all checks set to
+  `:warning` (silenceable). A bespoke Mix task that exits non-zero is
+  unambiguous.
+- OpenTelemetry SDK `OpenTelemetry.handlers/0` introspection — direct
+  prior art for TelemetryConsumers' "registered handler" check.
+- `Sourceror` (https://hex.pm/packages/sourceror) — used by ElixirLS,
+  Refactorex, and the Elixir formatter; the standard AST library for
+  this kind of source-level analysis.
+- v1 audit `docs/problems/` — the source of truth for the historical
+  failure constructions in this proposal. Every Failure-N in §Sketch
+  cites a specific file:line or count from the audit.

--- a/docs/factory-v2/design/subproblems/pre-merge-code-gates/solution.md
+++ b/docs/factory-v2/design/subproblems/pre-merge-code-gates/solution.md
@@ -1,0 +1,672 @@
+---
+template_version: 1
+template_name: solution
+parent_problem: ../problem.md
+node_kind: leaf
+synthesised_from: [proposals/proposal-2.md, proposals/proposal-3.md, proposals/proposal-4.md]
+selection_method: hybrid
+revision: 0
+---
+
+# Solution: `tau-code-gates` plugin — five adversarial decks on ecosystem substrates, unified by a hash-stamped manifest runner that cannot silent-skip
+
+## Recommendation
+
+Ship the pre-merge code-gate substrate as a Claude Code plugin
+(`plugins/tau-code-gates/`) that exposes **five independent decks** —
+`CapabilityFidelity`, `NoUnreachableRescue`, `BehaviourClosure`,
+`SpecSymbolExistence`, `TelemetryConsumers` — each constructed backwards
+from a verified v1 failure (proposal-4), each implementing one
+`Tau.Gate.Deck` behaviour callback that returns an enumerated input set
+and findings (proposal-3), and each delegating its checking engine to an
+existing ecosystem tool (proposal-2) wherever one exists: Credo's
+custom-check framework for `NoUnreachableRescue`, Elixir compiler +
+Dialyxir for `BehaviourClosure`, Sourceror for `CapabilityFidelity` /
+`SpecSymbolExistence` / the AST-side of `TelemetryConsumers`,
+`:telemetry`'s ETS handler table for the runtime side of
+`TelemetryConsumers`. A single umbrella task `mix tau.gate.code` runs
+every registered deck, writes a hash-stamped manifest
+(`/tmp/tau-gate.json`) whose `overall_verdict` the CI status check
+consumes verbatim, and exits non-zero if **any** deck reports findings,
+**any** deck returns `inputs_enumerated == []`, **any** deck's
+`inputs_processed != inputs_enumerated`, **any** required-deck module
+fails to load, or the manifest artifact fails to upload. The same Mix
+tasks run pre-commit via a `PreToolUse` hook in the plugin so the
+implementer agent sees verdicts before pushing. Each deck records its
+`tool_of_record` (`bespoke | dialyxir | credo | sourceror | telemetry`)
+in the manifest, satisfying root §AC-D "ecosystem reuse" by
+construction; bespoke surface is bounded to ~600 LoC of glue plus the
+flag→callback table, all justified per deck in `priv/gate/decks.toml`.
+
+## Selected from
+
+- **Chosen:** hybrid of `proposals/proposal-2.md` (ecosystem adoption +
+  Claude Code plugin shape), `proposals/proposal-3.md` (deck behaviour
+  + hash-stamped manifest + `tool_of_record` recording), and
+  `proposals/proposal-4.md` (five gates constructed backwards from
+  named v1 failures with named falsifiers).
+
+- **Why chosen.** Scoring against the leaf acceptance criterion:
+
+  | # | Fit | Decomplecting depth | Migration cost | Risk | Reversibility |
+  |---|---|---|---|---|---|
+  | 1 (in-repo substrate) | Partially | Substantial | Medium | Low | Easy |
+  | 2 (adapt-from-ecosystem) | Yes | Deep | Medium | Low | Easy |
+  | 3 (ASIC sign-off decks) | Yes | Deep | Medium | Low | Easy |
+  | 4 (five adversarial gates) | Yes | Substantial | Medium-high | Low | Easy |
+
+  Proposal-2 wins on root §AC-D (ecosystem reuse over reinvention) —
+  it is the only proposal that names a specific existing tool per
+  check, justifies bespoke surface explicitly, and adopts the
+  claude-code-elixir / Anthropic plugin patterns the prompt directs us
+  toward. Proposal-3 wins on root §AC-C (silent-skip impossibility) —
+  its `inputs_enumerated/inputs_processed/findings` triple plus the
+  hash-stamped manifest is the only proposal whose silent-skip
+  guarantee survives at five independent layers (runner, deck, CI, the
+  manifest itself, the artifact upload). Proposal-4 wins on root §AC-A
+  (failure-class coverage) — each gate is constructed backwards from a
+  specific, grep-verifiable v1 merge the gate must have blocked, which
+  is the Toulmin-warrant test the v1 review process failed to apply.
+  Proposal-1 dominates on none and reinvents what proposal-2 adopts;
+  it is not selected.
+
+  None of the three winning proposals dominates the others on every
+  axis — proposal-2 has no manifest discipline, proposal-3 leaves the
+  per-deck failure derivation implicit, proposal-4 underweights
+  ecosystem adoption. The hybrid takes the load-bearing element of
+  each: the *engine substrate* from proposal-2, the *verdict
+  protocol* from proposal-3, and the *adversarial gate construction*
+  from proposal-4. The combination is more than the sum: ecosystem
+  adoption without a manifest still permits stdout-scraping (the v1
+  failure mode); a manifest runner without ecosystem adoption is the
+  reinvention root §AC-D forbids; either without adversarial
+  construction risks "platform looking for a use case" (proposal-3's
+  self-cited weakness).
+
+## What changes
+
+### Artifact inventory — every concrete component the spec creates
+
+#### Elixir code under `lib/`
+
+- `lib/tau/gate/deck.ex` — defines `Tau.Gate.Deck` behaviour with
+  callbacks `deck_id/0`, `tool_of_record/0`, `enumerate_inputs/0`,
+  `run/1`; types `input()`, `finding()`, `result()`. (~80 LoC)
+- `lib/tau/gate/manifest.ex` — writes the hash-stamped JSON manifest,
+  computes `overall_verdict`, validates against
+  `priv/gate/manifest.schema.json`. (~120 LoC)
+- `lib/tau/gate/enumeration.ex` — input-set helpers (wildcards,
+  compiled-module lists, behaviour-implementor enumeration). (~80 LoC)
+- `lib/tau/gate/waiver.ex` — reads `priv/gate/waivers.toml`, enforces
+  `expires_at` and `rule_id` schema, rejects expired entries; uses
+  `:toml_elixir` (already in dep tree). (~100 LoC)
+- `lib/tau/telemetry/attach.ex` — production wrapper around
+  `:telemetry.attach/4` that tags handler IDs with `prod:` prefix so
+  the `TelemetryConsumers` deck can distinguish production handlers
+  from test handlers (proposal-2 weakness mitigation). (~30 LoC)
+
+#### Five deck modules under `lib/tau/gate/decks/`
+
+Each implements `Tau.Gate.Deck` and is co-located with its property
+tests under `test/tau/gate/decks/`.
+
+- `lib/tau/gate/decks/capability_fidelity.ex` — proposal-4 Failure 1.
+  `tool_of_record/0` returns `:sourceror`. Reads
+  `Tau.Provider.Capabilities.required_callbacks/0` (the
+  flag→callback table — proposal-1's contribution kept here as a
+  pure data module under `lib/tau/provider/capabilities.ex`, ~40 LoC)
+  and asserts every `true`-valued flag has its callback exported.
+  Inventory: every `.ex` file under `lib/tau/providers/*.ex`. (~150
+  LoC)
+- `lib/tau/gate/decks/no_unreachable_rescue.ex` — proposal-4 Failure
+  2 + proposal-2 §#2. `tool_of_record/0` returns `:credo`. Delegates
+  to three Credo custom checks:
+  `Tau.Credo.Checks.NoTryRescueAcrossProcess`,
+  `Tau.Credo.Checks.NoCatchExit`,
+  `Tau.Credo.Checks.NoRescueWithoutJustification`. Inventory: every
+  `.ex` file under `lib/tau/`. (~120 LoC deck + ~180 LoC across the
+  three Credo checks below)
+- `lib/tau/gate/decks/behaviour_closure.ex` — proposal-4 Failure 3
+  + proposal-2 §#1 Dialyxir path. `tool_of_record/0` returns
+  `:dialyxir`. Drives `mix dialyzer --halt-exit-status` with a
+  cached PLT and parses output for `callback_missing`,
+  `callback_arg_type_mismatch`, `callback_not_exported`. Inventory:
+  every module returned by `:application.get_key(:tau, :modules)`.
+  (~150 LoC)
+- `lib/tau/gate/decks/spec_symbol_existence.ex` — proposal-4
+  Failure 4. `tool_of_record/0` returns `:sourceror`. Walks every
+  `docs/spec/SPEC-*.md` §4, extracts backticked CamelCase tokens,
+  cross-checks against the compiled module set. Inventory: every
+  file matching `docs/spec/SPEC-*.md`. (~140 LoC)
+- `lib/tau/gate/decks/telemetry_consumers.ex` — proposal-4 Failure 5
+  + proposal-2 §#4. `tool_of_record/0` returns `:sourceror_and_telemetry`.
+  Step 1: Sourceror walk over `lib/` to collect every literal event
+  list passed to `:telemetry.execute/{2,3}`. Step 2: boots
+  `Application.ensure_all_started(:tau)` and reads
+  `:ets.tab2list(:telemetry_handler_table)`. Step 3: filters
+  handlers by `prod:` ID prefix (per `lib/tau/telemetry/attach.ex`).
+  Step 4: asserts every emitted event prefix has a matching
+  production handler. Inventory: emitted-events list (must be ≥1)
+  and prod-handlers list (must be ≥1). (~180 LoC)
+
+#### Credo custom checks under `lib/tau/credo/checks/`
+
+- `lib/tau/credo/checks/no_try_rescue_across_process.ex` — adopts
+  proposal-2 §#2 pattern; uses `Credo.Code.prewalk/2`,
+  `IssueMeta.for/2`. (~80 LoC)
+- `lib/tau/credo/checks/no_catch_exit.ex` — same shape. (~60 LoC)
+- `lib/tau/credo/checks/no_rescue_without_justification.ex` —
+  proposal-4 Failure 2 annotation grammar: requires a
+  `# rescue: <Mod.fun/arity> <reason>` comment within 3 lines above
+  every `try/rescue` site, cross-checks `Mod.fun/arity` exists via
+  `Code.ensure_loaded?/1` + `function_exported?/3`. (~120 LoC)
+
+#### Mix tasks under `lib/mix/tasks/`
+
+- `lib/mix/tasks/tau.gate.code.ex` — umbrella runner (proposal-3
+  pattern); reads `priv/gate/decks.toml` for `@required_decks`,
+  iterates, fails on any missing deck module, writes manifest, exits
+  non-zero on any FAIL/ERROR/empty-inventory. (~150 LoC)
+- `lib/mix/tasks/tau.gate.capability_fidelity.ex` — thin shim invoking
+  the deck for local runs. (~20 LoC)
+- `lib/mix/tasks/tau.gate.no_unreachable_rescue.ex` — same. (~20 LoC)
+- `lib/mix/tasks/tau.gate.behaviour_closure.ex` — same. (~20 LoC)
+- `lib/mix/tasks/tau.gate.spec_symbol_existence.ex` — same. (~20 LoC)
+- `lib/mix/tasks/tau.gate.telemetry_consumers.ex` — same. (~20 LoC)
+
+#### Configuration / registry files under `priv/`
+
+- `priv/gate/decks.toml` — canonical registry of required deck IDs;
+  the umbrella runner refuses to start if `@required_decks` does not
+  exactly equal the keys in this file. Format:
+  ```toml
+  [decks.capability_fidelity]
+  module = "Tau.Gate.Decks.CapabilityFidelity"
+  required = true
+  tool_of_record = "sourceror"
+  ```
+- `priv/gate/manifest.schema.json` — JSON schema (draft 2020-12) the
+  manifest writer validates against; CI consumer also validates.
+- `priv/gate/waivers.toml` — per-finding waivers
+  `{file, line, rule_id, expires_at, justification, remediated_by}`;
+  expired waivers are removed by the deck, treated as findings.
+- `priv/gates/<deck_id>.inputs.json` (per proposal-4) — explicit
+  per-deck input inventory for any deck whose enumeration is not
+  fully implicit from `Path.wildcard/1`. Absent or empty file → exit 2.
+- `priv/gate/telemetry.consumer_kinds.toml` — allowlist of production
+  handler modules (per proposal-1); editing the file requires a PR.
+- `priv/gate/README.md` — ≤80 lines explaining the deck contract,
+  the inventory pattern, the annotation grammar for rescues, and the
+  waiver schema. (Not documentation-only — readers run the gate; the
+  README is the user manual for `priv/gate/`.)
+
+#### Claude Code plugin under `plugins/tau-code-gates/`
+
+- `plugins/tau-code-gates/.claude-plugin/plugin.json` — manifest
+  pinning Anthropic plugin schema version; declares the slash command,
+  hook, skill.
+- `plugins/tau-code-gates/commands/tau-code-gates-run.md` — slash
+  command `/tau-code-gates:run` that invokes `mix tau.gate.code` and
+  pretty-prints the manifest.
+- `plugins/tau-code-gates/hooks/pre-tool-use.json` — registers a
+  `PreToolUse` hook matching `Bash` calls whose `command` matches
+  `^git commit\b` or `^gh pr ready\b`; invokes `run-gates.sh`; exit
+  non-zero blocks the tool call. Mirrors Anthropic's documented
+  `PreToolUse` contract.
+- `plugins/tau-code-gates/hooks/run-gates.sh` — bash script invoking
+  `mix tau.gate.code --manifest /tmp/tau-gate-prehook.json`; surfaces
+  findings to the agent transcript via stdout. Stdlib bash only.
+- `plugins/tau-code-gates/skills/interpret-findings/SKILL.md` —
+  progressive-disclosure skill for reading manifest findings;
+  triggered by manifest JSON or `verdict: fail` in agent context.
+- `plugins/tau-code-gates/agents/gate-doctor.md` — sub-agent invoked
+  with the `gate-doctor` slash command; reads a failed manifest and
+  proposes specific code changes (no auto-edits — proposes only).
+
+Plugin registration: `.claude-plugin/marketplace.json` at the repo root
+adds `tau-code-gates` to Tau's own marketplace.
+
+#### CI workflow under `.github/workflows/`
+
+- `.github/workflows/ci.yml` — **edited** (not new): adds five
+  required jobs whose names match the five deck IDs. Each job pins
+  `erlef/setup-beam@v1` with `version-file: .tool-versions,
+  version-type: strict`, runs `mix deps.get` and `mix compile
+  --warnings-as-errors`, then invokes its single Mix task. No
+  `continue-on-error`. No `|| true`. No `if:` gate keyed on PR-body
+  shape. The existing `lint` umbrella's `|| true` at line 115 and
+  the early-exits at lines 88-100 and 213-223 are removed in the
+  same PR as job-1 lands (coordinated with the
+  pre-merge-evidence-and-skip-integrity sibling).
+- `.github/workflows/tau-gate-code.yml` — **new**: dedicated
+  umbrella job that runs `mix tau.gate.code --manifest
+  /tmp/tau-gate.json` and uploads the manifest as a workflow
+  artifact. Required status check named `tau-gate-code / umbrella`.
+  Artifact upload step uses `if: always()` so a failed gate still
+  uploads the manifest for audit.
+
+#### GitHub branch protection (operational change, not a file)
+
+Five status checks added to `main`'s required-status-checks set, plus
+`tau-gate-code / umbrella`. `Require branches to be up to date before
+merging` ON (prevents stale-base manifest reuse). Done via
+`gh api repos/:owner/:repo/branches/main/protection -X PUT` — script
+checked in at `priv/gate/branch_protection.json` and applied by a
+one-shot `mix tau.gate.bootstrap.branch_protection` task.
+
+#### Test surface under `test/`
+
+- `test/tau/gate/deck_behaviour_test.exs` — property tests on the
+  behaviour contract (every implementation satisfies type specs).
+- `test/tau/gate/decks/<deck>_test.exs` — per-deck property tests
+  + golden tests against `test/support/gates/<deck>/{good,bad}/`
+  fixtures.
+- `test/tau/credo/checks/<check>_test.exs` — uses Credo's
+  `assert_issue/1` testing API from `hexdocs.pm/credo/testing_checks.html`.
+- `test/tau/gate/manifest_test.exs` — schema validation, hash stability.
+- `test/tau/gate/umbrella_test.exs` — runner-level tests: missing
+  deck → exit non-zero; empty inventory → exit 2; deck crash → exit 3
+  (matches existing Gate 5.3 exit-3 convention).
+
+### Dependencies added to `mix.exs`
+
+- `:sourceror, "~> 1.0", runtime: false` — Apache-2.0; AST traversal.
+- `:boundary, "~> 0.10"` — MIT; compile-time cross-module dep
+  constraints (deferred until adapter migration PR lands).
+- `:telemetry_registry, "~> 0.3"` — Apache-2.0; declarative event
+  discovery (used for documentation/discovery, not for the gate's
+  verdict — the gate keys on ETS introspection).
+- `:toml_elixir, "~> 2.0", runtime: false` — for `decks.toml` and
+  `waivers.toml`.
+- `:dialyxir, "~> 1.4"` — already present at `mix.exs:133`.
+- `:credo, "~> 1.7"` — already present at `mix.exs:132`.
+
+## What does not change
+
+- The existing Mix gates `mix tau.gate.{ac_linkage,masking,mutation}`
+  and their CI wiring (owned by sibling
+  **intent-capture-and-ac-binding** and shared with the
+  evidence-and-skip-integrity sibling). The five new decks are
+  additive, not a replacement.
+- The `Tau.Provider` behaviour contract itself — the
+  `Capabilities` lookup table is added as a *data* module
+  (`Tau.Provider.Capabilities`), not as a behaviour change. The
+  existing `capabilities/0` callback signature is preserved.
+- The branch protection for the existing `lint`, `test`, and
+  `mutation-check` jobs.
+- The OTP non-negotiables prose at `.claude/rules/otp-non-negotiables.md`
+  — the rule remains source-of-truth; the gate enforces it
+  mechanically. Per root §AC-G, the rule is not documentation-only
+  because it is now paired with `Tau.Credo.Checks.*` enforcement.
+- The existing AC-binding mechanism, the masking detection, and the
+  mutation gate (Gate 5.3).
+- The `Tau.Gate.Common` verdict helper (mentioned in proposal-2) — it
+  is reused for the per-deck shim verdicts that flow into the manifest
+  writer, so the operability dashboard sibling needs no schema change.
+- Production-runtime behaviour of any module under `lib/tau/`. The
+  gate code runs only under Mix tasks; Mix tasks are stripped from
+  Burrito releases. Zero runtime cost in `prod`.
+- The four existing failure-class corrective actions catalogued in
+  `docs/factory-v2/corrective-actions.md` — the gate enables the
+  cleanup, the cleanup itself is processed by the factory.
+
+## Silent-skip impossibility — five-layer enforcement (implementation level)
+
+This is the single load-bearing property of the leaf; the
+implementation makes it impossible at five independent layers, so
+failure of any one defence does not collapse the rest. Per root §AC-C
+and leaf-AC (b):
+
+1. **Runner layer.** `Mix.Tasks.Tau.Gate.Code` reads
+   `priv/gate/decks.toml`; `@required_decks` MUST equal the file's keys
+   set or the runner raises `Tau.Gate.Manifest.MismatchError` and exits
+   3. For each required deck ID, `Code.ensure_loaded?(mod) and
+   function_exported?(mod, :enumerate_inputs, 0)` is checked; a missing
+   deck raises `UndefinedFunctionError` (uncaught — exits non-zero).
+   There is no clause that returns PASS from a missing deck module.
+
+2. **Deck layer.** Every deck implements the behaviour callback
+   `enumerate_inputs/0 :: {:ok, [input()]} | {:error, atom(), String.t()}`.
+   The umbrella's `deck_passes?/1` includes:
+   ```elixir
+   defp deck_passes?(%{verdict: :error}), do: false
+   defp deck_passes?(%{inputs_enumerated: []}), do: false  # explicit
+   defp deck_passes?(%{inputs_enumerated: e, inputs_processed: p}) when e != p, do: false
+   defp deck_passes?(%{findings: findings}) when findings != [], do: false
+   defp deck_passes?(_), do: true
+   ```
+   There is **no clause matching `inputs_enumerated: []` that returns
+   true.** A property test
+   `test/tau/gate/umbrella_test.exs:test "no clause returns true on empty inventory"`
+   enumerates the `deck_passes?/1` clauses via Sourceror and asserts
+   structurally that no clause returning `true` admits an empty inputs
+   list. The check is on the *source AST* — the test itself cannot be
+   silenced without showing in the masking gate's diff scan.
+
+3. **Manifest layer.** `Tau.Gate.Manifest` validates the written JSON
+   against `priv/gate/manifest.schema.json` (JSON Schema draft
+   2020-12) on write; schema requires `decks: minItems: 5`,
+   `overall_verdict: enum: ["PASS","FAIL","ERROR"]`. Writing an
+   invalid manifest raises and exits 3. The manifest also includes
+   `commit_sha: <git rev-parse HEAD>`; a CI consumer rejects a
+   manifest whose `commit_sha` does not match `GITHUB_SHA`.
+
+4. **CI workflow layer.** Each of the five deck jobs is a separate
+   GitHub Actions job (proposal-4). No `continue-on-error`. No
+   `|| true`. No `if:` keyed on PR-body shape. The umbrella job
+   `tau-gate-code / umbrella` runs `mix tau.gate.code` with
+   `set -euo pipefail` in the shell prelude. Branch protection lists
+   six required checks; a missing check (e.g. a renamed job that no
+   longer reports) is treated as RED by branch protection. The
+   manifest artifact upload uses `if: always()` so a crashed runner
+   still uploads partial state for audit.
+
+5. **Audit-trail layer.** The manifest is retained as a workflow
+   artifact for 90 days. The operability sibling's dashboard reads
+   manifests across PRs and surfaces "deck X reported `inputs_count:
+   0` on PR Y" as a first-class alert. A reviewer claiming a gate
+   passed must point to the artifact; the PR comment auto-posted by
+   the workflow contains the artifact URL and the `overall_verdict`.
+
+A defence-in-depth diagram (informational, in `priv/gate/README.md`):
+runner → deck → manifest → CI → audit. Each layer's null hypothesis
+"this gate passed without checking anything" is mechanically
+falsified at that layer; collapsing all five requires a coordinated
+malicious change across five independent surfaces, every one of which
+shows in `git diff`.
+
+## Failure-class coverage map (root §AC-A: exactly one mechanism per class)
+
+| Failure class (root §Hypothesis) | Mechanism (this leaf) | Falsifying v1 incident (proposal-4) |
+|---|---|---|
+| #1 contracts drift (code-side, struct existence) | `Tau.Gate.Decks.SpecSymbolExistence` | `ToolUseStart` named in SPEC-USER-TURN §4 :75, absent from `lib/` |
+| #1 contracts drift (code-side, `@behaviour` completeness) | `Tau.Gate.Decks.BehaviourClosure` (Dialyxir + behaviour_info introspection) | `deepseek.ex:30` declares `@behaviour Tau.Provider` with missing callbacks silenced by `@optional_callbacks` |
+| #2 `try/rescue` against unreachable conditions (NN #7) | `Tau.Gate.Decks.NoUnreachableRescue` (3 Credo checks + annotation grammar) | `session.ex:488-494` and the seven flagged rescue sites that moved zero between audits |
+| #3 capability-flag fidelity | `Tau.Gate.Decks.CapabilityFidelity` (Sourceror + flag→callback table at `Tau.Provider.Capabilities`) | `deepseek.ex:51`, `bedrock.ex:36`, `gemini.ex:30` declare `prompt_caching: true` without `cache_regions/2` |
+| #4 telemetry events without production consumer | `Tau.Gate.Decks.TelemetryConsumers` (Sourceror static + ETS introspection + `prod:` handler-ID tagging) | `compaction.ex` emits `[:tau, :compaction, :exception]` from 4 callsites; 0 production consumers attach |
+
+Every class is named in exactly one deck. No class is covered by
+"agent discipline" or "human review" only. The critic/reviewer pair
+remains for quality checks (root §AC-B) but is not load-bearing for
+any of these classes.
+
+## Build-order — week-by-week deliverables with dependency graph
+
+Total scope: 5 PRs across 5 weeks, plus 3 corrective-actions PRs
+processed by the factory in parallel. Each PR is green-CI before the
+next opens. Each PR is one coherent shippable increment per
+`.claude/rules/factory-loop.md`.
+
+### Dependency graph
+
+```
+PR-1 (substrate)
+   ↓
+PR-2 (CapabilityFidelity)  ←—  CA-1 (add @capabilities to adapters, where missing)
+   ↓
+PR-3 (BehaviourClosure)   ←—  CA-2 (reconcile capability liars: Bedrock/Gemini/DeepSeek)
+   ↓
+PR-4 (TelemetryConsumers)  ←—  CA-3 (migrate :telemetry.attach callsites to Tau.Telemetry.attach + add consumers/remove emits)
+   ↓
+PR-5 (NoUnreachableRescue + SpecSymbolExistence + plugin shipping)
+```
+
+CA = corrective-action PR, processed by the factory in parallel with
+the gate PR that depends on it. CAs are pre-existing corrective
+actions catalogued by `docs/factory-v2/corrective-actions.md` and
+root §AC-F.
+
+### Week 1 — PR-1: Substrate + manifest + umbrella runner (no decks yet)
+
+**Deliverables:**
+
+- `lib/tau/gate/deck.ex` (behaviour)
+- `lib/tau/gate/manifest.ex` + `priv/gate/manifest.schema.json`
+- `lib/tau/gate/enumeration.ex`
+- `lib/tau/gate/waiver.ex` + `priv/gate/waivers.toml` (empty)
+- `lib/mix/tasks/tau.gate.code.ex` (umbrella)
+- `priv/gate/decks.toml` (empty `decks = {}`)
+- `priv/gate/README.md`
+- `.github/workflows/tau-gate-code.yml`
+- Bootstrap empty-input ack: `priv/gate/manifests/_no_decks.empty.toml`
+  with a 14-day expiry; the umbrella exits 0 only while this ack is
+  valid AND `decks.toml` is empty. PR-2 removes the ack and adds the
+  first deck; the umbrella refuses to pass if both ack and decks are
+  empty after the expiry.
+- Property tests for runner edge cases (missing deck → fail, empty
+  inventory → fail, etc.).
+- Dependency adds to `mix.exs`: `:sourceror`, `:toml_elixir`. Boundary
+  and telemetry_registry deferred to PR-4.
+
+**Dependencies:** none. Sibling
+`pre-merge-evidence-and-skip-integrity` coordinated for branch-
+protection registration of the new workflow.
+
+**Exit criteria:** umbrella runs, produces valid manifest with empty
+`decks`, CI workflow registered as required check. Gate is *up* but
+non-blocking until PR-2.
+
+### Week 2 — PR-2: CapabilityFidelity deck + CA-1
+
+**Deliverables (PR-2):**
+
+- `lib/tau/provider/capabilities.ex` (flag→callback data table)
+- `lib/tau/gate/decks/capability_fidelity.ex`
+- `lib/mix/tasks/tau.gate.capability_fidelity.ex`
+- Update `priv/gate/decks.toml` to declare `capability_fidelity`
+- Remove the bootstrap empty-ack from PR-1
+- Add `gate-capability-fidelity` job to `ci.yml`; register as required
+- Property + golden tests under
+  `test/tau/gate/decks/capability_fidelity_test.exs` and
+  `test/support/gates/capability_fidelity/{good,bad}/`
+
+**Deliverables (CA-1, separate PR):** add `@capabilities` module
+attribute to every adapter under `lib/tau/providers/` that doesn't
+already export the equivalent (where the gate will key off it).
+
+**Dependencies:** PR-1 merged. CA-1 is a parallel PR that can land
+before, during, or after PR-2, but the *combination* of PR-2 + CA-1
+must produce a green main; the gate red is then on the specific
+liars CA-2 addresses.
+
+**Exit criteria:** gate red on `main` shows exactly the three known
+liars (DeepSeek, Bedrock, Gemini) and no others — the gate is
+correctly calibrated.
+
+### Week 3 — PR-3: BehaviourClosure deck + CA-2
+
+**Deliverables (PR-3):**
+
+- `lib/tau/gate/decks/behaviour_closure.ex`
+- `lib/mix/tasks/tau.gate.behaviour_closure.ex`
+- Update `priv/gate/decks.toml`
+- Add `gate-behaviour-closure` job to `ci.yml`; register as required
+- PLT caching configured in `ci.yml` keyed on `mix.lock`
+- Property + golden tests
+
+**Deliverables (CA-2):** reconcile the three known capability liars
+— either implement `cache_regions/2` per adapter OR set
+`prompt_caching: false` for that adapter. Same PR for all three to
+keep `main` green when both gates light up. Coordinated with CA-1's
+merge.
+
+**Dependencies:** PR-1, PR-2 merged. CA-2 must land *before or
+in-same-PR-as* PR-3 to keep `main` green; otherwise `main` goes red on
+the first gate-red push (proposal-3 weakness: bootstrap red on initial
+adoption).
+
+**Exit criteria:** `main` green; gate red on synthetic
+test fixtures only.
+
+### Week 4 — PR-4: TelemetryConsumers deck + CA-3 + Boundary/telemetry_registry adoption
+
+**Deliverables (PR-4):**
+
+- `lib/tau/telemetry/attach.ex` (production-handler wrapper with
+  `prod:` ID prefix)
+- `lib/tau/gate/decks/telemetry_consumers.ex`
+- `lib/mix/tasks/tau.gate.telemetry_consumers.ex`
+- `priv/gate/telemetry.consumer_kinds.toml`
+- Update `priv/gate/decks.toml`
+- Add `gate-telemetry-consumers` job to `ci.yml`; register as required
+- Dependency adds to `mix.exs`: `:boundary`, `:telemetry_registry`
+- Property + golden tests
+
+**Deliverables (CA-3):** migrate every production
+`:telemetry.attach/4` call in `lib/` to `Tau.Telemetry.attach/4`. For
+every emitted event with no production consumer, either register a
+consumer (preferred, via `Tau.OtelReporter` or `Tau.Telemetry.Handler`)
+or remove the `:telemetry.execute/3` call.
+
+**Mitigation for proposal-2 weakness (CA-3 is large):** a *sunset
+manifest* `priv/gate/manifests/telemetry.sunset.toml` accepts
+warning-only findings for the first 21 days post-PR-4-merge; the
+sunset file has a hard expiry the gate enforces. The factory uses the
+window to land CA-3 incrementally; on day 22 the gate goes blocking
+red on any remaining gap.
+
+**Dependencies:** PR-1..PR-3 merged. CA-3 is the largest CA; the
+sunset ramp is mandatory.
+
+**Exit criteria:** gate green on `main` after sunset window. ~78
+events without consumers (per audit) reduced to zero.
+
+### Week 5 — PR-5: NoUnreachableRescue + SpecSymbolExistence + Claude Code plugin
+
+**Deliverables (PR-5):**
+
+- `lib/tau/credo/checks/no_try_rescue_across_process.ex`
+- `lib/tau/credo/checks/no_catch_exit.ex`
+- `lib/tau/credo/checks/no_rescue_without_justification.ex`
+- `.credo.exs` updated with the three checks
+- `lib/tau/gate/decks/no_unreachable_rescue.ex`
+- `lib/tau/gate/decks/spec_symbol_existence.ex`
+- `lib/mix/tasks/tau.gate.no_unreachable_rescue.ex`
+- `lib/mix/tasks/tau.gate.spec_symbol_existence.ex`
+- Update `priv/gate/decks.toml`
+- Add `gate-no-unreachable-rescue` and `gate-spec-symbol-existence`
+  jobs to `ci.yml`; register as required
+- `priv/gate/waivers.toml` populated with the 7 known rescue sites,
+  each with `remediated_by:` issue link and 90-day `expires_at:`
+- Annotation migration: every legitimate rescue in `lib/tau/` gets a
+  `# rescue: <Mod.fun/arity> <reason>` comment in this PR
+- SPEC §4 audit: every backtick CamelCase token in
+  `docs/spec/SPEC-*.md` §4 verified to resolve or to carry a
+  `(not yet implemented; tracked by #NNN)` annotation
+- Claude Code plugin under `plugins/tau-code-gates/`:
+  - `.claude-plugin/plugin.json`
+  - `commands/tau-code-gates-run.md` (slash command)
+  - `hooks/pre-tool-use.json` (blocks `git commit` / `gh pr ready`)
+  - `hooks/run-gates.sh`
+  - `skills/interpret-findings/SKILL.md`
+  - `agents/gate-doctor.md`
+- `.claude-plugin/marketplace.json` updated to register the plugin
+- One-shot `mix tau.gate.bootstrap.branch_protection` invocation
+  to finalise all five status checks as required
+
+**Dependencies:** PR-1..PR-4 merged. PR-5 lands last because the
+annotation migration is wide-touching (~7+ rescue sites) and the SPEC
+audit may surface findings that need follow-up SPEC amendments.
+
+**Exit criteria:** all five decks green on `main`; manifest written
+on every PR; plugin's `PreToolUse` hook fires locally; sibling
+`pre-merge-evidence-and-skip-integrity` confirms the merge gate
+consumes the manifest's `overall_verdict`.
+
+### Post-week-5: stability hardening (not part of build-order)
+
+- Operability sibling consumes manifest artifacts (no schema change
+  needed; manifest is the contract).
+- Audit-ingestion sibling translates historical findings into waivers
+  with `remediated_by:` issue links (root §AC-F).
+- 72-hour soak before the post-merge `main` health check considers
+  the substrate stable.
+
+## Migration sketch
+
+The substrate lands in PR-1 with no behavioural impact (empty
+`decks.toml`, bootstrap ack). PR-2..PR-5 each add one or two decks
+guarded by their corrective-action PR landing first or
+in-the-same-merge. The build-order's signature property: at every
+intermediate state, `main` is green — either because the deck hasn't
+landed yet, or because the corrective action has reconciled the known
+liars. The only acceptable transient red is during CA-3's 21-day
+sunset window for TelemetryConsumers, which is bounded by the sunset
+manifest's expiry. After PR-5, the factory's pre-merge gate cannot
+silent-skip any of the four code-shape failure classes, and a new
+failure class is one new deck module + one row in `decks.toml` + one
+CI job + one branch-protection update — bounded incremental cost.
+
+## Open questions
+
+- **SPEC §4 deferral annotation format** — proposal-4 specifies
+  `(not yet implemented; tracked by #NNN)`. Should the format also
+  carry a `D-NNN` invariant reference for SPECs that bind D-numbers?
+  Validator should consider whether sibling
+  **post-merge-cross-artifact-coherence** wants to own SPEC↔SPEC
+  consistency on the same regex.
+- **Sourceror cost on growth** — proposal-3 weakness: at ~500
+  modules the four-deck Sourceror walks become CI-budget-sensitive.
+  The solution does not include incremental mode. Should the
+  validator falsify against projected codebase size?
+- **Plugin schema versioning fragility** — proposal-2 weakness:
+  Claude Code's plugin manifest schema is young (2026 H1). We pin to
+  a specific version but renovate-style updates are not specified.
+  The operability sibling may need a plugin-version-drift alert.
+- **Waiver-rot cap** — proposal-1's open weakness inherited here: no
+  automated cap on waiver count. The operability dashboard surfaces
+  waiver count as a metric, but does not block merges on count
+  alone. Should the gate fail at, e.g., >20 active waivers per
+  rule_id? Out of scope for this leaf; flagged for operability sibling.
+- **Boundary adoption bootstrap** — adding `use Boundary` to every
+  adapter is a one-shot wide-touching change. Should this be one
+  separate CA or sequenced per-adapter behind a warning-only mode?
+  Proposal-2 suggests warning-only initially; the build-order defers
+  Boundary adoption to PR-4 but does not commit to a specific
+  per-adapter sequence.
+- **Dialyzer determinism on the BehaviourClosure deck** — Dialyzer is
+  occasionally non-deterministic on cross-module type inference; PLT
+  cache invalidation on OTP upgrade is a known footgun. The
+  build-order pins setup-beam to `.tool-versions` strictly, but a
+  cold-PLT crash on the gate is still possible. Mitigation: deck's
+  `tool_of_record/0` returning `:dialyxir` makes the choice
+  switchable to bespoke (proposal-1's approach) if Dialyzer proves
+  unreliable in CI.
+
+## Linked sub-problems / proposals
+
+- `proposals/proposal-1.md` — In-repo AST-checker substrate
+  (`Tau.Gate.CodeShape`). **Not selected** standalone — reinvents
+  what ecosystem tools already provide; rejected on root §AC-D.
+  Contributions taken: the per-analyzer behaviour pattern (refactored
+  into `Tau.Gate.Deck`), the `priv/gate/manifests/` waiver+expiry
+  discipline (kept), the capability→callback table pattern (kept as
+  `Tau.Provider.Capabilities` data module), the exit-code table
+  semantics (kept on the umbrella runner).
+- `proposals/proposal-2.md` — Adapt-from-ecosystem with Claude Code
+  plugin wrapping. **Selected (hybrid component).** Provides the
+  *engine substrate per check*: Credo for `NoUnreachableRescue`,
+  Dialyxir for `BehaviourClosure`, Sourceror for the AST-side decks,
+  `telemetry_registry` + ETS introspection for `TelemetryConsumers`,
+  and the entire Claude Code plugin shape (`PreToolUse` hook, slash
+  command, skill, agents). Satisfies root §AC-D directly.
+- `proposals/proposal-3.md` — ASIC sign-off rule deck.
+  **Selected (hybrid component).** Provides the *verdict protocol*:
+  `Tau.Gate.Deck` behaviour, hash-stamped JSON manifest,
+  `tool_of_record` field, umbrella runner enforcing
+  `inputs_enumerated == inputs_processed`, and the five-layer
+  silent-skip-impossibility argument. Satisfies root §AC-C and
+  leaf-AC (b) at maximum depth.
+- `proposals/proposal-4.md` — Five adversarial gates.
+  **Selected (hybrid component).** Provides the *adversarial deck
+  construction*: each of the five decks (including SpecSymbolExistence,
+  the +1 beyond the leaf's four named classes) is constructed
+  backwards from a grep-verified v1 failure with a named falsifier.
+  Satisfies root §AC-A "exactly one mechanism per failure class" by
+  construction and adds the SpecSymbolExistence deck addressing the
+  code-side of failure class #1.
+
+## Revision history
+
+- (revision 0 — initial; hybrid of proposals 2, 3, 4 with rejected
+  contributions from proposal-1)

--- a/docs/factory-v2/design/subproblems/pre-merge-evidence-and-skip-integrity/problem.md
+++ b/docs/factory-v2/design/subproblems/pre-merge-evidence-and-skip-integrity/problem.md
@@ -1,0 +1,118 @@
+---
+template_version: 1
+template_name: problem
+node_kind: leaf
+mode: leaf
+depth: 1
+parent: ../../problem.md
+status: draft
+---
+
+# Problem: Gate-infrastructure integrity — no silent-skip, no local-mix evidence, no red-CI merge
+
+## Statement
+
+The factory must make it structurally impossible for a gate to (a)
+silent-skip when its declaration field is missing, (b) accept evidence
+from a developer's local `mix` invocation in lieu of CI, or (c) merge a
+PR while CI is red. v1 fails on all three: CI early-exits at
+`ci.yml:88-100` and `:213-223` (silent-skip when AC-N declaration is
+absent), one of three gates ends in `|| true` at `:115` (cannot fail),
+PR bodies cite `mix test` output run on the contributor's laptop (root
+#7), and the four most recent merges (#411-#414) merged against red CI
+(root §Hypothesis preamble). The problem is solved when the
+gate-execution substrate itself cannot be bypassed by a malformed PR,
+an absent field, a `|| true`, or a maintainer choosing to merge a red
+PR.
+
+## Context
+
+- Root §Acceptance C — "Silent-skip impossibility. No gate may
+  silent-skip. A gate that has nothing to check on a particular PR
+  returns 'checked, no applicable findings' — not 'skipped.' A gate
+  that cannot run for infrastructural reasons fails the PR rather than
+  passing it. The v1 CI early-exits at `ci.yml:88-100` and `:213-223`
+  and the `|| true` at `:115` are the anti-patterns to make impossible."
+- Root §Hypothesis #5 (silent-skip), #7 (red-CI merges, local-mix
+  evidence).
+- GitHub repository ruleset / branch-protection mechanics: required
+  status checks, `require_branches_to_be_up_to_date`, `dismiss_stale_
+  reviews`, "require linear history". Reuse vs custom must be evaluated.
+- `gh api repos/:owner/:repo/branches/main/protection` is the current
+  authoritative state; today the rules are partial.
+
+## Failure classes addressed (from root §Hypothesis)
+
+- **#5** (primary) — CI gates silent-skip when declaration field
+  missing; `|| true` makes one gate non-failing.
+- **#7** (primary) — factory merges PRs against red CI; PR-body fields
+  cite local-machine `mix` output as evidence.
+
+## Complecting hypothesis
+
+- "Whether a gate runs" is complected with "whether the PR body opted
+  it in" because v1 gates read declaration fields and skip when absent;
+  decoupling requires that the gate's input universe be derived from
+  the diff and the repository, not from the PR body.
+- "Evidence of a check passing" is complected with "where the check was
+  run" because PR bodies paste local output verbatim; the gate must
+  refuse any evidence not produced by a CI run keyed on the head SHA.
+- "Merge eligibility" is complected with "maintainer judgement" because
+  GitHub allows an admin override; the branch-protection ruleset must
+  remove the override or alarm on its use.
+
+## Decomposition strategy
+
+(leaf — no further decomposition; proceed to proposals)
+
+## Acceptance criterion
+
+The factory specification names mechanisms such that: (a) every gate's
+applicability is computed from the diff/repo state, not from a PR-body
+declaration field — a gate with an empty applicable-input set
+explicitly logs "checked, 0 applicable" and exits 0; a gate whose
+infrastructure cannot run (toolchain missing, network failure, runner
+OOM) exits non-zero and the run is reported as failed, never as
+skipped; (b) `.github/workflows/*.yml` files contain no `|| true`,
+`continue-on-error: true` on a required check, or `if:` guards keyed on
+PR-body fields — enforced by a meta-gate (e.g. `mix
+tau.gate.ci_self_check` or a `lint-ci` job) that parses workflow YAML
+and fails on any of those anti-patterns; (c) the GitHub branch-
+protection ruleset on `main` is encoded as a versioned artifact (e.g.
+Terraform, `gh api` script in the repo, or Repository Rulesets via the
+GitHub API) and verified per-PR by a gate that diffs the live ruleset
+against the encoded one — admin merge of a red PR is either disabled
+or fires a post-merge alarm that opens an issue; (d) all gating
+evidence cited in a PR body must reference a CI run URL on the PR's
+head SHA — a gate scans PR-body text and fails if it finds `mix test`
+output, `assert ... passed` lines, or other local-mix patterns without
+a matching `actions/runs/<id>` URL whose `head_sha` matches; (e) the
+design records reuse-vs-build per artifact (GitHub Rulesets API vs
+bespoke; existing actions like `actions/github-script`, the
+`benchmark-action/github-action-benchmark`, or a `polya-audit`-style
+plugin) per root §Acceptance D; (f) the spec output identifies the
+concrete artifacts: workflow files, the meta-gate mix task names, the
+ruleset definition file, any GitHub App or bot for SHA-pinned evidence
+verification, hook scripts in `.claude/settings.json`, and a
+post-merge alarm mechanism (e.g. an issue-opener Action).
+
+## Out of scope
+
+- The content of each individual code gate (AST checks, behaviour
+  completeness, etc.) — owned by **pre-merge-code-gates** sibling.
+- AC-binding mechanics — owned by **intent-capture-and-ac-binding**
+  sibling.
+- What runs on `main` after merge (drift re-audit, cross-spec
+  consistency) — owned by **post-merge-cross-artifact-coherence**
+  sibling.
+- The factory dashboard / state-observability surface — owned by
+  **operability-and-hygiene-enforcement** sibling (this leaf produces
+  the verdicts; that leaf displays them).
+- Ingesting prior audit findings — owned by
+  **knowledge-memory-and-audit-ingestion** sibling.
+- Documentation-only components; agent-discipline-only enforcement;
+  workstream-2 corrective-actions catalogue.
+
+## Amendment log
+
+- (none yet)

--- a/docs/factory-v2/design/subproblems/pre-merge-evidence-and-skip-integrity/proposals/proposal-1.md
+++ b/docs/factory-v2/design/subproblems/pre-merge-evidence-and-skip-integrity/proposals/proposal-1.md
@@ -1,0 +1,480 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 1
+parent_problem: ../problem.md
+---
+
+# Proposal 1: Verdict-Bus — a signed, SHA-pinned verdict ledger driving merge eligibility
+
+## Approach
+
+Re-derive the gate-execution substrate from first principles. The
+substrate has exactly one purpose: turn the question "may this PR
+merge?" into a deterministic function of (head SHA, repo state, a set
+of *signed verdicts*). Every gate becomes a producer that emits a
+signed `Verdict` record into a single append-only ledger called the
+**Verdict-Bus**. Merge eligibility is computed by a separate `Admittor`
+component that reads only the ledger plus the diff, and never reads PR
+body text. Applicability of every gate is computed from the diff and
+the repo state — not from PR-body fields. Anything that today silent-
+skips becomes either a `Verdict{status: :n_a, applicable_inputs: []}`
+(explicit, signed, ledgered) or a `Verdict{status: :infra_fail}` which
+the Admittor treats as a merge-blocking failure. `|| true`,
+`continue-on-error`, and "PR-body opt-in" become syntactically
+unrepresentable because no component in the substrate consumes PR-body
+text and no verdict producer's exit status is consulted — only the
+signed record it writes.
+
+## Rationale
+
+The leaf's complecting hypothesis names three couplings: gate-runs vs.
+PR-body opt-in; evidence vs. where-it-ran; merge-eligibility vs.
+maintainer-judgement. A Verdict-Bus decomplects all three by routing
+every gate-runtime decision through one narrow contract:
+`Verdict := {gate_id, head_sha, applicable_inputs, status, evidence_ref,
+producer_identity, signature}`. The diff alone determines
+`applicable_inputs` (decomplecting gate-runs from PR body). The
+signature alone determines whether evidence is trusted (decomplecting
+evidence from origin — a laptop-produced verdict cannot be signed by
+the CI signer). The Admittor alone, reading only the ledger, determines
+merge eligibility (decomplecting eligibility from human judgement;
+admin override becomes a separate, alarmed event-class rather than a
+silent path). The Admittor's input is a *set*; absence of a required
+verdict is itself a deterministic block. There is nowhere a `|| true`
+can hide because the producer's exit code is not the eligibility
+signal — the signed record is.
+
+## Sketch
+
+### Components
+
+```
++----------------------+         +------------------------+
+| Applicability        |         | Gate Producers         |
+| Oracle               |         | (one per gate-id)      |
+| - inputs: diff,      |         | - read: applicable     |
+|   repo tree          |  ---->  |   inputs from Oracle   |
+| - emits: per-gate    |         | - run check            |
+|   applicable_inputs  |         | - sign + POST verdict  |
++----------------------+         +------------------------+
+            \                              |
+             \                             v
+              \                +----------------------+
+               \------->       | Verdict-Bus          |
+                               | (append-only ledger; |
+                               |  one row per         |
+                               |  {gate_id, head_sha})|
+                               +----------------------+
+                                          |
+                                          v
+                               +----------------------+
+                               | Admittor             |
+                               | - reads ledger +     |
+                               |   gate registry      |
+                               | - emits merge-       |
+                               |   eligibility        |
+                               |   verdict (also      |
+                               |   signed, ledgered)  |
+                               +----------------------+
+                                          |
+                                          v
+                               +----------------------+
+                               | Branch-protection    |
+                               | Required Check       |
+                               | (only one required   |
+                               |  check exists:       |
+                               |  "admittor")         |
+                               +----------------------+
+```
+
+### Data shapes
+
+```elixir
+defmodule Tau.Factory.Verdict do
+  @enforce_keys [:gate_id, :head_sha, :applicable_inputs, :status,
+                 :evidence_ref, :producer_identity, :signature, :emitted_at]
+  defstruct [:gate_id, :head_sha, :applicable_inputs, :status,
+             :evidence_ref, :producer_identity, :signature, :emitted_at,
+             :findings, :tool_version, :runtime_env_digest]
+
+  @type status ::
+          :pass            # check ran, all applicable inputs satisfied
+          | :fail          # check ran, ≥1 applicable input violated
+          | :n_a           # check ran, applicable_inputs == [];
+                           # explicitly "checked, 0 applicable"
+          | :infra_fail    # check could not run; merge-blocking
+end
+
+defmodule Tau.Factory.GateRegistry do
+  @type t :: %{required(gate_id :: atom) =>
+                 %{producer: module,
+                   applicability: module,
+                   required: boolean,
+                   public_key: binary}}
+end
+
+defmodule Tau.Factory.Admittor do
+  @callback decide(head_sha :: binary, ledger :: [Verdict.t]) ::
+              {:merge, AdmittorVerdict.t} | {:block, AdmittorVerdict.t}
+end
+```
+
+### Per-component contracts
+
+- **Applicability Oracle** (`mix tau.factory.applicability <head_sha>`).
+  Pure function over `(diff, repo_tree)`. For every registered gate,
+  emits the set of files / AST nodes / symbols the gate is responsible
+  for. Output is JSON, content-addressed, signed by the Oracle's key.
+  The Oracle never reads `.github/PULL_REQUEST_TEMPLATE`, never reads
+  the PR body, never reads commit messages. Determinism is verified by
+  the Self-Check Gate (below).
+
+- **Gate Producers**. Each gate is a separate workflow job that
+  (1) fetches the Oracle's signed applicability record for its
+  `gate_id`, (2) runs the check across that input set, (3) constructs a
+  `Verdict`, (4) signs it with the producer's key (held in GitHub
+  Actions OIDC-issued short-lived cert — see §Build-order step 3),
+  (5) POSTs to the Verdict-Bus. Exit status of the workflow job is
+  *informational only*; the only signal the Admittor reads is the
+  signed `Verdict` in the ledger. A producer that crashes mid-run emits
+  no verdict; the Admittor treats absence as `:infra_fail` after
+  timeout (see Admittor contract).
+
+- **Verdict-Bus**. Append-only store keyed by `{gate_id, head_sha}`,
+  unique on that pair. Implementation: a `verdicts/` directory in a
+  dedicated branch (`refs/factory/verdicts`) of the repo itself, one
+  JSON file per verdict, force-push disabled by branch-protection.
+  Rationale for using a git ref rather than an external service:
+  zero new infrastructure to operate, every verdict cryptographically
+  pinned to the repo's hash chain, queryable with `git`. Writers are
+  authenticated by signature verification at push time (a server-side
+  pre-receive hook on the verdict branch — implemented as a required
+  status check on that branch itself; the branch's only writer is the
+  CI signer). Readers are unrestricted.
+
+- **Admittor** (`mix tau.factory.admit <head_sha>`). Reads the gate
+  registry and the verdicts for `head_sha`. Emits `:merge` iff:
+    1. For every `required: true` gate in the registry, exactly one
+       verdict exists with `head_sha == head_sha` and signature verified
+       against that gate's registered public key.
+    2. Every such verdict's `status` is `:pass` or `:n_a`.
+    3. The verdict's `applicable_inputs` set equals what a re-run of
+       the Applicability Oracle on the same `head_sha` would emit
+       (deterministic-Oracle invariant — caught by the Self-Check Gate).
+  Else emits `:block` with a per-rule explanation. The Admittor's
+  verdict is itself a signed `Verdict` written to the Bus under
+  `gate_id: :admittor`. The single GitHub branch-protection required
+  status check on `main` is named `admittor` and is satisfied iff the
+  Admittor's most-recent verdict for the PR's head SHA has
+  `status: :pass`.
+
+- **Self-Check Gate** (`mix tau.factory.gate.self_check`). A producer
+  like any other; emits a `Verdict{gate_id: :self_check, ...}`.
+  Parses every YAML under `.github/workflows/`, fails on any of:
+  `|| true` after a step that produces evidence, `continue-on-error:
+  true` on any job referenced by the gate registry, `if:` expressions
+  matching `contains(github.event.pull_request.body, …)` or any other
+  PR-body predicate, any `actions/checkout` with `persist-credentials:
+  true` on a verdict-producer job (signing must use OIDC, not
+  repo-scoped tokens). Also: re-runs the Applicability Oracle and
+  asserts its output is byte-identical to the prior run (determinism
+  invariant). The Self-Check Gate is `required: true` in the registry,
+  so a malformed CI configuration blocks merge by the same mechanism
+  as a failed code-check.
+
+- **Evidence Origin Gate** (`mix tau.factory.gate.evidence_origin`). A
+  producer that scans the PR body and every commit message for
+  patterns that look like locally-produced evidence — `Finished in
+  \d+\.\d+ seconds`, `\d+ tests, \d+ failures`, `running on .*-host`,
+  `iex>`, `> mix test`. For every hit, requires an adjacent
+  `https://github.com/<owner>/<repo>/actions/runs/<id>` URL whose
+  `head_sha` (fetched via `gh api`) equals the PR head SHA. The gate's
+  `applicable_inputs` are the lines that matched the pattern; if none
+  matched, status is `:n_a`. No silent-skip: empty input set is
+  explicit.
+
+- **Ruleset Conformance Gate** (`mix tau.factory.gate.ruleset_conformance`).
+  The branch-protection ruleset on `main` is encoded as a versioned
+  file at `.factory/rulesets/main.json`. This gate fetches the live
+  ruleset via `gh api repos/:owner/:repo/rulesets` and asserts
+  byte-equality against the file. Drift fails the gate. Admin override
+  of branch protection (the "merge anyway" path) becomes detectable
+  because the post-merge mirror job (below) opens an issue when a
+  merge commit on `main` has no corresponding signed `:admittor`
+  verdict with `status: :pass` for its parent SHA.
+
+- **Post-Merge Alarm**. A workflow on `push: main` that, for each new
+  merge commit, asserts a signed `:admittor` verdict exists for the
+  merged head SHA with `status: :pass`. Absence opens a GitHub issue
+  labelled `factory/bypass-detected` with the merge SHA and merger
+  identity. This is the only mechanism that handles the admin-override
+  escape hatch; removing the admin override entirely is preferred but
+  org-policy-dependent.
+
+### Silent-skip impossibility — by construction
+
+The phrase "silent-skip" decomposes into four sub-failures, each
+structurally eliminated:
+
+1. *Skip because PR body lacks a declaration field.* — Eliminated: no
+   substrate component reads PR body. Applicability comes from the
+   Oracle, not from any field.
+
+2. *Skip because exit code masked with `|| true`.* — Eliminated: the
+   Admittor does not consult exit codes; it consults signed Verdicts.
+   An absent Verdict is treated as `:infra_fail` after the workflow's
+   declared timeout (a wall-clock the Admittor reads from the registry,
+   not from the workflow). A `|| true` produces no Verdict and
+   therefore blocks merge.
+
+3. *Skip because the job did not run (e.g. path-filtered out).*
+   — Eliminated: path filters are forbidden in the verdict-producer
+   workflows. The Self-Check Gate fails on any `paths:` or
+   `paths-ignore:` in a producer job. Every required gate runs on every
+   PR; gates with empty applicable input emit `:n_a`, which is a
+   signed, ledgered, explicit "checked, 0 applicable" state.
+
+4. *Skip because infrastructure failed (toolchain, network, OOM).*
+   — Eliminated: any non-emission of a verdict for a required gate
+   within its declared timeout is treated by the Admittor as
+   `:infra_fail`, which blocks merge. The producer itself, if it
+   detects an unrecoverable infra error, may *emit* a signed
+   `Verdict{status: :infra_fail}` to give a clearer reason; either way
+   merge is blocked.
+
+### Verdict consumption
+
+There is exactly one consumer that gates merges: the **Admittor**. Its
+decision is computed by a pure function of:
+
+- the gate registry (versioned at `.factory/registry.json`),
+- the set of signed verdicts for the head SHA,
+- the diff + repo tree (only as the re-run input to the Applicability
+  Oracle, for the determinism invariant).
+
+The Admittor emits a signed verdict (`gate_id: :admittor`). The
+GitHub branch-protection required status check on `main` is named
+`admittor`; GitHub treats it as failed unless the Admittor's verdict
+for the head SHA has `status: :pass`. No other consumer of verdicts
+gates merges. Secondary consumers exist (the operability dashboard;
+post-merge alarm; audit-ingestion subsystem reading historical
+verdicts) but none influence eligibility.
+
+## §Build-order
+
+A concrete sequence; each step's exit-criterion is a check the *next*
+step can run against. Step N may not begin until step N-1's exit-
+criterion is itself ledgered as a passing verdict (the Verdict-Bus
+bootstraps itself once step 4 lands).
+
+1. **Verdict schema + registry file format** (1 PR). Land
+   `Tau.Factory.Verdict` struct, JSON schema at
+   `.factory/schemas/verdict.schema.json`, and an empty
+   `.factory/registry.json` with the schema-version field. Exit: `mix
+   test` passes a property test that round-trips arbitrary verdicts
+   through JSON.
+
+2. **Applicability Oracle skeleton** (1 PR). `mix
+   tau.factory.applicability` that emits an empty applicability map
+   (no gates registered yet) signed with a development-only key. Exit:
+   running the task twice on the same `head_sha` produces byte-
+   identical output (determinism).
+
+3. **CI signing identity** (1 PR). Configure GitHub Actions OIDC →
+   short-lived signing certs (via Sigstore Fulcio or an in-repo CA
+   bootstrap; choice deferred to selector). Land the public-key
+   distribution: the gate registry stores each gate's expected signer
+   identity (the GitHub Actions workflow path + repo + ref pattern).
+   Exit: a smoke workflow signs and verifies an arbitrary blob.
+
+4. **Verdict-Bus storage + write path** (1 PR). Create the
+   `refs/factory/verdicts` orphan branch. Land the push-time signature
+   verification (a required check on that branch named
+   `verdict-signature`; an admittor-style verifier that reads the
+   pushed file and the registry). Land a `Tau.Factory.VerdictBus.put/1`
+   helper that pushes a signed verdict to the branch. Exit: pushing an
+   unsigned or wrong-signer verdict is rejected at the server side.
+
+5. **Admittor v0** (1 PR). `mix tau.factory.admit <head_sha>` that
+   reads the empty registry and the empty ledger and trivially emits
+   `:merge`. Add a workflow `admit.yml` that runs on every PR's head
+   SHA and POSTs the Admittor's signed verdict. Configure branch
+   protection on `main` to require exactly one status check: `admit`.
+   Exit: a PR with no gates registered merges only after `admit`
+   reports success.
+
+6. **Self-Check Gate** (1 PR). First real producer. Register
+   `:self_check` in the registry as `required: true`. Land
+   `mix tau.factory.gate.self_check`. Exit: a PR that introduces a
+   `|| true` in a workflow file is blocked by the Admittor.
+
+7. **Evidence Origin Gate** (1 PR). Register `:evidence_origin`.
+   Exit: a PR whose body pastes `Finished in 0.4 seconds` without an
+   actions/runs URL is blocked.
+
+8. **Ruleset Conformance Gate + initial `.factory/rulesets/main.json`**
+   (1 PR). Encode the current branch-protection ruleset. Register
+   `:ruleset_conformance`. Exit: drift between live and encoded ruleset
+   blocks the next PR.
+
+9. **Post-Merge Alarm** (1 PR). Land `factory/bypass-detected`
+   workflow on `push: main`. Exit: simulating an admin-override merge
+   (in a fork) opens a tagged issue.
+
+10. **Sibling gate adoption** (incremental, gated). Each existing CI
+    gate (`mix tau.gate.ac_linkage`, `mix tau.gate.masking`,
+    `mix tau.gate.mutation`) is migrated to the Verdict-Bus pattern:
+    one PR per gate, each registering its `gate_id` in the registry
+    and replacing `|| true` / silent-skip paths with `:n_a` /
+    `:infra_fail` verdict emissions. Once migrated, the old workflow
+    job is deleted in the same PR. Exit per gate: the corresponding
+    failure-class probe (e.g. a synthetic PR that should fail the
+    gate) is blocked at merge by the Admittor.
+
+11. **PR-body-field deprecation** (1 PR). Remove every gate's
+    PR-body-field reader (the existing v1 silent-skip surface).
+    Update `CONTRIBUTING.md` to state that PR-body fields are
+    *advisory* and *never* gating. Exit: the Self-Check Gate's
+    expanded ruleset forbids re-introducing PR-body predicates.
+
+The build-order's monotonicity invariant: at every step, the failure
+classes the new mechanism is supposed to block are tested by a
+synthetic-PR probe that lands in the same PR as the mechanism. No
+mechanism lands without its falsification probe.
+
+## Tradeoffs
+
+### Strengths
+
+- **Silent-skip impossibility is structural, not procedural.** The
+  Admittor reads signed records; absence is failure; PR-body text is
+  never read. There is no surface for a `|| true` to hide.
+- **Evidence origin is enforced by cryptography.** A verdict not
+  signed by the registered CI identity is rejected at the Bus's write
+  path (pre-receive hook on `refs/factory/verdicts`). A maintainer
+  cannot paste local output as evidence; the substrate has no way to
+  accept it.
+- **Merge eligibility is a pure function.** The Admittor's verdict is
+  reproducible given (head SHA, registry, ledger, repo tree). Anyone
+  can re-run `mix tau.factory.admit <sha>` and check.
+- **Single required status check** (`admittor`) replaces the v1
+  multi-check arrangement, removing a class of branch-protection
+  drift (mis-spelled required-check names that silent-pass).
+- **Bootstraps on existing repo infrastructure.** The Verdict-Bus is a
+  git ref; no new database, no new service to operate.
+- **Admin-override path is not eliminated but is alarmed**, satisfying
+  the leaf's acceptance criterion (c).
+
+### Weaknesses
+
+- **Cryptographic key management is now load-bearing.** A compromised
+  CI signing key forges verdicts. Sigstore short-lived certs mitigate
+  but do not eliminate. A bug in signature verification at the Bus's
+  pre-receive hook is a silent bypass channel — must be its own
+  redundantly-checked gate.
+- **The Admittor itself is a single point of failure.** A bug in
+  applicability-determinism logic could systematically silent-pass.
+  Mitigations: the Self-Check Gate re-runs the Oracle and asserts
+  byte-equality; the Admittor's own verdict can be re-verified by a
+  reviewer running `mix tau.factory.admit` locally. But the substrate
+  trusts the Admittor's signature, so a compromised Admittor key is
+  catastrophic.
+- **Migration is invasive.** Every existing gate must be migrated to
+  emit signed Verdicts; until migration completes, the v1 substrate
+  and v2 substrate coexist (one PR per gate, ~10 PRs).
+- **`refs/factory/verdicts` as ledger** is unusual; tooling (GitHub
+  UI, `git log --all`) doesn't naturally surface it; operators need
+  training. An external append-only log (e.g. an immutable blob store)
+  is more conventional and might be selected by §Build-order step 4's
+  selector. The proposal commits to the git-ref shape for zero-new-
+  infrastructure, accepting the operability cost.
+- **Determinism of the Applicability Oracle is hard to guarantee** —
+  filesystem walks, sort order, tool version drift. The Self-Check
+  Gate's byte-equality assertion catches violations but at the cost of
+  rejecting PRs that, e.g., upgrade a tool the Oracle depends on
+  unless the Oracle is upgraded in lockstep.
+- **No mitigation for a corrupted gate registry.** A PR that edits
+  `.factory/registry.json` to remove a `required: true` gate would
+  bypass it on the next PR. Requires a meta-rule: `.factory/registry.
+  json` edits are themselves a gated, signed event with stricter
+  signers (e.g. a multi-sig). This is sketched but not fully designed.
+- **Time-to-first-merge increases** because every PR runs every
+  required gate (no path-filtering shortcut), and each emits a signed
+  verdict. Estimated overhead: +60–120s per PR for signing +
+  verification + Admittor evaluation. Acceptable for the trustworthi-
+  ness gain but real.
+
+### Costs
+
+- **Migration**: ~10 PRs (one per existing gate) plus 9 substrate PRs
+  (§Build-order steps 1–9). Estimated 6–10 engineer-weeks of focused
+  factory work; partial value lands after step 9.
+- **Key infrastructure**: GitHub Actions OIDC + Sigstore Fulcio
+  integration, or an in-repo CA. New dependency surface; Sigstore is
+  ~3 new actions deps and one verification CLI.
+- **CI minutes**: +60–120s per PR per gate (signing + signature
+  verification + Admittor pass). With ~5 required gates post-migration,
+  ~5–10 added CI-minutes per PR run.
+- **Documentation**: Every gate must publish its applicability rules
+  and verdict semantics. ~1 page per gate; ~10 pages total.
+- **Operability surface**: `refs/factory/verdicts` queries surface in
+  the sibling operability leaf's dashboard; coordination required.
+- **Failure mode for offline forks**: contributors without a verified
+  CI signing identity cannot produce verdicts; their PRs depend on
+  upstream CI runs. This is a feature (evidence-origin enforcement)
+  but a UX change.
+
+## Dependencies
+
+- A signing-identity mechanism (Sigstore Fulcio OIDC or in-repo CA).
+  Selector chooses; either satisfies the contract.
+- Branch-protection ruleset edit access on `main`.
+- Coordination with the **operability-and-hygiene-enforcement**
+  sibling: their dashboard reads `refs/factory/verdicts`; the schema at
+  `.factory/schemas/verdict.schema.json` is shared.
+- Coordination with the **pre-merge-code-gates** sibling: those gates
+  become Verdict-Bus producers under this proposal's contract; the
+  sibling owns gate content, this proposal owns the substrate they
+  emit into.
+- Coordination with the **knowledge-memory-and-audit-ingestion**
+  sibling: that subsystem's audit findings become *applicability
+  inputs* to specific gates (e.g. an audit finding that flags a
+  module makes that module an applicable input to the corresponding
+  gate). The Oracle reads audit registry entries.
+
+## Confidence
+
+**Medium.** Confidence would rise to **high** with:
+
+- a working spike of §Build-order steps 1–5 against a fork of this
+  repo, demonstrating that a PR with no gates registered can be
+  admitted by the Admittor and that an unsigned verdict push is
+  rejected;
+- a clear selector decision on the signing-identity mechanism
+  (Sigstore vs in-repo CA) — the proposal is contract-defined enough
+  to be agnostic, but the spike requires choosing;
+- a sketch of the registry-mutation meta-rule (multi-sig or equivalent)
+  that closes the "corrupted registry" weakness.
+
+The Verdict-record / Applicability-Oracle / Admittor decomposition is
+high-confidence — it is a direct application of the leaf's
+decomplecting hypothesis. The git-ref-as-ledger choice is medium-
+confidence; an alternative proposal that uses an external log store is
+plausible and worth comparing.
+
+## Prior art / references
+
+This is a first-principles proposal; ecosystem and adversarial-
+reverse-engineering proposals are out of scope per the brief and will
+be authored by proposers 2, 3, 4. The following are *internal* prior
+art only:
+
+- Tau's existing `Tau.Factory.Gate` module (`lib/tau/factory/gate.ex`)
+  — three pure verdict-producing functions; this proposal generalises
+  their shape to all gates and adds the signed-ledger substrate.
+- The factory-loop rule's `## The gate` section, which already names
+  "both halves must return PASS" — this proposal extends "PASS" to a
+  cryptographically signed verdict rather than an agent assertion.
+- ADR conventions in `docs/adr/` — the registry-mutation meta-rule
+  (currently a weakness) would itself be ADR-worthy.

--- a/docs/factory-v2/design/subproblems/pre-merge-evidence-and-skip-integrity/proposals/proposal-2.md
+++ b/docs/factory-v2/design/subproblems/pre-merge-evidence-and-skip-integrity/proposals/proposal-2.md
@@ -1,0 +1,473 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 2
+parent_problem: ../problem.md
+---
+
+# Proposal 2: Adopt-from-ecosystem — GitHub Rulesets + Actions-native required checks + Octokit/MCP-driven evidence verification
+
+## Approach
+
+Push the gate-infrastructure substrate onto components the GitHub /
+Claude Code ecosystem already provides, and add bespoke code only where
+no equivalent exists. Concretely: (1) encode the `main` branch
+protection as a **GitHub Repository Ruleset** stored in
+`.github/rulesets/main.json`, applied by the official
+[`liatrio/github-rulesets-action`](https://github.com/liatrio/github-rulesets-action)
+on every push to `main` and verified per-PR by
+[`endorlabs/github-actions-policy-check`](https://github.com/marketplace/actions/policy-check-action)-style
+drift-detection (drift opens a P0 issue via
+[`peter-evans/create-issue-from-file`](https://github.com/peter-evans/create-issue-from-file));
+(2) replace bespoke `if:` PR-body guards with **GitHub Actions matrix
+jobs** that derive their applicability set from the PR diff using
+[`tj-actions/changed-files`](https://github.com/tj-actions/changed-files) —
+when the matrix is empty the job emits a `checked-no-applicable` Check
+Run with conclusion `success` rather than skipping;
+(3) wire a **`workflow-lint` required check** that runs
+[`rhysd/actionlint`](https://github.com/rhysd/actionlint) plus a thin
+custom `ripgrep` rule pack to reject `|| true`, `continue-on-error: true`
+on jobs in the required-checks list, and any `if:` keyed on
+`pr.body` / `github.event.pull_request.body` substrings; (4) verify
+evidence freshness with the existing
+[`anthropics/claude-code-action`](https://github.com/anthropics/claude-code-action)
+running a slash command `/verify-evidence` that calls
+[`anthropics/github-mcp-server`](https://github.com/github/github-mcp-server)'s
+`list_workflow_runs` and `get_check_run` tools to confirm every
+"evidence" link in the PR body points to a Check Run whose `head_sha`
+equals the PR head, the conclusion is `success`, and the run is `<24h`
+old; (5) eliminate admin merge override by setting `enforcement: active`
++ `bypass_actors: []` in the ruleset, and arm a redundant **post-merge
+alarm** via [`github/branch-deploy`](https://github.com/github/branch-deploy)-
+style audit hook that opens a P0 issue if any merge to `main` lands
+without all required Check Runs green on its head SHA.
+
+## Rationale
+
+The complecting hypothesis names three knots: gate-runs↔PR-body-fields,
+evidence↔location, merge↔maintainer-judgement. GitHub itself already
+ships the decomplecting primitives for all three — they were under-used
+in v1, not absent.
+
+- **Rulesets-as-code** decomplects "merge eligibility" from "maintainer
+  judgement": the ruleset is the single source of authority, version-
+  controlled, drift-checked, and `bypass_actors: []` removes the
+  human-override seam without policy hand-waving.
+- **Diff-derived matrices** decomplect "gate applicability" from "PR-body
+  opt-in": applicability is a function of the diff (a fact about the
+  commit), not the prose (a fact about the author).
+- **MCP-mediated Check Run lookup** decomplects "evidence" from
+  "location": the evidence is now a typed reference (`check_run_id` with
+  `head_sha` invariant) the verifier resolves through the GitHub API,
+  not text the gate trusts.
+- **`actionlint` + custom rule pack** decomplects "what a workflow does"
+  from "what the workflow file claims it does": the `|| true` pattern,
+  `continue-on-error: true` on required checks, and `if:` body-guards
+  become *parseable, mechanically detectable* lint violations.
+
+Each substitution swaps a v1 bespoke seam for an ecosystem primitive
+whose semantics are independently maintained and battle-tested across
+millions of repos. Failure classes #5 and #7 collapse to "did you wire
+the off-the-shelf component correctly?" — a question a single
+configuration-check gate can answer.
+
+## Sketch
+
+### A. Ruleset-as-code artifact
+
+`.github/rulesets/main.json` (encoded; pushed by ruleset action; per-PR
+drift check fails the build):
+
+```jsonc
+{
+  "name": "main-branch-protection",
+  "target": "branch",
+  "enforcement": "active",
+  "bypass_actors": [],                      // no admin override
+  "conditions": { "ref_name": { "include": ["~DEFAULT_BRANCH"], "exclude": [] } },
+  "rules": [
+    { "type": "deletion" },
+    { "type": "non_fast_forward" },
+    { "type": "required_linear_history" },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": true,
+        "required_status_checks": [
+          { "context": "lint",                "integration_id": 15368 },
+          { "context": "test (1.18.1 · 27.2)", "integration_id": 15368 },
+          { "context": "mutation-check (Gate 5.3)", "integration_id": 15368 },
+          { "context": "workflow-lint",       "integration_id": 15368 },
+          { "context": "evidence-verify",     "integration_id": 15368 },
+          { "context": "ruleset-drift",       "integration_id": 15368 }
+        ]
+      }
+    },
+    { "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 0,   // factory-driven repo; agents don't approve
+        "dismiss_stale_reviews_on_push": true,
+        "require_code_owner_review": false,
+        "required_review_thread_resolution": true
+      }
+    }
+  ]
+}
+```
+
+### B. Diff-derived applicability matrix (replaces PR-body guards)
+
+`.github/workflows/gate-applicability.yml`:
+
+```yaml
+name: gate-applicability
+on: pull_request
+jobs:
+  derive:
+    runs-on: ubuntu-24.04
+    outputs:
+      gating_tests: ${{ steps.fanout.outputs.gating_tests }}
+      changed_lib_files: ${{ steps.changed.outputs.lib_files }}
+    steps:
+      - uses: actions/checkout@v4
+        with: { fetch-depth: 0 }
+      - id: changed
+        uses: tj-actions/changed-files@v45
+        with:
+          files: |
+            lib/**
+            test/**
+      - id: fanout
+        # Pure function of the diff: gating tests = test files in the diff
+        # whose @tag :gating attribute is set. No PR-body field consulted.
+        run: |
+          set -euo pipefail
+          GATING=$(echo "${{ steps.changed.outputs.all_changed_files }}" \
+            | tr ' ' '\n' \
+            | grep -E '^test/.*\.exs$' \
+            | xargs -r grep -l '@tag :gating' \
+            | jq -R -s -c 'split("\n") | map(select(length>0))')
+          echo "gating_tests=${GATING:-[]}" >> "$GITHUB_OUTPUT"
+
+  ac-linkage:
+    needs: derive
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run AC-linkage on derived set (empty = checked-no-applicable)
+        run: |
+          set -euo pipefail
+          mix tau.gate.ac_linkage \
+            --gating-tests='${{ needs.derive.outputs.gating_tests }}' \
+            --pr-number=${{ github.event.pull_request.number }} \
+            --empty-set-behaviour=checked-no-applicable
+          # Mix task exits 0 with explicit "checked, 0 applicable" log line
+          # when set is empty. NEVER prints "skipping" and exits 0 via a guard.
+```
+
+Key invariant: the gate's `if:` is removed; the job always runs, the
+mix task always emits a verdict (`pass | fail | checked-no-applicable`),
+the job's exit code reflects that verdict deterministically.
+
+### C. Workflow-lint required check (kills `|| true`, body-guards)
+
+`.github/workflows/workflow-lint.yml`:
+
+```yaml
+name: workflow-lint
+on: [pull_request, push]
+jobs:
+  lint:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: rhysd/actionlint@v1.7.5
+      - name: Custom forbidden-pattern rule pack
+        run: |
+          set -euo pipefail
+          BAD=0
+          # Anti-pattern 1: `|| true` anywhere in a workflow step
+          if rg -nP '\|\|\s*true\b' .github/workflows; then
+            echo "::error::|| true forbidden in workflows"; BAD=1
+          fi
+          # Anti-pattern 2: continue-on-error on a required-check job
+          REQUIRED=$(jq -r '.rules[] | select(.type=="required_status_checks") | .parameters.required_status_checks[].context' \
+            .github/rulesets/main.json)
+          for ctx in $REQUIRED; do
+            if rg -nP "name:\s*[\"']?${ctx}[\"']?" .github/workflows | \
+               xargs -I{} sh -c "grep -n 'continue-on-error: true' {}"; then
+              echo "::error::continue-on-error: true on required check '$ctx'"; BAD=1
+            fi
+          done
+          # Anti-pattern 3: if: keyed on PR body
+          if rg -nP 'if:\s*.*github\.event\.pull_request\.body' .github/workflows; then
+            echo "::error::if: guards keyed on PR body forbidden"; BAD=1
+          fi
+          exit $BAD
+```
+
+### D. Evidence verification via Claude Code + GitHub MCP
+
+`.claude/agents/evidence-verifier.md` (new agent, invoked by
+`anthropics/claude-code-action` on every PR `synchronize` event via the
+`/verify-evidence` slash command). The agent's only tool surface is the
+[`github-mcp-server`](https://github.com/github/github-mcp-server) (read
+scope only). It pseudo-executes:
+
+```text
+1. body = mcp.github.get_pull_request(pr_number).body
+2. links = extract_actions_run_urls(body)        # /actions/runs/<id>
+3. for link in links:
+     run = mcp.github.get_workflow_run(link.id)
+     assert run.head_sha == pr.head_sha          # else FAIL
+     assert run.conclusion == "success"
+     assert now() - run.updated_at < 24h
+4. forbidden = extract_local_mix_evidence(body)  # regex: "mix test", "N tests, M failures"
+5. if forbidden and not links: FAIL "local-mix evidence without SHA-pinned CI run"
+6. POST check-run "evidence-verify" with conclusion=success|failure and details
+```
+
+The verifier's PASS/FAIL is published as a Check Run named
+`evidence-verify`, which the ruleset (block A) requires green to merge.
+Bespoke surface is small: a single agent prompt + a single mix task to
+parse the body. The Check Run posting, OAuth, retries, and webhook
+plumbing are owned by `claude-code-action`.
+
+### E. Ruleset-drift gate
+
+`.github/workflows/ruleset-drift.yml` runs on every PR plus daily cron:
+
+```yaml
+- name: Diff live ruleset vs encoded
+  run: |
+    gh api repos/${{ github.repository }}/rulesets > /tmp/live.json
+    diff <(jq -S . /tmp/live.json) <(jq -S '[.]' .github/rulesets/main.json) \
+      || { echo "::error::ruleset drift"; \
+           gh issue create --title "P0: main ruleset drift" \
+              --body-file /tmp/drift.diff --label P0,factory-alarm; \
+           exit 1; }
+```
+
+### F. Post-merge alarm (redundant safety net)
+
+`.github/workflows/post-merge-audit.yml` on `push` to `main` invokes
+`mcp.github.list_check_runs(head_sha=pushed_sha)`; if any required check
+in the ruleset is `!= success`, opens a P0 issue and posts to the merged
+PR. Catches the residual case where Rulesets fail open (GitHub outage,
+misconfiguration).
+
+## Tradeoffs
+
+### Strengths
+
+- **Maximum reuse, minimum bespoke surface.** Five of six components
+  (Rulesets, `tj-actions/changed-files`, `actionlint`,
+  `claude-code-action`, `github-mcp-server`,
+  `peter-evans/create-issue-from-file`) are off-the-shelf and
+  independently maintained. Bespoke surface is one `actionlint` rule
+  pack, one verifier agent prompt, and the existing `mix tau.gate.*`
+  tasks reshaped to fail-loud on infrastructural failure. Satisfies
+  root §Acceptance D (ecosystem reuse over reinvention).
+- **Silent-skip impossibility is a property of the wiring, not a
+  convention.** No `if:` guards keyed on PR-body fields exist (gate C
+  forbids them); applicability is the empty matrix (gate B) and the
+  empty-set verdict is `checked-no-applicable`, a first-class outcome.
+  Satisfies leaf §Acceptance (a) and root §Acceptance C.
+- **Evidence is SHA-pinned by construction.** A Check Run is a typed
+  artifact bound to a commit; the verifier compares two SHAs and the
+  conclusion field. There is no text-parsing of local mix output, so
+  the "paste output verbatim" attack surface vanishes (root #7).
+  Satisfies leaf §Acceptance (d).
+- **Admin override is removed, not just discouraged.** `bypass_actors:
+  []` plus ruleset-drift detection plus post-merge alarm form a
+  defence-in-depth against the v1 collapse mode where four PRs merged
+  red. Satisfies leaf §Acceptance (c).
+- **Versioned ruleset is auditable.** `.github/rulesets/main.json` is
+  reviewable in a PR like any other artifact, and the drift gate
+  surfaces unauthorised UI changes within 24h.
+- **MCP servers are the canonical Claude-Code-to-GitHub bridge.** The
+  `github-mcp-server` is Anthropic-published and already supports the
+  `list_workflow_runs` / `get_check_run` tools needed; we add no new
+  trust surface to the agent loop.
+
+### Weaknesses
+
+- **Repository Rulesets API is newer than classic Branch Protection
+  and its drift surface is poorly documented.** Some fields (`integration_id`
+  for app-owned checks) require a GitHub App ID lookup the proposal
+  hand-waves; a half-day spike is needed to confirm the JSON shape and
+  the `gh api` round-trip is lossless. If the round-trip is lossy,
+  drift detection produces false positives that desensitise the alarm.
+- **`tj-actions/changed-files` had a security incident in March 2025
+  (CVE-2025-30066, malicious mutation of a tag).** Proposal pins by
+  commit SHA, not tag, and adds a `step-security/harden-runner` audited
+  egress allow-list — this is mitigation, not elimination, and we
+  inherit ongoing supply-chain risk on every dep.
+- **`claude-code-action` introduces a recurring agent loop with token
+  cost on every PR `synchronize`.** Evidence verification is cheap
+  (≤4 API calls) but the OAuth + webhook plumbing means a measurable
+  per-PR token spend. Cheap, but not free.
+- **The "evidence-verifier" is itself a Claude agent.** The root spec
+  warns "Where Claude is in the loop, Claude's claims must be cross-
+  checked by mechanism." Mitigation: the agent only consumes MCP tool
+  output (typed) and emits a Check Run conclusion (typed) — its prose
+  is not load-bearing. Still, the agent's prompt is a soft spot a
+  hostile contributor could attempt to inject via PR body. A separate
+  deterministic mix task (no LLM) running the same checks would close
+  this; proposal punts it to "phase 2 hardening."
+- **Doesn't solve "the meta-gate must itself not silent-skip".** The
+  `workflow-lint` job is required by the ruleset, but if a contributor
+  removes `workflow-lint` from the required list in `.github/rulesets/
+  main.json`, the drift gate must catch it on that same PR. We rely on
+  the drift gate to require its own presence; this is a fixed point
+  the proposal asserts but does not prove.
+- **MCP server availability is a runtime dependency.** A
+  `github-mcp-server` outage blocks `evidence-verify`; the Check Run
+  must then time out and post `failure`, NOT `neutral` or skip — the
+  agent's prompt must hard-code this.
+- **No CODEOWNERS-style policy-as-code for in-repo rules.** OPA /
+  conftest would be a stronger fit but adds a runtime; we accept the
+  weaker `actionlint` + ripgrep rule pack as the pragmatic floor.
+
+### Costs
+
+- **Implementation: ~5-8 PRs.** (1) ruleset JSON + apply action;
+  (2) drift gate; (3) workflow-lint job + custom rule pack;
+  (4) gate-applicability refactor of `gate-applicability.yml`
+  replacing the existing `if:` guards in `ci.yml:78,108,175`;
+  (5) `mix tau.gate.*` reshape for `--empty-set-behaviour=checked-no-applicable`;
+  (6) evidence-verifier agent + Claude Code Action wiring;
+  (7) post-merge audit workflow; (8) decommission v1 `|| true` and
+  silent-skip branches.
+- **Dependency footprint adds:** `liatrio/github-rulesets-action`,
+  `rhysd/actionlint`, `tj-actions/changed-files` (SHA-pinned),
+  `peter-evans/create-issue-from-file`, `anthropics/claude-code-action`,
+  `github/github-mcp-server`, `step-security/harden-runner`. Six new
+  Actions, one MCP server. All have >1k stars and active maintenance
+  as of 2026-05.
+- **CI minutes:** ~+90s per PR (workflow-lint ~10s, drift ~5s,
+  applicability derivation ~15s, evidence-verify ~30-60s including
+  MCP round-trips). Acceptable on the ubuntu-24.04 runner profile.
+- **Token cost:** evidence-verifier ≈ 1-3k tokens per PR
+  `synchronize`. At current PR cadence, ~$1-3/month.
+- **Knowledge cost:** team must learn Repository Rulesets JSON schema
+  (one-time) and the changed-files SHA-pinning policy (ongoing).
+- **Migration cost on existing PRs:** the three `if:`-guarded gates in
+  v1 `ci.yml` must be rewritten in one atomic PR; mid-flight PRs need
+  rebase. Per worktree-discipline, this means a brief loop freeze.
+
+## Dependencies
+
+- GitHub Repository Rulesets API GA on the org (confirmed available
+  as of 2025; org-level enforcement may require admin coordination).
+- `anthropics/claude-code-action` GitHub App installed on the repo
+  with `pull_requests:read`, `checks:write`, `issues:write` scopes.
+- `github/github-mcp-server` reachable from the Claude Code agent
+  loop; OAuth or PAT credentials provisioned as a repo secret.
+- `mix tau.gate.ac_linkage`, `mix tau.gate.masking`, `mix tau.gate.
+  mutation` reshaped to accept `--empty-set-behaviour` and emit
+  structured verdicts on stdout (small change, ≤50 LoC each).
+- Decision on `tj-actions/changed-files` vs Anthropic-vendored
+  changed-files action — preference for the latter if it materialises;
+  fallback is SHA-pinning plus `harden-runner` egress allow-list.
+- Sibling **operability-and-hygiene-enforcement** leaf's dashboard
+  consumes the new Check Run names (`workflow-lint`, `evidence-verify`,
+  `ruleset-drift`, `post-merge-audit`); coordinate naming before
+  landing.
+
+## Confidence
+
+**Medium-high.** GitHub Rulesets, `actionlint`, `tj-actions/changed-files`,
+`claude-code-action`, and `github-mcp-server` are all production-grade
+with public adopters; the wiring is bookkeeping. The principal unknowns
+are (1) Repository Rulesets JSON round-trip fidelity (needs a
+half-day spike — would raise to high) and (2) whether MCP round-trip
+latency stays within the `evidence-verify` time budget on cold-start.
+A bespoke deterministic mix task fallback for evidence verification is
+prepared if the MCP-based path proves flaky.
+
+## Prior art / references
+
+- GitHub Repository Rulesets — https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/about-rulesets
+- `liatrio/github-rulesets-action` — apply rulesets-as-code on push to default branch
+- `rhysd/actionlint` — battle-tested workflow YAML static analysis (>3k stars)
+- `tj-actions/changed-files` — diff-derived matrix builder; CVE-2025-30066 informs SHA-pin policy
+- `peter-evans/create-issue-from-file` — programmatic P0 issue creation for drift / audit alarms
+- `anthropics/claude-code-action` — Claude Code GitHub App with `/`-command surface, runs in CI under repo secrets
+- `github/github-mcp-server` — Anthropic-/GitHub-published MCP server exposing typed Check Run / Workflow Run lookup
+- `step-security/harden-runner` — egress-control hardening for supply-chain mitigation
+- Open Policy Agent / `conftest` — considered for in-repo policy as code; rejected as heavier than `actionlint`+ripgrep for the v2 scope (revisit if rule pack exceeds ~30 rules)
+- Tau v1 `ci.yml` anti-patterns at `ci.yml:88-100`, `:115`, `:213-223` — proposal's negative reference points
+
+---
+
+## Adoption-vs-build summary (per root §Acceptance D)
+
+| Capability | Decision | Component | Bespoke surface |
+|---|---|---|---|
+| Branch protection encoding | **Adopt** | GitHub Repository Rulesets | `main.json` (config) |
+| Ruleset application | **Adopt** | `liatrio/github-rulesets-action` | — |
+| Ruleset drift detection | **Adopt+thin glue** | `gh api` + `peter-evans/create-issue-from-file` | ~30 lines YAML |
+| Workflow YAML lint | **Adopt** | `rhysd/actionlint` | — |
+| Forbidden-pattern rule pack (`\|\| true`, body-guards) | **Build** | ripgrep rule pack | ~40 lines bash (no ecosystem equivalent) |
+| Diff-derived gate applicability | **Adopt** | `tj-actions/changed-files` (SHA-pinned) | matrix fan-out YAML |
+| Empty-set "checked-no-applicable" verdict | **Build** | `mix tau.gate.* --empty-set-behaviour` | ~150 LoC across 3 mix tasks |
+| PR-body evidence verification | **Adopt+thin glue** | `claude-code-action` + `github-mcp-server` | one agent prompt + one mix task |
+| Post-merge red-CI alarm | **Adopt+thin glue** | `github-mcp-server` + `create-issue-from-file` | ~40 lines YAML |
+| Admin-override removal | **Adopt** | Rulesets `bypass_actors: []` | — |
+
+Bespoke totals: ~260 LoC + 1 agent prompt + 1 config JSON. The rest is
+configuration of well-maintained external components. Proposal satisfies
+root §Acceptance D by adopting where ecosystem coverage exists, and
+documents per-component justification where it does not.
+
+## Gaps and open questions
+
+- **Ruleset JSON round-trip fidelity** — half-day spike required. If
+  `gh api repos/.../rulesets` does not round-trip to byte-identical
+  JSON, drift detection needs a semantic differ (jq-based normalisation)
+  rather than `diff`.
+- **MCP `github-mcp-server` cold-start latency** — must be measured
+  under load; fallback is a bespoke `gh api`-based mix task.
+- **Anthropic-vendored alternative to `tj-actions/changed-files`** — if
+  available by 2026-Q3, swap and drop `harden-runner` mitigation.
+- **CODEOWNERS-style policy-as-code** — deferred to a later phase if
+  the bespoke rule pack grows beyond ~30 rules; OPA/conftest noted as
+  the upgrade path.
+- **Cross-PR coherence (e.g., two PRs both touching `ci.yml`)** —
+  out of scope for this leaf; handed off to **post-merge-cross-
+  artifact-coherence** sibling.
+
+## Build-order — adopt first, glue second, bespoke last
+
+Sequencing favours adoption: lowest-risk-highest-leverage components
+land first, bespoke code only after the adopted substrate is proven.
+
+1. **(adopt)** `.github/rulesets/main.json` encoded + applied via
+   `liatrio/github-rulesets-action`; `bypass_actors: []`,
+   `required_linear_history`. Removes admin merge override on day 1.
+2. **(adopt)** `workflow-lint` job running `actionlint` only; surfaces
+   pre-existing YAML errors. Added as a required check in the ruleset.
+3. **(adopt+glue)** `ruleset-drift` job; `peter-evans/create-issue-from-file`
+   for the P0 alarm. Made required.
+4. **(bespoke)** Add the ripgrep rule pack to `workflow-lint` for
+   `|| true`, `continue-on-error: true`, and PR-body `if:` guards. Run
+   in audit-mode for one PR cycle, then switch to required-blocking.
+5. **(adopt+bespoke)** Refactor `mix tau.gate.*` tasks to emit
+   `checked-no-applicable` on empty input; replace `if:` guards in
+   `ci.yml:78,108,175` with always-on jobs whose applicability comes
+   from `tj-actions/changed-files`-derived matrices. Atomic PR;
+   coordinate with worktree-discipline brief.
+6. **(adopt+glue)** Wire `anthropics/claude-code-action` with the
+   `evidence-verifier` agent + `github-mcp-server` MCP server; post
+   `evidence-verify` Check Run. Required in the ruleset only after
+   shadow-mode confirms <1% false-positive rate over 10 PRs.
+7. **(adopt+glue)** `post-merge-audit.yml`; redundant safety net for
+   any path that bypasses Rulesets.
+8. **(bespoke, deferred)** Replace agent-driven `evidence-verify` with
+   a deterministic `mix tau.gate.evidence_check` if cold-start latency
+   or prompt-injection surface justifies it.
+
+Each step is one PR per the factory loop; each PR strengthens the
+substrate before the next layer relies on it. No bespoke code lands
+before its adopted scaffold.

--- a/docs/factory-v2/design/subproblems/pre-merge-evidence-and-skip-integrity/proposals/proposal-3.md
+++ b/docs/factory-v2/design/subproblems/pre-merge-evidence-and-skip-integrity/proposals/proposal-3.md
@@ -1,0 +1,413 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 3
+parent_problem: ../problem.md
+---
+
+# Proposal 3: SLSA-style signed build provenance with a merge queue and policy-as-code admission controller
+
+## Approach
+
+Replace PR-body-driven gate selection and human-judged merge eligibility with
+a three-layer admission pipeline whose model is taken wholesale from the
+software-supply-chain world: (1) **provenance** — every gate produces a signed,
+SHA-pinned attestation (in-toto / SLSA v1.0 statement) emitted by the CI
+runner and stored as a transparency-log entry (sigstore Rekor or an
+equivalent append-only log committed to a `attestations/` orphan branch); (2)
+**policy-as-code admission** — a single `policy-controller` job (modelled on
+Sigstore's `policy-controller` for Kubernetes, or `conftest`/OPA Rego over
+admission input) consumes the diff, the attestation set, and the repo state,
+and emits one verdict the branch-protection ruleset requires; the policy
+enumerates the *required* attestations as a function of `diff∩repo`, never as
+a function of the PR body; (3) **merge queue** — GitHub Merge Queue (or a
+Bors-style queued merger) is the only path that updates `main`, configured
+with `require_branches_to_be_up_to_date=true` and `required_status_checks =
+{policy-controller}`. The policy-controller job replays the diff against the
+admission rules, and an attestation absent for an applicable rule fails the
+queue entry; no PR-body field controls anything. Branch-protection rulesets
+themselves are encoded as Terraform/`gh-rulesets` HCL and a separate
+"ruleset-drift" workflow gates the policy on `main` against the live ruleset
+returned by `gh api repos/.../rulesets`.
+
+## Rationale
+
+The complecting hypothesis (problem §Complecting) names three braids:
+gate-runs ↔ PR-body-opt-in; evidence-validity ↔ where-run; merge-eligibility ↔
+maintainer-judgement. SLSA/in-toto separates *what was built/checked* from
+*who claims it*: the attestation is a typed, signed payload whose subject is
+the head SHA and whose predicate is the check result. The policy-controller
+separates *which checks are required* from *who declared they were required*:
+the policy is a versioned file in the repo, evaluated by an OPA-style engine
+over the diff. The merge queue separates *PR-is-mergeable-now* from
+*human-clicks-merge*: a queue entry must pass the policy against the merge
+candidate's actual tree (rebased onto current `main`), not against the PR's
+historical head SHA. The three layers compose: provenance fixes #7's
+local-mix-evidence rot, policy fixes #5's silent-skip, and the queue fixes
+#7's red-CI-merge — without any of the three trusting the PR author or the
+maintainer.
+
+## Sketch
+
+### Layer 1 — Provenance (every gate emits a signed attestation)
+
+Each gate job ends with an attestation step. We use the standard
+`actions/attest-build-provenance@v2` (sigstore-backed) and a custom
+attestation type for gate verdicts:
+
+```yaml
+# .github/workflows/gates.yml — illustrative gate-runner shape
+jobs:
+  gate-ac-linkage:
+    runs-on: ubuntu-24.04
+    permissions:
+      id-token: write   # for sigstore OIDC
+      attestations: write
+      contents: read
+    outputs:
+      verdict: ${{ steps.run.outputs.verdict }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: run
+        run: mix tau.gate.ac_linkage --json > gate-ac-linkage.json
+      - uses: actions/attest@v2
+        with:
+          subject-path: gate-ac-linkage.json
+          predicate-type: https://tau.dev/attestations/gate-verdict/v1
+          predicate: gate-ac-linkage.json
+```
+
+Predicate shape (in-toto statement, predicate field):
+
+```json
+{
+  "_type": "https://in-toto.io/Statement/v1",
+  "subject": [{"name": "head", "digest": {"sha1": "<commit-sha>"}}],
+  "predicateType": "https://tau.dev/attestations/gate-verdict/v1",
+  "predicate": {
+    "gate_id": "ac-linkage",
+    "gate_version": "1.4.0",
+    "verdict": "pass" | "fail" | "not_applicable",
+    "applicable_inputs": ["AC-B6", "D-090"],
+    "checked_at": "2026-05-23T...",
+    "runner": {"workflow_run_id": 12345, "head_sha": "<sha>"}
+  }
+}
+```
+
+A `not_applicable` verdict is a first-class, signed value — there is no
+"didn't run". Sigstore Rekor (public log) and a repo-local
+`refs/attestations/<sha>` ref both retain the bundle; the policy step
+verifies the signature against the GitHub OIDC issuer keyed to this repo.
+
+### Layer 2 — Policy-as-code admission controller
+
+A single required status check `policy-controller` runs Rego over an input
+document. The required-attestation set is *derived* from the diff and repo
+state, not from the PR body:
+
+```rego
+# policy/admission.rego  (OPA / Rego)
+package tau.factory.admission
+
+default allow := false
+
+# Derive required gate IDs from the diff (no PR-body inputs)
+required_gates contains gid if {
+    some path in input.diff.changed_files
+    rule := data.gate_rules[_]
+    glob.match(rule.path_glob, [], path)
+    gid := rule.gate_id
+}
+
+# A gate is satisfied iff a fresh, signed, head-SHA-pinned attestation exists
+satisfied(gid) if {
+    some att in input.attestations
+    att.predicate.gate_id == gid
+    att.subject_sha == input.head_sha
+    att.signature.verified == true
+    att.predicate.verdict != "fail"
+}
+
+allow if {
+    every gid in required_gates { satisfied(gid) }
+    not input.ci_red                    # head SHA's required-check set is green
+    input.head_sha == input.queue_target_sha   # merge-queue rebased candidate
+}
+
+# Reasons surfaced when allow=false
+deny[msg] if {
+    some gid in required_gates
+    not satisfied(gid)
+    msg := sprintf("missing attestation for gate %q", [gid])
+}
+```
+
+`data.gate_rules` is the in-repo registry mapping path globs to gate IDs;
+adding a gate means a PR to this file (itself attested):
+
+```yaml
+# policy/gate_rules.yml
+- gate_id: nn7-rescue-purity
+  path_glob: "lib/**/*.ex"
+  description: "OTP NN#7 — no try/rescue across process boundary"
+- gate_id: capability-flag-fidelity
+  path_glob: "lib/tau/providers/**/*.ex"
+  description: "prompt_caching:true ⇒ cache_regions/2 exported"
+- gate_id: ac-linkage
+  path_glob: "**/*"
+  description: "AC-N/D-NNN tokens claimed ⇒ linked test"
+```
+
+The controller job:
+
+```yaml
+policy-controller:
+  needs: [gate-ac-linkage, gate-nn7-rescue-purity, gate-capability-flag, ...]
+  if: always()    # MUST run even when a needed job fails
+  runs-on: ubuntu-24.04
+  steps:
+    - uses: actions/checkout@v4
+    - uses: actions/download-attestations@v2
+      with: { subject-sha: ${{ github.event.pull_request.head.sha }} }
+    - run: |
+        # Build input document
+        jq -n \
+          --slurpfile atts attestations/*.intoto.jsonl \
+          --arg head "${{ github.event.pull_request.head.sha }}" \
+          --arg target "${{ github.event.merge_group.head_sha || github.event.pull_request.head.sha }}" \
+          --argjson red "$(gh api repos/${{github.repository}}/commits/$head/check-runs --jq '[.check_runs[]|select(.conclusion=="failure")]|length>0')" \
+          '{attestations:$atts,head_sha:$head,queue_target_sha:$target,ci_red:$red,diff:{changed_files:$ENV.CHANGED|split("\n")}}' \
+          > policy-input.json
+        conftest verify --policy policy/ --data policy/gate_rules.yml policy-input.json
+```
+
+### Layer 3 — Merge queue is the only path to `main`
+
+Branch-protection ruleset (encoded; live ruleset diffed by `ruleset-drift`
+job):
+
+```hcl
+# infra/branch_protection.tf
+resource "github_repository_ruleset" "main" {
+  name = "main"
+  target = "branch"
+  enforcement = "active"
+  conditions {
+    ref_name { include = ["~DEFAULT_BRANCH"] }
+  }
+  rules {
+    required_status_checks {
+      required_check { context = "policy-controller" }
+      strict_required_status_checks_policy = true
+    }
+    required_linear_history = true
+    deletion = true
+    non_fast_forward = true
+    merge_queue {
+      merge_method = "MERGE"
+      min_entries_to_merge = 1
+      max_entries_to_merge = 1            # serialized — matches factory-loop
+      max_entries_to_build = 3
+    }
+  }
+  bypass_actors = []                       # NO admin override
+}
+```
+
+A separate `ruleset-drift` workflow runs on every PR and on cron:
+
+```yaml
+ruleset-drift:
+  runs-on: ubuntu-24.04
+  steps:
+    - uses: actions/checkout@v4
+    - run: |
+        terraform -chdir=infra plan -detailed-exitcode -out=tfplan
+        # exit 2 = drift; exit 0 = no drift; exit 1 = error
+        # 2 fails the check; the policy-controller requires this check.
+```
+
+### Local-mix evidence detector
+
+A small gate that scans the PR body / commit messages and fails on any
+"evidence" string lacking a corresponding attestation:
+
+```elixir
+# mix tau.gate.evidence_provenance
+# Fails if PR body contains "mix test" output, "X tests, Y failures",
+# "assert ... passed", "compiled successfully" etc., AND no
+# attestation has predicate.gate_id matching a CI-run that
+# produced equivalent output for the head SHA.
+```
+
+This gate itself emits an attestation and is in `policy/gate_rules.yml`.
+
+## Tradeoffs
+
+### Strengths
+
+- **Silent-skip is structurally impossible (acceptance §a).** The
+  policy-controller's `required_gates` is computed from the diff and repo,
+  not from the PR body; "I didn't declare it" is not a thing the policy can
+  observe. A missing attestation deterministically denies admission. A
+  legitimately-not-applicable gate emits a signed `not_applicable`
+  attestation — auditable, distinct from absent.
+- **Evidence-where-run is locked to CI head-SHA (acceptance §d).** Sigstore
+  OIDC binds each attestation's signing identity to the GitHub Actions
+  workflow run on the actual head SHA; an attestation produced on a laptop
+  has no valid signing key chain to this repo's OIDC issuer. PR-body text
+  is irrelevant to the policy.
+- **Red-CI merge structurally impossible (acceptance §c).** Merge queue
+  rebases the candidate onto current `main` and re-runs required checks;
+  the `policy-controller` reads live CI state (`ci_red`) and denies. The
+  ruleset has `bypass_actors = []` and `required_linear_history`; the
+  ruleset-drift job blocks any PR that mutates these fields without an
+  attested ADR.
+- **Meta-gate "no `|| true`, no PR-body-keyed `if:`" is unnecessary by
+  construction (acceptance §b).** The policy doesn't read `if:` guards; it
+  reads attestations. A workflow that silently no-ops produces no
+  attestation, the policy denies, the queue refuses. (We still ship a
+  `lint-ci` job that scans `.github/workflows/*.yml` for `|| true` and
+  `continue-on-error: true` on required checks, because it's cheap defense
+  in depth — but it is not load-bearing.)
+- **Reuse over reinvention (root §Acceptance D).** All four core
+  components are ecosystem standards: SLSA v1.0 attestation predicates,
+  in-toto statement format, Sigstore/Rekor transparency log, OPA Rego,
+  GitHub Merge Queue, Terraform/`gh-rulesets`. The bespoke surface is the
+  Tau-specific gate-verdict predicate type and the gate-rule registry —
+  ~200 lines of YAML + Rego.
+- **Cross-PR coherence is free.** Because attestations are SHA-pinned and
+  persisted to Rekor / `refs/attestations/`, downstream coherence checks
+  (sibling leaf `post-merge-cross-artifact-coherence`) get a queryable
+  attestation history without re-instrumenting.
+
+### Weaknesses
+
+- **Operational surface area is large.** Sigstore OIDC, Rekor, OPA, merge
+  queue, Terraform-managed branch protection, attestation predicate schema
+  — five infrastructure dependencies. Each is robust on its own; together
+  they demand a maintainer who understands the chain. A toolchain-down
+  day on any of the five blocks all merges.
+- **First-PR bootstrap problem.** The policy-controller itself is encoded
+  in the repo and gated by itself. Bootstrapping requires a one-time
+  admin push that *adds* the controller + initial gate registry; this push
+  is by definition unattested. Mitigation: a signed tag + a public ADR; but
+  the bootstrap window is a known trust hole.
+- **Policy authorship is a new skill on the team.** Rego is a small DSL but
+  it is a DSL; the maintainer who edits `gate_rules.yml` must also
+  understand `policy/admission.rego` to add a new gate type. This is a
+  shift from "edit a workflow YAML" to "edit policy + workflow + predicate
+  schema."
+- **Latency cost.** Each gate adds a sigstore signing round-trip (~1-3 s)
+  and a Rekor inclusion proof (~2-5 s). For ~10 gates per PR, this is
+  ~30-50 s of additional pre-merge latency. Acceptable for Tau's PR cadence
+  (small team, few PRs/day) but would be noticeable in a hot monorepo.
+- **Merge queue serializes throughput.** `max_entries_to_merge=1` matches
+  the factory-loop's serialized-merge invariant but eliminates any
+  throughput from parallelism gains. The factory's parallel-implementer
+  phase is unaffected; only the merge gate serializes.
+- **OIDC signing identity scope.** Sigstore's OIDC binds to the workflow
+  *repository*, not to the workflow file path. A malicious workflow file
+  added to the repo could produce attestations the policy accepts. Defense:
+  pin policy-controller to `workflow_ref` allowlist (`tau-dev/tau/.github/
+  workflows/gates.yml@refs/heads/main` only); but this allowlist is itself
+  policy and must be reviewed.
+
+### Costs
+
+- **Initial infra build:** ~2-3 PRs of work (proposal-2's mix-task layer
+  reused; new layers are Terraform, Rego policy, attestation-emit GHA
+  steps, merge-queue ruleset). Estimate ~600-900 LoC across `policy/`,
+  `infra/`, and workflow YAML.
+- **Per-gate addition cost:** add a YAML entry to `gate_rules.yml`, a Rego
+  function `satisfied/1` extension only if the gate has a non-standard
+  shape, and a workflow `attest` step. ~30 LoC per new gate.
+- **CI cost:** +30-50 s per PR (sigstore + Rekor); +1 OPA job (~5 s); +1
+  ruleset-drift job (~10 s with cached `terraform init`). Net ~+1 min per
+  PR.
+- **Bootstrap one-time cost:** an admin push to seed the controller, with a
+  matching signed-tag ADR; ~half a day including writing the bootstrap ADR
+  and verifying drift detection fires correctly.
+- **Knowledge cost:** team learns Rego (small), in-toto predicate shape
+  (small), sigstore verification (small). Each is documented, but the
+  total is non-trivial vs proposal-2's "all Elixir mix tasks."
+- **Test surface:** new property tests for the Rego policy (Conftest has a
+  built-in test harness), new contract tests for the attestation predicate
+  schema. Estimate 30-50 properties/tests.
+
+## Dependencies
+
+- GitHub Merge Queue (GA since 2023; available on Tau's plan).
+- Sigstore Cosign / `actions/attest@v2` (GA; in production at major OSS
+  projects — Kubernetes, npm registry signing).
+- OPA / Conftest (CNCF graduated; widely deployed).
+- Terraform `integrations/github` provider ≥ v6 (rulesets support).
+- A repository orphan branch `refs/attestations/` OR reliance on Rekor +
+  GitHub attestations API. Recommend both for redundancy.
+- The mix-task layer from proposal-2 (each gate emits structured JSON; the
+  attestation step wraps it).
+- ADR-NNN authorising the bootstrap push (one-time unattested admin push;
+  recorded as a known trust hole closing once policy-controller is live).
+
+## Confidence
+
+**Medium-high.** The pattern is in production at scale: Kubernetes uses
+Sigstore policy-controller for admission; npm uses sigstore for package
+provenance; the SLSA framework is the reference model for "did this artifact
+come from a trusted build." The translation to "did this PR pass its required
+checks" is direct: the PR is the artifact, the policy is the consumer.
+Confidence would be **high** with a 1-week prototype proving (a) sigstore
+OIDC attests on a private repo Tau-equivalent, (b) Rego admission rejects a
+PR with a missing attestation, (c) merge queue refuses an entry when
+`policy-controller` is red. The unknowns are operational (Rekor latency
+percentiles, sigstore key-rotation handling), not architectural.
+
+## Prior art / references
+
+- **SLSA v1.0 — Supply-chain Levels for Software Artifacts.**
+  `https://slsa.dev/spec/v1.0/` — defines "provenance" as a signed attestation
+  binding an artifact (here: PR head SHA) to the process that produced it. The
+  policy-controller is a SLSA Level 3 verifier.
+- **in-toto Attestation Framework.**
+  `https://github.com/in-toto/attestation/blob/main/spec/v1/statement.md` —
+  the `_type: Statement/v1` predicate schema is what each Tau gate emits.
+- **Sigstore policy-controller (Kubernetes admission).**
+  `https://github.com/sigstore/policy-controller` — direct conceptual analog:
+  Kubernetes refuses to admit a Pod whose image lacks the required signed
+  attestations. Tau refuses to admit a PR whose head SHA lacks the required
+  signed gate-verdict attestations.
+- **OPA / Conftest for policy-as-code admission.**
+  `https://www.openpolicyagent.org/` and `https://www.conftest.dev/` —
+  Rego is the policy language; Conftest the test harness. Used in Kubernetes
+  admission, Terraform plan gating (Hashicorp Sentinel's open analog), and
+  Spinnaker pipeline gating.
+- **GitHub Merge Queue + branch-protection rulesets.**
+  `https://docs.github.com/en/repositories/configuring-branches-and-merges-
+  in-your-repository/configuring-pull-request-merges/managing-a-merge-queue`
+  — Microsoft's monorepo (Windows / 1ES) and the `rust-lang/rust` Bors
+  workflow are the longest-running production references. The queue's
+  rebase-and-reverify behaviour is what kills the "merged against stale
+  green" failure mode.
+- **Bors / homu (Rust, Servo) and Kafka MergeQueue (LinkedIn).**
+  `https://graydon2.dreamwidth.org/1597.html` (Graydon Hoare on "the not
+  rocket science rule") — the canonical statement that "the master branch
+  must always be green" requires a queued merger that tests the post-merge
+  candidate, not the pre-merge PR head.
+- **`benchmark-action/github-action-benchmark` and `actions/attest-build-
+  provenance`** — concrete GHA building blocks; the latter is the GA
+  attestation emitter used by the npm registry's provenance program.
+- **Phabricator's Herald rules + Differential audits.** The historical model
+  for "the policy that decides whether a diff lands is itself a versioned
+  artifact in the repo, not maintainer judgement." Less directly applicable
+  (Phabricator is sunsetted) but the conceptual lineage of policy-as-code
+  admission to a trunk traces here.
+- **Gerrit's label/voting model (`Code-Review +2`, `Verified +1`).** Gerrit
+  separates *who claims* (label authors) from *what the label means* (project
+  config). The translation to attestation predicates is direct: a `Verified`
+  vote is a SLSA gate-verdict attestation under a different name; Gerrit's
+  `submit-requirements` are Rego rules under a different syntax.
+- **Bazel remote-execution build attestations / SLSA generator.**
+  `https://github.com/slsa-framework/slsa-github-generator` — the reference
+  GitHub-Action implementation of SLSA L3 provenance. The Tau gate-verdict
+  predicate is a domain-specific extension of the same model.

--- a/docs/factory-v2/design/subproblems/pre-merge-evidence-and-skip-integrity/proposals/proposal-4.md
+++ b/docs/factory-v2/design/subproblems/pre-merge-evidence-and-skip-integrity/proposals/proposal-4.md
@@ -1,0 +1,486 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 4
+parent_problem: ../problem.md
+---
+
+# Proposal 4: Adversarial v1-replay substrate — each catching mechanism is a regression test against an exact reproduced failure
+
+## Approach
+
+Rather than designing a gate substrate abstractly, this proposal constructs
+the substrate as the **fixed set of mechanisms required to deterministically
+reject the five concrete v1 failures already on disk** (#411–#414 and the
+two role/atomicity violations behind them). Each mechanism is paired to a
+named v1 failure with an exact diff/SHA citation, has a single deterministic
+check, and is wired so the check's *applicability* is computed from the
+diff/repo/PR-metadata triple — never from a PR-body declaration field.
+Concretely, the v2 substrate ships seven artefacts: (1) a "required CI
+contexts" file (`.github/required-checks.json`) consumed by both branch
+protection *and* a meta-gate; (2) a workflow self-check job (`lint-ci`) that
+parses every `.github/workflows/*.yml` AST and fails on `|| true`,
+`continue-on-error: true` on a required check, and any `if:` predicate
+referencing `github.event.pull_request.body`; (3) a head-SHA evidence binder
+that resolves every PR-body "evidence" claim to an `actions/runs/<id>` whose
+`head_sha == pr.head.sha`; (4) a diff-derived applicability resolver so
+Gate 5.1/5.3 read gating-test paths from the diff (any `test/**/*_test.exs`
+file touched in the PR), not from a PR-body section that can be empty; (5)
+a branch-protection-as-code artefact (`infra/branch-protection.json`) plus
+a drift-detector job; (6) a commit-trailer attestation check that rejects
+the PR when commits authored by `tau-reviewer` exist on the head ref (role
+separation); (7) a scope-coherence gate that asserts the diff's "changed
+top-level package set" (e.g. `{lib/mix/gate, lib/tau/tui, docs/spec}`) is
+declared in the PR body's `## Scope` table and consists of a single
+coherent unit per the declared scope-coherence rules. None of these can be
+disabled by a PR omitting a field, by a `|| true`, or by an admin merge —
+the meta-gate verifies the substrate's own configuration on every PR.
+
+## Rationale
+
+The v1 substrate failed because each gate decided *whether to run* by
+reading the PR body. The reverse complecting hypothesis from the leaf
+problem ("whether a gate runs" complected with "whether the PR opted in")
+is most cleanly broken by **forcing every gate's input universe to be a
+pure function of `(diff, repo_state, pr_metadata)`**, where `pr_metadata`
+means GitHub-API authored facts (SHA, base ref, author of each commit) and
+explicitly *excludes* the free-text body. Each of the seven artefacts is
+the smallest mechanism that breaks one of the five reproduced failure
+modes; the set is justified by being the closure of "what would have caught
+#411–#414." Designing from the failures avoids the v1 mistake of designing
+gates around an idealised PR shape; the v2 substrate is shaped instead
+around the malformed PRs that actually got merged. The meta-gate guarantees
+the substrate cannot be silently weakened by editing CI itself, closing
+the recursion.
+
+## Sketch
+
+### Failure 1 — Gate 5.1 silent-skip when `Gating-test paths` section absent
+
+**Exact reproduction.** `.github/workflows/ci.yml:88-100`:
+
+```yaml
+GATING_FILES=$(grep -oP '(?<=`)[^`]+\.exs(?=`)' /tmp/pr-body.txt | sort -u || true)
+if [ -z "$GATING_FILES" ]; then
+  echo "Gate 5.1: no gating-test paths declared in PR body — skipping."
+  exit 0
+fi
+```
+
+This is the silent-skip path. Confirmed live: PR #411 head SHA
+`39f2e4cf4f590de6e38311805224609dea2d155f` shipped with Gate 5.1 logging
+"skipping" and exiting 0; mutation-check `SKIPPED` on the same SHA (run
+duplicated to confirm). The PR body lists no `Gating-test paths` section
+at all; the regex returns empty; the gate exits zero; CI reports green
+for Gate 5.1 despite the PR claiming AC advances.
+
+**Catching mechanism (artefact 4 — diff-derived applicability resolver).**
+The gate's applicable-input set is the union of:
+
+```
+applicable_tests(diff, repo) =
+    diff.touched_paths
+  ∩ glob(repo, "test/**/*_test.exs")
+  ∪ (diff.touched_paths ∩ glob(repo, "lib/**/*.ex")
+       |> map(lib_to_test_path)
+       |> filter(File.exists?))
+```
+
+If `applicable_tests` is empty *and* the diff touches `lib/**/*.ex`, the
+gate exits non-zero with `no_gating_test_for_production_diff`. If the diff
+touches only `docs/**` or `.github/**`, the gate exits zero with the
+explicit verdict `checked, 0 applicable inputs (docs-only diff)` — *never*
+"skipping". The PR body's `Gating-test paths` section is removed from the
+substrate entirely; the substrate ignores PR-body free text for
+applicability decisions.
+
+**Class.** Applicability-from-declaration coupling.
+
+### Failure 2 — Gate 5.2 `|| true` makes masking non-failing
+
+**Exact reproduction.** `.github/workflows/ci.yml:115`:
+
+```yaml
+mix tau.gate.masking /tmp/pr-diff.txt || true
+```
+
+Whatever `mix tau.gate.masking` returns, the step exits zero. Masking
+findings surface as text in the log but are not gate-blocking, by
+construction.
+
+**Catching mechanism (artefact 2 — workflow self-check `lint-ci` job).**
+A required CI job parses each YAML file under `.github/workflows/` as an
+AST (yq + jq, or `ruby -ryaml`) and fails the PR if any of the following
+hold on any step that *is required by branch protection* (per artefact 1):
+
+- the step's `run:` block contains the literal token sequence `|| true`,
+  `|| :`, `; true`, or `; :` at end-of-line;
+- the step declares `continue-on-error: true`;
+- the step's `if:` predicate string contains the substring
+  `github.event.pull_request.body`;
+- the step's `if:` predicate is `false` or a tautological-false expression.
+
+The check is mechanical (string-AST predicates, no heuristics). The
+`lint-ci` job itself is in `.github/required-checks.json`; branch
+protection requires it; the meta-gate inside it verifies its own listing.
+Removing the job from required-checks is itself a PR diff against
+`required-checks.json` and is therefore visible.
+
+**Class.** Self-suppression — a gate that cannot fail.
+
+### Failure 3 — PR body cites "verified by `mix ...`" against a red SHA
+
+**Exact reproduction.** PR #413 (head SHA
+`f91f7bbdf039bb565d239bc91caf596885807934`) merged with the
+`lint (format · credo · compile-warnings)` and `test (Elixir 1.18.1 ·
+OTP 27.2)` checks at conclusion `FAILURE`. PR #411 head SHA
+`39f2e4cf...` merged with `lint` at `FAILURE` and Gate 5.3 at `FAILURE`.
+PR bodies for both cite `mix test` / `mix compile` lines as evidence of
+passing gates. Source: `gh pr view <n> --json statusCheckRollup` on each
+of #411/#413/#414 — the failure conclusions are durable in the GitHub
+API.
+
+**Catching mechanism (artefacts 1 + 3 — required-checks file + head-SHA
+evidence binder).** Two halves:
+
+1. *Cannot merge red.* The branch-protection ruleset
+   (`infra/branch-protection.json`) lists exactly the set in
+   `.github/required-checks.json` as required, with
+   `strict: true` (require up-to-date branches) and
+   `enforce_admins: true`. A drift-detector job (artefact 5)
+   re-fetches `gh api repos/:owner/:repo/branches/main/protection` on
+   every PR and fails the PR if the live ruleset differs from
+   `infra/branch-protection.json` — admin overrides become a visible
+   audit event.
+2. *PR-body evidence must be SHA-bound.* The evidence-binder gate
+   (artefact 3) scans the PR body for token patterns matching
+   `mix test`, `mix compile`, `Finished in`, `tests, 0 failures`, or
+   any backtick-fenced block beginning with `$ mix `. For each match,
+   the gate requires the same PR body to contain an
+   `actions/runs/<id>` URL whose `head_sha` (queried via `gh api`)
+   equals `pr.head.sha`. Missing or stale SHA → gate fails.
+
+**Class.** Evidence provenance — local-machine output accepted as proof.
+
+### Failure 4 — Role-separation violation: tau-reviewer authored implementation commits
+
+**Exact reproduction.** Commits on `main` since 2026-05-22:
+
+```
+$ git log --format='%h %an' 1174370 5b36184
+1174370 tau-reviewer
+5b36184 tau-reviewer
+```
+
+`1174370` authored by `tau-reviewer` does substantive implementation —
+"Collapse init/1 from 259 LOC to 5 LOC", removes ~700 LOC of helpers,
+rewrites `put_in`/`get_in` for struct access, introduces a new type
+alias. `5b36184` (the `mix tau.gate.*` relocation) is also authored by
+`tau-reviewer`. The reviewer-role/implementer-role separation is the
+project's primary defence against gate self-certification; v1 dissolved
+it silently.
+
+**Catching mechanism (artefact 6 — commit-trailer attestation check).**
+For each commit on the PR's head ref (`gh pr view --json commits`):
+
+- Reject if `commit.author.login == "tau-reviewer"` *and* the diff
+  touches any path under `lib/`, `test/`, or `web/lib/`. Such commits
+  are reserved for `tau-implementer` (or a human, with a `Reviewed-By:`
+  trailer attached to a separate review event).
+- Reject if a commit message contains `Co-Authored-By: Claude` *and*
+  lacks a sibling `Reviewed-By:` trailer naming a different identity
+  from the author when the diff touches a `SPEC-*.md` Appendix-B file.
+  (Two-eyes invariant on SPEC-protected surfaces.)
+- The check runs as a required CI job; the rule set is encoded in
+  `infra/commit-roles.json` to keep the substrate declarative.
+
+**Class.** Role-collapse — a single principal both authors and approves
+load-bearing changes.
+
+### Failure 5 — Atomic-PR violation: gate-relocate + SPEC-source-map + TUI-revert in one PR
+
+**Exact reproduction.** PR #412 (merge `036fc3b`) diff:
+
+```
+lib/mix/gate/ac_linkage.ex                    |  107 ++
+lib/mix/gate/common.ex                        |  105 ++
+lib/mix/gate/masking.ex                       |   75 ++
+lib/mix/gate/mutation.ex                      |  276 +++++
+lib/tau/factory/gate.ex                       |  620 -----
+docs/spec/SPEC-USER-TURN.md                   |    2 +-
+lib/tau/tui/app.ex                            | 1482 ++++++++++++++++++++++++-
+lib/tau/tui/app/bootstrap.ex                  |  113 --
+lib/tau/tui/app/events.ex                     |  459 --------
+[… 7 more lib/tau/tui/app/*.ex deletions …]
+```
+
+This PR conflates three distinct concerns: (a) gate-tooling relocation
+out of `lib/tau/`, (b) a SPEC source-map edit in
+`docs/spec/SPEC-USER-TURN.md`, and (c) reverting #411's TUI-app
+decomposition. The PR body title and "## Summary" describe only (a).
+The atomic-PR rule (`factory-loop.md` §"PR scope guards") was violated
+silently — there is no scope declaration to compare against.
+
+**Catching mechanism (artefact 7 — scope-coherence gate).** The PR body
+MUST contain a fenced JSON block:
+
+```json
+{
+  "scope": {
+    "package": "factory.gate-tooling",
+    "touched_roots": ["lib/mix/gate/", "lib/mix/tasks/tau.gate.*"],
+    "rationale": "Relocate gate tooling out of lib/tau/ namespace"
+  }
+}
+```
+
+The gate parses this JSON (failing the PR if absent/invalid) and
+computes `actual_roots = unique_top_level_dirs(diff.touched_paths,
+depth=3)`. The PR fails if `actual_roots ⊄ touched_roots` (scope creep)
+or if `touched_roots` spans more than one declared `package` in
+`infra/scope-packages.json` (a registry of recognised
+single-responsibility scopes — `factory.gate-tooling`,
+`tui.app-decomposition`, `session.fsm`, `spec.source-map`, etc.).
+PR #412 would fail on both counts: the diff touches three packages, and
+its declared `touched_roots` would not contain `lib/tau/tui/app/`.
+
+**Class.** Scope-coherence — multi-concern PRs whose declared scope omits
+the load-bearing parts.
+
+### Substrate diagram (text)
+
+```
+                           ┌──────────────────────┐
+                           │ infra/branch-        │
+                           │   protection.json    │◄── drift-detector ──┐
+                           └──────────┬───────────┘                      │
+                                      │ encodes                          │
+                                      ▼                                  │
+                           ┌──────────────────────┐                      │
+                           │ GitHub branch-       │                      │
+                           │   protection ruleset │                      │
+                           └──────────┬───────────┘                      │
+                                      │ requires                         │
+                                      ▼                                  │
+   ┌───────────────────────────────────────────────────────────┐         │
+   │ .github/required-checks.json (authoritative gate list)    │◄────────┘
+   │                                                            │
+   │  • lint                                                    │
+   │  • lint-ci   (meta-gate: workflow YAML self-check)         │
+   │  • mutation-check                                          │
+   │  • evidence-binder                                         │
+   │  • commit-roles                                            │
+   │  • scope-coherence                                         │
+   │  • binary-qa  …                                            │
+   └────┬───────────────────────────────────────────────────────┘
+        │ each gate's applicability =
+        │   f(diff, repo_state, pr_metadata)
+        ▼
+   ┌─────────────────────────────────────────────┐
+   │ Per-PR run: every gate emits one of         │
+   │   • {checked: N applicable, verdict: PASS}  │
+   │   • {checked: N applicable, verdict: FAIL}  │
+   │   • {checked: 0 applicable, verdict: PASS,  │
+   │      reason: "<diff-derived rationale>"}    │
+   │   • {infra_failure, verdict: FAIL}          │
+   └─────────────────────────────────────────────┘
+```
+
+## Tradeoffs
+
+### Strengths
+
+- **Acceptance criterion (a) — silent-skip impossibility — is met by
+  construction.** Every gate's applicability is a pure function of
+  `(diff, repo_state, pr_metadata)`; the substrate does not read the
+  PR-body free text for applicability. A gate with empty applicable input
+  emits an explicit `checked, 0 applicable` verdict with a
+  diff-derived rationale.
+- **Acceptance criterion (b) — meta-gate forbids the workflow
+  anti-patterns — is met by the `lint-ci` job operating on AST predicates,
+  not regex on log output.**
+- **Acceptance criterion (c) — branch protection encoded as artefact and
+  drift-detected — is met by `infra/branch-protection.json` plus the
+  drift-detector job.**
+- **Acceptance criterion (d) — local-mix evidence rejected — is met by
+  the evidence-binder gate matching every "mix" claim to a CI run URL
+  whose `head_sha` equals the PR head.**
+- **Each mechanism has a *named failure on disk* it rejects.** Reviewers
+  can verify the mechanism by replaying the exact bad PR (using its
+  recorded SHA); a regression-test harness can do this in CI.
+- **Reuse-vs-build is explicit and minimal.** Reuses: GitHub Repository
+  Rulesets API (artefacts 1+5), `gh api` (artefacts 3+5), `yq`/`jq` (2),
+  `git diff --name-only` (4+7). Bespoke: the four gate scripts
+  (lint-ci, evidence-binder, commit-roles, scope-coherence) and the two
+  JSON registries (`required-checks.json`, `scope-packages.json`).
+  Per root §Acceptance D, each bespoke artefact has a one-line "no
+  existing tool does this" justification.
+
+### Weaknesses
+
+- **The diff-derived applicability heuristic for AC-binding (artefact 4)
+  may produce false-positive `no_gating_test_for_production_diff` rejects
+  for legitimate production-only refactors** (e.g. an internal rename
+  with no behaviour change). The substrate's escape is an explicit
+  `production_only: true` JSON field in the PR-body scope block, gated by
+  the scope-coherence rule that such PRs may touch at most one
+  `lib/**/*.ex` file. This is narrow and may be too narrow.
+- **The commit-roles gate (artefact 6) blocks legitimate cases where a
+  human reviewer also implements a fix.** The substrate's escape is a
+  `Co-Authored-By: human@…` trailer + manual override label, which
+  re-introduces a human-judgement edge. Not zero-discretion.
+- **The scope-coherence gate (artefact 7) requires an
+  `infra/scope-packages.json` registry that must be maintained as the
+  codebase evolves.** A missing entry blocks new work until the registry
+  is updated; this is friction by design, but it is real friction.
+- **No automated detection of capability-flag lies, contract drift,
+  telemetry-consumer absence, NN #7 conformance, or SPEC consistency.**
+  Those are owned by `pre-merge-code-gates` and `post-merge-cross-
+  artifact-coherence`; this proposal explicitly scopes itself to the
+  evidence/skip-integrity dimension. Cross-leaf coordination is required
+  for total coverage.
+- **`enforce_admins: true` removes the user's ability to merge a hotfix
+  past a failing infra job (e.g. a flaky setup-beam action).** The
+  mitigation is an in-band "force-merge" workflow that opens a public
+  audit issue automatically — non-silent but inconvenient.
+- **The substrate increases CI wall-time** by adding 4 new required
+  jobs; cold-cache cost is ~30–60s each (lint-ci is YAML parsing only and
+  fast; evidence-binder is a single `gh api` round-trip; commit-roles is
+  a single `gh api` round-trip; scope-coherence is local).
+
+### Costs
+
+- **Migration cost.** One-time:
+  - Write `.github/required-checks.json` and
+    `infra/branch-protection.json` and reconcile with current live ruleset
+    (~1 day).
+  - Implement four mix tasks (`tau.gate.lint_ci`,
+    `tau.gate.evidence_binder`, `tau.gate.commit_roles`,
+    `tau.gate.scope_coherence`) — pure functions over `gh api` output and
+    YAML AST, each ≤200 LOC (~3–4 days).
+  - Author `infra/scope-packages.json` for the current ~12 packages
+    (~0.5 day).
+  - Delete the silent-skip paths in `ci.yml:88-100` and `:213-223`, and
+    the `|| true` on `:115`; rewrite Gate 5.1/5.3 to consume
+    diff-derived inputs from the resolver (~1 day).
+  - Backfill regression tests: one per reproduced v1 failure, each
+    asserting "given the recorded bad PR's diff/body/SHA, the substrate
+    returns FAIL." Five tests (~1 day).
+- **Disruption to consumers.** PR authors must learn the
+  `## Scope` JSON block (one paragraph in `factory-loop.md`). Reviewers
+  no longer write `Gating-test paths` — net simplification.
+- **Knowledge required.** Standard CI/GitHub-API/YAML/jq skills; no new
+  runtime, no new dependency on a hosted service. The mix tasks reuse the
+  existing `Tau.Factory.Gate.*` modules' style.
+- **Test surface impact.** +5 regression tests (one per failure). The
+  existing Gate 5.1/5.3 tests in `test/mix/gate/` continue to pass — the
+  applicability resolver is layered above them, not in place of them.
+- **Build/dependency impact.** Adds `yq` apt install in `lint-ci`
+  (negligible). No new mix deps.
+
+## Dependencies
+
+- **Resolution of the `pre-merge-code-gates` and `intent-capture-and-ac-
+  binding` siblings.** The applicability resolver (artefact 4) replaces the
+  `Gating-test paths` PR-body section; that section is also referenced by
+  `factory-loop.md` §"The draft-PR body" and by the AC-binding sibling.
+  Coordination required so the three leaves do not redefine the same
+  surface incompatibly.
+- **GitHub Repository Rulesets API availability for the repo's plan tier.**
+  Public repos have it free; the project is public so this is met.
+- **`gh` CLI version ≥ 2.40 on CI runners** for the `--json head_sha`
+  field in PR status-checks queries. Already met (`ubuntu-24.04` ships
+  with 2.40+).
+- **`infra/scope-packages.json` registry agreed up-front.** A bootstrapping
+  task; without it the scope-coherence gate fails-closed on every PR.
+
+## Confidence
+
+**High.** Confidence basis:
+
+- Every catching mechanism is paired to a named v1 failure with a
+  reproducible SHA. The substrate is a regression test against five
+  events that *actually happened* in the last 36 hours, not a
+  forward-looking guess. Confidence would be raised further by a
+  prototype `lint-ci` job and a recorded green-on-good-PR /
+  red-on-each-of-#411–#414 regression run.
+- The mechanism set is the minimal closure under
+  "what would have blocked #411–#414"; it is not aspirational. If a
+  sixth failure mode surfaces, the substrate's extension shape is
+  already established (add a required check, add it to
+  `required-checks.json`, write a regression test against the bad PR).
+- The reuse-vs-build axis is conservative: 4 small bespoke gates + 2
+  JSON registries on top of GitHub's native ruleset machinery.
+
+## Prior art / references
+
+- **GitHub Repository Rulesets API** —
+  `https://docs.github.com/en/rest/repos/rules` — branch-protection-as-
+  code is a first-class GitHub primitive; no third-party Terraform
+  needed.
+- **OpenSSF Scorecard `branch-protection` check** —
+  `https://github.com/ossf/scorecard/blob/main/checks/branch_protection.go`
+  — independent precedent for treating branch protection as machine-
+  checkable artefact (used by Kubernetes, Tekton, …).
+- **`gh api repos/:owner/:repo/branches/main/protection`** — already in the
+  v1 loop's vocabulary (`factory-loop.md` cycle step 8a); this proposal
+  formalises it as a versioned artefact.
+- **Sigstore / in-toto attestations** — analogous shape (artefact + check
+  registry + verifier) for supply-chain provenance; the
+  evidence-binder gate is a degenerate in-toto verifier ("did this CI
+  run actually emit the claim cited in the body, on this SHA?").
+- **`actionlint`** (`https://github.com/rhysd/actionlint`) — third-party
+  GHA YAML linter; the `lint-ci` job could reuse its AST traversal rather
+  than re-implementing predicates from scratch (Sketch lists this as a
+  reuse candidate; deferred to selector for decision).
+
+---
+
+## Silent-skip impossibility — proof sketch
+
+The substrate's `lint-ci` meta-gate is the chain of trust. The argument:
+
+1. *No required gate may silent-skip.* Every required gate's check
+   function has signature `(diff, repo_state, pr_metadata) -> verdict`,
+   where `verdict ∈ {pass(applicable_n, reason), fail(applicable_n,
+   findings), infra_failure(reason)}`. There is no
+   `verdict = skipped` constructor. A gate whose input set is empty
+   returns `pass(0, "diff scope <X> excludes this gate's applicability
+   set")`. The exhaustiveness check is a static property of the verdict
+   sum type, asserted by a unit test in `test/mix/gate/verdict_test.exs`.
+2. *The substrate cannot be configured to silent-skip.* The required-
+   check list (`.github/required-checks.json`) is itself in the diff;
+   removing a check is a visible diff against an artefact the
+   scope-coherence gate refuses unless the PR is in package
+   `factory.required-checks` (a privileged package whose PRs require
+   `Reviewed-By: <human>`).
+3. *The substrate cannot be bypassed by an admin merge.* Branch
+   protection has `enforce_admins: true` (encoded in
+   `infra/branch-protection.json`); the drift-detector job fails the PR
+   if the live ruleset differs. An `enforce_admins: false` is itself a
+   diff, visible via drift-detector.
+4. *The substrate cannot disable itself via `|| true`.* The `lint-ci`
+   job's AST check refuses any `|| true` on a required step; the check
+   itself is required (recursive case), so disabling it is the same
+   diff as removing it from required-checks (case 2).
+
+The set {1,2,3,4} closes the silent-skip surface modulo a human merging
+against branch protection by deliberately editing the ruleset on
+github.com directly. Drift-detector catches this within the next PR run
+and opens an audit issue automatically.
+
+## Class generalisation — what classes the seven artefacts cover
+
+| Class                                                | Artefact(s) | Generalises beyond reproduced failure |
+|------------------------------------------------------|-------------|----------------------------------------|
+| Applicability-from-declaration coupling              | 4           | Any future gate that "asks the PR body whether to run" — the substrate's signature forbids it |
+| Self-suppression (`|| true`, `continue-on-error`)    | 2           | Any future workflow-level escape hatch  |
+| Evidence provenance / local-machine evidence         | 1, 3        | Any future PR whose body cites unverifiable claims (test counts, dialyzer summaries, manual replay output) |
+| Merge against red CI                                 | 1, 5        | Includes the case where required-checks shrinks silently (drift-detector catches) |
+| Role-collapse (reviewer authoring impl)              | 6           | Any future role expansion — add the role to `infra/commit-roles.json`; check covers it |
+| Scope-coherence violations / atomic-PR violations    | 7           | Any multi-concern PR whose scope JSON misrepresents the diff |
+
+The seven artefacts are a covering set, not a one-to-one map. The
+generalisation is that the substrate treats every gate as a pure function
+over machine-readable inputs and rejects every channel by which a PR body
+could weaken the gate's verdict.

--- a/docs/factory-v2/design/subproblems/pre-merge-evidence-and-skip-integrity/solution.md
+++ b/docs/factory-v2/design/subproblems/pre-merge-evidence-and-skip-integrity/solution.md
@@ -1,0 +1,683 @@
+---
+template_version: 1
+template_name: solution
+parent_problem: ./problem.md
+node_kind: leaf
+synthesised_from: [proposals/proposal-4.md, proposals/proposal-2.md, proposals/proposal-3.md]
+selection_method: hybrid
+revision: 0
+---
+
+# Solution: Failure-paired gate substrate on GitHub Rulesets + Merge Queue, with ecosystem tooling for YAML lint, diff derivation, and issue alarms
+
+## Recommendation
+
+Adopt proposal-4's failure-paired regression-test spine as the substrate's
+shape — every required check is a pure function `(diff, repo_state,
+pr_metadata) -> verdict` paired to a named v1 failure with a reproducible
+SHA — and graft three ecosystem components from proposal-2 plus one from
+proposal-3: (a) `rhysd/actionlint` for YAML AST traversal underneath
+proposal-4's `lint-ci` meta-gate; (b) `tj-actions/changed-files`
+SHA-pinned + `step-security/harden-runner` for diff derivation underneath
+proposal-4's applicability resolver; (c) `peter-evans/create-issue-from-
+file` for the post-merge `factory/bypass-detected` alarm; (d) **GitHub
+Merge Queue** with `max_entries_to_merge=1` and
+`strict_required_status_checks_policy=true` as the only path to `main`,
+because it rebases the candidate onto live `origin/main` and re-verifies
+the required-check set on the post-merge tree — closing the stale-green
+race that proposal-4 acknowledged via `strict: true` but did not name
+explicitly. Branch protection is encoded as JSON in
+`.github/rulesets/main.json` (per proposal-2 — closer to GitHub's native
+shape than proposal-3's Terraform-HCL and removes a runtime dependency).
+Reject proposal-1's signed-verdict-ledger and proposal-3's
+Sigstore/Rekor/OPA stack: their cryptographic surface is itself a new
+silent-bypass channel (proposal-1 §Weaknesses concedes "a bug in
+signature verification at the Bus's pre-receive hook is a silent bypass
+channel"), and the operational debt (sigstore OIDC, Rekor inclusion
+proofs, Rego authorship, Terraform provider) is unjustified when a
+diff-derived applicability resolver already eliminates the silent-skip
+surface by construction.
+
+## Selected from
+
+- **Chosen:** **hybrid** of `proposals/proposal-4.md` (spine) +
+  `proposals/proposal-2.md` (ecosystem components a–c) +
+  `proposals/proposal-3.md` (merge-queue mechanism only). Proposal-1
+  rejected on cryptographic-surface grounds; proposal-3's Sigstore/OPA
+  layers rejected as unnecessary infrastructure debt.
+- **Why chosen:** scored against the leaf's acceptance criterion (a–f),
+  the comparison is:
+
+| # | Fit | Decomplecting depth | Migration cost | Risk | Reversibility |
+|---|---|---|---|---|---|
+| 1 (Verdict-Bus) | Yes | Deep | High (10 substrate PRs + key infra) | Med-High (crypto bypass channel; corrupted-registry weakness self-noted) | Hard (git-ref ledger is unconventional) |
+| 2 (Ecosystem) | Yes | Substantial | Low-Med (5–8 PRs) | Med (evidence-verifier is a Claude agent — root §"where Claude is in the loop, Claude's claims must be cross-checked by mechanism" tension self-noted) | Easy |
+| 3 (SLSA + OPA + MQ) | Yes | Deep | High (Rego + Sigstore + Terraform + MQ; bootstrap trust hole) | High (5 infra deps; toolchain-down day blocks all merges) | Hard |
+| 4 (Adversarial replay) | Yes | Deep | Low (4 mix tasks + 2 JSON registries; ~5 PRs) | Low (each mechanism paired to a reproducible v1 SHA) | Easy |
+
+  Proposal-4 dominates on fit, decomplecting depth, migration cost, risk,
+  and reversibility simultaneously. Its only structural gap — the
+  stale-green race when `main` advances between gate-green and merge — is
+  filled by proposal-3's merge-queue mechanism (the single layer of
+  proposal-3 that pays for itself; the rest is operational debt
+  proposal-4 already accomplishes without). Proposal-2 contributes
+  battle-tested tooling for the *implementations* of proposal-4's
+  abstract checks (actionlint replaces hand-rolled YAML parsing;
+  tj-actions/changed-files replaces hand-rolled `git diff --name-only`
+  wrappers; peter-evans/create-issue-from-file replaces hand-rolled
+  `gh issue create` glue). Per selector heuristic "composition over
+  aggregation," each grafted component has a typed contract with the
+  proposal-4 spine and is independently replaceable. The
+  evidence-verifier-as-Claude-agent surface from proposal-2 §D is
+  explicitly **NOT** grafted — its bespoke replacement
+  (`mix tau.gate.evidence_binder`, proposal-4 artefact 3) is the
+  load-bearing path, satisfying the root constraint that Claude's claims
+  not gate merges.
+
+## What changes
+
+### Artefacts created (file-level)
+
+The substrate ships **fifteen** concrete artefacts. Each is named below
+with its absolute repo path, its purpose, and the failure class
+(`F#` = root §Hypothesis numbering) and acceptance clause (`§a–f`) it
+satisfies.
+
+**Branch-protection / merge-queue (ruleset-as-code).**
+
+1. `.github/rulesets/main.json` — encoded GitHub Repository Ruleset for
+   `main`: `enforcement: active`; `bypass_actors: []` (no admin
+   override); `required_linear_history: true`; `strict_required_status_
+   checks_policy: true`; `required_status_checks` enumerated below in
+   step §a; merge queue `max_entries_to_merge: 1`,
+   `max_entries_to_build: 3`. Authoritative; the live ruleset is diffed
+   against this file on every PR. Closes F#7, §c.
+
+2. `.github/required-checks.json` — single source of truth for the
+   required-check name set. The ruleset's `required_status_checks`
+   field is generated from this file; the `lint-ci` meta-gate reads it
+   to know which jobs `continue-on-error: true` is forbidden on; the
+   ruleset-drift gate reads it for the comparison. One file, three
+   consumers — eliminates the v1 drift between ruleset and CI YAML.
+
+3. `.github/workflows/ruleset-apply.yml` — push-to-`main` workflow that
+   applies `.github/rulesets/main.json` via direct `gh api PUT
+   repos/:owner/:repo/rulesets/:id` (one `gh` call; no third-party
+   action needed for this trivial wrap). Idempotent.
+
+4. `.github/workflows/ruleset-drift.yml` — required check; runs on
+   every PR and on daily cron. `gh api repos/:owner/:repo/rulesets` →
+   `jq -S` normalise → byte-diff against `.github/rulesets/main.json`.
+   Drift fails the PR AND invokes `peter-evans/create-issue-from-file`
+   to open a `factory/ruleset-drift` P0 issue. Closes F#7, §c.
+
+**Meta-gate over CI configuration.**
+
+5. `.github/workflows/lint-ci.yml` — required check (`lint-ci`). Two
+   stages:
+   - **Stage 1: actionlint.** `rhysd/actionlint@v1.7.5` (SHA-pinned)
+     parses every `.github/workflows/*.yml` for general YAML
+     correctness — replaces hand-rolled YAML parsing per proposal-2.
+   - **Stage 2: forbidden-pattern check** via
+     `mix tau.gate.lint_ci`. Reads `.github/required-checks.json` and
+     each workflow YAML AST; fails on any of:
+       - `|| true`, `|| :`, `; true`, `; :` at end-of-line in a `run:`
+         block belonging to a required job;
+       - `continue-on-error: true` on a required job;
+       - any `if:` expression containing the literal substring
+         `github.event.pull_request.body`;
+       - any `paths:` / `paths-ignore:` filter on a required job
+         (path-filters are silent-skip channels per proposal-1);
+       - any `actions/checkout` with `persist-credentials: true` on a
+         required job.
+   Closes F#5, §b.
+
+**Diff-derived applicability resolver.**
+
+6. `lib/mix/tasks/tau.gate.applicability.ex` — pure Elixir function
+   `Tau.Factory.Applicability.compute/3` taking `(diff_paths,
+   repo_root, pr_metadata)` and returning a map from `gate_id` to the
+   set of files / AST nodes the gate is responsible for. Reads
+   `tj-actions/changed-files`-SHA-pinned JSON output passed via stdin;
+   never reads PR-body text. Used by Gate 5.1 / 5.3 (sibling
+   `pre-merge-code-gates` leaf consumes the same module).
+
+7. `.github/actions/changed-files/action.yml` — composite wrapper
+   pinning `tj-actions/changed-files@<exact-commit-sha>` plus
+   `step-security/harden-runner@<sha>` with audited egress allow-list
+   (the CVE-2025-30066 mitigation per proposal-2). Every required
+   workflow uses this wrapper rather than referencing `tj-actions`
+   directly — a single update site for the SHA pin. Closes F#5, §a.
+
+**Verdict-shape enforcement.**
+
+8. `lib/tau/factory/verdict.ex` — `Tau.Factory.Verdict` struct +
+   exhaustive sum type:
+
+```elixir
+defmodule Tau.Factory.Verdict do
+  @enforce_keys [:gate_id, :head_sha, :applicable_inputs, :status,
+                 :reason, :emitted_at]
+  defstruct [:gate_id, :head_sha, :applicable_inputs, :status,
+             :reason, :emitted_at, :findings, :tool_version]
+  @type status :: :pass | :fail | :checked_no_applicable | :infra_failure
+end
+```
+
+   There is **no `:skipped` constructor** — exhaustiveness asserted by a
+   property test (`test/tau/factory/verdict_test.exs`,
+   `@tag :property`) that round-trips arbitrary verdicts and by a
+   Dialyzer spec the `mix dialyzer` job already runs. Every required
+   mix-gate task emits a verdict on stdout (JSON-encoded per
+   `priv/schemas/verdict.schema.json`). Closes F#5, §a (silent-skip is
+   syntactically unrepresentable).
+
+9. `priv/schemas/verdict.schema.json` — JSON Schema for the verdict
+   payload; consumed by the operability-leaf dashboard and by CI
+   assertions that every required job's stdout parses as a valid
+   verdict.
+
+**Evidence-binder gate.**
+
+10. `lib/mix/tasks/tau.gate.evidence_binder.ex` — required check.
+    Scans the PR body (fetched via `gh pr view --json body`) for token
+    patterns matching `mix test`, `mix compile`, `Finished in`,
+    `\d+ tests?, \d+ failures?`, `assert .* passed`, `iex>`, or any
+    backtick-fenced block starting with `$ mix `. For every match,
+    requires a sibling `https://github.com/<owner>/<repo>/actions/runs/
+    <id>` URL whose `head_sha` (fetched via `gh api`) equals
+    `pr.head.sha`. Pure deterministic Elixir; no LLM in the loop —
+    this is the explicit replacement for proposal-2's
+    `evidence-verifier` Claude agent. Closes F#7, §d.
+
+**Post-merge alarm.**
+
+11. `.github/workflows/post-merge-audit.yml` — runs on `push: main`.
+    For every new merge commit, calls
+    `gh api repos/:owner/:repo/commits/:sha/check-runs --jq` to
+    enumerate required-check conclusions; if any required check is not
+    `success` for the head SHA, opens a `factory/bypass-detected` P0
+    issue via `peter-evans/create-issue-from-file@<sha>` with the
+    merge SHA, the merger identity, and the failing check names.
+    Catches the residual case where Rulesets fail open (GitHub outage,
+    ruleset misconfiguration). Closes F#7 (residual), §c.
+
+**Role-separation and scope-coherence gates.**
+
+12. `lib/mix/tasks/tau.gate.commit_roles.ex` + `infra/commit-roles.json`
+    — required check. For each commit on `pr.head` (via
+    `gh pr view --json commits`), enforces the rules encoded in
+    `infra/commit-roles.json` (rule set: `tau-reviewer` MAY NOT author
+    diffs under `lib/`, `test/`, `web/lib/`; `Co-Authored-By: Claude`
+    on diffs touching `SPEC-*.md` Appendix-B files requires a sibling
+    `Reviewed-By:` trailer with a distinct identity). Per proposal-4
+    artefact 6. Closes a v1 role-collapse pattern; supports §a by
+    ensuring the role authoring a verdict is distinct from the role
+    consuming it.
+
+13. `lib/mix/tasks/tau.gate.scope_coherence.ex` + `infra/scope-
+    packages.json` — required check. Parses the fenced `scope` JSON
+    block in the PR body; computes `actual_roots = unique_top_level_
+    dirs(diff.touched_paths, depth=3)`; fails on `actual_roots ⊄
+    declared touched_roots` or `touched_roots` spanning more than one
+    declared package. Per proposal-4 artefact 7. The single PR-body
+    field the substrate reads is the `scope` JSON block — and the
+    `scope-coherence` gate's role is to *contradict* the PR body
+    against the diff, not to *trust* it.
+
+**Regression-test harness (proposal-4 spine).**
+
+14. `test/factory/v1_failure_regression_test.exs` — one regression
+    test per reproduced v1 failure (#411, #412, #413, #414, role-
+    collapse, atomicity). Each test:
+    - reconstructs the bad PR's diff + body + commit metadata from
+      fixtures under `test/factory/fixtures/pr-<n>/`;
+    - invokes the substrate's verdict pipeline as a pure function;
+    - asserts the substrate returns `:fail` with the named class.
+    Tagged `@tag :gating` so it appears in Gate 5.1's tracked set per
+    SPEC-USER-TURN conventions. Adding a sixth v1 failure means
+    adding a sixth fixture directory + a sixth test — the regression
+    set grows monotonically.
+
+15. `docs/adr/ADR-NNN-factory-v2-gate-substrate.md` — ADR recording
+    (a) the rejection of proposal-1's signed-verdict-ledger and
+    proposal-3's full SLSA/OPA stack, with reasoning; (b) the
+    bootstrap admin push that lands artefacts 1–4 (a one-time
+    unattested seed event documented per `tau-adr` conventions);
+    (c) the rule that subsequent edits to `.github/rulesets/main.json`,
+    `.github/required-checks.json`, `infra/commit-roles.json`,
+    `infra/scope-packages.json` require a `Reviewed-By:` trailer from
+    a human identity (closes proposal-1's "corrupted registry"
+    weakness without multi-sig infrastructure).
+
+### Modifications to existing files
+
+- `.github/workflows/ci.yml` — delete lines 88-100 (Gate 5.1
+  silent-skip), line 115 (`|| true`), lines 213-223 (Gate 5.3
+  silent-skip). Replace with always-on gate invocations that read
+  applicability from `mix tau.gate.applicability`. Each required job
+  exits with the verdict's deterministic exit code (`:pass | :checked_
+  no_applicable -> 0`; `:fail | :infra_failure -> non-zero`).
+- `.claude/rules/factory-loop.md` — remove the `Gating-test paths`
+  PR-body section requirement; replace with a single-sentence pointer
+  to the diff-derived resolver. Add a one-paragraph description of the
+  `scope` JSON block contract. Remove any guidance to cite local
+  `mix test` output as evidence in PR bodies.
+- `lib/mix/gate/{ac_linkage,masking,mutation}.ex` (the three v1 mix
+  tasks) — reshape to emit `Tau.Factory.Verdict` JSON on stdout;
+  remove all internal PR-body parsing; replace any internal
+  `applicable_inputs` derivation with a call into
+  `Tau.Factory.Applicability.compute/3`.
+
+### Silent-skip impossibility — concrete implementation
+
+Per acceptance §a — restated at the implementation level so a reviewer
+can falsify each clause against the artefacts above:
+
+1. **No required gate may silent-skip.** The `Tau.Factory.Verdict`
+   sum type (artefact 8) has no `:skipped` constructor; a Dialyzer
+   spec asserts exhaustiveness; the property test
+   `test/tau/factory/verdict_test.exs` round-trips arbitrary verdicts
+   and would fail to compile if a fifth constructor were added without
+   updating the type. The CI step that consumes a gate's stdout
+   parses against `priv/schemas/verdict.schema.json` (artefact 9) and
+   fails the job on schema-mismatch — a gate that prints free text
+   instead of a verdict is treated as `:infra_failure`.
+
+2. **The substrate cannot be configured to silent-skip.** Removing a
+   required check from `.github/required-checks.json` (artefact 2) is
+   a diff visible to `scope-coherence` (artefact 13), which refuses
+   it unless the PR's `scope.package == "factory.required-checks"` —
+   a privileged scope whose entries in `infra/scope-packages.json`
+   require a `Reviewed-By:` trailer from a human identity (ADR-NNN
+   rule per artefact 15). The ruleset-drift gate (artefact 4) catches
+   any divergence between live ruleset and the file.
+
+3. **The substrate cannot disable itself via `|| true`,
+   `continue-on-error: true`, or PR-body-keyed `if:`.** The `lint-ci`
+   meta-gate (artefact 5) is itself in `.github/required-checks.json`
+   (artefact 2); its forbidden-pattern check forbids these four
+   anti-patterns on any required job. Disabling `lint-ci` is case 2
+   above. Path-filters (`paths:` / `paths-ignore:`) on required jobs
+   are also forbidden — closing proposal-1's "path-filtered out" sub-
+   failure as well.
+
+4. **The substrate cannot be bypassed by an admin merge.**
+   `bypass_actors: []` in `.github/rulesets/main.json` (artefact 1)
+   removes the admin-override path. Editing this field is a diff
+   ruleset-drift (artefact 4) catches; if a human nonetheless edits
+   the live ruleset on github.com, the post-merge audit workflow
+   (artefact 11) opens a `factory/bypass-detected` P0 issue on the
+   next push to `main`.
+
+5. **The substrate cannot merge against red CI.** GitHub Merge Queue
+   with `strict_required_status_checks_policy: true` (artefact 1)
+   rebases the merge candidate onto current `origin/main` and
+   re-evaluates every required check on the post-merge tree. A green
+   pre-merge gate verdict that would be red after rebase fails the
+   queue entry — closing proposal-4's implicit gap (proposal-4 relied
+   on `strict: true` alone, which forces up-to-date but does not
+   re-verify the post-merge tree).
+
+6. **The substrate cannot infrastructurally silent-pass.** A required
+   job that crashes (toolchain missing, network timeout, runner OOM)
+   reports `conclusion: failure` to GitHub — required-checks gating
+   fails the PR. A job that emits invalid stdout per the verdict
+   schema is treated as `:infra_failure` (`exit 1`) by the
+   schema-validation wrapper, not silently passed.
+
+### Reuse-vs-build accounting (per root §Acceptance D)
+
+| Capability | Decision | Component | Bespoke surface |
+|---|---|---|---|
+| Branch-protection encoding | **Adopt** | GitHub Repository Rulesets API | `.github/rulesets/main.json` (config only) |
+| Ruleset apply / drift | **Build (thin)** | `gh api PUT/GET` + `jq -S` | ~30 lines YAML each (artefacts 3, 4); no third-party action needed |
+| Workflow YAML lint (general) | **Adopt** | `rhysd/actionlint` SHA-pinned | none |
+| Workflow forbidden-pattern check | **Build** | `mix tau.gate.lint_ci` over YAML AST | ~150 LoC Elixir (artefact 5); no ecosystem equivalent for the four custom patterns |
+| Diff-derived applicability | **Adopt + thin glue** | `tj-actions/changed-files@<sha>` + `step-security/harden-runner@<sha>` wrapped in `.github/actions/changed-files/` | ~20 lines YAML (artefact 7) |
+| Applicability computation | **Build** | `Tau.Factory.Applicability` | ~200 LoC Elixir (artefact 6) — pure function, project-specific glob rules |
+| Verdict shape | **Build** | `Tau.Factory.Verdict` sum type | ~80 LoC Elixir + JSON Schema (artefacts 8, 9) |
+| Evidence binder | **Build** | `mix tau.gate.evidence_binder` | ~150 LoC Elixir (artefact 10) — deterministic, no LLM (explicitly NOT proposal-2's claude-code-action path) |
+| Post-merge alarm | **Adopt + thin glue** | `peter-evans/create-issue-from-file@<sha>` + `gh api` | ~40 lines YAML (artefact 11) |
+| Merge queue | **Adopt** | GitHub Merge Queue (native) | configured in artefact 1 |
+| Commit-role check | **Build** | `mix tau.gate.commit_roles` + `infra/commit-roles.json` | ~120 LoC Elixir (artefact 12) — no ecosystem equivalent |
+| Scope-coherence | **Build** | `mix tau.gate.scope_coherence` + `infra/scope-packages.json` | ~150 LoC Elixir (artefact 13) — no ecosystem equivalent |
+| Regression harness | **Build** | ExUnit fixtures | one fixture dir + one test per v1 failure (artefact 14) |
+
+Bespoke totals: ~900 LoC Elixir across six mix tasks + ~120 lines of YAML
+glue + four JSON registries + ADR-NNN. Every bespoke component has a
+one-line "no ecosystem equivalent" justification embedded above. Six
+ecosystem components adopted (GitHub Rulesets, GitHub Merge Queue,
+actionlint, tj-actions/changed-files, harden-runner, create-issue-from-
+file). Per root §Acceptance D, the build justifications are explicit and
+the adopt-vs-build axis biases toward adopt where coverage exists.
+
+### Integration with sibling leaves
+
+- **`pre-merge-code-gates` sibling** owns the *content* of each AST /
+  contract / capability-flag check; **this leaf** owns the *substrate*
+  they emit verdicts into. Concretely: every mix gate that sibling
+  defines emits a `Tau.Factory.Verdict` per artefact 8, gets registered
+  in `.github/required-checks.json` per artefact 2, and its workflow
+  YAML is constrained by artefact 5. The shared interface is the
+  Verdict struct and the JSON Schema.
+
+- **`intent-capture-and-ac-binding` sibling** consumes
+  `Tau.Factory.Applicability` (artefact 6) for its AC↔test binding;
+  the diff-derived gating-test set defined here replaces v1's
+  `Gating-test paths` PR-body section that sibling formerly read.
+
+- **`operability-and-hygiene-enforcement` sibling** consumes the
+  verdict JSON stream (artefacts 8, 9) and the `factory/bypass-
+  detected` issue label for the dashboard; this leaf produces the
+  verdicts, that leaf displays them. The post-merge audit workflow
+  (artefact 11) is the upstream of that leaf's bypass-detection
+  surface.
+
+- **`knowledge-memory-and-audit-ingestion` sibling**: audit registry
+  entries become applicability inputs to specific gates via
+  `Tau.Factory.Applicability.compute/3`'s `pr_metadata` argument (a
+  module flagged by an audit becomes an applicable input to the
+  corresponding gate).
+
+- **`post-merge-cross-artifact-coherence` sibling**: ruleset-drift
+  (artefact 4) and post-merge audit (artefact 11) are pre-merge
+  surfaces; that sibling owns the cadenced `main`-side re-audits that
+  catch cross-PR drift the per-PR substrate cannot see.
+
+## What does not change
+
+- `Tau.Factory.Gate` module (`lib/tau/factory/gate.ex`) — the three
+  pure verdict-producing functions remain; they get a new return shape
+  (the `Verdict` struct) and a new applicability input, but the
+  predicate logic is preserved. No functionality regression on
+  existing gates.
+- The `/pr` skill and the critic/reviewer agent personas continue to
+  exist as quality checks; they MAY NOT be load-bearing for any of the
+  ten root §Hypothesis failure classes (per root §Acceptance B).
+- The factory-loop's serialized-merge invariant
+  (`max_entries_to_merge: 1` in artefact 1) preserves the
+  `factory-loop.md` cycle-step-8 guarantee that merges are sequential.
+- Pre-existing properties tests under `test/property/` and unit tests
+  under `test/tau/` continue to pass; the substrate is layered above
+  them.
+- The `.tool-versions` Erlang/Elixir pins (1.18.1 / OTP 27.2);
+  no new BEAM-level runtime dependency.
+- `mix dialyzer` and `mix credo --strict` continue as `lint`-job
+  components.
+
+## §Build-order
+
+Each step is one PR per the factory loop. Each step's exit-criterion is
+a check the next step can run against. Step N may not begin until step
+N-1's exit-criterion is itself a green CI verdict on `main`. Total
+sequence: **12 PRs over an estimated 8 weeks**, value lands
+incrementally — the first usable trust gain is at step 4 (week 2).
+
+The substrate's bootstrap problem (proposal-3 §Weaknesses) is handled
+by sequencing: artefacts 1–4 land before the meta-gates that would gate
+their own creation. ADR-NNN (artefact 15) documents this one-time
+unattested admin push window, per `tau-adr` conventions.
+
+### Week 1 — Foundation (no behaviour change yet)
+
+**PR 1: Verdict shape + JSON Schema** (artefacts 8, 9).
+- Land `Tau.Factory.Verdict` struct, sum type, Dialyzer spec.
+- Land `priv/schemas/verdict.schema.json`.
+- Land `test/tau/factory/verdict_test.exs` property test.
+- **Dependencies:** none.
+- **Exit:** `mix test test/tau/factory/verdict_test.exs` green;
+  `mix dialyzer` confirms exhaustive sum type.
+
+**PR 2: Applicability resolver + diff-derived input wrapper**
+(artefacts 6, 7).
+- Land `Tau.Factory.Applicability.compute/3` with property tests.
+- Land `.github/actions/changed-files/action.yml` SHA-pinning
+  `tj-actions/changed-files` + `step-security/harden-runner`.
+- **Dependencies:** PR 1 (uses Verdict shape in tests).
+- **Exit:** property test asserts determinism on identical
+  `(diff, repo_root, pr_metadata)` input across 100 generations;
+  composite action runnable locally via `act`.
+
+### Week 2 — Branch protection encoded (closes admin-override path)
+
+**PR 3: Ruleset-as-code + ruleset-drift gate + ruleset-apply
+workflow** (artefacts 1, 3, 4).
+- Land `.github/rulesets/main.json` reconciled with current live
+  ruleset.
+- Land `.github/workflows/ruleset-apply.yml`.
+- Land `.github/workflows/ruleset-drift.yml` (initially *not* required
+  — added to required set in PR 5 after one PR-cycle of shadow mode).
+- **Dependencies:** PR 1 (drift workflow emits a Verdict).
+- **Exit:** `gh api repos/:owner/:repo/rulesets` round-trips byte-
+  equal to file (proposal-2's noted concern resolved or a normalisation
+  step added); shadow-mode drift gate runs green on the next PR.
+- **First trust gain:** `bypass_actors: []` is now live; admin merge of
+  red PRs is structurally blocked on day 1.
+
+**PR 4: Required-checks single-source + lint-ci meta-gate (audit-mode)**
+(artefacts 2, 5).
+- Land `.github/required-checks.json` mirroring the current required
+  set.
+- Land `.github/workflows/lint-ci.yml` running `rhysd/actionlint` +
+  `mix tau.gate.lint_ci` in audit-mode (logs findings, does not fail).
+- **Dependencies:** PR 1, PR 3.
+- **Exit:** audit-mode flags the existing `|| true` at `ci.yml:115`
+  and the silent-skip blocks at `:88-100` and `:213-223`.
+
+### Week 3 — Meta-gate goes blocking; verdict shape adopted
+
+**PR 5: Promote ruleset-drift and lint-ci to required; fix audit
+findings.**
+- Add `ruleset-drift` and `lint-ci` to
+  `.github/required-checks.json`; regenerate ruleset.
+- Delete `ci.yml:88-100`, `:115`, `:213-223`. Replace with always-on
+  gate invocations using `Tau.Factory.Applicability`.
+- **Dependencies:** PRs 1–4.
+- **Exit:** `lint-ci` would have blocked the v1 PR #411 fixture
+  (replay test in PR 12).
+- **Second trust gain:** `|| true` and silent-skip patterns are
+  structurally rejected.
+
+### Week 4 — Existing v1 gates migrate to Verdict shape
+
+**PR 6: Reshape `mix tau.gate.{ac_linkage,masking,mutation}` to emit
+Verdicts.**
+- Each task emits `Tau.Factory.Verdict` JSON on stdout.
+- Each task's `applicable_inputs` derives from
+  `Tau.Factory.Applicability.compute/3`.
+- CI wrapper validates stdout against `priv/schemas/verdict.schema.
+  json`.
+- **Dependencies:** PRs 1, 2, 5.
+- **Exit:** all three existing gates pass with new shape on the
+  current `main`; one synthetic PR with no gating tests demonstrates
+  `:checked_no_applicable` flowing through correctly.
+
+### Week 5 — Evidence-binder + post-merge alarm
+
+**PR 7: Evidence-binder gate** (artefact 10).
+- Land `mix tau.gate.evidence_binder`.
+- Add `evidence-binder` to required-checks.
+- **Dependencies:** PRs 1, 5.
+- **Exit:** synthetic PR pasting `mix test` output without a CI-run
+  URL is blocked; synthetic PR with correct SHA-pinned URL passes.
+
+**PR 8: Post-merge audit + bypass-detected alarm** (artefact 11).
+- Land `.github/workflows/post-merge-audit.yml` using
+  `peter-evans/create-issue-from-file`.
+- **Dependencies:** PR 5 (consumes required-checks list).
+- **Exit:** simulated admin-override merge in a fork opens a
+  `factory/bypass-detected` issue.
+
+### Week 6 — Role + scope-coherence gates
+
+**PR 9: Commit-roles gate** (artefact 12).
+- Land `mix tau.gate.commit_roles` + `infra/commit-roles.json`.
+- Add `commit-roles` to required-checks.
+- **Dependencies:** PR 5.
+- **Exit:** synthetic PR with `tau-reviewer` authoring `lib/**`
+  changes is blocked; PR with the same diff authored by
+  `tau-implementer` passes.
+
+**PR 10: Scope-coherence gate** (artefact 13).
+- Land `mix tau.gate.scope_coherence` + `infra/scope-packages.json`
+  populated with current ~12 packages.
+- Add `scope-coherence` to required-checks.
+- **Dependencies:** PR 5.
+- **Exit:** PR #412 fixture (three-package PR with single-package
+  declaration) is blocked; well-scoped synthetic PR passes.
+
+### Week 7 — Merge queue (closes stale-green race)
+
+**PR 11: Enable GitHub Merge Queue.**
+- Update `.github/rulesets/main.json` to add `merge_queue` block with
+  `max_entries_to_merge: 1`, `max_entries_to_build: 3`,
+  `merge_method: MERGE`, `strict_required_status_checks_policy: true`.
+- Update `factory-loop.md` cycle step 8 to enqueue rather than
+  direct-merge.
+- **Dependencies:** PRs 1–10 (queue runs the now-complete required set
+  against post-merge tree).
+- **Exit:** PR that was gate-green pre-rebase but fails post-rebase
+  (e.g. test broken by an intervening `main` advance) is rejected by
+  the queue.
+- **Third trust gain:** stale-green race is closed; the v1 collapse
+  pattern of merging against advanced-`main` is structurally
+  impossible.
+
+### Week 8 — Regression harness + ADR + cleanup
+
+**PR 12: V1 failure regression tests + ADR** (artefacts 14, 15).
+- Land `test/factory/v1_failure_regression_test.exs` with fixtures
+  reconstructing #411, #412, #413, #414, role-collapse, atomicity.
+- Land `docs/adr/ADR-NNN-factory-v2-gate-substrate.md`.
+- Tag the regression tests `@tag :gating` so Gate 5.1 tracks them.
+- **Dependencies:** all prior PRs (the substrate is now complete; the
+  tests prove it rejects every reproduced v1 failure).
+- **Exit:** each regression test green; ADR merged per `tau-adr`
+  conventions.
+
+### Build-order monotonicity invariant
+
+At every step, the failure classes the new mechanism is supposed to
+block are tested by a synthetic-PR probe or the regression-test
+harness, landed in the same PR as the mechanism. No mechanism lands
+without its falsification probe. The PR-12 regression suite is the
+final, comprehensive falsification.
+
+### Sequencing dependencies (visual)
+
+```
+Week 1:  PR1 ───────────────────┐
+         PR2 ───┐               │
+                │               │
+Week 2:  PR3 ───┤               │
+         PR4 ───┤               │
+                │               │
+Week 3:  PR5 ───┴───┐           │
+                    │           │
+Week 4:  PR6 ───────┤           │
+                    │           │
+Week 5:  PR7 ───────┤           │
+         PR8 ───────┤           │
+                    │           │
+Week 6:  PR9 ───────┤           │
+         PR10 ──────┤           │
+                    │           │
+Week 7:  PR11 ──────┤           │
+                    │           │
+Week 8:  PR12 ──────┴───────────┘
+```
+
+PRs in the same week may proceed in parallel iff the factory-loop's
+parallel-execution conflict check clears (per `factory-loop.md`
+§Parallel execution). PR 5 is the serialization point — every gate
+that follows it relies on the lint-ci / ruleset-drift required-check
+guarantees.
+
+## Open questions
+
+- **GitHub Rulesets API round-trip fidelity.** Proposal-2 flagged this;
+  PR 3 must include a half-day spike that confirms `gh api repos/:owner/
+  :repo/rulesets` round-trips byte-equal to `.github/rulesets/main.json`.
+  If lossy, PR 3 adds a `jq`-based semantic normaliser to the drift
+  check (still mechanical, just one more transformation step).
+
+- **GitHub Merge Queue's behaviour when the post-rebase tree fails a
+  required check that was green pre-rebase.** Documentation says the
+  queue rejects the entry and notifies the author; needs confirmation
+  that the failure is logged (so the operability dashboard can surface
+  it) rather than silently dropped.
+
+- **Hotfix path when an infra failure (e.g. flaky setup-beam Action)
+  affects every PR.** With `bypass_actors: []` and
+  `enforce_admins: true`, there is no admin override. The mitigation is
+  a documented "infra-hotfix" workflow: revert the broken Action SHA
+  via a PR that does not require the affected Action (path-restricted
+  to `.github/`). This is an inconvenience by design; the alternative —
+  leaving an admin-override path — re-introduces the v1 collapse mode.
+  May need user input on whether this is acceptable; default is "yes,
+  per root §Hypothesis #7".
+
+- **`tj-actions/changed-files` supply-chain risk.** SHA-pinning +
+  `step-security/harden-runner` mitigates CVE-2025-30066-class
+  incidents but does not eliminate them. An Anthropic-vendored
+  alternative (if it materialises by 2026-Q3) would drop the
+  mitigation requirement; until then, the wrapper at artefact 7 is
+  the single update site.
+
+- **Substrate self-modification policy.** ADR-NNN (artefact 15)
+  asserts that edits to `.github/rulesets/main.json`,
+  `.github/required-checks.json`, `infra/commit-roles.json`,
+  `infra/scope-packages.json` require a `Reviewed-By:` trailer from a
+  human identity. This is enforced by the `commit-roles` gate via an
+  entry in `infra/commit-roles.json`. The bootstrapping case — the PR
+  that first lands `infra/commit-roles.json` — is the one-time admin
+  push documented in the ADR; subsequent edits are gated. Confirm with
+  user that "human Reviewed-By" is a satisfactory closure of
+  proposal-1's "corrupted registry" weakness without escalating to
+  multi-sig.
+
+- **Coordination with the `pre-merge-code-gates` sibling on the
+  Verdict struct interface.** The struct is the shared contract; if
+  that sibling needs additional fields (e.g. `severity`,
+  `category`), the struct must accommodate them additively
+  (`@enforce_keys` minimal; optional fields free). Coordinate
+  before PR 1 lands.
+
+- **Operability-leaf consumer naming.** The dashboard reads
+  `factory/bypass-detected`, `factory/ruleset-drift` issue labels and
+  the verdict JSON stream. Coordinate label naming before PR 8 to
+  avoid renaming churn.
+
+## Linked sub-problems / proposals
+
+- `proposals/proposal-1.md` — *Verdict-Bus signed ledger*. Rejected:
+  cryptographic surface itself a silent-bypass channel
+  (self-documented weakness); `refs/factory/verdicts` ledger
+  unconventional; corrupted-registry weakness unresolved without
+  multi-sig. Some terminology adopted (`Verdict` struct name,
+  applicability oracle pattern).
+- `proposals/proposal-2.md` — *Ecosystem reuse*. Hybrid contributor:
+  `rhysd/actionlint`, `tj-actions/changed-files`+`harden-runner`,
+  `peter-evans/create-issue-from-file`, ruleset-as-JSON shape (vs
+  proposal-3's HCL), and the structural argument that GitHub already
+  ships the decomplecting primitives. Explicitly rejected:
+  `claude-code-action`-driven evidence-verifier (LLM in the
+  load-bearing path violates root §"Claude's claims must be
+  cross-checked by mechanism").
+- `proposals/proposal-3.md` — *SLSA + OPA + Merge Queue*. Single
+  contribution: **GitHub Merge Queue** as the only path to `main`,
+  closing the stale-green race. Rejected: SLSA attestations,
+  Sigstore/Rekor, OPA/Rego, Terraform-managed branch protection —
+  operational debt unjustified once diff-derived applicability
+  eliminates silent-skip by construction.
+- `proposals/proposal-4.md` — *Adversarial v1-replay*. Spine of the
+  solution: failure-paired regression-test substrate, diff-derived
+  applicability resolver, commit-roles gate, scope-coherence gate,
+  lint-ci meta-gate, evidence-binder gate, required-checks JSON
+  single-source. Every catching mechanism inherits proposal-4's
+  property of being paired to a reproducible v1 failure SHA.
+
+## Revision history
+
+- (revision 0 — initial; 2026-05-23)

--- a/docs/problems-archive-v1-modules/tau-cli/problem.md
+++ b/docs/problems-archive-v1-modules/tau-cli/problem.md
@@ -1,0 +1,119 @@
+---
+template_version: 1
+template_name: problem
+node_kind: root
+depth: 0
+parent: "—"
+status: decomposed
+---
+
+# Problem: tau-cli error isolation, run-loop coupling, and data fidelity
+
+## Statement
+
+`lib/tau/cli.ex` and its `lib/tau/cli/` siblings contain four distinct
+defects that cause silent failures, OTP non-negotiable violations, and
+incorrect user-visible output: (1) supervised callees wrapped in
+`rescue`/`catch :exit` that swallow process crashes; (2) a hand-rolled
+`receive` loop in `drain_run_loop/2` that bypasses the project's PubSub
+abstraction and silently discards unrecognised events; (3) the `tau init`
+wizard persisting only the first selected provider and using a mismatched
+credential key for Bedrock; (4) reflective module construction from
+untrusted user input that leaks atoms and silently produces wrong modules.
+Each defect is independently fixable, but together they make the CLI
+surface untrustworthy without extensive manual testing.
+
+## Context
+
+- `lib/tau/cli.ex:344–362` — `run_cmd/1` uses `try/after` (legitimate) but
+  also contains the hand-rolled `drain_run_loop/2` event loop.
+- `lib/tau/cli.ex:427–486` — `drain_run_loop/2`: raw `receive` with wildcard
+  catch-all silently discards every unrecognised `Events.*` struct.
+- `lib/tau/cli.ex:489–497` — `drain_session_end/2`: `receive after 10_000`
+  reports success on timeout rather than error.
+- `lib/tau/cli/extensions.ex:67–81` and `lib/tau/cli/mcp.ex:98–112` —
+  `safe_list/0` / `safe_reload/0` catch every exception AND `:exit` from
+  supervised callees.
+- `lib/tau/cli/init.ex:60–65` — `@providers` maps Bedrock to `AWS_ACCESS_KEY_ID`.
+- `lib/tau/commands/builtin/logout.ex:38–43` — `@credential_map` maps
+  `"bedrock"` to `AWS_SECRET_ACCESS_KEY` — different key than Init stores.
+- `lib/tau/cli/init.ex:152–153` — `List.first(providers)` discards all
+  selected providers except one after the user chose several.
+- `lib/tau/cli.ex:782–788` / `lib/tau/cli.ex:812–814` — `resolve_coding_agent/1`
+  and `resolve_provider/1` tail clauses use `Module.concat` on arbitrary CLI strings.
+- OTP non-negotiables in scope: #4 (cross-process events via PubSub, not raw
+  `receive`), #7 (let it crash; MUST NOT `try/rescue` across process
+  boundaries; MUST NOT catch `:exit`).
+
+## Complecting hypothesis
+
+- Error-reporting is complected with process supervision: `safe_list/0` and
+  `safe_reload/0` treat a supervised-process crash as a data absence, making
+  process health invisible to the operator.
+- Session-event consumption is complected with progress rendering: `drain_run_loop/2`
+  both drives the PubSub mailbox drain and inline-formats stderr progress,
+  forcing a single raw-`receive` loop that cannot delegate to a proper stream.
+- User input parsing is complected with atom/module resolution: `resolve_provider/1`
+  and `resolve_coding_agent/1` conflate "known short name" with "arbitrary module
+  derivation from user bytes", creating an atom leak in the same clause.
+
+## Decomposition strategy
+
+The four defects decompose cleanly along the **concern (Hickey)** axis — each
+cluster of defects involves a different observable concern and can be understood
+and fixed without knowing the others:
+
+1. **Error-swallowing rescues** — `rescue`/`catch :exit` shims in Extensions
+   and MCP CLI handlers that hide supervision failures.
+2. **Run-loop raw-receive** — `drain_run_loop/2` and `drain_session_end/2`
+   hand-rolling a PubSub mailbox drain in violation of OTP NN #4/#7.
+3. **Wizard data fidelity** — `tau init` discarding all but first provider and
+   using the wrong AWS credential key for Bedrock.
+4. **Reflective module dispatch** — `resolve_provider/1` and
+   `resolve_coding_agent/1` building modules from untrusted user strings,
+   leaking atoms and producing wrong modules.
+
+These four sub-problems are mutually exclusive in the code they own and
+collectively exhaust the concerns named in the audit lens. Each can be
+proposed and reviewed independently.
+
+## Sub-problems (filled by decomposer)
+
+1. **error-swallowing-rescues** — `Tau.CLI.Extensions` and `Tau.CLI.MCP` wrap
+   supervised callees in `rescue`/`catch :exit`, silently converting process
+   crashes into empty results.
+2. **run-loop-raw-receive** — `drain_run_loop/2` and `drain_session_end/2` use
+   hand-rolled `receive` loops to consume PubSub events, violating OTP NN #4
+   and silently discarding unknown events.
+3. **wizard-data-fidelity** — `tau init` persists only the first selected
+   provider (`List.first/1`) and stores the wrong AWS credential key for Bedrock
+   (`AWS_ACCESS_KEY_ID` vs logout's `AWS_SECRET_ACCESS_KEY`).
+4. **reflective-module-dispatch** — `resolve_provider/1` and
+   `resolve_coding_agent/1` derive module atoms from arbitrary user strings via
+   `Module.concat`/`String.capitalize`, leaking atoms and producing silently
+   wrong module names.
+
+## Acceptance criterion
+
+The CLI layer is considered correct when: (a) a crashed supervised callee
+surfaces as an explicit error exit code rather than an empty result; (b) the
+headless run loop does not use raw `receive` and does not silently discard any
+`Events.*` struct; (c) `tau init` persists all selected providers and uses a
+consistent credential key for Bedrock across init and logout; (d)
+`resolve_provider/1` and `resolve_coding_agent/1` do not create atoms from
+unconstrained user input.
+
+## Out of scope
+
+- `doctor_cmd/0` provider-status duplication (per-provider `doctor_status/0` polymorphism)
+- Mix task `resolve_target/0` / `bust_burrito_cache/0` copy-paste deduplication
+- `run_cmd/1` size (splitting into `setup_session/3` etc.) beyond what the
+  run-loop sub-problem addresses
+- `commands/builtin/` defects (copy, export, tree, help injection) outside the
+  files named above
+- Comment-narration / issue-archaeology cleanup
+- `main/1` dispatch table compression
+
+## Amendment log
+
+- (none yet)

--- a/docs/problems-archive-v1-modules/tau-cli/solution.md
+++ b/docs/problems-archive-v1-modules/tau-cli/solution.md
@@ -1,0 +1,266 @@
+---
+template_version: 1
+template_name: solution
+parent_problem: problem.md
+node_kind: root
+synthesised_from:
+  - subproblems/error-swallowing-rescues/solution.md
+  - subproblems/run-loop-raw-receive/solution.md
+  - subproblems/wizard-data-fidelity/solution.md
+  - subproblems/reflective-module-dispatch/solution.md
+selection_method: synthesis
+mode: non-leaf
+revision: 0
+---
+
+# Solution: tau-cli — four-PR module-wide correctness pass with one NN amendment
+
+## Recommendation
+
+The four child sub-problems compose directly: each owns a disjoint file set
+and a disjoint concern, so they land as four independent PRs whose only shared
+artefact is a one-time amendment to `.claude/rules/otp-non-negotiables.md` rule
+#7 (the targeted-`catch :exit` carve-out required by the error-swallowing
+fix). Order is determined by two real coupling edges, not by perceived
+priority: (1) the NN #7 amendment must land first because the rescues PR
+depends on it being in effect; (2) the run-loop and reflective-dispatch PRs
+both touch `lib/tau/cli.ex` and must serialize against each other to avoid
+mechanical merge conflicts. The wizard-data-fidelity PR is independent of all
+others (touches `lib/tau/cli/init.ex`, `lib/tau/commands/builtin/logout.ex`,
+`lib/tau/settings/schema.ex`, and the new `lib/tau/providers/catalog.ex`).
+The resulting sequence is: **PR-0** (NN #7 amendment, doc-only) → **PR-1**
+(rescues + targeted catches in `Tau.CLI.Extensions` / `Tau.CLI.MCP`) → **PR-2**
+(run-loop `stream_from` + pure `classify_event/2` in `lib/tau/cli.ex`) →
+**PR-3** (reflective-dispatch registries in `lib/tau/cli.ex`), with **PR-4**
+(wizard `Catalog` extraction + `enabled_providers` schema key) parallelisable
+against PR-1 and PR-2 once PR-0 has landed. The module-wide acceptance criterion
+is the conjunction of the four child ACs; no child weakens another, and no
+gap requires a new sub-problem.
+
+## Selected from
+
+- **Synthesised from:**
+  - `subproblems/error-swallowing-rescues/solution.md` — hybrid of proposals 1+2: delete `safe_list/0` / `safe_reload/0`; targeted `rescue _` + `catch :exit, {:noproc, _}` + `catch :exit, reason` at the command-handler boundary; amend NN #7 with a targeted-form carve-out in the same PR family.
+  - `subproblems/run-loop-raw-receive/solution.md` — hybrid of proposals 1+3: introduce `Tau.Session.stream_from/3` (no-op setup; already-subscribed); drive the headless drain via `Enum.reduce_while` over a pure `classify_event/2` reducer with `render_event/1` for `ToolStart`/`ToolEnd` side effects; delete `drain_run_loop/2` and `drain_session_end/2`.
+  - `subproblems/wizard-data-fidelity/solution.md` — single (proposal 2): extract `Tau.Providers.Catalog` as the compile-time single source of truth for provider key/label/env-var/string-key; derive `Init.@providers` and `Logout.@credential_map` from it; persist the multi-selection set under a new top-level `"enabled_providers"` array key (not `"providers"`, which collides with ADR-0012 fallback chains).
+  - `subproblems/reflective-module-dispatch/solution.md` — single (proposal 2): replace `resolve_provider/1` / `resolve_coding_agent/1` tail clauses with `@provider_registry` and `@coding_agent_registry` static maps in `lib/tau/cli.ex`; unknown strings produce `{:error, :unknown_*, name, known_list}`; the `Module.concat` / `String.capitalize` paths are deleted.
+- **Composition rationale:** the four solutions are mutually disjoint in code
+  ownership — Extensions/MCP CLI handlers, the `Tau.Session` stream surface +
+  `cli.ex` drain, the wizard + logout + schema, and `cli.ex` resolver
+  attributes — and mutually disjoint in concern: error isolation, OTP-compliant
+  event consumption, persisted-data fidelity, and atom-safety of dispatch. The
+  only real coupling is mechanical:
+  - **NN #7 amendment ⇒ rescues PR.** The rescues child solution names the
+    targeted-`catch :exit` carve-out as a precondition for its `catch :exit,
+    {:noproc, _}` clauses to satisfy the literal reading of NN #7. Resolving
+    this in a separate doc-only PR (PR-0) lets PR-1 ship without conflating
+    a rule change with a code change.
+  - **`lib/tau/cli.ex` shared file.** Both run-loop (PR-2) and
+    reflective-dispatch (PR-3) edit `lib/tau/cli.ex`. They touch distinct
+    regions (`drain_run_loop`/`drain_session_end` at lines 427–497 vs
+    `resolve_provider`/`resolve_coding_agent` at lines 782–814) so are not
+    semantically coupled, but the factory-loop conflict check requires
+    serialization on a shared file. Land PR-2 first because its diff is
+    larger and its rebase cost on a registry refactor is higher.
+  - **No conflicts.** No child solution proposes a change that another
+    contradicts. No child requires data or interfaces that another removes.
+    The wizard solution adds a new module under `lib/tau/providers/`; the
+    reflective-dispatch solution adds module attributes inside
+    `lib/tau/cli.ex` and does NOT consult `Tau.Providers.Catalog` (Open
+    questions §3 in the wizard solution flags the future cross-derivation
+    of `Schema.@known_providers` from `Catalog` as a separate concern; the
+    same flag now also applies to `cli.ex`'s `@provider_registry`, which
+    could derive from `Catalog` in a follow-up — see Open questions below).
+
+## What changes
+
+PRs and files, in landing order:
+
+- **PR-0 — NN #7 carve-out amendment (doc-only).**
+  - `.claude/rules/otp-non-negotiables.md` — amend rule #7 to add: a targeted
+    `catch :exit, {:noproc, _}` (or other named exit-reason shape) at a CLI /
+    TUI command boundary is permitted as an OTP-recommended availability
+    escape hatch; precedent `lib/tau/providers/rate_limiter.ex:86`.
+  - No code changes.
+
+- **PR-1 — Error-swallowing rescues in `Tau.CLI.Extensions` / `Tau.CLI.MCP`.**
+  - `lib/tau/cli/extensions.ex` — delete `safe_list/0` and `safe_reload/0`;
+    wrap `list/1` and `reload/1` in `try` blocks with `rescue _ -> stderr; N`
+    and `catch :exit, {:noproc, _} -> stderr; N` / `catch :exit, reason ->
+    stderr; N` arms; remove the dead `{:error, _}` arm in `reload/1` (callee
+    is `GenServer.cast`); widen `@spec list/1` from `0` to `0 | 1`; keep
+    `@spec reload/1` as `0 | 2`.
+  - `lib/tau/cli/mcp.ex` — identical shape across `list/1`, `status/1`,
+    `reload/1`; widen `@spec` for `list/1` and `status/1`; keep `reload/1`
+    spec.
+
+- **PR-2 — Run-loop raw-receive elimination in `lib/tau/cli.ex` +
+  `Tau.Session`.**
+  - `lib/tau/session.ex` — add `stream_from/3` (no-op setup;
+    `:already_subscribed` sentinel) backed by `Stream.resource/3`; same
+    receive body as `stream/2` with `after timeout -> {:halt, :ok}`.
+  - `lib/tau/cli.ex` —
+    - extract `classify_event/2` (pure: `struct() × map() →
+      {:continue, map()} | {:halt, 0 | 1}`; fallback clause `Logger.debug`s
+      unknown structs);
+    - extract `render_event/1` and `render_event/2` (pure side-effecting:
+      `ToolStart` / `ToolEnd` progress; `ToolEnd` takes `tool_names` as
+      second arg);
+    - replace `drain_run_loop/2` call in `run_cmd/1` with
+      `Tau.Session.stream_from(session_id, :already_subscribed, timeout:
+      10_000) |> Enum.reduce_while({%{}, 1}, fn e, {names, _} ->
+      render_event(e, names); classify_event(e, names) end) |> elem(1)`;
+    - delete `drain_run_loop/2` (lines 427–486) and `drain_session_end/2`
+      (lines 489–497).
+  - Tests — pure unit tests over `classify_event/2`; integration tests over
+    `stream_from`.
+
+- **PR-3 — Reflective-dispatch registries in `lib/tau/cli.ex`.**
+  - `lib/tau/cli.ex` — add `@provider_registry %{String.t() => module()}`
+    and `@coding_agent_registry %{String.t() => module()}`; replace all
+    `resolve_provider/1` clauses (`nil` → default, binary →
+    `Map.fetch(@provider_registry, name)`, no tail); replace all
+    `resolve_coding_agent/1` clauses (`nil`, atom-passthrough, binary →
+    `Map.fetch(@coding_agent_registry, name)`, no tail); update internal
+    callsites to unwrap `{:ok, mod}` or handle `{:error, :unknown_*, name,
+    known_list}` with `halt(1)` + stderr enumerating `known_list`; delete
+    the `String.capitalize` limitation comment at lines 807–811.
+
+- **PR-4 — Wizard data fidelity: `Tau.Providers.Catalog` + `enabled_providers`
+  schema key.** (Parallelisable with PR-1 and PR-2 once PR-0 has landed.)
+  - **New:** `lib/tau/providers/catalog.ex` — pure compile-time data;
+    `@entries` with `key`, `label`, `env_var`, `string_key`; expose `all/0`,
+    `by_key/1`, `by_string_key/1`, `credential_map/0`.
+  - **New:** `test/tau/providers/catalog_test.exs` — property tests on
+    uniqueness and non-nil env_var.
+  - `lib/tau/cli/init.ex` — delete `@providers`; alias `Catalog`; in
+    `drive_flow/1`, persist `"provider"` (first selection, backwards
+    compatible) AND `"enabled_providers"` (the full ordered list of
+    `Catalog.by_key(&1).string_key`).
+  - `lib/tau/commands/builtin/logout.ex` — delete the `@credential_map`
+    literal; replace with `@credential_map Catalog.credential_map()`
+    (compile-time derivation; map values identical, so the Bedrock key
+    drift is structurally eliminated).
+  - `lib/tau/settings/schema.ex` — add `"enabled_providers" => %{"type" =>
+    "array", "items" => %{"type" => "string"}}` to the top-level
+    `"properties"` map. MUST NOT reuse `"providers"` (line 121 — ADR-0012
+    fallback-chain object).
+  - `test/tau/cli/init_test.exs` — assert written settings carry both
+    `"provider"` (first) and `"enabled_providers"` (all).
+
+## What does not change
+
+- `Tau.Session.stream/2` — existing callers untouched; `stream_from/3` is
+  additive.
+- `Phoenix.PubSub` usage / D-004 subscribe-before-start in `run_cmd/1` — the
+  subscription is still established before `Tau.start_session/1`; `stream_from`
+  takes the `:already_subscribed` sentinel.
+- `try/after` in `run_cmd/1` (telemetry-handler detachment) — explicitly out
+  of scope; remains as-is.
+- `Tau.Extensions.Loader.list/0` / `Tau.Extensions.Loader.reload_all/0` /
+  `Tau.MCP.Reconciler.list/0` / `Tau.MCP.Reconciler.reload/0` — interfaces
+  unchanged. The cast-based async reload semantics remain: `tau extensions
+  reload` and `tau mcp reload` still return `0` on cast delivery; surfacing
+  async-reload failures is out of scope (flagged in Open questions).
+- Public function arities of `list/1`, `reload/1`, `status/1` — unchanged
+  (only `@spec` ranges widen).
+- `lib/tau/provider.ex` behaviour — no new callback.
+- Provider modules under `lib/tau/providers/*` — no required change (the
+  reflective-dispatch fix lives entirely in `cli.ex`'s module attributes).
+- Coding-agent modules under `lib/tau/coding_agents/*` — no change.
+- `lib/tau/cli/config.ex` `safe_to_atom/1` / `validate/1`, the rate-limiter's
+  own targeted catch, `Tau.CLI.MCP.transport_for/1`,
+  `Init.provider_string/1` (may be replaced by `Catalog.by_key/1` lookup but
+  not required) — all out of scope per the children.
+- The existing `"providers"` (plural) schema key — remains an object for
+  ADR-0012 fallback-chain configuration; no shape or semantic change.
+- The singular `"provider"` settings key — retained for backwards
+  compatibility; a future deprecation pass (rename to `"default_provider"`)
+  is flagged in Open questions and out of scope here.
+- All items in the root problem's "Out of scope" section
+  (`doctor_cmd/0` duplication, Mix-task copy-paste, `run_cmd/1` size
+  beyond run-loop, `commands/builtin/` defects outside named files,
+  comment cleanup, `main/1` dispatch compression).
+
+## Migration sketch
+
+PR-0 lands first as a doc-only PR; it is small and has no test surface. PR-1
+is then unblocked and may proceed concurrently with PR-4. After PR-1 merges,
+PR-2 lands (large diff in `lib/tau/cli.ex`); after PR-2 merges, PR-3 lands
+(small diff in `lib/tau/cli.ex`, but on the same file so serialised against
+PR-2 by the conflict-check rule). Each PR carries its own `mix compile
+--warnings-as-errors` and `mix test` pass, including the test rewrites named
+in each child solution (Extensions/MCP supervisor-down tests, `classify_event/2`
+unit tests, registry-based resolver tests, `init_test.exs` assertions on the
+new array key). The full module-wide AC is observable after PR-4 merges:
+  - (a) crashed supervised callee → non-zero exit + stderr line (PR-1);
+  - (b) headless run loop uses `stream_from`; unknown events log at `:debug`
+    rather than being silently dropped (PR-2);
+  - (c) `tau init` persists all selected providers under
+    `"enabled_providers"`; `init`-side and `logout`-side credential keys for
+    Bedrock are derived from the same `Catalog` entry (PR-4);
+  - (d) `resolve_provider/1` and `resolve_coding_agent/1` reject unknown
+    strings without `Module.concat` / `String.to_atom` on user input (PR-3).
+
+## Open questions
+
+- **NN #7 amendment review risk.** PR-0 is a rule change. If review rejects
+  the targeted-`catch :exit` carve-out, the rescues child's documented
+  fallback (pure deletion + top-level `Tau.CLI.main/1` rescue, both in PR-1)
+  applies. The fallback bounds PR-1's risk but defers the rate-limiter
+  precedent's compliance question to a separate cleanup.
+- **Async reload failures invisible** (`Tau.Extensions.Loader.reload_all/0`
+  and `Tau.MCP.Reconciler.reload/0` are `GenServer.cast`). Both child
+  solutions flag this; module-wide it remains out of scope. A follow-up PR
+  would convert one or both to `GenServer.call` (changing concurrency
+  semantics) or add a telemetry feedback channel.
+- **`main/1` top-level safety net.** The error-swallowing child notes that
+  `Tau.CLI.main/1` (lines 69–136) has no top-level rescue, so handlers
+  outside the four named commands remain exposed to raw BEAM crash dumps
+  on uncaught exceptions. This is a sibling sub-problem not covered by any
+  of the four children; surface to the root for triage rather than expand
+  any PR's scope.
+- **Cross-derivation of registries.** The reflective-dispatch child's
+  `@provider_registry` and the wizard child's `Tau.Providers.Catalog` are
+  two compile-time representations of the same provider set viewed through
+  different lenses (CLI dispatch string → module vs wizard short string →
+  vault env_var). They can drift on coverage. A future cleanup PR could
+  derive `@provider_registry` from `Catalog` (`Map.new(Catalog.all(), fn e
+  -> {e.string_key, e.module} end)`) after adding a `:module` field to
+  `Catalog.@entries`. Flagged here so the divergence is intentional and
+  reviewable, not silent.
+- **`Tau.Settings.Schema.@known_providers` drift** — the wizard child's
+  Open questions §3 also names this as a separate compile-time list of
+  provider modules used by ADR-0012 fallback-chain resolution. It remains
+  out of scope here for the same reason; a unified cross-derivation
+  (Catalog ↔ `@known_providers` ↔ `@provider_registry`) is a sensible
+  M-wide follow-up.
+- **`stream_from/3` setup contract visibility.** The run-loop child notes
+  that a mis-formed topic causes a silent empty drain. A guard or
+  `{:ok, pid} | {:error, :not_subscribed}` setup return would make the
+  contract explicit. Deferred to the implementer of PR-2.
+- **Singular `"provider"` key deprecation.** Retained for backwards
+  compatibility in PR-4; a future PR may rename to `"default_provider"` and
+  treat `"enabled_providers"` as the sole list of record.
+
+## Linked sub-problems / proposals
+
+- `subproblems/error-swallowing-rescues/` → "Delete `safe_list/0` /
+  `safe_reload/0`; targeted `rescue _` + `catch :exit, {:noproc, _}` at the
+  command-handler boundary; amend NN #7 with a targeted-form carve-out."
+- `subproblems/run-loop-raw-receive/` → "Add `Tau.Session.stream_from/3`;
+  drive the headless drain via `Enum.reduce_while` over pure
+  `classify_event/2` + `render_event/1`; delete `drain_run_loop/2` and
+  `drain_session_end/2`."
+- `subproblems/wizard-data-fidelity/` → "Extract `Tau.Providers.Catalog` as
+  single source of truth; persist all selections under a new
+  `enabled_providers` array key; derive `Logout.@credential_map` from
+  `Catalog` at compile time."
+- `subproblems/reflective-module-dispatch/` → "Replace `resolve_provider/1`
+  / `resolve_coding_agent/1` tail clauses with `@provider_registry` /
+  `@coding_agent_registry` static maps; unknown strings produce
+  `{:error, :unknown_*, name, known_list}`."
+
+## Revision history
+
+- (revision 0 — initial root synthesis of four validated child solutions)

--- a/docs/problems-archive-v1-modules/tau-cli/subproblems/error-swallowing-rescues/problem.md
+++ b/docs/problems-archive-v1-modules/tau-cli/subproblems/error-swallowing-rescues/problem.md
@@ -1,0 +1,69 @@
+---
+template_version: 1
+template_name: problem
+node_kind: leaf
+depth: 1
+parent: ../../problem.md
+status: draft
+---
+
+# Problem: error-swallowing rescues in CLI MCP and Extensions handlers
+
+## Statement
+
+`Tau.CLI.Extensions.safe_list/0`, `safe_reload/0`, `Tau.CLI.MCP.safe_list/0`,
+and `safe_reload/0` wrap calls to supervised processes in `rescue _ -> []` /
+`catch :exit, _ -> []` blocks, converting any process crash, noproc exit, or
+runtime error into an empty-result or silent error. A user running `tau
+extensions list` when the `Extensions.Loader` is down sees "(no extensions
+loaded)" rather than an error; `tau mcp reload` failing silently returns 0
+instead of a non-zero exit. The supervision-tree failure mode is invisible.
+
+## Context
+
+- `lib/tau/cli/extensions.ex:67–73` — `safe_list/0`: `rescue _ -> []` and
+  `catch :exit, _ -> []` around `Tau.Extensions.Loader.list/0`.
+- `lib/tau/cli/extensions.ex:75–81` — `safe_reload/0`: `rescue e -> {:error, ...}`
+  and `catch :exit, reason -> {:error, reason}` around
+  `Tau.Extensions.Loader.reload_all/0`.
+- `lib/tau/cli/mcp.ex:98–104` — `safe_list/0`: identical pattern around
+  `Tau.MCP.Reconciler.list/0`.
+- `lib/tau/cli/mcp.ex:106–112` — `safe_reload/0`: identical pattern around
+  `Tau.MCP.Reconciler.reload/0`.
+- OTP non-negotiable #7: "Let it crash; supervise; restart. MUST NOT
+  `try/rescue` across process boundaries. MUST NOT catch `:exit`."
+- `Tau.Extensions.Loader` and `Tau.MCP.Reconciler` are both supervised
+  GenServers; a `:noproc` exit from them is a supervision-tree signal that
+  should surface to the operator, not be swallowed.
+
+## Complecting hypothesis
+
+- Error reporting is complected with data retrieval: the same function that
+  fetches the data also decides whether a process crash constitutes "no data"
+  or an error, removing the operator's ability to distinguish between "nothing
+  is configured" and "the subsystem is down".
+
+## Decomposition strategy
+
+(leaf — no further decomposition; proceed to proposals)
+
+## Acceptance criterion
+
+`tau extensions list`, `tau extensions reload`, `tau mcp list`, and
+`tau mcp reload` return a non-zero exit code and print a diagnostically useful
+error message to stderr whenever the underlying supervised process is
+unavailable (`:noproc`, process exit, or an unexpected exception), rather than
+printing an empty-result message and returning 0.
+
+## Out of scope
+
+- `safe_to_atom/1` in `Tau.CLI.Config` (different file, different concern —
+  belongs to the reflective-dispatch sub-problem)
+- `validate/1` rescue in `Tau.CLI.Config` and `Tau.CLI.Init` (different
+  failure mode — those wrap library calls, not supervised processes)
+- Run-loop rescue/catch in `drain_run_loop/2` (owned by run-loop-raw-receive)
+- Any extension loader internals beyond the CLI shim boundary
+
+## Amendment log
+
+- (none yet)

--- a/docs/problems-archive-v1-modules/tau-cli/subproblems/error-swallowing-rescues/proposals/proposal-1.md
+++ b/docs/problems-archive-v1-modules/tau-cli/subproblems/error-swallowing-rescues/proposals/proposal-1.md
@@ -1,0 +1,141 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 1
+parent_problem: ../problem.md
+---
+
+# Proposal 1: Delete safe_list/safe_reload and let GenServer calls crash normally
+
+## Approach
+
+Remove `safe_list/0` and `safe_reload/0` entirely from `Tau.CLI.Extensions` and
+`Tau.CLI.MCP`. The call sites — `list/1`, `status/1`, and `reload/1` — call the
+supervised GenServers directly (`Tau.Extensions.Loader.list/0`,
+`Tau.MCP.Reconciler.list/0`, etc.) with no rescue/catch wrapper. An `:exit,
+:noproc` or any other process exception propagates to `Tau.CLI.main/1`, which
+already wraps its dispatch in a top-level rescue that converts unhandled
+exceptions to exit code 1 with an error message to stderr. The operator sees a
+traceable crash-report rather than an empty-result lie.
+
+## Rationale
+
+The complecting hypothesis identifies a single woven concern: error-reporting
+coupled inside the data-fetch function. The simplest decomplecting move is
+deletion — the rescue shim is the coupling; removing it exposes the two
+concerns separately (data retrieval raises naturally; the top-level CLI boundary
+handles exit codes). OTP NN #7 forbids `try/rescue` across process boundaries
+exactly because a `:noproc` exit is a meaningful signal, not an empty result.
+Deletion preserves that signal with zero new code.
+
+## Sketch
+
+**`lib/tau/cli/extensions.ex` — before (lines 67–81):**
+```elixir
+defp safe_list do
+  Tau.Extensions.Loader.list()
+rescue
+  _ -> []
+catch
+  :exit, _ -> []
+end
+
+defp safe_reload do
+  Tau.Extensions.Loader.reload_all()
+rescue
+  e -> {:error, Exception.message(e)}
+catch
+  :exit, reason -> {:error, reason}
+end
+```
+
+**After — `safe_list/0` and `safe_reload/0` deleted; call sites updated:**
+```elixir
+# In list/1 — was: entries = safe_list()
+entries = Tau.Extensions.Loader.list()
+
+# In reload/1 — was: case safe_reload() do
+case Tau.Extensions.Loader.reload_all() do
+```
+
+Same pattern in `lib/tau/cli/mcp.ex` (lines 98–112): delete both private
+functions, inline the direct calls.
+
+**Expected runtime behaviour on `:noproc`:**
+
+`Tau.CLI.main/1` top-level rescue (if present) catches the exit and emits:
+```
+Error: Extensions.Loader process unavailable: :noproc
+```
+exit code 1. If no top-level rescue exists today, one must be added (see
+Dependencies).
+
+**Signature change summary:**
+- `Tau.CLI.Extensions.list/1` — `@spec` return type unchanged (`0`), but now
+  may raise rather than always returning `0` on crash.
+- `Tau.CLI.Extensions.reload/1` — same.
+- `Tau.CLI.MCP.list/1`, `status/1`, `reload/1` — same.
+
+## Tradeoffs
+
+### Strengths
+
+- Smallest diff: deletes ~30 lines, adds 0. Least opportunity for new defects.
+- Directly satisfies OTP NN #7 with no new abstraction.
+- Full crash information (stacktrace + reason) reaches the operator.
+- Acceptance criterion satisfied: non-zero exit + stderr diagnostic on process
+  unavailability, sourced from the top-level handler.
+
+### Weaknesses
+
+- **Error message quality depends on the top-level rescue.** If `Tau.CLI.main/1`
+  does not currently produce a human-readable message for `:exit, :noproc`, the
+  operator sees a raw Elixir term rather than a diagnostic. Requires audit of
+  the top-level boundary.
+- **Loss of the `{:error, reason}` tagged-tuple contract** that `reload/1`
+  currently relies on from `safe_reload/0`. The `case` in `reload/1` must be
+  restructured (the `{:error, reason}` arm disappears; the only error path is
+  via exception propagation). The existing `IO.puts(:stderr, "... reload
+  failed")` branch becomes unreachable.
+- **No per-command granularity.** A callee crash produces a uniform "unhandled
+  exception" message rather than "extensions reload failed" or "mcp list
+  unavailable". The error is real but the context is coarser.
+- **`list/1` spec claim of always returning `0` becomes stale.** The spec must
+  be updated or the top-level handler must be documented as the exit-code
+  owner.
+
+### Costs
+
+- ~30 lines deleted; ~10 lines changed (inlining call sites, restructuring
+  reload/1's case branches).
+- Must audit `Tau.CLI.main/1` (or wherever `list/1` / `reload/1` are called)
+  to confirm a top-level exception-to-exit-code boundary exists and produces
+  readable output.
+- One test change: tests that assert `list/1` returns `0` when the loader is
+  down must be updated to assert raise/exit propagation or test at the `main/1`
+  boundary instead.
+
+## Dependencies
+
+- `Tau.CLI.main/1` (or the outermost dispatch in `lib/tau/cli.ex`) MUST have a
+  top-level rescue that converts unhandled exceptions/exits to exit code 1 and
+  emits a diagnostic to stderr. If absent, this must be added in the same PR.
+- No library additions required.
+
+## Confidence
+
+medium — the deletion is mechanically straightforward; confidence is bounded by
+not having audited whether `main/1` already provides an adequate top-level
+boundary. If it does, confidence rises to high.
+
+## Prior art / references
+
+- OTP NN #7: "Let it crash; supervise; restart. MUST NOT `try/rescue` across
+  process boundaries. MUST NOT catch `:exit`." — the non-negotiable this
+  directly satisfies.
+- Erlang/OTP "let-it-crash" philosophy: errors propagate until an intentional
+  boundary; CLI binaries are natural boundaries (process exit maps directly to
+  shell exit code).
+- Elixir `System.stop/1` / `exit/1` patterns for CLI exit codes in Burrito
+  releases: process exits from GenServer calls in a Burrito binary terminate
+  the VM with the exit reason, which Burrito maps to exit code 1 by default.

--- a/docs/problems-archive-v1-modules/tau-cli/subproblems/error-swallowing-rescues/proposals/proposal-2.md
+++ b/docs/problems-archive-v1-modules/tau-cli/subproblems/error-swallowing-rescues/proposals/proposal-2.md
@@ -1,0 +1,179 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 2
+parent_problem: ../problem.md
+---
+
+# Proposal 2: Replace rescue/catch with GenServer.call timeout + tagged-tuple contract
+
+## Approach
+
+Replace the `rescue`/`catch :exit` blocks with an explicit `GenServer.call/3`
+using a short timeout, returning `{:ok, result}` or `{:error, reason}` tagged
+tuples. The callers (`list/1`, `status/1`, `reload/1`) pattern-match on the
+tagged tuple and emit a non-zero exit code plus stderr diagnostic on `{:error,
+_}`. No rescue or catch is used anywhere. The `:noproc` exit from a dead
+GenServer surfaces as `{:error, :noproc}` through the `GenServer.call` timeout
+path using `Process.whereis/1` + nil guard, or by catching only the specific
+`:noproc` exit at the call boundary via `catch :exit, {:noproc, _}` — a
+targeted, documented catch rather than a wildcard swallow.
+
+## Rationale
+
+The problem's complecting hypothesis is that error-reporting is woven into data
+retrieval via a wildcard `rescue`/`catch`. This proposal decomplects by
+separating two concerns: (a) a thin call adapter that translates OTP process
+errors into tagged tuples at the boundary (`call_loader/1`), and (b) the CLI
+handlers that interpret tagged tuples and produce user-visible output. The
+adapter is explicit about which exits it handles (`:noproc`, `:timeout`) and
+converts them to `{:error, reason}` — it does not swallow unknown exceptions.
+The CLI handlers gain a real `{:error, reason}` branch that prints to stderr and
+returns exit code 1 or 2.
+
+## Sketch
+
+**New private helper (shared pattern, shown for `Tau.CLI.Extensions`):**
+
+```elixir
+# lib/tau/cli/extensions.ex
+
+@spec call_loader((() -> term())) :: {:ok, term()} | {:error, term()}
+defp call_loader(fun) do
+  {:ok, fun.()}
+catch
+  :exit, {:noproc, _} -> {:error, :process_unavailable}
+  :exit, {:timeout, _} -> {:error, :timeout}
+  :exit, reason -> {:error, {:exit, reason}}
+end
+```
+
+**Updated `safe_list/0` → renamed, typed:**
+
+```elixir
+defp fetch_list do
+  call_loader(&Tau.Extensions.Loader.list/0)
+end
+
+defp request_reload do
+  call_loader(&Tau.Extensions.Loader.reload_all/0)
+end
+```
+
+**Updated `list/1` call site:**
+
+```elixir
+@spec list(opts()) :: 0 | 1
+def list(opts \\ []) do
+  case fetch_list() do
+    {:ok, entries} ->
+      # ... existing rendering logic ...
+      0
+
+    {:error, reason} ->
+      IO.puts(:stderr, "extensions list failed: #{format_reason(reason)}")
+      1
+  end
+end
+```
+
+**Updated `reload/1` call site:**
+
+```elixir
+@spec reload(opts()) :: 0 | 1 | 2
+def reload(opts \\ []) do
+  case request_reload() do
+    {:ok, :ok} ->
+      # ... existing success output ...
+      0
+
+    {:ok, {:error, inner}} ->
+      IO.puts(:stderr, "extensions reload failed: #{inspect(inner)}")
+      2
+
+    {:error, reason} ->
+      IO.puts(:stderr, "extensions reload unavailable: #{format_reason(reason)}")
+      1
+  end
+end
+
+defp format_reason(:process_unavailable), do: "Extensions.Loader process is not running"
+defp format_reason(:timeout), do: "Extensions.Loader call timed out"
+defp format_reason({:exit, r}), do: "process exited: #{inspect(r)}"
+```
+
+Same pattern mirrored in `lib/tau/cli/mcp.ex` with `Tau.MCP.Reconciler` as the
+callee.
+
+**Type shape:**
+```
+fetch_list()     :: {:ok, [extension_entry()]} | {:error, process_error()}
+request_reload() :: {:ok, :ok | {:error, term()}} | {:error, process_error()}
+process_error()  :: :process_unavailable | :timeout | {:exit, term()}
+```
+
+## Tradeoffs
+
+### Strengths
+
+- Explicit about which exit reasons are handled; unknown exits still propagate
+  (the `catch :exit, reason` arm re-wraps rather than silently discarding).
+- Gives the CLI handlers per-command diagnostic messages ("extensions list
+  failed", "mcp reload unavailable") rather than a uniform crash report.
+- The `{:error, reason}` tagged-tuple contract is preserved and clarified;
+  all call sites are already `case`-dispatching on it.
+- Acceptance criterion is fully met: non-zero exit (1) + stderr message on
+  `:noproc`.
+- No new library dependencies; uses Elixir's `catch` for the specific exit
+  shapes, not wildcard rescue.
+
+### Weaknesses
+
+- **Still uses `catch` at the boundary** — purists may argue this is still
+  crossing a process boundary with a catch; OTP NN #7's prohibition is on
+  `try/rescue` across process boundaries, but the spirit equally applies to
+  `catch :exit`. The adapter is more targeted than the current wildcard but
+  is not zero-catch.
+- **Duplicates the adapter pattern** across two modules. A shared utility
+  (`Tau.CLI.ProcessCall` or similar) would DRY this, but adds a new module.
+  Leaving it duplicated violates DRY; extracting adds scope.
+- **`{:ok, {:error, inner}}` nesting** for `reload/1` is awkward — the callee
+  returns `{:error, reason}` on application-level reload failure, so the
+  outer `{:ok, _}` wraps an inner `{:error, _}`. Callers must pattern-match
+  two levels.
+- **`list/1` spec changes** from always returning `0` to returning `0 | 1`,
+  which may affect documentation and any call sites that hard-assume `0`.
+
+### Costs
+
+- ~40 lines changed; ~20 lines added (call_loader, format_reason, updated specs).
+- Two modules (`extensions.ex`, `mcp.ex`) each get a nearly-identical private
+  helper — ~10 lines of duplication unless extracted.
+- Tests for `list/1` and `reload/1` must be extended to cover the `{:error, _}`
+  branch with a mock/stub of the GenServer being unavailable.
+
+## Dependencies
+
+- No upstream module changes required — `Tau.Extensions.Loader.list/0` and
+  `Tau.MCP.Reconciler.list/0` interfaces are unchanged.
+- The `list/1` spec change (`0` → `0 | 1`) must not break any call site that
+  hard-pattern-matches on the return value (audit `lib/tau/cli.ex`).
+
+## Confidence
+
+high — the pattern (catch specific exits at a thin boundary, return tagged
+tuples) is idiomatic Elixir for wrapping GenServer calls in CLI adapters. The
+catch arms are targeted, not wildcard. The `format_reason/1` function is
+concrete. Sketch is complete enough to implement directly.
+
+## Prior art / references
+
+- Elixir `GenServer.call/3` documentation: `:noproc` exit shape is `{:noproc,
+  {GenServer, :call, [pid, msg, timeout]}}` — the `catch :exit, {:noproc, _}`
+  arm matches this precisely.
+- OTP NN #7: the non-negotiable targets `try/rescue` and wildcard `:exit` catch;
+  targeted `catch :exit, {:noproc, _}` is the recommended escape hatch in
+  service-availability checks in OTP documentation.
+- `Tau.CLI.Extensions` and `Tau.CLI.MCP` current code: the `{:error, reason}`
+  branch in `reload/1` already exists but is unreachable through the top-level
+  handler; this proposal makes it reachable with correct exit codes.

--- a/docs/problems-archive-v1-modules/tau-cli/subproblems/error-swallowing-rescues/proposals/proposal-3.md
+++ b/docs/problems-archive-v1-modules/tau-cli/subproblems/error-swallowing-rescues/proposals/proposal-3.md
@@ -1,0 +1,186 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 3
+parent_problem: ../problem.md
+---
+
+# Proposal 3: Introduce a Tau.CLI.ProcessQuery behaviour + pre-flight availability check
+
+## Approach
+
+Introduce a `Tau.CLI.ProcessQuery` behaviour with a single callback
+`query(command :: atom()) :: {:ok, term()} | {:error, :unavailable | term()}`.
+Both `Tau.CLI.Extensions` and `Tau.CLI.MCP` implement the behaviour. The
+pre-call check uses `Process.whereis/1` (or the named GenServer's registered
+name) to test availability synchronously before issuing the GenServer call.  If
+the process is not registered, the handler returns `{:error, :unavailable}`
+immediately — no call, no rescue, no catch. Unknown exceptions from registered
+but malfunctioning GenServers propagate freely to the top-level CLI handler.
+
+## Rationale
+
+The complecting hypothesis points to data retrieval and error reporting being
+woven in the same function. This proposal decomplects along the
+**interface axis**: introducing a shared behaviour enforces the tagged-tuple
+contract across both modules and places the availability check in a single,
+named, testable step. The check (`Process.whereis/1` → nil guard) is a pure
+function that does not cross a process boundary by itself, so it does not
+violate OTP NN #7. The GenServer call that follows is uncovered by rescue —
+unexpected exceptions still crash and propagate. The behaviour also creates an
+explicit seam for testing: mock implementations satisfy the behaviour without
+requiring a live supervision tree.
+
+## Sketch
+
+**New behaviour (`lib/tau/cli/process_query.ex`):**
+
+```elixir
+defmodule Tau.CLI.ProcessQuery do
+  @moduledoc """
+  Behaviour for CLI modules that query a supervised GenServer.
+  Implementors must check process availability before calling.
+  """
+
+  @type result :: {:ok, term()} | {:error, :unavailable | term()}
+
+  @callback list() :: result()
+  @callback reload() :: result()
+
+  @doc """
+  Guards a GenServer call with a pre-flight availability check.
+  Returns `{:error, :unavailable}` if the named process is not registered.
+  Does NOT rescue or catch; unexpected exceptions propagate.
+  """
+  @spec guarded_call(name :: atom(), fun :: (() -> term())) :: result()
+  def guarded_call(name, fun) do
+    case Process.whereis(name) do
+      nil -> {:error, :unavailable}
+      _pid -> {:ok, fun.()}
+    end
+  end
+end
+```
+
+**Updated `lib/tau/cli/extensions.ex`:**
+
+```elixir
+defmodule Tau.CLI.Extensions do
+  @behaviour Tau.CLI.ProcessQuery
+
+  @loader Tau.Extensions.Loader
+
+  @impl Tau.CLI.ProcessQuery
+  def list do
+    Tau.CLI.ProcessQuery.guarded_call(@loader, &@loader.list/0)
+  end
+
+  @impl Tau.CLI.ProcessQuery
+  def reload do
+    case Tau.CLI.ProcessQuery.guarded_call(@loader, &@loader.reload_all/0) do
+      {:ok, :ok} -> {:ok, :ok}
+      {:ok, {:error, r}} -> {:error, r}
+      {:error, _} = err -> err
+    end
+  end
+end
+```
+
+**Updated public command handlers (still in `Tau.CLI.Extensions`):**
+
+```elixir
+@spec list_cmd(opts()) :: 0 | 1
+def list_cmd(opts \\ []) do
+  case list() do
+    {:ok, entries} ->
+      render_list(entries, opts)
+      0
+    {:error, :unavailable} ->
+      IO.puts(:stderr, "extensions list: Extensions.Loader is not running")
+      1
+    {:error, reason} ->
+      IO.puts(:stderr, "extensions list failed: #{inspect(reason)}")
+      1
+  end
+end
+```
+
+Identical pattern in `lib/tau/cli/mcp.ex` with `Tau.MCP.Reconciler` as the
+guarded name.
+
+**File moves / additions:**
+- `lib/tau/cli/process_query.ex` — new (behaviour + `guarded_call/2`)
+- `lib/tau/cli/extensions.ex` — `@behaviour Tau.CLI.ProcessQuery`; delete
+  `safe_list/0` and `safe_reload/0`; public functions renamed
+  `list/0` → `list/0` (callback), `list_cmd/1` (command handler).
+- `lib/tau/cli/mcp.ex` — same structural change.
+
+## Tradeoffs
+
+### Strengths
+
+- `Process.whereis/1` check does not cross a process boundary via
+  message-passing, so it does not violate OTP NN #7 in the way `rescue :exit`
+  does.
+- The `guarded_call/2` helper is a single, centralised point that both modules
+  share — no duplication of the nil-guard pattern.
+- Behaviour enforcement ensures any future CLI module querying a supervised
+  GenServer follows the same contract.
+- Test surface: `list/0` and `reload/0` can be tested with a mock behaviour
+  implementation without a live BEAM supervision tree.
+- `:unavailable` is a typed, human-readable distinction from other errors,
+  satisfying the acceptance criterion's "diagnostically useful error" requirement.
+
+### Weaknesses
+
+- **TOCTOU race**: `Process.whereis/1` returning a pid does not guarantee the
+  GenServer is still alive when `fun.()` is called. On a fast restart cycle the
+  pre-flight check passes, then the call exits `:noproc`. This exit propagates
+  freely (no catch), which is correct OTP behaviour, but the error message will
+  not say "unavailable" — it will be an unhandled exit. The acceptance criterion
+  is still met (non-zero exit, stderr output from the top-level handler) but the
+  message quality degrades on the race path.
+- **Renames the public API**: `list/1` (formerly the command handler) is now
+  split into `list/0` (the behaviour callback returning a tagged tuple) and
+  `list_cmd/1` (the command handler). If `Tau.CLI.main/1` dispatches to
+  `Tau.CLI.Extensions.list/1`, it must be updated.
+- **New file and new behaviour** add surface area. For a fix to ~30 lines of
+  rescue/catch, introducing a behaviour and a new module is higher structural
+  cost than the problem demands.
+- **Doesn't cover `reload_all/0` returning `{:error, reason}`** on application-
+  level failures without double-wrapping — same awkward `{:ok, {:error, _}}`
+  shape as proposal 2.
+
+### Costs
+
+- ~50 lines added (new behaviour module + guarded_call + updated impls).
+- ~30 lines deleted (safe_list, safe_reload in both files).
+- `lib/tau/cli.ex` dispatch callsite must be updated if public function names change.
+- Tests must be added for `guarded_call/2` covering: nil pid → `{:error, :unavailable}`;
+  live pid → `{:ok, result}`; TOCTOU race path (harder to test deterministically).
+
+## Dependencies
+
+- `Tau.Extensions.Loader` and `Tau.MCP.Reconciler` must use registered names
+  (not anonymous pids) for `Process.whereis/1` to work. Verify both are
+  registered under their module name in the supervision tree.
+- `lib/tau/cli.ex` dispatch table must be audited for callsite signature changes.
+
+## Confidence
+
+medium — `Process.whereis/1` as an availability guard is a well-known Elixir
+idiom but the TOCTOU window is real and the structural cost (new behaviour, new
+module) is higher than the problem warrants if the acceptance criterion can be
+met with a smaller change. Confidence rises to high if the dispatch table audit
+confirms clean rename paths and the TOCTOU path's unhandled exit is acceptable.
+
+## Prior art / references
+
+- Elixir `Process.whereis/1` documentation: standard availability check idiom
+  before sending to a registered process.
+- OTP design principles: pre-flight availability checks (`whereis/1`) are
+  explicitly mentioned as the correct pattern when callers need to handle
+  "process not running" without `try/catch`.
+- Tau OTP NN #2: "Extensibility seams MUST be behaviours" — the
+  `ProcessQuery` behaviour enforces the tagged-tuple contract across CLI
+  modules rather than relying on convention.

--- a/docs/problems-archive-v1-modules/tau-cli/subproblems/error-swallowing-rescues/proposals/proposal-4.md
+++ b/docs/problems-archive-v1-modules/tau-cli/subproblems/error-swallowing-rescues/proposals/proposal-4.md
@@ -1,0 +1,194 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 4
+parent_problem: ../problem.md
+---
+
+# Proposal 4: Structured exit-code API — lift error signals to the command boundary, removing private helpers entirely
+
+## Approach
+
+This is an API-breaking, behaviour-correcting refactor at the command-handler
+layer. The public functions `Tau.CLI.Extensions.list/1`, `reload/1`,
+`Tau.CLI.MCP.list/1`, `status/1`, `reload/1` currently assume the callee always
+returns data and hard-code exit code 0 on success. This proposal changes their
+contract: public functions always call the supervised GenServer directly (no
+shim), wrap the entire body in a `try` at the **command boundary** (not the
+callee boundary), and return a structured `{exit_code, output}` tuple that the
+CLI dispatcher renders. The private `safe_*` helpers are deleted entirely. Error
+output format follows a structured schema: `%{ok: false, error: "...", code: N}`
+for `--json` and a consistent `"<command> failed: <reason>"` line to stderr for
+plain text.
+
+## Rationale
+
+The complecting hypothesis is that data retrieval is woven with error reporting.
+Proposals 1–3 decouple them by adjusting the fetch side. This proposal
+decouples from the other direction: the command handlers themselves become the
+error boundary, explicitly responsible for mapping any failure to an exit code
+and error output, regardless of cause. This is an **interface change** —
+changing what the public functions return — rather than a rescue/catch placement
+change. The key insight is that a CLI command is already an error boundary
+(every shell command is); making that explicit in the Elixir type signature
+aligns the module's contract with its actual responsibility. The private
+`safe_*` helpers vanish because no intermediate translation layer is needed
+when the outer boundary handles all failures uniformly.
+
+## Sketch
+
+**New return type for command handlers:**
+
+```elixir
+@type command_result :: {exit_code :: non_neg_integer(), output :: iodata()}
+```
+
+**Updated `lib/tau/cli/extensions.ex`:**
+
+```elixir
+defmodule Tau.CLI.Extensions do
+  @type command_result :: {non_neg_integer(), iodata()}
+
+  @spec list(opts()) :: command_result()
+  def list(opts \\ []) do
+    try do
+      entries = Tau.Extensions.Loader.list()
+      {0, format_list(entries, opts)}
+    catch
+      :exit, reason ->
+        msg = format_process_error("extensions list", reason, opts)
+        {1, {:stderr, msg}}
+    end
+  end
+
+  @spec reload(opts()) :: command_result()
+  def reload(opts \\ []) do
+    try do
+      case Tau.Extensions.Loader.reload_all() do
+        :ok ->
+          {0, format_reload_ok(opts)}
+        {:error, reason} ->
+          {2, {:stderr, format_error("extensions reload", reason, opts)}}
+      end
+    catch
+      :exit, reason ->
+        {1, {:stderr, format_process_error("extensions reload", reason, opts)}}
+    end
+  end
+
+  defp format_process_error(cmd, {:noproc, _}, _opts),
+    do: "#{cmd}: subsystem process is not running\n"
+  defp format_process_error(cmd, reason, _opts),
+    do: "#{cmd}: process exit: #{inspect(reason)}\n"
+
+  defp format_error(cmd, reason, _opts),
+    do: "#{cmd} failed: #{inspect(reason)}\n"
+
+  # No safe_list/0, no safe_reload/0
+end
+```
+
+**Dispatcher update in `lib/tau/cli.ex`:**
+
+Current call pattern (assumed):
+```elixir
+Tau.CLI.Extensions.list(opts)   # returns exit code integer
+```
+
+Updated call pattern:
+```elixir
+{code, output} = Tau.CLI.Extensions.list(opts)
+emit(output)
+code
+```
+
+Where `emit/1` dispatches `{:stderr, text}` to `IO.puts(:stderr, text)` and
+`iodata` directly to `IO.puts/1`.
+
+**JSON shape on error:**
+
+```elixir
+# --json path in format_process_error when opts[:json]
+Jason.encode!(%{ok: false, error: "subsystem process is not running", code: 1})
+```
+
+**File changes:**
+- `lib/tau/cli/extensions.ex`: delete `safe_list/0`, `safe_reload/0`; update
+  `list/1`, `reload/1` specs to return `command_result()`; add `format_*`
+  private helpers.
+- `lib/tau/cli/mcp.ex`: same pattern.
+- `lib/tau/cli.ex`: update dispatch call sites to destructure `{code, output}`
+  and call `emit/1`.
+
+## Tradeoffs
+
+### Strengths
+
+- Eliminates the private-helper indirection layer entirely: zero `safe_*`
+  functions, zero wildcard rescue.
+- Command handlers are now explicitly the error boundary, which matches the
+  conceptual model (a command either succeeds with output or fails with a
+  message and exit code).
+- The `try/catch :exit` at the command boundary is narrower than a wildcard
+  rescue but broader than proposal 2's per-exit-shape catch — it covers all
+  process exits while still leaving non-exit exceptions to propagate.
+- Structured `command_result()` type makes it trivially testable: assert `{0,
+  _}` or `{1, {:stderr, _}}` without inspecting stdout.
+- Satisfies acceptance criterion fully: non-zero exit + stderr diagnostic on
+  `:noproc`.
+
+### Weaknesses
+
+- **API-breaking**: the public functions currently return `0 | 2` (integers);
+  changing to `{exit_code, output}` requires updating every callsite in
+  `lib/tau/cli.ex`. If any external consumer calls these functions directly,
+  it breaks them too.
+- **`try/catch :exit` at the command boundary** is still a catch across a
+  process boundary — arguably still a violation of the spirit of OTP NN #7,
+  even if narrowed to `:exit` tuples. The difference from the current code is
+  the match shape (`:exit, {:noproc, _}` vs `:exit, _`) and the removal of
+  wildcard `rescue _`.
+- **`emit/1` coupling**: the output-as-iodata approach ties the format to the
+  command boundary, making it harder to test the format independently of the
+  exit-code logic.
+- **Larger diff** than proposals 1 or 2: command handler signatures change,
+  dispatcher changes, output format helpers added.
+- Does not eliminate `try/catch` entirely (proposal 1 does); it restructures
+  and narrows it.
+
+### Costs
+
+- ~60–70 lines changed/added across `extensions.ex`, `mcp.ex`, `cli.ex`.
+- Dispatch call sites in `lib/tau/cli.ex` must be updated (count: 4 handler
+  call sites for Extensions and MCP).
+- Tests asserting integer return values from `list/1` and `reload/1` must be
+  updated to assert `{code, _}` tuples.
+- JSON contract for `--json --error` paths changes (new `{ok: false, error:
+  ..., code: N}` shape); any integration tests or scripts consuming JSON output
+  on error must be updated.
+
+## Dependencies
+
+- `lib/tau/cli.ex` dispatch table must be refactored to consume `command_result()`
+  tuples — this is the largest callsite change and must land in the same PR.
+- No new library dependencies.
+
+## Confidence
+
+medium — the approach is mechanically clear and the sketch is complete. Confidence
+is bounded by the API-breaking nature: the exact shape of the dispatch table in
+`lib/tau/cli.ex` must be audited before the cost of callsite changes is known.
+If dispatch is centralised (one place), cost is low; if distributed, cost rises.
+
+## Prior art / references
+
+- Elixir Escript and Burrito CLI patterns: command handlers returning `{exit_code,
+  output}` tuples with a top-level `emit + halt` dispatcher are a documented
+  idiom in the Elixir CLI ecosystem (see `Mix.Task` protocol: `run/1` returns
+  `nil` but side-effecting commands can return structured results when composed).
+- Haskell `ExitCode + String` pattern from `System.Exit`: separates exit code
+  and output into a product type, used in CLI libraries like `optparse-applicative`.
+- Tau OTP NN #8: "MUST NOT swallow errors. Use tagged tuples or
+  `%Tau.Provider.Event.Error{}` stream items." — this proposal converts the
+  command handlers to return tagged result tuples, directly satisfying NN #8 at
+  the CLI layer.

--- a/docs/problems-archive-v1-modules/tau-cli/subproblems/error-swallowing-rescues/solution.md
+++ b/docs/problems-archive-v1-modules/tau-cli/subproblems/error-swallowing-rescues/solution.md
@@ -1,0 +1,219 @@
+---
+template_version: 1
+template_name: solution
+parent_problem: problem.md
+node_kind: leaf
+synthesised_from: [proposals/proposal-1.md, proposals/proposal-2.md]
+selection_method: hybrid
+revision: 1
+---
+
+# Solution: Delete wildcard rescue/catch; targeted catch + rescue at the command boundary; amend NN #7
+
+## Recommendation
+
+Delete `safe_list/0` and `safe_reload/0` from `Tau.CLI.Extensions` and
+`Tau.CLI.MCP`. Replace them with a targeted `try` block at the command-handler
+boundary that uses BOTH `rescue _ -> {stderr; exit_code}` (for non-exit
+exceptions named by problem.md's AC) AND `catch :exit, {:noproc, _} -> ...` /
+`catch :exit, reason -> ...` (targeted, not wildcard). The `case`-on-result
+structure of `reload/1` is collapsed: the callees (`Tau.Extensions.Loader.reload_all/0`
+and `Tau.MCP.Reconciler.reload/0`) are both `GenServer.cast`, so they return
+only `:ok` — the existing `{:error, reason}` application-level arm is dead
+(reachable today only through the swallow itself) and is removed. Exit codes:
+`list/1` and `status/1` widen their `@spec` from `0` to `0 | 1` and return `1`
+on failure; `reload/1` keeps its existing `@spec 0 | 2` and returns `2` on
+failure. The NN #7 carve-out the targeted catch relies on is made explicit in
+the same PR family via a documented amendment to
+`.claude/rules/otp-non-negotiables.md` (precedent: `lib/tau/providers/rate_limiter.ex:86`).
+
+## Selected from
+
+- **Chosen:** hybrid of `proposals/proposal-1.md` and `proposals/proposal-2.md`
+- **Why chosen:** Proposal 1's core move — delete the private rescue shims —
+  is the load-bearing decomplecting step. Its weakness, that diagnostic quality
+  becomes hostage to a `Tau.CLI.main/1` top-level handler that does not exist
+  today (`lib/tau/cli.ex:69–136` has no top-level rescue), is closed by
+  proposal 2's insight: a targeted catch at the command-handler boundary
+  produces per-command diagnostics without a new abstraction. The hybrid takes
+  proposal 1's deletion of `safe_list/0` / `safe_reload/0`, takes proposal 2's
+  targeted `catch :exit, {:noproc, _}` shape, and additionally adds a
+  `rescue _` arm to cover non-exit exceptions (which neither proposal covered
+  in its sketch but problem.md's AC explicitly names). Proposals 3 and 4 were
+  rejected: proposal 3's `ProcessQuery` behaviour adds structural weight
+  disproportionate to the problem scope and carries a TOCTOU race; proposal 4's
+  API-breaking `command_result()` return type is out of scope for a
+  rescue-removal fix.
+
+## Scoring table
+
+| # | Fit | Decomplecting depth | Migration cost | Risk | Reversibility |
+|---|-----|---------------------|----------------|------|---------------|
+| 1 | Partially | Deep | Low | Medium | Easy |
+| 2 | Partially | Substantial | Medium | Low | Easy |
+| 3 | Partially | Substantial | High | Medium | Easy |
+| 4 | Yes | Substantial | High | Medium | Hard |
+
+Proposals 1 and 2 each score "Partially" on fit as written, because each leaves
+one branch of the AC uncovered (proposal 1: per-command context lost on the
+top-level handler path that does not exist; proposal 2: non-exit exceptions
+uncovered, dead `{:error, _}` arm preserved). The hybrid closes both gaps by
+combining proposal 1's deletion with proposal 2's targeted catch AND a `rescue
+_` arm for non-exit exceptions. Proposal 4 fits the AC outright but at the cost
+of an API-breaking `command_result()` return-type change — disproportionate to
+this PR.
+
+## What changes
+
+- `lib/tau/cli/extensions.ex` — delete `safe_list/0` (lines 67–73) and
+  `safe_reload/0` (lines 75–81). In `list/1`, wrap the direct
+  `Tau.Extensions.Loader.list()` call in a `try` block with:
+    - normal body: bind the result to `entries`, run existing render logic,
+      return `0`;
+    - `rescue e -> IO.puts(:stderr, "extensions list failed: " <> Exception.message(e)); 1`;
+    - `catch :exit, {:noproc, _} -> IO.puts(:stderr, "extensions list: Extensions.Loader is not running"); 1`;
+    - `catch :exit, reason -> IO.puts(:stderr, "extensions list: process exit: " <> inspect(reason)); 1`.
+  In `reload/1`, wrap the direct `Tau.Extensions.Loader.reload_all()` call in
+  the same shape: normal body returns `0` after the success print; the prior
+  `case … {:error, reason} → … 2 end` is REMOVED (the arm is dead because
+  `reload_all/0` is `GenServer.cast` returning `:ok` only). The
+  `catch`/`rescue` arms return `2` (preserving `@spec 0 | 2`) with the existing
+  "extensions reload failed: …" stderr prefix repurposed for process-level
+  errors.
+- `lib/tau/cli/mcp.ex` — identical change in shape: delete `safe_list/0`
+  (lines 98–104) and `safe_reload/0` (lines 106–112). Apply the same targeted
+  `try/rescue/catch` block in `list/1`, `status/1`, and `reload/1`. `list/1`
+  and `status/1` return `1` on failure (widen `@spec` to `0 | 1`); `reload/1`
+  returns `2` on failure (keep `@spec 0 | 2`); the dead `{:error, reason}` arm
+  in `reload/1` is REMOVED for the same reason as Extensions
+  (`Tau.MCP.Reconciler.reload/0` is also `GenServer.cast` returning `:ok`).
+- `@spec` updates in same PR:
+    - `Tau.CLI.Extensions.list/1` — `@spec list(opts()) :: 0` → `0 | 1`;
+    - `Tau.CLI.MCP.list/1` and `Tau.CLI.MCP.status/1` — same widening
+      (currently `@spec :: 0`);
+    - `Tau.CLI.Extensions.reload/1` and `Tau.CLI.MCP.reload/1` — `@spec ::
+      0 | 2` unchanged (the `2` arm is repurposed from "application reload
+      error" to "process unavailable / unexpected exception").
+- `.claude/rules/otp-non-negotiables.md` — amend rule #7 in the SAME PR family
+  to add an explicit carve-out: "MUST NOT wildcard-catch `:exit`. A *targeted*
+  `catch :exit, {:noproc, _}` (or other named exit-reason shape) AT A CLI /
+  TUI command boundary is permitted as an OTP-recommended availability escape
+  hatch; the precedent is `lib/tau/providers/rate_limiter.ex:86`." The
+  amendment makes the existing `rate_limiter.ex` precedent compliant under
+  literal reading and makes this PR's targeted catches compliant.
+- No other files change. `lib/tau/cli.ex` dispatch table (lines 95–113) is
+  unaffected: public function arities are unchanged and the `halt/1` sink
+  (`lib/tau/cli.ex:816–817`) accepts any integer the handlers return.
+
+## What does not change
+
+- Public function arities: `list/1`, `reload/1`, `status/1` all continue to
+  accept the same `opts` and return integer exit codes (now in the widened
+  `@spec` ranges named above).
+- `lib/tau/cli.ex` dispatch table — no callsite changes required.
+- `Tau.Extensions.Loader.list/0`, `Tau.Extensions.Loader.reload_all/0`,
+  `Tau.MCP.Reconciler.list/0`, and `Tau.MCP.Reconciler.reload/0` interfaces —
+  untouched.
+- The cast-based asynchronous reload semantics: `tau extensions reload` and
+  `tau mcp reload` still return `0` as soon as the cast is delivered, even if
+  the actual reload work fails asynchronously. Surfacing async-reload errors
+  requires changing the callee API (cast → call, or a feedback channel) and is
+  out of scope here (flagged for the parent in Open questions).
+- The existing rescue/catch sites outside the four named functions (per
+  problem.md's "Out of scope" section): `safe_to_atom/1`, `validate/1` in
+  `Tau.CLI.Config`, `drain_run_loop/2`, and the rate-limiter's own targeted
+  catch.
+
+## Migration sketch
+
+Single PR, three files. (1) `lib/tau/cli/extensions.ex`: delete the two `defp`
+helpers; replace `list/1`'s body with a `try`-wrapped direct call carrying the
+`rescue _` and two `catch :exit, …` arms; replace `reload/1`'s body the same
+way, REMOVING the prior `case` and its `{:error, _}` arm entirely (the callee
+returns `:ok` only); update the `@spec` on `list/1` from `0` to `0 | 1`.
+(2) `lib/tau/cli/mcp.ex`: mirror exactly in `list/1`, `status/1`, and
+`reload/1`; update `@spec` on `list/1` and `status/1` from `0` to `0 | 1`.
+(3) `.claude/rules/otp-non-negotiables.md`: append the targeted-form carve-out
+to rule #7 with the `rate_limiter.ex:86` precedent. Run `mix compile
+--warnings-as-errors` (Dialyzer will confirm the `@spec` widening); run `mix
+test` and update any test asserting `list/1 == 0` when the supervisor is down
+to assert `1` plus the corresponding stderr line. The PR description must
+explicitly link the NN #7 amendment commit to the rescue-removal commits so a
+single reviewer sees the carve-out at the same time as the new catches.
+
+## Open questions
+
+- `Tau.CLI.main/1` has no top-level rescue (verified at
+  `lib/tau/cli.ex:69–136`). The hybrid's per-handler `rescue _` closes the
+  in-scope AC for the four named commands, but other CLI handlers (e.g.
+  `config_get`, `init_cmd`, `tui_cmd`) remain exposed to raw BEAM crash dumps
+  on uncaught exceptions. Flagged for the parent as a sibling sub-problem
+  ("`main/1` lacks a top-level safety net") — out of scope here.
+- `Tau.Extensions.Loader.reload_all/0` and `Tau.MCP.Reconciler.reload/0` are
+  `GenServer.cast` and therefore fire-and-forget. `tau extensions reload`
+  returns `0` on cast delivery regardless of whether the asynchronous reload
+  succeeds. Surfacing async-reload errors would require either converting the
+  callees to `GenServer.call` (changes their concurrency semantics — a
+  long-running reload would block the caller) or adding a result-feedback
+  channel (telemetry + a synchronous follow-up query). Both are out of scope
+  for the rescue-removal PR; flagged for the parent.
+- If the NN #7 amendment is rejected during PR review, the fallback is
+  proposal 1's deletion-only form PLUS a top-level rescue in `Tau.CLI.main/1`
+  (added in the same PR). That pivot keeps the rescue-removal intact while
+  routing exit-translation through `main/1` rather than a per-handler catch.
+  Pre-deciding the fallback bounds the PR's risk.
+- Why NOT a `Task.async + Task.yield`-based "convert crash to `{:error, _}`"
+  pattern? Two reasons: (a) `Task.yield` itself relies on monitored exits and
+  the monitor's `:DOWN` message — under the literal NN #7 reading, that is
+  *also* a process-boundary crash interception, just spelled differently. The
+  carve-out NN amendment is needed either way. (b) Wrapping every CLI call in
+  a `Task` triples the process count for the simplest operations and is
+  disproportionate to the four affected functions; the targeted `catch :exit`
+  is mechanically smaller and matches the existing precedent.
+
+## Linked sub-problems / proposals
+
+- `proposals/proposal-1.md` — Delete safe_list/safe_reload; let calls crash to top-level handler
+- `proposals/proposal-2.md` — Replace rescue/catch with targeted GenServer.call boundary + tagged tuples
+- `proposals/proposal-3.md` — Introduce Tau.CLI.ProcessQuery behaviour + pre-flight whereis check (rejected: disproportionate structural cost, TOCTOU race)
+- `proposals/proposal-4.md` — Lift error signals to command boundary via `command_result()` return type (rejected: API-breaking, out of scope)
+
+## Revision history
+
+- revision 0 — initial hybrid of proposal 1 + proposal 2; placed targeted
+  `catch :exit` at the command-handler boundary, kept the `case` structure in
+  `reload/1`, asserted NN #7's wildcard-only reading as settled.
+- revision 1 — validator falsified four points; this revision corrects all
+  four:
+    1. **Dead error arm (claim 4).** Confirmed `Tau.Extensions.Loader.reload_all/0`
+       (`lib/tau/extensions/loader.ex:65`) and `Tau.MCP.Reconciler.reload/0`
+       (`lib/tau/mcp/reconciler.ex:44`) are `GenServer.cast`, returning `:ok`
+       only. The `{:error, reason}` arm in the current `reload/1` is reachable
+       today only via the `safe_reload/0` rescue itself. Removed: the new
+       `reload/1` body has no `case` and no `{:error, _}` arm. (Switching the
+       callees to `GenServer.call` was considered and rejected — it changes
+       async concurrency semantics for the rescue-removal PR's scope.)
+    2. **Exit-code/spec contradiction (claim 5).** Chosen explicitly: keep
+       `@spec reload(opts()) :: 0 | 2` and use `2` for the rescue/catch arms
+       in `reload/1`; widen `@spec list(opts()) :: 0` → `0 | 1` for
+       `list/1` / `status/1` and use `1`. No `System.halt(1)` anywhere; each
+       handler returns its integer to `halt/1` in `lib/tau/cli.ex` as before.
+    3. **Uncovered non-exit exceptions (claim 3).** Added `rescue _ ->
+       stderr; exit_code` to each handler's `try` block. The four AC failure
+       modes (`:noproc`, other process exit, non-exit exception, and the
+       `:timeout` shape covered by the fallthrough `catch :exit, reason`) all
+       produce non-zero exit + stderr diagnostic.
+    4. **NN #7 wildcard carve-out (claim 6).** Acknowledged that NN #7 as
+       authored has no "wildcard" qualifier — the targeted-form carve-out the
+       prior solution asserted is not established. Adopted the validator's
+       preferred path (option a): amend NN #7 in the same PR to add an
+       explicit carve-out for targeted `catch :exit, {:noproc, _}` at CLI/TUI
+       command boundaries, citing the existing `rate_limiter.ex:86` precedent.
+       Pivoting to a `Task.async + Task.yield` pattern was considered and
+       rejected (see Open questions): `Task.yield`'s monitored-`:DOWN`
+       mechanism is itself a process-boundary crash interception under the
+       literal reading, so the amendment is needed either way; the targeted
+       catch is mechanically smaller and matches the existing precedent. The
+       fallback if the NN amendment is rejected during PR review (pure
+       deletion + top-level `main/1` rescue) is also stated explicitly in
+       Open questions.

--- a/docs/problems-archive-v1-modules/tau-cli/subproblems/error-swallowing-rescues/validation.md
+++ b/docs/problems-archive-v1-modules/tau-cli/subproblems/error-swallowing-rescues/validation.md
@@ -1,0 +1,469 @@
+---
+template_version: 1
+template_name: validation
+parent_solution: solution.md
+parent_problem: problem.md
+toulmin_complete: true
+falsification_attempted: true
+falsification_outcome: withstood
+revision_triggered: none
+---
+
+# Validation: Delete wildcard rescue/catch; targeted catch + rescue at command boundary; amend NN #7
+
+## Overview
+
+This validation enumerates seven distinct propositions from `solution.md`
+(four about code shape, one about exit-code/`@spec` alignment, one about
+the rules-file amendment, one about asynchronous reload semantics being
+preserved). The chosen falsification strategies are a mix of dependency
+check (verifying that `reload_all/0` and `reload/0` are indeed
+`GenServer.cast`), counter-example construction (probing for non-exit
+exception escape paths and TOCTOU windows), edge-case enumeration (the
+four AC-named failure modes), and type-level check (`@spec`
+widening). Outcome across all seven claims: **withstood**. This revision
+materially addresses the four prior falsifications recorded in
+solution.md's revision-1 history; no new falsifications surfaced. One
+outstanding doubt is noted regarding the per-PR scope of the NN #7
+amendment.
+
+## Toulmin per claim
+
+### Claim 1: `safe_list/0` and `safe_reload/0` are deleted from both modules
+
+- **Claim (C):** The four private helpers (`Tau.CLI.Extensions.safe_list/0`,
+  `Tau.CLI.Extensions.safe_reload/0`, `Tau.CLI.MCP.safe_list/0`,
+  `Tau.CLI.MCP.safe_reload/0`) are removed, eliminating the wildcard
+  rescue/catch sites.
+- **Grounds (G):** Solution §"What changes" first two bullets specify
+  deletion of `lib/tau/cli/extensions.ex:67-73` and `:75-81` and
+  `lib/tau/cli/mcp.ex:98-104` and `:106-112`. Confirmed at the named
+  line ranges: `lib/tau/cli/extensions.ex:67-73` contains
+  `defp safe_list … rescue _ -> [] catch :exit, _ -> []`;
+  `lib/tau/cli/extensions.ex:75-81`, `lib/tau/cli/mcp.ex:98-104`, and
+  `lib/tau/cli/mcp.ex:106-112` carry the matching shapes.
+- **Warrant (W):** OTP non-negotiable #7 ("MUST NOT `try/rescue` across
+  process boundaries. MUST NOT catch `:exit`")
+  (`.claude/rules/otp-non-negotiables.md:26-27`) makes wildcard rescue/
+  catch of supervised-process calls a rule violation; the only way to
+  bring the four files into compliance with the existing rule is to
+  remove the wildcard sites.
+- **Qualifier (Q):** Scoped to the four named helpers; the broader
+  rescue/catch surface in `Tau.CLI.Config`, `Tau.CLI.Init`, and the
+  run-loop (`drain_run_loop/2`) is explicitly out of scope per
+  problem.md.
+- **Rebuttal (R):** Deletion alone is not sufficient if the replacement
+  surface still contains a wildcard interception. Claim 2 covers the
+  shape of the replacement.
+- **Backing (B):** `.claude/rules/otp-non-negotiables.md` §"Invariants"
+  rule 7; problem.md "Out of scope" section (which the solution honours
+  by not touching `safe_to_atom/1`, etc.).
+
+#### Falsification attempt for claim 1
+
+- **Strategy:** Dependency check — verify the named line ranges still
+  contain the helpers the solution proposes to delete.
+- **Attempt:** Read `lib/tau/cli/extensions.ex:67-81` and
+  `lib/tau/cli/mcp.ex:98-112`. Both contain the exact patterns
+  problem.md cites: two `defp` helpers per file with the wildcard
+  rescue/catch shapes.
+- **Outcome:** withstood — the helpers exist at the named lines and
+  match the description; deletion is a mechanical edit with no hidden
+  dependency.
+- **Action:** none.
+
+### Claim 2: Targeted `catch :exit, {:noproc, _}` + fallthrough `catch :exit, reason` + `rescue _` replace the deleted shims at the command-handler boundary
+
+- **Claim (C):** Each of `list/1`, `status/1`, and `reload/1` wraps its
+  direct call to the supervised process in a `try` block carrying three
+  arms: `rescue e -> stderr + non-zero exit`,
+  `catch :exit, {:noproc, _} -> stderr + non-zero exit`, and
+  `catch :exit, reason -> stderr + non-zero exit`. None of the arms are
+  wildcard `:exit, _`.
+- **Grounds (G):** Solution §"What changes" bullets 1 and 2 enumerate
+  the three arms explicitly for each handler. The fallthrough is
+  `catch :exit, reason -> …`, which under Erlang/Elixir pattern-matching
+  semantics binds (does not unconditionally accept) `reason`; the
+  preceding `{:noproc, _}` clause already removed that case, so the
+  fallthrough catches the residual set (e.g. `{:timeout, _}`,
+  `:killed`, application-specific exits) — a *targeted-by-position*
+  catch, not a wildcard in the NN #7 sense (which the rule names as
+  `catch :exit, _ -> ignore` style swallows).
+- **Warrant (W):** Pattern-matched exit-reason arms produce
+  observability (each reason routed to a tagged stderr line and
+  non-zero exit) rather than swallowing. The `rate_limiter.ex:86`
+  precedent — `catch :exit, {:timeout, _} -> {:error, …}; catch :exit,
+  {:noproc, _} -> :ok` — establishes that targeted, named catches at
+  CLI/operational boundaries are accepted house practice even today.
+- **Qualifier (Q):** Targeted in the sense of "no wildcard `_`-only
+  pattern over arbitrary exit reasons that discards the reason". The
+  `reason` binding is preserved into the stderr message; it is not
+  discarded.
+- **Rebuttal (R):** A literal reading of NN #7 ("MUST NOT catch
+  `:exit`") admits no exception by reason-shape; this is precisely the
+  concern Claim 6 addresses by amending NN #7 in the same PR.
+- **Backing (B):** `lib/tau/providers/rate_limiter.ex:80-92` precedent;
+  Elixir documentation on `try/catch` pattern-matching semantics
+  (https://hexdocs.pm/elixir/try-catch-and-rescue.html).
+
+#### Falsification attempt for claim 2
+
+- **Strategy:** Counter-example construction — try to construct an
+  exit-reason shape that would slip past both `catch :exit` arms or
+  that would be swallowed without a stderr line.
+- **Attempt:** Enumerate the documented exit shapes:
+  - `{:noproc, mfa}` — matched by arm 1.
+  - `{:timeout, mfa}` — matched by arm 2 (binds `reason`), prints
+    diagnostic, returns non-zero.
+  - `:killed` — matched by arm 2.
+  - `{:shutdown, term}` — matched by arm 2.
+  - Application-thrown `{:tau_error, …}` — matched by arm 2.
+  Each path produces a stderr message including the bound `reason` and
+  a non-zero exit. No swallowing path remains.
+- **Outcome:** withstood — every exit-reason shape this validator could
+  construct is routed to a diagnostic-plus-exit path; none is
+  swallowed.
+- **Action:** none.
+
+### Claim 3: Non-exit exceptions (e.g., `ArgumentError`, `FunctionClauseError`) raised inside the supervised call are caught by `rescue _` and produce non-zero exit + diagnostic
+
+- **Claim (C):** Adding `rescue e -> stderr; exit_code` to the `try`
+  block covers the AC-named "unexpected exception" failure mode
+  (non-exit exceptions), closing the prior revision's gap.
+- **Grounds (G):** Solution §"What changes" bullets 1 and 2 specify
+  `rescue e -> IO.puts(:stderr, "<cmd> failed: " <>
+  Exception.message(e)); <code>` on each handler. `Exception.message/1`
+  accepts any value implementing the `Exception` behaviour and returns
+  a binary; the bound `e` is the raised exception struct.
+- **Warrant (W):** `rescue _` (or `rescue e ->`) in Elixir matches any
+  exception (not exits); combined with the two `catch :exit` arms, the
+  three-arm structure partitions the error space into
+  exceptions-via-`rescue` and exits-via-`catch`, covering both
+  failure-signal channels in the BEAM.
+- **Qualifier (Q):** Only covers exceptions and named exit reasons —
+  throws (`throw(term)`) are NOT covered. Per Erlang convention,
+  `throw` is reserved for non-local control flow within a single
+  process and should not cross a GenServer.call boundary; supervised
+  processes that misuse `throw` are themselves NN-violating.
+- **Rebuttal (R):** A misbehaving callee that `throw(term)`-s inside
+  its caller process context (i.e., the throw escapes
+  `GenServer.call/2`) would crash the CLI process — but this is
+  pathological and itself a callee bug.
+- **Backing (B):** Elixir `try/rescue/catch` docs
+  (https://hexdocs.pm/elixir/try-catch-and-rescue.html) — `rescue`
+  matches exceptions; `catch` (without atom prefix or with `:throw`)
+  matches throws; `catch :exit` matches exits.
+
+#### Falsification attempt for claim 3
+
+- **Strategy:** Edge-case enumeration over the AC's four named failure
+  modes (`:noproc`, process exit, unexpected exception, fail silently
+  returning 0).
+- **Attempt:** Walk each mode through the proposed `try`:
+  - `:noproc`: caught by arm 2 (`{:noproc, _}`) — non-zero + stderr.
+  - Other process exit: caught by arm 3 (`catch :exit, reason`) —
+    non-zero + stderr.
+  - Unexpected exception (e.g., `MatchError` if the callee returns an
+    unexpected shape): caught by `rescue e` — non-zero + stderr.
+  - Silent return of 0: removed — every failure path now returns a
+    non-zero code.
+- **Outcome:** withstood — all four AC modes are covered.
+- **Action:** none. (Throws-escaping-GenServer.call remain uncovered
+  but are explicitly out of scope as pathological callee bugs.)
+
+### Claim 4: The `{:error, reason}` arm in `reload/1` is dead and is removed
+
+- **Claim (C):** Both `Tau.Extensions.Loader.reload_all/0` and
+  `Tau.MCP.Reconciler.reload/0` are `GenServer.cast`-based and return
+  only `:ok`; the existing `case … {:error, reason} -> … 2 end` arm in
+  `reload/1` is reachable today only via the `safe_reload/0` rescue
+  itself, and is removed in this PR.
+- **Grounds (G):** `lib/tau/extensions/loader.ex:65` defines
+  `def reload_all, do: GenServer.cast(__MODULE__, :reload_all)` with
+  `@spec reload_all() :: :ok`. `lib/tau/mcp/reconciler.ex:44` defines
+  `def reload, do: GenServer.cast(__MODULE__, :reload)` with
+  `@spec reload() :: :ok`. `GenServer.cast/2` returns `:ok` and never
+  blocks; it cannot return `{:error, _}`. The current `safe_reload/0`
+  shims convert exit-style failures (caught from the cast's local
+  registry lookup or send) into `{:error, reason}`, which is the only
+  source of that arm being reached today.
+- **Warrant (W):** Dead-code elimination is correctness-preserving when
+  the call path proves the arm unreachable. The OTP `GenServer.cast/2`
+  contract (returns `:ok` synchronously after enqueueing) is part of
+  the public API; an unreachable error arm is a code smell that
+  obscures the actual error path (the new `try`/`rescue`/`catch`).
+- **Qualifier (Q):** Holds only as long as the callees remain `cast`.
+  If a future PR converts them to `call` (which would surface
+  async-reload errors), this claim no longer applies and the
+  `{:error, _}` arm must be re-introduced. Solution §"Open questions"
+  flags this trade-off explicitly.
+- **Rebuttal (R):** If a developer reintroduces `{:error, _}` returns
+  by changing the callee to `call`, the now-deleted arm must be
+  restored. The amendment log of solution.md and the @spec on the
+  callee make this discoverable.
+- **Backing (B):** Erlang/OTP `GenServer.cast/2` documentation
+  (https://hexdocs.pm/elixir/GenServer.html#cast/2); revision-1 history
+  in solution.md confirms manual inspection of both callee files.
+
+#### Falsification attempt for claim 4
+
+- **Strategy:** Dependency check — verify the callee return shapes at
+  the cited line numbers.
+- **Attempt:** Read `lib/tau/extensions/loader.ex:65` and
+  `lib/tau/mcp/reconciler.ex:44`. Both are exactly
+  `GenServer.cast(__MODULE__, …)` with `@spec :: :ok`. No alternative
+  return shape can flow from these callees as written.
+- **Outcome:** withstood — the dead arm is genuinely dead.
+- **Action:** none.
+
+### Claim 5: `@spec` widening for `list/1` and `status/1` (0 → 0 | 1) and preservation of `0 | 2` for `reload/1` aligns Dialyzer with the new exit-code shape
+
+- **Claim (C):** `Tau.CLI.Extensions.list/1`, `Tau.CLI.MCP.list/1`, and
+  `Tau.CLI.MCP.status/1` widen `@spec :: 0` to `0 | 1`;
+  `Tau.CLI.Extensions.reload/1` and `Tau.CLI.MCP.reload/1` keep
+  `@spec :: 0 | 2`; the `2` exit code is repurposed from
+  "application-level reload error" to "process unavailable / unexpected
+  exception".
+- **Grounds (G):** Current `@spec`s at
+  `lib/tau/cli/extensions.ex:17` (`@spec list(opts()) :: 0`),
+  `:49` (`@spec reload(opts()) :: 0 | 2`),
+  `lib/tau/cli/mcp.ex:21` (`@spec list(opts()) :: 0`),
+  `:48` (`@spec status(opts()) :: 0`),
+  `:80` (`@spec reload(opts()) :: 0 | 2`). The dispatch sink at
+  `lib/tau/cli.ex:816-817` (`defp halt(code) when is_integer(code), do:
+  System.halt(code)`) accepts any integer.
+- **Warrant (W):** Dialyzer reads `@spec` declarations to constrain
+  return-type inference; if a function can now return `1` but the
+  `@spec` says only `0`, Dialyzer raises a contract violation. The
+  widening is the type-level mirror of the behavioural change.
+- **Qualifier (Q):** Conditional on Dialyzer being run as part of CI.
+  `CLAUDE.md` lists `mix dialyzer` in the project lint set, so this is
+  satisfied in normal operation.
+- **Rebuttal (R):** If a future patch narrows `@spec` back to `0`
+  without removing the `1` return path, Dialyzer will catch it on next
+  run — the alignment is self-checking by tooling.
+- **Backing (B):** Dialyzer success-typing documentation
+  (https://hexdocs.pm/dialyxir/readme.html); CLAUDE.md project-rules
+  section listing `mix dialyzer` in the lint set.
+
+#### Falsification attempt for claim 5
+
+- **Strategy:** Type-level check — mentally simulate Dialyzer over the
+  proposed new shapes.
+- **Attempt:** For `list/1` post-change, body is `try` returning `0` on
+  success, `1` on `rescue` / `catch` arms. Union of returns is `0 | 1`,
+  matching the proposed widened `@spec`. For `reload/1`, body is `try`
+  returning `0` on success, `2` on `rescue` / `catch` arms. Union is
+  `0 | 2`, matching the preserved `@spec`. Caller at `lib/tau/cli.ex`
+  pipes into `halt/1` which accepts any integer; no caller-side
+  contract is violated.
+- **Outcome:** withstood — the `@spec` updates exactly match the
+  function bodies; Dialyzer would not flag the change.
+- **Action:** none.
+
+### Claim 6: Amending NN #7 in the same PR family adds a documented carve-out for targeted `catch :exit, {:noproc, _}` at CLI/TUI command boundaries
+
+- **Claim (C):** `.claude/rules/otp-non-negotiables.md` rule #7 is
+  amended in the same PR to add an explicit carve-out permitting
+  *targeted* (named exit-reason) `catch :exit` at CLI/TUI command
+  boundaries, citing `lib/tau/providers/rate_limiter.ex:86` as the
+  existing precedent.
+- **Grounds (G):** Current text at `.claude/rules/otp-non-negotiables.md:26-27`
+  reads "Let it crash; supervise; restart. MUST NOT `try/rescue` across
+  process boundaries. MUST NOT catch `:exit`" — no qualifier
+  distinguishing wildcard from targeted catches. Existing
+  `rate_limiter.ex:80-92` already uses
+  `catch :exit, {:timeout, _} -> …; :exit, {:noproc, _} -> :ok` and
+  ships today; the carve-out makes the precedent and the new code
+  literally rule-compliant.
+- **Warrant (W):** Rules that admit unwritten exceptions ("the rule
+  doesn't really mean that case") are weaker than rules whose
+  carve-outs are written down. The amendment converts an implicit
+  pattern (already present) into an explicit rule, restoring the
+  rule's literal correspondence to the practice.
+- **Qualifier (Q):** The carve-out is narrowly scoped to CLI/TUI
+  command boundaries and to *named* (pattern-matched) exit reasons; a
+  bare `catch :exit, _ -> _` remains forbidden under the amended rule.
+- **Rebuttal (R):** If during PR review the amendment is rejected on
+  the grounds that NN #7's literal reading is load-bearing for other
+  reasons, the fallback (solution §"Open questions" bullet 3) is the
+  deletion-only form plus a top-level `Tau.CLI.main/1` rescue. That
+  fallback also requires touching `cli.ex`, which the current solution
+  avoids; the trade-off is explicit.
+- **Backing (B):** Project's `tau-architecture` and
+  `factory-loop.md`'s spec-amendment-in-same-PR pattern; the existing
+  precedent at `rate_limiter.ex:86`; solution.md's revision-1
+  acknowledgement that NN #7 has no wildcard qualifier today.
+
+#### Falsification attempt for claim 6
+
+- **Strategy:** Counter-example construction — try to find a pattern of
+  `catch :exit` that the amendment would (perhaps unintentionally)
+  permit but that is genuinely harmful (i.e., a wildcard-equivalent
+  spelled as a near-wildcard).
+- **Attempt:** Consider `catch :exit, reason when is_term(reason) ->
+  swallow(reason)`. This pattern names `reason` but `is_term/1` matches
+  everything; semantically it is a wildcard with a guard that never
+  fires. The amendment as drafted ("a *targeted* `catch :exit,
+  {:noproc, _}` (or other named exit-reason shape)") emphasises
+  shape-matching on the exit reason, not mere binding; a guard-as-
+  wildcard sidesteps the spirit. This is a real loophole the amendment
+  text should close by requiring the named pattern to be a *structural*
+  shape (tuple, atom-literal, or specific exception), not a bound
+  variable with a true-everywhere guard.
+- **Outcome:** partially falsified — the amendment as drafted is
+  open to a "named-but-wildcard" reading; in practice the rate_limiter
+  precedent and the solution's own code use structural matches, but
+  the rule text should be tightened to forbid the loophole.
+- **Action:** narrow Qualifier. The amendment text should be tightened
+  to read approximately: "a *targeted* `catch :exit, <structural
+  pattern>` (e.g., `{:noproc, _}`, `{:timeout, _}`, or a specific atom
+  reason) — but NOT a bound-variable-only pattern such as
+  `catch :exit, reason -> swallow(reason)` without a structural
+  match". This narrowing does not invalidate Claim 6 or require a
+  solution revision; it adds a textual constraint to the amendment
+  that the PR author should incorporate. Recorded here for the
+  PR-time tightening; not severe enough to require a fresh
+  propose/select cycle.
+
+  Note: solution.md's draft already includes the fallthrough `catch
+  :exit, reason -> …` arm, which under a tightened amendment would
+  itself need to satisfy "structural pattern OR explicit allowlist of
+  diagnostic-only fallthroughs at the command boundary". Since that
+  fallthrough surfaces the reason via stderr (does not swallow), it is
+  within the spirit of the rule and should be admitted by the amended
+  text — the tightening must permit `reason`-binding when the binding
+  is forwarded to diagnostic output.
+
+### Claim 7: Asynchronous cast-based reload semantics are preserved (reload returns 0 on cast delivery regardless of async outcome)
+
+- **Claim (C):** `tau extensions reload` and `tau mcp reload` continue
+  to return `0` as soon as the cast is delivered; surfacing async-
+  reload errors would require changing the callee API and is out of
+  scope.
+- **Grounds (G):** Solution §"What does not change" bullet 4 names this
+  explicitly. Both callees remain `GenServer.cast`
+  (`lib/tau/extensions/loader.ex:65`, `lib/tau/mcp/reconciler.ex:44`);
+  the new `try` block wraps only the cast call, so any failure to
+  *deliver* the cast (registry lookup yielding `:noproc`, etc.) is
+  surfaced, but failure of the *handler* code that runs asynchronously
+  is not.
+- **Warrant (W):** `GenServer.cast/2`'s contract is fire-and-forget;
+  the caller cannot observe handler outcomes without a separate
+  feedback channel. Preserving the callee API preserves the
+  semantics.
+- **Qualifier (Q):** "Reload requested" vs "reload completed" is the
+  cast/call distinction; users who need confirmation must use a
+  separate query.
+- **Rebuttal (R):** If a user expects `tau mcp reload` to return
+  non-zero when the reload *handler* fails, this PR does not deliver
+  that — and the existing `safe_reload/0` shim never did either (the
+  shim only caught delivery-time exits, not handler-time failures).
+  The user-visible behaviour is unchanged in this dimension.
+- **Backing (B):** Erlang/OTP `GenServer.cast/2` documentation;
+  solution.md "Open questions" bullet 2.
+
+#### Falsification attempt for claim 7
+
+- **Strategy:** Integration check — verify that the test surface at
+  `test/tau/cli/extensions_test.exs` and `test/tau/cli/mcp_test.exs`
+  does not assert async-reload outcomes.
+- **Attempt:** Read both test files. They assert only that `reload/1`
+  exits 0 in the happy path (`test "asks Tau.MCP.Reconciler to
+  reconcile and exits 0" do … assert 0 == CLI.reload([])`) — no
+  async-outcome assertion. The PR's behaviour matches the existing
+  test surface.
+- **Outcome:** withstood — async-cast semantics are preserved, and
+  the test surface does not contradict the claim.
+- **Action:** none.
+
+## Cross-claim consistency
+
+The seven claims form a coherent set:
+
+- Claims 1–3 describe the code-shape change at the four named
+  functions; Claim 4 removes a now-dead arm; Claim 5 aligns the
+  type-level contract with the new shape; Claim 6 makes the rule
+  amendment explicit; Claim 7 documents what intentionally does not
+  change.
+- Claim 4's removal of the `{:error, _}` arm is consistent with
+  Claim 7's preservation of async-cast semantics: both rest on the
+  same observation (`reload_all/0` and `reload/0` are `GenServer.cast`
+  and return only `:ok`). If one of these claims were false, the other
+  would also need revision — and the dependency check on
+  `lib/tau/extensions/loader.ex:65` and `lib/tau/mcp/reconciler.ex:44`
+  confirms both.
+- Claims 2 and 6 are mutually load-bearing: Claim 2's targeted catch
+  is rule-compliant only under Claim 6's amendment. The solution
+  states the dependency explicitly and provides a fallback (top-level
+  `main/1` rescue) in §"Open questions" if Claim 6's amendment is
+  rejected at PR review.
+- The partial falsification on Claim 6 (named-but-wildcard loophole in
+  the amendment text) does not destabilise Claim 2: the solution's
+  actual code uses structural matches (`{:noproc, _}`) plus a
+  diagnostic-forwarding fallthrough (`reason`-binding sent to stderr),
+  which a tightened amendment would still permit.
+
+No tension between the seven claims; no escalation needed.
+
+## Falsification summary
+
+| # | Claim (short) | Strategy | Outcome | Action |
+|---|---|---|---|---|
+| 1 | Delete four safe_* helpers | Dependency check | withstood | none |
+| 2 | Three-arm try at command boundary | Counter-example | withstood | none |
+| 3 | `rescue _` covers non-exit exceptions | Edge-case enumeration | withstood | none |
+| 4 | `{:error, _}` arm is dead, removed | Dependency check | withstood | none |
+| 5 | `@spec` widening aligns with Dialyzer | Type-level check | withstood | none |
+| 6 | NN #7 amendment with targeted carve-out | Counter-example | partially falsified — named-but-wildcard loophole | narrow Qualifier; tighten amendment text at PR time |
+| 7 | Async cast semantics preserved | Integration check | withstood | none |
+
+## Revision required
+
+None at the solution level. The single partial falsification (Claim 6)
+narrows the Qualifier of the amendment-text wording in place: the PR
+author should ensure the carve-out language requires a *structural*
+exit-reason pattern (or a documented diagnostic-forwarding fallthrough),
+not a bound-variable-with-true-guard. This is a textual tightening of
+the rule amendment, recordable on the PR itself, and does not require
+re-running propose/select.
+
+- **Target file:** none for re-dispatch; advisory note to the PR
+  author for the amendment-text wording in
+  `.claude/rules/otp-non-negotiables.md`.
+- **Revision kind:** advisory only (PR-time tightening of amendment
+  text).
+- **Rationale:** The structural-loophole concern is a textual
+  refinement that does not affect the code change or the chosen
+  solution shape. Treating it as a full solution revision would be
+  pre-emptive over-narrowing per the validate.md anti-pattern list.
+
+## Outstanding doubts
+
+- The NN #7 amendment is asserted in solution.md to ship in the same
+  PR family as the code change. The `factory-loop.md` rule (cited in
+  CLAUDE.md) requires SPEC amendments to land *in the same PR* as the
+  code that depends on them. The rules file
+  (`.claude/rules/otp-non-negotiables.md`) is not strictly a SPEC, but
+  the same principle applies — the validator notes the PR should bundle
+  the amendment with the code change, not split them. If the
+  amendment is split into a separate PR, the code-change PR would
+  ship a rule violation under literal NN #7 reading; the parent
+  validator should confirm same-PR landing.
+- The solution's "fallback if NN amendment is rejected" pivot (top-level
+  rescue in `Tau.CLI.main/1`) widens the PR's blast radius from three
+  files to four and changes the failure-diagnosis surface (top-level
+  rescue cannot produce per-command stderr prefixes without
+  threading command identity through). This is acceptable as a
+  fallback, but the parent should be aware that the fallback is
+  meaningfully different from the primary plan and may itself warrant
+  a fresh propose/select for the wider scope.
+- The existing tests (`test/tau/cli/extensions_test.exs:24,29,37,43`
+  and `test/tau/cli/mcp_test.exs:27,35,43,48,56,62`) all assert
+  `assert 0 == CLI.<fn>(...)` in the happy path. The PR must add
+  failure-path tests asserting the `1` / `2` return codes and the
+  stderr diagnostic content — the solution's migration sketch mentions
+  updating tests "asserting `list/1 == 0` when the supervisor is down"
+  but does not require new positive failure-path tests. The parent
+  should consider whether the AC's "diagnostically useful error
+  message" clause demands an explicit test on stderr content.

--- a/docs/problems-archive-v1-modules/tau-cli/subproblems/reflective-module-dispatch/problem.md
+++ b/docs/problems-archive-v1-modules/tau-cli/subproblems/reflective-module-dispatch/problem.md
@@ -1,0 +1,71 @@
+---
+template_version: 1
+template_name: problem
+node_kind: leaf
+depth: 1
+parent: ../../problem.md
+status: draft
+---
+
+# Problem: resolve_provider and resolve_coding_agent build modules from arbitrary user strings
+
+## Statement
+
+The tail clauses of `Tau.CLI.resolve_provider/1` and
+`Tau.CLI.resolve_coding_agent/1` call `Module.concat(["Tau", "Providers",
+String.capitalize(other)])` and `Module.concat(["Tau", "CodingAgents",
+String.capitalize(other)])` on any string that does not match a known short
+name. `String.capitalize/1` applies only to the first byte, so compound names
+like `"openai"` produce `Tau.Providers.Openai` rather than
+`Tau.Providers.OpenAI`; the code even acknowledges this in a comment but ships
+the defect anyway. More broadly, `Module.concat/1` with an atom-producing path
+derived from user input unconditionally occupies an atom-table slot per unique
+CLI invocation, which is an atom-leak from a bounded resource.
+
+## Context
+
+- `lib/tau/cli.ex:782–788` — `resolve_coding_agent/1` tail clause:
+  `Module.concat(["Tau", "CodingAgents", String.capitalize(other)])`.
+- `lib/tau/cli.ex:812–814` — `resolve_provider/1` tail clause:
+  `Module.concat(["Tau", "Providers", String.capitalize(other)])`. Comment
+  at line 807–811 explains the `String.capitalize/1` limitation but accepts it.
+- `String.capitalize/1` uppercases only the first codepoint; "openai" → "Openai",
+  not "OpenAI". The known short names above handle all production providers; this
+  tail clause is only reachable with genuinely custom provider modules.
+- Elixir atoms are never garbage collected; `Module.concat/1` interns a new atom
+  for every distinct user-supplied string that reaches the tail clause.
+- The Optimus CLI surface provides no input validation before these functions
+  are called, so any string from `--provider` / `--coding-agent` can reach the
+  tail clause.
+
+## Complecting hypothesis
+
+- Known-name resolution is complected with open-ended module derivation in the
+  same function: the early clauses handle the closed set of registered providers
+  while the tail clause attempts to handle an open set via reflection, coupling
+  "parse a known flag value" to "create arbitrary atoms from user input".
+
+## Decomposition strategy
+
+(leaf — no further decomposition; proceed to proposals)
+
+## Acceptance criterion
+
+`resolve_provider/1` and `resolve_coding_agent/1` do not create atoms from
+arbitrary user-supplied strings; unknown provider/coding-agent strings are
+rejected with a clear error message before any atom is created; the documented
+`String.capitalize/1` limitation is removed.
+
+## Out of scope
+
+- `Tau.CLI.MCP.transport_for/1` string-vs-atom key probing (different function,
+  no atom-leak concern)
+- `safe_to_atom/1` in `Tau.CLI.Config` (uses `String.to_existing_atom/1` — no
+  atom leak; correct pattern)
+- `Init.provider_string/1` atom-to-string direction (inverse concern; no leak)
+- Doctor-cmd per-provider bespoke resolution (different function, no
+  Module.concat)
+
+## Amendment log
+
+- (none yet)

--- a/docs/problems-archive-v1-modules/tau-cli/subproblems/reflective-module-dispatch/proposals/proposal-1.md
+++ b/docs/problems-archive-v1-modules/tau-cli/subproblems/reflective-module-dispatch/proposals/proposal-1.md
@@ -1,0 +1,128 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 1
+parent_problem: ../problem.md
+---
+
+# Proposal 1: Delete the tail clauses — known-set closed, unknown-input error
+
+## Approach
+
+Remove the `Module.concat`/`String.capitalize` tail clauses from both
+`resolve_provider/1` and `resolve_coding_agent/1` entirely. Replace each tail
+clause with a pattern that returns `{:error, :unknown_provider, input}` /
+`{:error, :unknown_coding_agent, input}`. Change the callsite(s) that receive
+the resolved module to pattern-match on `{:error, reason, input}` and call
+`halt(1)` with a human-readable message naming the unrecognised value. The
+return type of both functions changes from `module()` to
+`{:ok, module()} | {:error, :unknown_provider | :unknown_coding_agent, String.t()}`.
+
+## Rationale
+
+The tail clauses exist to handle a putative "open set" of custom
+provider/coding-agent modules. In practice the comment at line 807–811 already
+admits the clause is wrong (`"Openai" ≠ "OpenAI"`), and no production code path
+benefits from it — every known provider has an explicit clause. Removing the
+clause eliminates the atom leak and the silent-wrong-module defect simultaneously.
+The decomplecting move is to split "input parsing" (closed-set match on a known
+value) from "module derivation" (open-ended reflection), and then simply not
+implement the open-ended reflection at all. The acceptance criterion's three
+requirements (no atom creation from user input, clear error on unknown input,
+`String.capitalize` limitation removed) are all satisfied by deletion alone.
+
+## Sketch
+
+```elixir
+# lib/tau/cli.ex
+
+@type resolve_error :: {:error, :unknown_provider | :unknown_coding_agent, String.t()}
+
+# resolve_coding_agent/1 — replaces current tail clause
+@doc false
+def resolve_coding_agent(nil), do: {:ok, nil}
+def resolve_coding_agent("claude_code"), do: {:ok, Tau.CodingAgents.ClaudeCode}
+def resolve_coding_agent("claudecode"), do: {:ok, Tau.CodingAgents.ClaudeCode}
+def resolve_coding_agent("replay"), do: {:ok, Tau.CodingAgents.Replay}
+
+def resolve_coding_agent(other) when is_binary(other),
+  do: {:error, :unknown_coding_agent, other}
+
+def resolve_coding_agent(mod) when is_atom(mod), do: {:ok, mod}
+
+# resolve_provider/1 — replaces current tail clause
+defp resolve_provider(nil), do: {:ok, Tau.Provider.default()}
+defp resolve_provider("anthropic"), do: {:ok, Tau.Providers.Anthropic}
+# ... existing known-name clauses wrapped in {:ok, ...} ...
+
+defp resolve_provider(other) when is_binary(other),
+  do: {:error, :unknown_provider, other}
+
+# Callsite (run_cmd/1 or wherever RuntimeOpts is built):
+defp require_provider!(input) do
+  case resolve_provider(input) do
+    {:ok, mod} ->
+      mod
+
+    {:error, :unknown_provider, v} ->
+      IO.puts(:stderr, "Unknown provider: #{inspect(v)}. Known providers: anthropic, openai, ...")
+      halt(1)
+  end
+end
+```
+
+File changes: `lib/tau/cli.ex` only. No new modules, no new files.
+
+## Tradeoffs
+
+### Strengths
+
+- Satisfies all three acceptance-criterion requirements with the minimum
+  possible diff: no new abstraction, no new module, no new dependency.
+- Atom leak is closed unconditionally — no path through the code can reach
+  `Module.concat` from user input.
+- Return type is now honest about failure; callers must handle it explicitly.
+- Zero scope creep: touches only the two functions named in the problem.
+
+### Weaknesses
+
+- **API-breaking**: any caller that currently relies on `resolve_coding_agent/1`
+  or `resolve_provider/1` returning a bare module must be updated to unwrap
+  `{:ok, mod}`. This is an internal API (`@doc false` / `defp`) so scope is
+  bounded, but it still requires touching every callsite.
+- **Drops the open-set capability entirely**: a user who genuinely has a custom
+  provider module named `Tau.Providers.MyCustom` can no longer pass
+  `--provider mycustom` and have it resolved. They must add an explicit clause or
+  pass the full module name through a different mechanism. This is a
+  behaviour-correcting, not merely behaviour-preserving, change.
+- No migration path for that use case is provided within scope; downstream
+  breakage from an undocumented open-set use cannot be ruled out without a
+  codebase-wide grep.
+
+### Costs
+
+- Callsite changes: `resolve_provider` is `defp` so all callers are local to
+  `cli.ex`; estimated 1–3 callsites. `resolve_coding_agent` is `def` so callers
+  may be in tests. Expected test updates: any test that passes an unknown string
+  expecting a module back will need updating.
+- One PR, atomic, ~30–50 lines changed.
+
+## Dependencies
+
+- No prerequisite changes. Self-contained.
+
+## Confidence
+
+Medium. The closed-set is the correct model for this function. Confidence would
+be high if a codebase-wide grep confirms no caller depends on the open-set
+behaviour for a string not in the known set.
+
+## Prior art / references
+
+- Erlang/OTP convention: atoms are finite; `String.to_existing_atom/1` (used
+  elsewhere in the project, as noted in the problem's out-of-scope) is the
+  sanctioned pattern for the one case where the atom already must exist.
+- The `safe_to_atom/1` pattern in `Tau.CLI.Config` (out-of-scope but noted) is
+  an example of the correct "only atoms that already exist" discipline.
+- Elixir docs for `Module.concat/1`: "Creates a module from a list of atoms and
+  binaries. Atoms are preferred over strings." — but atoms are never GC'd.

--- a/docs/problems-archive-v1-modules/tau-cli/subproblems/reflective-module-dispatch/proposals/proposal-2.md
+++ b/docs/problems-archive-v1-modules/tau-cli/subproblems/reflective-module-dispatch/proposals/proposal-2.md
@@ -1,0 +1,146 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 2
+parent_problem: ../problem.md
+---
+
+# Proposal 2: Static registry map — data-driven closed set, `String.to_existing_atom` validation
+
+## Approach
+
+Replace the function-clause dispatch in both `resolve_provider/1` and
+`resolve_coding_agent/1` with module attributes that define the complete
+allowed-string-to-module mapping as a `%{String.t() => module()}` map. The
+tail clause is replaced by a map lookup that returns `{:error, :unknown}` on
+miss. No `Module.concat`, no atom creation from user input. The maps become
+the single source of truth for the project's known short names; the
+`String.capitalize` code path is removed entirely.
+
+## Rationale
+
+The current implementation conflates two distinct responsibilities inside function
+clauses: (1) a lookup table of string → module, and (2) a reflective
+fallback. Separating these by making the lookup table explicit as a module
+attribute turns the "closed set" into a data structure that is
+introspectable (for documentation, `--help` output, error messages that list
+valid values). The reflective fallback is simply not added. The atom-leak
+concern disappears because map keys are compile-time string literals and map
+lookups produce existing atoms (the module literals) or `nil`.
+
+## Sketch
+
+```elixir
+# lib/tau/cli.ex  (module attribute section)
+
+@provider_registry %{
+  "anthropic"   => Tau.Providers.Anthropic,
+  "openai"      => Tau.Providers.OpenAI.Chat,
+  "ollama"      => Tau.Providers.OpenAI.Chat,
+  "local"       => Tau.Providers.OpenAI.Chat,
+  "bedrock"     => Tau.Providers.Bedrock,
+  "gemini"      => Tau.Providers.Gemini,
+  "deepseek"    => Tau.Providers.DeepSeek,
+  "groq"        => Tau.Providers.Groq,
+  "mistral"     => Tau.Providers.Mistral,
+  "azure"       => Tau.Providers.AzureOpenAI,
+  "azure-openai"=> Tau.Providers.AzureOpenAI,
+  "custom"      => Tau.Providers.Custom,
+  "replay"      => Tau.Providers.Replay
+}
+
+@coding_agent_registry %{
+  "claude_code" => Tau.CodingAgents.ClaudeCode,
+  "claudecode"  => Tau.CodingAgents.ClaudeCode,
+  "replay"      => Tau.CodingAgents.Replay
+}
+
+# resolve_provider/1 — replaces all current clauses
+defp resolve_provider(nil), do: {:ok, Tau.Provider.default()}
+
+defp resolve_provider(name) when is_binary(name) do
+  case Map.fetch(@provider_registry, name) do
+    {:ok, mod} -> {:ok, mod}
+    :error     -> {:error, :unknown_provider, name, Map.keys(@provider_registry)}
+  end
+end
+
+# resolve_coding_agent/1 — replaces all current clauses
+def resolve_coding_agent(nil), do: {:ok, nil}
+
+def resolve_coding_agent(mod) when is_atom(mod), do: {:ok, mod}
+
+def resolve_coding_agent(name) when is_binary(name) do
+  case Map.fetch(@coding_agent_registry, name) do
+    {:ok, mod} -> {:ok, mod}
+    :error     -> {:error, :unknown_coding_agent, name, Map.keys(@coding_agent_registry)}
+  end
+end
+
+# Error tuple carries the known-values list so callers can print:
+# "Unknown provider 'foo'. Known providers: anthropic, bedrock, ..."
+```
+
+The error tuple is `{:error, :unknown_provider | :unknown_coding_agent, String.t(), [String.t()]}` —
+the fourth element is the list of valid keys, enabling rich error messages
+without hard-coding the list a second time in the error handler.
+
+File changes: `lib/tau/cli.ex` only.
+
+## Tradeoffs
+
+### Strengths
+
+- No `Module.concat`, no `String.capitalize`, no atom leak — acceptance
+  criterion fully satisfied.
+- The registry map is the single source of truth for valid short names; the
+  `--help` / error message can enumerate it without duplication.
+- Error messages can include "did you mean one of: ..." without a separate
+  constant, reducing the chance of documentation drift.
+- Behaviour-preserving for the closed known-set: all currently-working inputs
+  continue to resolve to the same module.
+- Easy to extend: adding a new provider is one map entry, not a new function
+  clause.
+
+### Weaknesses
+
+- **API-breaking** in the same way as Proposal 1: return type changes from
+  `module()` to tagged tuple; all callsites must be updated.
+- **More surface area than Proposal 1**: the map attribute is a new concept
+  in a file that currently uses function-clause dispatch everywhere else; it
+  departs from the local idiom.
+- **Still drops open-set capability**: same tradeoff as Proposal 1 — custom
+  module strings that are not in the map will error.
+- Pattern-match on function clauses is compiled to a jump table by the BEAM;
+  map lookup is a hash lookup. Both are O(1) for the sizes involved, but the
+  perf characteristic is different. Not a practical concern at CLI startup.
+
+### Costs
+
+- Callsite changes: same as Proposal 1. Estimated 1–3 for `resolve_provider`,
+  somewhat more for `resolve_coding_agent` since it is public.
+- The four-tuple error type is slightly more complex to handle than a
+  two-tuple; callers must destructure or ignore the hints list.
+- Test updates: tests for known strings need no change; tests passing unknown
+  strings expecting a module back will fail and need updating.
+
+## Dependencies
+
+- No prerequisite changes. Self-contained within `lib/tau/cli.ex`.
+
+## Confidence
+
+Medium-high. The map-registry pattern is used widely in Elixir CLI tools
+for `--option value` validation (e.g. `OptionParser` atom coercion, `ExDoc`
+formatter registry). Confidence would be high after verifying all callsites
+in tests.
+
+## Prior art / references
+
+- Elixir standard library `OptionParser` — uses atom keys in a keyword list
+  (effectively a static registry) for `--switches` type coercion.
+- Phoenix `plug_router` approach: route → handler is a compile-time map;
+  the pattern is ubiquitous in the BEAM ecosystem.
+- `Tau.CLI.Config.safe_to_atom/1` (project-internal, noted in problem
+  out-of-scope) demonstrates the project's existing preference for
+  existing-atom-only patterns.

--- a/docs/problems-archive-v1-modules/tau-cli/subproblems/reflective-module-dispatch/proposals/proposal-3.md
+++ b/docs/problems-archive-v1-modules/tau-cli/subproblems/reflective-module-dispatch/proposals/proposal-3.md
@@ -1,0 +1,171 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 3
+parent_problem: ../problem.md
+---
+
+# Proposal 3: Behaviour-based registry — providers and coding agents self-register, resolution via `String.to_existing_atom`
+
+## Approach
+
+Introduce a `Tau.Provider` behaviour callback `short_name/0 :: String.t()` (and
+the equivalent `Tau.CodingAgent.short_name/0`) that each provider/coding-agent
+module implements. At compile time, a module attribute in `Tau.CLI` is built by
+calling `short_name/0` on every module in the known list and inverting the
+result into a `%{String.t() => module()}` map — exactly as in Proposal 2, but
+derived from the modules themselves rather than hand-listed. The tail clause is
+replaced with a map lookup. `Module.concat` and `String.capitalize` are removed.
+For the open-set case (a user supplies a string not in the map), the proposal
+**optionally** allows `String.to_existing_atom/1` to probe whether the atom
+already exists in the system (meaning the module was compiled and loaded), which
+is atom-safe by construction.
+
+## Rationale
+
+The current coupling is: the `cli.ex` author must know every module name AND
+must maintain a parallel list of short-name aliases in function clauses. Adding
+a new provider requires changes in two places (the provider module and the CLI
+dispatcher). Giving each provider a `short_name/0` callback makes the module
+itself the source of truth. The CLI becomes a simple collector: enumerate known
+modules, collect their short names, build the map. The `String.capitalize`
+defect is removed because short names are now explicit strings, not derived by
+capitalisation. The atom-leak concern is addressed by deriving the map at
+compile time from module literals (not from user input) and using
+`String.to_existing_atom/1` for the optional open-set probe — that function
+only succeeds if the atom was already interned (i.e. the module was compiled in),
+never creating a new atom from user bytes.
+
+## Sketch
+
+```elixir
+# lib/tau/provider.ex  — add to existing behaviour
+@callback short_name() :: String.t() | [String.t()]
+
+# Example implementation in lib/tau/providers/openai/chat.ex
+@impl Tau.Provider
+def short_name(), do: ["openai", "ollama", "local"]
+
+# Example implementation in lib/tau/providers/anthropic.ex
+@impl Tau.Provider
+def short_name(), do: "anthropic"
+
+# lib/tau/cli.ex — compile-time registry construction
+@known_provider_modules [
+  Tau.Providers.Anthropic,
+  Tau.Providers.OpenAI.Chat,
+  Tau.Providers.Bedrock,
+  Tau.Providers.Gemini,
+  Tau.Providers.DeepSeek,
+  Tau.Providers.Groq,
+  Tau.Providers.Mistral,
+  Tau.Providers.AzureOpenAI,
+  Tau.Providers.Custom,
+  Tau.Providers.Replay
+]
+
+# Expand multi-value short_name/0 results at compile time
+@provider_registry (
+  for mod <- @known_provider_modules,
+      name <- List.wrap(mod.short_name()),
+      into: %{},
+      do: {name, mod}
+)
+
+defp resolve_provider(nil), do: {:ok, Tau.Provider.default()}
+
+defp resolve_provider(name) when is_binary(name) do
+  case Map.fetch(@provider_registry, name) do
+    {:ok, mod} ->
+      {:ok, mod}
+
+    :error ->
+      # Atom-safe open-set probe: only succeeds if the atom is already interned.
+      # Does NOT create a new atom when the module is unknown.
+      try do
+        mod = String.to_existing_atom("Elixir." <> name)
+        if :erlang.function_exported(mod, :stream, 3), do: {:ok, mod}, else: :error
+      rescue
+        ArgumentError -> :error
+      end
+      |> case do
+        {:ok, mod} -> {:ok, mod}
+        _          -> {:error, :unknown_provider, name, Map.keys(@provider_registry)}
+      end
+  end
+end
+```
+
+The `String.to_existing_atom` probe is safe: it raises `ArgumentError` (not
+creates a new atom) when the atom does not already exist. This restores
+meaningful open-set support for modules the user has compiled into the release,
+without the atom leak.
+
+File changes: `lib/tau/provider.ex` (add callback), each provider module (add
+`short_name/0` implementation), `lib/tau/cli.ex` (replace resolve functions).
+
+## Tradeoffs
+
+### Strengths
+
+- Removes `Module.concat` / `String.capitalize` — acceptance criterion fully
+  satisfied.
+- Each provider owns its short name: adding a new provider no longer requires
+  touching `cli.ex`.
+- The `String.to_existing_atom` probe restores a meaningful open-set path for
+  modules compiled into the release — the one real-world scenario where the
+  tail clause was useful — without creating atoms from arbitrary strings.
+- Compile-time map means registry errors (duplicate short names, typos) surface
+  at compile time, not at runtime.
+- `@known_provider_modules` attribute is also useful for `doctor_cmd`,
+  documentation generation, and `--help` enumeration.
+
+### Weaknesses
+
+- **Largest scope of change**: touches `lib/tau/provider.ex`, every provider
+  module, `lib/tau/cli.ex`, and analogously `Tau.CodingAgent` behaviour and
+  each coding-agent module.
+- Adding `short_name/0` to the `Tau.Provider` behaviour is an API-breaking
+  behaviour change: any external adapter that does not implement it will fail to
+  compile against the new behaviour. This is a real cost if the behaviour is used
+  outside the main repo.
+- The `String.to_existing_atom` probe is correct but slightly surprising; its
+  inclusion must be explained in a comment to avoid a future maintainer removing
+  it as "dead code".
+- The `try/rescue` around `String.to_existing_atom` conflicts with OTP
+  non-negotiable #7 ("MUST NOT `try/rescue` across process boundaries") in
+  letter if not in spirit — this is an intra-function defensive pattern, not
+  a cross-process boundary, but it will attract scrutiny in review.
+- Incremental delivery is harder: the `short_name/0` callback must land before
+  or with the `cli.ex` refactor.
+
+### Costs
+
+- Changes to 10+ provider modules (add one callback each), `provider.ex`,
+  `coding_agent.ex`, and `cli.ex`.
+- Test impact: provider behaviour tests must include `short_name/0`; CLI tests
+  for the open-set probe.
+- Estimated PR size: 150–250 lines changed across many files.
+
+## Dependencies
+
+- `Tau.Provider` behaviour already exists (`lib/tau/provider.ex`). The
+  `short_name/0` callback is additive; it does not alter existing callbacks.
+- All provider modules must be in scope in the same PR.
+
+## Confidence
+
+Medium. The approach is sound and the atom-safety of `String.to_existing_atom`
+is well-established. Confidence would be higher with a prototype confirming
+the compile-time `for` comprehension over module attributes works as expected
+in Mix (it does, but it is worth verifying with a spike).
+
+## Prior art / references
+
+- Elixir `Ecto.Adapter` behaviour: adapters declare their capabilities via
+  callbacks; the Ecto registry enumerates known adapters.
+- `String.to_existing_atom/1` — Elixir docs explicitly describe this as the
+  safe alternative to `String.to_atom/1`: "Will raise an ArgumentError if the
+  atom does not exist."
+- Hex `nerves_system_*` packages: each declares a `target/0` callback used by
+  Nerves CLI to discover available targets — same pattern as `short_name/0`.

--- a/docs/problems-archive-v1-modules/tau-cli/subproblems/reflective-module-dispatch/proposals/proposal-4.md
+++ b/docs/problems-archive-v1-modules/tau-cli/subproblems/reflective-module-dispatch/proposals/proposal-4.md
@@ -1,0 +1,156 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 4
+parent_problem: ../problem.md
+---
+
+# Proposal 4: Input-validation façade at the CLI boundary — reject before resolution
+
+## Approach
+
+Do not change the internals of `resolve_provider/1` or `resolve_coding_agent/1`
+at all. Instead, insert an explicit validation step at the Optimus argument
+parsing boundary — before either function is called — that checks the
+`--provider` and `--coding-agent` flag values against an allowlist of known
+short-name strings. Unknown values are rejected at the CLI boundary with a
+usage-style error message and `halt(1)`, so the `Module.concat` tail clauses are
+never reached in practice. In a separate, follow-on change (not this PR), the
+tail clauses are removed because they are now dead code. The `String.capitalize`
+limitation is also documented as a `@deprecated` or removed comment warning
+since the open-set path becomes inaccessible.
+
+## Rationale
+
+The atom-leak is a runtime hazard only if user input reaches `Module.concat`.
+If it never reaches that call, the hazard is closed. Inserting the guard at the
+CLI boundary is the "parse, don't validate" principle applied inward: by the
+time `run_cmd/1` calls `resolve_provider`, the string has already been validated
+to be a known member. This decomplects the CLI boundary concern (valid user
+input) from the resolution concern (string → module). It is also the most
+incremental path: the resolution functions are left structurally intact in this
+PR, and the tail-clause deletion is a trivial follow-on.
+
+## Sketch
+
+```elixir
+# lib/tau/cli.ex — add before run_cmd/1 or in the Optimus post-parse step
+
+@known_provider_strings ~w[
+  anthropic openai ollama local bedrock gemini deepseek groq
+  mistral azure azure-openai custom replay
+]
+
+@known_coding_agent_strings ~w[claude_code claudecode replay]
+
+# Validation function — called immediately after Optimus.parse! returns
+defp validate_cli_args!(parsed_args) do
+  with :ok <- validate_provider(parsed_args),
+       :ok <- validate_coding_agent(parsed_args) do
+    :ok
+  else
+    {:error, :unknown_provider, v} ->
+      IO.puts(:stderr,
+        "Unknown --provider value: #{inspect(v)}.\n" <>
+        "Known values: #{Enum.join(@known_provider_strings, ", ")}"
+      )
+      halt(1)
+
+    {:error, :unknown_coding_agent, v} ->
+      IO.puts(:stderr,
+        "Unknown --coding-agent value: #{inspect(v)}.\n" <>
+        "Known values: #{Enum.join(@known_coding_agent_strings, ", ")}"
+      )
+      halt(1)
+  end
+end
+
+defp validate_provider(args) do
+  case args[:provider] do
+    nil -> :ok
+    v when v in @known_provider_strings -> :ok
+    v -> {:error, :unknown_provider, v}
+  end
+end
+
+defp validate_coding_agent(args) do
+  case args[:coding_agent] do
+    nil -> :ok
+    v when v in @known_coding_agent_strings -> :ok
+    v -> {:error, :unknown_coding_agent, v}
+  end
+end
+
+# resolve_provider/1 and resolve_coding_agent/1 are UNCHANGED in this PR.
+# The tail clauses become dead code; removal is a separate PR.
+```
+
+`validate_cli_args!` is called once per command dispatch, after Optimus parsing
+and before `run_cmd/1`. This adds a single guard layer without restructuring
+the resolution logic.
+
+File changes: `lib/tau/cli.ex` only (add ~30 lines; no existing code deleted in
+this PR).
+
+## Tradeoffs
+
+### Strengths
+
+- **Behaviour-preserving and non-breaking**: `resolve_provider/1` and
+  `resolve_coding_agent/1` signatures are unchanged; no callsite updates
+  required; no test changes to existing tests.
+- **Minimal diff in this PR**: ~30 lines added; no deletions. Easiest to
+  review and least likely to introduce a regression.
+- **Incremental**: the tail-clause deletion is a trivial follow-on PR that
+  removes dead code. The two PRs together complete the fix; neither is risky
+  alone.
+- **Atom leak is closed immediately**: the guard fires before `Module.concat`
+  is reached, satisfying the acceptance criterion.
+- Clear error messages enumerate the known values using the `@known_*_strings`
+  attributes, which are the single source of truth for the validation step.
+
+### Weaknesses
+
+- **Duplicates the known-names list**: `@known_provider_strings` and the
+  existing function clauses in `resolve_provider/1` are now two representations
+  of the same closed set. If a new provider is added, both must be updated —
+  the exact coupling problem Proposal 2 and 3 solve. This is the central
+  weakness.
+- **Does not remove `String.capitalize` in this PR**: the comment at line
+  807–811 ("wrong for compound names") remains until the follow-on PR. The
+  acceptance criterion includes "documented limitation is removed", which
+  technically requires the follow-on.
+- **Tail clauses remain as dead code** until the follow-on PR: a future reader
+  who does not know the guard exists may re-enable or rely on the tail clause.
+- **Open-set capability is removed silently** at the boundary without a clear
+  migration path: a user with `--provider mycustom` gets "unknown provider"
+  where before they got (wrongly-cased) module resolution.
+
+### Costs
+
+- This PR: ~30 lines added to `lib/tau/cli.ex`. No signature changes, no
+  other file changes, no test changes.
+- Follow-on PR (tail-clause deletion): ~15 lines deleted.
+- Total cost across both PRs is comparable to Proposal 1, but requires two
+  PRs rather than one.
+
+## Dependencies
+
+- No prerequisite changes.
+- The follow-on deletion PR depends on this PR merging first (the tail clauses
+  are only safe to delete after the guard is in place).
+
+## Confidence
+
+High. The pattern is trivially correct: a guard that rejects non-members of a
+compile-time set cannot leak atoms because it calls `halt(1)` before any atom
+creation. No new abstraction, no behaviour change for valid inputs.
+
+## Prior art / references
+
+- "Parse, don't validate" (Alexis King, 2019): parse user input into a known
+  type at the boundary; do not pass unvalidated strings inward.
+- Elixir's own `OptionParser` `:switches` option — validates that flag values
+  belong to the declared type at parse time, before the application sees them.
+- Standard CLI idiom: `argparse` (Python), `clap` (Rust), and `optparse` (Ruby)
+  all validate enum-constrained flag values at the boundary, before dispatch.

--- a/docs/problems-archive-v1-modules/tau-cli/subproblems/reflective-module-dispatch/solution.md
+++ b/docs/problems-archive-v1-modules/tau-cli/subproblems/reflective-module-dispatch/solution.md
@@ -1,0 +1,128 @@
+---
+template_version: 1
+template_name: solution
+parent_problem: ../../../problem.md
+node_kind: leaf
+synthesised_from: [proposals/proposal-2.md]
+selection_method: single
+revision: 0
+---
+
+# Solution: Static registry map replaces reflective tail clauses
+
+## Recommendation
+
+Replace the function-clause dispatch in `resolve_provider/1` and
+`resolve_coding_agent/1` with module attributes (`@provider_registry` and
+`@coding_agent_registry`) that define the complete allowed-string-to-module
+mapping as `%{String.t() => module()}` compile-time maps. The `Module.concat` /
+`String.capitalize` tail clauses are deleted. Unknown strings produce a tagged
+error tuple `{:error, :unknown_provider | :unknown_coding_agent, String.t(),
+[String.t()]}` where the fourth element is the map's key list, enabling
+self-updating error messages. Callsites unwrap `{:ok, mod}` or handle the error
+and `halt(1)`.
+
+## Selected from
+
+- **Chosen:** `proposals/proposal-2.md` (static registry map)
+- **Why chosen:** Proposal 2 is the only candidate that simultaneously satisfies
+  all three acceptance-criterion requirements in a single PR AND elevates the
+  closed set to a first-class data structure. Proposal 1 (deletion) satisfies the
+  AC with equal or less code but embeds the known set inside function-clause
+  structure rather than a named, inspectable attribute — the set is not decomplected
+  from the dispatch mechanism, only reorganised within it. Proposal 2's
+  `@provider_registry` attribute is the single source of truth for both dispatch
+  and error enumeration, removing the dual-representation risk that Proposal 4
+  explicitly creates and accepts. Proposal 3 satisfies the AC at far higher
+  migration cost (behaviour change across 10+ provider modules, `try/rescue`
+  conflicting with OTP non-negotiable #7 in letter) for a benefit — open-set
+  probing — that is out of scope and not required by the acceptance criterion.
+  Proposal 4 fails the acceptance criterion outright: it defers `String.capitalize`
+  removal to a follow-on PR and leaves duplicate known-name representations as a
+  permanent coupling. On the comparison heuristics, Proposal 2 has Substantial
+  decomplecting depth (the closed set becomes data); Proposal 1 has Surface depth
+  (still function-clause shaped, just error-returning); Proposal 3 is Deep but
+  costs High migration and Medium risk; Proposal 4 does not decomplect.
+
+| # | Fit | Decomplecting depth | Migration cost | Risk | Reversibility |
+|---|-----|---------------------|----------------|------|---------------|
+| 1 | Yes | Surface | Low | Low | Easy |
+| 2 | Yes | Substantial | Low | Low | Easy |
+| 3 | Yes | Deep | High | Medium | Hard |
+| 4 | Partially | None | Low | Low | Easy |
+
+## What changes
+
+- `lib/tau/cli.ex` — all changes are contained in this single file:
+  - Add `@provider_registry %{String.t() => module()}` module attribute
+    enumerating all known provider short-name → module mappings.
+  - Add `@coding_agent_registry %{String.t() => module()}` module attribute
+    enumerating all known coding-agent short-name → module mappings.
+  - Replace all existing function clauses in `resolve_provider/1` with:
+    a `nil` clause returning `{:ok, Tau.Provider.default()}`, a binary clause
+    doing `Map.fetch(@provider_registry, name)`, and no tail clause.
+  - Replace all existing function clauses in `resolve_coding_agent/1` with:
+    a `nil` clause, an atom-passthrough clause, a binary clause doing
+    `Map.fetch(@coding_agent_registry, name)`, and no tail clause.
+  - Update each callsite of `resolve_provider/1` and `resolve_coding_agent/1`
+    within `cli.ex` to unwrap `{:ok, mod}` or handle
+    `{:error, :unknown_provider | :unknown_coding_agent, name, known_list}`
+    with a `halt(1)` and a human-readable stderr message enumerating `known_list`.
+  - Delete the comment at lines 807–811 that documented the `String.capitalize`
+    limitation (the limitation is removed, not just documented away).
+
+## What does not change
+
+- `lib/tau/provider.ex` — the behaviour definition is unchanged; no new callback.
+- All provider modules under `lib/tau/providers/` — no change required.
+- All coding-agent modules under `lib/tau/coding_agents/` — no change required.
+- `Tau.CLI.MCP.transport_for/1` — explicitly out of scope.
+- `Tau.CLI.Config.safe_to_atom/1` — explicitly out of scope.
+- `Init.provider_string/1` — explicitly out of scope.
+- The existing `resolve_coding_agent/1` public API signature (the function
+  remains `def`, not `defp`); only the return type changes.
+
+## Migration sketch
+
+Single PR touching only `lib/tau/cli.ex`. Sequence:
+
+1. Add the two `@provider_registry` / `@coding_agent_registry` attributes.
+2. Replace `resolve_provider/1` clauses; wrap existing `{:ok, mod}` returns;
+   add error clause; delete tail clause.
+3. Replace `resolve_coding_agent/1` clauses; same pattern.
+4. Update the 1–3 internal callsites of `resolve_provider` in `cli.ex` to
+   handle tagged returns.
+5. Update `resolve_coding_agent` callers — check tests for external callers;
+   update any that expect a bare module.
+6. Verify `mix compile --warnings-as-errors` and `mix test`.
+
+The PR is fully atomic: either both resolution functions are map-based with
+error-returning types, or neither is. No partial-landing state.
+
+## Open questions
+
+- Are there external callers of `resolve_coding_agent/1` (it is `def`, not
+  `defp`) in tests or other modules that expect a bare `module()` return and
+  would need updating? A codebase-wide grep is required before implementation.
+- The error tuple carries `[String.t()]` as the fourth element (the known keys).
+  Callers must destructure this; if any caller only handles `{:error, reason}`
+  two-tuples today, those callsites will need updating beyond the resolution
+  functions. Check for defensive `{:error, _}` pattern matches.
+
+## Linked sub-problems / proposals
+
+- `proposals/proposal-1.md` — Delete tail clauses entirely, error-returning
+  return type. Satisfies AC; Surface decomplecting depth; ultimately dominated
+  by Proposal 2 on data-vs-code axis.
+- `proposals/proposal-2.md` — Static registry map. **Selected.** Substantial
+  decomplecting depth; same migration cost as Proposal 1; single source of truth.
+- `proposals/proposal-3.md` — Behaviour-based self-registration with
+  compile-time map derivation. Deep decomplecting but High migration cost,
+  `try/rescue` OTP tension, API-breaking behaviour change.
+- `proposals/proposal-4.md` — Validation façade at CLI boundary. Partially
+  satisfies AC (defers `String.capitalize` removal; introduces dual
+  representation). Not selected.
+
+## Revision history
+
+- (revision 0 — initial)

--- a/docs/problems-archive-v1-modules/tau-cli/subproblems/reflective-module-dispatch/validation.md
+++ b/docs/problems-archive-v1-modules/tau-cli/subproblems/reflective-module-dispatch/validation.md
@@ -1,0 +1,440 @@
+---
+template_version: 1
+template_name: validation
+parent_solution: solution.md
+parent_problem: problem.md
+toulmin_complete: true
+falsification_attempted: true
+falsification_outcome: partially_falsified — claim/3
+revision_triggered: none
+---
+
+# Validation: Static registry map replaces reflective tail clauses
+
+## Overview
+
+The solution proposes replacing the `Module.concat([..., String.capitalize(other)])`
+tail clauses in `Tau.CLI.resolve_provider/1` and `Tau.CLI.resolve_coding_agent/1`
+with compile-time `@provider_registry` / `@coding_agent_registry` maps, returning
+`{:ok, module}` or `{:error, :unknown_*, name, known_list}` and deleting the
+reflective fallback. This validation extracts six claims spanning AC satisfaction,
+file scope, atom-leak elimination, decomplecting depth, single-source-of-truth,
+and migration atomicity. The falsification strategies span dependency check,
+edge-case enumeration, integration check, counter-example construction, type-level
+check, and prior-art counter-case. Five claims withstood; **claim 3 (single-file
+change) is partially falsified** — the same defective pattern exists in
+`lib/mix/tasks/tau.hello.ex:74`, and the existing test
+`test/tau/cli_coding_agent_flag_test.exs:55` will break and must be updated as part
+of the same PR. Neither finding falsifies the acceptance criterion; both narrow
+claim 3's qualifier in place. No solution or problem revision is triggered.
+
+## Toulmin per claim
+
+The MITRE empirical study on Toulmin formalism found that "participants found
+it difficult to generate Toulmin structures, and their structures varied greatly
+even though they started with the same content"
+(https://www.mitre.org/news-insights/publication/empirical-evaluation-structured-argumentation-using-toulmin-argument).
+This template enforces all six components explicitly with prompts to counter
+that variance.
+
+### Claim 1: The acceptance criterion is fully satisfied — no atoms are created from arbitrary user strings, unknown values are rejected with a clear error, and the `String.capitalize/1` limitation is removed.
+
+- **Claim (C):** "Proposal 2 is the only candidate that simultaneously satisfies
+  all three acceptance-criterion requirements in a single PR" (solution.md
+  "Why chosen"). Concretely: post-change, `resolve_provider/1` and
+  `resolve_coding_agent/1` cannot atom-leak; unknown values produce
+  `{:error, :unknown_*, name, known_list}` which callsites translate to a
+  human-readable stderr message + `halt(1)`; the `String.capitalize/1` code
+  path and its apologetic comment (lines 807–811) are deleted.
+- **Grounds (G):** The post-change definitions sketched in
+  `proposals/proposal-2.md:36–78` use `Map.fetch/2` against compile-time map
+  attributes whose keys are literal strings and whose values are module
+  literals. `Map.fetch/2` does not create atoms (it hashes the binary key
+  against existing entries). No call to `Module.concat/1` or
+  `String.to_atom/1` remains anywhere in the function bodies. The acceptance
+  criterion in `problem.md:53–57` enumerates exactly these three
+  requirements; each is structurally addressed by the sketch.
+- **Warrant (W):** A function whose body is a closed-form map lookup over
+  literal keys with no atom-producing call site cannot create atoms from its
+  argument. This is the Elixir/Erlang atom-table contract: atoms enter the
+  table only via the documented constructors (`String.to_atom/1`,
+  `Module.concat/1`, `:erlang.binary_to_atom/2`, source/compile-time
+  literals, etc.). Map lookup is not such a constructor.
+- **Qualifier (Q):** Holds for all binary inputs to `resolve_provider/1` and
+  `resolve_coding_agent/1` after the change lands, given the callsites are
+  updated to handle the tagged-tuple return type. Does NOT extend to other
+  resolution functions in the codebase (covered by claim 6's out-of-scope
+  set).
+- **Rebuttal (R):** A maintainer could partially apply the change — e.g.
+  add the registries but leave the tail clause as a fallback — recreating
+  the leak. The solution's "fully atomic" sequencing (`solution.md` migration
+  sketch step 6 — "either both resolution functions are map-based with
+  error-returning types, or neither is") addresses this through PR discipline,
+  not code structure. The PR must be reviewed as a unit.
+- **Backing (B):** Erlang/OTP atom-table semantics (Erlang Efficiency Guide
+  §11.2, "Atoms are not garbage-collected"); the `.claude/rules/otp-non-negotiables.md`
+  invariant against runtime-derived atoms; `Tau.CLI.Config.safe_to_atom/1`
+  in this project (named in problem.md out-of-scope) which adopts
+  `String.to_existing_atom/1` for the same reason.
+
+#### Falsification attempt for claim 1
+
+- **Strategy:** Dependency check on the Elixir/Erlang primitive set used in
+  the post-change body — does any one of them implicitly create atoms?
+- **Attempt:** Enumerated the calls in the sketch:
+  `Map.fetch/2`, `Map.keys/1`, function-clause head matching, module-literal
+  returns (`Tau.Providers.Anthropic` etc.). Cross-checked each against
+  HexDocs / Erlang docs: `Map.fetch/2` performs hash lookup against the
+  existing key set with no atom-construction side effect;
+  `Map.keys/1` returns the existing map's atom values (no construction);
+  function-clause head matching does not construct atoms; module literals
+  are interned at compile time. Verified no `Module.concat` / `String.to_atom` /
+  `String.capitalize` remain in the sketched bodies.
+- **Outcome:** withstood — no atom-creating primitive remains in the proposed
+  bodies.
+- **Action:** none.
+
+### Claim 2: The registry map is the single source of truth for valid short names — dispatch and error enumeration both read from one inspectable data structure.
+
+- **Claim (C):** "Proposal 2's `@provider_registry` attribute is the single
+  source of truth for both dispatch and error enumeration, removing the
+  dual-representation risk that Proposal 4 explicitly creates and accepts"
+  (solution.md "Why chosen").
+- **Grounds (G):** The sketch returns
+  `{:error, :unknown_provider, name, Map.keys(@provider_registry)}` from the
+  miss branch (`proposals/proposal-2.md:64`). The error-handling callsite
+  consumes `known_list` directly (solution.md "What changes"); the list is
+  not duplicated. Adding a new entry to the map is the only edit needed for
+  it to appear in both dispatch and the error message.
+- **Warrant (W):** Hickey's "complect" lens: data and code are decomplected
+  when one is not derivable from the other. By making the map the source
+  and `Map.keys/1` the projection used for both dispatch and error display,
+  the closed set has exactly one representation; any drift between dispatch
+  and enumeration becomes structurally impossible.
+- **Qualifier (Q):** Holds while callsites use `Map.keys(@provider_registry)`
+  (or pass through the `known_list` carried by the error tuple) rather than
+  introducing a separately-maintained list in the error formatter.
+- **Rebuttal (R):** A future maintainer adding a "short alias" only to the
+  error message (e.g. "did you mean 'openai'?") would re-introduce a
+  second representation. The shape of the change does not prevent this; only
+  reviewer vigilance does.
+- **Backing (B):** Rich Hickey, "Simple Made Easy" (Strange Loop 2011) —
+  decomplecting closed-set representation from dispatch. ADR convention in
+  this repo (per `docs/adr/`) of keeping protocol/dispatch tables as data,
+  not as embedded code branches.
+
+#### Falsification attempt for claim 2
+
+- **Strategy:** Counter-example construction — try to construct a post-change
+  callsite shape that requires a second list to be maintained alongside
+  the registry.
+- **Attempt:** Considered (a) the `--help` enumeration of valid providers;
+  (b) error stderr messages; (c) doctor-command provider iteration. In
+  case (a), Optimus help text is generated from the option spec — if the
+  option spec ever needs an enumerated `validator:` callback, it would
+  use `Map.keys(@provider_registry)`, no second list. In (b), the error
+  tuple carries `known_list` directly. In (c) (out-of-scope per
+  `problem.md`), the doctor command currently iterates its own bespoke
+  list. The proposed change does not extend to it; if a future PR
+  consolidates, it would naturally use the registry.
+- **Outcome:** withstood — no callsite within the proposed change scope
+  requires a second representation.
+- **Action:** none.
+
+### Claim 3: The change is contained in a single file (`lib/tau/cli.ex`).
+
+- **Claim (C):** "all changes are contained in this single file" (solution.md
+  "What changes"). The migration sketch is "Single PR touching only
+  `lib/tau/cli.ex`."
+- **Grounds (G):** `grep -rn "resolve_provider\|resolve_coding_agent"` over
+  `lib/` and `test/` shows: production callsites of `Tau.CLI.resolve_*` in
+  `lib/tau/cli.ex` and only two external production sites —
+  `lib/tau/session/data.ex:366` and `lib/tau/session/coding_agent_turn.ex:749`,
+  both of which call only `Tau.CLI.resolve_coding_agent/1`. Two unrelated
+  `resolve_provider/1` functions exist (`lib/tau/session/provider_turn.ex:35`
+  and `lib/tau/session.ex:486`), but both already use
+  `String.to_existing_atom/1` — they are not subject to the atom-leak and
+  are correctly out of scope.
+- **Warrant (W):** A change's file scope is the union of (a) the function
+  bodies being modified, (b) every callsite whose contract is broken by
+  the signature change, and (c) every test that asserts the old behaviour.
+- **Qualifier (Q):** Holds for *production* code paths within the
+  problem's scope. Does **not** hold once we expand the scope to include
+  (i) the existing test at `test/tau/cli_coding_agent_flag_test.exs:53–56`
+  which asserts the reflective fallback ("foo" → `Tau.CodingAgents.Foo`),
+  and (ii) the duplicate `Module.concat([..., String.capitalize(other)])`
+  pattern at `lib/mix/tasks/tau.hello.ex:74` in `Mix.Tasks.Tau.Hello`.
+- **Rebuttal (R):** The test file is a legitimate part of the same PR by
+  every convention in the repo (tests live with the change they enforce);
+  the `mix/tasks/tau.hello.ex` site is a separate `defp resolve_provider/1`
+  inside an unrelated Mix task and is explicitly outside the problem's
+  scope (`problem.md` names only `Tau.CLI.resolve_provider/1` and
+  `Tau.CLI.resolve_coding_agent/1`). Strictly, the "single file" claim is
+  read as "of the two functions named in the problem, both live in
+  `lib/tau/cli.ex`", which is true.
+- **Backing (B):** `problem.md:14–24` explicitly scopes the problem to
+  `Tau.CLI.resolve_provider/1` and `Tau.CLI.resolve_coding_agent/1`; the
+  `spec-before-code.md` rule treats out-of-scope production sites as
+  separate problems requiring their own issue/PR.
+
+#### Falsification attempt for claim 3
+
+- **Strategy:** Counter-example construction — search the codebase for any
+  file outside `lib/tau/cli.ex` that either depends on the existing return
+  contract of `Tau.CLI.resolve_*` or duplicates the defective pattern.
+- **Attempt:** Ran `grep -rn "resolve_provider\|resolve_coding_agent"` and
+  `grep -rn "Module.concat.*String.capitalize"` across `lib/` and `test/`.
+  Findings:
+  1. `test/tau/cli_coding_agent_flag_test.exs:55` asserts
+     `Tau.CLI.resolve_coding_agent("foo") == Tau.CodingAgents.Foo`. This
+     test will FAIL after the change (return becomes
+     `{:error, :unknown_coding_agent, "foo", ["claude_code", "claudecode", "replay"]}`).
+     The test must be updated in the same PR.
+  2. `lib/tau/session/data.ex:366` and `lib/tau/session/coding_agent_turn.ex:749`
+     call `Tau.CLI.resolve_coding_agent(str)` and assign the result to a
+     case-arm value. After the change, both will receive a tagged tuple
+     instead of a module atom. These two callsites MUST be updated in the
+     same PR to unwrap `{:ok, mod}` and decide what to do on `{:error, …}`.
+     Neither is listed in `solution.md`'s "What changes" or
+     "What does not change"; the open question in solution.md gestures at
+     this risk but does not commit to fixing those sites.
+  3. `lib/mix/tasks/tau.hello.ex:74` duplicates the defective pattern
+     verbatim (`Module.concat(["Tau", "Providers", String.capitalize(other)])`)
+     in a private `resolve_provider/1`. It is in a Mix task module, not
+     `Tau.CLI`, and the problem scopes the work to `Tau.CLI` only. The
+     defect remains in the codebase after this change.
+- **Outcome:** partially falsified — the "single file" claim is true if
+  read as "the two named functions live in one file"; it is false if
+  read as "the PR touches only one file." At minimum the PR must edit
+  `test/tau/cli_coding_agent_flag_test.exs` and update the two external
+  callsites in `lib/tau/session/data.ex` and
+  `lib/tau/session/coding_agent_turn.ex`. The narrowed claim:
+- **Action:** Narrow the qualifier in place. The PR's actual file scope is
+  `lib/tau/cli.ex` + `lib/tau/session/data.ex` + `lib/tau/session/coding_agent_turn.ex` +
+  `test/tau/cli_coding_agent_flag_test.exs`. The `lib/mix/tasks/tau.hello.ex`
+  duplicate is a follow-up issue (same defect class, out of this problem's
+  scope per `problem.md:14`). The implementer brief MUST name the three
+  additional files; an "Outstanding doubts" entry below tracks the
+  hello-task duplicate.
+
+### Claim 4: The change has Substantial decomplecting depth — the closed set becomes data.
+
+- **Claim (C):** "Proposal 2 has Substantial decomplecting depth (the
+  closed set becomes data)" (solution.md "Why chosen"); table row:
+  Decomplecting depth = Substantial.
+- **Grounds (G):** Pre-change, the closed set is encoded as the sequence
+  of `defp resolve_provider("anthropic"), do: Tau.Providers.Anthropic`
+  clauses at `lib/tau/cli.ex:792–805` and equivalent for coding agents at
+  `:782–784`. The set is implicit in function-clause order; introspection
+  requires reading source. Post-change, the set is `@provider_registry`
+  and `@coding_agent_registry` — first-class data structures inspectable
+  via `Map.keys/1`, `Map.values/1`, and usable in error messages,
+  validators, and docstrings.
+- **Warrant (W):** Hickey's decomplecting principle (Simple Made Easy):
+  data is simpler than code that encodes the same information, because
+  data composes under standard operators (here: `Map.keys`, `Map.values`,
+  `Enum.sort`, `Enum.join`) without modifying its definition. Function-
+  clause dispatch entangles "this is a known name" with "this is what
+  the name resolves to" with "this is how dispatch fails," because
+  enumerating the set requires reading function bodies.
+- **Qualifier (Q):** Holds for the dispatch + enumeration pair; does not
+  extend to richer reflection (e.g. fetching a behaviour module's
+  `__info__/1` from the registry value), which neither the old nor new
+  shape supports.
+- **Rebuttal (R):** If the resolver ever needs to map a *runtime-derived*
+  module to a short name (the inverse direction), the map shape requires
+  `Map.new(@provider_registry, fn {k, v} -> {v, k} end)` or a second
+  attribute. Proposal 1 (function clauses) has the same problem in
+  inverse. Not a differential weakness.
+- **Backing (B):** Rich Hickey, "Simple Made Easy" (Strange Loop 2011);
+  this project's existing pattern in `lib/tau/tools/builtin/delegate.ex:118–119`
+  which uses exactly this idiom (`%{"claude_code" => Tau.CodingAgents.ClaudeCode, "replay" => Tau.CodingAgents.Replay}`)
+  as a module-level data registry for adapter lookup.
+
+#### Falsification attempt for claim 4
+
+- **Strategy:** Edge-case enumeration — list the kinds of consumer the
+  closed-set might face, and check whether the data form serves each
+  strictly better than the function-clause form.
+- **Attempt:** Enumerated consumers: (a) dispatch; (b) error enumeration;
+  (c) `--help` value-list rendering; (d) tests iterating over all known
+  names; (e) docstring auto-generation; (f) telemetry tagging by short
+  name. (a) is a tie; (b)–(f) require data. The function-clause form
+  cannot serve (b)–(f) without `Tau.CLI.__info__(:functions)` introspection
+  and re-deriving the closed set from clause heads — that itself is
+  reflection over compile-time information and is fragile.
+- **Outcome:** withstood — the data form dominates the function-clause
+  form for every consumer except parity-tie dispatch.
+- **Action:** none.
+
+### Claim 5: The PR is atomic — either both functions are map-based with tagged-tuple returns, or neither is. No partial-landing intermediate state.
+
+- **Claim (C):** "The PR is fully atomic: either both resolution functions
+  are map-based with error-returning types, or neither is. No partial-
+  landing state." (solution.md migration sketch.)
+- **Grounds (G):** Both functions live in the same file and are modified
+  in the same commit. Return-type changes are signature-level (every
+  caller breaks at compile time if not updated). The atomicity is
+  enforced by the BEAM compiler: a half-converted state cannot pass
+  `mix compile --warnings-as-errors`.
+- **Warrant (W):** When a signature change is detected by the compiler
+  at every callsite, partial-landing is impossible without ignoring
+  build errors, which the repo's CI gates (`lint` job:
+  `mix compile --warnings-as-errors`) forbid.
+- **Qualifier (Q):** Holds as long as CI's `--warnings-as-errors` gate
+  is in force (which it is, per `.github/workflows/ci.yml`).
+- **Rebuttal (R):** A developer running `mix compile` locally without
+  `--warnings-as-errors` could ship a half-updated callsite as a warning,
+  not an error. CI catches it before merge.
+- **Backing (B):** `.github/workflows/ci.yml` `lint` job;
+  `.claude/rules/factory-loop.md` gate-green requirement that
+  CI pass before merge.
+
+#### Falsification attempt for claim 5
+
+- **Strategy:** Type-level check — reason about the dialyzer / compile
+  warnings the change would produce. Identify any callsite that uses a
+  permissive pattern (`_ = result`) that would silently accept the
+  changed return.
+- **Attempt:** Inspected the three known callsites:
+  - `lib/tau/cli.ex:303`: `provider = resolve_provider(parsed.options[:provider])`
+    — assigns to a variable and passes to subsequent functions expecting
+    a module. Tagged-tuple return creates a compile-clean but
+    runtime-failing path UNLESS the next consumer pattern-matches; in
+    practice the variable is fed to `Tau.start_session/3` whose typespec
+    expects an atom, so dialyzer (if enabled) flags it.
+  - `lib/tau/cli.ex:764, 766`: `tui_put(opts, :provider, opts[:provider], &resolve_provider/1)`
+    — the transformer's result is `Keyword.put`'d directly. A tagged
+    tuple under `:provider` would not be a module atom; the TUI runtime
+    would crash on first use.
+  - `lib/tau/session/data.ex:366`, `lib/tau/session/coding_agent_turn.ex:749`:
+    `str when is_binary(str) -> Tau.CLI.resolve_coding_agent(str)` —
+    case-arm value; tagged tuple would propagate as the case result.
+  All three sites need updating; none currently use `_ = result`, so
+  the type change is visible at compile or test time, not silent.
+- **Outcome:** withstood — the type change is visible (test failure or
+  dialyzer warning) at every callsite; partial landing fails CI. Note:
+  this strengthens claim 5 by relying on the *same* callsites that
+  partially-falsify claim 3.
+- **Action:** none for claim 5. The callsite list discovered here is
+  the same one feeding claim 3's narrowed qualifier.
+
+### Claim 6: Out-of-scope items (other `resolve_provider/1` functions, `transport_for/1`, `safe_to_atom/1`, `Init.provider_string/1`, doctor-cmd resolution) are correctly excluded — they do not have the atom-leak defect.
+
+- **Claim (C):** "What does not change" lists `lib/tau/provider.ex`,
+  all provider/coding-agent modules, `MCP.transport_for/1`,
+  `Config.safe_to_atom/1`, `Init.provider_string/1`, and the
+  `resolve_coding_agent/1` public API signature.
+- **Grounds (G):**
+  - `lib/tau/session/provider_turn.ex:38–44`: uses
+    `String.to_existing_atom/1` inside try/rescue, returning
+    `Tau.Provider.default()` on failure — no leak.
+  - `lib/tau/session.ex:488–494`: same pattern, no leak.
+  - `Tau.CLI.Config.safe_to_atom/1` — explicitly named in `problem.md`
+    out-of-scope as "uses `String.to_existing_atom/1` — no atom leak;
+    correct pattern".
+  - `Tau.CLI.MCP.transport_for/1` — explicitly out of scope per
+    `problem.md`: "string-vs-atom key probing (different function, no
+    atom-leak concern)".
+- **Warrant (W):** A function leaks atoms only if it calls a constructor
+  that creates atoms from arbitrary binary input (`String.to_atom/1`,
+  `Module.concat/1` over user-derived strings, `:erlang.binary_to_atom/2`).
+  Functions using `String.to_existing_atom/1` or static
+  `Module.concat/1` over compile-time literals do not leak.
+- **Qualifier (Q):** Holds for the named functions today. Holds only as
+  long as those functions are not modified to use atom-creating
+  constructors in the future.
+- **Rebuttal (R):** The duplicate at `lib/mix/tasks/tau.hello.ex:74`
+  IS an additional atom-leak site (`Module.concat(["Tau", "Providers",
+  String.capitalize(other)])`) that this solution does NOT address.
+  It is genuinely out of scope per `problem.md` (which scopes only
+  `Tau.CLI.*`), but the defect remains in the repo after the change.
+  The "What does not change" list should mention it explicitly as
+  "out of scope by problem boundary, not by absence of defect."
+- **Backing (B):** `problem.md:60–67` explicit out-of-scope list;
+  Erlang Efficiency Guide §11.2 atom-table semantics.
+
+#### Falsification attempt for claim 6
+
+- **Strategy:** Prior-art counter-case + grep — search the codebase
+  for any other use of `Module.concat([..., String.capitalize(...)])`
+  or similar atom-creating patterns over user input.
+- **Attempt:** Ran `grep -rn "Module.concat.*String.capitalize" lib/`.
+  Result: two hits — the in-scope `lib/tau/cli.ex` (the target),
+  and `lib/mix/tasks/tau.hello.ex:74` (a Mix task duplicate). Also
+  ran `grep -rn "String.to_atom\b" lib/`; only safe uses (DSL macro
+  contexts, compile-time literals). Verified the named out-of-scope
+  functions do not use these constructors.
+- **Outcome:** withstood for the items the solution lists; partially
+  reinforces claim 3's narrowing (the hello-task duplicate is real
+  and unaddressed, but out of *this problem's* scope per `problem.md`).
+- **Action:** Surface the hello-task duplicate as an outstanding doubt
+  for the parent-level node to convert into a follow-up issue.
+
+## Cross-claim consistency
+
+Claims 1, 2, 4, 5, 6 are mutually consistent and reinforcing.
+
+Claim 3 (single-file change) and claim 5 (atomic PR via compile-time
+signature break) interact: the compile-time signature change that makes
+claim 5 robust is precisely what forces the additional file edits that
+narrow claim 3. The tension resolves cleanly — claim 5 is correctly
+"atomic *given* the additional callsites are updated in the same PR,"
+and claim 3's qualifier is narrowed in place to enumerate those callsites.
+
+Claim 6 (out-of-scope correctness) and claim 3 (single-file) interact
+weakly via the `lib/mix/tasks/tau.hello.ex:74` duplicate: the defect
+class is the same, but the problem boundary correctly excludes it.
+This is documented as an outstanding doubt for the parent node, not
+a falsification of either claim.
+
+No internal inconsistency requires escalation.
+
+## Falsification summary
+
+| # | Claim (short) | Strategy | Outcome | Action |
+|---|---|---|---|---|
+| 1 | AC fully satisfied | dependency check | withstood | none |
+| 2 | Map is single source of truth | counter-example construction | withstood | none |
+| 3 | Single-file change | counter-example construction | partially falsified | narrow qualifier; PR scope includes 3 extra files |
+| 4 | Substantial decomplecting depth | edge-case enumeration | withstood | none |
+| 5 | Atomic PR | type-level check | withstood | none |
+| 6 | Out-of-scope items correct | prior-art counter-case | withstood | hello-task duplicate noted as outstanding |
+
+## Revision required
+
+None. Claim 3's narrowed qualifier is documented in place; the implementer
+brief derived from this solution MUST name the additional files
+(`lib/tau/session/data.ex`, `lib/tau/session/coding_agent_turn.ex`,
+`test/tau/cli_coding_agent_flag_test.exs`) as in-scope for the same PR.
+No solution or problem revision is triggered.
+
+- **Target file:** n/a — no revision required.
+- **Revision kind:** n/a.
+- **Rationale:** All partial falsifications are absorbed by qualifier
+  narrowing without changing the chosen approach or the acceptance
+  criterion. The chosen solution still satisfies the AC.
+
+## Outstanding doubts
+
+- **Hello-task duplicate.** `lib/mix/tasks/tau.hello.ex:74` has the same
+  `Module.concat([..., String.capitalize(other)])` defect. It is out of
+  scope for this problem (which scopes only `Tau.CLI.*`) but the defect
+  class is identical. The parent-level node should convert this into a
+  follow-up issue/sub-problem so the codebase-wide cleanup is tracked.
+- **Existing test "unknown name fallback" semantics.**
+  `test/tau/cli_coding_agent_flag_test.exs:53–56` documents the current
+  reflective fallback as a *feature* ("unknown short name falls back to
+  Tau.CodingAgents.<X> shape"). The solution deletes that feature
+  intentionally. The implementer must update the test to assert the
+  new tagged-tuple `{:error, :unknown_coding_agent, …}` return instead.
+  This is a behaviour change visible to any external user who was
+  relying on the documented fallback; the PR description should call
+  it out, even though no in-tree caller depends on it.
+- **Default-provider nil return type.** Current
+  `resolve_provider(nil), do: Tau.Provider.default()` returns a bare
+  module; the sketch changes it to `{:ok, Tau.Provider.default()}`.
+  Symmetry with the binary clause is correct, but every nil-default
+  callsite (e.g. `lib/tau/cli.ex:303`) must unwrap the same way. This
+  is captured by claim 5's type-level check but is worth re-stating
+  for the implementer.

--- a/docs/problems-archive-v1-modules/tau-cli/subproblems/run-loop-raw-receive/problem.md
+++ b/docs/problems-archive-v1-modules/tau-cli/subproblems/run-loop-raw-receive/problem.md
@@ -1,0 +1,76 @@
+---
+template_version: 1
+template_name: problem
+node_kind: leaf
+depth: 1
+parent: ../../problem.md
+status: draft
+---
+
+# Problem: drain_run_loop uses hand-rolled receive instead of PubSub stream
+
+## Statement
+
+`Tau.CLI.drain_run_loop/2` and `drain_session_end/2` consume PubSub events
+via raw `receive` loops with a wildcard catch-all (`_ -> drain_run_loop/2`)
+that silently discards every `Events.*` struct not in their explicit allowlist.
+`drain_session_end/2` uses `receive after 10_000 -> exit_code`, returning the
+caller-seeded exit code on timeout — meaning a failed `SessionEnd` flush is
+reported as success. Both patterns violate OTP non-negotiable #4 (cross-process
+events must not be consumed via raw `receive`) and #7 (no `try/rescue` across
+process boundaries).
+
+## Context
+
+- `lib/tau/cli.ex:427–486` — `drain_run_loop/2`: handles `MessageEnd`,
+  `SessionEnd`, `ToolStart`, `ToolEnd`; wildcard `_ ->` clause recurses,
+  discarding `MessageStart`, `MessageUpdate`, `SessionStart`, `SystemNotice`,
+  `SkillActivated`, `Cancelled`, `ToolUpdate` and any future `Events.*` structs.
+- `lib/tau/cli.ex:489–497` — `drain_session_end/2`: `receive after 10_000 ->
+  exit_code` — returns the given `exit_code` on timeout instead of signalling
+  the flush failure.
+- The moduledoc at `lib/tau/cli.ex:36–46` acknowledges that `Tau.stream/2`
+  cannot be used here due to D-004 subscribe-before-start semantics, but the
+  chosen alternative (hand-rolled `receive`) violates the project's own
+  event-abstraction rules.
+- `run_cmd/1` at `lib/tau/cli.ex:344–362` wraps `Tau.send/2` in `try/after`
+  solely to guarantee telemetry-handler detachment — this is legitimate use of
+  `try/after` but is coupled to the hand-rolled loop.
+- OTP non-negotiable #4: "Cross-process events MUST use `Phoenix.PubSub` or
+  monitored refs."
+- OTP non-negotiable #7: "MUST NOT `try/rescue` across process boundaries."
+
+## Complecting hypothesis
+
+- Session-event consumption is complected with progress rendering:
+  `drain_run_loop/2` both drains the mailbox and inline-renders stderr
+  progress lines, which is why the wildcard discard appears necessary — the
+  loop is trying to do two things at once.
+- Exit-code semantics are complected with flush timing: `drain_session_end/2`
+  conflates "we timed out waiting" with "the session ended cleanly at the
+  exit code the caller chose", producing a silent false-positive on flush
+  failure.
+
+## Decomposition strategy
+
+(leaf — no further decomposition; proceed to proposals)
+
+## Acceptance criterion
+
+`tau run` drives the headless session without a raw `receive` loop; unknown
+`Events.*` structs are not silently discarded; a missing `SessionEnd` within
+the drain window results in a non-zero exit code rather than the caller-seeded
+success code; the D-004 subscribe-before-start invariant is preserved.
+
+## Out of scope
+
+- `safe_list/safe_reload` rescues in Extensions and MCP (owned by
+  error-swallowing-rescues)
+- `validate/1` rescue in Config and Init
+- `run_cmd/1` size beyond the loop extraction
+- Telemetry `attach_progress_handlers/4` — its `try/after` detach wrapper
+  is legitimate and is not part of this sub-problem
+
+## Amendment log
+
+- (none yet)

--- a/docs/problems-archive-v1-modules/tau-cli/subproblems/run-loop-raw-receive/proposals/proposal-1.md
+++ b/docs/problems-archive-v1-modules/tau-cli/subproblems/run-loop-raw-receive/proposals/proposal-1.md
@@ -1,0 +1,155 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 1
+parent_problem: ../problem.md
+---
+
+# Proposal 1: Subscribe-before-start wrapper around Tau.Session.stream/2
+
+## Approach
+
+Fix the D-004 constraint directly: extend `Tau.Session.stream/2` (or add a new
+`Tau.Session.stream_from/2` variant) to accept an already-open subscription
+handle rather than subscribing internally. `run_cmd/1` subscribes manually as it
+does today, then passes the subscription handle to the stream constructor; the
+stream function's setup phase becomes a no-op when a handle is supplied. The
+`drain_run_loop/2` and `drain_session_end/2` raw-`receive` bodies are deleted
+and replaced by a pipeline over `Tau.Session.stream_from/2 |> Enum.reduce_while`.
+
+## Rationale
+
+The D-004 comment in `cli.ex` explains exactly why `Tau.stream/2` is currently
+bypassed: subscription happens lazily inside `Stream.resource/3`'s setup
+function, which fires only on first pull — after `start_session` may have
+broadcast `SessionStart`. The fix is to accept an already-open subscription,
+making the stream's setup idempotent. This decomplects subscription timing from
+the stream's inner loop, removes the raw `receive`, and gives the stream's
+`after` clause (60 s timeout → `:halt`) the correct semantics for headless use
+rather than requiring a bespoke `after 10_000` timeout. Unknown events are
+handled by the existing passthrough clause (`msg when is_struct(msg)`) in the
+stream rather than silently discarded.
+
+## Sketch
+
+```elixir
+# lib/tau/session.ex — new variant (or new arity on stream/2)
+@spec stream_from(id(), :already_subscribed, keyword()) :: Enumerable.t()
+def stream_from(id, :already_subscribed, opts \\ []) do
+  timeout = Keyword.get(opts, :timeout, 60_000)
+  Stream.resource(
+    fn -> :ok end,   # subscriber already holds the mailbox
+    fn :ok ->
+      receive do
+        %Events.SessionEnd{session_id: ^id} = e -> {[e], :halt}
+        msg when is_struct(msg) -> {[msg], :ok}
+        _other -> {[], :ok}   # non-struct messages dropped without silencing Events.*
+      after
+        timeout -> {:halt, :ok}
+      end
+    end,
+    fn _ -> :ok end
+  )
+end
+
+# lib/tau/cli.ex — run_cmd/1 (replacement for drain_run_loop / drain_session_end)
+Phoenix.PubSub.subscribe(Tau.PubSub, "session:#{session_id}")
+
+session_id
+|> Tau.Session.stream_from(:already_subscribed, timeout: 10_000)
+|> Enum.reduce_while({%{}, 0}, fn event, {tool_names, _exit_code} ->
+  case event do
+    %Events.MessageEnd{message: msg} ->
+      handle_message_end(msg, session_id, tool_names)
+
+    %Events.SessionEnd{reason: reason} ->
+      code = if reason in [:normal, :user], do: 0, else: 1
+      {:halt, {tool_names, code}}
+
+    %Events.ToolStart{tool_call_id: id, name: name, arguments: args} ->
+      IO.puts(:stderr, "[tau] → #{name}(#{summarise_args(args)})")
+      {:cont, {Map.put(tool_names, id, name), 0}}
+
+    %Events.ToolEnd{tool_call_id: id, result: result} ->
+      name = Map.get(tool_names, id, "?")
+      marker = if is_struct(result, Tau.Message.ToolResult) && result.is_error, do: "✗", else: "✓"
+      IO.puts(:stderr, "[tau] ← #{name} #{marker}")
+      {:cont, {Map.delete(tool_names, id), 0}}
+
+    _unknown ->
+      # Unknown Events.* struct: log at debug, do not discard silently
+      Logger.debug("[tau] drain: unhandled event #{inspect(event.__struct__)}")
+      {:cont, {tool_names, 0}}
+  end
+end)
+|> then(fn {_tool_names, exit_code} -> exit_code end)
+```
+
+Timeout semantics: the stream's `after` timeout fires when no event arrives
+within the window. The `Enum.reduce_while` pipeline will exhaust (returning the
+accumulator) — the final `exit_code` in the accumulator is `0` by default,
+which is wrong if `SessionEnd` never arrived. Fix: sentinel initial exit code
+of `1` plus a `:halt` on `SessionEnd`:
+
+```elixir
+# Initial accumulator uses 1 (fail-safe) until SessionEnd delivers the correct code
+|> Enum.reduce_while({%{}, 1}, ...)
+```
+
+`drain_session_end` disappears entirely; the stream's timeout becomes the drain
+window, and a missing `SessionEnd` yields exit code 1 rather than the
+caller-seeded value.
+
+## Tradeoffs
+
+### Strengths
+
+- Removes both raw `receive` functions entirely; the entire event loop becomes a
+  single `Enum.reduce_while` over a typed stream.
+- Unknown `Events.*` structs are no longer silently discarded; they hit the
+  `_unknown` clause and can be logged.
+- `drain_session_end/2`'s silent false-positive on timeout is fixed: initial
+  accumulator carries `1`; only `SessionEnd` delivers `0`.
+- D-004 invariant preserved: subscription still precedes `start_session`.
+- `Tau.Session.stream_from/2` is reusable by any headless consumer that needs to
+  subscribe before starting.
+- Behaviour-preserving for all currently handled events.
+
+### Weaknesses
+
+- Adds a second entry point to `Tau.Session`'s stream API; callers must
+  understand the `:already_subscribed` sentinel contract.
+- The `after` clause in `stream_from/2` halts with no `SessionEnd` in the
+  accumulator — the calling code must treat the stream's natural exhaustion as a
+  timeout signal, which requires care in the `reduce_while` accumulator design.
+- Progress rendering (`IO.puts`) remains coupled to the event loop; this
+  proposal does not separate those concerns.
+- Does not fix the `run_cmd/1` size or its `try/after` coupling (out of scope,
+  but still visible).
+
+### Costs
+
+- `Tau.Session` gains one new exported function (or a new arity on `stream/2`).
+- `drain_run_loop/2` and `drain_session_end/2` are deleted (~60 lines removed,
+  ~35 lines of pipeline added).
+- Any test that exercises `drain_run_loop/2` / `drain_session_end/2` directly
+  must be rewritten against the pipeline (small: these functions are `@doc false`).
+- No dependency changes.
+
+## Dependencies
+
+- None. `Tau.Session.stream_from/2` depends only on `Phoenix.PubSub` and the
+  existing `Events` module, both already in scope.
+
+## Confidence
+
+Medium. The approach is straightforward; the D-004 fix and the accumulator
+design are both clear. Confidence would be high after a prototype run confirming
+that the stream's `after` clause fires correctly on a timeout and that the
+reduce-while terminates on `SessionEnd`.
+
+## Prior art / references
+
+- `Tau.Session.stream/2` (`lib/tau/session.ex:175`) — the existing `Stream.resource` pattern being extended.
+- D-004 comment at `lib/tau/cli.ex:296-299` — explicit description of the constraint being addressed.
+- Elixir `Stream.resource/3` docs — setup/next/cleanup contract.

--- a/docs/problems-archive-v1-modules/tau-cli/subproblems/run-loop-raw-receive/proposals/proposal-2.md
+++ b/docs/problems-archive-v1-modules/tau-cli/subproblems/run-loop-raw-receive/proposals/proposal-2.md
@@ -1,0 +1,201 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 2
+parent_problem: ../problem.md
+---
+
+# Proposal 2: Tau.CLI.RunLoop GenServer — supervised event consumer with monitored ref
+
+## Approach
+
+Replace the raw `receive` loops with a supervised `GenServer` (`Tau.CLI.RunLoop`)
+that subscribes to the session's PubSub topic in `init/1` (satisfying D-004:
+`GenServer.start_link` returns only after `init/1` completes, so the subscription
+is open before `start_session` is called), handles each `Events.*` struct as a
+distinct `handle_info/2` clause, and signals completion via a monitored ref.
+`run_cmd/1` starts the `RunLoop` process under a one-off `Task.Supervisor`,
+sends the prompt, then blocks with `receive do {:run_result, ref, code} -> code end`.
+Unknown events fall into a `handle_info({_, _}, state)` wildcard clause that
+logs at `:debug` but does NOT recurse on a raw-`receive` sentinel.
+
+## Rationale
+
+OTP NN #4 says cross-process events MUST use PubSub or monitored refs. This
+proposal uses both: PubSub for the inbound event subscription (same topic as
+today) and a monitored ref for the result handoff from `RunLoop` to `run_cmd/1`.
+The raw `receive` pattern is replaced by `handle_info/2` pattern matching —
+the canonical OTP mechanism for consuming mailbox messages. Separation of
+concerns: rendering (`IO.puts`) and event-dispatching are both in `RunLoop`,
+but each event type has its own `handle_info/2` clause rather than being
+crammed into a single recursive function. `drain_session_end/2`'s false-positive
+timeout disappears: the `RunLoop` `state.exit_code` starts at `1` and is updated
+only when a `SessionEnd` with `:normal` or `:user` reason arrives.
+
+## Sketch
+
+```elixir
+# lib/tau/cli/run_loop.ex
+
+defmodule Tau.CLI.RunLoop do
+  @moduledoc """
+  Supervised GenServer that consumes PubSub events for a headless `tau run`.
+  Subscribes to the session topic in init/1 (D-004 compliance).
+  Reports result via {:run_result, ref, exit_code} to the caller.
+  """
+  use GenServer
+  alias Tau.Session.Events
+
+  defstruct [:session_id, :caller, :ref, :tool_names, exit_code: 1]
+
+  def start_link(session_id, caller, ref) do
+    GenServer.start_link(__MODULE__, {session_id, caller, ref})
+  end
+
+  @impl true
+  def init({session_id, caller, ref}) do
+    # D-004: subscribe here, before caller calls Tau.start_session/1.
+    Phoenix.PubSub.subscribe(Tau.PubSub, "session:#{session_id}")
+    {:ok, %__MODULE__{session_id: session_id, caller: caller, ref: ref, tool_names: %{}}}
+  end
+
+  @impl true
+  def handle_info(%Events.MessageEnd{session_id: sid, message: msg}, %{session_id: sid} = state) do
+    tool_calls =
+      is_list(msg.content) && Enum.any?(msg.content, &match?(%{type: :tool_call}, &1))
+
+    cond do
+      tool_calls ->
+        {:noreply, state}
+
+      msg.stop_reason in [:error, :tool_loop_aborted, :aborted, :compaction_failed] ->
+        IO.puts(:stderr, "session error (#{msg.stop_reason}): #{Tau.CLI.extract_error_text(msg)}")
+        Tau.stop(sid)
+        {:noreply, %{state | exit_code: 1}}
+
+      true ->
+        text = Tau.CLI.extract_assistant_text(msg)
+        if text != "", do: IO.puts(text)
+        Tau.stop(sid)
+        {:noreply, %{state | exit_code: 0}}
+    end
+  end
+
+  def handle_info(%Events.SessionEnd{session_id: sid, reason: reason}, %{session_id: sid} = state) do
+    code = if reason in [:normal, :user], do: 0, else: 1
+    send(state.caller, {:run_result, state.ref, code})
+    {:stop, :normal, state}
+  end
+
+  def handle_info(%Events.ToolStart{session_id: sid, tool_call_id: id, name: name, arguments: args},
+                  %{session_id: sid} = state) do
+    IO.puts(:stderr, "[tau] → #{name}(#{Tau.CLI.summarise_args(args)})")
+    {:noreply, %{state | tool_names: Map.put(state.tool_names, id, name)}}
+  end
+
+  def handle_info(%Events.ToolEnd{session_id: sid, tool_call_id: id, result: result},
+                  %{session_id: sid} = state) do
+    name = Map.get(state.tool_names, id, "?")
+    marker = if is_struct(result, Tau.Message.ToolResult) && result.is_error, do: "✗", else: "✓"
+    IO.puts(:stderr, "[tau] ← #{name} #{marker}")
+    {:noreply, %{state | tool_names: Map.delete(state.tool_names, id)}}
+  end
+
+  # Timeout: no SessionEnd within the drain window → exit 1 (fail-safe)
+  def handle_info(:timeout, state) do
+    send(state.caller, {:run_result, state.ref, 1})
+    {:stop, :normal, state}
+  end
+
+  # Unknown Events.* struct: log, do not silently discard
+  def handle_info(unknown, state) when is_struct(unknown) do
+    require Logger
+    Logger.debug("[tau] RunLoop: unhandled event #{inspect(unknown.__struct__)}")
+    {:noreply, state}
+  end
+
+  def handle_info(_other, state), do: {:noreply, state}
+end
+
+# lib/tau/cli.ex — run_cmd/1 replacement for drain_run_loop call
+ref = make_ref()
+{:ok, _pid} = Task.Supervisor.start_child(
+  Tau.TaskSupervisor,
+  fn -> Tau.CLI.RunLoop.start_link(session_id, self(), ref) end
+)
+# RunLoop is now subscribed; safe to start session
+case Tau.start_session(start_opts) do
+  {:ok, ^session_id} ->
+    Tau.send(session_id, prompt)
+    receive do
+      {:run_result, ^ref, exit_code} -> exit_code
+    after
+      60_000 -> 1   # absolute wall-time safety net
+    end
+end
+```
+
+The `drain_session_end/2` function is deleted. The `RunLoop` GenServer's
+10-second `:timeout` (passed as `{:noreply, state, 10_000}` on the final
+`handle_info` after `Tau.stop/1`) provides the drain window; a missing
+`SessionEnd` causes `handle_info(:timeout, state)` to fire and reply with `1`.
+
+## Tradeoffs
+
+### Strengths
+
+- Fully OTP-compliant: `handle_info/2` replaces raw `receive`, and the
+  subscription opens in `init/1` before the caller proceeds.
+- Each event type is its own `handle_info/2` clause — adding a new handled
+  event is a one-clause addition, not a modification of a recursive function.
+- Unknown `Events.*` structs hit a named clause with a `Logger.debug` call,
+  not a wildcard recurse.
+- Timeout produces exit code `1` (fail-safe), not the caller-seeded value.
+- `Tau.CLI.RunLoop` is independently testable: you can `GenServer.start_link`
+  it in tests, send `Events.*` structs directly, and assert on replies.
+
+### Weaknesses
+
+- Introduces a new supervised process and a new module file for what is
+  currently a ~60-line set of private functions.
+- The caller still uses a raw `receive` for the final `{:run_result, ref,
+  exit_code}` handoff — technically complying with OTP NN #4 (the
+  result-signalling is a monitored ref, not a PubSub event), but it is a
+  raw `receive` in `run_cmd/1`.
+- `Tau.TaskSupervisor` must exist in the application's supervision tree; if it
+  does not, a `DynamicSupervisor` must be added first.
+- `summarise_args/1` and `extract_error_text/1` / `extract_assistant_text/1`
+  must be made `@doc false` public (they already are per the code) or duplicated.
+- Progress rendering remains coupled to event handling (same concern as Proposal 1).
+
+### Costs
+
+- One new file: `lib/tau/cli/run_loop.ex` (~70 lines).
+- `drain_run_loop/2` and `drain_session_end/2` deleted (~60 lines).
+- `run_cmd/1` loses 2 private function calls, gains ~10 lines of supervisor/ref
+  wiring.
+- Tests for the raw-`receive` functions must be replaced with tests for
+  `RunLoop` GenServer behaviour.
+- `Tau.TaskSupervisor` dependency: verify it exists in `lib/tau/application.ex`.
+
+## Dependencies
+
+- `Tau.TaskSupervisor` (or equivalent `DynamicSupervisor`) must be present in
+  the application supervision tree.
+- `Tau.CLI.extract_error_text/1`, `Tau.CLI.extract_assistant_text/1`, and
+  `Tau.CLI.summarise_args/1` must remain accessible from the new module (they
+  are already `@doc false` public).
+
+## Confidence
+
+Medium. The GenServer structure is straightforward; the D-004 compliance via
+`init/1` subscription is clean. Confidence would be high after confirming
+`Tau.TaskSupervisor` is available and verifying that `handle_info(:timeout)` is
+reachable when the `{:noreply, state, timeout_ms}` tuple is returned from the
+right clause.
+
+## Prior art / references
+
+- OTP NN #4 — "Cross-process events MUST use Phoenix.PubSub or monitored refs."
+- `Tau.TUI.App` — existing pattern of a supervised GenServer consuming PubSub events via `handle_info/2`.
+- Elixir `GenServer` docs — `handle_info/2` and the `{:noreply, state, timeout}` 3-tuple.

--- a/docs/problems-archive-v1-modules/tau-cli/subproblems/run-loop-raw-receive/proposals/proposal-3.md
+++ b/docs/problems-archive-v1-modules/tau-cli/subproblems/run-loop-raw-receive/proposals/proposal-3.md
@@ -1,0 +1,210 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 3
+parent_problem: ../problem.md
+---
+
+# Proposal 3: Split drain_run_loop into render and control; use selective receive via Task
+
+## Approach
+
+Decouple the two things `drain_run_loop/2` currently does — (1) decide when to
+stop and with what exit code, and (2) render progress to stderr — by introducing
+two separate, pure functions: `classify_event/2` (pure, returns `{:continue,
+new_state} | {:halt, exit_code} | :ignore`) and `render_event/1` (pure,
+`IO.puts` side-effect only). The raw `receive` itself is preserved but
+restructured as a `Task` inside `run_cmd/1` that owns the PubSub mailbox. The
+`Task` subscribes in its setup (`Task.async(fn -> subscribe; loop end)`), so
+subscription precedes the `start_session` call in the parent — which is achieved
+by `Task.async` + `Task.await`. `drain_session_end/2` is absorbed into the
+loop's terminal `{:halt, code}` path; a timeout in the task yields exit code `1`
+instead of the caller's seeded value.
+
+## Rationale
+
+This proposal addresses the complecting hypothesis directly: rendering is
+separated from control flow by making both explicit, named, pure functions.
+The raw `receive` is retained as the mechanism for mailbox consumption — it is
+not OTP NN #4-violating on its own when the receiving process IS the PubSub
+subscriber (the violation is doing it in the parent process across a process
+boundary, not in the subscriber itself). By moving the `receive` loop into a
+`Task` that subscribes and drains its own mailbox, OTP NN #4 is satisfied: the
+subscriber and the consumer are the same process. The `classify_event/2` function
+is property-testable in isolation. Unknown events return `:ignore` from
+`classify_event/2` and log at `:debug` rather than silently recurse.
+
+## Sketch
+
+```elixir
+# lib/tau/cli.ex — replace drain_run_loop/2 + drain_session_end/2
+
+# Pure classifier: all decision logic in one named, testable function
+@spec classify_event(struct(), map()) ::
+        {:continue, map()}
+        | {:halt, 0 | 1}
+        | :ignore
+defp classify_event(%Events.MessageEnd{message: msg}, tool_names) do
+  tool_calls = is_list(msg.content) && Enum.any?(msg.content, &match?(%{type: :tool_call}, &1))
+  cond do
+    tool_calls ->
+      {:continue, tool_names}
+    msg.stop_reason in [:error, :tool_loop_aborted, :aborted, :compaction_failed] ->
+      IO.puts(:stderr, "session error (#{msg.stop_reason}): #{extract_error_text(msg)}")
+      {:halt, 1}    # caller must invoke Tau.stop/1 before awaiting
+    true ->
+      text = extract_assistant_text(msg)
+      if text != "", do: IO.puts(text)
+      {:halt, :pending}   # stop was requested; wait for SessionEnd
+  end
+end
+
+defp classify_event(%Events.SessionEnd{reason: reason}, _tool_names) do
+  code = if reason in [:normal, :user], do: 0, else: 1
+  {:halt, code}
+end
+
+defp classify_event(%Events.ToolStart{tool_call_id: id, name: name}, tool_names) do
+  {:continue, Map.put(tool_names, id, name)}
+end
+
+defp classify_event(%Events.ToolEnd{tool_call_id: id}, tool_names) do
+  {:continue, Map.delete(tool_names, id)}
+end
+
+defp classify_event(unknown, tool_names) when is_struct(unknown) do
+  require Logger
+  Logger.debug("[tau] drain: unhandled #{inspect(unknown.__struct__)}")
+  {:continue, tool_names}  # :ignore semantics: carry state unchanged
+end
+
+# Pure renderer (called before classify so progress prints even on terminal events)
+defp render_event(%Events.ToolStart{name: name, arguments: args}) do
+  IO.puts(:stderr, "[tau] → #{name}(#{summarise_args(args)})")
+end
+
+defp render_event(%Events.ToolEnd{tool_call_id: id, result: result} = e) do
+  # name is looked up by caller since render_event is stateless
+  marker = if is_struct(result, Tau.Message.ToolResult) && result.is_error, do: "✗", else: "✓"
+  IO.puts(:stderr, "[tau] ← #{Map.get(e, :name, "?")} #{marker}")
+end
+
+defp render_event(_), do: :ok
+
+# Inner loop: runs inside the Task; receives from its own mailbox
+defp event_loop(session_id, tool_names, stop_requested?) do
+  receive do
+    event when is_struct(event) ->
+      render_event(event)
+      case classify_event(event, tool_names) do
+        {:continue, new_names} ->
+          event_loop(session_id, new_names, stop_requested?)
+        {:halt, :pending} ->
+          Tau.stop(session_id)
+          event_loop(session_id, tool_names, true)
+        {:halt, code} ->
+          code
+      end
+  after
+    # No SessionEnd within drain window → fail-safe exit 1
+    10_000 ->
+      if stop_requested?, do: 1, else: 1
+  end
+end
+
+# In run_cmd/1 — replace drain_run_loop(session_id) call:
+task =
+  Task.async(fn ->
+    Phoenix.PubSub.subscribe(Tau.PubSub, "session:#{session_id}")
+    # Signal parent that subscription is open
+    send(parent, {:subscribed, ref})
+    receive do
+      {:start, ^ref} -> event_loop(session_id, %{}, false)
+    end
+  end)
+
+# Wait for subscription to open before calling start_session
+receive do
+  {:subscribed, ^ref} -> :ok
+end
+
+case Tau.start_session(start_opts) do
+  {:ok, ^session_id} ->
+    send(task.pid, {:start, ref})
+    try do
+      case Tau.send(session_id, prompt) do
+        :ok   -> Task.await(task, :infinity)
+        {:error, reason} ->
+          Task.shutdown(task, :brutal_kill)
+          IO.puts(:stderr, "send error: #{inspect(reason)}")
+          1
+      end
+    after
+      :telemetry.detach(handler_id)
+    end
+end
+```
+
+`drain_session_end/2` is removed. The `event_loop/3` `after 10_000` clause
+handles the drain-window timeout, returning `1` rather than a caller-seeded
+value.
+
+## Tradeoffs
+
+### Strengths
+
+- `classify_event/2` is a pure function, directly property-testable: generate
+  sequences of events and assert on accumulated exit codes without any process
+  infrastructure.
+- Rendering and control flow are explicit, named, separate functions — the
+  complecting hypothesis is addressed at the code level.
+- The `receive` loop lives in the Task (the PubSub subscriber), not in the
+  parent process — OTP NN #4 is satisfied.
+- Unknown structs produce a `Logger.debug` log and continue; silent discard
+  is eliminated.
+- Timeout returns `1` (fail-safe).
+- Incremental: the inner pure functions can be extracted before the Task
+  wiring is changed.
+
+### Weaknesses
+
+- The `receive` loop is still a raw `receive` loop — it is now in a `Task`
+  rather than the parent process, but the pattern persists. Reviewers who
+  interpret OTP NN #4 strictly as "no raw receive anywhere" will object.
+- The Task-based subscription handshake (`{:subscribed, ref}` / `{:start, ref}`)
+  adds coordination boilerplate that is not idiomatic OTP — it is a hand-rolled
+  synchronisation protocol between two processes.
+- `render_event/1` is stateless, so `ToolEnd` rendering cannot access the
+  `tool_names` map to look up the name; requires either passing state or
+  enriching the event. The sketch above is slightly incomplete on this point.
+- The `Task.await(task, :infinity)` timeout relies on the inner `after 10_000`
+  to bound wait time; callers of `run_cmd/1` have no external timeout knob.
+
+### Costs
+
+- `drain_run_loop/2` and `drain_session_end/2` replaced by `classify_event/2`,
+  `render_event/1`, and `event_loop/3` (~80 lines, roughly equal to what is
+  removed).
+- `run_cmd/1` gains ~15 lines of Task wiring.
+- Tests for `classify_event/2` can be pure unit tests without process setup
+  (benefit).
+- No new modules, no new dependencies.
+
+## Dependencies
+
+- None beyond what already exists. `Phoenix.PubSub` and `Task` are both in
+  scope.
+
+## Confidence
+
+Medium. The decomplecting via `classify_event/2` is clear and testable. The
+Task-based subscription handshake is the uncertain part; it should work but adds
+non-trivial coordination boilerplate. Confidence would be raised by prototyping
+the handshake under property-based simulation of subscription-before-start
+race conditions.
+
+## Prior art / references
+
+- Elixir `Task.async/1` + `Task.await/2` — documented pattern for spawning a linked task and awaiting its result.
+- `classify_event/2` pure-function approach mirrors `Tau.Permissions.Evaluator` pattern: pure dispatch function over event structs.
+- Rich Hickey "Simple Made Easy" — separating rendering (side-effect) from classification (logic) as a core decomplecting move.

--- a/docs/problems-archive-v1-modules/tau-cli/subproblems/run-loop-raw-receive/proposals/proposal-4.md
+++ b/docs/problems-archive-v1-modules/tau-cli/subproblems/run-loop-raw-receive/proposals/proposal-4.md
@@ -1,0 +1,226 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 4
+parent_problem: ../problem.md
+---
+
+# Proposal 4: Headless event behaviour — pluggable drain via Tau.CLI.EventHandler behaviour
+
+## Approach
+
+Define a new `Tau.CLI.EventHandler` behaviour with a single callback
+`handle_event/2` that returns `{:continue, state} | {:halt, exit_code}`. The
+default implementation (`Tau.CLI.DefaultEventHandler`) replicates the current
+`drain_run_loop/2` logic per-event. `run_cmd/1` subscribes before `start_session`
+(D-004), then drives the event loop via `Tau.CLI.HeadlessDrainer.run/3` — a
+pure tail-recursive function that calls `Phoenix.PubSub`-received messages
+through `EventHandler.handle_event/2`. The drain function itself is a single,
+non-wildcard `receive` that pattern-matches on `is_struct(msg)` and passes
+anything else to a `:non_event` handler clause. A missing `SessionEnd` within
+the drain window causes the drain to return `{:error, :timeout}` → exit code 1.
+
+## Rationale
+
+This proposal replaces raw `receive` with a typed extension point: the
+`Tau.CLI.EventHandler` behaviour declares the contract, and concrete
+implementations are separately authored and tested. The complecting of rendering
+and control flow is addressed by allowing `DefaultEventHandler` to delegate
+rendering to a pure `render/1` sub-function while `handle_event/2` returns only
+control signals. More importantly, the behaviour seam means future headless
+consumers (batch mode, test harness, webhook sink) can plug in their own
+handler without touching `cli.ex`. This is materially different from the other
+proposals: it does not merely restructure the existing loop, it replaces it with
+an extensibility seam aligned with OTP NN #2 ("extensibility seams MUST be
+behaviours").
+
+## Sketch
+
+```elixir
+# lib/tau/cli/event_handler.ex
+
+defmodule Tau.CLI.EventHandler do
+  @moduledoc """
+  Behaviour for headless CLI event consumers. Implement this to customise
+  how `tau run` processes session events without touching the drain loop.
+  """
+  alias Tau.Session.Events
+
+  @type state :: term()
+  @type result :: {:continue, state()} | {:halt, non_neg_integer()}
+
+  @doc """
+  Called for every Events.* struct received from PubSub.
+  Return {:continue, new_state} to keep draining, {:halt, exit_code} to stop.
+  """
+  @callback handle_event(event :: struct(), state :: state()) :: result()
+
+  @doc "Initial state for the handler."
+  @callback init() :: state()
+
+  @doc "Called when the drain window expires without a SessionEnd."
+  @callback on_timeout(state :: state()) :: non_neg_integer()
+end
+
+# lib/tau/cli/default_event_handler.ex
+
+defmodule Tau.CLI.DefaultEventHandler do
+  @behaviour Tau.CLI.EventHandler
+  alias Tau.Session.Events
+  require Logger
+
+  @impl true
+  def init(), do: %{tool_names: %{}}
+
+  @impl true
+  def handle_event(%Events.MessageEnd{message: msg, session_id: sid}, state) do
+    tool_calls = is_list(msg.content) && Enum.any?(msg.content, &match?(%{type: :tool_call}, &1))
+    cond do
+      tool_calls ->
+        {:continue, state}
+      msg.stop_reason in [:error, :tool_loop_aborted, :aborted, :compaction_failed] ->
+        IO.puts(:stderr, "session error (#{msg.stop_reason}): #{extract_error_text(msg)}")
+        Tau.stop(sid)
+        {:halt, 1}
+      true ->
+        text = extract_assistant_text(msg)
+        if text != "", do: IO.puts(text)
+        Tau.stop(sid)
+        {:continue, Map.put(state, :awaiting_session_end, true)}
+    end
+  end
+
+  def handle_event(%Events.SessionEnd{reason: reason}, _state) do
+    {:halt, if(reason in [:normal, :user], do: 0, else: 1)}
+  end
+
+  def handle_event(%Events.ToolStart{tool_call_id: id, name: name, arguments: args}, state) do
+    IO.puts(:stderr, "[tau] → #{name}(#{Tau.CLI.summarise_args(args)})")
+    {:continue, put_in(state, [:tool_names, id], name)}
+  end
+
+  def handle_event(%Events.ToolEnd{tool_call_id: id, result: result}, state) do
+    name = get_in(state, [:tool_names, id]) || "?"
+    marker = if is_struct(result, Tau.Message.ToolResult) && result.is_error, do: "✗", else: "✓"
+    IO.puts(:stderr, "[tau] ← #{name} #{marker}")
+    {:continue, update_in(state, [:tool_names], &Map.delete(&1, id))}
+  end
+
+  def handle_event(unknown, state) do
+    Logger.debug("[tau] DefaultEventHandler: unhandled #{inspect(unknown.__struct__)}")
+    {:continue, state}
+  end
+
+  @impl true
+  def on_timeout(_state), do: 1
+
+  defp extract_error_text(msg), do: Tau.CLI.extract_error_text(msg)
+  defp extract_assistant_text(msg), do: Tau.CLI.extract_assistant_text(msg)
+end
+
+# lib/tau/cli/headless_drainer.ex
+
+defmodule Tau.CLI.HeadlessDrainer do
+  @moduledoc """
+  Drives the headless drain loop via an EventHandler behaviour module.
+  The calling process MUST already be subscribed to the session's PubSub topic.
+  """
+  @drain_timeout_ms 10_000
+
+  @spec run(session_id :: String.t(), handler :: module(), state :: term()) ::
+          non_neg_integer()
+  def run(session_id, handler, state) do
+    receive do
+      msg when is_struct(msg) and :erlang.map_get(:session_id, msg) == session_id ->
+        case handler.handle_event(msg, state) do
+          {:continue, new_state} -> run(session_id, handler, new_state)
+          {:halt, code}          -> code
+        end
+      msg when is_struct(msg) ->
+        # Event for a different session_id — ignore, keep draining
+        run(session_id, handler, state)
+      _non_struct ->
+        # Non-event mailbox message — ignore
+        run(session_id, handler, state)
+    after
+      @drain_timeout_ms -> handler.on_timeout(state)
+    end
+  end
+end
+
+# lib/tau/cli.ex — in run_cmd/1
+Phoenix.PubSub.subscribe(Tau.PubSub, "session:#{session_id}")
+# ... start_session, send ...
+handler = Application.get_env(:tau, :cli_event_handler, Tau.CLI.DefaultEventHandler)
+state0 = handler.init()
+Tau.CLI.HeadlessDrainer.run(session_id, handler, state0)
+```
+
+`drain_run_loop/2` and `drain_session_end/2` are deleted. The wildcard `_ ->`
+clause in the drain becomes `_non_struct ->` with no recursion into event
+handling. Unknown `Events.*` structs are handled by `DefaultEventHandler`'s
+wildcard `handle_event/2` clause with a `Logger.debug` call.
+
+## Tradeoffs
+
+### Strengths
+
+- OTP NN #2 satisfied: extensibility is via a behaviour, not an ad-hoc function.
+- `HeadlessDrainer.run/3` is a single, non-growing function; new event types are
+  handled by implementing `handle_event/2`, not by modifying the drain loop.
+- Test harness implementations become trivial: a test handler that collects events
+  into a list can be passed in via `Application.put_env(:tau, :cli_event_handler, ...)`.
+- `on_timeout/1` callback explicitly addresses the `drain_session_end/2`
+  false-positive: the handler controls what a timeout means, and the default
+  returns `1`.
+- Unknown `Events.*` structs are never silently discarded; any handler must
+  provide a fallback clause.
+- Behaviour module is a stable seam for future headless modes (batch, webhook,
+  test).
+
+### Weaknesses
+
+- Three new files (`event_handler.ex`, `default_event_handler.ex`,
+  `headless_drainer.ex`) for what is currently ~60 lines of private functions.
+  This may be over-engineering for a single callsite.
+- `HeadlessDrainer.run/3` still contains a raw `receive` loop — the loop is
+  now justified (it is the subscriber process's own mailbox), but it is
+  still a raw `receive`, which may draw OTP purist objections.
+- `Application.get_env/3` for plugging the handler is a runtime configuration
+  mechanism; an alternative (passing handler explicitly in `run_cmd/1`'s opts)
+  is cleaner but requires plumbing through the CLI argument chain.
+- Pattern-matching on `:erlang.map_get(:session_id, msg)` in a `when` guard
+  will crash (and the clause will be skipped) if a struct lacks a `session_id`
+  field — must add a `Map.get/3` guard or a separate clause.
+
+### Costs
+
+- Three new source files: ~150 lines total.
+- `drain_run_loop/2` and `drain_session_end/2` deleted: ~60 lines removed.
+- Net addition: ~90 lines.
+- All existing tests of `drain_run_loop/2` / `drain_session_end/2` replaced
+  by behaviour-module unit tests and `HeadlessDrainer` integration tests.
+- Future event authors must be made aware of `DefaultEventHandler` as a
+  secondary location needing updates alongside `Tau.TUI.App`.
+
+## Dependencies
+
+- `Tau.CLI.extract_error_text/1`, `extract_assistant_text/1`, `summarise_args/1`
+  must remain accessible from `DefaultEventHandler` (already `@doc false` public).
+- Application config key `:cli_event_handler` documented in `config/config.exs`
+  or passed explicitly through `run_cmd/1` opts.
+
+## Confidence
+
+Low–medium. The behaviour design is sound and the drain loop is simpler. The
+risk is the `:erlang.map_get` guard and the three-file overhead for a
+single callsite. Confidence would rise to medium after confirming (a) the guard
+clause handles structs without `session_id` cleanly, and (b) a test implementation
+of `EventHandler` successfully intercepts events without changes to `run_cmd/1`.
+
+## Prior art / references
+
+- OTP NN #2 — "Extensibility seams MUST be behaviours."
+- `Tau.Provider` behaviour — same pattern: a callback module is configured and dispatched by a driver (the session FSM); handlers plug in without touching the driver.
+- Plug (`Plug.Conn` + `Plug` behaviour) — analogous extensibility: a pipeline driver calls handler callbacks; the driver doesn't know or care what the handler does.
+- `Tau.CLI.MCP` / `Tau.CLI.Extensions` — parallel concern: those modules also have `safe_list/0` wrappers over supervised callees; the behaviour pattern could eventually extend there too.

--- a/docs/problems-archive-v1-modules/tau-cli/subproblems/run-loop-raw-receive/solution.md
+++ b/docs/problems-archive-v1-modules/tau-cli/subproblems/run-loop-raw-receive/solution.md
@@ -1,0 +1,133 @@
+---
+template_version: 1
+template_name: solution
+parent_problem: ../problem.md
+node_kind: leaf
+synthesised_from: [proposals/proposal-1.md, proposals/proposal-3.md]
+selection_method: hybrid
+revision: 0
+---
+
+# Solution: Stream-from variant with pure classify_event/2 as fold kernel
+
+## Recommendation
+
+Extend `Tau.Session` with a `stream_from/3` variant that accepts an
+already-open subscription handle (satisfying D-004 without a hand-rolled
+handshake), and drive the headless drain via a single `Enum.reduce_while`
+whose reducer is an extracted, pure `classify_event/2` function. Rendering
+is decomplected into a separate `render_event/1` pure function called
+before the classify step. `drain_run_loop/2` and `drain_session_end/2` are
+deleted. Unknown `Events.*` structs log at `:debug` via the `classify_event`
+fallback clause and do not silently recurse. A missing `SessionEnd` yields
+exit code `1` because the initial reduce accumulator is `{%{}, 1}`.
+
+## Selected from
+
+- **Chosen:** hybrid of `proposals/proposal-1.md` and `proposals/proposal-3.md`
+- **Why chosen:** Proposal 1 provides the cleanest elimination of raw `receive`
+  by routing through the existing `Stream.resource/3` abstraction in
+  `Tau.Session`, preserving the project's established stream idiom and satisfying
+  D-004 without a bespoke inter-process handshake. Its weakness is that rendering
+  and control-flow remain entangled in the `reduce_while` body. Proposal 3
+  addresses exactly that complecting by extracting `classify_event/2` (pure,
+  property-testable) and `render_event/1` (pure side-effect) as named functions —
+  but it retains a raw `receive` loop inside a `Task` and introduces a
+  `{:subscribed, ref}` / `{:start, ref}` hand-rolled synchronisation that
+  replaces one OTP violation with another form of process-coordination boilerplate.
+  The hybrid takes Proposal 1's stream-based drain (no raw `receive`, no
+  hand-rolled handshake, D-004 via `init/1`-equivalent subscription-before-start)
+  and Proposal 3's pure-function decomposition of the reducer body. The result
+  is a `reduce_while` whose per-event logic is `render_event/1` → `classify_event/2`,
+  each independently testable, with the stream machinery handling receive and
+  timeout. Proposal 2's GenServer adds a new supervised process and a remaining
+  raw `receive` in `run_cmd/1` for the result handoff; it scores lower on
+  reversibility and adds more infrastructure than the problem warrants. Proposal 4
+  introduces three new files and an `Application.get_env` plug seam for a single
+  callsite; the behaviour extensibility is over-engineered relative to the
+  acceptance criterion, which does not require pluggability.
+
+## Scoring table
+
+| # | Fit | Decomplecting depth | Migration cost | Risk | Reversibility |
+|---|-----|--------------------|-----------------|----|--------------|
+| 1 | Yes | Substantial | Low | Low | Easy |
+| 2 | Yes | Substantial | Medium | Medium | Medium |
+| 3 | Partially | Substantial | Low | Medium | Easy |
+| 4 | Yes | Substantial | High | Low–Medium | Medium |
+
+Proposal 3 scores "Partially" on fit because its raw `receive` inside a `Task`
+is still a raw `receive` loop; stricter reading of OTP NN #4 flags it as
+non-compliant even when in the subscriber process. Proposal 1 and the hybrid
+eliminate raw `receive` entirely.
+
+## What changes
+
+- **`lib/tau/session.ex`** — add `stream_from/3` (or `stream/3` with an
+  `:already_subscribed` sentinel) that skips internal subscription, using
+  `Stream.resource/3` with a no-op setup, the same `receive` body as the
+  existing `stream/2`, and `after timeout -> {:halt, :ok}`.
+- **`lib/tau/cli.ex`** — replace `drain_run_loop/2` and `drain_session_end/2`
+  with:
+  - `classify_event/2` — pure function, `struct() × map() → {:continue, map()} | {:halt, 0|1}`, handles all current event types plus a fallback `Logger.debug` clause.
+  - `render_event/1` — pure side-effecting function, `struct() → :ok`, handles `ToolStart` / `ToolEnd` progress output.
+  - Inline `run_cmd/1` drain: `Tau.Session.stream_from(session_id, :already_subscribed, timeout: 10_000) |> Enum.reduce_while({%{}, 1}, fn e, {names, _} -> render_event(e); classify_event(e, names) end) |> elem(1)`.
+- **Tests** — any test exercising `drain_run_loop/2` / `drain_session_end/2`
+  directly is rewritten as pure unit tests over `classify_event/2` (no process
+  setup required) and integration tests over `stream_from`.
+
+## What does not change
+
+- D-004 subscribe-before-start invariant: `run_cmd/1` still calls
+  `Phoenix.PubSub.subscribe/2` before `Tau.start_session/1`; `stream_from`'s
+  setup is a no-op that respects the already-open subscription.
+- `Tau.Session.stream/2` — existing callers unaffected.
+- `run_cmd/1`'s `try/after` wrapping `Tau.send/2` for telemetry-handler
+  detachment — explicitly out of scope, remains as-is.
+- All currently handled event types (`MessageEnd`, `SessionEnd`, `ToolStart`,
+  `ToolEnd`) — behaviour-preserving.
+- No new dependencies, no new supervised processes.
+
+## Migration sketch
+
+1. Add `Tau.Session.stream_from/3` with tests confirming: (a) timeout fires
+   when no `SessionEnd` arrives, (b) the stream yields all events before halt.
+2. Extract `classify_event/2` and `render_event/1` as private functions in
+   `cli.ex`; write pure unit tests for both (no process infra needed).
+3. Replace the `drain_run_loop/2` call in `run_cmd/1` with the
+   `stream_from |> reduce_while` pipeline; delete `drain_run_loop/2` and
+   `drain_session_end/2`.
+4. Run full test suite; confirm `mix compile --warnings-as-errors` clean.
+
+Steps 1 and 2 can land together; step 3 is the deleting change that must pass
+the existing integration tests.
+
+## Open questions
+
+- The `stream_from/3` setup no-op relies on the caller having subscribed to
+  the correct topic before the stream is constructed; if the topic string is
+  mis-formed, the stream silently drains nothing. A guard or a `{:ok, pid}` /
+  `{:error, :not_subscribed}` return from the setup phase would make this
+  contract visible.
+- `render_event/1` for `ToolEnd` needs the `tool_names` map to look up the
+  tool name by ID. The pure-function boundary requires either (a) enriching the
+  event before calling `render_event` or (b) accepting that `render_event` for
+  `ToolEnd` takes `(event, tool_names)` — breaking the single-arity signature.
+  This is the known incomplete point from Proposal 3; the implementer must
+  resolve it (passing `tool_names` as a second argument to `render_event/1` for
+  `ToolEnd` is the simplest fix).
+- Timeout value: the current `drain_session_end/2` uses `10_000` ms; `stream/2`
+  uses `60_000` ms. The hybrid should settle on one value or make it configurable
+  via `run_cmd/1` opts. Recommendation: use `10_000` ms for the headless drain
+  (matching current behaviour) and keep `60_000` ms as the `stream/2` default.
+
+## Linked sub-problems / proposals
+
+- `proposals/proposal-1.md` — Subscribe-before-start wrapper around `Tau.Session.stream/2`: stream-based drain that fixes D-004 and removes raw `receive`.
+- `proposals/proposal-2.md` — `Tau.CLI.RunLoop` GenServer: OTP-compliant supervised consumer; not chosen due to residual raw `receive` in caller and heavier infrastructure.
+- `proposals/proposal-3.md` — Split `drain_run_loop` into render/control; use `Task`: pure `classify_event/2` decomposition; not chosen as primary due to hand-rolled Task handshake and retained raw `receive`.
+- `proposals/proposal-4.md` — Headless event behaviour (`Tau.CLI.EventHandler`): pluggable extensibility seam; not chosen as primary due to over-engineering relative to the single-callsite acceptance criterion.
+
+## Revision history
+
+- (revision 0 — initial)

--- a/docs/problems-archive-v1-modules/tau-cli/subproblems/run-loop-raw-receive/validation.md
+++ b/docs/problems-archive-v1-modules/tau-cli/subproblems/run-loop-raw-receive/validation.md
@@ -1,0 +1,402 @@
+---
+template_version: 1
+template_name: validation
+parent_solution: ./solution.md
+parent_problem: ./problem.md
+toulmin_complete: true
+falsification_attempted: true
+falsification_outcome: partially_falsified — claim/3
+revision_triggered: none
+---
+
+# Validation: Stream-from variant with pure classify_event/2 as fold kernel
+
+## Overview
+
+The solution proposes deleting `drain_run_loop/2` and `drain_session_end/2`
+from `lib/tau/cli.ex` and replacing the consumption path with a new
+`Tau.Session.stream_from/3` whose `Stream.resource/3` setup is a no-op
+(the caller has already subscribed to satisfy D-004) plus two extracted
+pure helpers (`classify_event/2`, `render_event/1`) folded over the
+stream with `Enum.reduce_while`. The drain seeds the accumulator at
+`{%{}, 1}` so that a missing `SessionEnd` within the drain window
+surfaces as exit-code 1 rather than the present silent success.
+
+Six checkable claims are extracted from the **Recommendation** and
+**What changes** sections. Each receives full Toulmin treatment (six
+fields) and an explicit, named falsification strategy. Five claims
+withstood falsification; **claim 3** (the `Stream.resource/3` setup-as-
+no-op design) was **partially falsified** by a resource-ownership
+counter-example: the no-op setup cannot also unsubscribe on teardown
+without breaking the caller's still-live subscription, so the
+`stream_from/3` contract MUST explicitly state that subscription
+ownership remains with the caller. The qualifier is narrowed in place
+(no revision required); the implementer notes are sufficient to land
+the change safely.
+
+## Toulmin per claim
+
+### Claim 1: "`drain_run_loop/2` and `drain_session_end/2` are deleted."
+
+- **Claim (C):** The two raw-`receive` functions at `lib/tau/cli.ex:427-486`
+  and `lib/tau/cli.ex:489-497` are removed entirely; the headless run
+  path no longer contains a hand-rolled `receive` loop.
+- **Grounds (G):** `lib/tau/cli.ex:427-486` defines `drain_run_loop/2`
+  with a `receive do … _ -> drain_run_loop/2 end` body and a wildcard
+  catch-all. `lib/tau/cli.ex:489-497` defines `drain_session_end/2`
+  with `receive after 10_000 -> exit_code`. The solution's "What
+  changes" §2 explicitly states "replace `drain_run_loop/2` and
+  `drain_session_end/2` with [the new helpers and pipeline]" and the
+  migration sketch step 3 says "delete `drain_run_loop/2` and
+  `drain_session_end/2`".
+- **Warrant (W):** OTP non-negotiable #4 — "Cross-process events MUST
+  use `Phoenix.PubSub` or monitored refs"; the project reads this
+  rule as forbidding hand-rolled `receive` in client code over
+  PubSub-delivered events. Replacing the loop with a `Stream.resource/3`
+  consumer concentrates the `receive` inside the established stream
+  idiom (already in `Tau.Session.stream/2` at `lib/tau/session.ex:175-191`).
+- **Qualifier (Q):** Holds for the headless `tau run` path. The TUI
+  path is out of this sub-problem's scope; existing `Tau.Session.stream/2`
+  callers are unaffected (solution §"What does not change").
+- **Rebuttal (R):** If a hidden caller (test, neighbour module) calls
+  `Tau.CLI.drain_run_loop/2` or `drain_session_end/2` directly,
+  deletion breaks compilation. `Grep` over `lib/` and `test/` shows
+  call sites in `test/tau/cli/headless_run_test.exs:84,92,107,140,166,
+  190,211,252` and `test/tau/cli/headless_run_tool_exposure_test.exs:124,
+  128` — all are tests; the comment at `lib/tau/tools/builtin/agent.ex:433`
+  is a docstring-only reference. The solution's "What changes" §3
+  explicitly notes the test rewrite obligation, so the rebuttal is
+  pre-conceded.
+- **Backing (B):** `.claude/rules/otp-non-negotiables.md` §4; module
+  docs at `lib/tau/cli.ex:36-46` already concede the present pattern
+  is a workaround for D-004 (`SPEC-USER-TURN.md:497`).
+
+#### Falsification attempt for claim 1
+
+- **Strategy:** Dependency check + edge-case enumeration over the
+  enumerated `Events.*` catalog.
+- **Attempt:** Grep'd `Events.*` struct names in
+  `lib/tau/session/events.ex` (full list: `SessionStart`, `MessageStart`,
+  `MessageUpdate`, `MessageEnd`, `ToolStart`, `ToolUpdate`, `ToolEnd`,
+  `Cancelled`, `SkillActivated`, `SystemNotice`, `SessionEnd`,
+  `CommandCatalog`, `PermissionRequest`). Confirmed each appears in
+  the present `drain_run_loop/2` either by name or via the wildcard
+  catch-all. The post-deletion replacement (`classify_event/2` with a
+  fallback clause that emits `Logger.debug` for unknown structs)
+  covers every enumerated event with named clauses or a single safe
+  fallback. No event-shape is silently lost.
+- **Outcome:** Withstood.
+- **Action:** None.
+
+### Claim 2: "Unknown `Events.*` structs log at `:debug` via the `classify_event` fallback clause and do not silently recurse."
+
+- **Claim (C):** A struct delivered on the session topic that is not
+  in the explicit `classify_event/2` head set produces a `Logger.debug`
+  line and a `{:continue, names}` reduce-step, rather than the
+  present silent wildcard `_ -> drain_run_loop(...)` recursion.
+- **Grounds (G):** Present `lib/tau/cli.ex:483-484` is the literal
+  silent-discard clause the problem statement names. The solution
+  "What changes" §2 names a "fallback `Logger.debug` clause" in
+  `classify_event/2`.
+- **Warrant (W):** Hickey "Simple Made Easy": a single explicit
+  fallback that names what it discards (via the log line) decomplects
+  observability from control-flow; OTP NN §5 requires telemetry for
+  user-visible/perf-sensitive behaviour, and a debug log is the
+  minimum visibility bar for an unhandled-event class.
+- **Qualifier (Q):** Holds for events delivered on the
+  `"session:<id>"` topic. Cross-topic deliveries are out of scope —
+  the subscriber only joins that one topic.
+- **Rebuttal (R):** If a future event type carries information the
+  drain MUST act on (e.g. a hypothetical `MidStreamFailure` that
+  ought to short-circuit to exit 1), the fallback would silently
+  continue. Solution does not pre-empt this; the implementer is
+  obligated to update `classify_event/2` whenever a new event has
+  drain-relevant semantics. This is acceptable because it converts
+  a silent-discard bug into a "named extension point" risk surfaced
+  by code review of any new `Events.*` struct.
+- **Backing (B):** `.claude/rules/otp-non-negotiables.md` §5
+  (telemetry / observability); Hickey, "Simple Made Easy" (2011) —
+  decomplecting "what to do" from "what to log".
+
+#### Falsification attempt for claim 2
+
+- **Strategy:** Counter-example construction.
+- **Attempt:** Attempted to construct an event shape that would
+  bypass `classify_event/2`'s fallback. Pattern-matching on
+  `struct() x map() -> {:continue, map()} | {:halt, 0|1}` with a
+  fallback clause `def classify_event(_, names), do: {:continue, names}`
+  catches any term reachable through `receive` (all PubSub broadcasts
+  are structs per the event catalog). The only non-struct deliverable
+  would be a `{:permission_decision, …}` style cast — but those go to
+  the FSM, not the subscriber.
+- **Outcome:** Withstood.
+- **Action:** None.
+
+### Claim 3: "`stream_from/3` accepts an already-open subscription handle and satisfies D-004 without a hand-rolled handshake."
+
+- **Claim (C):** A new `Tau.Session.stream_from/3` variant (or
+  `stream/3` with an `:already_subscribed` sentinel) whose
+  `Stream.resource/3` setup is a no-op preserves the D-004 invariant
+  (subscribe-before-`start_session`) without requiring an inter-process
+  `{:subscribed, ref}` / `{:start, ref}` handshake.
+- **Grounds (G):** `lib/tau/cli.ex:314-327` shows the present
+  manual `Phoenix.PubSub.subscribe/2` precedes `Tau.start_session/1`.
+  `lib/tau/session.ex:175-191` shows the existing `stream/2` performs
+  subscription inside its setup function — exactly the late-subscribe
+  that violates D-004 (acknowledged in `lib/tau/cli.ex:296-299`).
+  A setup-as-no-op preserves the caller's pre-existing subscription
+  without re-subscribing or unsubscribing.
+- **Warrant (W):** `Stream.resource/3` semantics: setup runs once at
+  first pull, the reducer runs per element, teardown runs once on
+  halt. If subscription is already held by the calling process (which
+  also owns the `receive` mailbox the stream consumes), a no-op
+  setup/teardown is sufficient — the receive body simply consumes
+  messages already destined for the caller. D-004 is about *temporal
+  ordering*; once subscription is established before `start_session`
+  the invariant holds regardless of where in the pipeline the
+  stream pulls.
+- **Qualifier (Q):** Holds **only when the calling process is the
+  subscription owner AND the same process consumes the stream.** If
+  a `Task` or other process consumes the stream, the receive body
+  reads the wrong mailbox.
+- **Rebuttal (R):** If `Stream.resource/3`'s teardown were to
+  `Phoenix.PubSub.unsubscribe/2`, it would break the caller's
+  subscription that the caller still owns. The solution's setup-as-
+  no-op implies teardown-as-no-op; the caller (`run_cmd/1`) retains
+  ownership and the subscription dies with the calling process at
+  exit. This is correct but **MUST be made explicit in the new
+  function's docstring** — a future maintainer adding "polite
+  teardown" would silently break the contract.
+- **Backing (B):** SPEC-USER-TURN §4 B6, D-004 row at
+  `docs/spec/SPEC-USER-TURN.md:497`; `Stream.resource/3` HexDocs
+  (https://hexdocs.pm/elixir/Stream.html#resource/3) on
+  setup/reducer/teardown semantics.
+
+#### Falsification attempt for claim 3
+
+- **Strategy:** Counter-example construction over resource-ownership.
+- **Attempt:** Constructed the hypothetical "polite teardown" case:
+  if `stream_from/3` adds `Phoenix.PubSub.unsubscribe/2` on teardown,
+  the caller's subscription is severed mid-`run_cmd/1` lifetime,
+  silently breaking any further consumption (e.g. a future
+  post-drain step that re-uses the subscription). The solution does
+  not state this constraint in the function contract; only the
+  migration sketch implies it. This is **not** a falsification of the
+  claim that D-004 is satisfied — but it falsifies the broader
+  reading that the new API is contract-complete without a docstring
+  warning. **Partial falsification.**
+- **Outcome:** Partially falsified.
+- **Action:** Narrow the qualifier in place: the claim holds only
+  under "caller-owned subscription, no-op teardown, contract
+  documented". The implementer must encode this in the new function's
+  `@doc` and `@spec`. No solution revision required; this is a
+  drafting tightening that fits inside the implementation PR.
+
+### Claim 4: "A missing `SessionEnd` yields exit code `1` because the initial reduce accumulator is `{%{}, 1}`."
+
+- **Claim (C):** When the drain stream halts (timeout) without ever
+  delivering `%SessionEnd{}`, `Enum.reduce_while/3` returns the
+  initial accumulator `{%{}, 1}`, and the `elem(1)` projection
+  yields exit code `1`.
+- **Grounds (G):** Solution "What changes" §2: pipeline is
+  `… |> Enum.reduce_while({%{}, 1}, fn e, {names, _} -> render_event(e);
+  classify_event(e, names) end) |> elem(1)`. The present
+  `drain_session_end/2` at `lib/tau/cli.ex:489-497` returns the
+  caller-seeded `exit_code` on timeout — which the problem statement
+  identifies as the silent-success bug.
+- **Warrant (W):** `Enum.reduce_while/3` semantics: when the
+  enumerable is exhausted without a `{:halt, _}` reducer step, the
+  current accumulator is returned. The seed `{%{}, 1}` thus survives
+  timeout untouched; any successful `MessageEnd`-without-tool_calls
+  path explicitly returns `{:halt, {names, 0}}` via `classify_event/2`,
+  overwriting the seed's `1`.
+- **Qualifier (Q):** Holds **only if** `classify_event/2` for the
+  non-failure `MessageEnd` clause produces `{:halt, {names, 0}}` —
+  not `{:cont, {names, 0}}` — and the `SessionEnd` clause produces
+  the same. The solution describes `{:halt, 0|1}` but the actual
+  shape passed to `reduce_while` must be `{:halt, {names, 0|1}}`
+  because the accumulator is the pair. The solution's wording is
+  shorthand; the implementer must lift the integer into the pair.
+- **Rebuttal (R):** If `render_event/1` raises before `classify_event/2`
+  is reached (e.g. on a malformed event), the reducer crashes and
+  the caller never receives `1` — it receives the exception. This is
+  acceptable under OTP NN #7 ("let it crash") but slightly
+  changes the failure mode versus today's silent-success-on-timeout.
+  The escript halt path will surface an error exit; this is strictly
+  better than silent success.
+- **Backing (B):** `Enum.reduce_while/3` HexDocs
+  (https://hexdocs.pm/elixir/Enum.html#reduce_while/3) on accumulator
+  return semantics; `.claude/rules/otp-non-negotiables.md` §7
+  (let-it-crash).
+
+#### Falsification attempt for claim 4
+
+- **Strategy:** Edge-case enumeration over reduce_while termination
+  modes.
+- **Attempt:** Three termination modes: (i) reducer returns
+  `{:halt, acc}` — `acc` is returned; (ii) enumerable exhausted —
+  current acc is returned; (iii) reducer raises — exception
+  propagates. For mode (i), explicit halt clauses in
+  `classify_event/2` set the exit-code value. For mode (ii) — the
+  timeout path — seed survives; `elem(1)` is `1`. For mode (iii) —
+  unexpected — the escript exits non-zero via OTP crash. No mode
+  produces a silent success after the seed initialisation.
+- **Outcome:** Withstood.
+- **Action:** None — but ensure implementer encodes the pair-lifting
+  (Qualifier note above) and writes a property test that timeout →
+  exit 1.
+
+### Claim 5: "Rendering is decomplected into a separate `render_event/1` pure function called before the classify step."
+
+- **Claim (C):** `render_event/1` is a separate, pure side-effecting
+  function (`struct() → :ok`) called before `classify_event/2` in
+  the `reduce_while` body; rendering and control-flow are not
+  interleaved.
+- **Grounds (G):** Present `lib/tau/cli.ex:467-468,477-478` shows
+  rendering (`IO.puts(:stderr, …)`) interleaved with control-flow
+  (`drain_run_loop(session_id, Map.put(…))`). Solution "What
+  changes" §2 names `render_event/1` and the inline pipeline
+  `… fn e, {names, _} -> render_event(e); classify_event(e, names) end`.
+- **Warrant (W):** Hickey's "Simple Made Easy" complecting test: a
+  function that both renders and decides exit-code complects two
+  concerns; separating them per call ordering decomplects render-
+  before-classify and lets each be tested independently.
+- **Qualifier (Q):** Holds for events whose render output does not
+  depend on classify state. `ToolEnd` needs `tool_names` to print
+  the tool name — solution Open Questions explicitly flags this and
+  requires either event-enrichment or a `(event, tool_names)`
+  signature for `render_event/1`.
+- **Rebuttal (R):** The Open-Question concession means `render_event/1`
+  is **not** strictly `struct() → :ok` for `ToolEnd`; it needs
+  `(struct(), map()) → :ok` at least there. The solution
+  acknowledges this; the implementer must commit to one of the two
+  paths. Either path preserves the decomplecting intent.
+- **Backing (B):** Hickey, "Simple Made Easy" (2011) — complecting
+  vs orthogonal composition; `.claude/skills/design-reasoning`
+  (PSDH) on decomplecting as a triage outcome.
+
+#### Falsification attempt for claim 5
+
+- **Strategy:** Counter-example construction over the `ToolEnd` path.
+- **Attempt:** Tried to construct a `render_event/1` that handles
+  `ToolEnd` without access to `tool_names`. Result: it would print
+  `"[tau] ← ? ✓"` for every `ToolEnd`, losing the name lookup the
+  present implementation performs at `lib/tau/cli.ex:474-478`. The
+  decomplecting is preserved if `render_event/1` takes `tool_names`
+  as a second argument (the Open Question's recommended fix) — but
+  the strict-arity-1 reading of the claim is falsifiable for `ToolEnd`.
+- **Outcome:** Withstood under the qualifier "with the Open Question
+  resolved by the recommended `(event, tool_names)` shape". The
+  claim's *intent* (decomplect render from control-flow) is
+  preserved; only the literal arity-1 wording yields if pressed.
+- **Action:** None — solution itself flags this as an implementer
+  decision.
+
+### Claim 6: "Existing `Tau.Session.stream/2` callers are unaffected; no new supervised processes; no new dependencies."
+
+- **Claim (C):** The change adds `stream_from/3` as a new sibling of
+  `stream/2` without modifying `stream/2`; no new GenServer, no new
+  application-tree entry, no new Mix dep.
+- **Grounds (G):** Solution "What does not change" §2-5 enumerates
+  these non-changes. `lib/tau/session.ex:175-191` shows `stream/2` is
+  a standalone function — adding `stream_from/3` does not touch it.
+- **Warrant (W):** Additive API extension preserves caller contracts
+  by construction; OTP NN #3 ("MUST NOT wrap stateless logic in a
+  GenServer") cuts against the GenServer proposal-2 alternative,
+  which is why the hybrid wins on this axis.
+- **Qualifier (Q):** Holds for the production tree. Test code may
+  add helper processes for the new function's properties; that is
+  expected and non-objectionable.
+- **Rebuttal (R):** If the implementer chooses the `stream/3`-with-
+  sentinel form (vs a separate `stream_from/3`), they are modifying
+  `stream/2`'s arity. The solution explicitly accepts either shape
+  ("`stream_from/3` (or `stream/3` with an `:already_subscribed`
+  sentinel)"); the sentinel form is a non-breaking arity-2-to-3
+  default-arg extension and remains contract-preserving.
+- **Backing (B):** `.claude/rules/otp-non-negotiables.md` §3 (no
+  GenServer for stateless logic); SPEC-USER-TURN §4 B6 on the
+  stream contract.
+
+#### Falsification attempt for claim 6
+
+- **Strategy:** Dependency check + integration check.
+- **Attempt:** Grep'd `lib/tau/application.ex` for current supervised
+  children and `mix.exs` for current deps; neither requires
+  modification for an additive function. Existing callers of
+  `Tau.stream/2` are unaffected because `stream/2` is unchanged
+  (additive extension only). No counter-example surfaced.
+- **Outcome:** Withstood.
+- **Action:** None.
+
+## Cross-claim consistency
+
+Claims 1, 2, and 3 form a chain: deletion of the raw-receive loop
+(C1) presupposes a working stream-based replacement (C3), which in
+turn requires the unknown-event fallback (C2) to absorb everything
+the wildcard previously absorbed. The chain is consistent: C3's
+no-op-setup design holds the caller's subscription, C2's
+`Logger.debug` fallback absorbs unenumerated structs, and C1's
+deletion becomes safe.
+
+Claims 4 and 5 share the `reduce_while` body. C5's `render_event/1`
+runs before C4's `classify_event/2`; if `render_event/1` raises,
+C4's seed-survives-timeout property does not apply (the reduce never
+completes). The let-it-crash rebuttal under C4 resolves this: an
+exception is acceptable, and is strictly better than the present
+silent-success bug.
+
+Claim 6 is orthogonal to 1-5 and consistent with all of them.
+
+The only friction is between Claim 3's "no-op teardown" implication
+and any future maintainer who reads the new `stream_from/3` and
+adds an `unsubscribe/2` for symmetry. This is the partial
+falsification under Claim 3 and is mitigated by docstring
+clarification at implementation time.
+
+## Falsification summary
+
+| # | Claim (short) | Strategy | Outcome | Action |
+|---|---|---|---|---|
+| 1 | Delete drain_run_loop/2 + drain_session_end/2 | Dependency + edge-case enum | withstood | none |
+| 2 | Unknown events log at :debug, not silently discarded | Counter-example | withstood | none |
+| 3 | stream_from/3 with no-op setup preserves D-004 | Counter-example (resource ownership) | partially falsified | narrow Q in place — docstring must state caller-owned subscription, no-op teardown |
+| 4 | Missing SessionEnd → exit 1 via {%{}, 1} seed | Edge-case enum over reduce_while modes | withstood | none |
+| 5 | render_event/1 separated from classify_event/2 | Counter-example (ToolEnd) | withstood (under Open-Q resolution) | none |
+| 6 | Additive API; no new procs, no new deps | Dependency + integration | withstood | none |
+
+## Revision required
+
+None at the solution-revision or problem-revision level. Claim 3's
+partial falsification is resolved by narrowing the qualifier in
+place: the implementer MUST document, in `stream_from/3`'s `@doc`,
+that subscription ownership remains with the caller and that
+teardown is intentionally a no-op. This is a drafting tightening
+that lands inside the implementation PR, not a solution rewrite.
+
+- **Target file:** none (qualifier narrowed in place)
+- **Revision kind:** n/a
+- **Rationale:** The solution's intent is correct and achievable;
+  only the contract documentation needs to be explicit. Treating
+  this as a solution revision would be Toulmin theater — the design
+  decision is sound; the docstring is an implementation detail the
+  reviewer will catch.
+
+## Outstanding doubts
+
+- The `tool_names` accumulator in the `reduce_while` second slot
+  is correct for `ToolStart`/`ToolEnd` correlation but does not
+  appear in the solution's Recommendation prose — only in the
+  pipeline snippet. The parent-level validator should ensure the
+  `(map, integer)` accumulator shape is explicit in any parent
+  synthesis.
+- The solution's "10 s vs 60 s" timeout Open Question is unresolved.
+  The recommendation (10 s for headless, 60 s for `stream/2`) is
+  sound but means `stream_from/3` MUST accept `:timeout` as an
+  option — the snippet shows `timeout: 10_000` but the function
+  signature `stream_from/3` does not enumerate options in the
+  Recommendation. Implementer obligation, surfaced for the parent.
+- The pure-vs-side-effect framing of `render_event/1` ("pure side-
+  effecting function") is contradictory at the surface; the intent
+  is "isolated side-effect; no control-flow return" but the wording
+  invites a reviewer challenge. Parent validator should rewrite to
+  "isolated I/O function returning `:ok`" or similar.

--- a/docs/problems-archive-v1-modules/tau-cli/subproblems/wizard-data-fidelity/problem.md
+++ b/docs/problems-archive-v1-modules/tau-cli/subproblems/wizard-data-fidelity/problem.md
@@ -1,0 +1,72 @@
+---
+template_version: 1
+template_name: problem
+node_kind: leaf
+depth: 1
+parent: ../../problem.md
+status: draft
+---
+
+# Problem: tau init wizard discards providers and uses wrong Bedrock credential key
+
+## Statement
+
+`tau init`'s provider selection step presents a multi-select prompt but then
+calls `List.first(providers)` when building `new_settings`, silently discarding
+every provider the user selected except the first. Separately, `@providers` in
+`Tau.CLI.Init` maps Bedrock to `AWS_ACCESS_KEY_ID`, while
+`Tau.Commands.Builtin.Logout.@credential_map` maps `"bedrock"` to
+`AWS_SECRET_ACCESS_KEY`. A user who stores a Bedrock credential via `tau init`
+and then runs `/logout bedrock` removes a different vault entry than was stored;
+the actual stored credential is never cleared.
+
+## Context
+
+- `lib/tau/cli/init.ex:152–153` — `Map.put(... "provider", providers |> List.first() |>
+  provider_string())` — `List.first/1` discards all but the first element of
+  the `providers` list returned by `provider_selection/1`.
+- `lib/tau/cli/init.ex:136–139` — `provider_selection/1` correctly returns a
+  list of selected keys; the multi-select prompt at line 203 reads "[1/5]
+  Which providers do you want to enable?" (plural).
+- `lib/tau/cli/init.ex:60–65` — `@providers` for `:bedrock` sets
+  `env: "AWS_ACCESS_KEY_ID"`.
+- `lib/tau/commands/builtin/logout.ex:38–43` — `@credential_map` maps
+  `"bedrock" => "AWS_SECRET_ACCESS_KEY"`.
+- These two are the only places in the codebase that map the "bedrock"
+  provider identity to a vault credential name; they disagree on the key.
+- `Tau.Settings.Vault.put/2` and `Tau.Settings.Vault.delete/1` operate on the
+  vault key name directly — no indirection normalises this divergence at runtime.
+
+## Complecting hypothesis
+
+- Provider identity is complected with credential-key knowledge in two separate
+  modules: `Init.@providers` owns the "what to store" side and
+  `Logout.@credential_map` owns the "what to remove" side, with no shared
+  source of truth, so they drift independently.
+
+## Decomposition strategy
+
+(leaf — no further decomposition; proceed to proposals)
+
+## Acceptance criterion
+
+After a `tau init` run where the user selects N > 1 providers, the written
+`settings.local.json` reflects all N selections; AND `tau init` and
+`/logout bedrock` use the same vault credential key name for Bedrock, so that
+credentials stored during init can be removed by logout.
+
+## Out of scope
+
+- `provider_string/1` divergence from `Atom.to_string/1` (style; no behaviour
+  change)
+- `handle_one_credential/3` `tap/2` readability issue
+- `validate/1` schema-resolve performance (re-resolving on every call)
+- Multi-provider persistence in `settings.json` format — whether the settings
+  schema supports a list of providers is a schema question, not a wizard question;
+  the fix may be to correct the prompt or to persist a list depending on schema
+  support
+- Logout behaviour for providers other than Bedrock
+
+## Amendment log
+
+- (none yet)

--- a/docs/problems-archive-v1-modules/tau-cli/subproblems/wizard-data-fidelity/proposals/proposal-1.md
+++ b/docs/problems-archive-v1-modules/tau-cli/subproblems/wizard-data-fidelity/proposals/proposal-1.md
@@ -1,0 +1,155 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 1
+parent_problem: ../problem.md
+---
+
+# Proposal 1: Unify credential map in `Init` and fix `List.first` — inlined correction
+
+## Approach
+
+Correct both defects entirely within `lib/tau/cli/init.ex` and
+`lib/tau/commands/builtin/logout.ex`, touching no other module. Change
+`@providers` in `Init` so `:bedrock` maps to `"AWS_SECRET_ACCESS_KEY"`
+(matching `Logout.@credential_map`). Change `new_settings` construction
+at line 153 to persist a list of provider strings rather than a single
+string (requires the settings schema to accept either `"provider"` as a
+string for single-provider backwards-compat, or a new `"providers"` array
+key — see Sketch). No new module is introduced; the two files become
+independently correct and their credential maps happen to agree.
+
+## Rationale
+
+The complecting hypothesis names two separate modules holding divergent
+knowledge about the same fact (which vault key names Bedrock's credential).
+The minimal decomplect is to correct the wrong one: `Init` stores
+`AWS_ACCESS_KEY_ID` but `Logout` deletes `AWS_SECRET_ACCESS_KEY`; the
+Bedrock provider's env var for authentication is `AWS_SECRET_ACCESS_KEY`,
+so `Init` is the incorrect one. This proposal corrects `Init` and also
+fixes the `List.first` truncation in the same atomic change. No structural
+refactor is required — the duplication remains, but the two copies agree.
+The tradeoff is that they can drift again in the future, but the immediate
+defects are resolved without touching the settings schema or introducing a
+new abstraction.
+
+## Sketch
+
+### 1. Fix credential key in `Init.@providers`
+
+```elixir
+# lib/tau/cli/init.ex — before
+@providers [
+  %{key: :anthropic, label: "Anthropic",           env: "ANTHROPIC_API_KEY"},
+  %{key: :openai_chat, label: "OpenAI Chat",        env: "OPENAI_API_KEY"},
+  %{key: :openai_responses, label: "OpenAI Responses", env: "OPENAI_API_KEY"},
+  %{key: :gemini, label: "Gemini",                  env: "GEMINI_API_KEY"},
+  %{key: :bedrock, label: "Bedrock",                env: "AWS_ACCESS_KEY_ID"}  # WRONG
+]
+
+# After
+@providers [
+  %{key: :anthropic, label: "Anthropic",           env: "ANTHROPIC_API_KEY"},
+  %{key: :openai_chat, label: "OpenAI Chat",        env: "OPENAI_API_KEY"},
+  %{key: :openai_responses, label: "OpenAI Responses", env: "OPENAI_API_KEY"},
+  %{key: :gemini, label: "Gemini",                  env: "GEMINI_API_KEY"},
+  %{key: :bedrock, label: "Bedrock",                env: "AWS_SECRET_ACCESS_KEY"}  # FIXED
+]
+```
+
+### 2. Fix `List.first` truncation
+
+The settings schema's `"provider"` key is `"type" => "string"`, which
+cannot hold a list. Two options exist at this sub-step:
+
+**Option A** — persist only the first provider in `"provider"` (schema
+stays unchanged), but correct the prompt text to say "primary provider"
+rather than implying multi-select:
+
+```elixir
+# lib/tau/cli/init.ex line ~153
+|> Map.put("provider", providers |> List.first() |> provider_string())
+```
+
+This keeps `List.first` but changes the prompt from "[1/5] Which providers
+do you want to enable?" to "[1/5] Which providers do you want to configure
+credentials for? (first selection becomes active provider)".
+
+**Option B** — persist the full list under a new `"providers"` key (schema
+must be extended to allow `"providers": ["string"]`), keeping `"provider"`
+as the primary active provider for backwards-compat:
+
+```elixir
+# lib/tau/cli/init.ex line ~150-154
+|> Map.put("provider", providers |> List.first() |> provider_string())
+|> Map.put("providers", Enum.map(providers, &provider_string/1))
+```
+
+The acceptance criterion says "the written `settings.local.json` reflects
+all N selections", which Option B satisfies; Option A only satisfies it if
+the problem's intent is that credentials are stored for all N, even if only
+one is the active provider. Given the credential-handling step already
+iterates all `providers`, Option B is recommended within this proposal.
+
+### Schema amendment (Option B)
+
+```elixir
+# lib/tau/settings/schema.ex — add to "properties"
+"providers" => %{
+  "type" => "array",
+  "items" => %{"type" => "string"}
+}
+```
+
+## Tradeoffs
+
+### Strengths
+
+- Smallest diff: two files changed (three counting the schema amendment),
+  no new modules.
+- No API surface change for callers of `Init.run/2`.
+- Credential key fix is obviously correct and verifiable by inspection.
+- No new abstractions to test; existing unit tests for `run/2` and
+  `Logout.run/2` can be updated directly.
+
+### Weaknesses
+
+- The duplication between `Init.@providers` and `Logout.@credential_map`
+  persists; they remain free to drift again in the future.
+- Option A does not fully satisfy the acceptance criterion (all N
+  selections persisted); it only satisfies credential storage for all N.
+- Schema amendment (Option B) is a dependency that must land atomically
+  with the wizard fix or `validate/1` will reject the new key.
+- No structural enforcement: a future contributor editing either file
+  independently will not be warned about the coupling.
+
+### Costs
+
+- 2–3 files changed.
+- Test updates: `test/tau/cli/init_test.exs` (multi-provider selection
+  assertions), `test/tau/commands/builtin/logout_test.exs` (credential key
+  assertion). Likely < 20 lines of test change.
+- Schema change is additive (no existing JSON breaks); existing
+  `settings.local.json` files without the `"providers"` key remain valid.
+
+## Dependencies
+
+- If Option B: the `"providers"` schema key must be added to
+  `Tau.Settings.Schema` in the same PR so `validate/1` accepts it.
+- No other external dependencies.
+
+## Confidence
+
+medium — the fix logic is straightforward and the code paths are short.
+Confidence would rise to high after a `mix test` run confirming no
+schema-validation regressions and a manual trace of the Bedrock credential
+round-trip (init → vault → logout).
+
+## Prior art / references
+
+- `lib/tau/settings/schema.ex:69` — current `"provider"` key definition
+  (string only).
+- `lib/tau/cli/init.ex:245–253` — `handle_credentials/3` already maps over
+  all selected providers; the fix at line 153 mirrors that iteration pattern.
+- `lib/tau/commands/builtin/logout.ex:38–43` — the authoritative credential
+  key names (treated as correct in this proposal).

--- a/docs/problems-archive-v1-modules/tau-cli/subproblems/wizard-data-fidelity/proposals/proposal-2.md
+++ b/docs/problems-archive-v1-modules/tau-cli/subproblems/wizard-data-fidelity/proposals/proposal-2.md
@@ -1,0 +1,185 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 2
+parent_problem: ../problem.md
+---
+
+# Proposal 2: Extract `Tau.Providers.Catalog` as single source of truth
+
+## Approach
+
+Introduce a new module `Tau.Providers.Catalog` that owns the complete,
+authoritative mapping from provider key atom to `%{label, env_var,
+string_key}`. Both `Tau.CLI.Init` and `Tau.Commands.Builtin.Logout` are
+refactored to delegate all provider-identity lookups to this module.
+`Init.@providers` and `Logout.@credential_map` are deleted; their values
+become compile-time derivations of `Catalog`. The `List.first` truncation
+is fixed in the same PR by changing `Init.drive_flow/1` to persist all
+selected provider strings.
+
+## Rationale
+
+The complecting hypothesis is explicit: provider identity is split across
+two modules with no shared source, so they drift. The structural fix is
+extraction — move the fact ("Bedrock's vault credential is
+`AWS_SECRET_ACCESS_KEY`") to a single module that both consumers import.
+After this change, a future edit to a provider's credential key has one
+and only one callsite; a compile-time `@credential_map` derived from
+`Catalog` at `Logout` load time ensures the two are always identical
+without runtime indirection. The `List.first` fix is a one-line change
+once the surrounding data structures are stabilised.
+
+## Sketch
+
+### New module: `lib/tau/providers/catalog.ex`
+
+```elixir
+defmodule Tau.Providers.Catalog do
+  @moduledoc """
+  Compile-time registry of Tau's recognised providers.
+
+  Each entry defines:
+    * `:key`       — internal atom identifier
+    * `:label`     — human-readable display name
+    * `:env_var`   — vault credential name (key stored/retrieved by Vault)
+    * `:string_key` — the string representation written to settings JSON
+  """
+
+  @entries [
+    %{key: :anthropic,         label: "Anthropic",          env_var: "ANTHROPIC_API_KEY",    string_key: "anthropic"},
+    %{key: :openai_chat,       label: "OpenAI Chat",         env_var: "OPENAI_API_KEY",       string_key: "openai_chat"},
+    %{key: :openai_responses,  label: "OpenAI Responses",    env_var: "OPENAI_API_KEY",       string_key: "openai_responses"},
+    %{key: :gemini,            label: "Gemini",              env_var: "GEMINI_API_KEY",       string_key: "gemini"},
+    %{key: :bedrock,           label: "Bedrock",             env_var: "AWS_SECRET_ACCESS_KEY",string_key: "bedrock"}
+  ]
+
+  @doc "All registered provider entries."
+  @spec all() :: [map()]
+  def all, do: @entries
+
+  @doc "Look up a provider entry by atom key. Returns `nil` if not found."
+  @spec by_key(atom()) :: map() | nil
+  def by_key(key), do: Enum.find(@entries, &(&1.key == key))
+
+  @doc "Look up a provider entry by string key. Returns `nil` if not found."
+  @spec by_string_key(String.t()) :: map() | nil
+  def by_string_key(str), do: Enum.find(@entries, &(&1.string_key == str))
+
+  @doc "Build the credential map `%{string_key => env_var}` for all providers."
+  @spec credential_map() :: %{String.t() => String.t()}
+  def credential_map do
+    Map.new(@entries, &{&1.string_key, &1.env_var})
+  end
+end
+```
+
+### `Init` after refactor (relevant excerpts)
+
+```elixir
+# lib/tau/cli/init.ex — remove @providers module attribute, import Catalog
+
+alias Tau.Providers.Catalog
+
+# provider_selection/1 uses Catalog.all()
+defp provider_selection(io) do
+  io.puts("[1/5] Which providers do you want to enable?")
+  Catalog.all()
+  |> Enum.with_index(1)
+  |> Enum.each(fn {p, i} -> io.puts("  [#{i}] #{p.label} (env: #{p.env_var})") end)
+  # ... parse_provider_indices unchanged ...
+end
+
+# drive_flow — fix List.first truncation; persist all selected providers
+new_settings =
+  base_settings
+  |> Map.put("permissions", merge_permissions(base_settings, perms_mode))
+  |> Map.put("provider", providers |> List.first() |> then(&Catalog.by_key(&1).string_key))
+  |> Map.put("providers", Enum.map(providers, &Catalog.by_key(&1).string_key))
+```
+
+### `Logout` after refactor
+
+```elixir
+# lib/tau/commands/builtin/logout.ex — remove @credential_map, derive from Catalog
+
+alias Tau.Providers.Catalog
+
+# At module level, derive at compile time:
+@credential_map Catalog.credential_map()
+```
+
+Because `Catalog.credential_map/0` is a pure function returning a literal
+map (no runtime state), `@credential_map Catalog.credential_map()` compiles
+identically to the current hardcoded literal. The existing `run/2` body is
+unchanged.
+
+### File moves
+
+```
+(new)  lib/tau/providers/catalog.ex
+(mod)  lib/tau/cli/init.ex        — remove @providers, alias Catalog
+(mod)  lib/tau/commands/builtin/logout.ex — remove @credential_map literal, derive from Catalog
+(new)  test/tau/providers/catalog_test.exs
+```
+
+## Tradeoffs
+
+### Strengths
+
+- Single source of truth: the Bedrock credential key lives in exactly one
+  place; future drift is structurally impossible.
+- Compile-time derivation: `Logout.@credential_map` is built at compile
+  time from `Catalog`, not at runtime — no performance cost, no process
+  dependency.
+- The new module is pure data; it requires no GenServer, no supervision,
+  no ETS — consistent with OTP NN #3 and #8.
+- Makes the `List.first` fix easy: `Enum.map(providers, &Catalog.by_key(&1).string_key)`
+  replaces the single-value path.
+- Testable in isolation: `Tau.Providers.Catalog` can be property-tested
+  for completeness (every entry has non-nil `:env_var`, unique `:key`
+  and `:string_key`, etc.).
+
+### Weaknesses
+
+- Introduces a new module and file that future contributors must know
+  about; slight discovery burden.
+- Schema still stores `"provider"` as a single string; the
+  `"providers"` list key must be added to `Tau.Settings.Schema` in the
+  same PR to satisfy the "all N selections persisted" AC.
+- `Catalog.by_key/1` returns `nil` on an unknown atom; callers must guard
+  against this (easy but adds a nil-path in `drive_flow`).
+- If a provider is added to `@known_providers` in `Settings.Schema` but
+  not added to `Catalog`, the divergence reappears at a different level —
+  though the type system cannot catch this unless a compile-time check is
+  added.
+
+### Costs
+
+- 1 new file (`catalog.ex`, ~40 lines), 1 new test file.
+- Refactor of `Init` and `Logout`: ~20 lines changed each.
+- Schema amendment: +3 lines.
+- Total: ~90 lines changed/added.
+- Compile-time impact: nil (pure data module).
+
+## Dependencies
+
+- `"providers"` array key must be added to `Tau.Settings.Schema` in the
+  same PR.
+- No library upgrades or OTP changes required.
+
+## Confidence
+
+high — the pattern (compile-time credential registry derived from a
+central catalog) is idiomatic Elixir, has a concrete sketch, and the
+credential-key discrepancy is confirmed by code inspection.
+
+## Prior art / references
+
+- `lib/tau/settings/schema.ex:47–54` — `@known_providers` list is a
+  precedent for compile-time provider registries in this codebase.
+- Elixir idiom: module attributes evaluated at compile time to derive
+  secondary data structures (e.g. `@credential_map Catalog.credential_map()`).
+- `lib/tau/cli/init.ex:245–253` — `handle_credentials/3` already treats
+  the `@providers` list as the single credential truth for the init path;
+  the proposal extends that authority to the logout path.

--- a/docs/problems-archive-v1-modules/tau-cli/subproblems/wizard-data-fidelity/proposals/proposal-3.md
+++ b/docs/problems-archive-v1-modules/tau-cli/subproblems/wizard-data-fidelity/proposals/proposal-3.md
@@ -1,0 +1,187 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 3
+parent_problem: ../problem.md
+---
+
+# Proposal 3: Fix `List.first` by correcting the prompt to single-select; fix Bedrock key in `Init`
+
+## Approach
+
+Reinterpret the `List.first` call not as a bug-to-be-removed but as a
+design constraint to be made explicit: change the provider-selection
+prompt from multi-select (plural language, comma-separated input) to
+single-select (unambiguous single choice), so `List.first` is no longer
+truncating — it is taking the sole element of a length-1 list. Separately,
+fix the Bedrock `env` value in `Init.@providers` from `"AWS_ACCESS_KEY_ID"`
+to `"AWS_SECRET_ACCESS_KEY"` to match `Logout.@credential_map`. This
+approach preserves the existing settings schema (`"provider"` as a string),
+keeps both `@providers` and `@credential_map` as independent module
+attributes, and avoids any schema change. Credential collection still
+runs for all configured providers; only the "active provider" concept is
+narrowed to one.
+
+## Rationale
+
+The acceptance criterion has two parts: (a) settings reflect all N
+selections, and (b) init and logout agree on the Bedrock credential key.
+This proposal satisfies (b) unconditionally. For (a), it satisfies it by
+redefining the prompt semantics: the settings schema's `"provider"` key is
+a string (single value); if the schema does not support a list, then
+prompting for multiple selections and then silently discarding them is
+the actual bug — the fix is to align the prompt with what the schema can
+store, rather than to change the schema. The credential collection step
+(which already iterates all selected providers) is preserved or adapted so
+users can still configure credentials for providers other than the primary,
+but only one provider is written to `"provider"`. This is a
+behaviour-preserving refactor with respect to the settings schema and the
+logout command.
+
+## Sketch
+
+### 1. Fix Bedrock credential key in `Init.@providers`
+
+```elixir
+# lib/tau/cli/init.ex — same one-line fix as other proposals
+@providers [
+  %{key: :anthropic,         label: "Anthropic",          env: "ANTHROPIC_API_KEY"},
+  %{key: :openai_chat,       label: "OpenAI Chat",         env: "OPENAI_API_KEY"},
+  %{key: :openai_responses,  label: "OpenAI Responses",    env: "OPENAI_API_KEY"},
+  %{key: :gemini,            label: "Gemini",              env: "GEMINI_API_KEY"},
+  %{key: :bedrock,           label: "Bedrock",             env: "AWS_SECRET_ACCESS_KEY"}  # FIXED
+]
+```
+
+### 2. Rewrite `provider_selection/1` as single-select
+
+```elixir
+# lib/tau/cli/init.ex — replace provider_selection/1
+
+defp provider_selection(io) do
+  io.puts("")
+  io.puts("[1/5] Which provider do you want to use?")
+
+  @providers
+  |> Enum.with_index(1)
+  |> Enum.each(fn {p, i} ->
+    io.puts("  [#{i}] #{p.label} (env: #{p.env})")
+  end)
+
+  raw = prompt(io, "index (default: 1): ")
+
+  case parse_single_provider_index(raw) do
+    nil -> List.first(@providers).key
+    key -> key
+  end
+end
+
+defp parse_single_provider_index(""), do: nil
+defp parse_single_provider_index(nil), do: nil
+
+defp parse_single_provider_index(str) do
+  str = String.trim(str)
+  case Integer.parse(str) do
+    {n, ""} when n >= 1 and n <= length(@providers) ->
+      Enum.at(@providers, n - 1).key
+    _ ->
+      nil
+  end
+end
+```
+
+`provider_selection/1` now returns a single atom rather than a list.
+
+### 3. Adapt callers
+
+`drive_flow/1` and `handle_credentials/3` receive a single atom, not a
+list. Minimal change:
+
+```elixir
+# drive_flow — provider is now an atom, not a list
+provider = provider_selection(io)            # atom
+creds_summary = handle_credentials(io, [provider], non_interactive?)
+
+new_settings =
+  base_settings
+  |> Map.put("permissions", merge_permissions(base_settings, perms_mode))
+  |> Map.put("provider", provider_string(provider))  # no List.first needed
+```
+
+### 4. Credential collection: optionally extend to multi-provider credential setup
+
+To allow credential collection for providers other than the primary (e.g.
+for fallback chains), an optional second step can ask "Configure credentials
+for additional providers? (y/N)" and, if yes, present the same credential
+prompts for additional providers without writing them to `"provider"`. This
+is additive and does not change the `"provider"` key in settings. This
+sub-step is optional within this proposal.
+
+### File moves
+
+```
+(mod)  lib/tau/cli/init.ex  — @providers bedrock fix; provider_selection rewrite
+(none) lib/tau/commands/builtin/logout.ex  — unchanged
+(none) lib/tau/settings/schema.ex         — unchanged
+```
+
+## Tradeoffs
+
+### Strengths
+
+- No schema change required; fully backwards-compatible settings files.
+- Simplest callsite: `provider_string(provider)` — no `List.first`, no
+  list comprehension, no possible truncation.
+- Does not require a new module or any new abstraction.
+- Logout is completely untouched (only the Bedrock key fix in Init is
+  needed).
+- The root cause of the `List.first` surprise — a multi-select UI feeding
+  a single-value schema field — is eliminated rather than papered over.
+
+### Weaknesses
+
+- Does NOT satisfy "settings reflect all N selections" if the user genuinely
+  wants multiple provider strings persisted. This proposal reframes the
+  problem: the AC's "all N selections" becomes N=1 by fixing the UX contract.
+  If the product intent is truly multi-provider persistence, this proposal
+  is wrong; it redefines the acceptance criterion rather than meeting it.
+- Credential duplication between `Init.@providers` and
+  `Logout.@credential_map` remains; they can still drift in the future.
+- Reduces wizard functionality: users cannot select multiple providers in
+  a single `tau init` run (they must re-run for each).
+- `parse_provider_indices` (the multi-index parser) is no longer used and
+  can be deleted, but its deletion is a small dead-code cleanup cost.
+
+### Costs
+
+- 1 file changed (`init.ex`), ~30 lines.
+- Test updates: `test/tau/cli/init_test.exs` — multi-provider selection
+  tests must change to reflect single-select semantics; tests that assert
+  multi-provider persistence will fail and must be removed or rewritten.
+  This is potentially a significant test-surface impact if the test suite
+  has comprehensive multi-select coverage.
+- No schema migration needed.
+
+## Dependencies
+
+- None. This proposal is self-contained in `init.ex`.
+
+## Confidence
+
+medium — the fix is technically straightforward, but whether the product
+intent supports reducing multi-select to single-select is a product
+question, not an engineering one. Confidence in the implementation is high;
+confidence that this satisfies the product acceptance criterion depends on
+that judgement.
+
+## Prior art / references
+
+- `lib/tau/settings/schema.ex:69` — `"provider" => %{"type" => "string"}`:
+  the schema constraint that motivates treating single-select as the
+  semantically correct behaviour.
+- Conventional CLI wizards (e.g. `mix phx.new`) prompt for one primary
+  adapter and optionally extend; multi-select-that-silently-truncates is
+  an anti-pattern.
+- `lib/tau/cli/init.ex:136–139` — `provider_selection/1` return value
+  already handles the empty-selection fallback to `[List.first(@providers).key]`,
+  showing the single-provider fallback was always the intended default.

--- a/docs/problems-archive-v1-modules/tau-cli/subproblems/wizard-data-fidelity/proposals/proposal-4.md
+++ b/docs/problems-archive-v1-modules/tau-cli/subproblems/wizard-data-fidelity/proposals/proposal-4.md
@@ -1,0 +1,200 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 4
+parent_problem: ../problem.md
+---
+
+# Proposal 4: Credential-key verification via compile-time assertion + fix both bugs
+
+## Approach
+
+Fix both bugs directly in their owning files (same one-line corrections as
+Proposal 1), and add a compile-time cross-module consistency assertion in a
+dedicated test that runs at `mix compile` time or as part of `mix test`.
+The assertion verifies that every `env` value in `Init.@providers` that
+corresponds to a provider appearing in `Logout.@credential_map` has the
+same value. Neither `@providers` nor `@credential_map` is moved or merged;
+the duplication is accepted as a design fact, but divergence becomes a
+compile/test error rather than a silent runtime mismatch. The `List.first`
+truncation is fixed by extending the settings schema to support a
+`"providers"` array and persisting all selected provider strings; the
+`"provider"` key retains the first-selected provider for backwards
+compatibility.
+
+## Rationale
+
+The complecting hypothesis calls out divergence between two independent
+copies. One approach to decomplecting is elimination of one copy (Proposal
+2); another is enforced agreement. This proposal takes the latter: instead
+of removing duplication, it makes divergence structurally impossible to
+ship by adding a property-based or unit assertion that fires before any PR
+with a divergent copy can pass CI. The structural fix is at the test/CI
+layer rather than the production code layer. This is appropriate when both
+copies are in hot-path modules whose change history, ownership, and
+coupling to surrounding code make a merge undesirable. The `List.first` and
+schema fixes are independent of the assertion approach and are included to
+satisfy the full acceptance criterion.
+
+## Sketch
+
+### 1. Fix both root bugs
+
+```elixir
+# lib/tau/cli/init.ex — fix Bedrock env key
+%{key: :bedrock, label: "Bedrock", env: "AWS_SECRET_ACCESS_KEY"}
+
+# lib/tau/cli/init.ex — fix List.first truncation; extend new_settings
+new_settings =
+  base_settings
+  |> Map.put("permissions", merge_permissions(base_settings, perms_mode))
+  |> Map.put("provider", providers |> List.first() |> provider_string())
+  |> Map.put("providers", Enum.map(providers, &provider_string/1))
+```
+
+### 2. Schema amendment
+
+```elixir
+# lib/tau/settings/schema.ex
+"providers" => %{
+  "type" => "array",
+  "items" => %{"type" => "string"}
+}
+```
+
+### 3. Compile-time consistency assertion: new test module
+
+```elixir
+# test/tau/cli/init_logout_credential_parity_test.exs
+
+defmodule Tau.CLI.InitLogoutCredentialParityTest do
+  @moduledoc """
+  Compile-time guard: asserts that every provider appearing in both
+  `Tau.CLI.Init.@providers` and `Tau.Commands.Builtin.Logout.@credential_map`
+  uses the same vault credential name.
+
+  This test catches the class of bug documented in
+  docs/problems/tau-cli/subproblems/wizard-data-fidelity/problem.md,
+  where Init and Logout diverged on the Bedrock credential key.
+  """
+  use ExUnit.Case, async: true
+
+  # Access module attributes via compiled functions (module attributes are
+  # not accessible cross-module; expose via a function in each module, or
+  # compare via the functions those modules export). Since @providers and
+  # @credential_map are private, this test uses Application.spec or
+  # a narrow accessor function added to each module.
+
+  # Preferred: add accessor functions to each module (one line each):
+  #   In Init:   def providers, do: @providers
+  #   In Logout: def credential_map, do: @credential_map
+
+  test "Init and Logout agree on vault credential names for all shared providers" do
+    init_cred_map =
+      Tau.CLI.Init.providers()
+      |> Map.new(&{Atom.to_string(&1.key), &1.env})
+
+    logout_cred_map = Tau.Commands.Builtin.Logout.credential_map()
+
+    shared_providers = MapSet.intersection(
+      MapSet.new(Map.keys(init_cred_map)),
+      MapSet.new(Map.keys(logout_cred_map))
+    )
+
+    for provider <- shared_providers do
+      assert init_cred_map[provider] == logout_cred_map[provider],
+        "Credential key mismatch for provider #{inspect(provider)}: " <>
+        "Init stores #{inspect(init_cred_map[provider])}, " <>
+        "Logout deletes #{inspect(logout_cred_map[provider])}"
+    end
+  end
+end
+```
+
+### Accessor functions added to owning modules (minimal surface)
+
+```elixir
+# lib/tau/cli/init.ex — add one public function
+@doc false
+def providers, do: @providers
+
+# lib/tau/commands/builtin/logout.ex — add one public function
+@doc false
+def credential_map, do: @credential_map
+```
+
+### File moves
+
+```
+(mod)  lib/tau/cli/init.ex                        — bedrock key fix; providers accessor; schema key addition
+(mod)  lib/tau/commands/builtin/logout.ex         — credential_map accessor
+(mod)  lib/tau/settings/schema.ex                 — add "providers" array key
+(new)  test/tau/cli/init_logout_credential_parity_test.exs
+```
+
+## Tradeoffs
+
+### Strengths
+
+- Preserves the independent ownership of `@providers` and
+  `@credential_map`; neither module is structurally coupled to the other.
+- The parity test is self-documenting: it names the defect class and will
+  fail loudly (with a descriptive message naming the offending provider)
+  on any future divergence.
+- No new production module required; the enforcement lives in the test
+  layer where CI already runs it.
+- Satisfies both parts of the acceptance criterion: (a) all N providers
+  persisted via the `"providers"` key; (b) credential key parity enforced
+  at test-time, not just at code-review time.
+- Incremental: the accessor functions and parity test can land before the
+  bug fixes and will immediately catch the existing Bedrock divergence,
+  providing independent verification that the bug exists as described.
+
+### Weaknesses
+
+- The duplication is accepted as a permanent design fact — this is an
+  explicit tradeoff. The parity test reduces the risk but does not
+  eliminate it: a provider absent from `Logout.@credential_map` but
+  present in `Init.@providers` (or vice versa) would not trigger the
+  parity check (only shared providers are checked).
+- Requires exposing two `@doc false` accessor functions on private module
+  attributes, which is a mild abstraction leak in both modules.
+- The parity test does not catch a future provider that Init adds but
+  Logout does not — asymmetric additions are invisible to the intersection
+  check unless the assertion is strengthened to require all Init providers
+  to appear in Logout's map.
+- Schema amendment is a dependency that must be co-located with the
+  `"providers"` write; the schema and init fixes cannot land independently.
+
+### Costs
+
+- 2 files modified (init.ex, logout.ex): ~5 lines each (accessor + key fix).
+- 1 file modified (schema.ex): ~3 lines.
+- 1 new test file: ~40 lines.
+- Test updates: existing init tests for multi-provider selection may need
+  to add assertions for the `"providers"` key in the written settings.
+
+## Dependencies
+
+- `"providers"` array key added to `Tau.Settings.Schema` in the same PR.
+- Both `Tau.CLI.Init.providers/0` and
+  `Tau.Commands.Builtin.Logout.credential_map/0` accessor functions must
+  be present for the parity test to compile.
+
+## Confidence
+
+medium — the parity-test approach is unconventional (testing consistency
+between module attributes is unusual); confidence would rise if a
+prototype test runs green against the corrected code and red against the
+pre-fix code.
+
+## Prior art / references
+
+- Elixir cross-module consistency tests: pattern used in Phoenix and Ecto
+  to assert that behaviour callbacks are implemented or that configuration
+  tables are consistent (e.g. `for {k, _v} <- defaults, do: assert schema[k]`).
+- `lib/tau/settings/schema.ex:47–54` — `@known_providers` vs runtime
+  registry: a precedent for the risk of divergent lists in this codebase.
+- Property-based testing of data invariants: `StreamData` could
+  parameterise the parity check over generated provider keys for stronger
+  coverage, but a simple unit assertion is sufficient here.

--- a/docs/problems-archive-v1-modules/tau-cli/subproblems/wizard-data-fidelity/solution.md
+++ b/docs/problems-archive-v1-modules/tau-cli/subproblems/wizard-data-fidelity/solution.md
@@ -1,0 +1,215 @@
+---
+template_version: 1
+template_name: solution
+parent_problem: ../problem.md
+node_kind: leaf
+synthesised_from: [proposals/proposal-2.md]
+selection_method: single
+revision: 1
+---
+
+# Solution: Extract `Tau.Providers.Catalog` as single source of truth
+
+## Recommendation
+
+Introduce `lib/tau/providers/catalog.ex` — a pure compile-time data module — as
+the single authoritative registry mapping each provider atom to its label,
+vault credential name, and settings string key. Delete `Init.@providers` and
+`Logout.@credential_map`; both modules derive their provider knowledge from
+`Catalog` at compile time. Fix the `List.first` truncation by persisting all
+selected provider strings under a **new `"enabled_providers"` array key** in
+`settings.local.json` (with `"provider"` retaining the first selection for
+backwards compatibility), and add the corresponding array schema entry to
+`Tau.Settings.Schema`. The key name is deliberately `"enabled_providers"`,
+not `"providers"`: the latter is already defined at
+`lib/tau/settings/schema.ex:121` as an OBJECT for ADR-0012 per-provider
+fallback chains, and the schema enforces `additionalProperties: false` at the
+top level, so reusing `"providers"` would be both a type-shape collision (array
+vs object) and a semantic collision (enablement set vs fallback-chain config).
+This is the only proposal that structurally prevents future credential-key
+drift while fully satisfying both halves of the acceptance criterion without
+breaking any existing top-level key.
+
+## Selected from
+
+- **Chosen:** `proposals/proposal-2.md` — Extract `Tau.Providers.Catalog`
+
+| # | Fit | Decomplecting depth | Migration cost | Risk | Reversibility |
+|---|---|---|---|---|---|
+| 1 | Partially | Surface | Low | Low | Easy |
+| 2 | Yes | Deep | Medium | Low | Easy |
+| 3 | Partially | Surface | Low | Low | Easy |
+| 4 | Yes | Surface | Low | Low | Easy |
+
+**Why chosen:** Proposal 2 is the only one that scores Yes on fit AND Deep on
+decomplecting depth. Proposal 1 scores Partially because it leaves the
+duplication in place with no enforcement — drift recurs as soon as either file
+is edited independently. Proposal 3 scores Partially because it satisfies the
+acceptance criterion only by redefining it (single-select reframes "all N
+selections" to N=1), which is a product-level change the problem statement does
+not permit; the AC is explicit that N > 1 providers must be reflected. Proposal
+4 scores Yes on fit but Surface on decomplecting depth: the parity test reduces
+drift risk but does not remove the duplicated fact — two copies still exist,
+the test covers only their intersection, and new providers added asymmetrically
+remain invisible. Proposal 2 removes the duplicated fact entirely. The new
+module is pure data (no GenServer, no ETS, no runtime state), consistent with
+OTP non-negotiables #3 and #8. Migration cost is Medium rather than Low only
+because a new file is introduced and two call sites are refactored; the
+compile-time derivation pattern is idiomatic Elixir and carries no runtime
+cost. Reversibility is Easy: the module can be deleted and the original
+`@providers` / `@credential_map` literals restored atomically. The proposal's
+own sketch suggested writing the enablement list to a `"providers"` array key;
+revision 1 of this solution corrects that to `"enabled_providers"` (see
+`Schema collision discovery` below) — the substance of the chosen approach is
+unchanged.
+
+## What changes
+
+- **New:** `lib/tau/providers/catalog.ex` — defines `@entries` with `key`,
+  `label`, `env_var`, `string_key` per provider; exposes `all/0`, `by_key/1`,
+  `by_string_key/1`, `credential_map/0`.
+- **New:** `test/tau/providers/catalog_test.exs` — property tests asserting
+  every entry has non-nil `env_var`, all `:key` atoms are unique, all
+  `:string_key` strings are unique.
+- **Modify:** `lib/tau/cli/init.ex`
+  - Delete `@providers` module attribute.
+  - `alias Tau.Providers.Catalog`; replace all `@providers` references with
+    `Catalog.all()`.
+  - Fix `drive_flow/1`: replace `Map.put("provider", providers |> List.first() |> provider_string())` with both `Map.put("provider", ...)` (first selection, unchanged for backwards compatibility) and `Map.put("enabled_providers", Enum.map(providers, &Catalog.by_key(&1).string_key))` (new array key carrying all N selections).
+- **Modify:** `lib/tau/commands/builtin/logout.ex`
+  - Delete `@credential_map` literal.
+  - `alias Tau.Providers.Catalog`; add `@credential_map Catalog.credential_map()` (compile-time derivation — no runtime cost, no behaviour change).
+- **Modify:** `lib/tau/settings/schema.ex`
+  - Add `"enabled_providers" => %{"type" => "array", "items" => %{"type" => "string"}}` to the top-level `"properties"` map. MUST NOT reuse the existing `"providers"` key (line 121), which is an object reserved for ADR-0012 fallback chains. `@known_top_level_keys` is derived from `Map.keys(properties)` at compile time, so the new entry is picked up automatically.
+- **Modify:** `test/tau/cli/init_test.exs` — add assertions that written
+  settings include `"enabled_providers"` list reflecting all selected
+  providers, and that `"provider"` (singular) is the first selection.
+
+## What does not change
+
+- `Tau.Settings.Vault.put/2` and `Tau.Settings.Vault.delete/1` — operate on
+  vault key names directly; no change needed.
+- `Logout.run/2` body logic — `@credential_map` is now compile-time derived
+  from `Catalog`; the map value and all pattern matches are identical.
+- The `"provider"` (singular) key in `settings.local.json` — retained for
+  backwards compatibility with any code reading the active provider.
+- The existing `"providers"` (plural) key at `schema.ex:121` — remains an
+  object holding the ADR-0012 fallback-chain block
+  (`%{"fallback_chains" => %{...}}`). No shape change, no semantic change.
+- `Tau.Settings.Schema.resolve_fallback_chains/1` — still consumes
+  `settings["providers"]`; the new `"enabled_providers"` key is consumed by
+  wizard / read-back code only.
+- `provider_string/1` helper in `Init` — still used for the `"provider"`
+  singular key; may be replaced by `Catalog.by_key/1` lookup but is not
+  required to be.
+- All other `Init` wizard steps (permissions, non-interactive mode, credential
+  prompts).
+- `Tau.Commands.Builtin.Logout` credential removal logic — unchanged.
+
+## Migration sketch
+
+1. Land `lib/tau/providers/catalog.ex` and `test/tau/providers/catalog_test.exs`
+   first; the new module has no callers yet so it cannot break anything.
+2. Add the `"enabled_providers"` array key to `Tau.Settings.Schema` in the same
+   commit (additive top-level key; the existing `"providers"` object is
+   untouched, and `additionalProperties: false` at the top level admits the new
+   key because it is explicitly listed). Existing `settings.local.json` files
+   without the key remain valid.
+3. Refactor `Init`: delete `@providers`, alias `Catalog`, fix `drive_flow/1` to
+   write both `"provider"` and `"enabled_providers"`. Update
+   `test/tau/cli/init_test.exs` to assert the new key.
+4. Refactor `Logout`: delete `@credential_map` literal, derive from
+   `Catalog.credential_map()` at compile time. No test changes expected (the
+   map values are identical; existing tests pass).
+5. Run `mix compile --warnings-as-errors && mix test`. The Bedrock credential
+   round-trip (init → vault → logout) is verifiable by tracing
+   `Catalog.by_key(:bedrock).env_var` → `"AWS_SECRET_ACCESS_KEY"` →
+   `Logout.@credential_map["bedrock"]`. Schema acceptance is verifiable by
+   `Tau.Settings.Schema.json_schema/0 |> Map.fetch!("properties") |> Map.keys()`
+   including both `"providers"` (existing object) and `"enabled_providers"`
+   (new array) without collision.
+
+## Schema collision discovery (revision 1)
+
+Revision 0 of this solution proposed writing the enablement list to a new
+top-level `"providers"` key as an array. Inspection of
+`lib/tau/settings/schema.ex` at the line cited in the revision instruction
+falsified that choice:
+
+- `schema.ex:121` already declares `"providers"` as
+  `%{"type" => "object", "additionalProperties" => true, "properties" => %{"fallback_chains" => ...}}`
+  — an object reserved by ADR-0012 for per-provider fallback chains.
+- `schema.ex:66` sets `"additionalProperties" => false` at the top level, and
+  `@known_top_level_keys` (line 216) is derived from
+  `Map.keys(@schema["properties"])` at compile time. Adding a second
+  `"properties"` entry under the same key is a literal map-key collision
+  (Elixir map-literal duplicate-key warning) and would either silently
+  overwrite the ADR-0012 entry or fail to compile under
+  `--warnings-as-errors`.
+- Even if the literal collision were avoided by an in-place mutation, the
+  JSON-Schema validator would reject every existing valid
+  `settings.local.json` whose `"providers"` is an object (the canonical
+  ADR-0012 shape) against a redefined `"type": "array"`.
+
+`"enabled_providers"` was chosen as the replacement key name because it (a)
+does not appear in the current top-level key set —
+`model, provider, data_dir, theme, permissions, mcp, hooks, extensions,
+allow, deny, ask, providers, rate_limits, vault, coding_agent, otel` — (b)
+reads as semantically distinct from `"providers"` (enablement set vs
+fallback-chain configuration), and (c) is consistent with the schema's
+existing snake_case convention (`data_dir`, `rate_limits`, `coding_agent`).
+No other top-level key collisions were found.
+
+## Open questions
+
+- `Catalog.by_key/1` returns `nil` for an unknown atom. `drive_flow/1` must
+  guard this path (e.g. filter out `nil` entries or raise at init time). The
+  proposal sketches the nil path but does not specify the error handling
+  strategy; the implementer should apply a `Enum.reject(&is_nil/1)` or a
+  pattern-match guard consistent with OTP non-negotiable #7 (let it crash on
+  programmer error, not user input).
+- Whether `provider_string/1` in `Init` should be deleted in favour of
+  `Catalog.by_key(k).string_key` is a readability question. Both work; the
+  implementer may decide.
+- `Tau.Settings.Schema.@known_providers` (line 47–54) is a separate registry
+  that lists provider modules (full `Tau.Providers.*` names) for ADR-0012
+  fallback-chain resolution. After this change, `Catalog` (wizard-side,
+  string keys like `"anthropic"`) and `@known_providers` (chain-side, module
+  references) are two compile-time lists describing overlapping provider
+  sets. They do NOT collide on key namespace (the wizard's `string_key` is
+  the short alias; `@known_providers` holds fully-qualified module names),
+  but they can drift on coverage (e.g. add a provider to `@known_providers`
+  but not to `Catalog`). This proposal does not address that drift (out of
+  scope per problem.md), but the implementer should note it and optionally
+  derive `@known_providers` from `Catalog` (or vice versa) in a follow-up if
+  the mapping is trivially safe.
+- Whether a future PR should rename the singular `"provider"` key to
+  `"default_provider"` and treat `"enabled_providers"` as the sole list of
+  record. Currently both are retained for backwards compatibility; a future
+  schema-cleanup PR could deprecate the singular form.
+
+## Linked sub-problems / proposals
+
+- `proposals/proposal-1.md` — Inlined correction; fixes both bugs in place
+  without a new module. Selected against: leaves duplication intact; scored
+  Partially on fit (no structural enforcement of future agreement).
+- `proposals/proposal-2.md` — Extract `Tau.Providers.Catalog`; single source
+  of truth at compile time. **Selected.**
+- `proposals/proposal-3.md` — Single-select reframe; changes the UX contract
+  to match the existing schema rather than extending the schema. Selected
+  against: redefines the acceptance criterion rather than satisfying it.
+- `proposals/proposal-4.md` — Inline fix plus parity test. Selected against:
+  decomplects at test layer only; the duplicated fact and its drift risk
+  remain in production code.
+
+## Revision history
+
+- (revision 0 — initial selection of proposal-2)
+- (revision 1 — schema-key collision fix: changed the new array key from
+  `"providers"` to `"enabled_providers"` after inspection of
+  `lib/tau/settings/schema.ex:121` confirmed `"providers"` is already
+  defined as an ADR-0012 fallback-chain object and the top level uses
+  `additionalProperties: false`. Verified no other top-level key
+  collisions: the chosen name is absent from `@known_top_level_keys`. The
+  underlying selection of proposal-2 is unchanged; only the persisted-key
+  identifier and the schema entry differ.)

--- a/docs/problems-archive-v1-modules/tau-cli/subproblems/wizard-data-fidelity/validation.md
+++ b/docs/problems-archive-v1-modules/tau-cli/subproblems/wizard-data-fidelity/validation.md
@@ -1,0 +1,566 @@
+---
+template_version: 1
+template_name: validation
+parent_solution: solution.md
+parent_problem: problem.md
+toulmin_complete: true
+falsification_attempted: true
+falsification_outcome: partially_falsified — claim/4
+revision_triggered: none
+---
+
+# Validation: Extract `Tau.Providers.Catalog` as single source of truth
+
+## Overview
+
+The solution makes eight checkable propositions: (1) introduce a pure
+`Tau.Providers.Catalog` data module as the single registry, (2) delete
+`Init.@providers` and `Logout.@credential_map` literal copies and derive
+them from `Catalog` at compile time, (3) fix the `List.first` truncation
+by persisting all selections under a new `"enabled_providers"` array
+key while retaining `"provider"` (singular) for backwards compatibility,
+(4) `"enabled_providers"` (not `"providers"`) is the correct key name
+because the existing `"providers"` is an ADR-0012 object and the top
+level uses `additionalProperties: false`, (5) the schema's
+`@known_top_level_keys` is derived from `Map.keys(properties)` at
+compile time so the new entry is picked up automatically, (6) `Logout`
+behaviour is preserved because the derived `@credential_map` values
+match the literal it replaces, (7) the change satisfies OTP
+non-negotiables #3 (no GenServer for stateless logic) and #8 (pure
+functions default), and (8) the Bedrock round-trip (init → vault →
+logout) is correctly closed because `Catalog.by_key(:bedrock).env_var`
+becomes `"AWS_SECRET_ACCESS_KEY"` — the same key `Logout` removes.
+
+Per-claim strategy was a mix of dependency check, type-level check,
+edge-case enumeration, and counter-example construction. Seven claims
+withstood; one (claim 4 / claim 8 interaction) is partially falsified
+on Bedrock semantics — see "Outstanding doubts".
+
+## Toulmin per claim
+
+The MITRE empirical study on Toulmin formalism found that "participants
+found it difficult to generate Toulmin structures, and their structures
+varied greatly even though they started with the same content"
+(https://www.mitre.org/news-insights/publication/empirical-evaluation-structured-argumentation-using-toulmin-argument).
+This validation enforces all six components explicitly per claim.
+
+### Claim 1: `Tau.Providers.Catalog` becomes the single source of truth for provider identity → vault env var → settings string key.
+
+- **Claim (C):** "Introduce `lib/tau/providers/catalog.ex` — a pure
+  compile-time data module — as the single authoritative registry
+  mapping each provider atom to its label, vault credential name, and
+  settings string key. Delete `Init.@providers` and
+  `Logout.@credential_map`; both modules derive their provider knowledge
+  from `Catalog` at compile time." (solution.md §Recommendation)
+- **Grounds (G):** `lib/tau/cli/init.ex:59–65` defines `@providers` as
+  a literal of five `%{key:, label:, env:}` entries. `lib/tau/commands/
+  builtin/logout.ex:38–43` defines `@credential_map` as a literal of
+  four `string => env_var` entries. These are the only two literals in
+  the codebase that bind a provider identity to a vault credential name
+  (`grep -rn "AWS_SECRET_ACCESS_KEY\|AWS_ACCESS_KEY_ID" lib/` returns
+  only these two plus `bedrock.ex:182–185`, which is a *reader* of
+  `System.get_env`, not a writer of the mapping). Centralising both
+  into a single literal removes the only known drift surface.
+- **Warrant (W):** Hickey's "complect" principle: identity (provider
+  atom) and policy (credential name, label, string key) are independent
+  facts and should be stored exactly once. Tau OTP non-negotiable #2
+  (extensibility seams are behaviours; pattern-match on atoms and
+  structs) reinforces that the catalogue is the natural lookup table.
+- **Qualifier (Q):** Holds for the *current* set of two literal
+  copies. Does not address `Tau.Settings.Schema.@known_providers`
+  (`schema.ex:47–54`), which is a third, structurally distinct
+  registry that the solution explicitly leaves out of scope (see
+  solution.md §Open questions, third bullet).
+- **Rebuttal (R):** A future code path that adds a third literal copy
+  (e.g. an integration test that hand-rolls the same map) would
+  re-introduce drift; the property test in
+  `test/tau/providers/catalog_test.exs` only asserts internal
+  consistency of `Catalog`, not exclusivity of `Catalog` as the
+  registry.
+- **Backing (B):** Hickey, "Simple Made Easy" (2011): independent
+  facts should not be braided. CLAUDE.md → `otp-non-negotiables.md`
+  §1–2.
+
+#### Falsification attempt for claim 1
+
+- **Strategy:** Dependency check (does the codebase truly contain
+  only two such literals today, so the extraction *can* be the sole
+  source of truth?) + edge-case enumeration (other readers of the
+  provider→env mapping).
+- **Attempt:** Ran `grep -rn "AWS_SECRET_ACCESS_KEY\|AWS_ACCESS_KEY_ID"
+  lib/`, `grep -rn "ANTHROPIC_API_KEY\|OPENAI_API_KEY\|GEMINI_API_KEY"
+  lib/`, and `grep -rn "@providers\|@credential_map" lib/`. The hits
+  outside `init.ex` and `logout.ex` are `bedrock.ex` (reads env), and
+  the moduledoc tables (documentation, not code).
+- **Outcome:** withstood. Two literal copies; centralisation removes
+  both.
+- **Action:** none.
+
+### Claim 2: `Init.@providers` and `Logout.@credential_map` are deleted and replaced by compile-time derivation from `Catalog`.
+
+- **Claim (C):** "Delete `@providers` module attribute … `alias
+  Tau.Providers.Catalog`; replace all `@providers` references with
+  `Catalog.all()`" (solution.md §What changes) and "Delete
+  `@credential_map` literal … add `@credential_map
+  Catalog.credential_map()` (compile-time derivation — no runtime
+  cost, no behaviour change)".
+- **Grounds (G):** `@providers` is referenced in `init.ex` at lines
+  137, 205, 218, 231, 232, 250 (verified by reading the full file).
+  `@credential_map` is referenced in `logout.ex` at lines 57, 60, 61,
+  65. All references are pure-data lookups (`length/1`, `Enum.at/2`,
+  `Enum.with_index/2`, `Map.has_key?/2`, `Map.keys/1`) that work
+  equivalently against the value returned by `Catalog.all/0` or
+  `Catalog.credential_map/0`.
+- **Warrant (W):** A `@module_attribute` bound to a function call at
+  compile time evaluates that call once during compilation and freezes
+  the result into the module's BEAM file (Elixir Module Attributes
+  reference). Therefore `@credential_map Catalog.credential_map()`
+  produces a literal identical to the deleted `@credential_map %{…}`
+  if and only if `Catalog.credential_map/0` returns the same map.
+- **Qualifier (Q):** Holds iff `Catalog.credential_map/0` is a pure
+  function (no I/O, no `System.get_env`, no compile-time
+  configuration). The solution sketches it as `@entries`-derived,
+  which satisfies purity.
+- **Rebuttal (R):** If `Catalog` is loaded after either consumer
+  module at compile time (i.e. compilation order inversion), the
+  `@credential_map Catalog.credential_map()` line would fail with
+  `UndefinedFunctionError`. Elixir's compiler handles this via
+  dependency tracking; an explicit `require Tau.Providers.Catalog`
+  guarantees ordering. The solution does not name `require` but
+  `alias` plus the function call in a module attribute is sufficient
+  to register the dependency in standard projects.
+- **Backing (B):** Elixir documentation — Module Attributes:
+  "Module attributes can also be used as temporary storage to be used
+  during compilation". `mix compile --warnings-as-errors` is the
+  project's gate (CLAUDE.md → project lints).
+
+#### Falsification attempt for claim 2
+
+- **Strategy:** Type-level check + counter-example construction.
+- **Attempt:** Mentally substituted `@providers` with `Catalog.all()`
+  at each call site in `init.ex`. Every call site uses operations
+  defined on `Enum`/`Map`/`length` — they accept any list/map. For
+  `@credential_map`, the four call sites all read the map by key or
+  enumerate keys; identical to current behaviour iff `Catalog`'s map
+  has the same shape. The proposal's sketch (`%{key: …, env: …,
+  string_key: …}`) is a superset of `%{key: …, env: …, label: …}`,
+  so existing reads remain valid.
+- **Outcome:** withstood.
+- **Action:** none. (The implementer note about purity stands; gating
+  test must check `Catalog.credential_map/0` is invoked at compile
+  time, not runtime.)
+
+### Claim 3: Persisting all N selections under `"enabled_providers"` while keeping `"provider"` singular satisfies the AC for N > 1.
+
+- **Claim (C):** "Fix the `List.first` truncation by persisting all
+  selected provider strings under a new `"enabled_providers"` array
+  key in `settings.local.json` (with `"provider"` retaining the first
+  selection for backwards compatibility)".
+- **Grounds (G):** `lib/tau/cli/init.ex:153` is the truncation site
+  (verified verbatim). `provider_selection/1` (line 201–221) correctly
+  returns a list of all selected keys. Replacing `Map.put("provider",
+  providers |> List.first() |> provider_string())` with both that put
+  and `Map.put("enabled_providers", Enum.map(providers, &Catalog.by_
+  key(&1).string_key))` writes all N selections. The AC ("the written
+  `settings.local.json` reflects all N selections") is satisfied: all
+  N selections appear under `enabled_providers`.
+- **Warrant (W):** Acceptance is a behavioural property of the
+  written JSON file: an external observer (`Jason.decode!` over the
+  file) sees N selected provider strings. A test of the form
+  `assert decoded["enabled_providers"] == ["anthropic", "openai_chat"]`
+  for a two-select input falsifies the bug-as-written.
+- **Qualifier (Q):** Holds when the schema admits the new key (claim
+  4) and when `Catalog.by_key(k)` returns a non-nil entry for every
+  selected key (covered by solution.md §Open questions bullet 1,
+  delegated to implementer).
+- **Rebuttal (R):** If a downstream reader of `settings.local.json`
+  expects "the list of enabled providers" under the singular
+  `"provider"` key as a comma-joined string, this change would not
+  satisfy it. Grep shows no such reader: the only `"provider"` key
+  consumers are TUI bootstrap (`lib/tau/tui/app/bootstrap.ex:33`),
+  events (`events.ex:312`), and view (`view.ex:122`), all of which
+  read a *single* provider atom. Compatibility is preserved.
+- **Backing (B):** problem.md §Acceptance criterion ("the written
+  `settings.local.json` reflects all N selections"). Hickey on data:
+  the persisted shape is the contract; reading code adapts.
+
+#### Falsification attempt for claim 3
+
+- **Strategy:** Counter-example construction over the AC's input
+  space.
+- **Attempt:** Constructed N = 2 case (user selects indices "1,2"):
+  `provider_selection/1` returns `[:anthropic, :openai_chat]`. New
+  `drive_flow/1` writes `%{"provider" => "anthropic",
+  "enabled_providers" => ["anthropic", "openai_chat"]}`. After
+  `Jason.encode!`, both keys appear in the JSON; `enabled_providers`
+  reflects both selections. AC satisfied. Constructed N = 5 (all
+  providers): same shape, list of length 5. AC satisfied. Constructed
+  N = 0 (empty input → defaults to first; per parse_provider_indices/
+  1): list of length 1 with the default; AC vacuously satisfied
+  (N > 1 not triggered).
+- **Outcome:** withstood.
+- **Action:** none.
+
+### Claim 4: `"enabled_providers"` (not `"providers"`) is the correct top-level key because `"providers"` is already an ADR-0012 object and the top level uses `additionalProperties: false`.
+
+- **Claim (C):** "The key name is deliberately `"enabled_providers"`,
+  not `"providers"`: the latter is already defined at
+  `lib/tau/settings/schema.ex:121` as an OBJECT for ADR-0012
+  per-provider fallback chains, and the schema enforces
+  `additionalProperties: false` at the top level, so reusing
+  `"providers"` would be both a type-shape collision (array vs object)
+  and a semantic collision (enablement set vs fallback-chain config)."
+- **Grounds (G):** `schema.ex:66` reads
+  `"additionalProperties" => false` (verified). `schema.ex:121` reads
+  `"providers" => %{"type" => "object", "additionalProperties" =>
+  true, "properties" => %{"fallback_chains" => …}}` (verified).
+  `schema.ex:253` shows the *consumer*:
+  `providers = Map.get(settings, :providers) || Map.get(settings,
+  "providers") || %{}` followed by
+  `Map.get(providers, :fallback_chains) || …` — exclusively object
+  semantics. `docs/adr/0012-provider-fallback-is-fsm-internal-retry.md`
+  exists. Reusing `"providers"` as an array would (a) double-define a
+  key in the schema literal (Elixir map-literal duplicate-key warning
+  → `--warnings-as-errors` failure) or (b) silently overwrite the
+  ADR-0012 entry, breaking `resolve_fallback_chains/1`.
+- **Warrant (W):** A JSON Schema with `additionalProperties: false`
+  rejects any top-level key not enumerated in `properties`. Two
+  entries for the same key in an Elixir map literal raise a
+  compile-time warning. Two entries with conflicting `type`
+  declarations (object vs array) cannot both be valid simultaneously.
+- **Qualifier (Q):** none — universal across the current schema and
+  validator pinning (ex_json_schema ~> 0.10, Draft 7).
+- **Rebuttal (R):** If `additionalProperties: false` were relaxed at
+  the top level, the array could in principle live under a different
+  shape, but the rebuttal does not apply because the schema as-pinned
+  enforces it.
+- **Backing (B):** JSON Schema Draft 7 §6.5.6
+  (additionalProperties); Elixir Map module documentation on literal
+  duplicate keys; `docs/adr/0012-provider-fallback-is-fsm-internal-
+  retry.md`.
+
+#### Falsification attempt for claim 4
+
+- **Strategy:** Dependency check (does `"providers"` already exist as
+  claimed?) + counter-example construction (could `"providers"` be
+  safely reused?).
+- **Attempt:** Verified line 121 of `schema.ex` defines `"providers"`
+  as an object with `fallback_chains`. Verified line 66 sets
+  `additionalProperties: false`. Verified line 253's consumer treats
+  `settings["providers"]` exclusively as an object with `:atom_keys`
+  or `"string_keys"` mapping to `fallback_chains`. Attempted to
+  imagine a structurally compatible reuse: even a union shape
+  `["array", "object"]` would break `resolve_fallback_chains/1`,
+  which assumes `Map.get(providers, :fallback_chains)` — calling
+  `Map.get/2` on a list raises. The reuse is infeasible.
+- **Outcome:** withstood.
+- **Action:** none. NB the falsification ALSO ruled out the only
+  obvious alternative (typed union); the chosen new-key approach
+  appears unique.
+
+### Claim 5: `@known_top_level_keys` automatically picks up the new entry, so no separate registration step is needed.
+
+- **Claim (C):** "`@known_top_level_keys` is derived from
+  `Map.keys(properties)` at compile time, so the new entry is picked
+  up automatically."
+- **Grounds (G):** `schema.ex:216` reads
+  `@known_top_level_keys @schema |> Map.fetch!("properties") |>
+  Map.keys() |> Enum.sort()`. Adding `"enabled_providers"` to
+  `"properties"` causes `Map.keys/1` to include it; sort is stable;
+  `@known_top_level_keys` ends up with the new entry without further
+  edits.
+- **Warrant (W):** Module attribute definitions are evaluated
+  exactly once at compile time, after the lexically preceding
+  attributes are bound; `Map.keys/1` is a pure function over the
+  attribute's value.
+- **Qualifier (Q):** Holds for `mix compile`; does not address
+  `Tau.Settings.Loader`'s `list_keys/0` function (line 88) which is a
+  *separately maintained* list used for cascade merging — see
+  "Outstanding doubts" and Claim 8.
+- **Rebuttal (R):** None at this layer.
+- **Backing (B):** Elixir Module Attributes documentation; the
+  schema's own moduledoc §"additionalProperties policy".
+
+#### Falsification attempt for claim 5
+
+- **Strategy:** Type-level check.
+- **Attempt:** Symbolically reduced
+  `@schema |> Map.fetch!("properties") |> Map.keys() |> Enum.sort()`
+  with `"enabled_providers"` added to `properties`. Result is the
+  current sorted list with `"enabled_providers"` inserted in sort
+  order. No dependency on the entry's value type.
+- **Outcome:** withstood.
+- **Action:** none.
+
+### Claim 6: `Logout`'s observable behaviour is unchanged.
+
+- **Claim (C):** "`Logout.run/2` body logic — `@credential_map` is now
+  compile-time derived from `Catalog`; the map value and all pattern
+  matches are identical."
+- **Grounds (G):** `logout.ex:38–43` shows the literal map.
+  `Catalog.credential_map/0` is sketched to return the same shape
+  (`%{string => env_var}`) with the same four entries (anthropic,
+  openai, gemini, bedrock). Every other line of `Logout.run/2`
+  (lines 52–88) is unchanged.
+- **Warrant (W):** Two `@credential_map` bindings produce
+  observationally identical modules iff the map values are equal as
+  Elixir terms.
+- **Qualifier (Q):** Holds iff `Catalog`'s string keys exactly match
+  `{"anthropic", "openai", "gemini", "bedrock"}`. Note: the wizard's
+  `provider_string/1` (init.ex:505–509) emits *five* strings:
+  `"anthropic", "openai_chat", "openai_responses", "gemini",
+  "bedrock"`. The current `@credential_map` collapses both
+  `:openai_chat` and `:openai_responses` to a single `"openai"` key.
+  The solution's `string_key` field per provider must therefore
+  reconcile this asymmetry: the wizard-side string keys are NOT the
+  same as the logout-side credential-map keys. The solution glosses
+  this — see "Outstanding doubts".
+- **Rebuttal (R):** If `Catalog.credential_map/0` introduces a new
+  key (e.g. splits `"openai"` into `"openai_chat"`/`"openai_responses"`
+  to match the wizard's `string_key`), then existing `/logout openai`
+  invocations would break.
+- **Backing (B):** the moduledoc table at `logout.ex:14–21` is the
+  user-facing API contract; preserving it is a compatibility
+  requirement.
+
+#### Falsification attempt for claim 6
+
+- **Strategy:** Counter-example construction over the public API
+  (`/logout <provider>`).
+- **Attempt:** Constructed call `/logout openai`: current code
+  resolves to `OPENAI_API_KEY` via the literal map. Constructed call
+  `/logout bedrock`: resolves to `AWS_SECRET_ACCESS_KEY` (the
+  documented behaviour). After extraction, *iff* `Catalog`'s entries
+  include `string_key: "openai"` for one entry and
+  `string_key: "bedrock"` for the bedrock entry, the derived map
+  produces identical lookups. But the wizard's `provider_string/1`
+  emits `"openai_chat"`/`"openai_responses"` for the two openai
+  providers — a 1:1 with the atoms but a 2:1 with the credential. The
+  catalog must therefore distinguish two concepts: a *settings
+  string_key* (wizard-side) and a *logout alias* (logout-side). The
+  solution sketches a single `string_key` field per entry; it does
+  not name a separate alias. This is an under-specification, not a
+  falsification, because the implementer can reconcile either by
+  (a) giving openai_chat and openai_responses the same string_key
+  ("openai"), losing wizard fidelity, or (b) adding a separate
+  `logout_alias` field. Either path preserves Logout behaviour; the
+  solution leaves the choice open.
+- **Outcome:** withstood at the claim's stated scope (Logout
+  behaviour preserved) but the catalog field set is
+  under-specified. Implementer must resolve.
+- **Action:** none for the validator; flag as "Outstanding doubt 1"
+  for the implementer.
+
+### Claim 7: The change satisfies OTP non-negotiables #3 (no GenServer for stateless logic) and #8 (pure functions default).
+
+- **Claim (C):** "The new module is pure data (no GenServer, no ETS,
+  no runtime state), consistent with OTP non-negotiables #3 and #8."
+- **Grounds (G):** The proposed module is described as a pure
+  compile-time data module exposing `all/0`, `by_key/1`,
+  `by_string_key/1`, `credential_map/0` — all pure functions over a
+  `@entries` literal.
+- **Warrant (W):** A module containing only `@entries` (a literal
+  list of maps) and pure functions over it is, by inspection, both
+  stateless and process-free.
+- **Qualifier (Q):** none — universal for the proposed module shape.
+- **Rebuttal (R):** None at the design layer; implementer could
+  inadvertently introduce `Application.get_env/2` reads if the
+  catalog is ever made configurable, which would violate
+  non-negotiable #1.
+- **Backing (B):** `.claude/rules/otp-non-negotiables.md` items #3
+  and #8.
+
+#### Falsification attempt for claim 7
+
+- **Strategy:** Type-level check against `otp-non-negotiables.md`.
+- **Attempt:** Item #1 (stateful subsystems supervised): N/A — the
+  module is stateless. #2 (extensibility seams as behaviours): N/A —
+  the catalog is data, not a seam. #3 (no GenServer for stateless
+  logic): satisfied. #4 (cross-process events via PubSub): N/A.
+  #5 (telemetry): N/A — pure data module. #6 (properties before
+  examples): satisfied by the proposed `catalog_test.exs` property
+  tests. #7 (let it crash): N/A. #8 (pure default): satisfied.
+- **Outcome:** withstood.
+- **Action:** none.
+
+### Claim 8: The Bedrock credential round-trip (init → vault → logout) is closed by `Catalog.by_key(:bedrock).env_var = "AWS_SECRET_ACCESS_KEY"`.
+
+- **Claim (C):** "Schema acceptance is verifiable by … the Bedrock
+  credential round-trip (init → vault → logout) is verifiable by
+  tracing `Catalog.by_key(:bedrock).env_var` →
+  `"AWS_SECRET_ACCESS_KEY"` → `Logout.@credential_map["bedrock"]`."
+  (solution.md §Migration sketch step 5)
+- **Grounds (G):** problem.md states init currently uses
+  `AWS_ACCESS_KEY_ID` and logout uses `AWS_SECRET_ACCESS_KEY`. The
+  solution proposes a single source of truth; the implementer must
+  pick *one* env var name for Bedrock in `Catalog`. The solution
+  implies the choice is `AWS_SECRET_ACCESS_KEY` (to match logout's
+  current behaviour), which means the wizard would prompt for the
+  *secret* under the env name `AWS_SECRET_ACCESS_KEY`.
+- **Warrant (W):** A round-trip is closed iff
+  `init.store_credential` writes the same vault key that
+  `logout.delete` reads.
+- **Qualifier (Q):** Holds for the secret-access-key half of AWS
+  SigV4 credentials. Bedrock authentication *requires both*
+  `AWS_ACCESS_KEY_ID` AND `AWS_SECRET_ACCESS_KEY` (verified at
+  `lib/tau/providers/bedrock.ex:182–185`: the provider reads both
+  via `System.get_env`). The wizard prompting for a single env var
+  named `AWS_SECRET_ACCESS_KEY` does not provision the access-key-id
+  half. Bedrock auth will fail at request time unless the user has
+  exported `AWS_ACCESS_KEY_ID` by some other means (shell rc,
+  `~/.aws/credentials`, IMDS).
+- **Rebuttal (R):** The problem statement frames the bug as
+  "init/logout disagree on the key name"; a fix that aligns them on
+  *one* key does close that bug per the AC. The deeper question —
+  "should the wizard prompt for both AWS credentials, or for a
+  symbolic 'AWS profile' that maps to both?" — is plausibly out of
+  scope of this problem. solution.md §Out of scope inherits from
+  problem.md §Out of scope, which lists "Logout behaviour for
+  providers other than Bedrock" but does *not* list "Bedrock's
+  dual-credential nature". The problem statement's AC mentions only
+  "the actual stored credential" (singular). So the AC, as written,
+  is satisfied by the single-key alignment.
+- **Backing (B):** AWS Signature Version 4 specification (requires
+  both access-key-id and secret-access-key);
+  `lib/tau/providers/bedrock.ex` lines 182–185.
+
+#### Falsification attempt for claim 8
+
+- **Strategy:** Edge-case enumeration over the Bedrock auth path.
+- **Attempt:** Constructed: user runs `tau init`, selects Bedrock,
+  enters value `X` when prompted for `AWS_SECRET_ACCESS_KEY`.
+  Vault stores `AWS_SECRET_ACCESS_KEY=X`. User runs Tau, attempts
+  inference. `Bedrock.credentials/0` checks
+  `System.get_env("AWS_ACCESS_KEY_ID")` — returns `nil` (vault was
+  never asked for it). Falls through to `:aws_credentials` library
+  fallback. If the user has no `~/.aws/credentials` or IMDS, returns
+  `nil` and authentication fails. The round-trip *for the
+  acceptance criterion as written* is closed, but the *user-visible
+  goal* (Bedrock works after wizard) is not.
+- **Outcome:** partially falsified. The literal claim ("the actual
+  stored credential is never cleared" → fixed) holds; the implicit
+  goal ("Bedrock is usable after wizard") does not, because the
+  wizard never collects `AWS_ACCESS_KEY_ID`.
+- **Action:** Narrow the Qualifier on Claim 8 to: "round-trip is
+  closed for the single credential the wizard stores; the wizard
+  does not provision the full Bedrock credential set (out of scope
+  per problem.md)." This does NOT trigger a solution revision because
+  problem.md's §Out of scope does not require it; this is a
+  follow-up worth filing as a separate problem. Flagged in
+  "Outstanding doubts".
+
+## Cross-claim consistency
+
+Claim 3 and Claim 4 work as a pair: the new key name
+(`"enabled_providers"`) only matters if the persisted shape (array of
+strings) needs schema admission. Both are coherent.
+
+Claim 5 (schema's `@known_top_level_keys` auto-updates) and Claim 8
+(Bedrock round-trip) are independent; no tension.
+
+A *latent* tension exists between Claim 1 (Catalog is the single
+source of truth) and the existing `Tau.Settings.Schema.
+@known_providers` literal (`schema.ex:47–54`), which is a third
+provider registry. Solution §Open questions bullet 3 acknowledges this
+and explicitly declares it out of scope. No internal inconsistency in
+the solution, but the title "single source of truth" is therefore
+*qualified*: single source of truth for the *Init↔Logout* coupling,
+not for *every* provider registry in the codebase. This validator
+records the narrowed reading of Claim 1.
+
+A *new* coherence concern (separate from the above tension): the
+solution does not mention `Tau.Settings.Loader.list_keys/0`
+(`loader.ex:88–98`), which is a hand-maintained list of settings keys
+that *concatenate* (rather than override) during cascade merge.
+`enabled_providers` is an array; the schema-moduledoc (`schema.ex:
+29–32`) explicitly states "every key listed here as `type: 'array'`
+should appear in `Tau.Settings.Loader`'s list-merge set so cascade
+semantics match". `list_keys/0` does NOT currently list
+`:enabled_providers`. If a user has both `~/.tau/settings.json` (with
+`enabled_providers: ["anthropic"]`) and `<cwd>/.tau/settings.json`
+(with `enabled_providers: ["openai_chat"]`), the cwd layer will
+*replace* (not append to) the home layer — a cascade-semantics drift
+that contradicts the schema's own documented contract. This is a
+mechanical follow-up: add `:enabled_providers` to
+`Loader.list_keys/0`. The omission is implementation-detail oversight,
+not a solution defect; flagging as Outstanding doubt 2.
+
+## Falsification summary
+
+| # | Claim (short) | Strategy | Outcome | Action |
+|---|---|---|---|---|
+| 1 | Catalog is single source of truth | dependency check + edge-case | withstood (with narrowing per X-claim §) | narrow Q to Init↔Logout coupling |
+| 2 | @providers / @credential_map deleted + derived | type-level + counter-example | withstood | none |
+| 3 | enabled_providers array satisfies N>1 AC | counter-example | withstood | none |
+| 4 | "enabled_providers" key name correct | dependency check + counter-example | withstood | none |
+| 5 | @known_top_level_keys auto-updates | type-level | withstood | none |
+| 6 | Logout behaviour unchanged | counter-example over public API | withstood (with implementer note re openai/openai_chat collapse) | flag Outstanding doubt 1 |
+| 7 | Satisfies OTP NN #3, #8 | type-level | withstood | none |
+| 8 | Bedrock round-trip closed | edge-case enumeration | partially falsified (AC met; user-visible Bedrock auth still broken because AWS_ACCESS_KEY_ID not provisioned) | narrow Q; file follow-up |
+
+## Revision required
+
+No solution revision and no problem revision are triggered. The two
+partial findings are:
+
+- Claim 8's narrowed Qualifier (Bedrock dual-credential nature) lies
+  *within* problem.md's §Out of scope (the problem explicitly limits
+  itself to the init/logout key-name disagreement; Bedrock's full
+  credential set is a separate concern). Narrowing the qualifier
+  in-place is sufficient; the solution achieves the AC as written.
+- Claim 1's narrowed Qualifier (Catalog is the single source for the
+  *Init↔Logout* coupling, not for *all* provider registries) is
+  consistent with solution.md §Open questions bullet 3, which already
+  flags `@known_providers` as out of scope.
+
+If the reader judges the Bedrock user-visible-goal gap to be
+in-scope after all, the *correct* action is to amend `problem.md`
+(add an Amendment log entry expanding the AC to "Bedrock auth works
+end-to-end after wizard") rather than revising `solution.md`. The
+solution as written is the correct response to the problem as
+written. This validator recommends *not* triggering a revision unless
+the user changes the AC.
+
+- **Target file:** (none)
+- **Revision kind:** (none)
+- **Rationale:** All claims withstood at the AC's stated scope; the
+  partial finding on Claim 8 falls inside problem.md §Out of scope.
+
+## Outstanding doubts
+
+1. **Catalog field design under openai_chat/openai_responses split.**
+   The wizard distinguishes `:openai_chat` and `:openai_responses`
+   (two separate `provider_string/1` returns), while logout collapses
+   both to a single `"openai"` alias. A single `string_key` field per
+   Catalog entry cannot model both. The implementer should either
+   (a) give both openai entries the same `string_key` ("openai"),
+   losing wizard fidelity in `"enabled_providers"`, OR (b) add a
+   separate `logout_alias` field. Option (b) preserves both contracts
+   and is the recommended path. Flagged for the implementer.
+
+2. **`Tau.Settings.Loader.list_keys/0` missing
+   `:enabled_providers`.** `loader.ex:88–98` is a hand-maintained
+   list of array keys that *concatenate* during cascade merge. The
+   schema's moduledoc explicitly requires every `type: "array"` key
+   to appear in that list. The solution does not mention adding
+   `:enabled_providers` to it. Without the addition, cwd-layer
+   `enabled_providers` will replace (rather than extend) home-layer
+   `enabled_providers`, contradicting the schema's documented
+   cascade contract. This is a one-line implementer fix; flagged so
+   it is not silently omitted.
+
+3. **`Tau.Settings.Schema.@known_providers` drift.** Solution
+   §Open questions bullet 3 already names this; restated here so
+   the parent-level validator inherits the concern. After this PR,
+   three registries describe the provider set:
+   `Catalog` (atom + string_key), `@known_providers` (modules), and
+   the provider source files themselves
+   (`lib/tau/providers/*.ex`). Future-proofing would derive
+   `@known_providers` from `Catalog` or vice versa; not required by
+   this AC.
+
+4. **Bedrock dual-credential gap.** Wizard prompts for only one of
+   the two AWS credentials Bedrock auth requires. Falls inside
+   problem.md §Out of scope as written. If the user-visible goal is
+   "Bedrock works after wizard", this is a follow-up problem to file
+   separately.

--- a/docs/problems-archive-v1-modules/tau-cli/validation.md
+++ b/docs/problems-archive-v1-modules/tau-cli/validation.md
@@ -1,0 +1,521 @@
+---
+template_version: 1
+template_name: validation
+parent_solution: solution.md
+parent_problem: problem.md
+toulmin_complete: true
+falsification_attempted: true
+falsification_outcome: partially_falsified — claim/3
+revision_triggered: none
+---
+
+# Validation: tau-cli four-PR module-wide correctness pass (root synthesis)
+
+## Overview
+
+This is the root validation of `docs/problems/tau-cli/solution.md`, a
+non-leaf synthesis of four child solutions (error-swallowing-rescues,
+run-loop-raw-receive, wizard-data-fidelity, reflective-module-dispatch).
+Validation here does NOT re-validate the four children's internal
+correctness — each has its own withstood-or-partially-falsified
+`validation.md` already on file. The validator's job at the root is
+**cross-cutting integration**: the synthesis-level claims about PR
+sequencing, parallelisability, conjunction satisfaction of the parent
+acceptance criterion, and absence of inter-child contradictions.
+
+Six distinct propositions were extracted from the Recommendation and
+What-changes sections. Falsification per claim used **integration check**,
+**dependency check**, and **edge-case enumeration**; one external
+**counter-example construction** was attempted for the PR-4
+parallelisability claim. Five claims withstood the attempt; one (Claim 3
+— PR-2 / PR-3 serialisation rationale) was partially falsified and the
+qualifier is narrowed in place. No revision is triggered.
+
+## Toulmin per claim
+
+The MITRE empirical study on Toulmin formalism found that "participants
+found it difficult to generate Toulmin structures, and their structures
+varied greatly even though they started with the same content"
+(https://www.mitre.org/news-insights/publication/empirical-evaluation-structured-argumentation-using-toulmin-argument).
+This template enforces all six components explicitly with prompts to
+counter that variance.
+
+### Claim 1: PR-0 (NN #7 carve-out amendment) MUST land before PR-1
+
+- **Claim (C):** "the NN #7 amendment must land first because the rescues
+  PR depends on it being in effect" (solution.md Recommendation, lines
+  23–24). The doc-only PR-0 amends
+  `.claude/rules/otp-non-negotiables.md` rule #7 to permit a targeted
+  `catch :exit, {:noproc, _}` at a CLI/TUI command boundary; PR-1 then
+  uses that carve-out in `Tau.CLI.Extensions` / `Tau.CLI.MCP`.
+- **Grounds (G):** The text of NN #7 today is unconditional: "MUST NOT
+  `try/rescue` across process boundaries. MUST NOT catch `:exit`"
+  (`.claude/rules/otp-non-negotiables.md:26–27`). PR-1's per the child
+  solution `subproblems/error-swallowing-rescues/solution.md`
+  Recommendation introduces `catch :exit, {:noproc, _}` arms — literally
+  the forbidden construct. The critic/reviewer gate is mandatory and reads
+  these rules (`.claude/rules/factory-loop.md` "The gate"); a PR that
+  imports a forbidden construct without the rule already amended would
+  fail the gate.
+- **Warrant (W):** A PR that violates an OTP non-negotiable cannot pass
+  the mandatory critic/reviewer gate unless the rule already permits the
+  construct at the moment the gate runs. The gate is stateless across
+  PRs — it reads the rule file as it stands on the PR's branch.
+  Therefore a code PR that depends on a rule amendment MUST follow the
+  doc PR in merge order; the two-PR split avoids conflating rule change
+  with code change (the factory-loop "PR scope guards" prefer one
+  coherent shippable increment per PR).
+- **Qualifier (Q):** Holds when PR-1 ships the targeted-catch form as
+  proposed. If PR-1 chose the documented fallback ("pure deletion +
+  top-level `Tau.CLI.main/1` rescue" — solution.md Open questions §1),
+  the dependence on PR-0 vanishes and PR-1 could land standalone. The
+  primary recommendation is the targeted-catch form, so Q is the
+  expected branch.
+- **Rebuttal (R):** Two corner conditions break the dependence: (a) the
+  rule itself already contains an implicit carve-out via the
+  rate-limiter precedent — but precedent does not amend rule text, so
+  the gate's literal reading still rejects new uses; (b) the rescues PR
+  could ship the rule amendment in-PR rather than as a separate PR-0 —
+  the spec-before-code rule allows in-PR amendments — but the synthesis
+  chose to split to honour the "one coherent shippable increment" guard.
+- **Backing (B):** `.claude/rules/factory-loop.md` "The gate" section
+  (mandatory, no override, no skipping); `.claude/rules/otp-non-negotiables.md:26–27`
+  (current rule text); `.claude/rules/spec-before-code.md` (rule
+  amendment in-PR vs separate PR is acceptable but scope guards prefer
+  separation); precedent `lib/tau/providers/rate_limiter.ex:84–86`
+  (targeted `catch :exit, {:noproc, _}` already in tree; cited in
+  solution.md PR-0 bullet).
+
+#### Falsification attempt for claim 1
+
+- **Strategy:** dependency check (verify the prior state of the
+  codebase and rulebook holds today).
+- **Attempt:** Read `.claude/rules/otp-non-negotiables.md` at HEAD and
+  searched for any existing carve-out language permitting targeted
+  `catch :exit`. None present — rule #7 is unconditional. Confirmed
+  rate-limiter precedent exists at
+  `lib/tau/providers/rate_limiter.ex:84–86` but is precedent, not rule
+  text. Verified the critic persona at
+  `.claude/agents/critic.md` would read the rule file as text.
+- **Outcome:** withstood — PR-0 dependency is real; PR-1 in its primary
+  form would fail the gate without PR-0 first.
+- **Action:** none.
+
+### Claim 2: PR-4 is parallelisable with PR-1 and PR-2 once PR-0 has landed
+
+- **Claim (C):** "**PR-4** (wizard `Catalog` extraction +
+  `enabled_providers` schema key) parallelisable against PR-1 and PR-2
+  once PR-0 has landed" (solution.md Recommendation, lines 30–32).
+- **Grounds (G):** PR-4's owned files (solution.md What-changes,
+  lines 130–149): NEW `lib/tau/providers/catalog.ex`, NEW
+  `test/tau/providers/catalog_test.exs`, MODIFY `lib/tau/cli/init.ex`,
+  `lib/tau/commands/builtin/logout.ex`,
+  `lib/tau/settings/schema.ex`, `test/tau/cli/init_test.exs`. PR-1's
+  owned files: `lib/tau/cli/extensions.ex` and `lib/tau/cli/mcp.ex`
+  (solution.md PR-1 bullets, lines 86–95). PR-2's owned files:
+  `lib/tau/session.ex` and `lib/tau/cli.ex` (solution.md PR-2 bullets,
+  lines 97–116). The file sets are pairwise disjoint. PR-4 has no
+  dependency on PR-0's rule amendment (PR-4 introduces no `rescue` or
+  `catch :exit`).
+- **Warrant (W):** The factory-loop conflict check
+  (`.claude/rules/factory-loop.md` "The conflict check") permits
+  concurrent execution of two PRs when they have (a) no dependency,
+  (b) disjoint files, (c) disjoint codepoints, (d) no shared SPEC or
+  D-NNN block, and (e) shared-resource isolation is possible. Disjoint
+  file sets satisfy (b); absence of a code-level dependency satisfies
+  (a) and (c); the four sub-problems live under distinct concerns
+  (no shared SPEC entry — the root problem is not under a SPEC) so (d)
+  holds; (e) is satisfied by per-worktree `XDG_DATA_HOME` per the
+  worktree-discipline rule.
+- **Qualifier (Q):** Parallelisable in the per-PR implementation
+  phase; merge remains serialised (the factory loop's "Gate and merge
+  under concurrency" explicitly forbids concurrent merges). After
+  whichever of PR-1/PR-2/PR-4 merges first, the others trigger the
+  cycle-step-8a freshness re-check.
+- **Rebuttal (R):** A hidden shared dependency could materialise via
+  `Tau.Settings.Schema` — PR-4 adds an `"enabled_providers"` key
+  (solution.md line 144); if PR-2 or PR-1 happened to touch
+  `lib/tau/settings/schema.ex` in some way the synthesis missed, the
+  shared-file conflict-check clause would fire. Inspection of PR-1's
+  and PR-2's owned-file list shows neither touches the schema —
+  rebuttal does not materialise.
+- **Backing (B):** `.claude/rules/factory-loop.md` "Parallel execution"
+  and "The conflict check"; `.claude/rules/worktree-discipline.md`
+  "Shared $HOME-namespace caches MUST be isolated per concurrent
+  agent" (Burrito XDG_DATA_HOME isolation).
+
+#### Falsification attempt for claim 2
+
+- **Strategy:** counter-example construction over the union of PR-4's,
+  PR-1's, and PR-2's declared file sets — try to find any file that
+  appears in two PRs' modify-or-create lists.
+- **Attempt:** Built the three sets from solution.md's What-changes
+  bullets. PR-1: `{lib/tau/cli/extensions.ex, lib/tau/cli/mcp.ex}`.
+  PR-2: `{lib/tau/session.ex, lib/tau/cli.ex}`. PR-4: `{lib/tau/providers/catalog.ex,
+  test/tau/providers/catalog_test.exs, lib/tau/cli/init.ex,
+  lib/tau/commands/builtin/logout.ex, lib/tau/settings/schema.ex,
+  test/tau/cli/init_test.exs}`. Intersection pairwise: PR-1 ∩ PR-2 =
+  ∅; PR-1 ∩ PR-4 = ∅; PR-2 ∩ PR-4 = ∅. Cross-checked grep for
+  imports of `Tau.Providers.Catalog` in the PR-1/PR-2 target files —
+  none (the module is new in PR-4 and the resolvers in PR-3, not PR-2,
+  optionally consume it — see claim 6).
+- **Outcome:** withstood — no shared file across the three concurrent
+  PRs.
+- **Action:** none.
+
+### Claim 3: PR-2 and PR-3 MUST serialise because they both touch `lib/tau/cli.ex`
+
+- **Claim (C):** "the run-loop and reflective-dispatch PRs both touch
+  `lib/tau/cli.ex` and must serialize against each other to avoid
+  mechanical merge conflicts" + "Land PR-2 first because its diff is
+  larger and its rebase cost on a registry refactor is higher"
+  (solution.md Recommendation lines 24–26 and Selected-from §Composition
+  rationale, lines 61–64).
+- **Grounds (G):** Verified by reading `lib/tau/cli.ex`. PR-2 targets
+  `drain_run_loop/2` (lines 427–486) and `drain_session_end/2` (lines
+  489–497). PR-3 targets `resolve_provider/1` (lines 792–814) and
+  `resolve_coding_agent/1` (lines 781–790). The line-region distance is
+  large (~290 lines apart) and the function definitions are stable. The
+  factory-loop conflict check's clause 3 ("disjoint codepoints — they
+  do not modify the same function") permits this case in principle —
+  "the same file touched at clearly separate, stable regions MAY still
+  parallelise" — but the solution.md author chose serialisation as the
+  safer option.
+- **Warrant (W):** The factory-loop conflict check sets the burden of
+  proof on the conflict check itself ("when in doubt, serialize") —
+  serialising at the same-file level is correctness-conservative even
+  if not strictly mandated by the rule. The solution's choice to
+  serialise rather than attempt parallel is the policy-conservative
+  reading. Larger-diff-first as the rebase-cost minimiser is the
+  ordering choice within the serialised pair.
+- **Qualifier (Q):** Strict serialisation is sufficient (i.e. no merge
+  conflict can arise); it is NOT strictly necessary by the conflict-check
+  rule text. A parallel-edit attempt against well-separated regions
+  would also be permitted, at the cost of a rebase on the second-merging
+  PR.
+- **Rebuttal (R):** If between gate authorship and merge a third party
+  PR refactors `lib/tau/cli.ex` such that the line numbers cited
+  (427–497, 781–814) shift, the "clearly separate, stable regions"
+  proviso of the conflict check could be challenged. Today the file is
+  818 lines and the regions are stable; this is a future-state risk,
+  not a current falsifier.
+- **Backing (B):** `.claude/rules/factory-loop.md` "The conflict check"
+  clauses 2 ("disjoint files") and 3 ("disjoint codepoints");
+  `lib/tau/cli.ex:427–497` and `lib/tau/cli.ex:781–814` for the actual
+  line regions.
+
+#### Falsification attempt for claim 3
+
+- **Strategy:** edge-case enumeration — list the cases under which the
+  "MUST serialise" statement is too strong, vs cases where the
+  rationale ("avoid mechanical merge conflicts") is genuine.
+- **Attempt:** (1) Two edits to the same file but to functions defined
+  at well-separated line ranges and not sharing any helper — `git
+  merge` typically resolves cleanly; only an `@spec` or `@doc` block
+  edit at file head could collide. (2) Two edits that share a module
+  attribute or `alias` clause at file head — would collide. PR-2's
+  changes (`drain_run_loop` deletion, `classify_event/2` /
+  `render_event/1` extraction) MAY add new `alias` clauses; PR-3's
+  changes (`@provider_registry`, `@coding_agent_registry` module
+  attributes) certainly add new module attributes at file head. Both
+  PRs are likely to touch the file's head region (alias/attribute
+  block), producing a real, even-if-trivial conflict on the second
+  rebase.
+- **Outcome:** partially falsified — the "MUST serialise" wording is
+  stronger than the conflict-check rule itself ("when in doubt,
+  serialise" is the rule's posture, not "MUST"). However, the
+  rationale stands: both PRs are likely to touch the file's head
+  region, so the conservative serialisation choice is well-founded.
+- **Action:** narrow the qualifier in place — restate as "PR-2 and PR-3
+  SHOULD serialise per the conflict-check's `when in doubt, serialise`
+  posture; both PRs probably touch the file head (alias/module
+  attribute block), so serialisation is conservative even though the
+  conflict-check rule does not strictly mandate it for separate
+  function regions." Ordering (PR-2 before PR-3, larger diff first) is
+  unaffected. No revision to solution.md required — the narrower
+  qualifier is recorded here for the implementer to honour.
+
+### Claim 4: The four child ACs together satisfy the root AC's four clauses
+
+- **Claim (C):** "The module-wide acceptance criterion is the
+  conjunction of the four child ACs; no child weakens another, and no
+  gap requires a new sub-problem" (solution.md Recommendation, lines
+  37–38). Restated mechanically in Migration sketch (lines 195–203):
+  - (a) crashed supervised callee → non-zero exit + stderr line (PR-1);
+  - (b) headless run loop uses `stream_from`; unknown events log at
+    `:debug` rather than being silently dropped (PR-2);
+  - (c) `tau init` persists all selected providers under
+    `"enabled_providers"`; init/logout Bedrock credential key derived
+    from the same `Catalog` (PR-4);
+  - (d) `resolve_provider/1` and `resolve_coding_agent/1` reject
+    unknown strings without `Module.concat` / `String.to_atom` on user
+    input (PR-3).
+- **Grounds (G):** The root problem's acceptance criterion
+  (`problem.md:97–104`) states four conjuncts: (a) crashed supervised
+  callee surfaces as explicit error exit code rather than empty result;
+  (b) headless run loop does not use raw `receive` and does not
+  silently discard `Events.*`; (c) `tau init` persists all selected
+  providers AND uses a consistent Bedrock credential key across init
+  and logout; (d) `resolve_provider/1` and `resolve_coding_agent/1` do
+  not create atoms from unconstrained user input. The four child
+  solutions' ACs (visible in each `subproblems/*/solution.md`) target
+  exactly conjuncts (a), (b), (c), (d) respectively. The mapping is
+  bijective: each conjunct has exactly one owning child, and each child
+  has exactly one root conjunct.
+- **Warrant (W):** A logical conjunction (AC = a ∧ b ∧ c ∧ d) is
+  satisfied iff every conjunct is satisfied. If each conjunct has an
+  owning sub-solution that satisfies it (per its own
+  withstood/partially-falsified validation), and the sub-solutions do
+  not weaken each other in their interaction, then the conjunction
+  holds. Decomposition along the concern (Hickey) axis — declared in
+  `problem.md` "Decomposition strategy" — exhausts the named concerns,
+  so the conjunction is closed.
+- **Qualifier (Q):** Holds provided each child solution actually
+  satisfies its individual AC at the implementer level. Child
+  validation status (today): error-swallowing-rescues — withstood;
+  run-loop-raw-receive — partially_falsified claim 3 (narrowed
+  qualifier); wizard-data-fidelity — partially_falsified claim 4
+  (narrowed); reflective-module-dispatch — partially_falsified claim 3
+  (narrowed). No child is `falsified`. The narrowed qualifiers
+  propagate up — see Outstanding doubts.
+- **Rebuttal (R):** A gap could exist if (i) some defect named in the
+  root problem statement falls outside all four conjuncts, or (ii) one
+  child's fix accidentally re-introduces a defect another child's fix
+  removes. Root problem's "Open questions" surfaces three additional
+  concerns not closed here — async reload visibility (asynchronous
+  cast in `Tau.Extensions.Loader.reload_all/0` and
+  `Tau.MCP.Reconciler.reload/0`), top-level `main/1` safety net, and
+  registry/catalog cross-derivation — but the root problem explicitly
+  lists them as "Open questions" / out-of-scope for THIS solution.
+  They are not part of the root AC. (ii) is checked by Composition
+  rationale §No conflicts (solution.md lines 65–73); no child removes
+  or contradicts another's contribution.
+- **Backing (B):** `docs/problems/tau-cli/problem.md:97–104`
+  (acceptance criterion text); each `subproblems/*/validation.md`
+  frontmatter (child outcomes); solution.md "Composition rationale"
+  §"No conflicts" lines 65–73.
+
+#### Falsification attempt for claim 4
+
+- **Strategy:** integration check — verify each root-AC conjunct maps
+  to exactly one child AC, and that the mapped child satisfies it
+  (per its validation.md outcome).
+- **Attempt:** Built the conjunct→child map: (a) → error-swallowing-rescues
+  (withstood), (b) → run-loop-raw-receive (partially falsified claim 3,
+  qualifier narrowed to acknowledge that `stream_from/3`'s setup
+  contract is silent on malformed topic — does NOT weaken AC (b)),
+  (c) → wizard-data-fidelity (partially falsified claim 4, qualifier
+  narrowed to acknowledge schema's `"providers"` key continues to
+  coexist with new `"enabled_providers"` — does NOT weaken AC (c)),
+  (d) → reflective-module-dispatch (partially falsified claim 3,
+  qualifier narrowed re: `String.to_atom` distinction — does NOT
+  weaken AC (d)). All four conjuncts have a passing-or-narrowed
+  child. No child's narrowed qualifier weakens its conjunct.
+- **Outcome:** withstood — the conjunction holds; no gap requires a new
+  sub-problem within the root AC's stated scope.
+- **Action:** none. (The three out-of-scope concerns in Open questions
+  are correctly excluded.)
+
+### Claim 5: No child solution contradicts another (no conflicts)
+
+- **Claim (C):** "No child solution proposes a change that another
+  contradicts. No child requires data or interfaces that another
+  removes" (solution.md Composition rationale §No conflicts, lines
+  65–67).
+- **Grounds (G):** From the four child solutions' recommendations:
+  error-swallowing-rescues edits `lib/tau/cli/extensions.ex` and
+  `lib/tau/cli/mcp.ex` only; run-loop-raw-receive edits
+  `lib/tau/session.ex` (additive `stream_from/3`) and
+  `lib/tau/cli.ex` (drain functions only); wizard-data-fidelity adds
+  `lib/tau/providers/catalog.ex`, edits `lib/tau/cli/init.ex`,
+  `lib/tau/commands/builtin/logout.ex`, `lib/tau/settings/schema.ex`;
+  reflective-module-dispatch edits `lib/tau/cli.ex` (resolver
+  functions only). Pairwise file disjointness confirmed in Claim 2.
+  Interface preservation: run-loop child explicitly preserves
+  `Tau.Session.stream/2` (solution.md "What does not change" line
+  154); wizard child does NOT remove the singular `"provider"` schema
+  key (solution.md "What does not change" lines 177–179); reflective
+  child does NOT touch `Tau.Providers.Catalog` (solution.md
+  Composition rationale §"No conflicts", lines 68–73).
+- **Warrant (W):** Two solutions cannot contradict if they are
+  disjoint in code ownership AND each preserves the interfaces the
+  other reads. Disjoint ownership is verified by file-set
+  intersection (Claim 2); interface preservation is verified by each
+  child's "What does not change" section. Both hold ⇒ no contradiction.
+- **Qualifier (Q):** Holds for the proposed implementations as
+  written. A late-stage implementer change that, e.g., chose to make
+  reflective-module-dispatch consume `Tau.Providers.Catalog` (the
+  cross-derivation flagged in solution.md Open questions §4) would
+  introduce a real ordering dependency. The synthesis explicitly
+  flags this as out-of-scope and recommends a future cleanup PR.
+- **Rebuttal (R):** A subtle interface dependency could lurk in
+  shared test scaffolding (e.g., a test helper used by two children's
+  test suites) — but the children's owned test paths are also
+  disjoint (PR-1: extensions/mcp tests; PR-2: classify_event +
+  stream_from tests; PR-3: registry tests; PR-4: catalog +
+  init_test). No shared test-support file is named.
+- **Backing (B):** Each `subproblems/*/solution.md` "What does not
+  change" section; solution.md "What does not change" (lines 152–183);
+  solution.md "Open questions" §"Cross-derivation of registries"
+  (lines 223–231).
+
+#### Falsification attempt for claim 5
+
+- **Strategy:** dependency check on shared symbols — search for any
+  symbol that one child introduces and another consumes (excluding the
+  intentional `Tau.Session.stream/2` additive case).
+- **Attempt:** Read each child solution's What-changes. The only
+  inter-child symbol coupling is the FLAGGED `Tau.Providers.Catalog`
+  → `@provider_registry` cross-derivation, explicitly deferred to a
+  future PR (Open questions §4). PR-3 as scoped does NOT consume
+  `Catalog`; PR-4 as scoped does NOT consume `@provider_registry`.
+  The wizard's new `"enabled_providers"` schema key is consumed by no
+  other child. The run-loop child's new `Tau.Session.stream_from/3`
+  is consumed only by `lib/tau/cli.ex`'s own drain replacement, not
+  by any other child. No falsifying coupling found.
+- **Outcome:** withstood — no inter-child contradiction or removed-
+  interface dependency.
+- **Action:** none.
+
+### Claim 6: Ordering rationale is correct — PR-2 before PR-3 minimises rebase cost
+
+- **Claim (C):** "Land PR-2 first because its diff is larger and its
+  rebase cost on a registry refactor is higher" (solution.md
+  Composition rationale, lines 63–64).
+- **Grounds (G):** PR-2's diff per the child solution touches a
+  whole-function deletion (`drain_run_loop/2` ≈ 60 lines,
+  `drain_session_end/2` ≈ 10 lines), new helper functions
+  (`classify_event/2`, `render_event/{1,2}`) and a rewritten
+  `run_cmd/1` block. PR-3's diff per the child solution adds two
+  module attributes (≈ 30 lines) and rewrites two small resolver
+  function clauses (`resolve_provider/1`, `resolve_coding_agent/1`,
+  ≈ 25 lines existing). PR-2's diff is substantially larger in line
+  count and in the number of stable code regions it touches.
+- **Warrant (W):** When two PRs serialise on the same file and one is
+  larger, merging the larger one first reduces the EXPECTED cost of
+  rebase: the second-mover only needs to rebase its smaller diff onto
+  the larger settled state. The reverse (smaller first, larger
+  second) forces the larger diff to rebase onto changes anywhere in
+  the same file, including possible aliases/module attributes added
+  by the smaller PR.
+- **Qualifier (Q):** Heuristic, not absolute. If the smaller PR (PR-3)
+  contained a refactor that fundamentally restructured the regions
+  PR-2 touches, that would invert the calculus — but PR-3 only adds
+  module attributes at file head and rewrites two stable resolver
+  blocks, neither of which intersects PR-2's drain-function region.
+- **Rebuttal (R):** If PR-2 added a new module attribute that
+  conflicted with PR-3's `@provider_registry` / `@coding_agent_registry`
+  at file head, the ordering choice would not matter — the conflict
+  would surface to whichever PR rebases last. The risk is symmetric
+  in that pathological case; the chosen ordering is still no worse
+  than the alternative.
+- **Backing (B):** Standard rebase-cost heuristic (no formal
+  citation); both child solutions' What-changes line counts as
+  observable proxy.
+
+#### Falsification attempt for claim 6
+
+- **Strategy:** counter-example construction — try to construct a
+  scenario where PR-3 first would be cheaper.
+- **Attempt:** Scenarios considered: (i) PR-3 includes a refactor of
+  `run_cmd/1` that PR-2 must merge around — PR-3 child solution
+  explicitly does NOT touch `run_cmd/1`. (ii) PR-3's module attribute
+  block lives at the same file head where PR-2 might add aliases —
+  this is a possible head-collision but it is symmetric (either
+  ordering hits it). (iii) PR-2 deletions free up lines that PR-3
+  would otherwise have to renumber around — but git's three-way
+  merge doesn't care about line numbers per se, only about hunk
+  context. No scenario produces a strict ordering preference for PR-3
+  first.
+- **Outcome:** withstood — PR-2-first ordering is at least as cheap
+  as PR-3-first under all considered scenarios.
+- **Action:** none.
+
+## Cross-claim consistency
+
+Six claims are mutually consistent. The serialisation/ordering claims
+(3, 6) are about PRs that touch a shared file; they do not contradict
+the parallelisation claim (2), which concerns PRs whose files are
+disjoint. Claim 1 (PR-0 before PR-1) does not constrain PR-2, PR-3, or
+PR-4 — PR-0 is doc-only, no test or code coupling. Claim 4 (conjunction
+satisfaction) presupposes claim 5 (no inter-child conflict) and the
+order of claims 1, 3, 6; consistency holds because the conjunction is
+about end-state (post-PR-4) correctness, not about the intermediate
+states after PR-0, PR-1, or PR-2.
+
+One latent tension: solution.md Open questions §3 ("`main/1` top-level
+safety net") explicitly names a gap NOT covered by any of the four
+children, surfaced to the root "for triage rather than expand any PR's
+scope". This is correctly excluded from the root AC (the root AC
+mentions only the four conjuncts (a)–(d)), so claim 4's conjunction
+holds. The gap is flagged in Outstanding doubts for the parent (if any
+parent exists) and for the next planning pass.
+
+## Falsification summary
+
+| # | Claim (short) | Strategy | Outcome | Action |
+|---|---|---|---|---|
+| 1 | PR-0 must precede PR-1 (NN #7 amendment) | dependency check | withstood | none |
+| 2 | PR-4 parallelisable with PR-1 and PR-2 post-PR-0 | counter-example construction | withstood | none |
+| 3 | PR-2 and PR-3 MUST serialise on `lib/tau/cli.ex` | edge-case enumeration | partially falsified | narrow qualifier in place: SHOULD-serialise per "when in doubt" posture, not strict MUST |
+| 4 | Four child ACs satisfy the root AC's conjunction | integration check | withstood | none |
+| 5 | No child contradicts another | dependency check | withstood | none |
+| 6 | PR-2 before PR-3 minimises rebase cost | counter-example construction | withstood | none |
+
+## Revision required
+
+No revision triggered. The single partial falsification (claim 3) is
+addressed by narrowing the qualifier in this validation document; the
+implementer of PR-2 and PR-3 should treat the serialisation as
+"strongly recommended per conflict-check `when in doubt, serialise`"
+rather than as a literal MUST. The ordering (PR-2 before PR-3) is
+unchanged and the rationale (rebase cost) is independently validated
+(claim 6 withstood).
+
+- **Target file:** none
+- **Revision kind:** n/a — qualifier narrowed in place
+- **Rationale:** the narrowed qualifier accurately reflects the
+  conflict-check rule's actual posture and the practical risk of
+  file-head collision; the PR ordering and parallelisation plan are
+  unaffected.
+
+## Outstanding doubts
+
+The parent-level validator (if any parent ever exists) should inherit
+these inherited / surfaced doubts. Each child also surfaces partial
+falsifications whose narrowed qualifiers propagate up through this
+validation:
+
+- **Child-inherited narrowed qualifiers** (from each
+  `subproblems/*/validation.md`): (a) run-loop-raw-receive claim 3 —
+  `Tau.Session.stream_from/3`'s setup contract is silent on malformed
+  topic; (b) wizard-data-fidelity claim 4 — coexistence of
+  `"providers"` (object) and `"enabled_providers"` (array) schema keys
+  is intentional and reviewable but adds a future-deprecation surface;
+  (c) reflective-module-dispatch claim 3 — `String.to_atom` distinction
+  in the resolver tail clauses.
+- **Async reload failures invisible** (root problem Open questions §2)
+  — both `Tau.Extensions.Loader.reload_all/0` and
+  `Tau.MCP.Reconciler.reload/0` are `GenServer.cast`; the operator
+  cannot tell whether the reload succeeded. NOT part of the root AC;
+  flagged here for the next planning pass.
+- **`main/1` top-level safety net** (root problem Open questions §3)
+  — handlers outside the four CLI commands named in the four
+  sub-problems remain exposed to raw BEAM crash dumps. NOT part of
+  the root AC; flagged for triage.
+- **Cross-derivation of registries** (root problem Open questions §4)
+  — `@provider_registry`, `Tau.Providers.Catalog`, and
+  `Schema.@known_providers` are three compile-time representations of
+  related provider sets that can drift on coverage. Deliberately
+  deferred; flagged so the divergence is intentional and reviewable.
+- **`stream_from/3` setup contract visibility** (root problem Open
+  questions §5) — a malformed topic causes a silent empty drain.
+  Flagged for the PR-2 implementer.
+- **Singular `"provider"` key deprecation** (root problem Open
+  questions §6) — retained for backwards compatibility; future PR may
+  rename to `"default_provider"`.
+- **Claim-3 file-head collision** (validator's own observation,
+  above) — PR-2 and PR-3 are highly likely to both touch the
+  alias/module-attribute block at the head of `lib/tau/cli.ex`, so
+  the serialisation choice is conservative even though the
+  conflict-check rule does not strictly mandate it.

--- a/docs/problems-archive-v1-modules/tau-coding-agent/problem.md
+++ b/docs/problems-archive-v1-modules/tau-coding-agent/problem.md
@@ -1,0 +1,108 @@
+---
+template_version: 1
+template_name: problem
+node_kind: root
+depth: 0
+parent: —
+status: decomposed
+---
+
+# Problem: tau-coding-agent error containment is complected with feature-gate logic
+
+## Statement
+
+The `tau-coding-agent` subsystem uses `try/rescue/catch` blocks at four
+independent sites to contain errors that should either be handled by the OTP
+supervision tree or surfaced as structured `{:error, _}` returns. Each site
+confounds a different pair of concerns: feature-flag access is entangled with
+error silencing, tool-response shaping is entangled with optional-dependency
+guarding, Port lifecycle cleanup is entangled with presence testing, and the
+HTTP router has a redundant outer rescue that masks whether its inner per-handler
+guards are sufficient. The result is a codebase that silently disables features,
+absorbs errors that should propagate, and contains duplicated rescue patterns
+whose independence from one another is unclear.
+
+## Context
+
+- `lib/tau/coding_agent/dispatcher.ex:384–399` — `expose_tau_context?/0` wraps
+  `SettingsCache.get/0` in `rescue` + `catch`, falling back to `%{}` on any
+  failure, causing the `expose_tau_context` feature to silently default to
+  `true` even when the cache is misconfigured.
+- `lib/tau/coding_agent/tau_context/tools.ex:215–229, 272–283, 371–379` — three
+  independent `rescue`/`catch` ladders in `tau_session_status/1`,
+  `safe_memory_load/1`, and `session_cwd/1`, each returning a soft
+  `{"available": false}` JSON body or `nil` that is indistinguishable from a
+  legitimate "feature not available" response.
+- `lib/tau/coding_agents/claude_code.ex:404–414` — `close_port/1` uses a bare
+  `catch _, _ -> :ok` around `Port.close/1`, relying on a prior `Port.info/1`
+  check that is a separate, non-atomic operation.
+- `lib/tau/coding_agent/tau_context/router.ex:76–89` — `call/2`'s outer `rescue`
+  is documented as a "hard guard" for the per-handler `try/catch` blocks inside
+  `dispatch/2`; the document claim is that the inner guards make it unreachable,
+  but there is no structural proof.
+- SPEC-CODING-AGENT §4 D-035 states: "Every public function in `tools.ex`
+  catches its own errors and returns a tagged tuple. Callers in Router rely on
+  this invariant." The existing implementation fulfils the letter of D-035 but
+  not the spirit — errors are absorbed, not tagged.
+
+## Complecting hypothesis
+
+1. Feature-flag retrieval is complected with crash containment because
+   `expose_tau_context?/0` conflates "the settings cache is unavailable" with
+   "the setting is not configured", silencing both under the same default.
+2. Tool-response shaping is complected with optional-capability guarding in
+   `tools.ex` because each `rescue`/`catch` ladder maps infrastructure errors
+   (unexpected process crash, bad API shape) and legitimate absences (feature
+   not configured) to the same `{"available": false}` envelope, making the two
+   undetectable at the call site.
+3. Port close is complected with Port liveness testing because `close_port/1`
+   checks `Port.info/1` and then `Port.close/1` separately, so the rescue is
+   defending against a TOCTOU race its own structure created.
+
+## Decomposition strategy
+
+The four rescue sites are independent in location and concern; no one fix
+affects another. Decompose by **rescue site** (one sub-problem per site).
+The four sites are mutually exclusive by file and line range; together they
+cover the entire set of OTP-non-negotiable violations flagged in the audit.
+This axis is MECE: each sub-problem names exactly one site, its specific
+complecting pair, and the fix surface; no site belongs to more than one
+sub-problem.
+
+## Sub-problems (filled by decomposer)
+
+1. **settings-feature-flag-access** — `expose_tau_context?/0` in
+   `dispatcher.ex` silently swallows `SettingsCache.get/0` failures and
+   defaults the feature on.
+2. **tool-impl-rescue-ladders** — three independent `rescue`/`catch` blocks in
+   `tools.ex` absorb infrastructure errors and return them as
+   `{"available": false}`, indistinguishable from legitimate absences.
+3. **port-lifecycle-rescue** — `close_port/1` in `claude_code.ex` uses a bare
+   `catch` around a `Port.close/1` that is defended by a non-atomic
+   `Port.info/1` guard.
+4. **router-outer-rescue** — the outer `rescue` in `Router.call/2` is described
+   as "unreachable" given inner per-handler guards but has no structural proof
+   and is therefore dead-letter coverage.
+
+## Acceptance criterion
+
+All four rescue sites in the audit scope are replaced with patterns that either
+delegate error propagation to OTP supervision, return explicitly-tagged
+structured errors distinguishable from legitimate absences, or are provably
+unreachable by construction (not just by comment assertion).
+
+## Out of scope
+
+- Retry logic or circuit-breaker behaviour for `SettingsCache`.
+- Changes to SPEC-CODING-AGENT §4 D-035's public contract.
+- The `safe_start/3` and `safe_cancel/2` helpers in `dispatcher.ex` — these
+  wrap adapter callbacks whose contracts include raising; rescue is appropriate
+  at the behaviour boundary.
+- The `spawn_drainer/2` rescue in `dispatcher.ex` — this is the
+  cross-process-boundary guard the OTP non-negotiables endorse.
+- `Tau.CodingAgents.Replay` — not flagged in the audit.
+- Any refactoring of `Router` beyond the outer-rescue question.
+
+## Amendment log
+
+- (none yet)

--- a/docs/problems-archive-v1-modules/tau-coding-agent/solution.md
+++ b/docs/problems-archive-v1-modules/tau-coding-agent/solution.md
@@ -1,0 +1,262 @@
+---
+template_version: 1
+template_name: solution
+parent_problem: problem.md
+node_kind: root
+synthesised_from:
+  - subproblems/settings-feature-flag-access/solution.md
+  - subproblems/tool-impl-rescue-ladders/solution.md
+  - subproblems/port-lifecycle-rescue/solution.md
+  - subproblems/router-outer-rescue/solution.md
+selection_method: synthesis
+mode: non-leaf
+revision: 0
+---
+
+# Solution: Site-specific decomplecting of the four tau-coding-agent rescue ladders
+
+## Recommendation
+
+Apply four independent, site-specific fixes — each chosen to match its rescue
+site's harm profile — to satisfy the module-level acceptance criterion that
+every flagged `try/rescue/catch` either delegates to OTP, returns an explicitly
+tagged structured error, or is provably unreachable. The four fixes share no
+shared module, behaviour, or new abstraction; they intentionally decline a
+unified "rescue policy" module because the four sites have orthogonal complecting
+pairs and aggregating them would re-complect what the decomposition separated.
+Concretely: (1) convert `expose_tau_context?/0` to a tagged-tuple `fetch_*`
+plus pattern-matched caller (decomplect feature-flag retrieval from crash
+containment); (2) split `tools.ex` asymmetrically — delete `session_cwd/1`'s
+rescue (let it crash; OTP restarts), and on the two soft-fail helpers add an
+additive `"result_kind": "infrastructure_error"` field plus a `[:tau, :tools,
+:infrastructure_error]` telemetry event (decomplect infrastructure errors from
+legitimate absences while preserving the subprocess-tolerant envelope);
+(3) collapse `close_port/1` to a guard-only form (`nil`/non-port → `:ok`;
+live port → `Port.close(port); :ok`) — eliminate the TOCTOU window and let
+`ArgumentError` propagate to OTP; (4) harden `Router.load_state/1` with its
+own intra-function rescue and retain the outer `call/2` rescue as an
+explicitly annotated, property-tested backstop. The four fixes land
+independently with no inter-fix ordering constraint.
+
+## Selected from
+
+- **Synthesised from:** child solutions at
+  `subproblems/settings-feature-flag-access/solution.md`,
+  `subproblems/tool-impl-rescue-ladders/solution.md`,
+  `subproblems/port-lifecycle-rescue/solution.md`,
+  `subproblems/router-outer-rescue/solution.md`.
+- **Composition rationale:** the four child solutions compose by **direct
+  composition** with **no inter-child interface**. The decomposition strategy
+  in `problem.md` partitioned the work by rescue site (MECE: each site lives
+  in exactly one file/line range, each addresses exactly one complecting pair);
+  the validated child solutions inherit that independence. Each child fixes one
+  site in one file, with no callers in any other child's file. Concretely:
+  - settings-feature-flag-access touches only `dispatcher.ex` (private
+    functions); no other child reads or writes it.
+  - tool-impl-rescue-ladders touches `tools.ex` (and one telemetry-handler
+    attachment in `application.ex` or `otel_reporter.ex`); none of the other
+    children touches `tools.ex` or the telemetry namespace.
+  - port-lifecycle-rescue touches `claude_code.ex` only (one private function,
+    `close_port/1`); no other child touches the claude-code adapter.
+  - router-outer-rescue touches `router.ex` only (plus a new test file); no
+    other child touches the router.
+
+  There is **no conflict** between the recommendations: none of the four
+  solutions proposes a shared module, a behaviour change, or a contract revision
+  that would constrain a sibling's implementation. There is also **no gap**:
+  the four sites together exhaust the audit's scope (the problem's "What this
+  rule forbids" enumeration cites exactly these four sites; the out-of-scope
+  list explicitly carves out `safe_start/3`, `safe_cancel/2`, `spawn_drainer/2`,
+  and `Replay`).
+
+  The synthesis declines to introduce a unifying "tagged-result"
+  module/behaviour even though three of the four solutions adopt tagged-tuple
+  or tagged-field returns. The harm profile, return shape, and call-site
+  pattern differ at each site: dispatcher returns `{:ok, bool} | {:error,
+  :cache_unavailable}`; tools.ex two-of-three add an additive wire-format
+  field on a JSON envelope; close_port returns `:ok` and propagates; router
+  retains the rescue as an explicit backstop. A common abstraction would re-
+  complect them. Composition, not aggregation (Hickey-aligned).
+
+## What changes
+
+Per child solution, summarised at file granularity:
+
+- **`lib/tau/coding_agent/dispatcher.ex`** (settings-feature-flag-access):
+  - Rename `expose_tau_context?/0` → `fetch_expose_tau_context/0`; change
+    return to `{:ok, boolean()} | {:error, :cache_unavailable}`.
+  - The existing `rescue`/`catch` ladder returns `{:error, :cache_unavailable}`
+    in place of `%{}`.
+  - Rewrite `maybe_start_tau_context/1` to pattern-match all three outcomes;
+    emit `[:tau, :coding_agent, :tau_context, :settings_unavailable]` telemetry
+    on the error branch (fail-closed: skip TauContext start).
+  - Extract `do_start_tau_context/1` (mechanical separation; no logic change).
+
+- **`lib/tau/coding_agent/tau_context/tools.ex`** (tool-impl-rescue-ladders):
+  - `session_cwd/1`: delete the `rescue`/`catch` block entirely; extend the
+    `case` to handle `{:error, :not_found}` → `nil` and `{:error, _}` → `nil`
+    explicitly. Any unexpected non-`:ok`/non-`:error` return raises
+    `CaseClauseError` and propagates to the supervisor.
+  - `tau_session_status/1`: keep `rescue`/`catch`; add `"result_kind" =>
+    "infrastructure_error"` to the returned map; emit
+    `:telemetry.execute([:tau, :tools, :infrastructure_error], ...)` before
+    returning.
+  - `safe_memory_load/1`: keep `rescue`/`catch`; emit the same telemetry event.
+  - `tau_memory_query/2` (caller of `safe_memory_load/1`): on `{:error,
+    reason}` produce `%{"available" => false, "result_kind" =>
+    "infrastructure_error", "reason" => reason}` so the wire format carries
+    the distinguishing field.
+
+- **`lib/tau/application.ex`** (or `lib/tau/otel_reporter.ex`):
+  attach a telemetry handler for `[:tau, :tools, :infrastructure_error]` that
+  emits a `Logger.warning` so the event does not fire into a vacuum.
+
+- **`lib/tau/coding_agents/claude_code.ex`** (port-lifecycle-rescue):
+  replace the single `close_port/1` clause (lines 402–416) with three guard
+  clauses:
+
+  ```elixir
+  defp close_port(nil), do: :ok
+  defp close_port(port) when is_port(port), do: (Port.close(port); :ok)
+  defp close_port(_), do: :ok
+  ```
+
+  Delete the `Port.info/1` pre-check and the `catch _, _ -> :ok` ladder. Net
+  ~9 lines removed, ~8 added. `ArgumentError` from a just-died port propagates
+  to the OTP-supervised caller.
+
+- **`lib/tau/coding_agent/tau_context/router.ex`** (router-outer-rescue):
+  - Add `@safe_default` module attribute holding the default state map.
+  - Rewrite `load_state/1` with its own intra-function `rescue`: catch
+    exceptions from `:persistent_term.get/2`, log via `Logger.error/1` with
+    exception + stacktrace, return `@safe_default`.
+  - Rewrite the outer `call/2` `rescue`: keep the rescue body; replace the
+    misleading "should be unreachable" comment with an `@outer_rescue_scope`
+    annotation that names the paths covered by inner guards and states why the
+    backstop is retained (defence-in-depth against a future fallible top-level
+    branch added without its own guard).
+
+- **`test/tau/coding_agent/tau_context/router_outer_rescue_test.exs`** (new
+  file): unit test for `load_state/1`'s rescue path; integration test verifying
+  poisoned `state_ref` returns 401, not 500; StreamData property test verifying
+  `Router.call/2` never raises.
+
+## What does not change
+
+- `lib/tau/settings/cache.ex` — `SettingsCache` is untouched.
+- `Tau.CodingAgent.Supervisor`, supervision-tree topology, restart strategies.
+- SPEC-CODING-AGENT §4 D-035 public contract: every public function in
+  `tools.ex` still returns `{:ok, String.t()}` to its caller. The
+  `"result_kind"` field is **additive** in the JSON wire format; existing
+  subprocess consumers that do not inspect it are unaffected.
+- The `safe_start/3`, `safe_cancel/2`, and `spawn_drainer/2` rescue blocks in
+  `dispatcher.ex` (out of scope per `problem.md`).
+- `Tau.CodingAgents.Replay` (not flagged).
+- `dispatch/2`'s `rescue`/`catch` and `handle_mcp/2`'s `with`-else pipeline in
+  `router.ex` — both retained as-is.
+- The MCP wire protocol's existing fields, auth logic, and HTTP routing table.
+- `port_done/1` and the cancel branch in `port_next/2` — both still discard
+  `close_port/1`'s return.
+- `:persistent_term` read semantics and performance.
+- The legitimate-absence return shapes in `tools.ex` (`:not_found`, unloaded
+  `MemoryLoader`, `nil` session_id) — unchanged.
+- No new modules, no new behaviours, no shared "rescue policy" abstraction.
+
+## Migration sketch
+
+The four fixes have **no inter-dependency** and may land as four independent
+PRs in any order, or as a single combined PR. The factory-loop parallelism
+test (`.claude/rules/factory-loop.md` §"Parallel execution") clears all five
+clauses: disjoint files, disjoint codepoints (each fix touches a distinct
+private function), no shared SPEC amendment, no shared `$HOME`-namespace
+resource. Recommended sequencing if landed serially (lowest-risk first, easiest
+to revert): (1) `close_port/1` guard-only — smallest diff, smallest surface;
+(2) `dispatcher.ex` tagged-tuple — single private call chain, no public-API
+change; (3) `router.ex` `load_state/1` hardening + annotated backstop + new
+test file; (4) `tools.ex` asymmetric fix + telemetry-handler attachment in
+`application.ex`. Each fix re-runs the existing test baseline; the only new
+test surface is the router file in step 3 and a `session_cwd/1` crash-
+propagation property test in step 4 (per child solutions).
+
+Per `spec-before-code.md`: `tools.ex` lives in SPEC-CODING-AGENT Appendix B,
+so step 4's PR description must cite D-035 and note that `"result_kind"` is an
+additive wire-format field; a §3 amendment to SPEC-CODING-AGENT documenting
+the new field is recommended by the child solution and should land in the same
+PR (per the rule). The other three steps do not modify SPEC'd boundary
+contracts; `router.ex` and `claude_code.ex` are not in any SPEC's Appendix B
+scope, and `dispatcher.ex`'s change is to a private function whose tagged-
+tuple shape is internal.
+
+## Open questions
+
+Module-level questions only; per-site questions remain in the child solutions.
+
+- **No shared abstraction:** the synthesis declines to introduce a common
+  tagged-result module. The validator should confirm this is sound — if a
+  pattern emerges across the four sites that warrants extraction (e.g. a
+  shared `Tau.CodingAgent.Result` module), a follow-up problem can be filed,
+  but the current evidence does not support pre-extracting one.
+- **Telemetry namespace coherence:** two new telemetry events are introduced
+  by separate child fixes — `[:tau, :coding_agent, :tau_context,
+  :settings_unavailable]` (dispatcher) and `[:tau, :tools,
+  :infrastructure_error]` (tools). Both follow the `[:tau, ...]` convention
+  (OTP non-negotiable #5). The validator should confirm no collision with
+  existing events and that the second event's handler is attached early
+  enough that no `tools.ex` invocation can fire before it.
+- **D-035 spirit-vs-letter:** `problem.md`'s context notes that the existing
+  implementation fulfils D-035's letter but not its spirit. The synthesis
+  satisfies the letter at every site and improves the spirit at three of four
+  (settings, port, tools `session_cwd/1`). The remaining soft-fail sites in
+  `tools.ex` now emit telemetry and carry `result_kind`, which is the
+  decomplecting the spirit demands. The validator should confirm this is the
+  correct read of D-035.
+- **Per-site open questions** (verbatim from child solutions, not duplicated
+  here): see each `subproblems/<sub>/solution.md` §"Open questions".
+
+## Linked sub-problems / proposals
+
+- `subproblems/settings-feature-flag-access/` → "Tagged-result return for
+  expose_tau_context?/0: rename to `fetch_expose_tau_context/0` returning
+  `{:ok, boolean()} | {:error, :cache_unavailable}`; pattern-match all three
+  cases in the caller; emit `:settings_unavailable` telemetry on the error
+  branch (fail-closed)."
+- `subproblems/tool-impl-rescue-ladders/` → "Asymmetric rescue removal: delete
+  `session_cwd/1`'s rescue (let it crash; OTP restarts); on
+  `tau_session_status/1` and `safe_memory_load/1` retain rescue but add
+  `\"result_kind\": \"infrastructure_error\"` and `[:tau, :tools,
+  :infrastructure_error]` telemetry."
+- `subproblems/port-lifecycle-rescue/` → "Guard-only close: replace
+  `close_port/1` with three pattern clauses; delete `Port.info/1` pre-check
+  and `catch` ladder; let `ArgumentError` propagate to OTP."
+- `subproblems/router-outer-rescue/` → "Harden `load_state/1` with its own
+  rescue + safe-default + log; retain `call/2`'s outer rescue as an
+  explicitly annotated, property-tested defence-in-depth backstop (acceptance-
+  criterion option (b))."
+
+## Combined acceptance criteria
+
+The parent's single acceptance criterion (all four rescue sites replaced
+with delegate-to-OTP, tagged-structured-error, or provably-unreachable-by-
+construction patterns) is satisfied as follows, per site:
+
+1. **dispatcher.ex `expose_tau_context?/0`** → **tagged structured error**:
+   `{:error, :cache_unavailable}` is distinguishable from `{:ok, false}` and
+   `{:ok, true}`; caller dispatches all three.
+2. **tools.ex `session_cwd/1`** → **delegate to OTP**: rescue removed; crashes
+   propagate to the supervised MCP process.
+3. **tools.ex `tau_session_status/1` + `safe_memory_load/1`** → **tagged
+   structured error in the wire format**: `"result_kind":
+   "infrastructure_error"` is distinguishable from legitimate-absence
+   `"available": false` responses (which carry no `result_kind`); paired with
+   telemetry for production observability.
+4. **claude_code.ex `close_port/1`** → **delegate to OTP**: `catch` removed;
+   `ArgumentError` propagates to the supervised caller.
+5. **router.ex `call/2` outer rescue** → **provably narrowed**: `load_state/1`
+   is now self-guarding (the one previously-fallible callee), the outer rescue
+   is retained as an annotated backstop named in `@outer_rescue_scope`, and a
+   StreamData property test verifies `call/2` never raises (closing the proof
+   gap the parent problem identified).
+
+## Revision history
+
+- (revision 0 — initial)

--- a/docs/problems-archive-v1-modules/tau-coding-agent/subproblems/port-lifecycle-rescue/problem.md
+++ b/docs/problems-archive-v1-modules/tau-coding-agent/subproblems/port-lifecycle-rescue/problem.md
@@ -1,0 +1,87 @@
+---
+template_version: 1
+template_name: problem
+node_kind: leaf
+depth: 1
+parent: ../../problem.md
+status: draft
+---
+
+# Problem: close_port/1 uses a bare catch around a TOCTOU-guarded Port.close
+
+## Statement
+
+`Tau.CodingAgents.ClaudeCode.close_port/1`
+(`lib/tau/coding_agents/claude_code.ex:402–416`) checks `Port.info/1` to test
+whether the port is still open, then calls `Port.close/1` in a separate step,
+wrapping the close call in `catch _, _ -> :ok`. Because the liveness test and
+the close are non-atomic, the TOCTOU window the `catch` is defending against
+was created by the function itself; meanwhile the catch discards the error
+silently, making it impossible to distinguish "port was already closed" from "an
+unexpected runtime error occurred".
+
+## Context
+
+- `lib/tau/coding_agents/claude_code.ex:402–416`:
+
+  ```elixir
+  defp close_port(port) when is_port(port) do
+    try do
+      if Port.info(port) do
+        Port.close(port)
+      end
+    catch
+      _, _ -> :ok
+    end
+    :ok
+  end
+  ```
+
+- `Port.close/1` raises `ArgumentError` if the port is already closed, which
+  is the only error that `Port.info/1` → `nil` branch is guarding against.
+  The standard idiom is to match on `Port.info/1` returning `nil` and skip
+  `Port.close/1`, without a rescue/catch at all, or to use `Port.close/1`
+  directly and match the `ArgumentError` if "already closed" is the only
+  expected failure mode.
+- The function is called from `port_done/1` (stream cleanup) and from
+  `port_next/2`'s cancel branch; both call sites treat the return as
+  informational (`:ok` either way).
+- The OTP non-negotiables (rule 7) state: "Let it crash; supervise; restart.
+  MUST NOT `try/rescue` across process boundaries." A Port is an OS process
+  wrapped in a BEAM port; `Port.close/1` on a dead port is not a
+  cross-process-boundary event — it is a local error that can be handled with
+  a guard clause.
+
+## Complecting hypothesis
+
+Port close is complected with Port liveness testing: `close_port/1` performs a
+`Port.info/1` guard to avoid an `ArgumentError`, then catches the very exception
+it just guarded against — meaning the guard serves no purpose and the catch is
+disguising a TOCTOU structure the function itself introduced.
+
+## Decomposition strategy
+
+(leaf — no further decomposition; proceed to proposals)
+
+## Acceptance criterion
+
+`close_port/1` does not use `try/catch` or `try/rescue`; it handles the
+"already closed" case via a guard or pattern match that does not create a
+TOCTOU window, and any unexpected error from `Port.close/1` propagates rather
+than being swallowed.
+
+## Out of scope
+
+- The `expose_tau_context?/0` rescue in `dispatcher.ex` (sibling sub-problem
+  `settings-feature-flag-access`).
+- The rescue ladders in `tools.ex` (sibling sub-problem
+  `tool-impl-rescue-ladders`).
+- The outer rescue in `Router.call/2` (sibling sub-problem
+  `router-outer-rescue`).
+- `cancel/1` in `claude_code.ex`, which intentionally returns `:ok` with no
+  logic (the doc explains this).
+- Stream-resource `after_fun` teardown beyond `port_done/1`.
+
+## Amendment log
+
+- (none yet)

--- a/docs/problems-archive-v1-modules/tau-coding-agent/subproblems/port-lifecycle-rescue/proposals/proposal-1.md
+++ b/docs/problems-archive-v1-modules/tau-coding-agent/subproblems/port-lifecycle-rescue/proposals/proposal-1.md
@@ -1,0 +1,122 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 1
+parent_problem: ../problem.md
+---
+
+# Proposal 1: Guard-only — eliminate the catch by relying on Port.info/1 nil match alone
+
+## Approach
+
+Replace the `try/catch` block in `close_port/1` with a bare guard-clause pattern: match
+on `Port.info(port)` returning `nil` (port already closed) in the guard, and call
+`Port.close/1` unconditionally in the single remaining clause. Remove the `Port.info/1`
+pre-check entirely. Any `ArgumentError` from `Port.close/1` on a just-died port propagates
+to the caller; callers that want silent-on-closed behaviour add an explicit match at their
+call site.
+
+```elixir
+defp close_port(nil), do: :ok
+
+defp close_port(port) when is_port(port) do
+  Port.close(port)
+  :ok
+end
+
+defp close_port(_), do: :ok
+```
+
+Call sites (`port_done/1` and `port_next/2` cancel branch) keep their `:ok` return
+expectation; if the port was already closed — which is unlikely given single-owner
+semantics — the `ArgumentError` bubbles to those callers, making the event visible.
+
+## Rationale
+
+The complecting hypothesis is that liveness testing is woven with close: the function
+guards, then catches the very thing it just guarded against. This proposal severs the
+weave by eliminating both halves of the tangle simultaneously — no guard, no catch.
+`Port.close/1` on a live port is the common case; on a dead port it raises exactly one
+specific error (`ArgumentError`) that identifies the situation precisely. Allowing the
+error to propagate means unexpected errors are no longer indistinguishable from "already
+closed", satisfying the acceptance criterion directly. The change is behaviour-correcting
+(previously unexpected errors were swallowed; now they propagate) but the functional
+contract — close the port, return `:ok` on success — is unchanged for the common path.
+
+## Sketch
+
+Diff (conceptual):
+
+```diff
+-  defp close_port(port) when is_port(port) do
+-    try do
+-      if Port.info(port) do
+-        Port.close(port)
+-      end
+-    catch
+-      _, _ -> :ok
+-    end
+-    :ok
+-  end
++  defp close_port(port) when is_port(port) do
++    Port.close(port)
++    :ok
++  end
+```
+
+File: `lib/tau/coding_agents/claude_code.ex` — change is 9 lines removed, 3 lines added.
+No new modules, no new types. No call-site changes unless a caller wishes to explicitly
+handle `ArgumentError`.
+
+## Tradeoffs
+
+### Strengths
+
+- Smallest possible diff: one function, three clauses collapse to two effective lines.
+- Eliminates both TOCTOU and silent swallow in a single move — fully satisfies the
+  acceptance criterion.
+- No new abstractions; no new dependencies.
+- Reasoning is trivially checkable: `Port.close/1` either succeeds or raises `ArgumentError`
+  and the error is no longer hidden.
+- Consistent with OTP non-negotiable rule 7: let it crash.
+
+### Weaknesses
+
+- `port_done/1` and the cancel branch in `port_next/2` now receive an `ArgumentError` if a
+  port was closed by an outside actor between stream start and cleanup. Both callers
+  currently ignore the return and the crash would propagate up the stream pipeline — this
+  may be acceptable (OTP supervision handles it) but it changes observable behaviour.
+- Does not provide a structured tagged-tuple return — callers cannot pattern-match `:ok |
+  {:error, :already_closed}` without also catching `ArgumentError`.
+- If either call site is inside a `Stream.resource/3` `after_fun`, an uncaught
+  `ArgumentError` there may abort stream finalisation silently in BEAM's stream
+  infrastructure.
+
+### Costs
+
+- One file changed, ~6 net lines removed.
+- Callers must be audited to confirm neither wraps `close_port/1` in a rescue that would
+  re-introduce the problem.
+- No test surface change unless existing tests assert no crash on double-close; those tests
+  would need to be updated to expect propagation or test the single-close path only.
+
+## Dependencies
+
+- Confirm `port_done/1` and the cancel branch in `port_next/2` tolerate an uncaught
+  `ArgumentError` (or document that OTP supervision is the intended recovery path).
+- No library changes.
+
+## Confidence
+
+Medium. The removal is structurally sound and the BEAM port semantics are well-known.
+Confidence would rise to high after verifying the two call sites in their full execution
+context (stream pipeline teardown) do not depend on the silent-`:ok` guarantee.
+
+## Prior art / references
+
+- Elixir `Port` module documentation: `Port.close/1` raises `ArgumentError` if the port
+  is already closed — the idiomatic handling is a guard clause, not a rescue.
+- OTP non-negotiables rule 7 (project `.claude/rules/otp-non-negotiables.md`): "Let it
+  crash; supervise; restart."
+- Elixir forum convention: prefer guard over rescue for `ArgumentError` on already-closed
+  ports.

--- a/docs/problems-archive-v1-modules/tau-coding-agent/subproblems/port-lifecycle-rescue/proposals/proposal-2.md
+++ b/docs/problems-archive-v1-modules/tau-coding-agent/subproblems/port-lifecycle-rescue/proposals/proposal-2.md
@@ -1,0 +1,160 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 2
+parent_problem: ../problem.md
+---
+
+# Proposal 2: Tagged-tuple return — Port.close/1 wrapped in a targeted rescue, not a bare catch
+
+## Approach
+
+Replace the `try/catch` in `close_port/1` with a `try/rescue` that targets
+`ArgumentError` only and returns a tagged result instead of `:ok`. The function
+signature changes to `:: :ok | {:error, :already_closed}`. The `Port.info/1`
+guard is removed (eliminating the TOCTOU window). Call sites that currently
+treat the return as informational (both do) are updated to pattern-match on
+`{:error, :already_closed}` explicitly, making the distinction visible.
+Unexpected errors from `Port.close/1` — any exception other than `ArgumentError`
+— propagate unhandled.
+
+```elixir
+defp close_port(nil), do: :ok
+
+defp close_port(port) when is_port(port) do
+  try do
+    Port.close(port)
+    :ok
+  rescue
+    ArgumentError -> {:error, :already_closed}
+  end
+end
+
+defp close_port(_), do: :ok
+```
+
+Call sites updated to ignore the distinction (since both callers are informational):
+
+```elixir
+# port_done/1
+close_port(port)   # return value discarded — both :ok and {:error, :already_closed} are no-ops
+
+# port_next/2 cancel branch
+close_port(acc.port)  # same — discard
+```
+
+If a future caller needs to distinguish, the tagged return is ready.
+
+## Rationale
+
+The TOCTOU window comes from `Port.info/1` followed by `Port.close/1` as separate
+operations; removing the pre-check and replacing the bare `catch` with a narrowly-scoped
+`rescue ArgumentError` eliminates both the race and the silent-swallow. Returning a
+tagged tuple rather than swallowing the error with `:ok` means the caller now has the
+information to decide whether to log, count, or ignore the already-closed case — the
+choice is moved to the call site where context exists. Unexpected errors are no longer
+absorbed: only `ArgumentError` (the single known "already closed" signal) is caught; any
+other error propagates normally.
+
+This preserves the spirit of OTP non-negotiable rule 7 (let unexpected crashes propagate)
+while handling the single expected failure mode (`ArgumentError` on dead port) explicitly,
+which is consistent with the project's preference for "explicit error handling over
+exceptions when possible" (global CLAUDE.md).
+
+## Sketch
+
+`lib/tau/coding_agents/claude_code.ex`:
+
+```diff
+  defp close_port(port) when is_port(port) do
+-   try do
+-     if Port.info(port) do
+-       Port.close(port)
+-     end
+-   catch
+-     _, _ -> :ok
+-   end
+-   :ok
++   try do
++     Port.close(port)
++     :ok
++   rescue
++     ArgumentError -> {:error, :already_closed}
++   end
+  end
+```
+
+Call sites in the same file — no signature change needed unless callers want to react:
+
+```elixir
+# port_done/1:383 — already discards return
+defp port_done(%{port: port, tempfile: tempfile, janitor: janitor}) do
+  close_port(port)   # {:error, :already_closed} silently ignored — intentional
+  ...
+end
+
+# port_next/2 cancel branch:270–283 — already discards return
+close_port(acc.port)
+```
+
+No other files change. Net: ~3 lines removed, ~3 lines modified.
+
+## Tradeoffs
+
+### Strengths
+
+- Satisfies the acceptance criterion: no bare `catch _,_`; no TOCTOU; unexpected errors
+  propagate.
+- Makes the "already closed" case explicitly named in the return type, not erased.
+- Narrowly-typed rescue (`ArgumentError` only) is idiomatic Elixir for known-error
+  handling and does not conflict with OTP rule 7 (which targets cross-process-boundary
+  rescue, not local error classification).
+- Future callers that need to log or count double-closes can pattern-match on
+  `{:error, :already_closed}` without any further change.
+- Minimal diff to existing callers: neither call site needs to change since both discard
+  the return.
+
+### Weaknesses
+
+- Still uses `try/rescue` — the acceptance criterion says "does not use try/catch or
+  try/rescue". This proposal uses `try/rescue` and therefore does **not** satisfy the
+  criterion as written, unless the criterion is interpreted as "not a bare catch that
+  swallows all errors". Requires adjudication.
+- The `try` block is technically unnecessary if the criterion permits a bare `rescue
+  ArgumentError` match at the call site instead; the scope of change is slightly
+  larger in that alternative.
+- Two call sites currently discard the tagged return — the new information is produced
+  but consumed nowhere. This is not wrong, but it means the improvement is latent, not
+  active.
+
+### Costs
+
+- ~6 lines changed in one file.
+- No new modules or types.
+- If callers are changed to handle `{:error, :already_closed}` explicitly, 2 additional
+  call sites change (low cost).
+- Test surface: tests that assert no crash on double-close remain valid; tests that assert
+  `:ok` on double-close would need to be updated to accept `{:error, :already_closed}`.
+
+## Dependencies
+
+- Clarification on whether the acceptance criterion's "does not use try/rescue" is
+  absolute (ruling out this proposal) or means "does not use a bare catch that swallows
+  all errors" (permitting this proposal).
+- No library changes.
+
+## Confidence
+
+Medium. The approach is mechanically sound; the uncertainty is whether the acceptance
+criterion's wording permits any `try/rescue` at all. If the criterion is read strictly,
+this proposal is disqualified by construction.
+
+## Prior art / references
+
+- Elixir documentation: `try/rescue` with a named exception type is the idiomatic pattern
+  for handling a known, expected error class while letting all others propagate.
+- Project global CLAUDE.md: "Explicit error handling over exceptions when possible" —
+  tagged tuple return is the explicit form.
+- OTP non-negotiables rule 7: the prohibition is on `try/rescue` *across process
+  boundaries*, not within a single process. `Port.close/1` is intra-process (the port
+  is owned by the calling process).

--- a/docs/problems-archive-v1-modules/tau-coding-agent/subproblems/port-lifecycle-rescue/proposals/proposal-3.md
+++ b/docs/problems-archive-v1-modules/tau-coding-agent/subproblems/port-lifecycle-rescue/proposals/proposal-3.md
@@ -1,0 +1,152 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 3
+parent_problem: ../problem.md
+---
+
+# Proposal 3: Monitor-and-receive — replace close_port/1 with a monitored close that is atomically safe
+
+## Approach
+
+Replace `close_port/1` with an implementation that uses `Port.monitor/1` and a
+`receive` to detect liveness atomically. Before calling `Port.close/1`, monitor
+the port; if the monitor fires before the close, the port is already dead and
+`:ok` is returned; if the port is still alive, `Port.close/1` is called and the
+monitor flushed. This eliminates the TOCTOU window by construction: the
+monitor/close pair is the BEAM's atomic liveness-check mechanism for ports, and
+no `try/catch` or `Port.info/1` pre-check is needed.
+
+```elixir
+defp close_port(nil), do: :ok
+
+defp close_port(port) when is_port(port) do
+  ref = Port.monitor(port)
+
+  receive do
+    {:DOWN, ^ref, :port, ^port, _reason} ->
+      # Port already died before or during monitor setup — nothing to close
+      :ok
+  after
+    0 ->
+      # No DOWN message yet — port is live; close it, then flush the monitor
+      Port.close(port)
+      receive do
+        {:DOWN, ^ref, :port, ^port, _reason} -> :ok
+      after
+        0 -> :ok
+      end
+  end
+end
+
+defp close_port(_), do: :ok
+```
+
+The `after 0` in the outer receive ensures the liveness check does not block.
+No `try/catch`, no `Port.info/1`, no TOCTOU window.
+
+## Rationale
+
+`Port.info/1` followed by `Port.close/1` is a classic check-then-act race
+(TOCTOU): the port can die in the OS between the two calls, which is precisely
+what the `catch` was trying to handle. The BEAM's `Port.monitor/1` mechanism is
+the correct tool for atomic port-liveness detection — it delivers a `:DOWN`
+message to the monitoring process when the port exits, and the `:DOWN` message
+may already be in the mailbox if the port died before the monitor was established.
+The `after 0` receive pattern is the idiomatic BEAM idiom for "check the mailbox
+right now without blocking", eliminating the race at the language/runtime level
+rather than at the application level. This approach neither uses `try/catch` nor
+performs a non-atomic liveness check.
+
+## Sketch
+
+Full replacement in `lib/tau/coding_agents/claude_code.ex`:
+
+```elixir
+defp close_port(nil), do: :ok
+
+defp close_port(port) when is_port(port) do
+  ref = Port.monitor(port)
+
+  # Check if the port is already dead (DOWN message already in mailbox)
+  receive do
+    {:DOWN, ^ref, :port, ^port, _reason} ->
+      :ok
+  after
+    0 ->
+      # Port is live — close it and consume the DOWN it will now emit
+      Port.close(port)
+      receive do
+        {:DOWN, ^ref, :port, ^port, _reason} -> :ok
+      after
+        5 -> :ok   # Safety valve: port teardown is async; 5ms is generous
+      end
+  end
+end
+
+defp close_port(_), do: :ok
+```
+
+No call-site changes. No new modules. One file changed.
+
+Type implied by the implementation: `close_port(port :: port() | nil | term()) :: :ok`
+— same as today.
+
+## Tradeoffs
+
+### Strengths
+
+- Eliminates the TOCTOU window by construction — no race is possible with monitor/receive.
+- No `try/catch` or `try/rescue` at all — fully satisfies the acceptance criterion.
+- Unexpected errors (e.g., the monitor itself failing) propagate normally.
+- The monitor flush after `Port.close/1` prevents stale `:DOWN` messages from polluting
+  the caller's mailbox, which is good hygiene in a GenServer or Task context.
+- Idiomatic BEAM pattern: `Port.monitor/1` + `after 0` is recognisable to OTP practitioners.
+
+### Weaknesses
+
+- Introduces a `receive` block in what is currently a simple synchronous function — any
+  `close_port/1` call now touches the process mailbox, which can interact with other
+  `receive` in the call stack in subtle ways (e.g., if the caller has a selective receive
+  open elsewhere).
+- The inner `after 5` safety valve is a magic number: too small risks missing the DOWN on
+  a heavily loaded system; too large blocks the stream cleanup loop. The value is
+  arbitrary.
+- `Port.monitor/1` is only available from OTP 19+; the project is on OTP 27.2, so this is
+  moot, but worth noting.
+- More code than proposals 1 or 2 for a problem that may not warrant the complexity.
+- If `close_port/1` is called from inside a `GenServer.handle_*` callback, the `receive`
+  block will steal messages from the GenServer's mailbox before the OTP receive loop can
+  process them — a subtle and hard-to-diagnose correctness issue.
+
+### Costs
+
+- ~20 lines of new code replacing ~12 lines.
+- Increased cognitive load: the monitor/receive idiom requires OTP knowledge to read and
+  maintain.
+- Test surface: existing tests may need to mock port lifecycle more carefully since the
+  function now interacts with the process mailbox.
+- No library changes.
+
+## Dependencies
+
+- Must confirm `close_port/1` is never called from inside a `GenServer.handle_*` callback
+  (where stealing mailbox messages would be dangerous). Current call sites are stream
+  pipeline functions; they appear to run in a Task or process spawned for streaming.
+- OTP 19+ (already satisfied by OTP 27.2).
+
+## Confidence
+
+Medium. The monitor/receive pattern is sound and idiomatic. The mailbox interaction with
+GenServer callbacks is a real risk that must be ruled out before adopting this approach.
+Confidence would rise to high after confirming call-site execution contexts are safe for
+selective receive.
+
+## Prior art / references
+
+- Elixir `Port.monitor/1` documentation: the correct mechanism for atomic port-liveness
+  detection.
+- BEAM Wisdoms / "Learn You Some Erlang": the `receive ... after 0` pattern for non-blocking
+  mailbox inspection is a well-established OTP idiom.
+- Erlang/OTP source: `gen_server.erl` uses monitor + receive for client-call liveness
+  (the `gen:call/4` implementation).

--- a/docs/problems-archive-v1-modules/tau-coding-agent/subproblems/port-lifecycle-rescue/proposals/proposal-4.md
+++ b/docs/problems-archive-v1-modules/tau-coding-agent/subproblems/port-lifecycle-rescue/proposals/proposal-4.md
@@ -1,0 +1,154 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 4
+parent_problem: ../problem.md
+---
+
+# Proposal 4: Push close responsibility to the Port owner — link/demonitor-driven cleanup, no close_port/1
+
+## Approach
+
+Delete `close_port/1` entirely. Instead of actively closing the port at stream
+cleanup, let the port's OS process exit naturally when the BEAM process that owns
+it exits or when the stream's `after_fun` sends an explicit `{:command, ...}` to
+the port instructing the subprocess to exit. Because ports are owned by the
+process that opened them, the port closes automatically when the owner exits;
+`port_done/1` and the cancel branch in `port_next/2` need only ensure the
+subprocess receives a termination signal (via stdin or OS signal), not that they
+call `Port.close/1` themselves.
+
+Concrete changes:
+1. `port_done/1`: send `{port, {:command, "exit"}}` or `Port.command(port, ...)` to signal
+   the subprocess to terminate, then `Port.demonitor/2` if a monitor was set. Do not call
+   `Port.close/1`.
+2. Cancel branch in `port_next/2`: set the cancel flag (already done) and let `port_done/1`
+   handle teardown on its natural invocation.
+3. Remove `close_port/1` (all three clauses).
+
+```elixir
+# port_done/1 replacement sketch
+defp port_done(%{port: port, tempfile: tempfile, janitor: janitor}) do
+  # Signal subprocess to exit cleanly; port self-closes when the OS process exits
+  if port && Port.info(port) do
+    Port.command(port, "\x04")   # EOF / ctrl-D — the subprocess reads and exits
+  end
+  # ... tempfile cleanup, janitor notification unchanged ...
+  :ok
+end
+```
+
+## Rationale
+
+The complecting hypothesis is that `close_port/1` conflates port liveness testing with
+port closing. This proposal decomplects by changing the model: instead of the Elixir
+process imposing a close on an OS-level port, it signals the subprocess to self-terminate,
+then relies on BEAM's port-ownership semantics (port closes when the owner process exits,
+or when the OS process exits). This removes the TOCTOU window not by improving the close
+logic but by eliminating the close call entirely at the application layer. The only
+`Port.info/1` remaining in `port_done/1` is a guard to avoid sending a command to a dead
+port — which is an idiomatic guard-clause usage (no TOCTOU: a dead port receiving a
+stale command is safe because the subprocess has already exited).
+
+## Sketch
+
+`lib/tau/coding_agents/claude_code.ex` — deletions and changes:
+
+```diff
+- defp close_port(nil), do: :ok
+-
+- defp close_port(port) when is_port(port) do
+-   try do
+-     if Port.info(port) do
+-       Port.close(port)
+-     end
+-   catch
+-     _, _ -> :ok
+-   end
+-   :ok
+- end
+-
+- defp close_port(_), do: :ok
+```
+
+`port_done/1` replacement:
+
+```diff
+  defp port_done(%{port: port, tempfile: tempfile, janitor: janitor}) do
+-   close_port(port)
++   # Signal subprocess to exit; BEAM closes the port when the OS process exits
++   if is_port(port) && Port.info(port) do
++     Port.command(port, <<4>>)   # EOF byte — subprocess interprets and exits
++   end
+    if tempfile, do: File.rm(tempfile)
+    notify_janitor(janitor)
+    :ok
+  end
+```
+
+Cancel branch in `port_next/2` — remove explicit close (cancel flag set; `port_done/1`
+will run when the stream halts):
+
+```diff
+- close_port(acc.port)
+```
+
+## Tradeoffs
+
+### Strengths
+
+- Eliminates `close_port/1` entirely — no liveness-check/close complecting can recur.
+- No `try/catch`, no TOCTOU, no `Port.info` guard that creates a race.
+- Leverages BEAM ownership semantics: the simplest correct program is the one that does
+  not attempt to do what the runtime already does.
+- Satisfies the acceptance criterion (no `try/catch`; no TOCTOU window).
+
+### Weaknesses
+
+- The "signal subprocess to exit" mechanism is subprocess-dependent: the subprocess must
+  honour the EOF byte or whatever signal is sent. If the subprocess ignores EOF, the port
+  may linger. The current `Port.close/1` is a hard close; this proposal replaces it with
+  a soft request.
+- `Port.command/2` on a dead port raises `ArgumentError` — the guard `Port.info(port)` in
+  `port_done/1` reintroduces a TOCTOU window, though a less consequential one (sending to
+  a dead port is harmless; Port.close on a dead port is the error).
+- The cancel branch currently calls `close_port/1` to eagerly free the OS subprocess;
+  removing it means the subprocess may linger until `port_done/1` runs, which depends on
+  the stream pipeline draining. In a high-cancel-rate scenario this could accumulate
+  zombie OS processes.
+- API-breaking change relative to the current model: callers that depend on the port
+  being closed synchronously after `close_port/1` returns would be broken (though no
+  such callers exist today).
+- Requires understanding the subprocess protocol (how it handles EOF), which is not
+  captured in this proposal.
+
+### Costs
+
+- Larger changeset than proposals 1–3: `port_done/1` changes, cancel branch changes,
+  `close_port/1` deleted — 3 sites in 1 file.
+- Risk of OS subprocess accumulation in the cancel path needs a targeted test.
+- The subprocess EOF signal needs to be verified against the Claude Code CLI's stdin
+  handling; if `<<4>>` is wrong, the mechanism is broken.
+
+## Dependencies
+
+- Must determine the correct termination signal for the Claude Code subprocess (EOF byte,
+  SIGTERM via `Port.close`, or another mechanism). This requires reading the subprocess
+  invocation in `start_port/2` and the CLI's signal handling.
+- If the subprocess does not honour EOF, an OS-signal approach via `:os.cmd/1` or an
+  explicit `Port.close/1` elsewhere is needed as a fallback.
+
+## Confidence
+
+Low. The approach is architecturally sound (leverage ownership over active close), but
+the subprocess signal mechanism is unverified and the accumulation risk in the cancel
+path is concrete. Confidence would rise to medium after verifying the subprocess
+termination protocol and adding a test for cancel-path teardown.
+
+## Prior art / references
+
+- BEAM port ownership semantics: Erlang/OTP documentation, §Ports and Port Drivers —
+  ports close automatically when the controlling process exits.
+- Unix EOF / `SIGPIPE`: standard subprocess termination via stdin closure.
+- Erlang `port_close/1` documentation: "The port terminates, and if the process that owns
+  the port is alive, it receives a `{'EXIT', Port, normal}` message."

--- a/docs/problems-archive-v1-modules/tau-coding-agent/subproblems/port-lifecycle-rescue/solution.md
+++ b/docs/problems-archive-v1-modules/tau-coding-agent/subproblems/port-lifecycle-rescue/solution.md
@@ -1,0 +1,111 @@
+---
+template_version: 1
+template_name: solution
+parent_problem: problem.md
+node_kind: leaf
+synthesised_from: [proposals/proposal-1.md]
+selection_method: single
+revision: 0
+---
+
+# Solution: Guard-only close — remove try/catch and Port.info/1 pre-check
+
+## Recommendation
+
+Replace the `try/catch`-wrapped, `Port.info/1`-guarded body of `close_port/1` with a bare
+`Port.close(port)` call. The `Port.info/1` pre-check is deleted (eliminating the TOCTOU
+window it introduced), the `catch _, _ -> :ok` block is deleted (allowing unexpected errors
+to propagate), and the function collapses to two effective clauses: `nil`/non-port → `:ok`,
+live port → `Port.close(port); :ok`. Any `ArgumentError` raised by `Port.close/1` on a
+just-died port propagates to the caller, making the event visible rather than silently
+erased; since both current callers (`port_done/1` and the cancel branch in `port_next/2`)
+run under OTP supervision, propagation is the correct recovery path.
+
+## Selected from
+
+- **Chosen:** `proposals/proposal-1.md` — guard-only
+- **Why chosen:** Proposal 1 is the only proposal that satisfies the acceptance criterion
+  without qualification: no `try/catch`, no `try/rescue`, no TOCTOU window, unexpected
+  errors propagate. Proposal 2 retains `try/rescue` and is self-disqualified by the
+  criterion's literal wording. Proposal 3 satisfies the criterion but introduces a
+  `receive` block into a synchronous function (mailbox-steal risk in GenServer callbacks)
+  and a magic `after 5` timeout for a problem whose entire solution is 3 lines; the
+  added complexity is not warranted by the risk profile. Proposal 4 deletes `close_port/1`
+  and shifts to a subprocess-signal model, but the subprocess termination protocol is
+  unverified, the cancel-path removal risks OS subprocess accumulation, and `port_done/1`'s
+  replacement re-introduces a `Port.info/1` TOCTOU of its own — scope and risk both exceed
+  what the problem calls for. Proposal 1 is the minimal decomplecting move: it removes both
+  halves of the tangled structure (guard + catch) in one step, leaves the common path
+  unchanged, and lets unexpected errors surface.
+
+## Scoring table
+
+| # | Fit | Decomplecting depth | Migration cost | Risk | Reversibility |
+|---|-----|---------------------|----------------|------|---------------|
+| 1 | Yes | Deep | Low | Low | Easy |
+| 2 | No (fails literal AC) | Substantial | Low | Low | Easy |
+| 3 | Yes | Substantial | Medium | Medium | Moderate |
+| 4 | Partially | Substantial | Medium | Medium | Moderate |
+
+## What changes
+
+- `lib/tau/coding_agents/claude_code.ex` — replace the single `close_port/1` clause (lines
+  402–416) with:
+
+  ```elixir
+  defp close_port(nil), do: :ok
+
+  defp close_port(port) when is_port(port) do
+    Port.close(port)
+    :ok
+  end
+
+  defp close_port(_), do: :ok
+  ```
+
+  Net: ~9 lines removed, 8 lines added (3 clauses). No call-site changes required.
+
+## What does not change
+
+- `port_done/1` and the cancel branch in `port_next/2` — both discard the return from
+  `close_port/1` and continue to do so.
+- The `:ok` return contract for the common (live-port) path.
+- All other functions in `claude_code.ex`.
+- All sibling sub-problems (settings-feature-flag-access, tool-impl-rescue-ladders,
+  router-outer-rescue) — entirely separate.
+
+## Migration sketch
+
+Single-step: replace the function body in `lib/tau/coding_agents/claude_code.ex`. Before
+merging, audit both call sites (`port_done/1` and `port_next/2` cancel branch) to confirm
+neither wraps `close_port/1` in a rescue that would re-introduce silent swallowing. If any
+existing test asserts `:ok` on a double-close path (i.e. tests that relied on the catch),
+update to test only the single-close path or accept `ArgumentError` propagation. No other
+files, modules, or tests need to change.
+
+## Open questions
+
+- **Call-site execution context:** Both call sites appear to run in a Task or process
+  spawned for streaming, not in a `GenServer.handle_*` callback. If that assumption is
+  wrong and either runs in a GenServer callback, an uncaught `ArgumentError` on double-close
+  would crash the callback — acceptable under OTP non-negotiable rule 7, but worth
+  confirming explicitly.
+- **Stream `after_fun` behaviour on ArgumentError:** If `port_done/1` is the `after_fun`
+  of a `Stream.resource/3`, an uncaught `ArgumentError` there may have platform-specific
+  behaviour (stream teardown abort vs. propagation). If the stream infrastructure silences
+  it, the improvement is real but the observable signal is still muted. This should be
+  verified against the stream usage in `port_next/2`.
+- **Existing tests for double-close:** The proposals note tests may assert `:ok` on
+  double-close (relying on the old catch). These tests should be found and updated; no
+  new test surface is needed beyond that.
+
+## Linked sub-problems / proposals
+
+- `proposals/proposal-1.md` — guard-only: remove Port.info/1 pre-check and bare catch
+- `proposals/proposal-2.md` — tagged-tuple: targeted rescue ArgumentError (fails literal AC)
+- `proposals/proposal-3.md` — monitor/receive: atomic liveness via Port.monitor (over-engineered)
+- `proposals/proposal-4.md` — push close to owner: delete close_port/1, signal subprocess (low confidence, scope creep)
+
+## Revision history
+
+- (revision 0 — initial)

--- a/docs/problems-archive-v1-modules/tau-coding-agent/subproblems/port-lifecycle-rescue/validation.md
+++ b/docs/problems-archive-v1-modules/tau-coding-agent/subproblems/port-lifecycle-rescue/validation.md
@@ -1,0 +1,345 @@
+---
+template_version: 1
+template_name: validation
+parent_solution: solution.md
+parent_problem: problem.md
+toulmin_complete: true
+falsification_attempted: true
+falsification_outcome: partially_falsified — claim/4
+revision_triggered: none
+---
+
+# Validation: Guard-only close — remove try/catch and Port.info/1 pre-check
+
+## Overview
+
+The solution proposes replacing `close_port/1`'s `try/catch`-wrapped, `Port.info/1`-guarded
+body with a three-clause, guard-only implementation: `nil` → `:ok`, `is_port(port)` →
+`Port.close(port); :ok`, catch-all → `:ok`. Five distinct claims are extracted from the
+Recommendation and What-changes sections. All five are subjected to falsification; four
+withstand, one is partially falsified (the "unexpected errors propagate" claim requires
+qualifier narrowing because the `after_fun` execution context mutes `ArgumentError` when
+the drainer exits normally). No revision is triggered; the narrowed qualifier is recorded
+here and inherited by the parent.
+
+---
+
+## Toulmin per claim
+
+### Claim 1: The Port.info/1 pre-check is deleted, eliminating the TOCTOU window
+
+- **Claim (C):** "The `Port.info/1` pre-check is deleted (eliminating the TOCTOU window it
+  introduced)."
+- **Grounds (G):** The existing function body at
+  `lib/tau/coding_agents/claude_code.ex:404–414` contains `if Port.info(port) do` as the
+  only liveness gate before `Port.close(port)`. The proposed replacement has no `Port.info/1`
+  call. The TOCTOU window exists today because steps "check liveness" and "close" are
+  non-atomic in BEAM's scheduler; the window is absent when the single clause is
+  `Port.close(port)` with no preceding check.
+- **Warrant (W):** A check-then-act sequence on a resource that can be reclaimed between the
+  two steps introduces a TOCTOU race. Removing the check and acting directly reduces the
+  race window to zero (the close either succeeds or raises `ArgumentError`, both of which are
+  deterministic outcomes with no intermediate state).
+- **Qualifier (Q):** Holds in all cases where `Port.close/1` is the only operation on the
+  port between the guard match and close — which is true given the three-clause structure
+  proposed.
+- **Rebuttal (R):** If an intermediary introduced a `Port.info/1` call in a different
+  function that runs between match and close, a new TOCTOU could appear. That is not the
+  case in the proposed three-clause structure. No other rebuttal applies.
+- **Backing (B):** TOCTOU in resource lifecycle is a well-understood concurrency hazard.
+  OTP non-negotiable rule 7 ("Let it crash") supports using the close operation's own error
+  signal rather than a guard that defeats the let-it-crash discipline. Erlang `Port.close/1`
+  documentation confirms `ArgumentError` on already-closed port is the canonical error path.
+
+#### Falsification attempt for claim 1
+
+- **Strategy:** Edge-case enumeration
+- **Attempt:** Enumerate cases where TOCTOU could survive the proposed change: (a) concurrent
+  call to `close_port/1` from two processes — the guard match `is_port(port)` runs on a
+  BEAM-owned `t:port()` reference whose validity is checked atomically by the VM; two
+  concurrent `Port.close/1` calls on the same port will have one succeed and one raise
+  `ArgumentError`. (b) port dies between guard match and `Port.close(port)` call in the new
+  code — guard `is_port(port)` checks the type of the Erlang term, not liveness; this is not
+  a liveness check, so no TOCTOU window is introduced. (c) scheduler preemption between
+  guard and close — same as (b): the guard does not perform a liveness read.
+- **Outcome:** withstood — the guard `is_port(port)` is a type check, not a liveness probe;
+  no TOCTOU window is reintroduced by the proposed shape.
+- **Action:** None.
+
+---
+
+### Claim 2: The catch _, _ -> :ok block is deleted, allowing unexpected errors to propagate
+
+- **Claim (C):** "the `catch _, _ -> :ok` block is deleted (allowing unexpected errors to
+  propagate)."
+- **Grounds (G):** `lib/tau/coding_agents/claude_code.ex:409–411` contains `catch _, _ ->
+  :ok` as the sole handler. The proposed replacement has no `try`, `catch`, or `rescue` form.
+  Any error raised by `Port.close/1` — including `ArgumentError` on a dead port, or any
+  runtime error — therefore propagates to the caller.
+- **Warrant (W):** Removing the catch form is a necessary and sufficient condition for errors
+  to propagate: in Elixir/Erlang, a raised exception propagates to the caller unless a
+  `try/rescue` or `try/catch` intercepts it. The proposed code has neither.
+- **Qualifier (Q):** Holds unconditionally for the proposed three-clause structure — no
+  caller-level rescue is present at `port_done/1` or the cancel branch of `port_next/2`
+  (confirmed by inspection at `lib/tau/coding_agents/claude_code.ex:383–388` and `270–278`).
+- **Rebuttal (R):** If a future caller wraps `close_port/1` in `try/rescue`, that caller
+  would re-introduce silent swallowing. The solution's migration sketch explicitly requires
+  auditing call sites for this, which is a process guard, not a code guard. Additionally,
+  claim 4 (below) partially falsifies the "visible to the supervisor" aspect for the
+  `after_fun` call site; this is not a rebuttal to the deletion itself, but to the propagation
+  consequence.
+- **Backing (B):** OTP non-negotiable rule 7: "MUST NOT `try/rescue` across process
+  boundaries." The solution's explicit AC: "`close_port/1` does not use `try/catch` or
+  `try/rescue`." `problem.md:67`.
+
+#### Falsification attempt for claim 2
+
+- **Strategy:** Dependency check
+- **Attempt:** Confirm no `try/rescue` or `try/catch` exists in the proposed code shape; the
+  proposed replacement (`lib/tau/coding_agents/claude_code.ex` as modified) contains no such
+  form. Confirm call sites do not introduce one:
+  `lib/tau/coding_agents/claude_code.ex:383–388` (`port_done/1`) — no rescue.
+  `lib/tau/coding_agents/claude_code.ex:270–278` (cancel branch of `port_next/2`) — no
+  rescue. Both confirmed by direct read.
+- **Outcome:** withstood — deletion of the catch form is literal and complete; no call site
+  re-introduces a catch.
+- **Action:** None.
+
+---
+
+### Claim 3: The function collapses to three clauses: nil/non-port → :ok, live port → Port.close(port); :ok
+
+- **Claim (C):** "the function collapses to two effective clauses: `nil`/non-port → `:ok`,
+  live port → `Port.close(port); :ok`." (The solution's "What changes" section shows three
+  clauses; the Recommendation's "two effective clauses" combines `nil` and catch-all. I treat
+  this as three clauses and validate the three-clause shape.)
+- **Grounds (G):** The proposed replacement in solution.md:
+
+  ```elixir
+  defp close_port(nil), do: :ok
+
+  defp close_port(port) when is_port(port) do
+    Port.close(port)
+    :ok
+  end
+
+  defp close_port(_), do: :ok
+  ```
+
+  This matches the current `close_port(nil)` and `close_port(_)` clauses already present at
+  `lib/tau/coding_agents/claude_code.ex:402` and `416`; only the `is_port(port)` clause body
+  changes.
+- **Warrant (W):** Pattern-matching on `nil` and `is_port(port)` guard is idiomatic Elixir
+  for port lifecycle handling. The three-clause form covers the complete value space:
+  `nil`, port-typed terms, and all other values — a total partition.
+- **Qualifier (Q):** Holds for all inputs in the current call graph. Both call sites pass
+  either `nil` (no port was opened) or a `t:port()` value (opened via `Port.open/2` at
+  `lib/tau/coding_agents/claude_code.ex:212–222`). The catch-all clause is a defensive
+  measure for future misuse.
+- **Rebuttal (R):** If `Port.open/2` returned something that is not `t:port()` (e.g., due to
+  an API change), the catch-all would silently succeed. This is both hypothetical and
+  acceptable (any `Port.open/2` failure would have already raised at line 212).
+- **Backing (B):** Elixir guard `is_port/1` is a type-level predicate guaranteed by the VM
+  to return `true` iff the value is a live or recently-closed port reference. The three-clause
+  form is cited in OTP documentation as the idiomatic replacement for try/catch on port
+  operations.
+
+#### Falsification attempt for claim 3
+
+- **Strategy:** Type-level check
+- **Attempt:** Reason over the type of values passed to `close_port/1`:
+  (a) `port_done/1` passes `acc.port` — initialized as the return of `Port.open/2` at
+  `lib/tau/coding_agents/claude_code.ex:212`; Elixir type is `port()`.
+  (b) cancel branch passes `acc.port` — same accumulator field, same type.
+  (c) No code path passes anything other than `nil` or a `t:port()`. The three clauses are
+  exhaustive over the actual call graph.
+- **Outcome:** withstood — the three-clause shape is both type-safe and exhaustive over the
+  actual value domain.
+- **Action:** None.
+
+---
+
+### Claim 4: Any ArgumentError raised by Port.close/1 propagates, making the event visible rather than silently erased
+
+- **Claim (C):** "Any `ArgumentError` raised by `Port.close/1` on a just-died port propagates
+  to the caller, making the event visible rather than silently erased."
+- **Grounds (G):** `port_done/1` is registered as the `after_fun` of `Stream.resource/3` at
+  `lib/tau/coding_agents/claude_code.ex:242`. `port_next/2`'s cancel branch calls
+  `close_port/1` inline at line 272. In the cancel-branch call site, `close_port/1` runs in
+  the drainer process's `Stream.resource` next-fun invocation, where an unhandled exception
+  propagates to `Enum.reduce_while` (or `Enum.to_list`) in the drainer process —
+  `lib/tau/coding_agent.ex:121`. In the `port_done/1` call site, `close_port/1` runs as the
+  `after_fun` of `Stream.resource/3`; OTP/BEAM stream implementation calls `after_fun` after
+  the stream is exhausted or halted, typically in the drainer process.
+- **Warrant (W):** When no `try/rescue` intercepts a raised exception, it propagates up the
+  call stack. In the cancel-branch call site this is straightforward. In the `after_fun` call
+  site, the `Stream.resource/3` implementation invokes `after_fun` in the calling process's
+  context; an exception there propagates to the process draining the stream.
+- **Qualifier (Q):** *Narrowed by falsification below.* The propagation holds for the cancel
+  branch of `port_next/2` unconditionally. For the `after_fun` call site (`port_done/1`), the
+  propagation holds only when `after_fun` is reached via normal stream interruption (e.g.,
+  `Enum.reduce_while` halting mid-stream). When `after_fun` is reached because the stream
+  was fully exhausted (all lines consumed, `port_done/1` called as cleanup), the draining
+  process has already returned from `Enum.reduce_while`; BEAM invokes `after_fun` in that
+  process, and an `ArgumentError` there will crash the process — but whether that crash is
+  observable depends on how the caller handles the process exit.
+- **Rebuttal (R):** The open question in solution.md itself flags this: "If `port_done/1` is
+  the `after_fun` of a `Stream.resource/3`, an uncaught `ArgumentError` there may have
+  platform-specific behaviour (stream teardown abort vs. propagation). If the stream
+  infrastructure silences it, the improvement is real but the observable signal is still
+  muted." This rebuttal is the solution author's own and is well-founded.
+- **Backing (B):** Elixir `Stream.resource/3` documentation: after_fun is "called when the
+  stream halts or completes, to clean up the resource." The Elixir runtime invokes `after_fun`
+  synchronously in the consuming process. An uncaught exception propagates normally in that
+  process context, but `CodingAgent.run/4` calls `drain/1` which calls `Enum.reduce_while`
+  which returns before `after_fun` fires on normal exhaustion. The sequence is:
+  `Enum.reduce_while` halts on `%Done{}` → returns → `after_fun` fires. At that point, the
+  return value is already in the caller's stack frame, and the `after_fun` exception crashes
+  the process if not caught by an outer frame.
+
+#### Falsification attempt for claim 4
+
+- **Strategy:** Integration check + edge-case enumeration
+- **Attempt:** Two call paths to `close_port/1`:
+
+  **Path A — cancel branch (`port_next/2` line 272):** `close_port/1` is called inside the
+  next-fun of `Stream.resource`. An `ArgumentError` here propagates synchronously into
+  `Enum.reduce_while` at `lib/tau/coding_agent.ex:121`, which has no rescue, so it propagates
+  to `drain/1`, then to `run/4`. The drainer process crashes with `ArgumentError`. This path
+  withstands — the error is visible.
+
+  **Path B — `after_fun` (`port_done/1` line 384):** `close_port/1` is called inside the
+  after_fun. `port_done/1` is called by `Stream.resource` after the stream is halted/
+  exhausted. In `CodingAgent.run/4`, the stream is drained by `Enum.reduce_while`; on a
+  `%Done{}` event, `Enum.reduce_while` returns `{:halt, ...}` and the final result is
+  assembled. At that point, `port_done/1` is called (cleanup). The drainer is now past
+  the `Enum.reduce_while` call. An `ArgumentError` in `port_done/1` will propagate in the
+  drainer process, but `CodingAgent.run/4` has already returned its value. The exception
+  crashes the drainer process — but the caller of `run/4` has already received `{:ok, ...}`
+  or `{:error, ...}`. Whether the crash is observed depends on whether the caller monitors
+  or links to the draining process. In the test at
+  `test/tau/coding_agents/claude_code_test.exs:185`, the drainer is the test process itself
+  (stream consumed directly), so a crash would be visible. In production use via
+  `CodingAgent.run/4`, the drainer is the calling process; the exception would crash it
+  *after* the return value is in the calling frame — effectively a delayed crash that may or
+  may not be caught.
+
+  However: the scenario that reaches this path with an `ArgumentError` is a double-close
+  event. The normal (non-double-close) path does not raise. The question is: can a
+  double-close reach `port_done/1`? This requires `close_port/1` to have been called
+  earlier (in the cancel branch) and then `port_done/1` to fire as `after_fun`. The cancel
+  branch returns `{:halt, events}`, which terminates the stream — triggering `port_done/1`.
+  So yes: cancel path calls `close_port/1`, then `Stream.resource` cleanup calls
+  `port_done/1`, which calls `close_port/1` again on an already-closed port →
+  `ArgumentError` in the after_fun.
+
+- **Outcome:** partially falsified — in the `after_fun` double-close path (cancel branch
+  followed by cleanup), `ArgumentError` fires in the after_fun, which is invoked after the
+  return value is already delivered to the caller. The error is not silently erased (it
+  crashes the draining process), but the claim that it is "visible rather than silently
+  erased" requires narrowing: the crash is observable but occurs after the call site returns,
+  making it a process crash rather than a propagated exception visible to the caller's
+  `with` / `case` chain.
+- **Action:** Narrow qualifier (above). No solution revision required — the improvement is
+  real and the failure mode is a process crash, not silent erasure. The narrowed qualifier is
+  recorded.
+
+---
+
+### Claim 5: No call-site changes are required
+
+- **Claim (C):** "No call-site changes required."
+- **Grounds (G):** Both call sites (`port_done/1` at
+  `lib/tau/coding_agents/claude_code.ex:384` and the cancel branch at line 272) discard the
+  return value of `close_port/1` and rely only on its `:ok` return for the live-port path.
+  The proposed change preserves `:ok` on the live-port path. No return type changes.
+- **Warrant (W):** A function refactor that preserves the public return contract and error
+  propagation surface requires no call-site changes. The only change to the error surface is
+  that `ArgumentError` now propagates instead of being caught; both call sites' existing
+  code discard the return and neither wraps the call in rescue, so neither needs updating to
+  accommodate propagation.
+- **Qualifier (Q):** Holds as long as no call site wraps `close_port/1` in a pattern match
+  or rescue. Both current call sites have been inspected and neither does.
+- **Rebuttal (R):** The migration sketch in solution.md correctly notes that existing tests
+  asserting `:ok` on a double-close path need updating. These are test changes, not
+  production call-site changes. If future tests are written against the old `:ok`-on-error
+  contract, they would need updating when the function is changed.
+- **Backing (B):** Direct inspection at `lib/tau/coding_agents/claude_code.ex:383–388`
+  (port_done body) and lines 270–278 (cancel branch). Neither site assigns or pattern-matches
+  the return of `close_port/1`. No rescue wraps either call. Confirmed by
+  `grep -n "close_port" lib/tau/coding_agents/claude_code.ex` (two call sites, both
+  discard return).
+
+#### Falsification attempt for claim 5
+
+- **Strategy:** Counter-example construction
+- **Attempt:** Try to construct a call site that would require a change: (a) a call site that
+  pattern-matches the return — none found. (b) a call site that rescues `close_port/1` and
+  would need to be updated — none found. (c) a call site that relies on `:ok` being returned
+  even on a dead-port — both call sites discard return; the only behavioral change is
+  `ArgumentError` propagation, which is additive, not a contract break for the `:ok` path.
+- **Outcome:** withstood — no call-site changes required in production code.
+- **Action:** None. (Test changes may be needed per the migration sketch.)
+
+---
+
+## Cross-claim consistency
+
+Claims 1–5 are mutually consistent. Claim 1 (no TOCTOU) and claim 2 (no catch) are
+complementary removals that together satisfy the acceptance criterion. Claim 3 (three-clause
+shape) is the implementation vehicle for claims 1 and 2. Claim 4 (error propagation) is
+the consequence of claim 2; the partial falsification narrows its scope but does not
+contradict any other claim. Claim 5 (no call-site changes) is consistent with all other
+claims: the three-clause interface is backward-compatible on the `:ok` return path.
+
+One tension: the partially-falsified qualifier on claim 4 acknowledges that the
+double-close path in the cancel → cleanup sequence produces a delayed process crash rather
+than an in-call-chain exception. This does not contradict claim 2 (the catch is deleted) or
+claim 5 (no call-site changes needed), but it weakens the "making the event visible" framing
+in claim 4. The resolution is the narrowed qualifier: visible as a process crash, not as a
+caller-observable exception, in the after_fun double-close scenario.
+
+---
+
+## Falsification summary
+
+| # | Claim (short) | Strategy | Outcome | Action |
+|---|---|---|---|---|
+| 1 | Port.info/1 pre-check deleted, TOCTOU eliminated | Edge-case enumeration | withstood | None |
+| 2 | catch _, _ -> :ok deleted, errors propagate | Dependency check | withstood | None |
+| 3 | Three-clause shape is exhaustive and type-safe | Type-level check | withstood | None |
+| 4 | ArgumentError propagates, event visible not erased | Integration check + edge-case enumeration | partially falsified — claim/4 | Narrow qualifier: after_fun double-close produces process crash, not in-chain exception |
+| 5 | No call-site changes required | Counter-example construction | withstood | None |
+
+---
+
+## Revision required
+
+No full revision required. Claim 4 is partially falsified; the qualifier is narrowed in
+place. The narrowed qualifier is consistent with the solution's own open question ("If the
+stream infrastructure silences it, the improvement is real but the observable signal is still
+muted"), confirming the author already identified this risk. The solution is still the correct
+and minimal fix; the partial falsification does not falsify the acceptance criterion
+(`close_port/1` does not use `try/catch` or `try/rescue`; unexpected errors propagate rather
+than being swallowed — both remain true).
+
+No `revision_triggered` entry set.
+
+---
+
+## Outstanding doubts
+
+- **Double-close in production is not exercised by any test.** Neither
+  `test/tau/coding_agents/claude_code_test.exs` nor the lifecycle property test covers a
+  cancel-then-cleanup double-close sequence. The migration sketch's instruction to find and
+  update existing tests that assert `:ok` on double-close may be vacuous (no such tests
+  exist), but the positive case (double-close raises `ArgumentError`) is also untested. This
+  is not a falsification of any claim but is a test coverage gap.
+- **`Stream.resource/3` after_fun exception semantics under halt vs. normal exhaustion.**
+  The validation's edge-case enumeration shows that the `after_fun` fires after the caller
+  receives its return value in the normal-exhaustion case. If the stream halts mid-stream
+  (e.g., `Enum.reduce_while` with `{:halt, ...}`), the after_fun fires before `Enum.reduce_while`
+  returns control to the caller. The falsification covered both, but the exact BEAM guarantee
+  for the ordering of `after_fun` invocation relative to `reduce_while` return under the halt
+  path is derived from Elixir source reading, not a cited test. A unit test covering this
+  sequence would close the doubt.

--- a/docs/problems-archive-v1-modules/tau-coding-agent/subproblems/router-outer-rescue/problem.md
+++ b/docs/problems-archive-v1-modules/tau-coding-agent/subproblems/router-outer-rescue/problem.md
@@ -1,0 +1,76 @@
+---
+template_version: 1
+template_name: problem
+node_kind: leaf
+depth: 1
+parent: ../../problem.md
+status: draft
+---
+
+# Problem: Router.call/2 outer rescue is asserted unreachable but has no structural proof
+
+## Statement
+
+`Tau.CodingAgent.TauContext.Router.call/2`
+(`lib/tau/coding_agent/tau_context/router.ex:56–89`) contains an outer `rescue`
+block that catches any exception from the Plug dispatch path and returns a
+JSON-RPC 500 response. The comment reads "Should be unreachable given the
+per-handler try/catches below", but the claim rests on a code comment rather
+than on structural proof — either a typespec, a property test, or a proof by
+exhaustion that every path through `handle_mcp/2` and `dispatch/2` is covered
+by their own error boundaries. The result is a rescue that is either genuinely
+redundant (hiding the need to verify the inner guards) or genuinely necessary
+(meaning the inner guards have gaps).
+
+## Context
+
+- `lib/tau/coding_agent/tau_context/router.ex:56–89` — the outer rescue in
+  `call/2`.
+- `lib/tau/coding_agent/tau_context/router.ex:218–226` — `dispatch/2` has its
+  own `rescue`/`catch` around `handle_method/4`.
+- `lib/tau/coding_agent/tau_context/router.ex:93–130` — `handle_mcp/2` uses
+  a `with` pipeline; its `else` branches handle all expected error shapes from
+  `authorize/2`, `read_request_body/1`, and `decode_json/1`.
+- If `handle_mcp/2` raised unexpectedly (e.g. from `load_state/1`), the outer
+  rescue would be the only guard. `load_state/1` itself is currently safe
+  (pattern-matched on `:persistent_term.get`), but this is not enforced.
+- D-035 ("The Plug itself never raises on bad input") names this router's
+  contract but does not specify whether the outer rescue is the mechanism or
+  just a backstop; the distinction matters for test coverage.
+
+## Complecting hypothesis
+
+The outer rescue in `Router.call/2` is complected with the per-handler error
+boundaries inside `handle_mcp/2` and `dispatch/2`: the outer rescue's
+correctness depends on the completeness of the inner guards, but neither is
+verified against the other. A future change to `handle_mcp/2` that introduces
+a new fallible path would silently rely on the outer rescue without the author
+knowing the inner guard is now incomplete.
+
+## Decomposition strategy
+
+(leaf — no further decomposition; proceed to proposals)
+
+## Acceptance criterion
+
+The relationship between the outer rescue in `Router.call/2` and the inner
+error boundaries in `handle_mcp/2` / `dispatch/2` is made explicit: either (a)
+the outer rescue is provably unreachable by exhaustion of all fallible call
+sites and is removed, or (b) the outer rescue is retained as an explicit
+backstop and its scope is constrained to the specific paths the inner guards do
+not cover, with a comment or test that names those paths.
+
+## Out of scope
+
+- The `expose_tau_context?/0` rescue in `dispatcher.ex` (sibling sub-problem
+  `settings-feature-flag-access`).
+- The rescue ladders in `tools.ex` (sibling sub-problem
+  `tool-impl-rescue-ladders`).
+- `close_port/1` in `claude_code.ex` (sibling sub-problem
+  `port-lifecycle-rescue`).
+- Changes to the MCP wire protocol or auth logic.
+- Performance or concurrency of the `:persistent_term` state reads.
+
+## Amendment log
+
+- (none yet)

--- a/docs/problems-archive-v1-modules/tau-coding-agent/subproblems/router-outer-rescue/proposals/proposal-1.md
+++ b/docs/problems-archive-v1-modules/tau-coding-agent/subproblems/router-outer-rescue/proposals/proposal-1.md
@@ -1,0 +1,129 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 1
+parent_problem: ../problem.md
+---
+
+# Proposal 1: Remove outer rescue by exhaustion proof via @spec + Dialyzer
+
+## Approach
+
+Annotate every private function reachable from `call/2` — `handle_mcp/2`,
+`load_state/1`, `authorize/2`, `read_request_body/2`, `decode_json/1`,
+`respond_rpc/3`, `dispatch/2`, `handle_method/4`, `handle_notification/3` —
+with `@spec` declarations that exclude raise (i.e. return only tagged tuples or
+plain values). Add a `dialyzer` mix alias that runs in CI. Once Dialyzer confirms
+no unguarded raise paths exit any of these functions, remove the outer `rescue`
+block in `call/2` entirely. Replace the deleted rescue with an explanatory
+`@doc false` section-header comment citing D-035 and naming the structural
+invariant: "no private callee raises; see typespecs."
+
+## Rationale
+
+The problem is that the outer rescue's correctness claim is asserted in a
+comment, not enforced structurally. `@spec` + Dialyzer converts the assertion
+into a machine-checked invariant: if a future change introduces a new raise path,
+Dialyzer fails CI rather than silently relying on the outer rescue. Removing
+the rescue after the proof eliminates the complection entirely — there is no
+outer guard that inner guards can silently depend on. The acceptance criterion's
+option (a) ("provably unreachable by exhaustion") is satisfied mechanically.
+
+## Sketch
+
+```elixir
+# lib/tau/coding_agent/tau_context/router.ex
+
+@spec call(Plug.Conn.t(), map()) :: Plug.Conn.t()   # no raise in return type
+@impl Plug
+def call(%Conn{} = conn, opts) do
+  case {conn.method, conn.path_info} do
+    {"GET", ["healthz"]} -> send_text(conn, 200, "ok")
+    {"POST", ["mcp"]}    -> handle_mcp(conn, opts)
+    {"GET", ["mcp"]}     -> send_json(conn, 405, ...)
+    _                    -> send_text(conn, 404, "not found")
+  end
+  # outer rescue REMOVED — invariant held by typespecs below;
+  # Dialyzer CI gate enforces no unguarded raise in callees (D-035).
+end
+
+@spec handle_mcp(Plug.Conn.t(), map()) :: Plug.Conn.t()
+defp handle_mcp(conn, opts) do ... end
+
+@spec load_state(map()) :: map()           # :persistent_term.get never raises
+defp load_state(opts) do ... end
+
+@spec authorize(Plug.Conn.t(), map()) :: :ok | {:error, :unauthorized}
+defp authorize(conn, state) do ... end
+
+@spec read_request_body(Plug.Conn.t(), binary()) ::
+  {:ok, binary(), Plug.Conn.t()} | {:error, atom() | {atom(), term()}}
+defp read_request_body(conn, acc \\ "") do ... end
+
+@spec decode_json(binary()) :: {:ok, map() | list()} | {:error, {:parse_error, binary()}}
+defp decode_json(body) do ... end
+
+@spec dispatch(map(), map()) :: map() | :no_response
+# dispatch/2's existing rescue/catch ARE retained — they are the
+# per-handler guard and remain correct.
+defp dispatch(...) do ... rescue ... catch ... end
+```
+
+`mix.exs` — add to `:dialyzer` plt_add_apps and enable `--warnings-as-errors`
+for the `Tau.CodingAgent.TauContext.Router` module in `.dialyzer_ignore.exs`
+(clearing any existing suppression on this module).
+
+CI: add `mix dialyzer` step to the `lint` job in `.github/workflows/ci.yml`.
+
+## Tradeoffs
+
+### Strengths
+
+- Satisfies acceptance criterion option (a) (provably unreachable) without any
+  behavioural change — zero regression risk.
+- The proof is machine-checked by Dialyzer on every future PR touching this
+  module; the comment-assertion problem cannot recur.
+- No new runtime code path; no change to dispatch logic.
+- `dispatch/2`'s rescue/catch is explicitly preserved and its purpose remains
+  unambiguous.
+
+### Weaknesses
+
+- Dialyzer's success typing is not a full proof of no-raise: it can miss raises
+  inside `:persistent_term.get/2` or Cowboy internals if those functions are
+  not in the PLT with accurate specs. The proof is only as strong as the PLT.
+- Adding `@spec` to all private helpers is mechanical but verbose — ~10
+  annotations spanning 30–40 lines.
+- Dialyzer PLT builds are slow (~2–4 min cold); CI wall time increases.
+- If `Jason.encode/1` raises on a pathological value (it shouldn't, but it's an
+  external dep), Dialyzer may not catch it.
+
+### Costs
+
+- ~10 `@spec` annotations added across the module.
+- CI job extended by Dialyzer PLT build time (~2 min warm, ~8 min cold).
+- `.dialyzer_ignore.exs` may need updating if existing suppression entries
+  reference this module.
+- No consumer API changes; no test rewrites.
+
+## Dependencies
+
+- Dialyzer must be runnable in CI (OTP 27.2 includes it; no new dep).
+- The existing PLT must be seeded with Jason, Plug, and Cowboy specs — standard
+  for an Elixir project.
+- No other subproblem solutions are prerequisites.
+
+## Confidence
+
+medium — the approach is correct in principle and widely used in Elixir/OTP
+projects. Confidence would rise to high after a Dialyzer dry-run confirms no
+false-positives in the current codebase (specifically, that `Conn.send_resp/3`
+and `Jason.encode/1` are already spec'd cleanly in their PLTs).
+
+## Prior art / references
+
+- Elixir core library: all public Plug callbacks are `@spec`-annotated and
+  Dialyzer-clean in Phoenix.
+- OTP design principles: typespec-as-contract is the idiomatic structural proof
+  in the BEAM ecosystem.
+- `mix dialyzer` (Dialyxir): standard Elixir project tooling.

--- a/docs/problems-archive-v1-modules/tau-coding-agent/subproblems/router-outer-rescue/proposals/proposal-2.md
+++ b/docs/problems-archive-v1-modules/tau-coding-agent/subproblems/router-outer-rescue/proposals/proposal-2.md
@@ -1,0 +1,169 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 2
+parent_problem: ../problem.md
+---
+
+# Proposal 2: Retain outer rescue as an explicit named backstop with a property test
+
+## Approach
+
+Keep the outer `rescue` in `call/2` but promote it from a silent fallback to
+an explicitly-scoped backstop. Rename it with a module-attribute constant
+`@outer_rescue_scope` listing the exact paths the inner guards do NOT cover
+today, and add a `ExUnit` property test (using `StreamData`) that injects
+synthetic crashes at each of those paths and asserts the outer rescue fires
+correctly. The comment is replaced by a structured annotation that names the
+one real gap: `load_state/1` calling `:persistent_term.get/2`, which today has
+no rescue of its own. Optionally, add a minimal guard inside `load_state/1`
+to narrow the outer rescue's scope further.
+
+## Rationale
+
+The problem is that the outer rescue's claim ("unreachable") is unverified
+and its scope is ambiguous. This proposal takes option (b) from the acceptance
+criterion — retain the backstop, but constrain its scope explicitly and test
+it. A property test that deliberately forces the rescue path proves the rescue
+is live and correctly scoped; a module-attribute annotation enumerates the
+paths it covers so a future author cannot add a new fallible path without
+seeing the annotation. The complection is reduced (inner vs outer scopes are
+now named and tested) without the risk of removing a guard that may be
+genuinely needed.
+
+## Sketch
+
+```elixir
+# lib/tau/coding_agent/tau_context/router.ex
+
+# Named scope: the outer rescue covers ONLY load_state/1's
+# :persistent_term.get call, which has no inner guard. All paths
+# through handle_mcp/2 after load_state/1 are covered by the
+# with-else pipeline; dispatch/2 has its own rescue/catch.
+# If load_state/1 is ever hardened (e.g. its own rescue), remove
+# this outer rescue.
+@outer_rescue_scope [:load_state]
+
+@impl Plug
+def call(%Conn{} = conn, opts) do
+  case {conn.method, conn.path_info} do
+    {"GET", ["healthz"]} -> send_text(conn, 200, "ok")
+    {"POST", ["mcp"]}    -> handle_mcp(conn, opts)
+    {"GET", ["mcp"]}     -> send_json(conn, 405, ...)
+    _                    -> send_text(conn, 404, "not found")
+  end
+rescue
+  # Backstop for @outer_rescue_scope paths only (see annotation above).
+  # dispatch/2 and handle_mcp/2's with-else cover all other paths.
+  e ->
+    send_json(conn, 500, %{
+      "jsonrpc" => @rpc_version,
+      "error" => %{"code" => -32_603,
+                   "message" => "router exception: " <> Exception.message(e)}
+    })
+end
+```
+
+```elixir
+# test/tau/coding_agent/tau_context/router_outer_rescue_test.exs
+
+defmodule Tau.CodingAgent.TauContext.RouterOuterRescueTest do
+  use ExUnit.Case, async: true
+  use Plug.Test
+
+  import Mox
+
+  # Verifies the outer rescue fires when load_state/1 raises, and that
+  # the response is a well-formed JSON-RPC 500 (D-035 contract).
+  test "outer rescue fires on load_state crash and returns JSON-RPC 500" do
+    opts = Router.init(%{state_ref: :__nonexistent_term__})
+    conn = conn(:post, "/mcp", ~s({"jsonrpc":"2.0","method":"ping","id":1}))
+           |> put_req_header("content-type", "application/json")
+
+    # Poison the persistent_term lookup so load_state/1 receives a key
+    # whose get/2 default is bypassed by injecting a process-level override
+    # via :persistent_term.put — then immediately delete it to force ArgumentError.
+    :persistent_term.put(:__nonexistent_term__, :poison)
+    :persistent_term.erase(:__nonexistent_term__)
+
+    # Force the raise by using a fake key that makes :persistent_term.get raise
+    # (ArgumentError on bad key type works for this test).
+    opts_bad = Router.init(%{state_ref: {:bad, :tuple, :key}})
+
+    # Use :meck or direct call; here we test via the Plug interface.
+    # The key point: response must be 500 with jsonrpc error body, not a crash.
+    conn = Router.call(conn, opts_bad)
+    assert conn.status == 500
+    {:ok, body} = Jason.decode(conn.resp_body)
+    assert body["jsonrpc"] == "2.0"
+    assert body["error"]["code"] == -32_603
+  end
+
+  # Property: for any malformed opts map, call/2 never raises.
+  property "call/2 never raises regardless of opts shape" do
+    check all opts <- StreamData.map_of(StreamData.atom(:alphanumeric),
+                                        StreamData.term()) do
+      conn = conn(:post, "/mcp", "")
+      result = try do
+        Router.call(conn, opts)
+        :ok
+      rescue
+        _ -> :raised
+      end
+      assert result == :ok
+    end
+  end
+end
+```
+
+## Tradeoffs
+
+### Strengths
+
+- Satisfies acceptance criterion option (b): the outer rescue is retained and
+  its scope is named and tested.
+- No risk of silently exposing a crash path: the guard remains active.
+- The `@outer_rescue_scope` annotation is visible to `grep` and code review,
+  making future scope expansion detectable.
+- The property test exercises the full `call/2` Plug interface, not a hand-
+  built struct; it satisfies the user-facing path requirement.
+
+### Weaknesses
+
+- Does not remove the complection — inner and outer guards still coexist; the
+  naming improvement reduces ambiguity but does not eliminate the dual-guard
+  structure.
+- The property test relies on being able to force a raise through `load_state/1`
+  in a test environment; `:persistent_term` semantics make injection slightly
+  awkward (see sketch above — the exact mechanism may need refinement).
+- A future author could add a new fallible path and forget to update
+  `@outer_rescue_scope`; the annotation is advisory, not enforced.
+- The test exercises the rescue path but does not prove the inner guards are
+  exhaustive — it only verifies the outer rescue works when reached.
+
+### Costs
+
+- 1 new test file (~50 lines).
+- Minor comment/annotation rewrite in `router.ex` (~10 lines changed).
+- No API changes; no consumer disruption.
+- CI: test suite gains one property test (fast, <1 s).
+
+## Dependencies
+
+- `StreamData` is already a dev dependency in this project (used elsewhere for
+  property tests).
+- No other subproblem solutions are prerequisites.
+
+## Confidence
+
+medium — the approach is straightforward. Confidence would rise to high after
+confirming the exact mechanism for forcing `load_state/1` to raise in a test
+context (`:persistent_term` edge cases need a prototype run).
+
+## Prior art / references
+
+- Plug documentation: the Plug behaviour contract does not prevent outer rescue;
+  `Plug.ErrorHandler` uses a similar documented-backstop pattern.
+- OTP design principles: explicit scope annotation on catch-all handlers is
+  standard in gen_server `handle_call` overflow clauses.
+- `StreamData` property testing: existing usage in `test/tau/` (multiple files).

--- a/docs/problems-archive-v1-modules/tau-coding-agent/subproblems/router-outer-rescue/proposals/proposal-3.md
+++ b/docs/problems-archive-v1-modules/tau-coding-agent/subproblems/router-outer-rescue/proposals/proposal-3.md
@@ -1,0 +1,169 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 3
+parent_problem: ../problem.md
+---
+
+# Proposal 3: Push error boundary into load_state/1, then remove outer rescue
+
+## Approach
+
+Move the error boundary down to the only private callee not already protected:
+`load_state/1`. Wrap its `:persistent_term.get/2` call in a `rescue` that
+returns the same safe default map `%{token: nil, session_id: nil, cwd: nil,
+max_depth: 2}` and emits a `Logger.error/1` entry (not a silent swallow).
+Once `load_state/1` is self-guarding, every path through `call/2` is covered
+by its own local boundary: `handle_mcp/2`'s `with`-else, `dispatch/2`'s
+`rescue`/`catch`, and the new `load_state/1` guard. The outer `rescue` in
+`call/2` is then structurally provably redundant and can be deleted. Add a
+unit test for `load_state/1` covering the `:persistent_term` failure path.
+
+## Rationale
+
+The acceptance criterion can be reached by either removing or constraining the
+outer rescue. This proposal takes the structural route: instead of proving the
+outer rescue is unreachable from the top down, it makes it unreachable from the
+bottom up by filling the one gap the inner guards have (`load_state/1`). The
+result is that each private function owns its own failure mode, which is the
+OTP non-negotiable pattern: pure functions handle their own errors; the outer
+rescue becomes dead code and is deleted. The complection between outer and inner
+guards is dissolved because there is no outer guard remaining.
+
+## Sketch
+
+```elixir
+# lib/tau/coding_agent/tau_context/router.ex
+
+# Before — load_state/1 is unguarded:
+defp load_state(opts) do
+  case opts[:state_ref] do
+    nil -> %{token: nil, session_id: nil, cwd: nil, max_depth: 2}
+    key -> :persistent_term.get(key, %{token: nil, session_id: nil,
+                                        cwd: nil, max_depth: 2})
+  end
+end
+
+# After — load_state/1 owns its own error boundary:
+@safe_default %{token: nil, session_id: nil, cwd: nil, max_depth: 2}
+
+defp load_state(opts) do
+  case opts[:state_ref] do
+    nil -> @safe_default
+    key ->
+      :persistent_term.get(key, @safe_default)
+  end
+rescue
+  e ->
+    # :persistent_term.get/2 can raise ArgumentError if the key type is
+    # invalid (not a term — this is an internal misuse, not user input).
+    # Log and return safe default so the request still produces a valid
+    # JSON-RPC 401 (token: nil → unauthorized) rather than crashing the
+    # listener.
+    Logger.error("[Router] load_state/1 raised: #{Exception.message(e)}",
+                 crash_reason: {e, __STACKTRACE__})
+    @safe_default
+end
+
+# call/2 outer rescue REMOVED — load_state/1 is now self-guarding;
+# handle_mcp/2's with-else covers parse/auth/body errors;
+# dispatch/2's rescue/catch covers handler exceptions.
+@impl Plug
+def call(%Conn{} = conn, opts) do
+  case {conn.method, conn.path_info} do
+    {"GET", ["healthz"]} -> send_text(conn, 200, "ok")
+    {"POST", ["mcp"]}    -> handle_mcp(conn, opts)
+    {"GET", ["mcp"]}     -> send_json(conn, 405, ...)
+    _                    -> send_text(conn, 404, "not found")
+  end
+end
+```
+
+```elixir
+# test/tau/coding_agent/tau_context/router_load_state_test.exs
+
+defmodule Tau.CodingAgent.TauContext.RouterLoadStateTest do
+  use ExUnit.Case, async: true
+  use Plug.Test
+
+  # Verify that a bad state_ref key causes load_state to return safe
+  # default (leading to 401), not a 500 or crash.
+  test "bad state_ref key yields 401 not 500" do
+    # Use an atom key that has never been put into persistent_term;
+    # :persistent_term.get/2 with default returns default safely,
+    # so we simulate the raise path with a deliberate bad-type key.
+    opts = Router.init(%{state_ref: make_ref()})  # valid key type, no entry
+    conn =
+      conn(:post, "/mcp", ~s({"jsonrpc":"2.0","method":"ping","id":1}))
+      |> put_req_header("content-type", "application/json")
+      |> put_req_header("authorization", "Bearer wrong-token")
+
+    conn = Router.call(conn, opts)
+    # No state → token: nil → unauthorized → 401, not 500
+    assert conn.status == 401
+    {:ok, body} = Jason.decode(conn.resp_body)
+    assert body["error"]["code"] == -32_001
+  end
+end
+```
+
+## Tradeoffs
+
+### Strengths
+
+- Follows the OTP non-negotiable: each function handles its own errors; no
+  outer catch-all needed.
+- The outer rescue is removed (option a of acceptance criterion) but the reason
+  it can be removed is structural — each callee is self-guarding — not just
+  asserted.
+- `load_state/1`'s new guard is scoped precisely to the `:persistent_term`
+  call; it does not swallow arbitrary exceptions.
+- The `Logger.error/1` call makes the failure observable (telemetry could be
+  added; out of scope here).
+- Simpler than Proposal 1: no Dialyzer PLT dependency, no CI plumbing change.
+
+### Weaknesses
+
+- The `load_state/1` rescue introduces a new silent-ish fallback: a bad
+  `state_ref` yields a safe-default state, which causes a 401. This is
+  arguably better than a 500, but the root cause (misconfigured `state_ref`)
+  is only visible in logs, not in the HTTP response.
+- `:persistent_term.get/2` with a default does NOT raise for missing keys
+  (it returns the default). The rescue in `load_state/1` only fires for
+  invalid key types (e.g. a non-term). This is a narrow guard; if the concern
+  is future `load_state/1` changes adding new fallible logic, the rescue is
+  forward-looking rather than currently necessary.
+- Removing the outer rescue while relying on per-function guards means any
+  future addition of a new top-level branch in `call/2` (e.g. a new route)
+  that forgets its own guard will have no backstop.
+
+### Costs
+
+- ~15 lines changed in `router.ex` (add module attr, rewrite `load_state/1`,
+  remove outer rescue block, update comment header).
+- 1 small test file (~25 lines).
+- No API or supervisor changes.
+- No CI plumbing changes.
+
+## Dependencies
+
+- `Logger` is already in scope (no new deps).
+- No other subproblem solutions are prerequisites.
+
+## Confidence
+
+high — the `:persistent_term.get/2` behavior is well-documented; the
+structural invariant after the change is clear and simple to verify.
+Confidence is based on direct code reading plus Erlang/OTP persistent_term
+documentation.
+
+## Prior art / references
+
+- OTP non-negotiables (`.claude/rules/otp-non-negotiables.md`) rule 7: "Let
+  it crash; supervise; restart. MUST NOT `try/rescue` across process
+  boundaries." — `load_state/1` running in the request process is intra-
+  process; the rescue is appropriate.
+- Plug documentation: Plug callbacks should not raise; self-guarding callees
+  is the idiomatic way to satisfy this without a catch-all.
+- `:persistent_term` OTP docs: `get/2` raises `ArgumentError` only on non-term
+  key types; the default-valued variant never raises for missing keys.

--- a/docs/problems-archive-v1-modules/tau-coding-agent/subproblems/router-outer-rescue/proposals/proposal-4.md
+++ b/docs/problems-archive-v1-modules/tau-coding-agent/subproblems/router-outer-rescue/proposals/proposal-4.md
@@ -1,0 +1,189 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 4
+parent_problem: ../problem.md
+---
+
+# Proposal 4: Extract a SafePlug wrapper behaviour that encodes the no-raise invariant at the call site
+
+## Approach
+
+Introduce a `Tau.CodingAgent.TauContext.SafePlug` behaviour module with a
+`safe_call/2` callback. `Router` implements this behaviour; `SafePlug.wrap/3`
+is the single outer guard: it delegates to the implementation's `safe_call/2`
+and its own `rescue` is the only location where the no-raise invariant is
+enforced. `Router.call/2` is renamed to `Router.safe_call/2`; the outer
+`rescue` migrates from `call/2` into `SafePlug.wrap/3`; and `Router.call/2`
+becomes a one-liner delegation `SafePlug.wrap(__MODULE__, conn, opts)`.
+The inner `dispatch/2` rescue/catch are retained unchanged. The result is a
+single, named, tested boundary rather than an anonymous outer rescue that
+accidentally covers an unspecified set of paths.
+
+## Rationale
+
+The complection is: the outer rescue's scope is ambiguous because it lives
+inside `call/2` alongside route dispatch logic. This proposal separates the
+concerns by extracting the "ensure Plug never raises" invariant into a named
+module (`SafePlug`) that exists solely to enforce D-035 at the Plug boundary.
+`Router` no longer mixes routing and crash containment; the crash containment
+lives in `SafePlug.wrap/3`. Any future Plug that needs D-035 compliance can
+use the same wrapper, making the invariant reusable and independently testable.
+This is a behaviour-preserving refactor on the public API (`call/2` still works)
+but the internal structure is decomplected.
+
+## Sketch
+
+```elixir
+# lib/tau/coding_agent/tau_context/safe_plug.ex  (new file)
+
+defmodule Tau.CodingAgent.TauContext.SafePlug do
+  @moduledoc """
+  Wrapper that enforces D-035: a Plug's `call/2` must never raise.
+
+  Any Plug that must honour D-035 implements `safe_call/2` and delegates
+  its `call/2` to `SafePlug.wrap/3`. The rescue lives here, not in the
+  implementing Plug.
+  """
+
+  @rpc_version "2.0"
+
+  @callback safe_call(Plug.Conn.t(), any()) :: Plug.Conn.t()
+
+  @spec wrap(module(), Plug.Conn.t(), any()) :: Plug.Conn.t()
+  def wrap(mod, conn, opts) do
+    mod.safe_call(conn, opts)
+  rescue
+    # D-035 hard guard. Named and isolated here so Router.safe_call/2
+    # contains routing logic only. safe_call/2 implementations MUST NOT
+    # have their own outer rescue; each inner guard handles its own scope.
+    e ->
+      alias Plug.Conn
+      body =
+        case Jason.encode(%{
+               "jsonrpc" => @rpc_version,
+               "error" => %{"code" => -32_603,
+                            "message" => "router exception: " <> Exception.message(e)}
+             }) do
+          {:ok, b} -> b
+          _ -> ~s({"error":"json encode failed"})
+        end
+
+      conn
+      |> Conn.put_resp_content_type("application/json")
+      |> Conn.send_resp(500, body)
+  end
+end
+```
+
+```elixir
+# lib/tau/coding_agent/tau_context/router.ex (changes only)
+
+@behaviour Plug
+@behaviour Tau.CodingAgent.TauContext.SafePlug
+
+# call/2: one-liner; routing logic now in safe_call/2 below.
+@impl Plug
+def call(%Conn{} = conn, opts), do: SafePlug.wrap(__MODULE__, conn, opts)
+
+# safe_call/2: pure routing, no outer rescue.
+@impl SafePlug
+def safe_call(%Conn{} = conn, opts) do
+  case {conn.method, conn.path_info} do
+    {"GET", ["healthz"]} -> send_text(conn, 200, "ok")
+    {"POST", ["mcp"]}    -> handle_mcp(conn, opts)
+    {"GET", ["mcp"]}     -> send_json(conn, 405, ...)
+    _                    -> send_text(conn, 404, "not found")
+  end
+end
+# dispatch/2's rescue/catch retained unchanged.
+```
+
+```elixir
+# test/tau/coding_agent/tau_context/safe_plug_test.exs (new file)
+
+defmodule Tau.CodingAgent.TauContext.SafePlugTest do
+  use ExUnit.Case, async: true
+  use Plug.Test
+
+  defmodule AlwaysRaisePlug do
+    @behaviour Plug
+    @behaviour Tau.CodingAgent.TauContext.SafePlug
+
+    def init(opts), do: opts
+    def call(conn, opts), do: SafePlug.wrap(__MODULE__, conn, opts)
+    def safe_call(_conn, _opts), do: raise("boom")
+  end
+
+  test "SafePlug.wrap catches raise and returns JSON-RPC 500" do
+    conn = conn(:post, "/mcp", "")
+    result = SafePlug.wrap(AlwaysRaisePlug, conn, %{})
+    assert result.status == 500
+    {:ok, body} = Jason.decode(result.resp_body)
+    assert body["jsonrpc"] == "2.0"
+    assert body["error"]["code"] == -32_603
+    assert body["error"]["message"] =~ "boom"
+  end
+end
+```
+
+## Tradeoffs
+
+### Strengths
+
+- D-035 is now a named, tested module (`SafePlug`), not an anonymous rescue
+  inside a routing function. The invariant is discoverable and reusable.
+- `Router.safe_call/2` contains routing logic only; `SafePlug.wrap/3` contains
+  crash containment only — the complection is structurally eliminated.
+- The property test on `SafePlug` is simple and deterministic (use an
+  `AlwaysRaisePlug`); no awkward `:persistent_term` injection needed.
+- Future Plugs in the subsystem can adopt the same wrapper; the pattern
+  propagates the D-035 invariant at zero marginal cost.
+- Satisfies option (b) of the acceptance criterion: the outer rescue is
+  retained but explicitly scoped and tested.
+
+### Weaknesses
+
+- Introduces a new file (`safe_plug.ex`) and a new behaviour for what is
+  currently a single call site — possibly over-engineering for a single Plug.
+- The `SafePlug` behaviour adds an indirection layer; the routing path in tests
+  now goes `call → wrap → safe_call`, which can confuse stack traces.
+- The callback `safe_call/2` is a public function (required by behaviour
+  dispatch) but it is semantically internal — callers can invoke it directly
+  bypassing the rescue, which is undesirable. This is a Plug/behaviour
+  limitation with no clean fix short of a macro.
+- `Router.call/2` being a delegation wrapper means Plug.Test's `conn/3`-based
+  tests work, but any test that directly calls `Router.safe_call/2` bypasses
+  D-035 enforcement.
+
+### Costs
+
+- 1 new file (`safe_plug.ex`, ~45 lines).
+- 1 new test file (`safe_plug_test.exs`, ~25 lines).
+- `router.ex` diff: ~15 lines changed (rename `call/2` body to `safe_call/2`,
+  add delegation, add `@behaviour SafePlug`).
+- No API or supervisor changes.
+- No CI plumbing changes.
+
+## Dependencies
+
+- No new library dependencies.
+- No other subproblem solutions are prerequisites.
+- If other Plugs in the subsystem are to be migrated to `SafePlug`, they
+  become optional follow-on work (out of scope here).
+
+## Confidence
+
+medium — the behaviour extraction is mechanically straightforward. Confidence
+would rise to high after verifying that Plug.Test dispatches correctly through
+the `call → wrap → safe_call` chain (one prototype test run needed).
+
+## Prior art / references
+
+- Plug.ErrorHandler (in the Plug library): the canonical "wrap a Plug call in
+  a rescue and convert exceptions to responses" pattern; `SafePlug` is a
+  smaller, project-local version.
+- Phoenix.Router uses a similar outer-guard pattern via `Plug.Builder.compile/3`
+  wrapping the pipeline in a rescue before delegating to the generated `call/2`.
+- Elixir behaviour docs: `@callback` for enforcing a contract on implementing
+  modules.

--- a/docs/problems-archive-v1-modules/tau-coding-agent/subproblems/router-outer-rescue/solution.md
+++ b/docs/problems-archive-v1-modules/tau-coding-agent/subproblems/router-outer-rescue/solution.md
@@ -1,0 +1,134 @@
+---
+template_version: 1
+template_name: solution
+parent_problem: problem.md
+node_kind: leaf
+synthesised_from: [proposals/proposal-2.md, proposals/proposal-3.md]
+selection_method: hybrid
+revision: 0
+---
+
+# Solution: Harden load_state/1 + retain a named, tested backstop
+
+## Recommendation
+
+Harden `load_state/1` with its own intra-function `rescue` (logging and
+returning a safe default), then retain the outer rescue in `call/2` but
+rewrite it as an explicitly scoped, annotated, and property-tested backstop
+that names the paths the inner guards cover and acknowledges it fires only
+when an inner guard is missing or future code introduces a new fallible path.
+The result satisfies acceptance-criterion option (b): the outer rescue is not
+removed, but its scope is constrained and named, and both the `load_state/1`
+guard and the outer backstop are exercised by tests.
+
+## Selected from
+
+- **Chosen:** hybrid of `proposals/proposal-2.md` (named backstop + property
+  test) and `proposals/proposal-3.md` (harden `load_state/1` from the
+  inside).
+- **Why chosen:** Proposal 3 correctly identifies `load_state/1` as the one
+  unguarded callee and fills that gap structurally — each function owns its
+  own failure mode. However, proposal 3's conclusion (remove the outer rescue
+  entirely) creates a forward-looking risk: any future top-level branch added
+  to `call/2` that forgets its own guard will have no backstop. Proposal 2
+  addresses this by retaining the outer rescue as an explicitly scoped,
+  annotated backstop and adding tests that verify it fires correctly. The
+  hybrid combines proposal 3's structural bottom-up hardening with proposal
+  2's named-and-tested retention: `load_state/1` is self-guarding (narrowing
+  the outer rescue's practical scope to near-zero), and the outer rescue is
+  kept as a documented, tested safety net against future gaps rather than
+  silently removed. This is more reversible than proposal 1's Dialyzer-CI
+  plumbing and more conservative than proposal 3's full removal.
+
+  Proposals 1 and 4 were rejected:
+  - Proposal 1 (Dialyzer): Dialyzer's success typing is not a full no-raise
+    proof — external deps and PLT gaps leave holes. The CI plumbing cost
+    (PLT build time) is real and the confidence rating is only "medium."
+  - Proposal 4 (SafePlug behaviour): adds a new module, a new behaviour, and
+    an indirection layer for a single call site. The `safe_call/2` callback
+    must be public (behaviour dispatch), which exposes a bypass path. Over-
+    engineering for a single Plug.
+
+## What changes
+
+- `lib/tau/coding_agent/tau_context/router.ex`:
+  - Extract `@safe_default` module attribute for the default state map.
+  - Rewrite `load_state/1`: add an intra-function `rescue` that catches any
+    exception from `:persistent_term.get/2`, logs via `Logger.error/1` with
+    the exception message and stacktrace, and returns `@safe_default`.
+  - Rewrite the outer `rescue` block in `call/2`: replace the existing
+    comment ("Should be unreachable…") with a structured annotation listing
+    `@outer_rescue_scope` as the set of paths not covered by inner guards.
+    The annotation states: `load_state/1` is now self-guarding (so the outer
+    rescue's practical scope is near-zero today); the backstop is retained
+    explicitly for future routes or future `load_state/1` changes that might
+    introduce a new fallible path without their own guard.
+
+- `test/tau/coding_agent/tau_context/router_outer_rescue_test.exs` (new):
+  - Unit test: `load_state/1` rescue path — force a bad key type (e.g.
+    a function reference or a non-term) to trigger `ArgumentError` from
+    `:persistent_term.get/2`; assert the function returns `@safe_default`
+    and that a `Logger.error` entry is emitted.
+  - Integration test: end-to-end `Router.call/2` with a poisoned `state_ref`
+    yields 401 (token: nil → unauthorized) rather than 500 or a crash.
+  - Property test (StreamData): for any arbitrary `opts` map passed to
+    `Router.call/2`, `call/2` never raises — verifies the outer rescue fires
+    when needed and the response is always a valid `Plug.Conn`.
+
+## What does not change
+
+- `dispatch/2`'s existing `rescue`/`catch` — retained as-is; its scope and
+  purpose are already clear.
+- `handle_mcp/2`'s `with`-else pipeline — no changes; it correctly handles
+  all expected error shapes from `authorize/2`, `read_request_body/1`, and
+  `decode_json/1`.
+- The MCP wire protocol, auth logic, and HTTP routing table.
+- All public API surface (`call/2` signature, Plug behaviour contract).
+- `:persistent_term` read semantics and performance.
+- No supervisor or application changes.
+
+## Migration sketch
+
+1. Add `@safe_default` module attribute; rewrite `load_state/1` with its own
+   `rescue` (Logger + safe default return). Run existing tests — all should
+   pass; behaviour is unchanged for the non-raise path.
+2. Rewrite the outer `rescue` block in `call/2`: replace the misleading
+   comment with the `@outer_rescue_scope` annotation naming what the guard
+   covers and why it is retained. The rescue body is unchanged functionally.
+3. Add `router_outer_rescue_test.exs` with the three tests above.
+4. Run `mix test` — all tests green. Run `mix compile --warnings-as-errors`
+   — no new warnings.
+5. No CI plumbing changes required.
+
+## Open questions
+
+- The exact mechanism for forcing `load_state/1`'s `:persistent_term.get/2`
+  to raise in a test context needs a prototype run — proposal 2 noted this
+  same concern. If `:persistent_term.get/2` with a default never raises for
+  normal-type keys (it returns the default for missing keys; only invalid key
+  types raise `ArgumentError`), the unit test must use a deliberately
+  invalid key type (e.g. a function reference). This is implementable but
+  must be confirmed against OTP 27.2 `persistent_term` behaviour.
+- If a future caller of `load_state/1` depends on specific error semantics
+  (rather than safe-default fallback), the Logger-and-default behaviour of
+  the new guard may be surprising. The open question is whether any future
+  change to `load_state/1` should raise (letting the outer rescue handle it)
+  or return a tagged error tuple. This solution assumes safe-default-fallback
+  is correct for the current use case; revisit if `load_state/1` grows new
+  callers.
+
+## Linked sub-problems / proposals
+
+- `proposals/proposal-1.md` — Dialyzer + @spec exhaustion proof: rejected
+  (PLT coverage gaps; CI cost; medium confidence).
+- `proposals/proposal-2.md` — Retain outer rescue as a named, tested
+  backstop: partially adopted (annotation + property test).
+- `proposals/proposal-3.md` — Harden load_state/1, then remove outer rescue:
+  partially adopted (load_state/1 hardening); outer rescue retained rather
+  than removed.
+- `proposals/proposal-4.md` — SafePlug wrapper behaviour: rejected
+  (over-engineering for a single Plug; safe_call/2 bypass risk).
+
+## Revision history
+
+- (revision 0 — initial)

--- a/docs/problems-archive-v1-modules/tau-coding-agent/subproblems/router-outer-rescue/validation.md
+++ b/docs/problems-archive-v1-modules/tau-coding-agent/subproblems/router-outer-rescue/validation.md
@@ -1,0 +1,464 @@
+---
+template_version: 1
+template_name: validation
+parent_solution: solution.md
+parent_problem: problem.md
+toulmin_complete: true
+falsification_attempted: true
+falsification_outcome: partially_falsified — claim/3
+revision_triggered: none
+---
+
+# Validation: Harden load_state/1 + retain a named, tested backstop
+
+## Overview
+
+The solution makes five distinct propositions: (1) `load_state/1` is
+the one unguarded callee in `call/2`; (2) adding an intra-function
+`rescue` to `load_state/1` plus a `@safe_default` attribute closes
+that gap structurally; (3) the property test — "for any arbitrary
+`opts` map, `call/2` never raises" — verifies the outer rescue fires
+when needed; (4) a unit test can force `ArgumentError` from
+`:persistent_term.get/2` by passing an invalid key type; (5) the
+outer rescue is legitimately retainable as an explicit, tested
+backstop rather than being removed. Six claims are evaluated below
+using counter-example construction, dependency checks, edge-case
+enumeration, and integration checks. Claim 3 is partially falsified:
+the StreamData property test as described does not exercise the outer
+rescue because the proposed `load_state/1` guard will absorb all
+`opts`-derived raises before they propagate. All other claims
+withstand. No revision is triggered; the partially-falsified qualifier
+is narrowed in place.
+
+## Toulmin per claim
+
+### Claim 1: `load_state/1` is currently the one unguarded callee in `call/2`
+
+- **Claim (C):** "If `handle_mcp/2` raised unexpectedly (e.g. from
+  `load_state/1`), the outer rescue would be the only guard.
+  `load_state/1` itself is currently safe (pattern-matched on
+  `:persistent_term.get`), but this is not enforced."
+- **Grounds (G):** `router.ex:56–89` — outer `rescue` in `call/2` with
+  comment "Should be unreachable given the per-handler try/catches
+  below." `router.ex:218–226` — `dispatch/2` has its own
+  `rescue`/`catch`. `router.ex:93–130` — `handle_mcp/2` uses a
+  `with`-pipeline with an `else` covering all expected error shapes.
+  `router.ex:328–338` — `load_state/1` calls
+  `:persistent_term.get(key, default)` with no surrounding `rescue`.
+  No other callee in `call/2`'s dispatch path lacks its own guard.
+- **Warrant (W):** A function that calls a BIF (`:persistent_term.get`)
+  with an unconstrained user-supplied key (`opts[:state_ref]`) is
+  structurally unguarded when no `rescue` wraps that call: OTP 27.2
+  `persistent_term` raises `ArgumentError` on a key whose type is not a
+  valid persistent-term key (e.g. a function reference). Pattern-matching
+  on the `case opts[:state_ref]` dispatch — `nil` vs `key` — does not
+  prevent `ArgumentError` on the BIF call with a bad-type `key`.
+- **Qualifier (Q):** Holds for the current codebase at the commit under
+  review. Assumes no other callee in the `call/2` dispatch path (i.e.
+  `send_text/3`, `handle_mcp/2` → `authorize/2`, `read_request_body/1`,
+  `decode_json/1`) raises outside its own error boundary — this is
+  confirmed by inspection.
+- **Rebuttal (R):** `Jason.encode/1` in `send_json/4` could in principle
+  raise on a non-encodable value. However, `send_json/4` already handles
+  the `:error` tuple from `Jason.encode` (`router.ex:316–325`) and the
+  only values passed to it are maps with string keys and primitive
+  values, making an encode failure practically unreachable. This does not
+  falsify the claim that `load_state/1` is the primary unguarded callee.
+- **Backing (B):** `problem.md` §Context, citing `router.ex:56–89` and
+  `router.ex:93–130`. OTP non-negotiables rule 7 ("Let it crash;
+  supervise; restart. MUST NOT `try/rescue` across process boundaries"):
+  not violated here since `call/2` is itself a process boundary (Cowboy
+  request handler), making an intra-function rescue appropriate; confirms
+  the analysis frame.
+
+#### Falsification attempt for claim 1
+
+- **Strategy:** Counter-example construction — try to find a second
+  unguarded callee.
+- **Attempt:** Read all callees invoked from `call/2` and `handle_mcp/2`:
+  `send_text/3` (`router.ex:310–314`), `handle_mcp/2`
+  (`router.ex:93–130`), `authorize/2` (`router.ex:132–146`),
+  `read_request_body/1` (`router.ex:148–170`), `decode_json/1`
+  (`router.ex:173–179`), `respond_rpc/3` (`router.ex:185–216`),
+  `dispatch/2` (`router.ex:218–238` — has its own `rescue`/`catch`).
+  `Auth.verify/2` and `Auth.extract_token/1` are third-party-module
+  calls inside `authorize/2` but `authorize/2` itself uses `cond` and
+  returns tagged tuples — any raise there propagates to `handle_mcp/2`'s
+  `with` pipeline's `else` only if it matches an expected shape;
+  otherwise it would propagate up. However `Auth.verify` and
+  `Auth.extract_token` are thin wrappers over HMAC comparison and header
+  extraction — neither should raise on input. `Jason.decode/1` in
+  `decode_json/1` is wrapped by a `case` returning tagged tuples.
+  `load_state/1` is the only callee that invokes a BIF with an
+  unconstrained key type and no `rescue`.
+- **Outcome:** Withstood — no second unguarded callee found.
+- **Action:** None.
+
+---
+
+### Claim 2: Adding `@safe_default` + an intra-function `rescue` to `load_state/1` closes the structural gap
+
+- **Claim (C):** "Rewrite `load_state/1`: add an intra-function `rescue`
+  that catches any exception from `:persistent_term.get/2`, logs via
+  `Logger.error/1` with the exception message and stacktrace, and returns
+  `@safe_default`."
+- **Grounds (G):** `router.ex:328–338` shows `load_state/1`'s current
+  shape; the proposed change wraps the `:persistent_term.get(key, ...)`
+  call in a `rescue` block. The `@safe_default` attribute would be
+  `%{token: nil, session_id: nil, cwd: nil, max_depth: 2}` — identical
+  to the existing inline fallback at `router.ex:333` and `router.ex:336`.
+  Elixir `rescue` in a private function is syntactically valid and
+  well-supported by the compiler.
+- **Warrant (W):** OTP non-negotiable #8 ("Pure functions are the
+  default; processes are the exception") and #7 ("Let it crash") apply
+  at process-boundary granularity; a Cowboy request handler is a process
+  boundary, so guarding the BIF call inside the function is the right
+  scope — narrower than the outer `rescue`, wider than nothing. A safe
+  default is the correct fallback because the downstream `authorize/2`
+  call will reject a `nil` token anyway, converting a potential crash
+  into a clean 401.
+- **Qualifier (Q):** Holds provided `@safe_default` is consistent with
+  the existing inline defaults in `load_state/1` (it is, by inspection).
+  Assumes `Logger.error/1` is available (it is — `Logger` is a standard
+  OTP application always started before a Cowboy listener).
+- **Rebuttal (R):** If `Logger.error/1` itself raised (e.g. due to a
+  misconfigured logger backend), the rescue body would itself fail.
+  This is pathological and not guarded, but is covered by the outer
+  rescue in `call/2`, so it does not create an unguarded path.
+- **Backing (B):** OTP non-negotiables `otp-non-negotiables.md` rules 7,
+  8. `problem.md` §Acceptance criterion option (b): "the outer rescue is
+  retained as an explicit backstop and its scope is constrained to the
+  specific paths the inner guards do not cover."
+
+#### Falsification attempt for claim 2
+
+- **Strategy:** Dependency check — verify that the BIF call's failure
+  mode is exactly `ArgumentError` on invalid key types (not any other
+  exception), and that the proposed `rescue` catches it.
+- **Attempt:** `:persistent_term.get/2` raises `ArgumentError` when the
+  key is not a valid Erlang term usable as a persistent_term key (in
+  practice: when the key is a function reference, a port, or a PID on
+  certain OTP builds). The `rescue e ->` clause in Elixir catches all
+  Elixir exceptions (which includes `ArgumentError` re-raised from
+  Erlang). The `key` value in the `key ->` branch of `load_state/1`'s
+  `case` is whatever `opts[:state_ref]` is — it is not type-constrained
+  by `init/1` because `init/1` only converts list opts to a map and
+  returns them verbatim (`router.ex:52–53`). So the scenario is real.
+  The proposed `rescue` block covers the BIF call and returns
+  `@safe_default`, which is structurally the same as the existing inline
+  default.
+- **Outcome:** Withstood — the structural gap is real and the proposed
+  change correctly closes it.
+- **Action:** None.
+
+---
+
+### Claim 3: The StreamData property test ("for any arbitrary `opts`, `call/2` never raises") verifies the outer rescue fires when needed
+
+- **Claim (C):** "Property test (StreamData): for any arbitrary `opts`
+  map passed to `Router.call/2`, `call/2` never raises — verifies the
+  outer rescue fires when needed and the response is always a valid
+  `Plug.Conn`."
+- **Grounds (G):** The solution proposes `router_outer_rescue_test.exs`
+  with this property test. No such test file exists today
+  (`lib/tau/coding_agent/tau_context/router.ex` inspection; no existing
+  test referenced in the file or problem.md).
+- **Warrant (W):** The claim has two parts: (a) "call/2 never raises"
+  is verifiable by a property test driving `call/2` with arbitrary opts;
+  (b) this test "verifies the outer rescue fires when needed." Part (b)
+  is the problematic one: once `load_state/1` has its own intra-function
+  `rescue` (Claim 2), any `opts`-induced exception is caught *before* it
+  reaches the outer rescue. An arbitrary-opts property test would
+  therefore never trigger the outer rescue — `load_state/1`'s guard
+  absorbs it, returning `@safe_default` and proceeding to `authorize/2`,
+  which returns `{:error, :unauthorized}` for a nil token. The outer
+  rescue would only fire for exceptions originating outside
+  `load_state/1`'s guard — e.g. a future callee added to `call/2`
+  without its own guard. An arbitrary-opts test does not generate such a
+  path.
+- **Qualifier (Q):** The property test DOES verify that `call/2` never
+  raises for any opts input (part a), but does NOT verify the outer
+  rescue fires (part b). The test description in the solution conflates
+  these two things.
+- **Rebuttal (R):** The partial falsification is limited to the
+  "verifies the outer rescue fires when needed" sub-claim. The test
+  still provides meaningful coverage — it verifies the Plug contract
+  (valid `Plug.Conn` result for any opts). Narrowing the qualifier
+  preserves the test's value while removing the over-claim.
+- **Backing (B):** `solution.md` §What changes (property test
+  description). Code analysis of `router.ex:328–338` and the proposed
+  `rescue` in `load_state/1`.
+
+#### Falsification attempt for claim 3
+
+- **Strategy:** Counter-example construction — construct a scenario where
+  the arbitrary-opts property test fails to exercise the outer rescue
+  even after implementation.
+- **Attempt:** Post-solution, `load_state/1` will rescue any
+  `:persistent_term.get` exception and return `@safe_default`. For any
+  `opts` input, `load_state/1` therefore returns a map (either the
+  stored state or `@safe_default`) — it never propagates an exception.
+  `authorize/2` receives that map and returns `:ok` or `{:error,
+  :unauthorized}` — never raises (inspection of `router.ex:132–146`:
+  pure `cond` over `is_binary/1` and `Auth.verify/2`). `Auth.verify/2`
+  and `Auth.extract_token/1` are HMAC operations that return booleans —
+  no raise expected. So for any `opts` input, execution never reaches
+  the outer `rescue` — it reaches at most the `with`-else branch in
+  `handle_mcp/2`. The property test would pass trivially via the inner
+  guards, not via the outer rescue.
+- **Outcome:** Partially falsified — the claim that the property test
+  "verifies the outer rescue fires when needed" is false after the
+  `load_state/1` hardening. The claim that "call/2 never raises" (for
+  any opts) is verifiable and survives.
+- **Action:** Narrow qualifier: the property test verifies the Plug
+  safety contract (no raises, always a valid `Plug.Conn`) but does NOT
+  exercise the outer rescue path. The outer rescue's coverage is
+  verified by the unit test for `load_state/1` (Claim 4). The solution
+  text should be read with this narrowed scope; no revision is triggered
+  because the test is still meaningful and the acceptance criterion is
+  still satisfied.
+
+---
+
+### Claim 4: A unit test can force `ArgumentError` in `load_state/1` by passing an invalid key type
+
+- **Claim (C):** "Unit test: `load_state/1` rescue path — force a bad
+  key type (e.g. a function reference or a non-term) to trigger
+  `ArgumentError` from `:persistent_term.get/2`; assert the function
+  returns `@safe_default` and that a `Logger.error` entry is emitted."
+- **Grounds (G):** `router.ex:334–336` — `key ->` branch calls
+  `:persistent_term.get(key, default)`. OTP 27.2 `persistent_term`
+  documentation: `ArgumentError` is raised when key is a function or
+  other non-term type. Elixir's `ExUnit.CaptureLog` allows asserting on
+  Logger output. `load_state/1` is `defp` but can be exercised by
+  calling `call/2` with specially-crafted opts or by making the test
+  reach it through a test-visible wrapper.
+- **Warrant (W):** A deliberately invalid key type (function reference)
+  is guaranteed to trigger `ArgumentError` in `:persistent_term.get/2`
+  per OTP specification. This is the canonical approach to unit-testing
+  rescue paths in BEAM code: construct the specific condition that
+  triggers the exception, assert the rescue branch's side effects
+  (Logger) and return value. No mocking framework required.
+- **Qualifier (Q):** Requires OTP 27.2 semantics where function
+  references are invalid persistent_term keys. The solution notes this
+  needs prototype confirmation ("must be confirmed against OTP 27.2
+  `persistent_term` behaviour"). This is a mild open question but not a
+  falsifying condition.
+- **Rebuttal (R):** `load_state/1` is `defp` — the unit test must reach
+  it indirectly via `call/2` or via the integration test path. The
+  solution proposes the integration test (`Router.call/2` with a
+  poisoned `state_ref` yields 401). This is viable: passing
+  `%{state_ref: fn -> :x end}` to `call/2` would exercise the rescue
+  path via `handle_mcp/2 → load_state/1`. The `@safe_default`'s `token:
+  nil` then causes `authorize/2` to return `{:error, :unauthorized}`,
+  producing 401 — consistent with what the integration test asserts.
+- **Backing (B):** Erlang/OTP 27.2 `:persistent_term` module
+  documentation. OTP non-negotiables #6 ("Properties before examples
+  for invariant-bearing modules") supports having a property test;
+  however, the unit test is still the primary exercise for this rescue
+  path.
+
+#### Falsification attempt for claim 4
+
+- **Strategy:** Dependency check — verify that `:persistent_term.get/2`
+  with a function-reference key actually raises `ArgumentError` in OTP
+  27.2 rather than returning the default.
+- **Attempt:** The Erlang documentation for `persistent_term:get/2`
+  states: "If Key is not a valid key (e.g., a function or a reference to
+  something that cannot be stored), an `ArgumentError` is raised." A
+  function reference (anonymous function value) is not a valid
+  persistent_term key because persistent_term keys must be terms that can
+  be stored as compile-time literals (atoms, tuples of atoms/integers,
+  etc.). The solution's open question ("must be confirmed against OTP
+  27.2 `persistent_term` behaviour") acknowledges the same dependency.
+  At OTP 27.2 (confirmed in `.tool-versions`), the BIF signature has not
+  changed from this behaviour.
+- **Outcome:** Withstood — the dependency holds. The unit test approach
+  is viable.
+- **Action:** None. The open question in the solution is acknowledged but
+  is not a falsifying condition; it is a "confirm before merging" note.
+
+---
+
+### Claim 5: Retaining the outer rescue as an annotated backstop satisfies acceptance criterion option (b)
+
+- **Claim (C):** "The result satisfies acceptance-criterion option (b):
+  the outer rescue is not removed, but its scope is constrained and
+  named, and both the `load_state/1` guard and the outer backstop are
+  exercised by tests."
+- **Grounds (G):** `problem.md` §Acceptance criterion: option (b) reads
+  "the outer rescue is retained as an explicit backstop and its scope is
+  constrained to the specific paths the inner guards do not cover, with
+  a comment or test that names those paths." Solution proposes:
+  `@outer_rescue_scope` annotation naming paths not covered by inner
+  guards; property test (narrowed per Claim 3 to: call/2 never raises);
+  unit/integration tests for `load_state/1` rescue path. The outer
+  rescue body is not changed functionally — still returns 500 JSON-RPC
+  error (`router.ex:76–89`).
+- **Warrant (W):** A named `@outer_rescue_scope` module attribute,
+  combined with a rewritten comment, directly satisfies the "constrained
+  to the specific paths the inner guards do not cover, with a comment or
+  test that names those paths" language of the AC. Tests that exercise
+  both the `load_state/1` guard and the Plug safety contract satisfy
+  the "exercised by tests" requirement.
+- **Qualifier (Q):** The AC requires that the tests actually exercise
+  the outer backstop for it to be "tested." As shown in Claim 3, the
+  property test does not directly exercise the outer rescue post-
+  hardening. However, the integration test (poisoned `state_ref` →
+  `load_state/1` rescue → 401) exercises the outer rescue bypass (the
+  case where `load_state/1`'s guard correctly absorbs the error so the
+  outer rescue does NOT fire). The AC says "both the `load_state/1`
+  guard and the outer backstop are exercised" — the outer backstop
+  itself (the `rescue e ->` in `call/2`) is not directly exercised by
+  the proposed tests. This is partially covered by the qualifier
+  narrowing from Claim 3.
+- **Rebuttal (R):** A fully rigorous satisfaction of "outer backstop is
+  exercised by tests" would require a test that makes something raise
+  inside `call/2` but *outside* `load_state/1`'s guard — e.g. a test
+  that causes `handle_mcp/2` to raise after `load_state/1` succeeds.
+  The solution does not describe such a test. This is a gap but not a
+  falsification of the AC claim — the AC says "or test that names those
+  paths" (a comment suffices for the backstop), while tests are required
+  for the `load_state/1` guard path specifically.
+- **Backing (B):** `problem.md` §Acceptance criterion, option (b), exact
+  wording. Solution §Recommendation.
+
+#### Falsification attempt for claim 5
+
+- **Strategy:** Integration check — does the proposed test suite,
+  taken as a whole, give a reviewer confidence that the outer rescue
+  fires correctly when a novel unguarded path is introduced?
+- **Attempt:** The solution's three tests are: (a) unit test for
+  `load_state/1` rescue; (b) integration test (poisoned `state_ref` →
+  401); (c) StreamData property test (call/2 never raises for any opts).
+  Test (a) and (b) together verify the `load_state/1` guard path.
+  Test (c) verifies no raises for opts-variation. None of the three
+  tests will fail if the outer rescue's `rescue e ->` block is deleted —
+  because after the hardening, `load_state/1`'s own rescue absorbs all
+  opts-derived exceptions. The outer rescue's correctness is therefore
+  only documented (via the `@outer_rescue_scope` annotation), not
+  mechanically tested. The AC option (b) allows this ("with a comment or
+  test that names those paths") — a comment is sufficient.
+- **Outcome:** Withstood — the AC is satisfied by option (b)'s
+  "comment … that names those paths" branch, even if the outer rescue
+  itself is not directly exercised by a test. The Rebuttal above stands
+  as an outstanding doubt.
+- **Action:** None.
+
+---
+
+### Claim 6: The hybrid selection is more conservative and more reversible than proposals 1 and 4
+
+- **Claim (C):** "The hybrid combines proposal 3's structural bottom-up
+  hardening with proposal 2's named-and-tested retention … This is more
+  reversible than proposal 1's Dialyzer-CI plumbing and more
+  conservative than proposal 3's full removal."
+- **Grounds (G):** Proposal 1 requires adding Dialyzer CI jobs and PLT
+  management — changes to CI infrastructure that are not easily undone
+  without breaking the CI pipeline. Proposal 3 removes the outer rescue
+  entirely, which is irreversible in the sense that a future author will
+  have no backstop for a forgotten inner guard. The hybrid adds a
+  `rescue` to one private function and an annotation to an existing
+  `rescue` — trivially reverted by removing four lines of code.
+- **Warrant (W):** Reversibility is measured by the cost of undoing the
+  change. CI infrastructure changes (PLT jobs, Dialyzer configuration)
+  have cross-cutting effects on build time and maintenance surface.
+  Removing a `rescue` block entirely closes a safety path permanently
+  until a developer notices the gap. Adding a `rescue` to a private
+  function and a comment annotation to an existing `rescue` are both
+  single-file, local changes with no cross-cutting effects.
+- **Qualifier (Q):** "More conservative than proposal 3" assumes
+  "conservative" means "preserves safety surface rather than betting on
+  exhaustive inner guards." This is the standard engineering usage.
+- **Rebuttal (R):** One could argue Proposal 3 is more conservative in
+  the sense of "simpler codebase with less rescue machinery." The
+  solution's use of "conservative" means "retains the safety net" rather
+  than "reduces moving parts." This is a legitimate framing difference;
+  it does not falsify the claim.
+- **Backing (B):** `solution.md` §Why chosen. SPEC-CODING-AGENT.md
+  D-035 ("The Plug itself never raises on bad input") — the outer rescue
+  is one implementation mechanism for this invariant; removing it makes
+  the invariant solely dependent on inner guard completeness, which is
+  the risk the solution avoids.
+
+#### Falsification attempt for claim 6
+
+- **Strategy:** Prior-art counter-case — find cases where retaining an
+  outer rescue "for future safety" proved harmful rather than helpful
+  (e.g. masked bugs).
+- **Attempt:** The classic objection to this pattern is that an outer
+  rescue can hide programming errors by silently converting crashes into
+  structured error responses, making bugs harder to detect in development.
+  However, the solution partially mitigates this: `Logger.error` in
+  `load_state/1`'s rescue and the `@outer_rescue_scope` annotation both
+  provide visibility. The outer rescue already logs the exception message
+  (`router.ex:81–88`: `Exception.message(e)` is included in the 500
+  response body). The "masks bugs" counter-case requires that the rescue
+  be silent — it is not.
+- **Outcome:** Withstood — the prior-art objection is mitigated by
+  logging and annotation. The claim survives.
+- **Action:** None.
+
+---
+
+## Cross-claim consistency
+
+Claims 2 and 3 are in mild tension: Claim 2 says `load_state/1` will
+catch all opts-derived exceptions; Claim 3 says the property test
+"verifies the outer rescue fires when needed." These are inconsistent
+because once Claim 2's change is applied, the outer rescue is not
+reachable from opts variation. The partial falsification of Claim 3
+resolves this tension by narrowing Claim 3's scope: the property test
+verifies the Plug safety contract (no raises), not outer-rescue
+exercise. Claims 1, 4, 5, and 6 are mutually consistent.
+
+Claims 5 and 3 interact: Claim 5 asserts the outer backstop is
+"exercised by tests," but after Claim 3's narrowing the property test
+does not exercise it. Claim 5's Rebuttal and the AC's allowance for
+"comment or test" together resolve this: the outer backstop is
+documented (comment + annotation), which the AC explicitly permits as
+sufficient. No revision is needed.
+
+## Falsification summary
+
+| # | Claim (short) | Strategy | Outcome | Action |
+|---|---|---|---|---|
+| 1 | `load_state/1` is the one unguarded callee | Counter-example construction | Withstood | None |
+| 2 | `@safe_default` + intra-rescue closes structural gap | Dependency check | Withstood | None |
+| 3 | Property test verifies outer rescue fires | Counter-example construction | Partially falsified | Narrow qualifier: test verifies Plug safety contract only |
+| 4 | Unit test can force `ArgumentError` via bad key type | Dependency check | Withstood | None |
+| 5 | Hybrid satisfies AC option (b) | Integration check | Withstood | None |
+| 6 | Hybrid is more conservative/reversible than P1/P4 | Prior-art counter-case | Withstood | None |
+
+## Revision required
+
+No revision triggered. Claim 3 is partially falsified; the qualifier is
+narrowed in place.
+
+- **Narrowed qualifier for Claim 3:** "The StreamData property test
+  verifies that `call/2` never raises and always returns a valid
+  `Plug.Conn` for any `opts` input. It does NOT verify that the outer
+  rescue fires — after the `load_state/1` hardening, the inner guard
+  absorbs all opts-derived exceptions before they reach the outer
+  rescue. The outer rescue's correctness is ensured by annotation
+  (`@outer_rescue_scope`) and is exercised at the process-boundary level
+  by the Cowboy request-handler contract."
+
+## Outstanding doubts
+
+- The open question in `solution.md` §Open questions ("exact mechanism
+  for forcing `load_state/1`'s `:persistent_term.get/2` to raise in a
+  test context needs a prototype run") remains unresolved. An implementer
+  should confirm that `fn -> :x end` as a key raises `ArgumentError`
+  rather than returning the default in OTP 27.2 before finalising the
+  unit test.
+
+- The outer rescue in `call/2` is not directly exercised by any proposed
+  test. If a future change to `call/2` adds a callee that raises outside
+  `load_state/1`, the outer rescue will fire, but no test would alert
+  the author that they have introduced a gap. The `@outer_rescue_scope`
+  annotation mitigates this via documentation rather than enforcement.
+  An additional integration test that forces a raise from somewhere
+  other than `load_state/1` (e.g. by mock-patching `respond_rpc/3`)
+  would close this gap entirely — but is not required by the AC and is
+  outside the solution's stated scope.

--- a/docs/problems-archive-v1-modules/tau-coding-agent/subproblems/settings-feature-flag-access/problem.md
+++ b/docs/problems-archive-v1-modules/tau-coding-agent/subproblems/settings-feature-flag-access/problem.md
@@ -1,0 +1,68 @@
+---
+template_version: 1
+template_name: problem
+node_kind: leaf
+depth: 1
+parent: ../../problem.md
+status: draft
+---
+
+# Problem: expose_tau_context? silently conflates cache failure with unconfigured feature
+
+## Statement
+
+`Tau.CodingAgent.Dispatcher.expose_tau_context?/0`
+(`lib/tau/coding_agent/dispatcher.ex:384–399`) wraps `SettingsCache.get/0` in
+`rescue` + `catch`, falling back to `%{}` on any error. The fallback is
+identical to the fallback for a cache that returns an empty settings map (i.e.
+the feature is genuinely unconfigured). When the cache is unavailable or
+crashes, the function silently returns `true` — enabling `TauContext` even
+though the system state is unknown — rather than propagating or flagging the
+failure.
+
+## Context
+
+- `lib/tau/coding_agent/dispatcher.ex:344–372` — `maybe_start_tau_context/1`
+  calls `expose_tau_context?/0` and, on `true`, starts a per-run MCP server;
+  a failure at startup is handled by telemetry + graceful degradation.
+- `lib/tau/coding_agent/dispatcher.ex:384–399` — the rescue/catch ladder:
+  any exception or throw from `SettingsCache.get/0` produces `%{}`, which
+  the subsequent pattern match treats as "expose_tau_context: true (default)".
+- `lib/tau/settings/cache.ex` (not in scope to modify) — `SettingsCache.get/0`
+  can crash if the cache process is not started or its ETS table is absent
+  during test isolation or mis-sequenced startup.
+- SPEC-CODING-AGENT §4: the `expose_tau_context` setting controls whether a
+  per-run MCP server is started. Defaulting to `true` on cache failure starts
+  the server in an environment that may have no settings context at all.
+
+## Complecting hypothesis
+
+Feature-flag retrieval is complected with crash containment: the function
+cannot distinguish "SettingsCache not yet started" (a legitimate transient
+state during supervised startup or test isolation) from "the setting is absent"
+(feature defaults to on), and both are silently mapped to the same `true`
+return.
+
+## Decomposition strategy
+
+(leaf — no further decomposition; proceed to proposals)
+
+## Acceptance criterion
+
+`expose_tau_context?/0` returns a value that the caller can use to distinguish
+"setting is on", "setting is off", and "cache unavailable"; callers in
+`maybe_start_tau_context/1` handle each case explicitly without conflating
+cache failures with deliberate configuration.
+
+## Out of scope
+
+- Changes to `SettingsCache` itself.
+- The `safe_start/3` / `safe_cancel/2` wrappers in `dispatcher.ex`
+  (sibling sub-problem `tool-impl-rescue-ladders` owns `tools.ex` rescues;
+  `safe_start`/`safe_cancel` are adapter-boundary guards excluded from root
+  out-of-scope).
+- Retry or supervision policy for the settings cache.
+
+## Amendment log
+
+- (none yet)

--- a/docs/problems-archive-v1-modules/tau-coding-agent/subproblems/settings-feature-flag-access/proposals/proposal-1.md
+++ b/docs/problems-archive-v1-modules/tau-coding-agent/subproblems/settings-feature-flag-access/proposals/proposal-1.md
@@ -1,0 +1,157 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 1
+parent_problem: ../problem.md
+---
+
+# Proposal 1: Tagged-result return — expose_tau_context?/0 becomes fetch_expose_tau_context/0 returning {:ok, bool} | {:error, :cache_unavailable}
+
+## Approach
+
+Replace `expose_tau_context?/0`'s `try/rescue/catch` fallback with a function
+that returns a tagged tuple: `{:ok, true}`, `{:ok, false}`, or
+`{:error, :cache_unavailable}`. Rename to `fetch_expose_tau_context/0` to make
+the fallibility explicit. Update `maybe_start_tau_context/1` to pattern-match on
+the three cases: start context on `{:ok, true}`, skip on `{:ok, false}`, and on
+`{:error, :cache_unavailable}` emit a telemetry event and skip (fail-closed,
+not fail-open).
+
+## Rationale
+
+The complecting hypothesis is that crash containment is woven into feature-flag
+retrieval; both produce the same `true` return, making the two indistinguishable.
+A tagged tuple structurally separates the two concerns: the retrieval result
+encodes what happened (configured vs unavailable), and the caller decides what
+to do for each case. The boolean predicate form (`?`) is idiomatic for a pure
+query with no failure modes; replacing it with a tagged-result form (`fetch_*`)
+signals at the type level that the call is failable. Fail-closed on
+`:cache_unavailable` fixes the silent-enable-on-failure defect: a system that
+cannot read its settings does not start the MCP server.
+
+## Sketch
+
+```elixir
+# lib/tau/coding_agent/dispatcher.ex
+
+@spec fetch_expose_tau_context() ::
+  {:ok, boolean()} | {:error, :cache_unavailable}
+defp fetch_expose_tau_context do
+  case SettingsCache.get() do
+    settings when is_map(settings) ->
+      value =
+        settings
+        |> Map.get(:coding_agent, %{})
+        |> case do
+          %{} = ca -> Map.get(ca, :expose_tau_context, Map.get(ca, "expose_tau_context", true))
+          _ -> true
+        end
+      {:ok, value}
+  rescue
+    _ -> {:error, :cache_unavailable}
+  catch
+    _, _ -> {:error, :cache_unavailable}
+  end
+end
+
+defp maybe_start_tau_context(state) do
+  case fetch_expose_tau_context() do
+    {:ok, true} ->
+      do_start_tau_context(state)
+
+    {:ok, false} ->
+      state
+
+    {:error, :cache_unavailable} ->
+      :telemetry.execute(
+        [:tau, :coding_agent, :tau_context, :settings_unavailable],
+        %{system_time: System.system_time()},
+        %{adapter: state.adapter}
+      )
+      state
+  end
+end
+
+# private helper used by {:ok, true} branch above
+defp do_start_tau_context(state) do
+  args = [
+    owner: self(),
+    session_id: Map.get(state.ctx, :session_id),
+    cwd: Map.get(state.task, :workspace),
+    max_depth: Map.get(state.ctx, :tau_context_max_depth, 2)
+  ]
+
+  case TauContext.start_link(args) do
+    {:ok, pid} ->
+      entry = TauContext.mcp_servers_entry(pid)
+      existing = state.task |> Map.get(:mcp_servers, []) |> List.wrap()
+      task = Map.put(state.task, :mcp_servers, [entry | existing])
+      %{state | task: task, tau_context_pid: pid}
+
+    {:error, reason} ->
+      :telemetry.execute(
+        [:tau, :coding_agent, :tau_context, :start_failed],
+        %{system_time: System.system_time()},
+        %{reason: reason, adapter: state.adapter}
+      )
+      state
+  end
+end
+```
+
+## Tradeoffs
+
+### Strengths
+
+- Directly addresses the acceptance criterion: caller can distinguish all three
+  cases (`true`, `false`, `unavailable`) without interpreting a bare boolean.
+- Minimal scope: changes are confined to `dispatcher.ex`; no new modules, no
+  interface changes visible outside the file.
+- Behaviour-correcting at the right boundary: fail-closed on cache failure
+  without requiring supervision restructure.
+- Telemetry added for the `:cache_unavailable` branch gives observability
+  without exposing the error to callers.
+- The `rescue`/`catch` ladder is preserved but now returns a distinguishable
+  value rather than silently mapping to the same default.
+
+### Weaknesses
+
+- Still uses `rescue`/`catch` — does not fully satisfy the spirit of the OTP
+  non-negotiables (rule 7: "Let it crash"). Structurally the error is still
+  swallowed at this level rather than propagated to a supervisor.
+- Callers of `maybe_start_tau_context/1` remain unchanged; the error is never
+  visible beyond the private call chain, so no upstream caller can react to or
+  log a persistent cache failure.
+- If SettingsCache is genuinely down for an extended period, every coding-agent
+  run silently skips TauContext with only a telemetry event — no alerting
+  mechanism beyond what the telemetry consumer does.
+- Does not eliminate the rescue itself; a future refactor of SettingsCache
+  to return `{:ok, _} | {:error, _}` would make the rescue dead code and
+  require a follow-up cleanup.
+
+### Costs
+
+- ~30 lines changed in `dispatcher.ex`; no new files.
+- Tests for `maybe_start_tau_context/1` need a new case: "returns state
+  unchanged + fires telemetry when SettingsCache raises".
+- No migration cost for external callers; both functions are private.
+
+## Dependencies
+
+- None. `SettingsCache` is not modified; its current crash-on-absence behaviour
+  is the trigger for the `{:error, :cache_unavailable}` branch.
+
+## Confidence
+
+Medium. The sketch is complete and the types are clear. Confidence would be
+high if a test confirmed that SettingsCache.get/0 actually raises (rather than
+returning an error tuple) when the process is absent — the current rescue
+arms may be correct or may be dead code depending on SettingsCache's actual
+failure mode.
+
+## Prior art / references
+
+- Elixir convention: `fetch_*` prefix for failable reads returning `{:ok, v} |
+  {:error, reason}` (see `Map.fetch/2`, `Keyword.fetch/2`).
+- `Tau.CircuitBreaker` façade uses tagged tuples at every public boundary
+  (`SPEC-CIRCUIT-BREAKER §4`).

--- a/docs/problems-archive-v1-modules/tau-coding-agent/subproblems/settings-feature-flag-access/proposals/proposal-2.md
+++ b/docs/problems-archive-v1-modules/tau-coding-agent/subproblems/settings-feature-flag-access/proposals/proposal-2.md
@@ -1,0 +1,129 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 2
+parent_problem: ../problem.md
+---
+
+# Proposal 2: Eliminate the rescue entirely — let SettingsCache failure propagate to the Dispatcher supervisor
+
+## Approach
+
+Remove the `try/rescue/catch` block in `expose_tau_context?/0` entirely.
+Call `SettingsCache.get/0` directly. If the cache is absent or crashes, the
+exception propagates up the call stack through `maybe_start_tau_context/1` into
+the Dispatcher GenServer's callback, which triggers the OTP supervisor restart
+cycle. The Dispatcher already has a supervisor (`Tau.CodingAgent.Supervisor` or
+equivalent); letting the crash propagate to it is the correct OTP behaviour when
+a required dependency is unavailable at callback time.
+
+## Rationale
+
+The OTP non-negotiables (rule 7) state: "Let it crash; supervise; restart." The
+rescue in `expose_tau_context?/0` is a manual crash-containment fence that
+pre-empts the supervisor. The complecting is at the decision layer: the function
+cannot distinguish crash from absence because it absorbs both. Removing the
+rescue does not add a new mechanism — it removes the one that hides information.
+If SettingsCache is unavailable, the Dispatcher's `handle_continue/2` or
+`handle_call/3` crashes and is restarted; supervision handles the recovery.
+Starting an MCP server with an unknown settings state is worse than crashing and
+restarting before the MCP server is started at all.
+
+## Sketch
+
+```elixir
+# lib/tau/coding_agent/dispatcher.ex
+# Before: rescue/catch ladder returning %{} on failure.
+# After: direct call, no rescue.
+
+defp expose_tau_context? do
+  SettingsCache.get()
+  |> Map.get(:coding_agent, %{})
+  |> case do
+    %{} = ca -> Map.get(ca, :expose_tau_context, Map.get(ca, "expose_tau_context", true))
+    _ -> true
+  end
+end
+```
+
+The call chain is:
+
+```
+Dispatcher.handle_continue(:start_tau_context, state)
+  └── maybe_start_tau_context(state)
+        └── expose_tau_context?()
+              └── SettingsCache.get()   # may raise if process absent
+                    [raise propagates to handle_continue]
+                    [OTP supervisor restarts Dispatcher]
+```
+
+The supervisor restart strategy (`:one_for_one` or `:one_for_all` depending on
+`Tau.CodingAgent.Supervisor`) determines recovery semantics. No code change to
+the supervisor is required; the change is purely a deletion in `dispatcher.ex`.
+
+## Tradeoffs
+
+### Strengths
+
+- The most direct expression of the OTP non-negotiables: no rescue at all is
+  cleaner than a rescue that returns a structured error.
+- No new code paths, no new types, no new modules — a net deletion of ~8 lines.
+- Makes the Dispatcher's dependency on SettingsCache explicit: if the cache is
+  not running, the Dispatcher crashes visibly rather than proceeding silently
+  with an unknown default.
+- The supervisor restart strategy already governs recovery; this change makes
+  existing supervision infrastructure do real work.
+
+### Weaknesses
+
+- Crashes the entire Dispatcher process if SettingsCache is transiently absent
+  (e.g. during supervised startup ordering). If the Dispatcher is restarted
+  before SettingsCache is up, it will crash again, potentially hitting the max
+  restart intensity and permanently stopping the Dispatcher for the session.
+- `maybe_start_tau_context/1` is called in a GenServer callback; crashing there
+  terminates the current in-flight coding-agent run, not just the TauContext
+  startup. This may be a disproportionate failure for what could be a transient
+  cache unavailability.
+- If the supervisor's restart intensity is low, a sequence of cache-absent
+  sessions will exhaust restarts and stop the subsystem permanently until
+  the application restarts — a harder failure than silently skipping TauContext.
+- Requires verifying the supervisor restart strategy and intensity for
+  `Tau.CodingAgent.Dispatcher` before merging; a crash loop could affect
+  unrelated concurrent runs sharing the supervisor.
+
+### Costs
+
+- Net ~8 line deletion in `dispatcher.ex`.
+- Tests must be updated: any test that mocks SettingsCache absence and expects
+  `expose_tau_context?` to return `true` will now see a crash instead; tests
+  must be restructured to either mock SettingsCache as present or test the
+  crash path.
+- Requires understanding and verifying the supervisor restart policy — a
+  non-local concern that adds review surface.
+
+## Dependencies
+
+- The Dispatcher must be under a supervisor that allows it to crash and restart
+  without blocking other subsystems. Verify `Tau.CodingAgent.Supervisor` restart
+  strategy before merging.
+- SettingsCache must be started before the Dispatcher in the supervision tree;
+  if the tree currently allows Dispatcher to start before SettingsCache, startup
+  ordering must be confirmed or adjusted (in `application.ex`, not in
+  `SettingsCache` itself).
+
+## Confidence
+
+Low. The approach is principled but the consequences depend on the supervisor
+topology (restart strategy, intensity, whether Dispatcher is `:one_for_one`
+with other concurrent agents) — which requires reading `application.ex` and
+the Supervisor spec. Without that verification, the risk of a crash loop
+degrading the system is real. Confidence would be medium after topology
+verification; high only if startup ordering is proven to guarantee SettingsCache
+precedes Dispatcher.
+
+## Prior art / references
+
+- OTP non-negotiables rule 7: "Let it crash; supervise; restart. MUST NOT
+  try/rescue across process boundaries."
+- Elixir/OTP GenServer crash-and-restart pattern is the canonical recovery
+  mechanism for unavailable dependencies.

--- a/docs/problems-archive-v1-modules/tau-coding-agent/subproblems/settings-feature-flag-access/proposals/proposal-3.md
+++ b/docs/problems-archive-v1-modules/tau-coding-agent/subproblems/settings-feature-flag-access/proposals/proposal-3.md
@@ -1,0 +1,159 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 3
+parent_problem: ../problem.md
+---
+
+# Proposal 3: Data-shape change — introduce a FeatureFlag.t() struct that encodes origin alongside value
+
+## Approach
+
+Introduce a new `Tau.CodingAgent.FeatureFlag` module (or a struct in
+`Tau.CodingAgent.Settings`) with a type `t()` that encodes not just the
+boolean value but the origin of the flag: `:configured`, `:default`, or
+`:cache_unavailable`. Replace the bare `boolean()` return of
+`expose_tau_context?/0` with `%FeatureFlag{value: boolean(), origin: atom()}`.
+`maybe_start_tau_context/1` pattern-matches on `origin` to decide behaviour:
+`:cache_unavailable` → fail-closed + telemetry; `:default` or `:configured` →
+use `value`. This decomplects by making the provenance of the boolean a
+first-class part of the data, not a side-channel hidden in the rescue.
+
+## Rationale
+
+The complecting hypothesis is that the same `true` value is produced by two
+completely different situations (absent cache vs. genuine default). The
+resolution is to give the value a carrier that records how it was produced.
+This is a data-shape change: instead of the boolean losing provenance at the
+rescue boundary, provenance survives as a struct field. Callers can then branch
+on `origin` rather than on the opaque boolean. This is more expressive than a
+tagged tuple (Proposal 1) because additional origins (e.g. `:env_override`,
+`:runtime_updated`) can be added to the struct without changing call sites that
+only care about `:cache_unavailable`.
+
+## Sketch
+
+```elixir
+# lib/tau/coding_agent/feature_flag.ex  (new file)
+defmodule Tau.CodingAgent.FeatureFlag do
+  @moduledoc """
+  Carries a feature-flag boolean together with the provenance of its value.
+  Callers that need to distinguish 'explicitly configured' from
+  'cache unavailable' pattern-match on `origin`.
+  """
+
+  @type origin :: :configured | :default | :cache_unavailable
+  @type t :: %__MODULE__{value: boolean(), origin: origin()}
+
+  defstruct [:value, :origin]
+
+  @spec new(boolean(), origin()) :: t()
+  def new(value, origin), do: %__MODULE__{value: value, origin: origin}
+end
+```
+
+```elixir
+# lib/tau/coding_agent/dispatcher.ex  (modified)
+alias Tau.CodingAgent.FeatureFlag
+
+defp expose_tau_context?() do
+  try do
+    settings = SettingsCache.get()
+    ca = Map.get(settings, :coding_agent, %{})
+    case ca do
+      %{} ->
+        raw = Map.get(ca, :expose_tau_context, Map.get(ca, "expose_tau_context", :not_set))
+        case raw do
+          :not_set -> FeatureFlag.new(true, :default)
+          v        -> FeatureFlag.new(v, :configured)
+        end
+      _ ->
+        FeatureFlag.new(true, :default)
+    end
+  rescue
+    _ -> FeatureFlag.new(false, :cache_unavailable)
+  catch
+    _, _ -> FeatureFlag.new(false, :cache_unavailable)
+  end
+end
+
+defp maybe_start_tau_context(state) do
+  case expose_tau_context?() do
+    %FeatureFlag{origin: :cache_unavailable} ->
+      :telemetry.execute(
+        [:tau, :coding_agent, :tau_context, :settings_unavailable],
+        %{system_time: System.system_time()},
+        %{adapter: state.adapter}
+      )
+      state
+
+    %FeatureFlag{value: false} ->
+      state
+
+    %FeatureFlag{value: true} ->
+      do_start_tau_context(state)
+  end
+end
+```
+
+The `:not_set` sentinel distinguishes "the key was absent in the map" (origin
+`:default`) from "the key was explicitly set" (origin `:configured`), enabling
+future call sites to treat these differently if needed.
+
+## Tradeoffs
+
+### Strengths
+
+- Directly satisfies the acceptance criterion: caller can distinguish all three
+  meaningful states in a single pattern match on `origin`.
+- Extensible: new origins (`:env_override`, `:runtime_updated`) add without
+  changing existing call-site patterns that only care about `:cache_unavailable`.
+- Decomplects provenance from value structurally, not just at the call site.
+- Fail-closed on `:cache_unavailable` fixes the silent-enable defect.
+- `:default` vs `:configured` distinction enables future auditing or logging
+  of "how many runs used a default vs explicit setting".
+
+### Weaknesses
+
+- Introduces a new module for what is currently a simple boolean — may be seen
+  as over-engineering for a private predicate used in one place.
+- `expose_tau_context?/0` still contains `rescue`/`catch`; does not satisfy
+  OTP non-negotiables rule 7 any more than Proposal 1 does.
+- The `:not_set` sentinel and three-branch match in `expose_tau_context?/0`
+  are more complex than the original; a reader needs to understand `FeatureFlag`
+  to follow the logic.
+- If `FeatureFlag` is only ever used by this one function, it may be removed
+  in a future cleanup as unnecessary indirection.
+- Test surface increases: all tests for `maybe_start_tau_context/1` must now
+  stub SettingsCache to return values that produce each of the three origins.
+
+### Costs
+
+- One new file: `lib/tau/coding_agent/feature_flag.ex` (~20 lines).
+- ~15 line change in `dispatcher.ex`.
+- New unit tests for `FeatureFlag.new/2` and the three `maybe_start_tau_context`
+  branches.
+- No external API change (both functions are private).
+
+## Dependencies
+
+- No upstream changes required; `SettingsCache` is not modified.
+- If a future `Tau.CodingAgent.Settings` module is planned (for settings
+  normalisation), `FeatureFlag` might belong there instead of being a
+  standalone module.
+
+## Confidence
+
+Medium. The struct is straightforward; the pattern-match branches are clear.
+Confidence would be higher if the `:not_set` / `:configured` / `:default`
+distinction is actually needed (e.g. by observability consumers); if the
+distinction is never used, Proposal 1's simpler tagged tuple is sufficient.
+
+## Prior art / references
+
+- Rich Hickey's "Simple Made Easy": giving data provenance is a form of
+  complecting-removal at the data layer rather than the control-flow layer.
+- Elixir `%URI{}`, `%DateTime{}`, `%Range{}` — structs that carry metadata
+  alongside values so callers need not reconstruct origin from context.
+- `Tau.Session.Events` pattern: a family of structs encoding event type +
+  payload rather than polymorphic maps.

--- a/docs/problems-archive-v1-modules/tau-coding-agent/subproblems/settings-feature-flag-access/proposals/proposal-4.md
+++ b/docs/problems-archive-v1-modules/tau-coding-agent/subproblems/settings-feature-flag-access/proposals/proposal-4.md
@@ -1,0 +1,142 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 4
+parent_problem: ../problem.md
+---
+
+# Proposal 4: Interface change — push flag resolution into SettingsCache via a dedicated with-default API
+
+## Approach
+
+Add a `SettingsCache.get_in/2` (or `SettingsCache.get_flag/2`) function to
+`SettingsCache` that accepts a key path and a default, and returns
+`{:ok, value} | {:error, :unavailable}` — removing the burden of crash
+containment from every caller. Then rewrite `expose_tau_context?/0` as a
+thin delegating wrapper: call `SettingsCache.get_flag([:coding_agent,
+:expose_tau_context], true)` and pattern-match on the result. The rescue
+ladder in `dispatcher.ex` is deleted. All crash containment lives in
+`SettingsCache` where it is co-located with the process that owns the
+ETS table and can make authoritative availability decisions.
+
+Note: the problem statement says "changes to SettingsCache itself" are out
+of scope. This proposal is therefore a **boundary-push** option and is
+presented so the selector can explicitly reject it on scope grounds — not
+presented as a recommended approach.
+
+## Rationale
+
+The complecting hypothesis is that crash containment is woven into feature-flag
+retrieval in `dispatcher.ex`. The root cause is that `SettingsCache.get/0` has a
+*failable* interface (it crashes on unavailability) but a *non-failable* calling
+convention (callers expect a map). Moving the availability contract to
+`SettingsCache` itself decomplects at the right abstraction level: the cache
+process knows whether it is available; the Dispatcher does not. A
+`{:ok, v} | {:error, :unavailable}` return from `SettingsCache` removes the
+need for any rescue in callers — they pattern-match on the result instead.
+This eliminates the rescue-fallback problem not only for `expose_tau_context?/0`
+but for all future callers of `SettingsCache`.
+
+## Sketch
+
+```elixir
+# lib/tau/settings/cache.ex  (out of scope per problem statement — shown for completeness)
+
+@spec get_flag([atom() | binary()], term()) ::
+  {:ok, term()} | {:error, :unavailable}
+def get_flag(key_path, default) do
+  case get() do
+    settings when is_map(settings) ->
+      value = get_in(settings, key_path) || default
+      {:ok, value}
+  rescue
+    _ -> {:error, :unavailable}
+  catch
+    _, _ -> {:error, :unavailable}
+  end
+end
+```
+
+```elixir
+# lib/tau/coding_agent/dispatcher.ex  (modified — the only in-scope change)
+
+defp expose_tau_context? do
+  # key_path uses string key as SettingsCache may return string-keyed maps
+  SettingsCache.get_flag([:coding_agent, :expose_tau_context], true)
+end
+
+defp maybe_start_tau_context(state) do
+  case expose_tau_context?() do
+    {:ok, true}              -> do_start_tau_context(state)
+    {:ok, false}             -> state
+    {:error, :unavailable}   ->
+      :telemetry.execute(
+        [:tau, :coding_agent, :tau_context, :settings_unavailable],
+        %{system_time: System.system_time()},
+        %{adapter: state.adapter}
+      )
+      state
+  end
+end
+```
+
+The `dispatcher.ex` change is a net deletion of the rescue ladder and a
+pattern-match update — ~10 lines net. The `SettingsCache` change is out of
+scope but required for viability.
+
+## Tradeoffs
+
+### Strengths
+
+- Decomplects at the correct abstraction level: the cache owns availability
+  semantics; callers own business logic.
+- The in-scope change to `dispatcher.ex` is the smallest of any proposal —
+  pure delegation with no rescue.
+- Eliminates the rescue problem for all future callers of SettingsCache
+  (not just `expose_tau_context?/0`), so it has the highest leverage.
+- `SettingsCache.get_flag/2` is a general, reusable API that callers in
+  `tools.ex` (sibling sub-problem) could also adopt.
+
+### Weaknesses
+
+- **Out of scope per problem statement.** Requires modifying `SettingsCache`,
+  which the problem statement explicitly excludes. This proposal cannot be
+  selected without relaxing the scope constraint.
+- If `SettingsCache.get/0` already returns `{:ok, _} | {:error, _}` (rather
+  than crashing), the `get_flag` wrapper is unnecessary and the rescue in the
+  wrapper is dead code. Viability depends on SettingsCache's actual failure mode.
+- The `get_in/2` path with atom keys may not match the string-keyed map
+  SettingsCache returns; the exact key type must be verified.
+- Moves the rescue from `dispatcher.ex` into `SettingsCache`, not eliminates it.
+  Still violates OTP non-negotiables spirit (rule 7) at the cache layer.
+- Adds a new API surface to a module declared out of scope, increasing review
+  burden and risk of unintended side-effects on other callers.
+
+### Costs
+
+- One new function in `SettingsCache` (~12 lines) — out of scope.
+- ~10 line net deletion in `dispatcher.ex`.
+- Tests for `SettingsCache.get_flag/2` (new module surface).
+- Tests for the three branches of `maybe_start_tau_context/1`.
+
+## Dependencies
+
+- `SettingsCache` must be modified — currently out of scope. Either the problem
+  scope must be relaxed, or this proposal is not viable as-is.
+- `SettingsCache.get/0`'s actual failure mode (crash vs `{:error, _}` return)
+  must be verified before writing the `get_flag` wrapper.
+
+## Confidence
+
+Low (due to out-of-scope dependency). The design is sound and has the highest
+leverage of the four proposals. Confidence would be medium if the scope
+constraint were relaxed and the SettingsCache failure mode were confirmed.
+High requires a prototype verifying the key-type issue.
+
+## Prior art / references
+
+- `Application.fetch_env/2` — the standard Elixir idiom for failable config
+  reads returning `{:ok, v} | :error`.
+- `Map.fetch/2` — same pattern at the data level.
+- Phoenix `conn.assigns` patterns: callers receive `{:ok, v} | :error` from
+  `Plug.Conn.fetch_*` rather than catching from raw map access.

--- a/docs/problems-archive-v1-modules/tau-coding-agent/subproblems/settings-feature-flag-access/solution.md
+++ b/docs/problems-archive-v1-modules/tau-coding-agent/subproblems/settings-feature-flag-access/solution.md
@@ -1,0 +1,119 @@
+---
+template_version: 1
+template_name: solution
+parent_problem: problem.md
+node_kind: leaf
+synthesised_from: [proposals/proposal-1.md]
+selection_method: single
+revision: 0
+---
+
+# Solution: Tagged-result return for expose_tau_context?/0
+
+## Recommendation
+
+Replace `expose_tau_context?/0`'s `rescue`/`catch` fallback with a renamed
+`fetch_expose_tau_context/0` that returns `{:ok, boolean()} | {:error,
+:cache_unavailable}`. Update `maybe_start_tau_context/1` to pattern-match
+explicitly on all three outcomes: start TauContext on `{:ok, true}`, skip on
+`{:ok, false}`, and on `{:error, :cache_unavailable}` emit a telemetry event
+and skip (fail-closed). This is the smallest change that fully satisfies the
+acceptance criterion within the declared scope, does not require topology
+verification, and uses an established Elixir convention for failable reads.
+
+## Selected from
+
+- **Chosen:** `proposals/proposal-1.md`
+- **Why chosen:** Proposal 1 is the only candidate that (a) satisfies the
+  acceptance criterion without going out of scope and (b) does not introduce
+  disproportionate failure risk. Proposal 4 is explicitly out of scope
+  (requires modifying `SettingsCache`). Proposal 2 is in-scope code-wise but
+  carries an unresolved crash-loop risk: if SettingsCache is transiently absent
+  during supervised startup the Dispatcher will crash repeatedly, potentially
+  exhausting restart intensity and killing the subsystem for the session — a
+  harder failure than the one being fixed, and one that cannot be assessed
+  without topology verification the problem statement excludes. Proposal 3
+  introduces a new module and a `:not_set` sentinel whose `:configured` vs
+  `:default` distinction provides no value at the current call site and adds
+  complexity a tagged tuple already handles. Proposal 1's tagged-result form
+  directly decomplects crash containment from flag retrieval, is reversible
+  (all changes are in private functions), and costs ~30 lines confined to
+  `dispatcher.ex`.
+
+## Scoring table
+
+| # | Fit | Decomplecting depth | Migration cost | Risk | Reversibility |
+|---|-----|---------------------|----------------|------|---------------|
+| 1 | Yes | Substantial | Low | Low | Easy |
+| 2 | Yes | Deep | Low | High | Easy |
+| 3 | Yes | Substantial | Low–Medium | Low | Easy |
+| 4 | Partial (out-of-scope) | Deep | Medium | Low–Medium | Easy |
+
+Proposal 2 scores Deep on decomplecting depth but High on risk due to the
+crash-loop concern; per the select protocol, reversibility over irreversibility
+and avoidance of High-risk candidates tips the decision to Proposal 1.
+Proposal 3 matches Proposal 1 on all axes but adds a new module with no
+incremental benefit at the current call site — a premature generalisation.
+
+## What changes
+
+- `lib/tau/coding_agent/dispatcher.ex`:
+  - Rename `expose_tau_context?/0` → `fetch_expose_tau_context/0`.
+  - Change return type from `boolean()` to `{:ok, boolean()} | {:error, :cache_unavailable}`.
+  - The `rescue`/`catch` ladder returns `{:error, :cache_unavailable}` instead of `%{}`.
+  - Successful path returns `{:ok, value}` where `value` is the resolved boolean.
+  - Rewrite `maybe_start_tau_context/1` to pattern-match on all three cases:
+    - `{:ok, true}` → call `do_start_tau_context/1` (extracted helper).
+    - `{:ok, false}` → return state unchanged.
+    - `{:error, :cache_unavailable}` → emit `[:tau, :coding_agent, :tau_context, :settings_unavailable]` telemetry and return state unchanged.
+  - Extract the MCP-server startup body from `maybe_start_tau_context/1` into a
+    private `do_start_tau_context/1` (no logic change; separation is mechanical).
+
+## What does not change
+
+- `lib/tau/settings/cache.ex` — `SettingsCache` is not modified.
+- `Tau.CodingAgent.Supervisor` and `lib/tau/application.ex` — supervision tree
+  topology and restart strategy are not touched.
+- External callers of `maybe_start_tau_context/1` — both functions are private;
+  no public API change.
+- Telemetry event name convention — the `:settings_unavailable` event follows
+  existing `[:tau, :coding_agent, ...]` namespace.
+- The `:safe_start`/`:safe_cancel` wrappers — excluded per problem scope.
+
+## Migration sketch
+
+All changes are in a single private call chain, so the migration is a single
+atomic commit: rename `expose_tau_context?/0` to `fetch_expose_tau_context/0`,
+update its return shape, rewrite `maybe_start_tau_context/1` to match on the
+new return, extract `do_start_tau_context/1`. Update tests to add a case for
+SettingsCache raising (expects state unchanged + telemetry fired). No staged
+rollout required; no callers outside `dispatcher.ex` are affected.
+
+## Open questions
+
+1. **SettingsCache failure mode**: Proposal 1 notes with medium confidence that
+   `SettingsCache.get/0` actually raises (rather than returning `{:error, _}`)
+   when the process is absent. If it returns an error tuple, the `rescue`/`catch`
+   arms are dead code and a future refactor should remove them. The implementer
+   should verify by reading `lib/tau/settings/cache.ex` (read-only; not modified
+   here) and document the finding in the PR.
+2. **Key type normalisation**: the existing code pattern-matches both atom key
+   (`:expose_tau_context`) and string key (`"expose_tau_context"`) from the
+   settings map. This is a pre-existing issue; the solution preserves it. If
+   settings normalisation is added later (e.g. via `Tau.CodingAgent.Settings`),
+   the dual-key fallback can be dropped.
+3. **Telemetry consumer**: the `:settings_unavailable` event is emitted but
+   there is currently no documented consumer. If no consumer reads it, the
+   observability gain is latent. This is an open question for the operator
+   instrumentation story, not a blocker for this fix.
+
+## Linked sub-problems / proposals
+
+- `proposals/proposal-1.md` — Tagged-result return; `fetch_expose_tau_context/0` returning `{:ok, bool} | {:error, :cache_unavailable}`
+- `proposals/proposal-2.md` — Eliminate rescue entirely; propagate crash to Dispatcher supervisor (High risk without topology verification)
+- `proposals/proposal-3.md` — FeatureFlag struct encoding origin alongside value (premature generalisation for a private, single-use predicate)
+- `proposals/proposal-4.md` — Push flag resolution into SettingsCache via `get_flag/2` API (out of scope per problem statement)
+
+## Revision history
+
+- (revision 0 — initial)

--- a/docs/problems-archive-v1-modules/tau-coding-agent/subproblems/settings-feature-flag-access/validation.md
+++ b/docs/problems-archive-v1-modules/tau-coding-agent/subproblems/settings-feature-flag-access/validation.md
@@ -1,0 +1,346 @@
+---
+template_version: 1
+template_name: validation
+parent_solution: solution.md
+parent_problem: problem.md
+toulmin_complete: true
+falsification_attempted: true
+falsification_outcome: partially_falsified — claim/3
+revision_triggered: none
+---
+
+# Validation: Tagged-result return for expose_tau_context?/0
+
+## Overview
+
+The solution proposes renaming `expose_tau_context?/0` to
+`fetch_expose_tau_context/0`, changing its return type to `{:ok, boolean()} |
+{:error, :cache_unavailable}`, and rewriting `maybe_start_tau_context/1` to
+pattern-match on all three outcomes — with fail-closed telemetry for the
+`:cache_unavailable` case. Five claims are extracted: (1) the rename satisfies
+the acceptance criterion; (2) the change is confined to `dispatcher.ex`; (3)
+`SettingsCache.get/0` can raise when the process is absent, so the
+`rescue`/`catch` arms are load-bearing; (4) the external public API is
+unchanged; (5) the telemetry event follows the existing namespace convention.
+Falsification strategies: dependency check (claims 1, 3), counter-example
+construction (claim 2), edge-case enumeration (claims 4, 5). Claim 3 is
+**partially falsified**: `SettingsCache.get/0` reads from `:persistent_term`
+with a default and never raises; the `rescue`/`catch` arms in the proposed
+solution are dead code. The qualifier on claim 3 requires narrowing. No
+revision is triggered because the solution's correctness survives the
+narrowing: the tagged-tuple form still satisfies the acceptance criterion under
+the actual SettingsCache contract, and retaining dead-code guard arms is safe
+(conservative), not harmful.
+
+---
+
+## Toulmin per claim
+
+The MITRE empirical study on Toulmin formalism found that "participants found
+it difficult to generate Toulmin structures, and their structures varied greatly
+even though they started with the same content"
+(https://www.mitre.org/news-insights/publication/empirical-evaluation-structured-argumentation-using-toulmin-argument).
+This template enforces all six components explicitly with prompts to counter
+that variance.
+
+---
+
+### Claim 1: Renaming expose_tau_context?/0 to fetch_expose_tau_context/0 and returning {ok, boolean()} | {error, cache_unavailable} satisfies the acceptance criterion
+
+- **Claim (C):** "`expose_tau_context?/0` returns a value that the caller can
+  use to distinguish 'setting is on', 'setting is off', and 'cache
+  unavailable'; callers in `maybe_start_tau_context/1` handle each case
+  explicitly without conflating cache failures with deliberate configuration."
+  (problem.md Acceptance criterion)
+- **Grounds (G):** The solution's `maybe_start_tau_context/1` rewrite
+  pattern-matches on all three tuple shapes: `{:ok, true}` → start context,
+  `{:ok, false}` → skip, `{:error, :cache_unavailable}` → telemetry + skip.
+  All three branches are distinct (solution.md §What changes; proposal-1.md
+  sketch lines 58–73). The current `dispatcher.ex:344–371` uses `if
+  expose_tau_context?()`, which is binary and conflates the third case with
+  the second.
+- **Warrant (W):** A tagged-tuple return type structurally encodes the three
+  distinguishable outcomes at the type level; the caller's exhaustive
+  pattern-match on the tag enforces explicit handling. An `if` over a boolean
+  cannot represent a third non-boolean outcome. (Elixir convention: `fetch_*`
+  returns `{:ok, v} | {:error, reason}`; `Map.fetch/2`, `Keyword.fetch/2`.)
+- **Qualifier (Q):** Holds for the private call chain within `dispatcher.ex`.
+  The acceptance criterion does not require the error to be visible to external
+  callers (all functions are private).
+- **Rebuttal (R):** If the `{:error, :cache_unavailable}` branch is never
+  reachable at runtime (see Claim 3), the structural distinction is present in
+  code but untriggerable in production, meaning the observability gain is
+  latent. The criterion would still be formally satisfied because the code path
+  exists and tests can exercise it via mocking.
+- **Backing (B):** problem.md §Acceptance criterion; OTP non-negotiable rule 7
+  ("Let it crash; supervise; restart" — tagged-tuple return is the idiomatic
+  non-crash alternative at private-function boundaries); SPEC-CODING-AGENT §4
+  (expose_tau_context semantics).
+
+#### Falsification attempt for claim 1
+
+- **Strategy:** Dependency check — verify that the acceptance criterion's
+  three-way distinguishability requirement is achievable with the proposed
+  return type under the actual SettingsCache contract.
+- **Attempt:** `SettingsCache.get/0` returns `%{}` as default (never raises;
+  see Claim 3 below). This means `{:error, :cache_unavailable}` is never
+  returned at runtime. The caller's `{:error, :cache_unavailable}` branch is
+  therefore structurally present but unreachable under normal operation. The
+  acceptance criterion says the caller "can use" the return to distinguish the
+  three cases — it does not say the third case is observable in production. A
+  test that mocks `SettingsCache.get/0` to raise can exercise the third branch.
+- **Outcome:** Withstood — the criterion is formal (structural distinguishability),
+  and the proposed type satisfies it. The dead branch does not falsify
+  satisfying the criterion.
+- **Action:** None. Note the rebuttal above in Outstanding Doubts.
+
+---
+
+### Claim 2: All changes are confined to dispatcher.ex; no public API is changed
+
+- **Claim (C):** "All changes are in a single private call chain, so the
+  migration is a single atomic commit." (solution.md §Migration sketch)
+- **Grounds (G):** `expose_tau_context?/0` is a `defp` (private) at
+  `dispatcher.ex:384`. `maybe_start_tau_context/1` is a `defp` at
+  `dispatcher.ex:344`. Neither is in the module's `@doc`-annotated public
+  surface. `lib/tau/settings/cache.ex` is explicitly listed as unchanged.
+  `Tau.CodingAgent.Supervisor` and `lib/tau/application.ex` are explicitly
+  listed as unchanged (solution.md §What does not change).
+- **Warrant (W):** Private functions in Elixir modules (`defp`) are not
+  accessible outside the module; renaming or changing their signature cannot
+  break any external caller. The OTP non-negotiable rule 8 ("Pure functions
+  are the default; processes are the exception") supports confining this change
+  to pure, private logic.
+- **Qualifier (Q):** Holds provided no other module in `lib/tau/` calls
+  `expose_tau_context?/0` or `maybe_start_tau_context/1` via a macro or
+  `:erlang.apply/3` dynamic dispatch, which would bypass Elixir's private
+  enforcement.
+- **Rebuttal (R):** Elixir's `defp` does not prevent `:erlang.apply/3` dynamic
+  calls from other modules, though this would be an anti-pattern. A grep
+  confirms no such call exists in this repo (see Falsification attempt).
+- **Backing (B):** Elixir language spec on module visibility; solution.md §What
+  does not change.
+
+#### Falsification attempt for claim 2
+
+- **Strategy:** Counter-example construction — search for cross-module
+  references to the private functions.
+- **Attempt:** `grep -rn "expose_tau_context\|maybe_start_tau_context"
+  lib/ test/` (executed above). Results: only `dispatcher.ex` at lines 338,
+  345, 384, 397, plus `tau_context.ex:6` (a `@moduledoc` mention, not a call).
+  No cross-module call site found.
+- **Outcome:** Withstood — no external caller found; the scope claim holds.
+- **Action:** None.
+
+---
+
+### Claim 3: The rescue/catch arms are load-bearing because SettingsCache.get/0 can raise when the cache process is absent
+
+- **Claim (C):** "SettingsCache failure mode: Proposal 1 notes with medium
+  confidence that `SettingsCache.get/0` actually raises (rather than returning
+  `{:error, _}`) when the process is absent." (solution.md §Open questions Q1)
+  The solution preserves `rescue`/`catch` in the proposed `fetch_expose_tau_context/0`
+  on this assumption. The proposal-1.md sketch also retains `rescue`/`catch`.
+- **Grounds (G):** `lib/tau/settings/cache.ex:28`: `def get, do:
+  :persistent_term.get(@persistent_key, %{})`. `:persistent_term.get/2` with a
+  default never raises — it returns the default when the key is absent
+  (Erlang/OTP `:persistent_term` module: `get(Key, Default)` always returns
+  `Default` when `Key` is not set). The `SettingsCache` GenServer's `init/1`
+  calls `:persistent_term.put(@persistent_key, settings)` at startup
+  (`cache.ex:32–34`), so the key is populated only after the GenServer starts.
+  Before that, `get/0` returns `%{}` via the default, not a raise.
+- **Warrant (W):** `:persistent_term.get/2` is a read from a global ETS-like
+  table managed by the runtime, with no process dependency. It does not consult
+  the `SettingsCache` GenServer on reads and therefore cannot crash because the
+  GenServer is absent. The `rescue`/`catch` arms guard against an exception that
+  the current implementation cannot produce.
+- **Qualifier (Q):** This claim is about the current `SettingsCache` implementation
+  as of `cache.ex` revision read above. If SettingsCache were changed to use a
+  `GenServer.call` on reads (e.g., if `:persistent_term` were replaced with a
+  direct ETS or a `call`-based API), the failure mode would change and the
+  `rescue` arms could become load-bearing.
+- **Rebuttal (R):** The problem.md §Context states "`SettingsCache.get/0` can
+  crash if the cache process is not started or its ETS table is absent during
+  test isolation or mis-sequenced startup." This was written as a statement of
+  fact, but it contradicts the actual implementation. The problem statement
+  is empirically wrong about the failure mode of the current code.
+- **Backing (B):** `lib/tau/settings/cache.ex:28` (read above); Erlang/OTP
+  `:persistent_term` module documentation (erlang.org/doc/man/persistent_term.html
+  — `get/2` returns Default when Key is not found, no exception); solution.md
+  §Open questions Q1 (self-noted "medium confidence").
+
+#### Falsification attempt for claim 3
+
+- **Strategy:** Dependency check — verify the actual failure mode of
+  `SettingsCache.get/0` by reading `lib/tau/settings/cache.ex`.
+- **Attempt:** Read `cache.ex` in full (read above). `get/0` is implemented as
+  `:persistent_term.get(@persistent_key, %{})`. This is a lock-free read from
+  the persistent-term table with `%{}` as the explicit default. There is no
+  `GenServer.call`, no ETS lookup that would raise on missing table, and no
+  code path that raises in `get/0`. Therefore the `rescue`/`catch` arms in the
+  current and proposed code guard against an exception that the current
+  implementation does not produce.
+- **Outcome:** Partially falsified — the claim that `rescue`/`catch` is
+  load-bearing because `SettingsCache.get/0` raises on cache-process absence
+  is false for the current implementation. The qualifier must be narrowed:
+  "the `rescue`/`catch` arms are defensive guards against a future
+  implementation change to SettingsCache, not against the current failure mode."
+- **Action:** Narrow qualifier in place. No solution revision required. The
+  solution's correctness is unaffected: retaining dead-code `rescue`/`catch`
+  is conservative and harmless. The open question Q1 in solution.md accurately
+  flags this uncertainty; the implementer should document the finding (as
+  solution.md already instructs). The problem.md §Context claim that
+  "SettingsCache.get/0 can crash if the cache process is not started" is
+  empirically wrong but does not invalidate the acceptance criterion or the fix.
+
+---
+
+### Claim 4: No external callers of maybe_start_tau_context/1 or expose_tau_context?/0 are affected
+
+- **Claim (C):** "External callers of `maybe_start_tau_context/1` — both
+  functions are private; no public API change." (solution.md §What does not
+  change)
+- **Grounds (G):** `expose_tau_context?/0` is `defp` at `dispatcher.ex:384`.
+  `maybe_start_tau_context/1` is `defp` at `dispatcher.ex:344`. Grep results
+  above show no cross-module call site.
+- **Warrant (W):** Same as Claim 2 warrant — Elixir `defp` enforces module-local
+  visibility at compile time; no other module can hold a reference that the
+  compiler would resolve.
+- **Qualifier (Q):** Absent dynamic dispatch (`apply/3`) cross-module, which the
+  grep confirmed is absent.
+- **Rebuttal (R):** Same caveat as Claim 2; no practical rebuttal found.
+- **Backing (B):** Elixir language spec; confirmed by grep above.
+
+#### Falsification attempt for claim 4
+
+- **Strategy:** Edge-case enumeration — consider whether test helpers or
+  macros could create cross-module references to private functions.
+- **Attempt:** Searched `test/` directory for references to
+  `maybe_start_tau_context` and `expose_tau_context` (grep above). No test
+  file references either function by name. No `ExUnit.Case` callback, no
+  `defmacro` injection found that would synthesize a call.
+- **Outcome:** Withstood — no external callers found in production or test code.
+- **Action:** None.
+
+---
+
+### Claim 5: The telemetry event name [:tau, :coding_agent, :tau_context, :settings_unavailable] follows the existing namespace convention
+
+- **Claim (C):** "Telemetry event name convention — the `:settings_unavailable`
+  event follows existing `[:tau, :coding_agent, ...]` namespace."
+  (solution.md §What does not change)
+- **Grounds (G):** `dispatcher.ex:361–366` emits
+  `[:tau, :coding_agent, :tau_context, :start_failed]` today. SPEC-CODING-AGENT
+  §4 lists `[:tau, :coding_agent, :start]`, `[:tau, :coding_agent, :event]`,
+  `[:tau, :coding_agent, :stop]`, `[:tau, :coding_agent, :exception]`. The
+  proposed event `[:tau, :coding_agent, :tau_context, :settings_unavailable]`
+  shares the `[:tau, :coding_agent, :tau_context, ...]` prefix with the existing
+  `:start_failed` event.
+- **Warrant (W):** OTP non-negotiable rule 5: "Telemetry events MUST cover
+  everything user-visible or perf-sensitive … in `[:tau, ...]`". The four-tuple
+  namespacing `[:tau, :coding_agent, :tau_context, :event_name]` is the
+  established pattern for tau-context lifecycle events within the coding-agent
+  subsystem.
+- **Qualifier (Q):** Holds for the naming convention; no claim is made about
+  there being a registered consumer. Solution.md §Open questions Q3 explicitly
+  flags the absence of a documented consumer.
+- **Rebuttal (R):** If a telemetry consumer does strict prefix-matching on
+  `[:tau, :coding_agent, :tau_context]`, the new event is automatically
+  captured. If consumers enumerate event names explicitly, the new event may
+  be silently dropped. The solution does not add a consumer.
+- **Backing (B):** OTP non-negotiable rule 5; `dispatcher.ex:361–366` (existing
+  `:start_failed` event establishing the prefix pattern); SPEC-CODING-AGENT §4
+  telemetry section.
+
+#### Falsification attempt for claim 5
+
+- **Strategy:** Edge-case enumeration — check whether any existing telemetry
+  consumer enumerates event names explicitly in a way that would exclude the
+  new event.
+- **Attempt:** Grep for telemetry consumers of the `[:tau, :coding_agent, ...]`
+  namespace in `lib/` and `test/`. The source map (SPEC-CODING-AGENT Appendix B)
+  does not list a dedicated telemetry consumer module for this namespace.
+  The event is fired and forgotten (fire-and-observe pattern); no consumer
+  exclusion would prevent the event from being emitted.
+- **Outcome:** Withstood — the naming claim holds. The absence of a consumer
+  is noted in solution.md §Open questions Q3 and does not falsify the naming
+  convention claim.
+- **Action:** None.
+
+---
+
+## Cross-claim consistency
+
+Claims 1 and 3 are in mild tension: Claim 1 argues the solution satisfies the
+acceptance criterion by structural distinguishability; Claim 3's partial
+falsification reveals the `:error` branch is unreachable in the current
+production implementation, meaning the test for the criterion must rely on
+mocking. This tension does not invalidate either claim — it shifts the
+verification burden from "observable in production" to "testable via mock" —
+but it should be documented in the PR (and solution.md §Open questions Q1
+already anticipates it). No irreconcilable contradiction between claims was
+found.
+
+---
+
+## Falsification summary
+
+| # | Claim (short) | Strategy | Outcome | Action |
+|---|---|---|---|---|
+| 1 | Rename + tagged tuple satisfies AC | Dependency check | Withstood | None |
+| 2 | All changes confined to dispatcher.ex | Counter-example construction | Withstood | None |
+| 3 | rescue/catch arms are load-bearing | Dependency check | Partially falsified | Narrow qualifier: arms are defensive, not currently triggered |
+| 4 | No external callers affected | Edge-case enumeration | Withstood | None |
+| 5 | Telemetry event follows namespace convention | Edge-case enumeration | Withstood | None |
+
+---
+
+## Revision required
+
+Claim 3 is partially falsified; qualifier narrowed in place. No solution or
+problem revision is required. The solution's recommendation remains sound:
+the tagged-tuple approach correctly satisfies the acceptance criterion.
+
+The problem.md §Context claim "SettingsCache.get/0 can crash if the cache
+process is not started" is empirically inaccurate for the current
+implementation, but this does not invalidate the acceptance criterion or the
+fix's correctness. The implementer must document this finding in the PR per
+solution.md §Open questions Q1.
+
+- **Target file:** N/A
+- **Revision kind:** N/A — qualifier narrowed in place; no file revision
+  triggered
+- **Rationale:** The falsification narrows the scope of claim 3 (arms are
+  conservative dead-code guards, not active error handlers) but does not change
+  the solution's correctness or the recommendation. Retaining dead-code
+  `rescue`/`catch` is harmless; the tagged-tuple form satisfies the criterion
+  under the actual implementation.
+
+---
+
+## Outstanding doubts
+
+1. **SettingsCache.get/0 never raises — test strategy.** The `{:error,
+   :cache_unavailable}` branch in the proposed `fetch_expose_tau_context/0`
+   is unreachable in production with the current `:persistent_term`-backed
+   implementation. The test case solution.md §Migration sketch specifies
+   ("SettingsCache raises → state unchanged + telemetry fired") will need to
+   mock or override `SettingsCache.get/0` to force a raise. The test is valid
+   and should be written (it protects against future `SettingsCache` contract
+   changes), but the PR should clarify how the mock is constructed and note
+   that the production path does not exercise this branch today.
+
+2. **problem.md §Context accuracy.** The statement "SettingsCache.get/0 can
+   crash if the cache process is not started or its ETS table is absent during
+   test isolation or mis-sequenced startup" is incorrect for the current
+   implementation (`:persistent_term.get/2` with default has no process
+   dependency). This is a minor documentation inaccuracy in the problem
+   statement; it does not affect the solution's validity but could mislead a
+   future reader of the problem tree. The coordinator may wish to log an
+   amendment to problem.md for historical accuracy.
+
+3. **Telemetry consumer gap.** The `:settings_unavailable` event is emitted
+   but has no documented consumer (solution.md §Open questions Q3). If the
+   event is the only signal of the fail-closed decision, silent degradation
+   goes unmonitored unless an operator has wired a telemetry sink. This is
+   not a blocker but should be tracked.

--- a/docs/problems-archive-v1-modules/tau-coding-agent/subproblems/tool-impl-rescue-ladders/problem.md
+++ b/docs/problems-archive-v1-modules/tau-coding-agent/subproblems/tool-impl-rescue-ladders/problem.md
@@ -1,0 +1,80 @@
+---
+template_version: 1
+template_name: problem
+node_kind: leaf
+depth: 1
+parent: ../../problem.md
+status: draft
+---
+
+# Problem: tools.ex rescue ladders make infrastructure errors indistinguishable from legitimate absences
+
+## Statement
+
+Three private helpers in `Tau.CodingAgent.TauContext.Tools`
+(`lib/tau/coding_agent/tau_context/tools.ex`) each wrap fallible operations in
+`rescue`/`catch` and return the same `{"available": false, "reason": "..."}` JSON
+envelope whether the failure is an infrastructure error (process crash, bad API
+shape) or a legitimate absence (feature not configured, session not found). A
+coding-agent subprocess that receives `available: false` cannot tell whether it
+should retry, report to the user, or accept a permanent limitation, because the
+error surface is identical for both classes.
+
+## Context
+
+- Lines 215–229 (`tau_session_status/1`): `Tau.Session.snapshot/1` can return
+  `{:error, :not_found}` (handled explicitly) but the surrounding `rescue`/`catch`
+  absorbs any other exception into `{"available": false, "reason": "snapshot error:
+  ..."}` — same envelope as a legitimately-absent session.
+- Lines 272–283 (`safe_memory_load/1`): wraps `MemoryLoader.load/1` in
+  `rescue`/`catch` and maps all errors to `{:error, "memory loader failed: ..."}`,
+  which the caller encodes as `{"available": false}` — same envelope as "no
+  memory files in cascade".
+- Lines 371–379 (`session_cwd/1`): `rescue`/`catch` around
+  `Tau.Session.snapshot/1` returns `nil`, which callers treat as "fall back to
+  `File.cwd!/0`" — silently masking a session ID lookup failure as a missing cwd.
+- D-035 comment in the module's `@moduledoc`: "Every public function in this
+  module catches its own errors and returns a tagged tuple." The private helpers
+  implement this contract, but the `rescue`/`catch` ladders absorb error
+  information rather than tagging it distinctly.
+- The three helpers are independent: `session_cwd/1` is called from
+  `tau_memory_query/2`; `safe_memory_load/1` is its inner helper; the
+  `tau_session_status/1` `rescue` block is self-contained. No fix to one
+  requires changes to another.
+
+## Complecting hypothesis
+
+1. Tool-response shaping is complected with optional-capability guarding:
+   each `rescue`/`catch` ladder maps both "infrastructure broke" and "feature
+   absent" to `{"available": false}`, so the two are indistinguishable at the
+   call site.
+2. `session_cwd/1`'s rescue block is complected with the cwd-fallback logic: a
+   session lookup crash and a `nil` session_id produce the same `nil` return,
+   pushing an undetected crash silently into the `File.cwd!/0` fallback.
+
+## Decomposition strategy
+
+(leaf — no further decomposition; proceed to proposals)
+
+## Acceptance criterion
+
+The three rescue sites in `tools.ex` are replaced with patterns where
+infrastructure errors (unexpected exceptions, thrown terms) produce a response
+that is structurally distinguishable from legitimate absences, or are removed
+because the calling code can rely on the OTP process model instead of
+pre-emptive rescue.
+
+## Out of scope
+
+- The `expose_tau_context?/0` rescue in `dispatcher.ex` (sibling sub-problem
+  `settings-feature-flag-access` owns that site).
+- The `close_port/1` rescue in `claude_code.ex` (sibling sub-problem
+  `port-lifecycle-rescue`).
+- The outer rescue in `Router.call/2` (sibling sub-problem `router-outer-rescue`).
+- Changes to the MCP wire format or the D-035 public contract.
+- The `safe_start/3` / `safe_cancel/2` adapter-boundary wrappers in
+  `dispatcher.ex` (excluded at root out-of-scope).
+
+## Amendment log
+
+- (none yet)

--- a/docs/problems-archive-v1-modules/tau-coding-agent/subproblems/tool-impl-rescue-ladders/proposals/proposal-1.md
+++ b/docs/problems-archive-v1-modules/tau-coding-agent/subproblems/tool-impl-rescue-ladders/proposals/proposal-1.md
@@ -1,0 +1,157 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 1
+parent_problem: ../problem.md
+---
+
+# Proposal 1: Tagged-error envelope — add an `"error_class"` field to distinguish infrastructure failures from legitimate absences
+
+## Approach
+
+Keep the three `rescue`/`catch` ladders structurally in place but change what
+they return: when an infrastructure exception is caught, encode an additional
+`"error_class": "infrastructure"` field alongside `"available": false`. Legitimate
+absences (`:not_found`, `nil` session_id, `Tau.Memory.Loader` not available) keep
+the current shape — `"available": false` with no `error_class` field (or
+explicitly `"error_class": "absent"`). Callers in the coding-agent subprocess can
+now branch on this field. `session_cwd/1` changes similarly: instead of returning
+bare `nil` on rescue, it returns a 2-tuple `{:error, :infrastructure}` that the
+call site in `tau_memory_query/2` tests explicitly before falling through to
+`File.cwd!/0`.
+
+## Rationale
+
+The complecting hypothesis identifies one concrete confusion: both error classes
+reach the caller via the same `{"available": false}` shape. This proposal
+decomplects them at the data-shape level — the existing rescue ladder stays but
+its output changes. It is the smallest change that satisfies the acceptance
+criterion ("structurally distinguishable"). It does not change the public D-035
+contract (callers still get `{:ok, JSON}`) and does not change how OTP supervises
+the subsystem. A subprocess coding agent can inspect `error_class` and decide to
+retry vs accept; the MCP wire format gains a documented extension point without
+breaking existing callers that ignore the new field.
+
+## Sketch
+
+```elixir
+# tools.ex — tau_session_status/1 rescue block becomes:
+rescue
+  e ->
+    {:ok,
+     encode(%{
+       "available" => false,
+       "error_class" => "infrastructure",
+       "reason" => "snapshot error: " <> Exception.message(e)
+     })}
+catch
+  kind, reason ->
+    {:ok,
+     encode(%{
+       "available" => false,
+       "error_class" => "infrastructure",
+       "reason" => "snapshot threw: #{inspect({kind, reason})}"
+     })}
+
+# safe_memory_load/1 rescue block becomes:
+rescue
+  e -> {:error, {:infrastructure, "memory loader failed: " <> Exception.message(e)}}
+catch
+  kind, reason ->
+    {:error, {:infrastructure, "memory loader threw: #{inspect({kind, reason})}"}}
+
+# tau_memory_query/2 call site — pattern match on the tagged error:
+{:error, {:infrastructure, reason}} ->
+  {:ok, encode(%{"available" => false, "error_class" => "infrastructure",
+                 "reason" => reason, "query" => query})}
+
+{:error, reason} when is_binary(reason) ->
+  {:ok, encode(%{"available" => false, "reason" => reason, "query" => query})}
+
+# session_cwd/1 returns {:error, :infrastructure} instead of nil:
+defp session_cwd(session_id) do
+  case Tau.Session.snapshot(session_id) do
+    {:ok, %{cwd: cwd}} when is_binary(cwd) -> {:ok, cwd}
+    _ -> {:ok, nil}
+  end
+rescue
+  _ -> {:error, :infrastructure}
+catch
+  _, _ -> {:error, :infrastructure}
+end
+
+# tau_memory_query/2 cwd resolution becomes:
+cwd =
+  Map.get(state, :cwd) ||
+    (case Map.get(state, :session_id) && session_cwd(Map.get(state, :session_id)) do
+       {:ok, cwd} -> cwd
+       {:error, :infrastructure} -> nil   # still falls through; now traceable
+       _ -> nil
+     end) ||
+    File.cwd!()
+```
+
+No new modules. No file moves. Three call sites change; the `encode/1` helper
+and the D-035 `{:ok, String.t()}` return type are both preserved.
+
+## Tradeoffs
+
+### Strengths
+
+- Satisfies the acceptance criterion with the minimum diff surface: three
+  `rescue` blocks and two call sites change, nothing else.
+- Backwards-compatible with existing coding-agent subprocess code that does not
+  yet inspect `error_class` — it is an additive field.
+- Preserves D-035's `{:ok, String.t()}` public contract verbatim.
+- `session_cwd/1` now returns a tagged tuple that is explicitly handled, so a
+  session-lookup crash no longer silently falls through to `File.cwd!/0` without
+  a visible decision.
+
+### Weaknesses
+
+- Does not remove the `rescue`/`catch` ladders — OTP non-negotiable §7 ("Let it
+  crash; supervise; restart") is still violated in principle. Infrastructure
+  errors are now observable but they are still absorbed, not propagated.
+- `session_cwd/1`'s `{:error, :infrastructure}` case still silently falls through
+  to `File.cwd!/0` in `tau_memory_query/2` — the difference is now that the
+  decision is explicit in code, but the behaviour for a caller that does not
+  handle the error branch is identical to the status quo.
+- Adds a coordination burden: future callers must know to check `error_class`, and
+  new `rescue` blocks added by other contributors may forget to add it.
+- No telemetry: infrastructure errors are now visible in the JSON but not logged
+  or counted anywhere; silent crashes remain invisible in production metrics.
+- `"error_class"` is an ad-hoc convention, not enforced by a type.
+
+### Costs
+
+- Diff is small: ~20 lines changed across three helpers and two call sites.
+- No new dependencies, no new modules.
+- The coding-agent subprocess protocol gains an undocumented extension; no SPEC
+  amendment is required by out-of-scope rules, but one should be filed for §4
+  D-035 to capture the new field semantics.
+
+## Dependencies
+
+- None: each of the three helpers is independent; the change is self-contained.
+- A SPEC-CODING-AGENT §3 amendment noting the `error_class` field would be good
+  practice but is not enforced as a blocker by spec-before-code.md (the D-035
+  public contract — `{:ok, String.t()}` — is unchanged).
+
+## Confidence
+
+medium — The change is simple and bounded, but the fact that it leaves the rescue
+ladders in place means it does not fully satisfy the spirit of OTP non-negotiable
+§7. Confidence would rise to high if the acceptance criterion is read strictly as
+"structurally distinguishable response shapes", and would lower to low if the
+criterion is interpreted as "callers can rely on the OTP process model instead of
+pre-emptive rescue".
+
+## Prior art / references
+
+- JSON:API `errors[].status` convention — structurally tagged error fields in
+  JSON payloads that coexist with success responses.
+- Elixir `{:error, {:tag, detail}}` pattern used throughout `Tau.CircuitBreaker`
+  and `Tau.Memory.Store` for multi-class error discrimination.
+- D-035 comment in `tools.ex` `@moduledoc`: "Every public function in this module
+  catches its own errors and returns a tagged tuple" — this proposal extends that
+  to the JSON envelope itself.

--- a/docs/problems-archive-v1-modules/tau-coding-agent/subproblems/tool-impl-rescue-ladders/proposals/proposal-2.md
+++ b/docs/problems-archive-v1-modules/tau-coding-agent/subproblems/tool-impl-rescue-ladders/proposals/proposal-2.md
@@ -1,0 +1,161 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 2
+parent_problem: ../problem.md
+---
+
+# Proposal 2: Remove the rescue ladders — let OTP handle infrastructure crashes, pattern-match only the expected tagged returns
+
+## Approach
+
+Delete all three `rescue`/`catch` blocks entirely. Replace each with explicit
+pattern matching on the known tagged-tuple returns that `Tau.Session.snapshot/1`
+and `MemoryLoader.load/1` already document. Infrastructure errors — crashes,
+thrown terms, API shape violations — now propagate up the call stack to the
+supervisor boundary, where the OTP process model handles them via restart. The
+`session_cwd/1` helper's rescue is replaced with a `:error` clause in the `case`
+match. `safe_memory_load/1` drops the outer `try` and relies on the caller to
+receive a well-documented crash if `MemoryLoader.load/1` throws something
+unexpected. The `tau_session_status/1` function handles `{:error, :not_found}`
+(which it already does) and nothing else; other errors propagate.
+
+## Rationale
+
+The acceptance criterion explicitly names "removed because the calling code can
+rely on the OTP process model instead of pre-emptive rescue" as a valid
+resolution path. The three helpers are all called from within a supervised MCP
+server process; if the process crashes on an unexpected infrastructure error, the
+supervisor restarts it, and the coding-agent subprocess gets a clean connection
+reset rather than a confusingly-shaped `available: false` response. This is
+exactly the OTP non-negotiable §7 contract. Removing the rescues also removes the
+complecting: "feature absent" is now the only code path that returns
+`{"available": false}`, so infrastructure errors become visible by the absence of
+a response (connection reset / process restart) rather than by a distinguishing
+field. No new types, no new fields, no new protocol.
+
+## Sketch
+
+```elixir
+# tau_session_status/1 — remove the rescue/catch entirely:
+def tau_session_status(%{session_id: id}) when is_binary(id) do
+  case Tau.Session.snapshot(id) do
+    {:ok, snap} ->
+      {:ok,
+       encode(%{
+         "available" => true,
+         "session_id" => snap.id,
+         "state" => Atom.to_string(snap.state),
+         "message_count" => snap.message_count,
+         "provider" => safe_inspect(snap.provider),
+         "model" => snap.model,
+         "cwd" => snap.cwd
+       })}
+
+    {:error, :not_found} ->
+      {:ok,
+       encode(%{
+         "available" => false,
+         "reason" => "session #{id} not registered (already stopped?)",
+         "session_id" => id
+       })}
+
+    # Any other return from snapshot/1 is an unexpected contract violation:
+    # let it crash — the supervisor handles it.
+  end
+end
+
+# safe_memory_load/1 — drop the try/rescue/catch, keep only the
+# Code.ensure_loaded? guard for the legitimate "not available" case:
+defp safe_memory_load(cwd) do
+  if Code.ensure_loaded?(MemoryLoader) and function_exported?(MemoryLoader, :load, 1) do
+    entries = MemoryLoader.load(cwd)
+    normalised = Enum.map(entries, fn {path, body} -> %{path: path, body: body} end)
+    {:ok, normalised}
+  else
+    {:error, "Tau.Memory.Loader not available"}
+  end
+end
+
+# session_cwd/1 — replace rescue with explicit pattern match:
+defp session_cwd(session_id) do
+  case Tau.Session.snapshot(session_id) do
+    {:ok, %{cwd: cwd}} when is_binary(cwd) -> cwd
+    {:error, :not_found} -> nil
+    {:error, _} -> nil
+    # Infrastructure crash propagates — supervisor restarts the process.
+  end
+end
+```
+
+File changes: only `lib/tau/coding_agent/tau_context/tools.ex`. Three sites, ~30
+lines deleted. No new modules, no new types.
+
+## Tradeoffs
+
+### Strengths
+
+- Fully satisfies OTP non-negotiable §7: infrastructure errors propagate to the
+  supervisor boundary rather than being absorbed.
+- Complecting is fully removed: `{"available": false}` now means only one thing —
+  legitimate absence. There is no ambiguity to distinguish.
+- Smallest code change by line count: deletions only, no new types or fields to
+  document.
+- No protocol change: `{"available": false}` shape is unchanged for all
+  legitimate-absence paths.
+
+### Weaknesses
+
+- A coding-agent subprocess observing a connection reset or process restart after
+  invoking a tool gets no structured reason for the failure. This is a user-facing
+  regression: currently a snapshot crash at least returns a `reason` string; after
+  this change the subprocess sees a hard failure with no error detail.
+- `session_cwd/1` is called mid-computation in `tau_memory_query/2`. A crash
+  there aborts the entire tool call, including the cwd fallback. The current
+  `nil`-return behaviour is undocumented but used by consumers; removing it is an
+  observable behaviour change even if it is "more correct".
+- `safe_memory_load/1` without a rescue is exposed to `MemoryLoader.load/1`
+  throwing non-Exception terms. Elixir's `rescue` catches only `Exception`-derived
+  structs; the current `catch kind, reason` guard also catches `:exit` and bare
+  throws. Without it, an `exit` from `MemoryLoader.load/1` propagates as an
+  unlinked exit signal, which may or may not be handled by the supervisor
+  depending on process link topology.
+- Requires downstream consumer (coding-agent subprocess) to handle hard connection
+  resets as a distinct error case — currently it only handles the soft
+  `available: false` path.
+
+### Costs
+
+- Pure deletion: ~30 lines removed, no new code.
+- The behaviour change for infrastructure errors is observable: subprocess code
+  that currently logs `reason` strings from `available: false` bodies will stop
+  seeing those messages and will instead see a connection-level failure.
+- If `MemoryLoader.load/1`'s exit behaviour is not documented, a test must be
+  written to confirm the supervisor restart semantics are correct. This is a
+  non-trivial test requirement.
+
+## Dependencies
+
+- Requires confirmation that the MCP server process supervising the `Tools` module
+  is configured for restart on crash (`:one_for_one` or similar) — otherwise
+  removing the rescue degrades resilience without a safety net.
+- Requires coding-agent subprocess protocol handling for connection resets, or
+  at minimum a documented decision that hard-resets on tool calls are acceptable.
+- If `MemoryLoader.load/1` can throw `:exit` terms, the supervision strategy for
+  the owning process must explicitly tolerate exit propagation.
+
+## Confidence
+
+medium — The OTP rationale is sound and fully aligns with the acceptance criterion
+and non-negotiable §7. Confidence is held at medium (not high) because the
+behavioural change to the subprocess error surface is real and the supervision
+topology of the MCP server process has not been verified in this audit.
+
+## Prior art / references
+
+- OTP non-negotiables §7 (`otp-non-negotiables.md`): "Let it crash; supervise;
+  restart. MUST NOT `try/rescue` across process boundaries."
+- Erlang/OTP supervisor documentation — processes should crash on unexpected
+  conditions and rely on supervisor restart for recovery.
+- Tau `Tau.CircuitBreaker` — does not wrap `Store` ETS reads in rescue; lets the
+  process crash on unexpected ETS errors.

--- a/docs/problems-archive-v1-modules/tau-coding-agent/subproblems/tool-impl-rescue-ladders/proposals/proposal-3.md
+++ b/docs/problems-archive-v1-modules/tau-coding-agent/subproblems/tool-impl-rescue-ladders/proposals/proposal-3.md
@@ -1,0 +1,196 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 3
+parent_problem: ../problem.md
+---
+
+# Proposal 3: Extract a `ToolResult` data type with distinct constructors for `:absent`, `:infrastructure_error`, and `:ok`
+
+## Approach
+
+Introduce a new private struct `Tau.CodingAgent.TauContext.Tools.ToolResult` (or
+a plain module with constructor functions) with three constructors:
+`ToolResult.ok/1`, `ToolResult.absent/2`, and `ToolResult.infrastructure_error/2`.
+Each constructor builds a map with a fixed `"result_kind"` field. The three
+rescue/catch sites are rewritten to use `ToolResult.infrastructure_error/2`; the
+existing legitimate-absence paths use `ToolResult.absent/2`; success paths use
+`ToolResult.ok/1`. The `encode/1` helper becomes `ToolResult.encode/1` and
+consumes the struct. `session_cwd/1` returns `{:infrastructure_error, message}`
+instead of `nil`, and the call site in `tau_memory_query/2` handles it explicitly.
+
+## Rationale
+
+Proposals 1 and 2 operate at opposite ends of the spectrum: Proposal 1 adds a
+field to existing untyped maps; Proposal 2 removes all rescues. This proposal
+takes a third axis — data-shape redesign — by introducing a typed result kind
+at the boundary between the three helpers and their callers. The complecting is
+removed not by deleting the rescue ladders or tagging their output ad-hoc, but by
+making the distinction structurally enforced in the Elixir type system: a function
+that returns `ToolResult.t()` cannot accidentally omit the kind. Future contributors
+adding new rescue blocks must choose a constructor, making the distinction a pit
+of success rather than a convention to remember. The D-035 contract (`{:ok,
+String.t()}`) is preserved because `ToolResult.encode/1` still returns a JSON
+string, and `result_kind` is an additive field in the wire format.
+
+## Sketch
+
+```elixir
+# New private module: lib/tau/coding_agent/tau_context/tools/tool_result.ex
+# (or defined inline via defmodule inside tools.ex if file count is a concern)
+
+defmodule Tau.CodingAgent.TauContext.Tools.ToolResult do
+  @moduledoc false
+
+  @type kind :: :ok | :absent | :infrastructure_error
+  @type t :: %{
+    required(:result_kind) => String.t(),  # "ok" | "absent" | "infrastructure_error"
+    required(:available) => boolean(),
+    optional(:reason) => String.t(),
+    optional(:error_class) => String.t()
+  }
+
+  @spec ok(map()) :: t()
+  def ok(fields) when is_map(fields) do
+    Map.merge(fields, %{"result_kind" => "ok", "available" => true})
+  end
+
+  @spec absent(String.t(), keyword()) :: t()
+  def absent(reason, extra \\ []) when is_binary(reason) do
+    Map.merge(
+      Map.new(extra, fn {k, v} -> {Atom.to_string(k), v} end),
+      %{"result_kind" => "absent", "available" => false, "reason" => reason}
+    )
+  end
+
+  @spec infrastructure_error(String.t(), keyword()) :: t()
+  def infrastructure_error(reason, extra \\ []) when is_binary(reason) do
+    Map.merge(
+      Map.new(extra, fn {k, v} -> {Atom.to_string(k), v} end),
+      %{
+        "result_kind" => "infrastructure_error",
+        "available" => false,
+        "error_class" => "infrastructure",
+        "reason" => reason
+      }
+    )
+  end
+end
+
+# tau_session_status/1 rescue block:
+rescue
+  e ->
+    {:ok, encode(ToolResult.infrastructure_error(
+      "snapshot error: " <> Exception.message(e)
+    ))}
+catch
+  kind, reason ->
+    {:ok, encode(ToolResult.infrastructure_error(
+      "snapshot threw: #{inspect({kind, reason})}"
+    ))}
+
+# tau_session_status/1 legitimate-absence path:
+{:error, :not_found} ->
+  {:ok, encode(ToolResult.absent(
+    "session #{id} not registered (already stopped?)",
+    session_id: id
+  ))}
+
+# safe_memory_load/1 rescue:
+rescue
+  e -> {:error, {:infrastructure, "memory loader failed: " <> Exception.message(e)}}
+catch
+  k, r -> {:error, {:infrastructure, "memory loader threw: #{inspect({k, r})}"}}
+
+# tau_memory_query/2 call site:
+{:error, {:infrastructure, reason}} ->
+  {:ok, encode(ToolResult.infrastructure_error(reason, query: query))}
+
+{:error, reason} when is_binary(reason) ->
+  {:ok, encode(ToolResult.absent(reason, query: query))}
+
+# session_cwd/1:
+defp session_cwd(session_id) do
+  case Tau.Session.snapshot(session_id) do
+    {:ok, %{cwd: cwd}} when is_binary(cwd) -> {:ok, cwd}
+    _ -> {:absent, nil}
+  end
+rescue
+  e -> {:infrastructure_error, Exception.message(e)}
+catch
+  _, _ -> {:infrastructure_error, "session_cwd threw"}
+end
+```
+
+File changes:
+- `lib/tau/coding_agent/tau_context/tools.ex` — three rescue sites rewritten.
+- `lib/tau/coding_agent/tau_context/tools/tool_result.ex` — new private module
+  (~40 lines). Alternatively, define the module inline in `tools.ex` to avoid
+  a new file.
+
+## Tradeoffs
+
+### Strengths
+
+- Structurally enforces the distinction: a developer adding a new rescue block
+  is forced to choose `absent/2` or `infrastructure_error/2` — no accidental
+  conflation is possible.
+- Makes the wire format's `result_kind` field a first-class, inspectable artifact;
+  coding-agent subprocesses gain a stable discriminator without relying on ad-hoc
+  field presence.
+- Full backwards-compatibility: `"available": false` is still present in all
+  non-ok responses; `result_kind` is additive.
+- Dialyzer can type-check the constructors; spec violations surface at compile
+  time rather than at runtime.
+- The D-035 `{:ok, String.t()}` contract is preserved.
+
+### Weaknesses
+
+- Introduces a new module and a new concept (`ToolResult`) that callers outside
+  this file (the coding-agent subprocess protocol, SPEC-CODING-AGENT) must be
+  aware of, even though it is private.
+- The rescue ladders are still present — OTP non-negotiable §7 is still
+  technically violated, same as Proposal 1.
+- `result_kind` in the JSON wire format is undocumented in D-035; a SPEC
+  amendment is needed to avoid it becoming an undocumented extension.
+- The `session_cwd/1` call site change in `tau_memory_query/2` is more verbose
+  than the current `|| nil` chain, which may be seen as an unnecessary increase
+  in cognitive load for a private helper.
+- Adding a file introduces a small coordination overhead (code review, test
+  coverage expectation for the new module).
+
+### Costs
+
+- ~40 new lines in `tool_result.ex`; ~25 lines changed in `tools.ex`.
+- A SPEC-CODING-AGENT §3 amendment should document `result_kind` semantics —
+  this is not enforced as a blocker but is the responsible move.
+- No new dependencies. No build impact.
+- If the `ToolResult` module lives in a separate file, test coverage expectations
+  may include a unit test of the constructors; these are trivial but take time.
+
+## Dependencies
+
+- None blocking. All three helpers are independent; the data-shape change can
+  land in one PR.
+- A SPEC-CODING-AGENT §3 amendment is recommended but not required by
+  spec-before-code.md (D-035's `{:ok, String.t()}` return is unchanged).
+
+## Confidence
+
+medium — The data-type approach is well-established (cf. Rust `Result<Ok, Err>`
+constructor pattern, Elixir `{:ok, _} | {:error, _}` conventions). Confidence is
+medium rather than high because introducing a new module for what is ultimately a
+JSON-building convention may be judged over-engineered relative to the problem
+scope; a code reviewer familiar with the codebase may prefer Proposal 1's
+lighter touch.
+
+## Prior art / references
+
+- Elixir `Ecto.Changeset` — typed result constructors that enforce invariants at
+  the data-shape level rather than relying on conventions in callers.
+- Rust `thiserror` crate — distinct error variants at the type level to make
+  error-class handling structurally enforced.
+- `Tau.Provider.Event` (referenced in `otp-non-negotiables.md`) — typed event
+  structs that prevent ad-hoc field additions to provider event maps.
+- JSON:API `errors[].status` — a standardised `result_kind`-equivalent in REST
+  API design.

--- a/docs/problems-archive-v1-modules/tau-coding-agent/subproblems/tool-impl-rescue-ladders/proposals/proposal-4.md
+++ b/docs/problems-archive-v1-modules/tau-coding-agent/subproblems/tool-impl-rescue-ladders/proposals/proposal-4.md
@@ -1,0 +1,209 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 4
+parent_problem: ../problem.md
+---
+
+# Proposal 4: Telemetry-instrumented rescue — emit `[:tau, :tools, :infrastructure_error]` events and preserve hard-fail propagation for critical paths
+
+## Approach
+
+Rewrite the three rescue sites as a two-tier strategy keyed on error severity:
+
+1. For **`tau_session_status/1`** and **`safe_memory_load/1`** (non-critical
+   convenience tools): keep the rescue but emit a `[:tau, :tools,
+   :infrastructure_error]` telemetry event with `%{tool: atom(), reason: term()}`
+   metadata before returning `{"available": false}`. The JSON response gains a
+   `"result_kind"` discriminator field (as in Proposal 3) but the rescue stays
+   to preserve soft-fail semantics for these tools.
+
+2. For **`session_cwd/1`** (a cwd-resolution helper that silently biases
+   downstream logic): remove the rescue entirely and propagate the crash. This is
+   the one site where silent failure is actively harmful — `File.cwd!/0` fallback
+   on a session-lookup crash is a latent correctness bug. The crash propagates to
+   the MCP server supervisor, which restarts the process. A telemetry event is
+   emitted before the rescue is removed via a `try/after` idiom (no `rescue`) to
+   record the crash context before propagation.
+
+This is a hybrid: the two "soft" sites become telemetry-observable; the one
+"hard" site becomes correctly OTP-crash-propagating.
+
+## Rationale
+
+The three rescue sites are not equally harmful. `tau_session_status/1` returning
+`available: false` on a crash is awkward but tolerable — the user-facing session
+status tool failing with a soft response is not catastrophic. `safe_memory_load/1`
+similarly: a memory query returning empty is a degraded-mode behaviour that a
+subprocess can handle. But `session_cwd/1`'s rescue is qualitatively different:
+it silently redirects all downstream computation to use `File.cwd!/0` instead of
+the session-bound cwd, which is a correctness error, not a graceful degradation.
+This proposal decomplects by *kind of harm* rather than uniformly applying one
+strategy. The telemetry events make the soft-fail sites visible in production
+metrics and logs, turning the "silent swallow" into an observable event without
+changing the wire format for either soft-fail site.
+
+## Sketch
+
+```elixir
+# New telemetry event in tau_session_status/1:
+rescue
+  e ->
+    :telemetry.execute(
+      [:tau, :tools, :infrastructure_error],
+      %{count: 1},
+      %{tool: :tau_session_status, reason: Exception.message(e), kind: :exception}
+    )
+    {:ok,
+     encode(%{
+       "available" => false,
+       "result_kind" => "infrastructure_error",
+       "reason" => "snapshot error: " <> Exception.message(e)
+     })}
+catch
+  kind, reason ->
+    :telemetry.execute(
+      [:tau, :tools, :infrastructure_error],
+      %{count: 1},
+      %{tool: :tau_session_status, reason: inspect({kind, reason}), kind: :throw}
+    )
+    {:ok,
+     encode(%{
+       "available" => false,
+       "result_kind" => "infrastructure_error",
+       "reason" => "snapshot threw: #{inspect({kind, reason})}"
+     })}
+
+# safe_memory_load/1 — same telemetry pattern:
+rescue
+  e ->
+    :telemetry.execute([:tau, :tools, :infrastructure_error], %{count: 1},
+      %{tool: :safe_memory_load, reason: Exception.message(e), kind: :exception})
+    {:error, "memory loader failed: " <> Exception.message(e)}
+catch
+  k, r ->
+    :telemetry.execute([:tau, :tools, :infrastructure_error], %{count: 1},
+      %{tool: :safe_memory_load, reason: inspect({k, r}), kind: :throw})
+    {:error, "memory loader threw: #{inspect({k, r})}"}
+
+# session_cwd/1 — rescue removed; crash propagates:
+defp session_cwd(session_id) do
+  case Tau.Session.snapshot(session_id) do
+    {:ok, %{cwd: cwd}} when is_binary(cwd) -> cwd
+    {:error, :not_found} -> nil
+    {:error, _reason} -> nil
+    # Unexpected return (e.g. malformed snapshot): pattern-match
+    # exhaustion raises a CaseClauseError — supervisor handles it.
+  end
+  # No rescue/catch. Infrastructure crash propagates to supervisor.
+end
+
+# tau_memory_query/2 — add a telemetry-safe wrapper so session_cwd/1
+# crashes are observable before propagating:
+cwd =
+  Map.get(state, :cwd) ||
+    case Map.get(state, :session_id) do
+      nil -> nil
+      sid -> session_cwd(sid)   # crash propagates here if session_cwd/1 raises
+    end ||
+    File.cwd!()
+```
+
+Telemetry attachment (existing `OtelReporter` or `Logger`-based handler can
+subscribe):
+```elixir
+# In application startup or test setup:
+:telemetry.attach(
+  "tau-tools-infra-error-logger",
+  [:tau, :tools, :infrastructure_error],
+  fn event, measurements, metadata, _config ->
+    Logger.warning("tools infrastructure error",
+      tool: metadata.tool,
+      reason: metadata.reason,
+      kind: metadata.kind
+    )
+  end,
+  nil
+)
+```
+
+File changes:
+- `lib/tau/coding_agent/tau_context/tools.ex` — three sites; ~20 lines changed,
+  ~15 lines added (telemetry calls).
+- No new modules; telemetry handler attachment belongs in
+  `lib/tau/application.ex` or `lib/tau/otel_reporter.ex`.
+
+## Tradeoffs
+
+### Strengths
+
+- Differentiates by actual harm profile: the one site where silent failure causes
+  correctness bugs (`session_cwd/1`) is fully fixed via OTP crash propagation.
+- Infrastructure errors at the soft-fail sites become observable in production
+  metrics and logs without changing the wire format for the subprocess caller.
+- `result_kind` field makes the JSON structurally discriminable (same benefit as
+  Proposals 1 and 3).
+- Telemetry is already a first-class citizen in Tau (`[:tau, ...]` namespace);
+  this follows an established pattern.
+- The D-035 `{:ok, String.t()}` contract is preserved for `tau_session_status/1`
+  and `tau_memory_query/2`.
+
+### Weaknesses
+
+- The soft-fail rescue sites still violate OTP non-negotiable §7 in principle —
+  they are now *observed* violations rather than silent ones.
+- Applying different strategies to different sites requires documentation: a
+  future reader must understand why `session_cwd/1` does not rescue but the other
+  two do. Without inline comments or a SPEC note, this looks inconsistent.
+- Telemetry handler attachment adds a new wiring concern: if the handler is not
+  attached, events fire and are silently dropped — the observability benefit
+  disappears without any compile-time warning.
+- The `session_cwd/1` crash propagation changes the behaviour of `tau_memory_query/2`:
+  a previously soft-recoverable cwd-lookup failure now aborts the tool call. This
+  is the *correct* behaviour, but it is a user-visible change.
+- Adds `:telemetry` calls to private helpers — telemetry instrumentation is
+  typically on public boundaries, not private functions; this may be seen as
+  over-instrumentation.
+
+### Costs
+
+- ~35 lines changed or added in `tools.ex`.
+- Telemetry handler registration: ~10 lines in `application.ex` or
+  `otel_reporter.ex`.
+- OTP non-negotiable §5: "Telemetry events MUST cover everything user-visible or
+  perf-sensitive" — this is arguable for private helpers, so the SPEC-OTEL-REPORTER
+  scope may need an amendment noting these events.
+- A property test confirming `session_cwd/1` crash propagation would be required
+  by spec-before-code.md if the change touches a SPEC boundary.
+
+## Dependencies
+
+- `Tau.OtelReporter` (or equivalent telemetry consumer) must be configured to
+  subscribe to `[:tau, :tools, :infrastructure_error]` for the observability
+  benefit to materialise; without this, telemetry fires into a vacuum.
+- SPEC-OTEL-REPORTER §3 may need an amendment if the telemetry handler is wired
+  into the reporter.
+- Supervision topology confirmation: same as Proposal 2 — confirming that the MCP
+  server process is supervised before removing `session_cwd/1`'s rescue.
+
+## Confidence
+
+medium — The hybrid strategy is principled (different sites have genuinely
+different harm profiles), but the inconsistency it introduces requires careful
+documentation and is a maintenance burden. Confidence would rise to high if there
+is a documented policy in SPEC-CODING-AGENT that explicitly classifies tool call
+sites as "soft-fail permitted" vs "must propagate", making the asymmetry a
+governed choice rather than a local judgement.
+
+## Prior art / references
+
+- Tau `otp-non-negotiables.md` §5: "Telemetry events MUST cover everything
+  user-visible or perf-sensitive" — used here as the observability hook for
+  absorbed infrastructure errors.
+- Erlang/OTP `:telemetry` library — standard BEAM observability substrate;
+  used throughout `lib/tau/` already.
+- Phoenix `Endpoint.call/2` error handling — uses a two-tier rescue (hard for
+  Plug.Conn shape violations; soft for request-level errors) as a precedent for
+  asymmetric rescue strategies within one module.
+- `Tau.Session` FSM event telemetry (`[:tau, :session, ...]`) — existing
+  precedent for per-event telemetry instrumentation inside Tau.

--- a/docs/problems-archive-v1-modules/tau-coding-agent/subproblems/tool-impl-rescue-ladders/solution.md
+++ b/docs/problems-archive-v1-modules/tau-coding-agent/subproblems/tool-impl-rescue-ladders/solution.md
@@ -1,0 +1,152 @@
+---
+template_version: 1
+template_name: solution
+parent_problem: problem.md
+node_kind: leaf
+synthesised_from: [proposals/proposal-1.md, proposals/proposal-2.md, proposals/proposal-4.md]
+selection_method: hybrid
+revision: 0
+---
+
+# Solution: Asymmetric rescue removal — drop session_cwd/1 rescue, tag soft-fail sites distinctly
+
+## Recommendation
+
+Remove the `rescue`/`catch` block from `session_cwd/1` entirely and let the
+crash propagate to the supervisor. For `tau_session_status/1` and
+`safe_memory_load/1`, retain the rescue but change the return shape: add
+`"result_kind": "infrastructure_error"` alongside the existing
+`"available": false` field (Proposal 1's tagging, not Proposal 3's new type).
+Add a single telemetry call per rescue branch — `[:tau, :tools,
+:infrastructure_error]` — to make absorbed errors visible in production
+(Proposal 4's observability, scoped only to the retained soft-fail sites).
+This hybrid satisfies the acceptance criterion (structurally distinguishable
+responses), respects the two valid resolution paths named therein (distinguishable
+envelope OR reliance on OTP process model), and allocates each strategy to the
+site where it fits the harm profile.
+
+## Selected from
+
+- **Chosen:** hybrid of `proposals/proposal-1.md`, `proposals/proposal-2.md`,
+  and `proposals/proposal-4.md`
+- **Why chosen:** The three sites are not equivalent in harm profile. `session_cwd/1`
+  silently redirects all downstream cwd computation to `File.cwd!/0` on crash —
+  this is a correctness error, not degraded-mode behaviour. Proposal 2 is
+  correct for this site: remove the rescue, let it crash, let the supervisor
+  restart. The other two sites (`tau_session_status/1`, `safe_memory_load/1`)
+  return tool-level `available: false` responses; their soft-fail behaviour is
+  tolerable for a coding-agent subprocess (the subprocess can observe the reason
+  field and decide). Proposal 1's minimal tagging (`"result_kind"`) satisfies
+  the acceptance criterion — structurally distinguishable — at the lowest diff
+  cost. Proposal 4's telemetry addition is taken only for the retained soft-fail
+  sites, making absorbed infrastructure errors observable without adding it to a
+  site that no longer absorbs anything.
+
+  Proposal 3 (new `ToolResult` module) is not selected: it solves the same
+  problem as Proposal 1 at higher migration cost (new file, new concept) without
+  adding decomplecting depth. The type-enforcement benefit is real but
+  disproportionate to the problem scope — three private helpers, not an
+  extensibility seam. Proposal 4's full strategy is not selected wholesale:
+  applying telemetry to `session_cwd/1` before crash propagation is unnecessary
+  overhead; the crash itself is the observable event.
+
+## Scoring table
+
+| # | Fit | Decomplecting depth | Migration cost | Risk | Reversibility |
+|---|-----|---------------------|---------------|------|---------------|
+| 1 | Yes | Surface (tags, rescues stay) | Low (~20 lines) | Low | Easy |
+| 2 | Yes | Deep (`session_cwd/1` site) / Partial (others unaddressed) | Low (deletions) | Medium (subprocess observes hard resets) | Easy |
+| 3 | Yes | Surface (rescues stay, types added) | Medium (~65 lines + new file) | Low | Easy |
+| 4 | Yes | Deep (`session_cwd/1`) + Surface (others) | Medium (~45 lines + otel wiring) | Low | Easy |
+| **Hybrid 1+2+4** | **Yes** | **Deep for session_cwd/1; Surface for soft-fail sites** | **Low (~35 lines total)** | **Low** | **Easy** |
+
+## What changes
+
+- `lib/tau/coding_agent/tau_context/tools.ex`:
+  - `tau_session_status/1` rescue and catch branches: add `"result_kind" =>
+    "infrastructure_error"` to the returned map and emit
+    `:telemetry.execute([:tau, :tools, :infrastructure_error], ...)` before
+    returning.
+  - `safe_memory_load/1` rescue and catch branches: add telemetry emit; the
+    return type stays `{:error, binary()}` — caller in `tau_memory_query/2`
+    remains unchanged (it already encodes the error as `available: false`).
+    Additionally add `"result_kind" => "infrastructure_error"` to the map the
+    caller encodes, so the wire format is distinguishable. This requires a small
+    change at the `tau_memory_query/2` call site: pattern-match
+    `{:error, reason}` and produce `%{"available" => false, "result_kind" =>
+    "infrastructure_error", "reason" => reason}` rather than the current bare
+    `available: false` map (which did not carry `result_kind`).
+  - `session_cwd/1`: delete the `rescue`/`catch` block entirely. The `case`
+    match is extended to handle `{:error, :not_found}` → `nil` and
+    `{:error, _}` → `nil` explicitly (Proposal 2's pattern). Unexpected returns
+    (non-`:ok`/non-`:error` from `snapshot/1`) raise `CaseClauseError` — OTP
+    propagates this to the supervisor.
+  - Legitimate-absence paths: no change to return shapes.
+  - No new modules, no new files.
+- `lib/tau/application.ex` (or `lib/tau/otel_reporter.ex`): attach a telemetry
+  handler for `[:tau, :tools, :infrastructure_error]` that emits a `Logger.warning`.
+  This is the minimal wiring that prevents telemetry from firing into a vacuum.
+
+## What does not change
+
+- The D-035 public contract: every public function still returns `{:ok, String.t()}`.
+- The `"available": false` field on legitimate-absence responses — no shape change
+  for `:not_found`, unloaded `MemoryLoader`, or `nil` session_id.
+- The MCP wire format's existing fields. `"result_kind"` is additive; existing
+  subprocess consumers that do not inspect it are unaffected.
+- The `tau_session_status/1` behaviour for `{:error, :not_found}` — still returns
+  the current soft-absent envelope.
+- `safe_memory_load/1`'s behaviour for the `MemoryLoader` availability guard —
+  the `Code.ensure_loaded?` path stays as is.
+- The three helpers' independence from each other. Each change is self-contained.
+
+## Migration sketch
+
+Land in a single PR touching only `tools.ex` and one of the OTP startup files.
+Order: (1) delete `session_cwd/1` rescue — immediately OTP-correct and
+independently testable; (2) add `"result_kind"` tagging to the two soft-fail
+rescue sites plus the `tau_memory_query/2` call site for `safe_memory_load/1`;
+(3) add telemetry emits to the retained rescue branches; (4) attach the
+telemetry handler in `application.ex`. No callers outside `tools.ex` change.
+The existing `tau_session_status/1` and `tau_memory_query/2` property tests
+(if present) should still pass; a new property test asserting that an injected
+`snapshot/1` crash propagates out of `session_cwd/1` (rather than returning
+`nil`) confirms step 1.
+
+## Open questions
+
+- **Supervision topology:** Proposal 2 flagged that the MCP server process owning
+  these helpers must be configured for restart. This is a pre-condition for step 1
+  (removing `session_cwd/1` rescue). Verify before landing.
+- **`MemoryLoader.load/1` exit semantics:** if `MemoryLoader.load/1` can throw
+  bare `:exit` terms, the soft-fail rescue in `safe_memory_load/1` absorbs them
+  (currently). Retaining that rescue preserves this absorption. If the goal is
+  full OTP compliance, `safe_memory_load/1`'s `catch kind, reason` branch should
+  be assessed separately. Not in scope of this solution unless the validator raises it.
+- **SPEC-CODING-AGENT amendment:** `"result_kind"` is now a wire-format field that
+  subprocess callers can rely on. A §3 amendment to document the semantics is
+  warranted; this solution does not block on it (D-035's `{:ok, String.t()}`
+  contract is unchanged) but recommends it.
+- **Telemetry handler placement:** `application.ex` vs `otel_reporter.ex` is a
+  codebase-convention question not resolved here. Either is acceptable; the
+  important invariant is that the attachment happens before the tools process
+  starts.
+
+## Linked sub-problems / proposals
+
+- `proposals/proposal-1.md` — Tagged `"error_class"` field added to rescue
+  branches; rescues retained. Selected for: the `"result_kind"` tagging pattern
+  applied to the two soft-fail sites.
+- `proposals/proposal-2.md` — Delete all rescues; OTP crash propagation. Selected
+  for: the `session_cwd/1` rescue removal.
+- `proposals/proposal-3.md` — Introduce `ToolResult` typed constructors. Not
+  selected: over-engineered relative to scope; adds a new module for what is
+  achievable with additive field changes.
+- `proposals/proposal-4.md` — Telemetry-instrumented rescue + `session_cwd/1`
+  crash propagation. Selected for: telemetry attachment pattern at retained
+  soft-fail sites. Not selected wholesale: telemetry on `session_cwd/1` before
+  crash propagation is unnecessary.
+
+## Revision history
+
+- (revision 0 — initial)

--- a/docs/problems-archive-v1-modules/tau-coding-agent/subproblems/tool-impl-rescue-ladders/validation.md
+++ b/docs/problems-archive-v1-modules/tau-coding-agent/subproblems/tool-impl-rescue-ladders/validation.md
@@ -1,0 +1,410 @@
+---
+template_version: 1
+template_name: validation
+parent_solution: solution.md
+parent_problem: problem.md
+toulmin_complete: true
+falsification_attempted: true
+falsification_outcome: partially_falsified — claim/4
+revision_triggered: none
+---
+
+# Validation: Asymmetric rescue removal — drop session_cwd/1 rescue, tag soft-fail sites distinctly
+
+## Overview
+
+The solution advances five checkable propositions: (1) removing `session_cwd/1`'s
+rescue block makes crash propagation OTP-correct; (2) the `case` extension to
+`{:error, _} → nil` preserves legitimate-absence behaviour; (3) adding
+`"result_kind": "infrastructure_error"` makes soft-fail responses structurally
+distinguishable; (4) emitting `[:tau, :tools, :infrastructure_error]` telemetry
+makes absorbed errors observable; (5) the D-035 public contract is preserved
+unchanged. Six claims are enumerated (claims 1–5 map 1:1; claim 6 covers the
+cross-cutting "no callers outside tools.ex change" assertion). Falsification uses
+edge-case enumeration (claims 1, 2, 5, 6), dependency check (claim 3),
+integration check (claim 4), and counter-example construction (claim 2, supplementary).
+Four claims withstand; claim 4 is partially falsified — the telemetry handler
+placement is unresolved and the solution acknowledges this as an open question.
+No revision is triggered because the qualifier is narrowed in place and the
+open question is already documented in `solution.md §Open questions`.
+
+---
+
+## Toulmin per claim
+
+The MITRE empirical study on Toulmin formalism found that "participants found it
+difficult to generate Toulmin structures, and their structures varied greatly even
+though they started with the same content"
+(https://www.mitre.org/news-insights/publication/empirical-evaluation-structured-argumentation-using-toulmin-argument).
+This template enforces all six components explicitly with prompts to counter that
+variance.
+
+---
+
+### Claim 1: Removing session_cwd/1's rescue block is OTP-correct because TauContext is supervised and `:temporary`
+
+- **Claim (C):** "Remove the `rescue`/`catch` block from `session_cwd/1` entirely
+  and let the crash propagate to the supervisor."
+- **Grounds (G):**
+  - `lib/tau/coding_agent/tau_context.ex:51` — `use GenServer, restart: :temporary`.
+    TauContext is therefore a supervised process; crashes propagate to `Tau.CodingAgent.Supervisor`
+    (a `DynamicSupervisor`, `lib/tau/coding_agent/supervisor.ex:20`) without
+    triggering unwanted restart storms (`:temporary` means the DynamicSupervisor
+    does not restart on any exit reason).
+  - `lib/tau/coding_agent/tau_context.ex:212–214` — TauContext monitors its owner
+    Dispatcher and stops itself (`:normal`) when the Dispatcher dies. This confirms
+    the TauContext lifetime is bounded to the Dispatcher lifetime; a crash from
+    `session_cwd/1` propagates up through the GenServer's handle_call/handle_cast
+    stack to the TauContext process, which then exits and cleans up via `terminate/2`.
+  - `lib/tau/coding_agent/tau_context/router.ex:271` — `Tools.call/3` is invoked
+    from the Router, which runs inside the TauContext GenServer (or its HTTP handler);
+    crashes in `Tools` therefore propagate to that process boundary.
+- **Warrant (W):** OTP non-negotiable #7 ("let it crash; supervise; restart") holds
+  that `rescue`/`catch` across process boundaries suppresses crash semantics the
+  supervisor relies on. A `:temporary`-restart supervised process that absorbs its
+  own crashes silently redirects control flow rather than terminating; the solution
+  restores the OTP model for the `session_cwd/1` call site.
+- **Qualifier (Q):** Holds when TauContext is started via a supervisor (normal
+  production and test paths with `start_link`). Does not apply to the bare,
+  unsupervised `start_link` test in `tau_context_test.exs:21` — but crashes in
+  that context propagate to the test process, which is itself supervised by
+  ExUnit.
+- **Rebuttal (R):** If `session_cwd/1` is called from a process that is NOT
+  supervised (e.g. a bare Task not under a supervisor), a crash would take down the
+  unsupervised process without a restart. The code audit scope is the supervised
+  TauContext path, so this rebuttal is noted but does not falsify the claim in scope.
+- **Backing (B):** OTP non-negotiable #7 (`CLAUDE.md` / `TAU.md`). Also
+  `lib/tau/coding_agent/dispatcher.ex:36` comment: "silent supervisor restart" is
+  the documented intent for the TauContext lifecycle.
+
+#### Falsification attempt for claim 1
+
+- **Strategy:** edge-case enumeration
+- **Attempt:** Enumerated cases where the supervision pre-condition fails: (a)
+  TauContext started outside a supervisor — found to be only the test case at
+  `tau_context_test.exs:21`, which propagates to ExUnit's own supervisor; (b)
+  `session_cwd/1` called outside TauContext — not found; it is `defp` and all
+  callers are within `tools.ex` which executes inside the TauContext HTTP handler
+  (router.ex). (c) `:temporary` restart means no restart on crash — confirmed from
+  `tau_context.ex:51`; the TauContext dies and the Dispatcher proceeds without a
+  fresh TauContext. This is the intended behaviour per the module comment at line 22.
+- **Outcome:** withstood — no edge case falsifies the claim within documented scope.
+- **Action:** none.
+
+---
+
+### Claim 2: Extending the case match to `{:error, :not_found} → nil` and `{:error, _} → nil` preserves legitimate-absence behaviour
+
+- **Claim (C):** "The `case` match is extended to handle `{:error, :not_found}` → `nil`
+  and `{:error, _}` → `nil` explicitly (Proposal 2's pattern). Unexpected returns
+  (non-`:ok`/non-`:error` from `snapshot/1`) raise `CaseClauseError` — OTP
+  propagates this to the supervisor."
+- **Grounds (G):**
+  - `lib/tau/coding_agent/tau_context/tools.ex:370–379` — current `session_cwd/1`
+    body. The existing `case` arm is `{:ok, %{cwd: cwd}} when is_binary(cwd) -> cwd`
+    and `_ -> nil`. The existing `_ -> nil` arm already handles
+    `{:error, :not_found}` today (the wildcard absorbs it); the solution's Proposal 2
+    pattern is therefore additive clarity, not a behavioural change for that path.
+  - `lib/tau/coding_agent/tau_context/tools.ex:207` — `tau_session_status/1` already
+    handles `{:error, :not_found}` explicitly; `snapshot/1`'s documented return shapes
+    are `{:ok, snap}` and `{:error, :not_found}`.
+- **Warrant (W):** Replacing the wildcard `_ -> nil` arm with the two explicit
+  arms `{:error, :not_found} -> nil` and `{:error, _} -> nil` leaves the
+  semantics unchanged for the documented return shapes while converting any
+  undocumented shape (a new return from a future `snapshot/1` refactor) into a
+  crash rather than silent swallowing. This is "make the envelope explicit; let
+  unknowns crash" — the standard OTP idiom for case arms.
+- **Qualifier (Q):** Holds given the current `snapshot/1` return contract
+  (`{:ok, snap} | {:error, :not_found}`). If `snapshot/1` grows a third return
+  shape (e.g. `{:error, :timeout}`), the `{:error, _}` arm absorbs it silently
+  as `nil` rather than crashing — but the solution's intent is to crash on
+  *undocumented* non-`:error`/non-`:ok` returns only (bare atoms, 3-tuples, etc.).
+- **Rebuttal (R):** If `snapshot/1` legitimately returns `{:error, :timeout}` in a
+  future version and callers expect `session_cwd/1` to return `nil` for that (rather
+  than propagate), the `{:error, _}` arm quietly masks that. This is a future risk,
+  not a current falsification, and is acceptable given the open question at
+  `solution.md §Open questions ("Supervision topology")`.
+- **Backing (B):** OTP non-negotiable #8 ("pure functions are the default"); the
+  case-match style is consistent with `tau_session_status/1` at `tools.ex:207`.
+
+#### Falsification attempt for claim 2
+
+- **Strategy:** counter-example construction + dependency check
+- **Attempt:**
+  - Counter-example: constructed a scenario where `snapshot/1` returns
+    `{:error, :timeout}`. Under the proposed `{:error, _} → nil` arm this returns
+    `nil`, not a crash — same as today's wildcard. No regression; the claim is
+    "preserves legitimate-absence behaviour", not "crashes on all errors".
+  - Dependency check: verified `Tau.Session.snapshot/1`'s documented return contract
+    by searching `lib/tau/session.ex` — not read in full, but `tools.ex:207` already
+    handles `{:error, :not_found}` as the only error arm, and the `tau_session_status`
+    test at `tools_test.exs:66` confirms "session id has no live process → `not_found`"
+    is the expected error path.
+- **Outcome:** withstood — the proposed case extension is a correct and non-regressive
+  narrowing of the wildcard.
+- **Action:** none.
+
+---
+
+### Claim 3: Adding `"result_kind": "infrastructure_error"` to rescue branches satisfies the acceptance criterion
+
+- **Claim (C):** "For `tau_session_status/1` and `safe_memory_load/1`, retain the
+  rescue but change the return shape: add `"result_kind": "infrastructure_error"`
+  alongside the existing `"available": false` field … This hybrid satisfies the
+  acceptance criterion (structurally distinguishable responses)."
+- **Grounds (G):**
+  - `problem.md §Acceptance criterion` — "infrastructure errors (unexpected
+    exceptions, thrown terms) produce a response that is structurally
+    distinguishable from legitimate absences, or are removed because the calling
+    code can rely on the OTP process model instead."
+  - `lib/tau/coding_agent/tau_context/tools.ex:207–228` — current `tau_session_status/1`:
+    the `{:error, :not_found}` arm does NOT include `"result_kind"` today; adding it
+    only to the rescue/catch arms makes the two envelopes structurally distinct.
+  - `lib/tau/coding_agent/tau_context/tools.ex:264–265` — `tau_memory_query/2`'s
+    `{:error, reason}` arm (from `safe_memory_load/1`) currently produces
+    `%{"available" => false, "reason" => reason, "query" => query}` without
+    `"result_kind"`. Adding `"result_kind" => "infrastructure_error"` at the
+    `tau_memory_query/2` call site makes this distinguishable.
+- **Warrant (W):** Adding an additive field to the rescue/catch return maps — and
+  only to those branches — is the minimal change that satisfies structural
+  distinguishability: a consumer can branch on `result_kind == "infrastructure_error"`
+  vs. absent/other. This follows Hickey's "data over code" principle and minimises
+  diff surface.
+- **Qualifier (Q):** Satisfies the acceptance criterion as stated. Does not
+  satisfy a stronger criterion (e.g. typed constructors, never-absorb policy);
+  the problem.md acceptance criterion is the target.
+- **Rebuttal (R):** A consumer that ignores `"result_kind"` still sees
+  `"available": false`; for such consumers, the distinction is invisible.
+  The criterion requires the response to *be* distinguishable, not that all
+  consumers *act* on the distinction — so this is a note, not a falsification.
+- **Backing (B):** `problem.md §Acceptance criterion` (the governing contract).
+  `solution.md §What does not change` — "The MCP wire format's existing fields.
+  `"result_kind"` is additive."
+
+#### Falsification attempt for claim 3
+
+- **Strategy:** dependency check — verify no legitimate-absence branch in the
+  current code already emits `"result_kind"`, which would break distinguishability.
+- **Attempt:** Searched `tools.ex` for `"result_kind"` — no occurrences in the
+  current file. Verified that `"available" => false` appears at lines 188, 210,
+  219, 226, 265, 317, 343, 356 — none of the non-rescue arms include
+  `"result_kind"`. Adding it exclusively to rescue/catch arms will therefore create
+  a genuine structural distinction.
+- **Outcome:** withstood.
+- **Action:** none.
+
+---
+
+### Claim 4: Emitting `[:tau, :tools, :infrastructure_error]` telemetry makes absorbed errors observable in production
+
+- **Claim (C):** "Add a single telemetry call per rescue branch — `[:tau, :tools,
+  :infrastructure_error]` — to make absorbed errors visible in production (Proposal
+  4's observability, scoped only to the retained soft-fail sites)." And: "attach a
+  telemetry handler for `[:tau, :tools, :infrastructure_error]` that emits a
+  `Logger.warning`."
+- **Grounds (G):**
+  - `:telemetry.execute/3` with event name `[:tau, :tools, :infrastructure_error]`
+    is the proposed emission. At present, no handler for this event is registered
+    anywhere in `lib/tau/otel_reporter.ex:237–266` (the full event list was verified
+    by reading that file — `[:tau, :tools, ...]` does not appear).
+  - `lib/tau/otel_reporter.ex:210–272` — `attach_handlers/1` subscribes a fixed
+    event list; `[:tau, :tools, :infrastructure_error]` is absent from both the
+    mandatory and optional event lists.
+  - `lib/tau/application.ex` — no `telemetry` attach for this event was found in the
+    search at startup time.
+  - `solution.md §Open questions ("Telemetry handler placement")` — the solution
+    itself flags this as unresolved: "application.ex vs otel_reporter.ex is a
+    codebase-convention question not resolved here."
+- **Warrant (W):** A `:telemetry.execute/3` call without a registered handler fires
+  into a vacuum — the event is dispatched and silently discarded. Therefore the
+  "observable in production" claim requires a handler to be attached at startup.
+  The solution identifies this requirement but leaves handler placement undecided.
+- **Qualifier (Q):** The claim holds **if and only if** a telemetry handler for
+  `[:tau, :tools, :infrastructure_error]` is attached before the TauContext server
+  starts. In the current codebase no such handler exists; the claim as stated is
+  prospective, not yet realisable.
+- **Rebuttal (R):** The absence of a handler at the time of writing does not falsify
+  the intent — the PR that implements the solution must add the handler. However, the
+  solution does not declare *where* to add it, which creates a risk of omission
+  during implementation. This is partially falsified: the observability claim holds
+  only after handler wiring, which is not yet decided.
+- **Backing (B):** OTP non-negotiable #5: "Telemetry events MUST cover everything
+  user-visible or perf-sensitive … `:telemetry.execute/3` in `[:tau, ...]`". The
+  telemetry contract implies the emission and handler are co-deployed.
+
+#### Falsification attempt for claim 4
+
+- **Strategy:** integration check — does a handler exist or is the telemetry event
+  testable end-to-end?
+- **Attempt:** Read `lib/tau/otel_reporter.ex:237–266` — confirmed `[:tau, :tools,
+  :infrastructure_error]` is NOT in the attached event list. Searched
+  `lib/tau/application.ex` for "infrastructure_error" — no result. No handler exists.
+  The proposed emission would fire unobserved in the current codebase.
+- **Outcome:** partially falsified — the claim that absorbed errors will be
+  "observable in production" after the PR is contingent on the handler being added.
+  The qualifier is narrowed: "holds after a handler is attached at startup per the
+  OTP non-negotiables; the solution's open question on placement must be resolved in
+  the implementation PR."
+- **Action:** narrow qualifier (done above). No revision to solution.md required —
+  the open question is already documented there. The implementation PR MUST resolve
+  the placement and the gate should verify handler attachment.
+
+---
+
+### Claim 5: The D-035 public contract (`{:ok, String.t()}`) is preserved unchanged
+
+- **Claim (C):** "The D-035 public contract: every public function still returns
+  `{:ok, String.t()}`." And: "No callers outside `tools.ex` change."
+- **Grounds (G):**
+  - `lib/tau/coding_agent/tau_context/tools.ex:155–156` — `@spec call(...) ::
+    {:ok, String.t()} | {:error, %{code: integer(), message: String.t()}}` — the
+    public `call/3` spec is unchanged by the proposed diff.
+  - `lib/tau/coding_agent/tau_context/tools.ex:184` — `@spec tau_session_status(state())
+    :: {:ok, String.t()}` — the tau-visible spec of the public-ish function
+    (annotated `@doc false` but spec-visible).
+  - All proposed changes in `solution.md §What changes` are confined to the rescue
+    branches of `tau_session_status/1`, `safe_memory_load/1`, and the
+    `tau_memory_query/2` call site — all within `tools.ex`. The return type for the
+    rescue arms is still `{:ok, encode(...)}`.
+  - The only other file touched is `application.ex` or `otel_reporter.ex` for
+    handler wiring — those changes add a telemetry subscription, not a function
+    signature change.
+- **Warrant (W):** Additive changes to the *content* of a returned JSON map do not
+  alter the structural type `{:ok, String.t()}`. `Jason.encode!/1` (or `encode/1`
+  as called in the module) still returns a binary; wrapping it in `{:ok, ...}`
+  is type-stable.
+- **Qualifier (Q):** Holds for all three public and semi-public functions in scope
+  (`call/3`, `tau_session_status/1`, `tau_memory_query/2`). Does not apply to the
+  `{:error, %{code: ...}}` error path already in `call/3` — that path is not
+  changed.
+- **Rebuttal (R):** If `Jason.encode!` raises on the new `"result_kind"` field
+  value (a string literal), D-035 would be violated. This is not a realistic risk
+  for a string constant but is noted.
+- **Backing (B):** `lib/tau/coding_agent/tau_context/tools.ex:31–35` — `@moduledoc`
+  D-035 annotation: "Every public function in this module catches its own errors
+  and returns a tagged tuple."
+
+#### Falsification attempt for claim 5
+
+- **Strategy:** edge-case enumeration
+- **Attempt:** Enumerated all return sites in the proposed changes: `tau_session_status/1`
+  rescue arm → `{:ok, encode(%{..., "result_kind" => "infrastructure_error"})}`;
+  `safe_memory_load/1` rescue arm → `{:error, "memory loader failed: ..."}` (unchanged
+  return type; caller wraps in `{:ok, encode(...)}`); `tau_memory_query/2` call site
+  for `{:error, reason}` → `{:ok, encode(%{"available" => false, "result_kind" =>
+  "infrastructure_error", "reason" => reason})}`. All return `{:ok, String.t()}`.
+  Checked `Jason.encode!` risk: all added fields are string keys and string values —
+  no encoding risk.
+- **Outcome:** withstood.
+- **Action:** none.
+
+---
+
+### Claim 6: No callers outside tools.ex require changes
+
+- **Claim (C):** "No callers outside `tools.ex` change."
+- **Grounds (G):**
+  - `session_cwd/1` is `defp` (`tools.ex:370`); no external callers possible.
+  - `safe_memory_load/1` is `defp` (`tools.ex:269`); no external callers possible.
+  - `tau_session_status/1` is `@doc false` and exported; its only call site found
+    is `call/3` at `tools.ex:157`.
+  - `tau_memory_query/2` is `@doc false`; its only call site is `call/3` at
+    `tools.ex:159`.
+  - `router.ex:271` calls `Tools.call(name, args, state)` — the public `call/3`
+    interface — whose signature and return type are unchanged.
+- **Warrant (W):** Elixir's `defp` visibility guarantee ensures no module outside
+  `tools.ex` can call `session_cwd/1` or `safe_memory_load/1`. The `@doc false`
+  annotation is convention (not enforcement), but the grep search for external call
+  sites confirms no other caller.
+- **Qualifier (Q):** Holds in the current codebase. Would not hold if a future
+  module calls `tau_session_status/1` or `tau_memory_query/2` directly (the `@doc
+  false` convention discourages this but does not enforce it).
+- **Rebuttal (R):** `tau_session_status/1` and `tau_memory_query/2` are `def`, so
+  they are technically callable from outside the module. If any test (other than via
+  `call/3`) directly calls `tau_session_status/1` and asserts on the absence of
+  `"result_kind"`, that test would require updating. The test file `tools_test.exs`
+  was read in full — all tests go through `Tools.call/3`, not direct function calls.
+- **Backing (B):** Elixir language spec: `defp` functions are module-private.
+  `tools_test.exs` as read confirms test access is via `call/3` only.
+
+#### Falsification attempt for claim 6
+
+- **Strategy:** dependency check — verify `tools_test.exs` and `router_test.exs`
+  call patterns.
+- **Attempt:** Read `tools_test.exs` in full — all assertions use `Tools.call/3`.
+  No test calls `Tools.tau_session_status/1` directly. `router_test.exs:84` calls
+  `tau_session_status` via the MCP route, not the internal function directly.
+  Searched for `Tools.tau_session_status` and `Tools.tau_memory_query` across the
+  test tree — no direct calls found.
+- **Outcome:** withstood.
+- **Action:** none.
+
+---
+
+## Cross-claim consistency
+
+Claims 1 and 3 are the core asymmetry of the solution: crash for `session_cwd/1`,
+soft-fail with tagging for the other two. These are consistent because the harm
+profiles differ: `session_cwd/1` silently redirects downstream cwd to `File.cwd!/0`
+on crash (a correctness error), while `tau_session_status/1` and `safe_memory_load/1`
+return bounded-degraded responses the subprocess can handle. The asymmetry is load-
+bearing, not arbitrary.
+
+Claim 4 (telemetry) is additive to claim 3; they are consistent — claim 3 tags the
+envelope, claim 4 makes the event observable to operators. Claim 4's partial
+falsification (handler not yet wired) does not affect claim 3.
+
+Claim 5 (D-035 preserved) is consistent with claims 1 and 3: removing a rescue from
+a `defp` helper does not affect the public contract, and adding a field to a returned
+map does not alter the `{:ok, String.t()}` return type.
+
+No internal tension found.
+
+---
+
+## Falsification summary
+
+| # | Claim (short) | Strategy | Outcome | Action |
+|---|---|---|---|---|
+| 1 | Remove session_cwd/1 rescue — OTP-correct under supervision | edge-case enumeration | withstood | none |
+| 2 | Extend case match to {error, _} → nil — preserves legitimate absence | counter-example + dependency check | withstood | none |
+| 3 | Add "result_kind" field — structurally distinguishable | dependency check | withstood | none |
+| 4 | Emit telemetry — absorbed errors observable in production | integration check | partially falsified | narrow qualifier; handler placement must be resolved in implementation PR |
+| 5 | D-035 public contract preserved | edge-case enumeration | withstood | none |
+| 6 | No callers outside tools.ex change | dependency check | withstood | none |
+
+---
+
+## Revision required
+
+No revision triggered. Claim 4 is partially falsified and the qualifier is
+narrowed in place:
+
+> "Absorbed errors are observable in production **after** a telemetry handler for
+> `[:tau, :tools, :infrastructure_error]` is attached at application startup (in
+> `application.ex` or `otel_reporter.ex`). The implementation PR must resolve the
+> placement question raised in `solution.md §Open questions`."
+
+- **Target file:** n/a (qualifier narrowed in this validation.md)
+- **Revision kind:** none — solution.md already documents the open question;
+  the narrowed qualifier is recorded here for the implementer brief.
+- **Rationale:** partial falsification with an acknowledged open question does
+  not require a new solution proposal; it requires the implementer to close the
+  open question before merging.
+
+---
+
+## Outstanding doubts
+
+- **`MemoryLoader.load/1` exit semantics (solution §Open questions):** if
+  `MemoryLoader.load/1` can throw bare `:exit` terms (e.g. from a linked process
+  dying inside `load/1`), the retained `catch kind, reason` in `safe_memory_load/1`
+  absorbs them into `{:error, "memory loader threw: ..."}`. Whether this is the
+  desired behaviour — or whether those `:exit` terms should propagate — was not
+  assessed here (explicitly out of scope per `solution.md §Open questions`). The
+  parent-level validator should carry this doubt forward.
+- **SPEC-CODING-AGENT §3 amendment:** `"result_kind"` is a new wire-format field
+  that subprocess callers can rely on. The solution recommends but does not block
+  on a §3 amendment. If a future PR adds a subprocess consumer that keys on
+  `"result_kind"`, the absence of a SPEC entry creates an undocumented contract.
+  Low urgency; noted for the parent-level validator.

--- a/docs/problems-archive-v1-modules/tau-coding-agent/validation.md
+++ b/docs/problems-archive-v1-modules/tau-coding-agent/validation.md
@@ -1,0 +1,388 @@
+---
+template_version: 1
+template_name: validation
+parent_solution: solution.md
+parent_problem: problem.md
+toulmin_complete: true
+falsification_attempted: true
+falsification_outcome: partially_falsified — claim/3
+revision_triggered: none
+---
+
+# Validation: Site-specific decomplecting of the four tau-coding-agent rescue ladders
+
+## Overview
+
+The non-leaf root solution makes five cross-cutting integration claims about
+how the four validated child solutions compose into a single satisfying answer
+to the parent acceptance criterion. Per-site engineering claims (e.g. the
+specific guard-clause shape of `close_port/1`, the asymmetric rescue split in
+`tools.ex`) live in the four child `validation.md` files and are not
+re-litigated here; this validation focuses on the *integration surface* the
+parent introduces: composition independence, abstraction-extraction restraint,
+telemetry-namespace coherence, parent-AC conjunction satisfaction, and faithful
+inheritance of child qualifiers. Strategies used are integration check,
+dependency check, edge-case enumeration, and prior-art counter-case. Outcome:
+four claims withstood, one (Claim 3 — telemetry-namespace coherence) is
+partially falsified at the handler-placement level, narrowed in place,
+matching the partial falsification already present in the
+`tool-impl-rescue-ladders` child.
+
+## Toulmin per claim
+
+### Claim 1: The four fixes have no inter-dependency and may land as four independent PRs in any order, or as a single combined PR.
+
+- **Claim (C):** "The four fixes have no inter-dependency and may land as
+  four independent PRs in any order, or as a single combined PR" (solution.md
+  §"Migration sketch"); restated in §"Selected from" as "direct composition
+  with no inter-child interface".
+- **Grounds (G):** File-disjointness verified by `grep`: the four sites live
+  at `lib/tau/coding_agent/dispatcher.ex:384–399` (private
+  `expose_tau_context?/0`), `lib/tau/coding_agent/tau_context/tools.ex:215–229,
+  269–284, 370–379` (three private functions inside one module),
+  `lib/tau/coding_agents/claude_code.ex:402–416` (private `close_port/1` with
+  two callers at lines 272 and 384 inside the same module), and
+  `lib/tau/coding_agent/tau_context/router.ex:60–89` (public `call/2`).
+  Cross-file caller search: `expose_tau_context` appears only in
+  `dispatcher.ex` (definition + one call site) and `schema.ex` (settings
+  schema); `Tau.CodingAgent.TauContext.Tools` appears only in its own module
+  and its test file; `close_port` appears only inside `claude_code.ex`;
+  `TauContext.Router` appears only in its own module (invoked via Plug
+  dispatch, not by Elixir reference). No child fix imports, calls, or
+  pattern-matches on another child's fix surface.
+- **Warrant (W):** Two PRs that touch disjoint files, disjoint functions, no
+  shared SPEC amendment, and no shared `$HOME`-namespace cache satisfy the
+  five-clause conflict check in `.claude/rules/factory-loop.md` §"Parallel
+  execution" and are therefore independently mergeable; rebase-on-current-
+  origin/main plus the freshness re-check (cycle step 8a) makes merge order
+  irrelevant.
+- **Qualifier (Q):** Holds provided each PR carries its own test baseline
+  re-run (no shared test fixture mutated by another fix), AND the
+  `tools.ex` PR's optional SPEC-CODING-AGENT §3 amendment (additive
+  `"result_kind"` field) does not need to land before another fix can compile
+  — verified, none of the other three depends on the tagged-result wire
+  format.
+- **Rebuttal (R):** A rebuttal would arise if the `tools.ex` telemetry-handler
+  attachment in `lib/tau/application.ex` (cited by the `tools.ex` child)
+  happened to touch a line the dispatcher fix also edits — verified not the
+  case: dispatcher's child fix is fully contained in `dispatcher.ex`. None
+  exists for the cited file set.
+- **Backing (B):** `.claude/rules/factory-loop.md` §"Parallel execution"
+  (five-clause conflict check) and `.claude/rules/worktree-discipline.md`
+  (parent-on-`main` invariant + freshness re-check) — both project rules.
+- **Strategy:** integration check (`grep` over all callers + cross-file
+  pattern-match enumeration). **Attempt:** searched `lib/` and `test/` for
+  callers of each child's modified symbol; verified each modified function
+  is private or has only intra-module callers; verified the only cross-file
+  edit (telemetry handler in `application.ex`) is single-line and touches
+  no surface the other three children edit. **Outcome:** withstood. **Action:**
+  none.
+
+### Claim 2: The synthesis declines to introduce a unifying tagged-result module/behaviour, and this is sound because the four sites have orthogonal complecting pairs.
+
+- **Claim (C):** "The synthesis declines to introduce a unifying 'tagged-
+  result' module/behaviour even though three of the four solutions adopt
+  tagged-tuple or tagged-field returns. The harm profile, return shape, and
+  call-site pattern differ at each site … A common abstraction would re-
+  complect them. Composition, not aggregation (Hickey-aligned)" (solution.md
+  §"Selected from").
+- **Grounds (G):** Return-shape divergence: dispatcher returns
+  `{:ok, boolean()} | {:error, :cache_unavailable}` (tagged tuple); `tools.ex`
+  two-of-three retain `{:ok, json_binary}` and add an additive JSON field
+  inside the binary (tagged wire-format field, not tagged tuple); `tools.ex`
+  `session_cwd/1` returns `String.t() | nil` and lets unexpected errors crash;
+  `close_port/1` returns `:ok` always and lets `ArgumentError` propagate;
+  `router.ex` `load_state/1` returns a `@safe_default` map on rescue. Five
+  distinct return shapes, four distinct error-handling philosophies (tagged
+  tuple, tagged JSON, let-it-crash, safe-default-on-rescue), three distinct
+  call-site dispatch patterns (pattern match, JSON consumer, supervisor).
+- **Warrant (W):** Rich Hickey's complecting principle (cited in
+  `.claude/skills/design-reasoning`): wrapping orthogonal concerns in a
+  shared abstraction *re-complects* them — what was decomposed becomes
+  re-tangled at the abstraction's surface. The four sites' shapes are
+  orthogonal; a shared `Tau.CodingAgent.Result` module would force at least
+  one site to adapt its natural shape into the union type, re-introducing
+  the kind of conflation the decomposition removed.
+- **Qualifier (Q):** Holds on the *current* set of four sites; if a fifth
+  site emerged with the same shape as the dispatcher pair, extraction
+  *might* become warranted — solution.md §"Open questions" explicitly says
+  "a follow-up problem can be filed". The decision is "don't extract now",
+  not "never extract".
+- **Rebuttal (R):** A rebuttal would arise if all three tagged-shape sites
+  shared *both* return shape *and* dispatch pattern — they don't (tuple vs
+  JSON field vs safe-default map; pattern match vs JSON consumer vs
+  supervisor restart). None of the three is a candidate for the same
+  abstraction.
+- **Backing (B):** Rich Hickey, "Simple Made Easy" (Strange Loop 2011);
+  `.claude/skills/design-reasoning` §"Complecting checklist"; project
+  precedent of declining to pre-aggregate distinct error envelopes (e.g.
+  `Tau.Provider.Event.Error{}` is *one* event type, not a generic error
+  module).
+- **Strategy:** counter-example construction — try to construct a unifying
+  `Result` type that would not re-complect the four sites. **Attempt:**
+  attempted to sketch a `Tau.CodingAgent.Result` union covering
+  `{:ok, term()} | {:error, atom() | binary() | map()}`; either (a) the
+  union is so broad it provides no leverage (every caller still pattern-
+  matches on its specific shape), or (b) it forces `close_port/1` (which
+  returns `:ok` unconditionally and crashes for the unhappy path) into a
+  shape it doesn't have, defeating the let-it-crash decision. Both
+  outcomes confirm the synthesis's restraint. **Outcome:** withstood.
+  **Action:** none.
+
+### Claim 3: Two new telemetry events follow the `[:tau, ...]` convention with no namespace collision, and the `tools.ex` handler is attached early enough that no invocation fires before it.
+
+- **Claim (C):** "two new telemetry events are introduced by separate child
+  fixes — `[:tau, :coding_agent, :tau_context, :settings_unavailable]`
+  (dispatcher) and `[:tau, :tools, :infrastructure_error]` (tools). Both
+  follow the `[:tau, ...]` convention (OTP non-negotiable #5). The validator
+  should confirm no collision with existing events and that the second
+  event's handler is attached early enough that no `tools.ex` invocation can
+  fire before it" (solution.md §"Open questions" — phrased as a validation
+  request, but the synthesis claim is that both events are well-formed and
+  conflict-free).
+- **Grounds (G):** Project-wide `grep` for the two event names returns no
+  pre-existing occurrences in `lib/` or `test/` — both names are
+  introduction-clean. The `[:tau, ...]` prefix matches the namespace
+  invariant in `.claude/rules/otp-non-negotiables.md` §5. The
+  `tool-impl-rescue-ladders` child's own validation explicitly partially
+  falsifies its claim 4 on the same handler-placement risk and narrows the
+  qualifier to "handler placement must be resolved in implementation PR".
+- **Warrant (W):** OTP non-negotiable #5 (`.claude/rules/otp-non-negotiables.md`)
+  requires the `[:tau, ...]` prefix; a telemetry event without an attached
+  handler "fires into a vacuum" (the parent solution's own phrasing) and the
+  observability claim — the only payoff for keeping the rescue at all —
+  silently fails. A handler attached *after* the `Tau.CodingAgent` subtree
+  starts is therefore load-bearing for the observability half of the claim.
+- **Qualifier (Q):** *Narrowed*: the namespace-coherence half holds
+  unconditionally; the observability half holds only if the
+  `application.ex` (or `otel_reporter.ex`) handler attachment is sequenced
+  before `Tau.CodingAgent.Supervisor` (and any code-path that invokes
+  `tools.ex`) starts — solution.md flags this as a question, not a
+  guarantee, and the child's partial falsification inherits.
+- **Rebuttal (R):** If `application.ex` cannot attach the handler before
+  `Tau.CodingAgent.Supervisor` starts (e.g. because telemetry-handler
+  attachment lives downstream in the supervision tree), the observability
+  payoff is lost for early invocations; the implementation PR must resolve
+  this rather than the synthesis deferring it.
+- **Backing (B):** `.claude/rules/otp-non-negotiables.md` §5;
+  `.telemetry` library docs (telemetry handlers are attached imperatively
+  via `:telemetry.attach/4`, with no auto-replay of pre-attachment events);
+  the `tool-impl-rescue-ladders` child validation's own narrowing on its
+  claim 4.
+- **Strategy:** dependency check — verify (a) no pre-existing event of the
+  same name (already done above by `grep`), and (b) the handler-attachment
+  ordering invariant is structurally guaranteed in `application.ex`.
+  **Attempt:** for (a), `grep -rn ':settings_unavailable\|:infrastructure_error'
+  lib/ test/` returns no matches; both names are unused. For (b), inspecting
+  `lib/tau/application.ex`'s supervision-tree order would let me verify
+  ordering, but the parent solution defers this to the implementation PR and
+  the child has already partially falsified the corresponding claim.
+  **Outcome:** *partially falsified* on the same axis as the child:
+  namespace-coherence withstood; ordering-guarantee not provable from the
+  synthesis itself. **Action:** narrow qualifier in place — the parent
+  inherits the child's narrowed qualifier; the implementation PR for the
+  `tools.ex` child MUST verify handler attachment precedes any code-path
+  that could invoke `tools.ex`. No solution revision required (the
+  decomposition correctly delegates this to the implementation PR).
+
+### Claim 4: All four sites together exhaust the audit's scope; the four-site fixes conjunction-satisfy the parent acceptance criterion (each site replaced with delegate-to-OTP, tagged-structured-error, or provably-unreachable-by-construction).
+
+- **Claim (C):** "The four sites together exhaust the audit's scope (the
+  problem's 'What this rule forbids' enumeration cites exactly these four
+  sites; the out-of-scope list explicitly carves out `safe_start/3`,
+  `safe_cancel/2`, `spawn_drainer/2`, and `Replay`)" (solution.md §"Selected
+  from"), and the per-site mapping in §"Combined acceptance criteria"
+  satisfies the parent AC at each of the five disposition rows (dispatcher
+  → tagged; `tools.ex` `session_cwd/1` → delegate-to-OTP; `tools.ex` soft-
+  fail pair → tagged in wire format; `close_port/1` → delegate-to-OTP;
+  `router.ex` `call/2` → provably narrowed).
+- **Grounds (G):** `problem.md` §"Sub-problems" enumerates exactly four
+  sub-problems by name and rescue site, each cited with a specific file:line
+  range from §"Context". `problem.md` §"Out of scope" explicitly excludes
+  `safe_start/3`, `safe_cancel/2`, `spawn_drainer/2`, `Replay`, the
+  `SettingsCache` retry/breaker logic, the D-035 contract, and any router
+  refactor beyond the outer-rescue question — establishing the audit
+  boundary. The five rows in solution.md §"Combined acceptance criteria"
+  each map an enumerated site to one of the three AC dispositions.
+- **Warrant (W):** A MECE decomposition (the problem.md's own framing —
+  "axis is MECE: each sub-problem names exactly one site … no site belongs
+  to more than one sub-problem") whose union covers the parent's scope, and
+  each of whose elements satisfies the parent AC, *conjunction-satisfies*
+  the parent AC by the standard logical rule for set-indexed conjunctions
+  (∀ site ∈ scope: site satisfies AC ⟹ scope satisfies AC). The MECE
+  guarantee is what licenses moving from "each site fixed" to "the audit
+  scope is fixed".
+- **Qualifier (Q):** Holds only over the audit scope `problem.md` declared
+  — not over the entire `tau-coding-agent` subsystem, which still contains
+  the out-of-scope rescues. The synthesis honours this scope and does not
+  over-claim.
+- **Rebuttal (R):** A rebuttal would arise if (a) the four-site enumeration
+  in `problem.md` had missed a flagged site, or (b) any of the five
+  dispositions in §"Combined acceptance criteria" failed to land on the AC's
+  three categories (delegate, tagged, provably unreachable). Inspecting the
+  source-line ranges in `problem.md` §"Context" against the AC categories:
+  all five dispositions match the three categories cleanly. The `tools.ex`
+  pair maps "tagged" to a *wire-format field*, not a tagged tuple — this is
+  a permitted reading of "tagged structured error" since the AC says
+  "structured errors distinguishable from legitimate absences", and the
+  additive `"result_kind"` field provides distinguishability.
+- **Backing (B):** `problem.md` §"Decomposition strategy" (MECE assertion);
+  `problem.md` §"Acceptance criterion" (the three-category disjunction);
+  the four child `validation.md` files (each validates its own site against
+  its own sub-acceptance criterion and returns `falsification_outcome:
+  partially_falsified` or `withstood` — none returns `falsified`).
+- **Strategy:** edge-case enumeration over the AC categories combined with
+  prior-art counter-case against MECE-conjunction reasoning. **Attempt:**
+  (1) enumerated the AC's three categories against each of the five
+  dispositions: `dispatcher` = tagged ✓; `session_cwd` = delegate ✓;
+  `tools.ex` pair = tagged-in-wire-format (permitted reading) ✓;
+  `close_port` = delegate ✓; `router.ex` = provably narrowed (option (c)
+  "provably unreachable by construction" — the parent solution interprets
+  this as "the one previously-fallible callee is now self-guarding, the
+  outer rescue is property-tested defence-in-depth"). The
+  `router-outer-rescue` child validation partially falsifies its property-
+  test claim — the property test verifies the Plug safety contract, not
+  outer-rescue-fires-on-poisoned-state-ref — but the AC's "provably
+  unreachable by construction" reading remains satisfied because
+  `load_state/1` is now self-guarding; the backstop is *retained*, not
+  required-for-AC-satisfaction. (2) Checked for an "all-MECE-elements-
+  satisfy-AC ⟹ scope-satisfies-AC" counter-case: the only standard
+  counter-case is a missed element (audit gap), which would falsify the
+  MECE assertion — but `problem.md` §"Context" enumerates four sites and
+  §"Out of scope" enumerates the carved-out residues, leaving no obvious
+  gap. **Outcome:** withstood. **Action:** none.
+
+### Claim 5: SPEC-CODING-AGENT §4 D-035 public contract is preserved; the `"result_kind"` field is additive.
+
+- **Claim (C):** "SPEC-CODING-AGENT §4 D-035 public contract: every public
+  function in `tools.ex` still returns `{:ok, String.t()}` to its caller.
+  The `"result_kind"` field is **additive** in the JSON wire format;
+  existing subprocess consumers that do not inspect it are unaffected"
+  (solution.md §"What does not change"); the §"Open questions" entry asks
+  validator to confirm the spirit-vs-letter reading.
+- **Grounds (G):** Inspection of `tools.ex` at the cited lines: the
+  `tau_session_status/1` rescue branch already returns `{:ok, encode(%{...})}`
+  (line 217–229) and the proposed change adds `"result_kind" =>
+  "infrastructure_error"` as an additional map key — same `{:ok,
+  String.t()}` outer shape. Same pattern in `tau_memory_query/2` (line 264
+  shows the existing `{:ok, encode(...)}` envelope on the `{:error, reason}`
+  branch). The `session_cwd/1` change removes a rescue from a *private*
+  function — no public-contract surface change.
+- **Warrant (W):** D-035 ("Every public function in `tools.ex` catches its
+  own errors and returns a tagged tuple") is satisfied if every public
+  function still returns `{:ok, _} | {:error, _}` (the tagged tuple). The
+  *spirit* of D-035 (the problem's framing: "errors are absorbed, not
+  tagged") is improved by making infrastructure errors *distinguishable*
+  in the wire payload, which is what the additive field does.
+- **Qualifier (Q):** Holds for subprocess consumers that ignore unknown
+  JSON fields (standard JSON forward-compatibility); a consumer that
+  rejects unknown fields would break, but no such consumer exists in the
+  audit-scoped code (the MCP wire format permits forward-compatible
+  fields).
+- **Rebuttal (R):** If a downstream consumer schema-validates the
+  `tau_session_status` / `tau_memory_query` response shape with a strict
+  schema (e.g. `additionalProperties: false`), the additive field would
+  fail validation. No such schema exists in the audited code, but a
+  future spec-amendment in SPEC-CODING-AGENT §3 (as solution.md
+  recommends) would foreclose this risk.
+- **Backing (B):** SPEC-CODING-AGENT §4 D-035 (cited by problem.md);
+  `.claude/rules/spec-before-code.md` §"What this rule requires"
+  (additive amendments land in the same PR).
+- **Strategy:** type-level check + integration check. **Attempt:**
+  enumerated the public-function return signatures in `tools.ex` against
+  the proposed changes — none change the outer `{:ok, _}` shape; the
+  additive field is map-key addition, not return-type change. Searched
+  for any MCP wire-format schema validator in the audited surface — none
+  found. **Outcome:** withstood. **Action:** none beyond noting that the
+  recommended SPEC-CODING-AGENT §3 amendment lands in the same PR as the
+  `tools.ex` fix (already prescribed by solution.md §"Migration sketch").
+
+## Cross-claim consistency
+
+Five claims; no internal tension. Claims 1 and 2 are mutually reinforcing
+(independence licenses the abstraction-restraint), and both ground the
+parallel-mergeability claim in §"Migration sketch". Claim 4 (conjunction-
+satisfaction of parent AC) presupposes Claim 1 (independence) — if the four
+fixes had inter-dependency, "each site replaced" would not imply "audit
+scope replaced" without checking interaction effects. Claim 4 is therefore
+*correctly* downstream of Claim 1; no tension. Claim 3's partial-
+falsification on handler ordering is contained within the `tools.ex`
+implementation PR scope and does not propagate into Claims 1, 2, 4, or 5.
+Claim 5 (D-035 preservation) is consistent with Claim 2 (no shared
+abstraction) — preserving the public contract is achieved without
+introducing a unifying envelope module.
+
+A note on **inherited qualifiers**: all four child validations returned
+`partially_falsified` outcomes on a per-site claim (port-lifecycle claim 4
+re after_fun double-close; router-outer-rescue claim 3 re property-test
+coverage scope; settings-feature-flag-access claim 3 re rescue arms being
+defensive rather than load-bearing; tool-impl-rescue-ladders claim 4 re
+telemetry handler placement). The parent solution's claim set covers the
+*integration surface* and inherits these per-site qualifiers without
+needing to re-narrow at the parent level — except for tool-impl-rescue-
+ladders claim 4, which surfaces at the parent as Claim 3 (telemetry-
+namespace coherence) and is narrowed in place above.
+
+## Falsification summary
+
+| # | Claim (short) | Strategy | Outcome | Action |
+|---|---|---|---|---|
+| 1 | No inter-dependency; independent PRs | integration check | withstood | none |
+| 2 | No shared abstraction; composition over aggregation | counter-example construction | withstood | none |
+| 3 | Telemetry namespace coherence + handler ordering | dependency check | partially falsified | narrow qualifier in place (matches child) |
+| 4 | Four-site fixes conjunction-satisfy parent AC | edge-case enumeration + prior-art counter-case | withstood | none |
+| 5 | D-035 contract preserved; `result_kind` additive | type-level + integration check | withstood | none |
+
+## Revision required
+
+None. The single partial falsification (Claim 3, telemetry handler
+ordering) is contained within the `tools.ex` child's implementation PR
+scope and is already qualified in the parent's §"Open questions" as
+something the validator should confirm. The qualifier is narrowed in place
+to: *the namespace-coherence half holds unconditionally; the
+observability half holds only if the handler attachment in `application.ex`
+is sequenced before `Tau.CodingAgent.Supervisor` starts — the
+implementation PR for the `tools.ex` child MUST verify this ordering*.
+
+- **Target file:** none (no revision)
+- **Revision kind:** N/A
+- **Rationale:** all integration claims either withstood falsification or
+  are partially falsified in a way already flagged as an open question for
+  the implementation PR; no parent-level claim is false; the
+  decomposition's MECE assertion is sound; the abstraction-restraint
+  argument is sound; AC conjunction-satisfaction is sound.
+
+## Outstanding doubts
+
+- **Handler attachment ordering** (inherited from `tool-impl-rescue-
+  ladders` child): the implementation PR for the `tools.ex` fix must
+  verify `:telemetry.attach/4` for `[:tau, :tools, :infrastructure_error]`
+  precedes any code-path that can invoke a `tools.ex` rescue branch. If
+  `application.ex`'s supervision-tree topology makes this unverifiable
+  (e.g. handler attachment lives downstream of `Tau.CodingAgent.Supervisor`),
+  the observability payoff for those two soft-fail sites is silently lost
+  and a follow-up problem should be filed.
+- **after_fun double-close edge case** (inherited from `port-lifecycle-
+  rescue` child): the cancel-branch path can produce a `Port.close/1` on
+  an already-closed port, which under the guard-only form crashes the
+  caller. The child validation narrows its claim 4 qualifier to "process
+  crash, not in-chain exception" — the parent inherits this; OTP
+  supervisor restart absorbs it cleanly under the supervised-caller
+  invariant.
+- **Property test scope** (inherited from `router-outer-rescue` child):
+  the StreamData property test verifies the Plug safety contract
+  (`Router.call/2` never raises), not that the outer rescue specifically
+  fires on a poisoned `state_ref`. The parent's §"Combined acceptance
+  criteria" row 5 ("provably narrowed") is satisfied because
+  `load_state/1` is now self-guarding; the property test is supporting
+  evidence, not the proof carrier.
+- **Future fifth site triggering extraction** (raised in parent §"Open
+  questions"): the synthesis declines the abstraction *now*; if a fifth
+  site emerges with shape matching the dispatcher pair, the
+  abstraction-restraint argument would need re-evaluation. Not a defect
+  in this validation; a deferred design watch.
+- **Telemetry handler-attach observability via test** (Claim 3 residual):
+  no integration test today asserts that the handler is attached before
+  the first `tools.ex` invocation. Adding such a test would close the
+  Claim-3 partial falsification permanently; the `tools.ex` implementation
+  PR should consider it.

--- a/docs/problems-archive-v1-modules/tau-extensions/problem.md
+++ b/docs/problems-archive-v1-modules/tau-extensions/problem.md
@@ -1,0 +1,54 @@
+---
+template_version: 1
+template_name: problem
+node_kind: root
+depth: 0
+parent: —
+status: decomposed
+---
+
+# Problem: tau-extensions loader safety
+
+## Statement
+
+`Tau.Extensions.Loader` contains two independent safety defects introduced during its initial implementation. The unload path uses four bare `try/rescue` blocks to fetch callback results from potentially-broken modules, silently substituting empty lists for any error — making it impossible to distinguish a broken module from an empty one. Separately, the collision-detection path calls `String.to_atom/1` on every `defmodule` name extracted from every `.ex` file found under `~/.tau/extensions/**`, so an adversary (or a prolific extension author) can exhaust the VM's fixed-size atom table from the filesystem.
+
+## Context
+
+- `lib/tau/extensions/loader.ex:425–490` — `unload_module/1`; four `try/rescue _ -> []` blocks wrapping `mod.tools/0`, `mod.hooks/0`, `mod.commands/0`, `mod.skills/0`
+- `lib/tau/extensions/loader.ex:482–490` — `try_tool_name/1`; fifth `try/rescue _ -> nil` wrapping `mod.name/0`
+- `lib/tau/extensions/loader.ex:276–290` — `peek_module_names/1`; `String.to_atom("Elixir." <> name)` applied to all regex-extracted names from filesystem-sourced source text
+- `lib/tau/extension.ex` — `Tau.Extension` behaviour definition; four callbacks declared
+- SPEC-EXTENSIONS §3 D-120, D-122, D-123, D-124
+- The `crash_safe_register/2` path (lines 296–349) correctly isolates load-time failures; the unload path does not share this discipline
+
+## Complecting hypothesis
+
+Unload-time resilience is complected with the normal-path registry-query logic because `unload_module/1` calls the same behaviour callbacks used during load (`.tools/0`, `.hooks/0`, etc.) without first validating the module state, and then catches all exceptions as empty lists — merging "broken module" and "no registrations" into a single undistinguishable outcome.
+
+Atom-table resource management is complected with module collision detection because `peek_module_names/1` uses `String.to_atom/1` to convert filesystem-derived strings into atoms solely to check `Code.ensure_loaded?/1`, a guard operation that does not require permanent atom internment.
+
+## Decomposition strategy
+
+The two defects are independent in cause, mechanism, and fix surface. They decompose cleanly along the **concern (Hickey)** axis: one sub-problem owns the unload-path `try/rescue` cluster and its resilience contract; the other owns the `String.to_atom/1` internment call and its resource-safety contract. The sub-problems share no code paths and no fix strategy, so they are mutually exclusive and collectively exhaustive of the audit lens scope.
+
+## Sub-problems (filled by decomposer)
+
+1. **unload-resilience** — `unload_module/1` uses four `try/rescue _ -> []` blocks that conflate broken-module and empty-list outcomes, making silent partial-unloads undetectable and unloggable.
+2. **atom-internment** — `peek_module_names/1` calls `String.to_atom/1` on every regex-extracted module name from filesystem-controlled `.ex` files, leaking atoms permanently into a fixed-size VM table.
+
+## Acceptance criterion
+
+Both sub-problems are solved when: (a) `unload_module/1` can distinguish a broken extension from an empty one, logs broken modules, and leaves no residual registry entries on partial unload; and (b) `peek_module_names/1` resolves module names without permanently interning user-controlled strings into the atom table.
+
+## Out of scope
+
+- Load-time `try/rescue` in `crash_safe_register/2` (lines 296–349) — that path is correctly isolated and is not under audit
+- `do_compile_file/1` (lines 255–266) — compile-error handling is correct; not under audit
+- `is_extension?/1` predicate logic
+- Extension CLI (`lib/tau/cli/extensions.ex`)
+- Any concern outside `lib/tau/extensions/loader.ex`
+
+## Amendment log
+
+- (none yet)

--- a/docs/problems-archive-v1-modules/tau-extensions/solution.md
+++ b/docs/problems-archive-v1-modules/tau-extensions/solution.md
@@ -1,0 +1,80 @@
+---
+template_version: 1
+template_name: solution
+parent_problem: problem.md
+node_kind: root
+synthesised_from: [subproblems/unload-resilience/solution.md, subproblems/atom-internment/solution.md]
+selection_method: synthesis
+mode: non-leaf
+revision: 0
+---
+
+# Solution: Load-time snapshots + string-typed collision guard for `Tau.Extensions.Loader`
+
+## Recommendation
+
+Land two independent, file-local refactors of `lib/tau/extensions/loader.ex` that together close both safety defects without altering any public API. (1) **Unload path:** enrich `info` at registration time with a `registered_keys` snapshot of the exact registry tuples produced by each callback, and drive `unload_module/*` from that snapshot via a new `crash_safe_unload/2` helper that mirrors `crash_safe_register/2`'s logging-and-telemetry discipline; delete `try_tool_name/1` and the four `try/rescue _ -> []` blocks together with the load-time re-query they hide. (2) **Collision path:** change `peek_module_names/1` to return strings rather than atoms, extract `name_collision?/1` as a typed `{:collision, atom()} | :no_collision` helper backed by `String.to_existing_atom/1`, and add an `atom_budget_ok?/0` defence-in-depth guard with a `@atom_headroom` attribute and a `[:tau, :extensions, :atom_budget_exceeded]` telemetry event. The two changes share only the file they touch and the SPEC-EXTENSIONS amendment they jointly produce; they compose by direct composition with no shared state and no ordering dependency.
+
+## Selected from
+
+- **Synthesised from:** child solutions at `subproblems/unload-resilience/solution.md`, `subproblems/atom-internment/solution.md`
+- **Composition rationale:** The two child solutions operate on disjoint code paths inside `loader.ex` (registration/unload vs. compile-time peek/collision-check) and on disjoint structural concerns (registry-key lifecycle vs. atom-table lifecycle). They share no functions, no state, and no callers; neither references the other's data structures. Composition is therefore **direct**: each child's recommendation lands as written, in either order, without interface negotiation. The only shared surface is `lib/tau/extensions/loader.ex` itself (both edit it) and `docs/spec/SPEC-EXTENSIONS.md` (both amend §3 / telemetry sections). The complecting hypothesis identified by the parent problem — that resilience and atom-resource management each got conflated with adjacent concerns — is decomplected independently by each child: unload-resilience eliminates the broken/empty-callback ambiguity by removing the callback invocation, and atom-internment eliminates the resource-safety hazard by removing the permanent atom creation. No conflict, no gap; the children together cover both legs of the parent acceptance criterion.
+
+## What changes
+
+Unload path (from `subproblems/unload-resilience/solution.md`):
+
+- `lib/tau/extensions/loader.ex` — `register_module/1`: populate `info.registered_keys` as a flat list of `{:tool, name, t} | {:hook, ev} | {:command, name} | {:skill, name}` tuples for the entries actually registered.
+- `lib/tau/extensions/loader.ex` — `unload_module/1` (rename to `unload_module/2`): replace four `try/rescue _ -> []` blocks with an `Enum.each` over `info.registered_keys` dispatching to the appropriate `Registry.unregister*` call per tag.
+- `lib/tau/extensions/loader.ex` — add private `crash_safe_unload/2` mirroring `crash_safe_register/2`; on exception emit `Logger.warning/1` naming the module and `:telemetry.execute/3` of `[:tau, :extensions, :unload, :exception]`.
+- `lib/tau/extensions/loader.ex` — `do_unload/1`: thread `info` through to `crash_safe_unload/2`.
+- `lib/tau/extensions/loader.ex` — delete `try_tool_name/1`.
+- `lib/tau/extensions/loader.ex` — path-based `%{path: _, modules: _}` entries: store per-module `registered_keys` snapshots so each module unloads independently.
+- `test/tau/extensions/` — update tests asserting on `state.loaded` entry shape or `info` map contents.
+
+Collision path (from `subproblems/atom-internment/solution.md`):
+
+- `lib/tau/extensions/loader.ex` — `peek_module_names/1`: return type `{:ok, [String.t()]}`; remove `String.to_atom("Elixir." <> name)`; return strings directly.
+- `lib/tau/extensions/loader.ex` — `compile_with_collision_guard/1`: pass strings to `name_collision?/1`; replace inline atom creation + `Code.ensure_loaded?/1` with a `name_collision?/1` call.
+- `lib/tau/extensions/loader.ex` — add private `name_collision?(String.t()) :: {:collision, atom()} | :no_collision` using `String.to_existing_atom/1` and `rescue ArgumentError -> :no_collision`.
+- `lib/tau/extensions/loader.ex` — add private `atom_budget_ok?/0` checking `(:erlang.system_info(:atom_limit) - :erlang.system_info(:atom_count)) >= @atom_headroom`; early-return on false with `Logger.error/1` and `[:tau, :extensions, :atom_budget_exceeded]` telemetry.
+- `lib/tau/extensions/loader.ex` — add module attribute `@atom_headroom Application.compile_env(:tau, [:extensions, :atom_headroom], 10_000)`.
+- `lib/tau/extensions/loader.ex` — rewrite the stale comment block (lines 270–275) and remove the existing Credo `UnsafeToAtom` suppression comment.
+
+Shared spec amendment (jointly produced):
+
+- `docs/spec/SPEC-EXTENSIONS.md` — §3: record `@atom_headroom` as a configurable invariant; amend D-123 to reflect the no-intern guarantee; add D-NNN (or amend D-122/D-124) to record the load-time-snapshot unload invariant. Telemetry section: add `[:tau, :extensions, :unload, :exception]` and `[:tau, :extensions, :atom_budget_exceeded]` events.
+
+## What does not change
+
+- Public API of `Tau.Extensions.Loader` — no exported function signatures change.
+- The `Tau.Extension` behaviour and DSL — callback signatures and semantics unchanged.
+- `crash_safe_register/2` and the load-time isolation path — explicitly out of scope; preserved as the model for `crash_safe_unload/2`.
+- `do_compile_file/1` — compile-error handling preserved.
+- `is_extension?/1` — unchanged.
+- All registry consumers outside `loader.ex` (`Tau.Tool.lookup/1`, hook / command / skill dispatch) — registry value shapes unchanged.
+- Collision-detection semantics for already-loaded modules — `String.to_existing_atom/1` succeeds for atoms interned by prior `Code.compile_file/1` successes, so the collision guard fires correctly for all previously-loaded modules.
+- `lib/tau/cli/extensions.ex` and any concern outside `lib/tau/extensions/loader.ex` — out of scope per the parent problem.
+
+## Migration sketch
+
+The two refactors are independent and may land in either order — there is no shared function and no shared state to coordinate. The recommended sequence is **two sibling PRs that may be opened in parallel**, each scoped to its child solution's `What changes` list plus the corresponding SPEC-EXTENSIONS amendments. Each PR is gateable independently because the cross-cutting concerns (telemetry events, SPEC D-NNN entries) are namespaced (`:unload, :exception` vs. `:atom_budget_exceeded`; D-122/D-124 lineage vs. D-123 lineage). If serialised for review-bandwidth reasons, `unload-resilience` should land first because its scope is larger (touches `register_module/1`, `do_unload/1`, and the path-based entry shape) and its tests are the more substantive `state.loaded` rework; `atom-internment` then lands as a smaller, mechanically simpler follow-up. The combined acceptance criterion is checked in the second-merging PR by a regression-test run that exercises both: (a) a broken extension is logged and unloads cleanly with no residual registry entries (D-124 hot-reload property test); (b) processing N unique unloaded module-name strings interns zero atoms (property test asserted via `:erlang.system_info(:atom_count)` deltas).
+
+## Open questions
+
+- (Inherited from `unload-resilience`) `Tau.Tool.register/1`'s actual return contract — `:ok | :error` vs. unconditional `:ok` vs. raise — must be verified before the `registered_keys` capture for the `:tool` tag is written; the snapshot must record only keys actually registered.
+- (Inherited from `unload-resilience`) Grep `lib/` and `test/` for `state.loaded` / `entry.info` pattern-match callsites to confirm the enriched `info` shape's blast radius before the PR opens; any external matcher must accept the new `registered_keys` field.
+- (Inherited from `unload-resilience`) Path-based `%{path: _, modules: [mod1, mod2, ...]}` entries: the current `info` shape per path vs. per module must be re-read; the snapshot must be per-module to support independent unload.
+- (Inherited from `atom-internment`) Whether Credo `--strict` flags the `rescue ArgumentError` in `name_collision?/1`; if so, the response is a targeted `# credo:disable-for-next-line` with rationale, not removing the guard.
+- (Inherited from `atom-internment`) Calibration of `@atom_headroom`'s 10_000 default against a baseline atom count audit of the deployed application.
+- (Inherited from `atom-internment`) Whether `[:tau, :extensions, :atom_budget_exceeded]` should be a paired `:start`/`:stop` span or a single `:execute`; OTP non-negotiables §5 requires pairing for perf-sensitive events but this is a one-time guard so a single `:execute` is defensible.
+- (Coordination, parent-level) SPEC-EXTENSIONS D-NNN allocation for the new unload-snapshot invariant and the no-intern guarantee — single new D-NNN per concern or amendments to existing D-122/D-123/D-124. Resolved by the spec author at amendment time; not a blocker for either child's implementation.
+
+## Linked sub-problems / proposals
+
+- `subproblems/unload-resilience/` → "Enrich `info` with `registered_keys` at registration; drive unload from the snapshot via `crash_safe_unload/2`; delete `try_tool_name/1` and the four `try/rescue _ -> []` blocks."
+- `subproblems/atom-internment/` → "Return strings from `peek_module_names/1`; check collisions with `String.to_existing_atom/1` via a typed `name_collision?/1` helper; add an `atom_budget_ok?/0` defence-in-depth guard with `@atom_headroom` and an `:atom_budget_exceeded` telemetry event."
+
+## Revision history
+
+- (revision 0 — initial)

--- a/docs/problems-archive-v1-modules/tau-extensions/subproblems/atom-internment/problem.md
+++ b/docs/problems-archive-v1-modules/tau-extensions/subproblems/atom-internment/problem.md
@@ -1,0 +1,47 @@
+---
+template_version: 1
+template_name: problem
+node_kind: leaf
+depth: 1
+parent: ../../problem.md
+status: draft
+---
+
+# Problem: atom-internment
+
+## Statement
+
+`peek_module_names/1` in `Tau.Extensions.Loader` converts every module name extracted from user-controlled `.ex` files under `~/.tau/extensions/**` into a permanent VM atom via `String.to_atom/1`. Elixir's atom table is a fixed-size global resource (default ~1 M atoms); once exhausted the VM crashes. Because each `defmodule` declaration in each scanned extension file creates a new permanent atom regardless of whether the module is ever compiled or loaded, a malicious or pathological extension directory can exhaust the atom table by declaring many uniquely-named modules — without any of those modules needing to load successfully.
+
+## Context
+
+- `lib/tau/extensions/loader.ex:276–290` — `peek_module_names/1`; regex scan over raw source text, then `String.to_atom("Elixir." <> name)` for each match
+- `lib/tau/extensions/loader.ex:228–253` — `compile_with_collision_guard/1`: calls `peek_module_names/1` before every `Code.compile_file/1`; purpose is to detect module-name collisions via `Code.ensure_loaded?/1`
+- The in-code comment at line 270–275 acknowledges `String.to_atom/1` is used because `String.to_existing_atom/1` would fail on never-before-compiled modules; this reasoning conflates "must intern now" with "must use `String.to_atom`"
+- `Code.ensure_loaded?/1` accepts an atom; there is no API-level reason the atom must be permanent — the goal is simply to check whether the BEAM already has the module loaded
+- SPEC-EXTENSIONS D-123 (module-name collision guard, C-007)
+- Elixir default atom limit: `:erlang.system_info(:atom_limit)` ≈ 1_048_576; each unique extension defmodule name consumes one slot permanently
+
+## Complecting hypothesis
+
+Module collision detection is complected with atom-table resource management because `peek_module_names/1` uses `String.to_atom/1` both to produce atoms for `Code.ensure_loaded?/1` and to permanently intern those strings — a side-effect that is unnecessary for the guard's purpose. The collision check only needs to know "is this name already loaded?"; it does not need the atom to persist beyond the check.
+
+## Decomposition strategy
+
+(leaf — no further decomposition; proceed to proposals)
+
+## Acceptance criterion
+
+After the fix, processing an extension directory containing N uniquely-named `defmodule` declarations that are not already loaded adds zero new permanent atoms to the VM atom table for module names that do not ultimately compile successfully; module-name collision detection continues to work correctly for all previously-loaded modules.
+
+## Out of scope
+
+- `unload_module/1` `try/rescue` blocks — exclusively owned by `unload-resilience` sub-problem
+- `do_compile_file/1` — compile errors are handled correctly; not under audit
+- Performance of the regex scan itself (not a safety concern)
+- Sandboxing or capability-limiting of extension code at compile time (a separate, larger concern)
+- Changes to the `Tau.Extension` behaviour or DSL
+
+## Amendment log
+
+- (none yet)

--- a/docs/problems-archive-v1-modules/tau-extensions/subproblems/atom-internment/proposals/proposal-1.md
+++ b/docs/problems-archive-v1-modules/tau-extensions/subproblems/atom-internment/proposals/proposal-1.md
@@ -1,0 +1,108 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 1
+parent_problem: ../problem.md
+---
+
+# Proposal 1: Defer atom creation to post-compile — check by string, intern only on success
+
+## Approach
+
+Rewrite `peek_module_names/1` to return `{:ok, [String.t()]}` (bare strings, not atoms) and rewrite `compile_with_collision_guard/1` to perform the collision check using `String.to_existing_atom/1` with a guard: if the atom does not yet exist in the table, the module cannot be loaded, so the collision check returns false without interning anything. Only if `String.to_existing_atom/1` succeeds (meaning the atom is already in the table from a prior successful load) does the check proceed to `Code.ensure_loaded?/1`. Module names that have never been compiled therefore never have their atoms created during the peek phase; atoms are created only when `Code.compile_file/1` itself interns them as part of compilation.
+
+## Rationale
+
+The collision guard's job is to detect "is module X already loaded?" For a module that has never been compiled, the answer is trivially no — the BEAM cannot have it loaded — so there is nothing to intern. By switching to `String.to_existing_atom/1` and treating `ArgumentError` as "not loaded," the check becomes sound: it only succeeds on atoms that already exist (because a prior compilation created them), which is exactly the collision scenario. The permanent-intern side-effect is decomplected from the guard by moving it to the compiler, its only legitimate owner.
+
+## Sketch
+
+```elixir
+# peek_module_names/1 returns strings, not atoms
+defp peek_module_names(path) do
+  case File.read(path) do
+    {:ok, src} ->
+      names =
+        Regex.scan(~r/defmodule\s+([\w.]+)/, src, capture: :all_but_first)
+        |> List.flatten()
+        |> Enum.map(fn name -> "Elixir." <> name end)  # strings only
+
+      {:ok, names}
+
+    _error ->
+      :error
+  end
+end
+
+# collision_check/1 uses to_existing_atom — no intern on miss
+defp module_already_loaded?(name_string) do
+  atom = String.to_existing_atom(name_string)
+  Code.ensure_loaded?(atom)
+rescue
+  ArgumentError -> false  # atom does not exist → module not loaded → no collision
+end
+
+defp compile_with_collision_guard(path) do
+  case peek_module_names(path) do
+    {:ok, name_strings} ->
+      collisions = Enum.filter(name_strings, &module_already_loaded?/1)
+
+      if collisions != [] do
+        Logger.warning(
+          "Tau.Extensions.Loader: skipping #{path} — module name collision: " <>
+            inspect(collisions) <>
+            ". A prior extension already defined these modules. " <>
+            "Rename the conflicting module(s) to avoid a silent BEAM clobber."
+        )
+        []
+      else
+        do_compile_file(path)
+      end
+
+    :error ->
+      do_compile_file(path)
+  end
+end
+```
+
+No changes to `do_compile_file/1`, callers, or the `Tau.Extension` behaviour.
+
+## Tradeoffs
+
+### Strengths
+
+- Zero new permanent atoms for modules that never compile successfully — the acceptance criterion is met exactly.
+- Collision detection for already-loaded modules remains correct: `String.to_existing_atom/1` succeeds because the prior `Code.compile_file/1` interned the atom when that module was first loaded.
+- Minimal blast radius: changes two private functions (`peek_module_names/1` and `compile_with_collision_guard/1`); the public API and all callers are untouched.
+- The `rescue ArgumentError` pattern is idiomatic Elixir for this exact use case (see Elixir stdlib docs on `String.to_existing_atom/1`).
+- Removes the existing Credo suppression comment (the `UnsafeToAtom` warning goes away legitimately).
+
+### Weaknesses
+
+- The `rescue ArgumentError` in `module_already_loaded?/1` is technically a control-flow-via-exception pattern. It is correct and idiomatic here, but violates the project's stated preference for explicit error handling over exceptions (global CLAUDE.md).
+- If a future change causes `String.to_existing_atom/1` to raise something other than `ArgumentError` (unlikely in BEAM, but theoretically possible if module name is not a valid atom), the rescue clause would swallow an unexpected error as "not loaded."
+- Does not guard against an adversary who first loads a legitimate extension (interning its atoms), then floods the directory with uniquely-named files to exhaust remaining atom-table capacity via the regex scan. The atom-safety guarantee only applies to names not already in the table.
+- The comment at lines 270–275 ("adding atoms here is acceptable — D-123") must be updated; leaving it stale would mislead future readers.
+
+### Costs
+
+- Two private functions modified; no public API change.
+- One existing Credo suppression comment removed.
+- The comment block at lines 270–275 must be rewritten to document the new invariant.
+- Test surface: the existing property test for `compile_with_collision_guard/1` that covers collision detection continues to pass; a new property test is needed to assert that `peek_module_names/1` returns strings and that processing N unique names interns zero atoms when none are pre-loaded.
+
+## Dependencies
+
+- No other modules to change.
+- No library upgrades.
+- The `String.to_existing_atom/1` + `rescue ArgumentError` pattern is available in all supported Elixir versions (1.x+).
+
+## Confidence
+
+Medium. The logic is sound and the pattern is idiomatic, but the `rescue`-as-control-flow concern warrants a quick prototype to confirm Credo does not flag the `rescue ArgumentError` clause as an OTP-non-negotiable violation. Would raise to high after one successful `mix credo --strict` run on the modified file.
+
+## Prior art / references
+
+- Elixir docs: `String.to_existing_atom/1` — explicitly documents `ArgumentError` on missing atom, treating the rescue pattern as its canonical usage.
+- Erlang atom table semantics: `erlang:binary_to_existing_atom/2` — same guarantee in OTP; well-established pattern.
+- SPEC-EXTENSIONS D-123 — the invariant this fix is designed to enforce.

--- a/docs/problems-archive-v1-modules/tau-extensions/subproblems/atom-internment/proposals/proposal-2.md
+++ b/docs/problems-archive-v1-modules/tau-extensions/subproblems/atom-internment/proposals/proposal-2.md
@@ -1,0 +1,123 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 2
+parent_problem: ../problem.md
+---
+
+# Proposal 2: Eliminate peek entirely — use post-compile collision detection
+
+## Approach
+
+Remove `peek_module_names/1` and the pre-compile collision check from `compile_with_collision_guard/1` entirely. Replace the guard with a post-compile check: call `Code.compile_file/1`, then compare the returned module list against the existing registry to detect collisions. On collision, log the warning and purge the newly-loaded modules via `:code.purge/1` and `:code.delete/1`. This eliminates the atom-internment problem at its root by eliminating the pre-compile scan that caused it — no regex scan, no `String.to_atom/1`, no atom creation prior to compilation.
+
+## Rationale
+
+The pre-compile peek exists to avoid clobbering already-loaded modules. But the BEAM's `:code` server already tracks loaded modules; a post-compile registry comparison is a strictly more accurate collision signal than a regex-derived prediction. The complected side-effect (atom internment) disappears because the peek function disappears. Module names are only ever interned by `Code.compile_file/1` itself, which is unavoidable and correct — the BEAM must intern a module's name to define it. Post-compile purge is safe because the module has not yet been inserted into the extension registry.
+
+## Sketch
+
+```elixir
+# compile_with_collision_guard/1 — post-compile collision detection; no peek
+defp compile_with_collision_guard(path) do
+  compiled = do_compile_file(path)
+
+  collisions =
+    Enum.filter(compiled, fn mod ->
+      # Check the registry state BEFORE this load cycle started.
+      # @already_loaded is passed in from the call site (see below),
+      # or we query the registry directly:
+      Registry.lookup(Tau.Extensions.Registry, mod) != []
+    end)
+
+  if collisions != [] do
+    Logger.warning(
+      "Tau.Extensions.Loader: purging #{path} — module name collision: " <>
+        inspect(collisions) <>
+        ". A prior extension already defined these modules. " <>
+        "Rename the conflicting module(s) to avoid a silent BEAM clobber."
+    )
+
+    Enum.each(compiled, fn mod ->
+      :code.purge(mod)
+      :code.delete(mod)
+    end)
+
+    []
+  else
+    compiled
+  end
+end
+
+# peek_module_names/1 — DELETED
+# String.to_atom("Elixir." <> name) call — DELETED
+```
+
+The `do_compile_file/1` helper is unchanged. The `compile_with_collision_guard/1`
+call site in `load_entry/1` is unchanged — it still receives the path and returns
+a list of atoms.
+
+For the registry check, the simplest implementation queries `Code.ensure_loaded?/1`
+on each compiled module against a snapshot of what was loaded *before* this load
+cycle:
+
+```elixir
+# Alternative: snapshot-based collision check
+defp compile_with_collision_guard(path, pre_loaded_mods) do
+  compiled = do_compile_file(path)
+  collisions = Enum.filter(compiled, &MapSet.member?(pre_loaded_mods, &1))
+
+  if collisions != [] do
+    # ... log + purge as above
+    []
+  else
+    compiled
+  end
+end
+
+# Caller snapshots before the load cycle:
+pre_loaded = :code.all_loaded() |> Enum.map(&elem(&1, 0)) |> MapSet.new()
+Enum.flat_map(paths, &compile_with_collision_guard(&1, pre_loaded))
+```
+
+## Tradeoffs
+
+### Strengths
+
+- Eliminates the atom-internment problem at its source: no pre-compile scan, no `String.to_atom/1` call, no atom leak.
+- More accurate collision detection: uses what is actually loaded rather than a regex prediction. The current approach can miss a collision if the `defmodule` line is inside a quote block or a macro; the post-compile approach is exact.
+- Removes `peek_module_names/1` entirely — less code, fewer moving parts.
+- No `rescue`-as-control-flow; purge path uses explicit `{:ok, _} | :error` style if wrapped.
+
+### Weaknesses
+
+- Compilation is not free: the file is compiled (JIT'd and loaded into the BEAM) before the collision is detected. The existing approach skipped compilation on collision; this approach always pays the compile cost.
+- Post-compile purge via `:code.purge/1` / `:code.delete/1` is correct but not atomic. A concurrent process that somehow obtains a reference to the module between compile and purge could receive a stale code reference. In practice, the extension loader is single-process, but the guarantee is weaker than never loading the module at all.
+- `:code.purge/1` returns `false` if there are lingering processes running old code; this case must be handled explicitly or the module is not cleanly removed.
+- The snapshot approach (`pre_loaded_mods`) requires a small API change at the call site in `load_entry/1` — the `compile_with_collision_guard/1` signature changes arity.
+- Does not prevent atom exhaustion from the extension's own compilation creating atoms for its module names — but this is unavoidable: any approach that compiles the file will intern those atoms.
+
+### Costs
+
+- `peek_module_names/1` deleted (~15 lines).
+- `compile_with_collision_guard/1` rewritten (~25 lines net).
+- If snapshot approach is chosen: `load_entry/1` updated to pass `pre_loaded_mods`.
+- `:code.purge/1` / `:code.delete/1` are Erlang BIFs — no new dependencies.
+- Test surface: collision-detection property tests must be updated; the "peek returns string" test from proposal 1 is not needed but a "post-compile purge cleans modules" test is.
+- The behaviour change (compilation-then-purge instead of skip-before-compile) must be documented in SPEC-EXTENSIONS D-123.
+
+## Dependencies
+
+- No library changes.
+- Requires confirming that `:code.purge/1` behaviour in Erlang/OTP 27.2 is as expected (it is; the API is stable).
+- The `Tau.Extensions.Registry` module (or equivalent lookup mechanism) must be queryable before the load cycle begins; if the registry is only queryable after `crash_safe_register/2`, the snapshot approach is preferred.
+
+## Confidence
+
+Medium. The purge-based approach is well-established in hot-code-loading contexts, but using it in an extension loader is a less-common pattern. The `:code.purge/1` `false` return on lingering processes is a known rough edge. Would raise to high after a prototype that exercises the purge path under concurrent load.
+
+## Prior art / references
+
+- OTP `:code` module documentation — `:code.purge/1`, `:code.delete/1` semantics and return values.
+- Elixir `Code.compile_file/2` documentation — documents return value `[{module, binary}]`.
+- Erlang hot code loading discipline — load, check, purge pattern is established in release handler.

--- a/docs/problems-archive-v1-modules/tau-extensions/subproblems/atom-internment/proposals/proposal-3.md
+++ b/docs/problems-archive-v1-modules/tau-extensions/subproblems/atom-internment/proposals/proposal-3.md
@@ -1,0 +1,143 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 3
+parent_problem: ../problem.md
+---
+
+# Proposal 3: Change peek's return type — strings throughout, atom created once at guard site with arity guard
+
+## Approach
+
+Keep `peek_module_names/1` as a pure string-extraction function (returns `{:ok, [String.t()]}`) and introduce a new private function `name_collision?/1` that accepts a string, calls `:erlang.binary_to_existing_atom(name_string, :utf8)` (the OTP primitive, not the Elixir wrapper) directly, and returns `true` only when the atom exists AND `Code.ensure_loaded?/1` returns true. Wrap the `:erlang` call in a `case` on the atom-table result rather than a `rescue` block, by using the `:erlang.binary_to_existing_atom/2` variant that returns `{:ok, atom} | error` — except that primitive does not exist. Instead, introduce a narrow NIF-free guard using `:erlang.is_atom/1` and the atom-table check via the documented `:erlang.system_info(:atom_count)` delta to enforce a hard ceiling: if the atom count is within a configurable `@atom_headroom` of the limit, the loader refuses to process any further files and logs a clear error. This is an independent safety net distinct from the core fix.
+
+The core fix: `peek_module_names/1` returns strings; `compile_with_collision_guard/1` calls `name_collision?(string)` which wraps `String.to_existing_atom/1` (Elixir) in a structured helper that returns `{:collision, atom} | :no_collision`; the atom is only created if it already exists. This is similar to proposal 1 but extracted into a named, testable helper with an explicit return type and an additional atom-budget guard.
+
+## Rationale
+
+Proposal 1 solves the core problem but leaves the `rescue ArgumentError` inline in the calling function. Extracting the guard into `name_collision?/1` gives it an explicit type contract (`{:collision, atom} | :no_collision`) that the selector and future readers can reason about without parsing rescue logic. The atom-budget guard (check `:erlang.system_info(:atom_count)` vs `:erlang.system_info(:atom_limit)`) adds a defence-in-depth layer that fires even if some future code path reintroduces atom creation — it is a runtime enforcement of D-123's spirit, not just a local fix.
+
+## Sketch
+
+```elixir
+# Configurable headroom: refuse to process files when fewer than this many
+# atom slots remain. Default: 10_000.
+@atom_headroom Application.compile_env(:tau, [:extensions, :atom_headroom], 10_000)
+
+# peek_module_names/1 — returns strings only; no atom creation
+defp peek_module_names(path) do
+  case File.read(path) do
+    {:ok, src} ->
+      names =
+        Regex.scan(~r/defmodule\s+([\w.]+)/, src, capture: :all_but_first)
+        |> List.flatten()
+        |> Enum.map(fn name -> "Elixir." <> name end)
+
+      {:ok, names}
+
+    _error ->
+      :error
+  end
+end
+
+# name_collision?/1 — explicit return type; no intern on miss
+@spec name_collision?(String.t()) :: {:collision, atom()} | :no_collision
+defp name_collision?(name_string) do
+  case String.to_existing_atom(name_string) do
+    atom when is_atom(atom) ->
+      if Code.ensure_loaded?(atom), do: {:collision, atom}, else: :no_collision
+  end
+rescue
+  ArgumentError -> :no_collision
+end
+
+# atom_budget_ok?/0 — defence-in-depth guard
+defp atom_budget_ok? do
+  limit = :erlang.system_info(:atom_limit)
+  count = :erlang.system_info(:atom_count)
+  limit - count >= @atom_headroom
+end
+
+# compile_with_collision_guard/1 — uses name_collision?/1 and atom_budget_ok?/0
+defp compile_with_collision_guard(path) do
+  unless atom_budget_ok?() do
+    Logger.error(
+      "Tau.Extensions.Loader: atom table near capacity " <>
+        "(#{:erlang.system_info(:atom_count)}/#{:erlang.system_info(:atom_limit)}); " <>
+        "refusing to load #{path}"
+    )
+
+    :telemetry.execute([:tau, :extensions, :atom_budget_exceeded], %{count: :erlang.system_info(:atom_count)}, %{path: path})
+    return []
+  end
+
+  case peek_module_names(path) do
+    {:ok, name_strings} ->
+      collisions =
+        name_strings
+        |> Enum.map(&name_collision?/1)
+        |> Enum.filter(&match?({:collision, _}, &1))
+        |> Enum.map(fn {:collision, atom} -> atom end)
+
+      if collisions != [] do
+        Logger.warning(
+          "Tau.Extensions.Loader: skipping #{path} — module name collision: " <>
+            inspect(collisions) <>
+            ". A prior extension already defined these modules. " <>
+            "Rename the conflicting module(s) to avoid a silent BEAM clobber."
+        )
+        []
+      else
+        do_compile_file(path)
+      end
+
+    :error ->
+      do_compile_file(path)
+  end
+end
+```
+
+Note: `return []` above is pseudocode for an early return; in Elixir this would be a nested `if/case` — the actual implementation uses idiomatic early-branch returns.
+
+## Tradeoffs
+
+### Strengths
+
+- Zero new permanent atoms for never-compiled modules — acceptance criterion met.
+- `name_collision?/1` has an explicit, typed return (`{:collision, atom} | :no_collision`) — easier to unit-test and reason about than an inline rescue.
+- The atom-budget guard provides a defence-in-depth backstop that fires even if a future code path reintroduces atom creation. It also adds observability via telemetry.
+- Removes the Credo `UnsafeToAtom` suppression legitimately.
+- The `@atom_headroom` compile-env parameter lets operators tune the threshold without a code change.
+
+### Weaknesses
+
+- More code than proposal 1: adds `name_collision?/1`, `atom_budget_ok?/0`, and a telemetry event — roughly 20 extra lines for a local fix.
+- The atom-budget guard fires on total atom count, not extension-load-specific atom count; a burst of non-extension activity (e.g. dynamic module generation elsewhere) could trigger the guard spuriously.
+- `:erlang.system_info(:atom_count)` includes atoms created by the VM itself and all libraries; the `@atom_headroom` value is empirical, not derivable from first principles. The default of 10_000 may be too conservative or too permissive depending on workload.
+- Still uses `rescue ArgumentError` internally in `name_collision?/1` (the same control-flow-via-exception concern as proposal 1, but one level removed).
+- The atom-budget guard's `return []` silently drops extensions rather than returning a tagged error to the caller; callers cannot distinguish "skipped for budget" from "skipped for collision" from the return value alone — only the log message differentiates them.
+
+### Costs
+
+- Three private functions modified/added.
+- One `Application.compile_env/3` call at module level (compile-time config).
+- One new telemetry event: `[:tau, :extensions, :atom_budget_exceeded]` — must be added to SPEC-EXTENSIONS if the spec governs telemetry namespace.
+- Test surface: `name_collision?/1` is independently testable; the atom-budget guard needs a test that mocks `:erlang.system_info` or temporarily exhausts the table (difficult; property test recommended).
+- The comment at lines 270–275 must be updated.
+
+## Dependencies
+
+- No library changes.
+- `Application.compile_env/3` requires that the application is configured at compile time if a non-default headroom is desired; runtime config would require a different pattern.
+- SPEC-EXTENSIONS §3 / §4 should record the `@atom_headroom` parameter and the telemetry event.
+
+## Confidence
+
+Medium. The core fix (strings + `name_collision?/1`) is sound. The atom-budget guard adds value but introduces a new configuration surface that needs operational validation. Would raise to high after a prototype with configurable headroom tested under a synthetic atom-pressure workload.
+
+## Prior art / references
+
+- OTP `:erlang.system_info(:atom_count)` / `:atom_limit` — documented in OTP `erlang` module; used in production systems to monitor atom table pressure.
+- Elixir `Application.compile_env/3` — compile-time config idiom; well-established.
+- SPEC-EXTENSIONS D-123 — the invariant this fix enforces.
+- Erlang `:telemetry` — the telemetry pattern for atom-budget events follows `[:tau, ...]` namespace convention per OTP non-negotiables §5.

--- a/docs/problems-archive-v1-modules/tau-extensions/subproblems/atom-internment/proposals/proposal-4.md
+++ b/docs/problems-archive-v1-modules/tau-extensions/subproblems/atom-internment/proposals/proposal-4.md
@@ -1,0 +1,145 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 4
+parent_problem: ../problem.md
+---
+
+# Proposal 4: API-breaking — replace peek with a module-count quota enforced at the directory level
+
+## Approach
+
+Remove `peek_module_names/1` and its `String.to_atom/1` call entirely. Replace the per-file pre-compile collision check with a **directory-level module quota** enforced before any compilation begins: scan the extension directory for `.ex` files, count the `defmodule` occurrences using the same regex but without converting them to atoms (a raw integer count), and reject the entire directory load if the count exceeds a configurable `@max_extension_modules` limit. For collision detection, replace the pre-compile atom-based check with a post-compile registry comparison: after `Code.compile_file/1` returns, compare the returned module atoms against a snapshot of the known extension registry taken before the load cycle. This is an API-breaking change because `compile_with_collision_guard/1`'s internal contract changes and the public-facing load-cycle behavior changes (directory rejected as a unit rather than individual files skipped).
+
+## Rationale
+
+Both the pre-compile atom-intern problem and the collision-check mechanism share a common root: the attempt to answer "what will this file define?" before compiling it, using an approximation (regex + atom). This proposal rejects the approximation entirely. Atom exhaustion via `defmodule` counts is a volume attack; volume attacks are best stopped at the entry point with a hard cap rather than with per-name checks. Collision detection is more accurately done post-compile against real registry state than pre-compile against a speculative atom list. The result is simpler: no pre-compile scan, no atom creation, two independent concerns handled by two independent mechanisms.
+
+## Sketch
+
+```elixir
+# Module-count cap: refuse to load a directory whose files declare more than
+# this many defmodule forms in total. Configurable via application env.
+@max_extension_modules Application.compile_env(:tau, [:extensions, :max_modules], 100)
+
+# count_declared_modules/1 — pure integer count; no atom creation
+@spec count_declared_modules([Path.t()]) :: non_neg_integer()
+defp count_declared_modules(paths) do
+  Enum.reduce(paths, 0, fn path, acc ->
+    case File.read(path) do
+      {:ok, src} ->
+        acc + length(Regex.scan(~r/defmodule\s+[\w.]+/, src))
+      _error ->
+        acc
+    end
+  end)
+end
+
+# quota_ok?/1 — enforce the directory-level cap before any compilation
+@spec quota_ok?([Path.t()]) :: :ok | {:error, :quota_exceeded, non_neg_integer()}
+defp quota_ok?(paths) do
+  count = count_declared_modules(paths)
+
+  if count <= @max_extension_modules do
+    :ok
+  else
+    {:error, :quota_exceeded, count}
+  end
+end
+
+# load_entry/1 (modified excerpt) — quota check before compilation loop
+defp load_entry({:ok, dir, paths}) do
+  case quota_ok?(paths) do
+    :ok ->
+      pre_loaded_mods = MapSet.new(Map.keys(existing_registry_snapshot()))
+
+      registered =
+        Enum.flat_map(paths, fn path ->
+          compiled = do_compile_file(path)
+          {collisions, new_mods} = Enum.split_with(compiled, &MapSet.member?(pre_loaded_mods, &1))
+
+          if collisions != [] do
+            Logger.warning(
+              "Tau.Extensions.Loader: purging #{path} — module name collision: " <>
+                inspect(collisions)
+            )
+            Enum.each(compiled, fn m -> :code.purge(m); :code.delete(m) end)
+            []
+          else
+            Enum.flat_map(new_mods, fn mod ->
+              crash_safe_register(mod, dir_key(dir))
+            end)
+          end
+        end)
+
+      {:ok, dir, %{path: dir, modules: registered}}
+
+    {:error, :quota_exceeded, count} ->
+      Logger.error(
+        "Tau.Extensions.Loader: refusing to load #{dir} — " <>
+          "#{count} defmodule declarations exceed the limit of #{@max_extension_modules}. " <>
+          "Split the extension or raise :max_modules in config."
+      )
+      :telemetry.execute([:tau, :extensions, :quota_exceeded], %{count: count}, %{dir: dir})
+      :error
+  end
+end
+
+# peek_module_names/1 — DELETED
+# String.to_atom("Elixir." <> name) call — DELETED
+# compile_with_collision_guard/1 — DELETED (replaced inline in load_entry)
+```
+
+`existing_registry_snapshot/0` queries whatever ETS table backs the extension
+registry before the load cycle; its implementation depends on the registry
+internals (not changed by this proposal).
+
+## Tradeoffs
+
+### Strengths
+
+- Eliminates `String.to_atom/1` entirely — zero atom internment from the peek path under any scenario.
+- The directory-level quota is a volume-attack defence that scales with the attack surface (number of `defmodule` declarations) rather than trying to check each one.
+- No `rescue`-as-control-flow anywhere in the modified path.
+- Post-compile collision detection is exact rather than approximate (same strength as proposal 2).
+- The quota failure mode is explicit and tagged (`{:error, :quota_exceeded, count}`), not silently absorbed.
+- Telemetry event on quota breach provides observability.
+
+### Weaknesses
+
+- **API-breaking**: `compile_with_collision_guard/1` is deleted and its logic is merged into `load_entry/1`; any tests that call `compile_with_collision_guard/1` directly must be updated.
+- The quota cap is a blunt instrument: a legitimate extension with 101 modules (unlikely but possible) would be rejected regardless of atom-table state. The cap is a policy choice, not a technical necessity.
+- Post-compile purge via `:code.purge/1` has the same atomicity and lingering-process caveats as proposal 2.
+- `count_declared_modules/1` reads all `.ex` files a second time (already read during compilation), doubling file I/O. For large extension directories, this is measurable.
+- `existing_registry_snapshot/0` must be called before the load cycle and its implementation is not detailed here — the actual registry lookup mechanism needs to be confirmed to be snapshotable.
+- Removes a tested unit (`compile_with_collision_guard/1`) and merges its logic into `load_entry/1`, which reduces test isolation.
+
+### Costs
+
+- `peek_module_names/1` deleted.
+- `compile_with_collision_guard/1` deleted.
+- `count_declared_modules/1` added (~12 lines).
+- `quota_ok?/1` added (~10 lines).
+- `load_entry/1` significantly modified — the most disruptive change of the four proposals.
+- Two new telemetry events: `[:tau, :extensions, :quota_exceeded]`.
+- Test surface: existing `compile_with_collision_guard/1` tests need porting to test the new inline logic in `load_entry/1`; new tests needed for `count_declared_modules/1` and `quota_ok?/1`.
+- SPEC-EXTENSIONS D-123 must record the quota parameter and the changed load-cycle contract.
+- The `@max_extension_modules` default of 100 is an arbitrary policy decision — it should be documented as such and reviewed with the product owner.
+
+## Dependencies
+
+- The ETS registry backing `Tau.Extensions.Loader` must expose a snapshotable view before the load cycle begins. If it does not, the pre-loaded snapshot approach from proposal 2's alternative sketch applies instead.
+- `:code.purge/1` / `:code.delete/1` — Erlang/OTP 27.2 BIFs, no new deps.
+- `Application.compile_env/3` for the `@max_extension_modules` cap.
+- The quota default (100) should be validated against real-world extension directories.
+
+## Confidence
+
+Low-medium. The core approach (delete peek, add quota, post-compile collision) is sound, but the blast radius — deleting `compile_with_collision_guard/1`, modifying `load_entry/1`, adding a registry snapshot — is larger than the other proposals, and the `existing_registry_snapshot/0` dependency introduces uncertainty. Would raise to medium after confirming the registry is snapshotable and after a prototype that exercises the purge path under concurrent load.
+
+## Prior art / references
+
+- Rate-limiting / quota patterns in extension systems (VS Code extension validation, Ruby gem security scans) — domain-level quota on declaration count is an established entry-point defence.
+- OTP `:code.purge/1` / `:code.delete/1` documentation.
+- Erlang `:telemetry` — `[:tau, :extensions, ...]` namespace per OTP non-negotiables §5.
+- SPEC-EXTENSIONS D-123 — the invariant this fix enforces.

--- a/docs/problems-archive-v1-modules/tau-extensions/subproblems/atom-internment/solution.md
+++ b/docs/problems-archive-v1-modules/tau-extensions/subproblems/atom-internment/solution.md
@@ -1,0 +1,71 @@
+---
+template_version: 1
+template_name: solution
+parent_problem: problem.md
+node_kind: leaf
+synthesised_from: [proposals/proposal-3.md]
+selection_method: single
+revision: 0
+---
+
+# Solution: strings-throughout + named collision helper + atom-budget guard
+
+## Recommendation
+
+Replace `peek_module_names/1` with a pure string-returning variant (no atom creation), extract the collision check into a named `name_collision?/1` helper that returns `{:collision, atom} | :no_collision` using `String.to_existing_atom/1` (interning nothing on a miss), and add an `atom_budget_ok?/0` defence-in-depth guard that checks `:erlang.system_info(:atom_count)` against `:erlang.system_info(:atom_limit)` before any file is processed. This eliminates the permanent-atom side-effect from the peek path for all module names that are not already loaded, satisfies the acceptance criterion exactly, and adds observability and a runtime backstop without changing any public API or altering the collision-detection semantics for already-loaded modules.
+
+## Selected from
+
+- **Chosen:** `proposals/proposal-3.md`
+- **Why chosen:** Proposal 3 is a strict superset of Proposal 1 in decomplecting depth and testability. Both satisfy the acceptance criterion via the same core mechanism (`String.to_existing_atom/1` returning no-op on a miss), but Proposal 3 extracts the guard into `name_collision?/1` with an explicit typed contract (`{:collision, atom} | :no_collision`), making the unit independently testable and its invariant visible at the type level. The atom-budget guard is additive — it does not change the primary fix's correctness but adds a runtime backstop that fires even if a future code path reintroduces atom creation. Proposal 2 over-solves (compiles before checking collisions, introducing post-compile purge atomicity risk) without satisfying the AC more cleanly. Proposal 4 is API-breaking, blunt, and carries unresolved dependencies (`existing_registry_snapshot/0`). Proposal 3 does not force a choice between Proposals 1 and 3 — it IS Proposal 1 with the `rescue`-inline concern addressed by extraction.
+
+| # | Fit | Decomplecting depth | Migration cost | Risk | Reversibility |
+|---|-----|---------------------|----------------|------|---------------|
+| 1 | Yes | Substantial | Low | Low | Easy |
+| 2 | Yes | Deep | Medium | Medium | Medium |
+| 3 | Yes | Deep | Low | Low | Easy |
+| 4 | Yes | Deep | High | Medium | Hard |
+
+Proposal 3 wins on Fit + Decomplecting depth without being defeated on cost, risk, or reversibility.
+
+## What changes
+
+- `lib/tau/extensions/loader.ex` — `peek_module_names/1`: return type changes from `{:ok, [atom()]}` to `{:ok, [String.t()]}`; the `String.to_atom("Elixir." <> name)` call is removed; strings are returned directly.
+- `lib/tau/extensions/loader.ex` — `compile_with_collision_guard/1`: updated to pass name strings to `name_collision?/1`; the inline atom-creation and `Code.ensure_loaded?/1` call replaced by `name_collision?/1` calls.
+- `lib/tau/extensions/loader.ex` — add private `name_collision?(String.t()) :: {:collision, atom()} | :no_collision` using `String.to_existing_atom/1` + `rescue ArgumentError → :no_collision`.
+- `lib/tau/extensions/loader.ex` — add private `atom_budget_ok?/0` checking `(:erlang.system_info(:atom_limit) - :erlang.system_info(:atom_count)) >= @atom_headroom`; early-return with `Logger.error` + telemetry event `[:tau, :extensions, :atom_budget_exceeded]` when false.
+- `lib/tau/extensions/loader.ex` — add module attribute `@atom_headroom Application.compile_env(:tau, [:extensions, :atom_headroom], 10_000)`.
+- `lib/tau/extensions/loader.ex` — rewrite the comment block at lines 270–275 (currently rationalising `String.to_atom/1`) to document the new `String.to_existing_atom/1` invariant.
+- `lib/tau/extensions/loader.ex` — remove the existing Credo `UnsafeToAtom` suppression comment (the warning disappears legitimately).
+- `docs/spec/SPEC-EXTENSIONS.md` — §3: add `@atom_headroom` as a configurable invariant; §4 or telemetry section: record the `[:tau, :extensions, :atom_budget_exceeded]` event; update D-123 to reflect the new no-intern guarantee.
+
+## What does not change
+
+- `do_compile_file/1` — unmodified; compile errors remain handled by existing path.
+- Public API of `Tau.Extensions.Loader` — no public function signatures change.
+- Callers of `compile_with_collision_guard/1` — the function remains private and its arity and return type are unchanged from the caller's perspective.
+- Collision-detection semantics for already-loaded modules — `String.to_existing_atom/1` succeeds for atoms that exist (because `Code.compile_file/1` interned them on their first successful load), so the collision guard fires correctly for all previously-loaded modules.
+- The `Tau.Extension` behaviour and DSL — explicitly out of scope.
+- `unload_module/1` and `do_compile_file/1` error handling — owned by adjacent sub-problems.
+
+## Migration sketch
+
+Introduce the changes in a single PR touching only `lib/tau/extensions/loader.ex` and `docs/spec/SPEC-EXTENSIONS.md`: (1) update `peek_module_names/1` to return strings, (2) add `name_collision?/1`, (3) add `atom_budget_ok?/0` and `@atom_headroom`, (4) update `compile_with_collision_guard/1` to call both, (5) rewrite the stale comment block, (6) remove the Credo suppression, (7) amend SPEC-EXTENSIONS D-123 and add the telemetry event entry. Property tests: add a test asserting that processing N unique module name strings (none pre-loaded) interns zero atoms; add a unit test for `name_collision?/1`'s three cases (no atom, atom not loaded, atom loaded). The existing collision-detection property test continues to pass unchanged because the observable behaviour of `compile_with_collision_guard/1` is identical.
+
+## Open questions
+
+- Does Credo `--strict` flag the `rescue ArgumentError` in `name_collision?/1` under the `Credo.Check.Warning.UnsafeToAtom` or any related check? Proposal 1 noted this as a prototype verification step; the same applies here. If Credo flags it, a `# credo:disable-for-next-line` with a rationale comment is the correct response (not removing the guard).
+- Is a default `@atom_headroom` of 10_000 well-calibrated for this application's atom budget in a typical deployed state? The proposal acknowledges the value is empirical. A brief audit of baseline atom count at startup is recommended before picking the default.
+- Should the `[:tau, :extensions, :atom_budget_exceeded]` telemetry event be paired with a `[:tau, :extensions, :atom_budget_exceeded, :start]` / `[:tau, :extensions, :atom_budget_exceeded, :stop]` span or is a single `:execute` sufficient? OTP non-negotiables §5 requires pairing for perf-sensitive events; this is a one-time guard, so a single `:execute` is defensible.
+- SPEC-EXTENSIONS D-123 currently covers the module-name collision guard (C-007). Does the no-intern guarantee require a new D-NNN or an amendment to D-123? This is a clarification for the spec author, not a blocker for the implementation.
+
+## Linked sub-problems / proposals
+
+- `proposals/proposal-1.md` — Defer atom creation via `String.to_existing_atom/1`; inline rescue; minimal changes. Core mechanism identical to the chosen solution; rejected in favour of Proposal 3's named-helper extraction and budget guard.
+- `proposals/proposal-2.md` — Eliminate peek entirely; post-compile purge via `:code.purge/1`. More accurate collision detection but introduces compile-before-check cost and purge atomicity risk.
+- `proposals/proposal-3.md` — **Selected.** Strings throughout; `name_collision?/1` with explicit return type; `atom_budget_ok?/0` defence-in-depth guard; telemetry event on budget breach.
+- `proposals/proposal-4.md` — Directory-level module quota + post-compile collision; API-breaking; blunt instrument; unresolved registry snapshot dependency.
+
+## Revision history
+
+- (revision 0 — initial)

--- a/docs/problems-archive-v1-modules/tau-extensions/subproblems/atom-internment/validation.md
+++ b/docs/problems-archive-v1-modules/tau-extensions/subproblems/atom-internment/validation.md
@@ -1,0 +1,215 @@
+---
+template_version: 1
+template_name: validation
+parent_solution: solution.md
+parent_problem: problem.md
+toulmin_complete: true
+falsification_attempted: true
+falsification_outcome: partially_falsified — claim/4
+revision_triggered: none
+---
+
+# Validation: strings-throughout + named collision helper + atom-budget guard
+
+## Overview
+
+The solution proposes three coordinated changes to `Tau.Extensions.Loader`: (1) convert `peek_module_names/1` to return strings instead of atoms, (2) extract `name_collision?/1` using `String.to_existing_atom/1` with a `rescue ArgumentError` branch, and (3) add an `atom_budget_ok?/0` guard with a configurable `@atom_headroom` threshold. Eight claims are extracted from the Recommendation, What-changes, and What-does-not-change sections. Falsification strategies applied: counter-example construction (claims 1–3), dependency check (claim 4), edge-case enumeration (claims 5–6), integration check (claim 7), type-level check (claim 8). One partial falsification found (claim 4: the Credo question is unresolved), narrowing the qualifier. No full falsification; no revision triggered.
+
+---
+
+## Toulmin per claim
+
+The MITRE empirical study on Toulmin formalism found that "participants found it difficult to generate Toulmin structures, and their structures varied greatly even though they started with the same content" (https://www.mitre.org/news-insights/publication/empirical-evaluation-structured-argumentation-using-toulmin-argument). This template enforces all six components explicitly with prompts to counter that variance.
+
+---
+
+### Claim 1: `peek_module_names/1` with `String.to_existing_atom/1` interns zero new atoms for module names not already loaded
+
+- **Claim (C):** Replacing `String.to_atom("Elixir." <> name)` with `String.to_existing_atom/1` (inside `rescue ArgumentError → :no_collision`) means that processing a source file whose module names have never been compiled adds zero new permanent atoms to the VM atom table for those names.
+- **Grounds (G):** `loader.ex:283` calls `String.to_atom("Elixir." <> name)` today — this interns unconditionally. The Elixir standard library documents `String.to_existing_atom/1` as raising `ArgumentError` when the atom does not yet exist, leaving the atom table unchanged on the raise path. The rescue branch in the proposed `name_collision?/1` returns `:no_collision` without creating an atom. The acceptance criterion at `problem.md` §Acceptance criterion states this zero-intern property as the required post-condition.
+- **Warrant (W):** A function that exclusively raises without side-effecting the atom table, when wrapped in `rescue`, produces no atom-table writes on the failure path. This is an invariant of the BEAM runtime: atom creation is the exclusive domain of `String.to_atom/1`, `:erlang.binary_to_atom/2`, and the compiler; `String.to_existing_atom/1` raises on miss without interning.
+- **Qualifier (Q):** Holds for all module names not already in the BEAM atom table at the time `name_collision?/1` is called. Module names interned by prior successful `Code.compile_file/1` calls are already atoms; `String.to_existing_atom/1` succeeds on them (no new atom created either way).
+- **Rebuttal (R):** If the BEAM runtime were changed so that `String.to_existing_atom/1` interned on a miss (which it does not, but were it to), the claim would fail. Additionally, if any other code path between the `rescue` and the return of `:no_collision` created atoms from the name string, the claim would fail — but the proposed function contains no such path.
+- **Backing (B):** Erlang/OTP documentation `erlang:binary_to_existing_atom/2` (semantics carried into Elixir's `String.to_existing_atom/1`): "Failure: badarg if `Bin` does not correspond to an existing atom." The atom table is not modified on badarg. SPEC-EXTENSIONS D-123 (as amended by this PR) documents the no-intern guarantee.
+
+#### Falsification attempt for claim 1
+
+- **Strategy:** Counter-example construction — attempt to construct a BEAM state where `String.to_existing_atom/1` inside `rescue ArgumentError` interns a new atom on the miss path.
+- **Attempt:** Reviewed the OTP `atom_tables` implementation semantics and the Elixir `String.to_existing_atom/1` source path. The function calls `:erlang.binary_to_existing_atom/2`; on failure it raises `ArgumentError` before any atom is created. The `rescue` branch catches `ArgumentError` and returns `:no_collision` — no atom reference is stored. Attempted to find any intermediate allocation: there is none; the BEAM raises at the BIF level without committing to the atom table.
+- **Outcome:** Withstood — no counter-example found via this strategy.
+- **Action:** None.
+
+---
+
+### Claim 2: Collision detection for already-loaded modules is preserved
+
+- **Claim (C):** The proposed `name_collision?/1` using `String.to_existing_atom/1` fires correctly for all modules that were previously loaded (compiled) — i.e., the collision guard's observable behaviour is identical to the current `String.to_atom/1` + `Code.ensure_loaded?/1` path for that case.
+- **Grounds (G):** When a module has been compiled by `Code.compile_file/1`, the BEAM interns its module-name atom. `String.to_existing_atom/1` succeeds on an existing atom, returning it. The proposed function then calls `Code.ensure_loaded?/1` on that atom (or implicitly checks via the success branch). The existing integration test at `loader_test.exs:367–428` exercises exactly this two-directory collision scenario and currently relies on `Code.ensure_loaded?/1` catching the already-loaded atom.
+- **Warrant (W):** An atom that exists in the BEAM atom table is always retrievable by `String.to_existing_atom/1`; the lookup is a hash-table O(1) read. Therefore, the guard for already-loaded modules cannot be degraded by replacing `String.to_atom` with `String.to_existing_atom` in the success path.
+- **Qualifier (Q):** Holds for all modules that have completed at least one successful `Code.compile_file/1` call in the current VM session. Does not apply to modules compiled in a prior VM session that was restarted (but that is the same constraint the current implementation has).
+- **Rebuttal (R):** If `Code.compile_file/1` were somehow not to intern the module atom (e.g., due to a compile error that the compiler partially committed), `String.to_existing_atom/1` would miss and return `:no_collision` for a name that is partially in the code table. This is a pre-existing edge case not introduced by this fix.
+- **Backing (B):** `loader_test.exs:367–428` (AC-5 / D-123 describe block). SPEC-EXTENSIONS C-007 (`loader.ex:232–252`, `spec/SPEC-EXTENSIONS.md:108–115`). BEAM atom-table semantics: atoms are permanent once interned.
+
+#### Falsification attempt for claim 2
+
+- **Strategy:** Counter-example construction — attempt to find a sequence where an already-loaded module's name is missed by `String.to_existing_atom/1`.
+- **Attempt:** Examined `loader.ex:228–252` (`compile_with_collision_guard/1`). After `do_compile_file(path)` succeeds at line 246, the module is in the atom table. A subsequent call to `compile_with_collision_guard` for the same name would reach `peek_module_names/1` → `name_collision?/1` → `String.to_existing_atom/1` which succeeds → `{:collision, atom}` is returned → file is skipped. The test at `loader_test.exs:403–427` exercises this exact path (first dir compiled, second skipped). Counter-example cannot be constructed.
+- **Outcome:** Withstood.
+- **Action:** None.
+
+---
+
+### Claim 3: The `atom_budget_ok?/0` guard provides a runtime backstop even if a future code path reintroduces atom creation
+
+- **Claim (C):** Adding `atom_budget_ok?/0` (checking `atom_limit - atom_count >= @atom_headroom`) before processing any file means that even if a future code change reintroduces atom creation, the guard aborts the load attempt before the table is exhausted, logging an error and emitting `[:tau, :extensions, :atom_budget_exceeded]`.
+- **Grounds (G):** `:erlang.system_info(:atom_count)` and `:erlang.system_info(:atom_limit)` are documented BEAM BIFs returning current usage and configured limit respectively. The guard is inserted in `compile_with_collision_guard/1` before `peek_module_names/1` is called, ensuring no atom path is reached when headroom is insufficient. `loader.ex` currently has no such guard.
+- **Warrant (W):** A check that gates all atom-creating code paths behind a headroom assertion is a defence-in-depth measure: even if the primary fix is circumvented, the guard fires. OTP non-negotiables §5 requires telemetry for user-visible or perf-sensitive events; a guard preventing a VM crash is user-visible.
+- **Qualifier (Q):** Effective only when the guard is invoked before atom creation in the hot path. If atom creation occurs in a code path that bypasses `compile_with_collision_guard/1` (e.g., a direct `Code.compile_file/1` call without the guard), the backstop does not apply.
+- **Rebuttal (R):** The `@atom_headroom` default (10,000) is empirical and may be wrong. Too high a threshold aborts loading prematurely; too low fails to prevent exhaustion if a burst of atoms is created in one call. The solution acknowledges this as an open question.
+- **Backing (B):** OTP non-negotiables §5 (`otp-non-negotiables.md`). `:erlang.system_info/1` documentation (Erlang OTP). Solution §Open questions notes the calibration question.
+
+#### Falsification attempt for claim 3
+
+- **Strategy:** Edge-case enumeration — enumerate paths where the guard would not fire before atom creation.
+- **Attempt:** (1) `do_compile_file/1` at `loader.ex:255–266` calls `Code.compile_file/1` directly; the BEAM compiler interns module atoms at compile time. The proposed `atom_budget_ok?/0` guard in `compile_with_collision_guard/1` fires before `do_compile_file/1` is called — so this path is covered. (2) If `peek_module_names/1` returned early with `:error` (file unreadable), `compile_with_collision_guard/1` falls through to `do_compile_file/1` at line 251 — which would be AFTER the `atom_budget_ok?/0` check in the proposed revision. Covered. (3) A caller that bypasses `compile_with_collision_guard/1` and calls `do_compile_file/1` directly would bypass the guard — but `do_compile_file/1` is private, so no external caller can do this. Covered.
+- **Outcome:** Withstood — all atom-creation paths within the public interface are covered by the guard placement.
+- **Action:** None.
+
+---
+
+### Claim 4: Removing the Credo `UnsafeToAtom` suppression comment is a legitimate removal (the warning disappears on its own)
+
+- **Claim (C):** After replacing `String.to_atom/1` with `String.to_existing_atom/1`, Credo `--strict` will no longer emit a `UnsafeToAtom` warning for `loader.ex:282–283`, making the `# credo:disable-for-next-line` suppression comment redundant and correct to remove.
+- **Grounds (G):** `loader.ex:282` has `# credo:disable-for-next-line Credo.Check.Warning.UnsafeToAtom`. The project's `.credo.exs:13` sets `strict: true`; `UnsafeToAtom` is not disabled in the checks list (`.credo.exs:15–28`). The `UnsafeToAtom` check in Credo's source (`deps/credo/lib/credo/check/warning/unsafe_to_atom.ex`) specifically targets `String.to_atom/1`, `:erlang.binary_to_atom`, and similar "unsafe" atom-creation functions. The solution correctly notes the suppression line should be removed.
+- **Warrant (W):** Credo's `UnsafeToAtom` check is designed to flag atom creation from dynamic strings — `String.to_existing_atom/1` is the recommended safe alternative and is not flagged by this check. If the check is not triggered, the suppression comment is a stale no-op that will cause a Credo informational notice about unnecessary suppressions.
+- **Qualifier (Q):** Valid for the version of Credo currently depended on by the project. If a future Credo version were to flag `String.to_existing_atom/1` (which would be a regression in Credo), the suppression removal would re-introduce the warning.
+- **Rebuttal (R):** The solution's own open-questions section acknowledges uncertainty: "Does Credo `--strict` flag the `rescue ArgumentError` in `name_collision?/1` under `UnsafeToAtom` or any related check?" This is unresolved. If Credo flags the `rescue ArgumentError` path involving `String.to_existing_atom/1` as a related unsafe pattern (e.g., a new check added in the project's Credo version), the suppression removal may be premature or the new function may need its own suppression.
+- **Backing (B):** The Credo `UnsafeToAtom` check's stated purpose is to prevent atom-table exhaustion by flagging `String.to_atom/1` and `String.to_atom!/1` (plus Erlang equivalents). `String.to_existing_atom/1` is explicitly the recommended replacement. `.credo.exs` (project root).
+
+#### Falsification attempt for claim 4
+
+- **Strategy:** Dependency check — verify the project's Credo version does not flag `String.to_existing_atom/1` as `UnsafeToAtom`, and confirm no `rescue ArgumentError` handling is flagged.
+- **Attempt:** The Credo source for `UnsafeToAtom` is located at `deps/credo/lib/credo/check/warning/unsafe_to_atom.ex` but is not accessible from the repository's readable paths (denied by permissions). The solution itself explicitly lists this as an **open question** without resolution. The project's `.credo.exs` has `strict: true` and does not disable `UnsafeToAtom`, meaning the check is active and would surface during `mix credo --strict` in CI.
+- **Outcome:** Partially falsified — the claim that the suppression removal is legitimate cannot be confirmed without verifying the Credo check source. The qualifier must be narrowed: the removal is correct *provided* the project's pinned Credo version does not flag `String.to_existing_atom/1` or its `rescue` wrapper. This is a prototype verification step, not a blocker, as acknowledged in the solution's open questions.
+- **Action:** Narrow qualifier (done above). The solution should retain the open question and the implementer must run `mix credo --strict` to confirm before removing the suppression. No solution revision required; the solution already acknowledges this uncertainty.
+
+---
+
+### Claim 5: `compile_with_collision_guard/1` callers are unaffected (private, arity and return type unchanged)
+
+- **Claim (C):** The callers of `compile_with_collision_guard/1` are unaffected: the function remains private and its arity and return type are unchanged from the caller's perspective.
+- **Grounds (G):** `loader.ex:229` declares `defp compile_with_collision_guard(path)` — private, arity 1. Its return value is a list of compiled module atoms (via `do_compile_file/1` at `loader.ex:257`). The proposal changes the internal implementation but preserves this type. The function is called at line 232 via `peek_module_names/1`; the new `name_collision?/1` is an internal helper. No public API surfaces this function.
+- **Warrant (W):** A private function with an unchanged return type and arity imposes zero migration cost on callers, by the definition of "private" in Elixir (not accessible outside the module) and by the Liskov substitution principle applied to internal APIs.
+- **Qualifier (Q):** Holds for all callers within `Tau.Extensions.Loader`. If the function were re-exported as public in a future refactor, the internal-type changes (strings vs. atoms inside `peek_module_names/1`) would become visible — but that is a future concern, not this PR.
+- **Rebuttal (R):** None applicable within the declared scope; the function is private.
+- **Backing (B):** Elixir language spec on `defp` visibility. `loader.ex:229` (source citation). Solution §What does not change.
+
+#### Falsification attempt for claim 5
+
+- **Strategy:** Counter-example construction — find a caller of `compile_with_collision_guard/1` that would observe a changed contract.
+- **Attempt:** Searched `loader.ex` for calls to `compile_with_collision_guard`. It is called from `load_entry/1` at `loader.ex:213–222` (the `{:ok, path, ...}` branch). The return value is bound to `modules` at line 217. The function returns a list of atoms (module names); this return type is unchanged by the proposal (the strings-vs-atoms change is internal to `peek_module_names/1` and `name_collision?/1`). No external callers exist (private). Counter-example cannot be constructed.
+- **Outcome:** Withstood.
+- **Action:** None.
+
+---
+
+### Claim 6: The existing collision-detection property test continues to pass unchanged
+
+- **Claim (C):** The existing collision-detection tests (`loader_test.exs:367–428`) continue to pass after the change without modification.
+- **Grounds (G):** These tests exercise the observable behaviour of `compile_with_collision_guard/1` — that the second directory's module is skipped when its module name was already compiled. The solution's implementation preserves this behaviour by using `String.to_existing_atom/1` (which succeeds on already-loaded atoms) to detect collisions. The tests at `loader_test.exs:403–427` and `430–480` assert module identity, not atom creation mechanics.
+- **Warrant (W):** A test that asserts observable input/output behaviour (which module sticks after two directories define the same name) is decoupled from the internal mechanism (atom creation path). So long as the collision-detection correctness invariant holds, these tests pass regardless of whether the mechanism uses `to_atom` or `to_existing_atom`.
+- **Qualifier (Q):** Holds provided the test does not introspect the atom table size or atom creation count. Reviewing the test at `loader_test.exs:367–428`, no such assertion is present — the tests only assert `Code.ensure_loaded?/1` and `mod_atom.marker()` return values.
+- **Rebuttal (R):** If any test were added between now and the implementation that asserts "the following atoms do NOT exist after `peek_module_names/1`" (a negative atom-table check), the test would fail against the current code and pass after the fix — and thus would be a new test, not the existing tests.
+- **Backing (B):** `loader_test.exs:367–428` (source). Problem.md §Acceptance criterion ("module-name collision detection continues to work correctly for all previously-loaded modules"). Solution §Migration sketch ("The existing collision-detection property test continues to pass unchanged because the observable behaviour of `compile_with_collision_guard/1` is identical.").
+
+#### Falsification attempt for claim 6
+
+- **Strategy:** Integration check — verify the test does not assert on atom table contents or internment, only on module-load observable behaviour.
+- **Attempt:** Read `loader_test.exs:363–428`. The test: (1) writes two files with the same module name to two temp dirs, (2) calls `Loader.reload/1` for dir_a, waits, (3) calls `Loader.reload/1` for dir_b, (4) asserts `Code.ensure_loaded?(mod_atom)` is true and `mod_atom.marker() == :dir_a`. No assertion on atom count or atom table size. The integration check confirms the test is behavioural, not mechanistic.
+- **Outcome:** Withstood.
+- **Action:** None.
+
+---
+
+### Claim 7: `SPEC-EXTENSIONS` D-123 and C-007 require amendment to reflect the no-intern guarantee
+
+- **Claim (C):** D-123 (at `SPEC-EXTENSIONS.md:319–325`) and C-007 (at `SPEC-EXTENSIONS.md:108–115`) currently document `String.to_atom/1` as the mechanism and assert it is required to catch brand-new modules. After the fix, these constraints are inaccurate and must be amended.
+- **Grounds (G):** `SPEC-EXTENSIONS.md:321` reads "Module names are extracted from source text via `String.to_atom/1` (not `String.to_existing_atom/1`, which silently drops names for brand-new modules)." This is the design rationale the solution explicitly supersedes. C-007 at `SPEC-EXTENSIONS.md:111` repeats the same reasoning: "The guard extracts declared module names from the source text via `String.to_atom/1` (not `String.to_existing_atom/1` — the latter silently drops names for modules not yet compiled, defeating the guard for brand-new modules)."
+- **Warrant (W):** A specification document that records a design rationale which is now known to be incorrect (the solution demonstrates that `to_existing_atom/1` + `rescue` handles brand-new modules correctly without defeating the guard) must be updated. Leaving an incorrect rationale in the spec creates confusion for future engineers.
+- **Qualifier (Q):** Amendment scope is surgical: the mechanism description in D-123 and C-007 changes; the invariant (collision detection fires for already-loaded modules) does not change.
+- **Rebuttal (R):** A new D-NNN may be warranted for the no-intern guarantee rather than amending D-123. The solution flags this as an open question. The amendment may be either D-123 update or new D-NNN — both are valid; the claim is only that the spec must change, not how.
+- **Backing (B):** `spec-before-code.md` §What this rule requires: "Whether any new constraint surfaced during implementation that should be added to §3 of the SPEC. Adding a constraint is a spec amendment, not a silent slip." Problem.md §Acceptance criterion (grounds the no-intern guarantee that the spec must now record).
+
+#### Falsification attempt for claim 7
+
+- **Strategy:** Dependency check — verify the current spec text actually contradicts the proposed solution.
+- **Attempt:** Read `SPEC-EXTENSIONS.md:108–115` and `319–325`. Both passages assert `String.to_atom/1` is necessary and `String.to_existing_atom/1` is insufficient for brand-new modules. The solution's mechanism precisely contradicts this: `String.to_existing_atom/1` with `rescue ArgumentError` handles brand-new modules correctly (they miss → `:no_collision` → file is compiled → module atom is then interned by the compiler). The spec text is factually incorrect after the fix.
+- **Outcome:** Withstood — the dependency check confirms the spec must be updated; the claim stands.
+- **Action:** None (claim withstood).
+
+---
+
+### Claim 8: The new property tests (zero-atom-intern assertion and `name_collision?/1` unit test) are type-safe and cover the three cases
+
+- **Claim (C):** The migration sketch calls for: (1) a test asserting processing N unique module name strings (none pre-loaded) interns zero atoms; and (2) a unit test for `name_collision?/1`'s three cases (no atom, atom not loaded, atom loaded). The type signatures involved (`String.t() → {:collision, atom()} | :no_collision`) are internally consistent and the three cases are exhaustive.
+- **Grounds (G):** The three cases of `name_collision?/1` are: (a) atom not in table → `String.to_existing_atom/1` raises `ArgumentError` → `:no_collision`; (b) atom in table, module not loaded → `String.to_existing_atom/1` succeeds, `Code.ensure_loaded?/1` returns false → return value TBD by solution (`:no_collision` or `{:collision, atom}`); (c) atom in table, module loaded → `String.to_existing_atom/1` succeeds, `Code.ensure_loaded?/1` returns true → `{:collision, atom}`. Case (b) is an edge case the solution does not explicitly address in the return-type spec.
+- **Warrant (W):** A helper whose return type is `{:collision, atom()} | :no_collision` and whose three enumerated cases map cleanly to those two branches is type-safe if every branch returns one of those two shapes. Case (b) is ambiguous in the current solution text — an atom existing in the table but its module not loaded means the name is technically free for use without collision, so `:no_collision` is the correct return; this is internally consistent.
+- **Qualifier (Q):** Holds for the common cases. Case (b) (atom exists, module not loaded) can arise when a prior compile partially failed. If `:no_collision` is returned, two files could attempt to compile the same module name — but since `Code.ensure_loaded?` returns false, the BEAM module table is free, so the second compile would not collide at the BEAM level. This is correct behaviour.
+- **Rebuttal (R):** The zero-atom-intern assertion test requires access to `:erlang.system_info(:atom_count)` before and after calling the loader; concurrent test execution in `mix test --async` could see atom count change due to other test activity, making the assertion fragile without isolation.
+- **Backing (B):** Solution §Migration sketch. OTP non-negotiables §6 (properties before examples for invariant-bearing modules). BEAM atom-table documentation.
+
+#### Falsification attempt for claim 8
+
+- **Strategy:** Type-level check — trace the type of each return path of the proposed `name_collision?/1` against its declared type `{:collision, atom()} | :no_collision`.
+- **Attempt:** Path 1: `String.to_existing_atom/1` raises `ArgumentError` → `rescue ArgumentError → :no_collision`. Type: `:no_collision` ✓. Path 2: `String.to_existing_atom/1` succeeds → atom `a`. Then `Code.ensure_loaded?(a)` returns false → return `:no_collision`. Type: `:no_collision` ✓. Path 3: `String.to_existing_atom/1` succeeds → atom `a`. Then `Code.ensure_loaded?(a)` returns true → return `{:collision, a}`. Type: `{:collision, atom()}` ✓. All three paths produce the declared return type. Type-level check passes.
+- **Outcome:** Withstood. The Rebuttal about concurrent atom-count assertions is a test-design concern, not a falsification of the claim about the type safety of the helper itself.
+- **Action:** None. The concurrent-test rebuttal should be noted as an outstanding doubt.
+
+---
+
+## Cross-claim consistency
+
+Claims 1 and 2 are complementary and consistent: claim 1 covers the no-intern case (miss), claim 2 covers the collision-detection case (hit). Together they partition all inputs to `name_collision?/1`.
+
+Claims 3 and 1 are consistent: claim 3 is a backstop for regressions, claim 1 is the primary mechanism. They operate on different axes (prevention vs. detection) without tension.
+
+Claim 4 (Credo suppression removal) and claims 1–3 are logically independent — Credo is a linting tool; its warnings do not affect runtime correctness. The partial falsification of claim 4 does not affect claims 1–3.
+
+Claims 5–6 are preservation claims and do not conflict with claims 1–4.
+
+Claim 7 is a spec-update claim that is entailed by claims 1–2 being true: if the new mechanism works, the spec explaining why the old mechanism was necessary must change.
+
+Claim 8 (test coverage) is downstream of claims 1–3 and internally consistent with them.
+
+No cross-claim tensions identified.
+
+---
+
+## Falsification summary
+
+| # | Claim (short) | Strategy | Outcome | Action |
+|---|---|---|---|---|
+| 1 | `to_existing_atom/1` + rescue interns zero atoms on miss | Counter-example construction | Withstood | None |
+| 2 | Collision detection preserved for already-loaded modules | Counter-example construction | Withstood | None |
+| 3 | `atom_budget_ok?/0` covers all atom-creation paths | Edge-case enumeration | Withstood | None |
+| 4 | Credo suppression removal is legitimate | Dependency check | Partially falsified | Narrow qualifier; implementer must verify via `mix credo --strict` |
+| 5 | `compile_with_collision_guard/1` callers unaffected | Counter-example construction | Withstood | None |
+| 6 | Existing collision tests pass unchanged | Integration check | Withstood | None |
+| 7 | D-123 and C-007 require spec amendment | Dependency check | Withstood | None |
+| 8 | `name_collision?/1` type-safe; three cases exhaustive | Type-level check | Withstood | None |
+
+---
+
+## Revision required
+
+- **Target file:** N/A — no revision required.
+- **Revision kind:** N/A
+- **Rationale:** The partial falsification of claim 4 narrows the qualifier but does not falsify the claim's substance — the suppression removal is correct in intent, contingent on a prototype verification step already acknowledged by the solution as an open question. No revision to `solution.md` or `problem.md` is triggered.
+
+---
+
+## Outstanding doubts
+
+- The zero-atom-intern assertion property test (claim 8 rebuttal) may be fragile under concurrent `mix test` execution. The test author should either run it in a non-async context or compare atom-count deltas isolated to the loader's execution to avoid spurious failures from unrelated test activity.
+- The `@atom_headroom` default of 10,000 is empirical and uncalibrated against the project's actual startup atom count. The solution correctly flags this for the implementer; the validator notes it as a deployment-time risk: if the application's baseline atom count is high (e.g., warm Phoenix + Ecto + Tau OTP tree), 10,000 headroom may be insufficient to trigger the guard well before actual exhaustion.
+- Case (b) of `name_collision?/1` — atom exists in table, module not loaded — is logically correct to return `:no_collision` but is not called out explicitly in the solution's migration sketch. The unit test plan should cover this case explicitly to prevent a future implementer from accidentally returning `{:collision, atom}` for a module whose atom exists but whose code is not loaded (which would silently drop valid extension files).

--- a/docs/problems-archive-v1-modules/tau-extensions/subproblems/unload-resilience/problem.md
+++ b/docs/problems-archive-v1-modules/tau-extensions/subproblems/unload-resilience/problem.md
@@ -1,0 +1,49 @@
+---
+template_version: 1
+template_name: problem
+node_kind: leaf
+depth: 1
+parent: ../../problem.md
+status: draft
+---
+
+# Problem: unload-resilience
+
+## Statement
+
+`unload_module/1` in `Tau.Extensions.Loader` calls all four behaviour callbacks (`mod.tools/0`, `mod.hooks/0`, `mod.commands/0`, `mod.skills/0`) and wraps each call in a bare `try/rescue _ -> []`, silently treating any exception as an empty result list. A module that was successfully registered but has since become broken (e.g. reloaded with a compile error or missing dependency) will produce empty lists on unload, leaving its prior registry entries in place — a silent partial-unload that corrupts the registry without any log or telemetry signal.
+
+## Context
+
+- `lib/tau/extensions/loader.ex:425–480` — `unload_module/1`: four `try/rescue _ -> []` blocks, one per callback
+- `lib/tau/extensions/loader.ex:482–490` — `try_tool_name/1`: fifth `try/rescue _ -> nil` wrapping `mod.name/0`, used to resolve the tool-registry key during unload
+- `lib/tau/extensions/loader.ex:296–349` — `crash_safe_register/2`: the load path correctly isolates failures with logging and telemetry; the unload path has no equivalent
+- `lib/tau/extensions/loader.ex:397–408` — `unload_entry/2`: retrieves previously-stored `info` map (which records what was registered); this stored state is available but not used to drive unload
+- SPEC-EXTENSIONS D-120 (crash-isolated load), D-124 (hot reload unloads prior generation)
+- The loader's `state.loaded` map stores `%{module: mod}` or `%{modules: [mod]}` for every successfully-registered entry, meaning the loader already knows what it registered at load time
+
+## Complecting hypothesis
+
+The unload-time registry-query logic is complected with unload-time resilience because `unload_module/1` re-queries the module's callbacks at unload time to discover what to unregister, rather than using the load-time record already stored in `state.loaded`. This means a module that was correctly registered but subsequently broken cannot be cleanly unregistered — the very defect that made unload unsafe is the same one that makes the prior-generation cleanup in hot-reload (D-124) incomplete.
+
+The logged-and-skipped contract at load time (D-120) is complected with the silent-empty-list contract at unload time because both occur within the same GenServer process, giving the impression that all failures are handled — but only load failures are logged; unload failures are invisible.
+
+## Decomposition strategy
+
+(leaf — no further decomposition; proceed to proposals)
+
+## Acceptance criterion
+
+After the fix, a call to `unload_module/1` on a module that was successfully loaded but has since become broken (callbacks raise) produces: (a) a warning log naming the broken module and callback, (b) a `[:tau, :extensions, :unload, :exception]` telemetry event, and (c) no residual registry entries for the registrations that were recorded at load time.
+
+## Out of scope
+
+- Load-time isolation in `crash_safe_register/2` — correctly implemented; not under this sub-problem
+- `peek_module_names/1` and atom internment — exclusively owned by `atom-internment` sub-problem
+- `do_compile_file/1` compile error handling
+- The `is_extension?/1` guard
+- Changes to the `Tau.Extension` behaviour or DSL
+
+## Amendment log
+
+- (none yet)

--- a/docs/problems-archive-v1-modules/tau-extensions/subproblems/unload-resilience/proposals/proposal-1.md
+++ b/docs/problems-archive-v1-modules/tau-extensions/subproblems/unload-resilience/proposals/proposal-1.md
@@ -1,0 +1,168 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 1
+parent_problem: ../problem.md
+---
+
+# Proposal 1: Snapshot-driven unload — enrich `info` with registered keys at load time
+
+## Approach
+
+Enrich the `info` map stored in `state.loaded` at load time to include the exact registry
+keys that were registered for each callback category: `tools`, `hooks`, `commands`, and
+`skills`. During `unload_module/1`, use the snapshot from `info` to drive all four
+`Registry.unregister*` calls without invoking any behaviour callbacks. Remove the four
+`try/rescue _ -> []` blocks entirely. Wrap the unregister loop in a `crash_safe_unload/2`
+helper that mirrors `crash_safe_register/2`: emit a warning log and
+`[:tau, :extensions, :unload, :exception]` telemetry if a Registry call itself raises.
+
+## Rationale
+
+The complecting hypothesis is that `unload_module/1` calls behaviour callbacks to discover
+what to unregister, which fuses registry-key discovery with module-state assumptions. By
+storing registry keys at registration time (when the module is known-good), the unload path
+operates solely on load-time data. A module that has since become broken contributes no
+information at unload time — the snapshot is sufficient and independent of the module's
+current state. This decomplects "what was registered" (a historical fact in `info`) from
+"what the module says now" (a runtime query to a potentially-broken module).
+
+## Sketch
+
+```elixir
+# In register_module/1 — replace {:ok, mod, %{module: mod}} return
+
+defp register_module(mod) do
+  if is_extension?(mod) do
+    tool_keys =
+      Enum.flat_map(mod.tools(), fn t ->
+        case Tau.Tool.register(t) do
+          :ok -> [{:tool, try_tool_name(t), t}]
+          _ -> []
+        end
+      end)
+
+    hook_keys =
+      Enum.map(mod.hooks(), fn {ev, h} ->
+        Registry.register(Tau.Hooks.Registry, ev, h)
+        {:hook, ev}
+      end)
+
+    command_keys =
+      Enum.map(mod.commands(), fn {name, c} ->
+        Registry.register(Tau.Commands.Registry, name, c)
+        {:command, name}
+      end)
+
+    skill_keys =
+      Enum.flat_map(mod.skills(), fn {name, path} ->
+        case Tau.Skills.Loader.parse(path) do
+          {:ok, skill} ->
+            Registry.register(Tau.Skills.Registry, name, %{skill | name: name})
+            [{:skill, name}]
+          {:error, reason} ->
+            Logger.warning("Tau.Extensions.Loader: skipping skill ...")
+            []
+        end
+      end)
+
+    info = %{
+      module: mod,
+      registered_keys: tool_keys ++ hook_keys ++ command_keys ++ skill_keys
+    }
+
+    {:ok, mod, info}
+  else
+    :error
+  end
+end
+
+# In unload_module/1 — replace all four try/rescue blocks with snapshot-driven unregister
+
+defp unload_module(mod, %{registered_keys: keys}) do
+  Enum.each(keys, fn
+    {:tool, nil, _t} -> :ok
+    {:tool, name, t}  -> Registry.unregister_match(Tau.Tools.Registry, name, t)
+    {:hook, ev}       -> Registry.unregister(Tau.Hooks.Registry, ev)
+    {:command, name}  -> Registry.unregister(Tau.Commands.Registry, name)
+    {:skill, name}    -> Registry.unregister(Tau.Skills.Registry, name)
+  end)
+end
+
+defp unload_module(mod, _no_keys), do: unload_module_fallback(mod)
+
+# crash_safe_unload/2 — mirrors crash_safe_register/2
+defp crash_safe_unload(mod, info) do
+  try do
+    unload_module(mod, info)
+  rescue
+    e ->
+      Logger.warning(
+        "Tau.Extensions.Loader: unload of #{inspect(mod)} raised: #{Exception.message(e)}"
+      )
+      :telemetry.execute(
+        [:tau, :extensions, :unload, :exception],
+        %{system_time: System.system_time()},
+        %{module: mod, kind: :error, reason: e, stacktrace: __STACKTRACE__}
+      )
+  end
+end
+```
+
+`do_unload/1` is updated to thread `info` through to `crash_safe_unload/2`. `unload_entry/2`
+already has `info` available; no public API changes required.
+
+## Tradeoffs
+
+### Strengths
+
+- Fully satisfies the acceptance criterion: broken callbacks are never called at unload time;
+  the snapshot drives complete, clean registry removal.
+- Mirrors the existing `crash_safe_register/2` discipline exactly — consistency is high,
+  maintenance cost is low.
+- Snapshot fidelity: the keys recorded at `Registry.register` time are precisely the keys
+  that need to be unregistered, with no inference step.
+- No new public API surface; the change is entirely internal to the GenServer.
+- `try_tool_name/1` becomes unused and can be deleted.
+
+### Weaknesses
+
+- Requires enriching the `info` map stored per-entry in `state.loaded`. Any code that
+  pattern-matches on `%{module: mod}` must be updated to accept the enriched shape.
+- The `do_unload/1` / `unload_module/1` call chain must be refactored to thread `info`
+  through; currently `do_unload/1` receives `info` but `unload_module/1` does not.
+- If `Tau.Tool.register/1` doesn't currently return `:ok | error`, the tool-key capture
+  logic needs to be adjusted to match the actual return contract.
+- Path-based entries (`%{path: path, modules: registered}`) register multiple modules; the
+  enrichment must be per-module, requiring a per-module key list inside the entry info.
+
+### Costs
+
+- Moderate refactor: `register_module/1`, `do_unload/1`, `unload_module/1`,
+  `unload_entry/2`, and `crash_safe_unload/2` (new). Estimate 4–6 functions touched.
+- Test updates: tests that inspect `state.loaded` entry shapes or call `list/0` need to
+  handle the enriched `info` map.
+- The `registered_keys` field adds a small per-entry memory overhead (bounded by the count
+  of registered items per extension).
+
+## Dependencies
+
+- `Tau.Tool.register/1` return value must be inspectable to determine whether a tool key
+  was actually registered; if it currently returns `:ok` unconditionally, a `:ok | :error`
+  shape or exception-on-failure is needed.
+- No external dependency changes.
+
+## Confidence
+
+medium — the data-shape change is well-scoped and the Registry API supports keyed
+unregister. Confidence would be raised to high by verifying `Tau.Tool.register/1`'s
+return contract and confirming no external code pattern-matches on the bare `%{module: mod}`
+info shape.
+
+## Prior art / references
+
+- `crash_safe_register/2` in the same file (lines 296–349) — the load-path mirror this
+  proposal models the unload path on.
+- Erlang/OTP `ets:insert_new` + tombstone pattern: store facts at write time, use them at
+  delete time, never re-derive.
+- `unload_entry/2` (lines 397–408): already receives `info` — the threading path exists.

--- a/docs/problems-archive-v1-modules/tau-extensions/subproblems/unload-resilience/proposals/proposal-2.md
+++ b/docs/problems-archive-v1-modules/tau-extensions/subproblems/unload-resilience/proposals/proposal-2.md
@@ -1,0 +1,138 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 2
+parent_problem: ../problem.md
+---
+
+# Proposal 2: Per-callback safe-call wrapper with per-exception telemetry and log
+
+## Approach
+
+Keep the four `try/rescue` blocks in `unload_module/1` but transform their contract: instead
+of returning `[]` silently, each rescued exception emits a `Logger.warning/1` naming the
+broken module and the specific callback (`tools/0`, `hooks/0`, `commands/0`, `skills/0`),
+then emits a `[:tau, :extensions, :unload, :exception]` telemetry event, and finally
+substitutes an empty list. Introduce a shared private helper
+`safe_call_callback(mod, callback_name, default)` that encapsulates this pattern. The
+`try_tool_name/1` rescue is given the same treatment. No change to the info map, no change
+to how registry keys are discovered at unload time.
+
+## Rationale
+
+The acceptance criterion requires (a) a warning log naming module and callback, (b)
+`[:tau, :extensions, :unload, :exception]` telemetry, and (c) no residual registry
+entries for load-time registrations. This proposal satisfies (a) and (b) directly.
+For (c), it relies on the observation that a broken module returning `[]` from callbacks
+will cause zero unregister calls — which is a residual-entry failure only if callbacks
+actually return different results than what was registered. The bet is: if a module's
+`tools/0` raises, it is very unlikely that `tools/0` had returned a non-empty list at
+load time (compile errors clobber the entire module). This proposal decomplects the
+*visibility* of failures (silent vs. logged) without touching the registry-key-discovery
+mechanism.
+
+## Sketch
+
+```elixir
+# New helper — replace the four distinct try/rescue blocks
+
+@spec safe_call_callback(module(), atom(), term()) :: term()
+defp safe_call_callback(mod, callback, default) do
+  apply(mod, callback, [])
+rescue
+  e ->
+    Logger.warning(
+      "Tau.Extensions.Loader: #{inspect(mod)}.#{callback}/0 raised during unload: " <>
+        Exception.message(e)
+    )
+    :telemetry.execute(
+      [:tau, :extensions, :unload, :exception],
+      %{system_time: System.system_time()},
+      %{module: mod, callback: callback, kind: :error, reason: e, stacktrace: __STACKTRACE__}
+    )
+    default
+end
+
+# Updated unload_module/1
+
+defp unload_module(mod) do
+  if is_extension?(mod) do
+    tools = safe_call_callback(mod, :tools, [])
+    Enum.each(tools, fn t ->
+      tool_name = try_tool_name(t)
+      if tool_name, do: Registry.unregister_match(Tau.Tools.Registry, tool_name, t)
+    end)
+
+    hooks = safe_call_callback(mod, :hooks, [])
+    Enum.each(hooks, fn {ev, _h} ->
+      Registry.unregister(Tau.Hooks.Registry, ev)
+    end)
+
+    commands = safe_call_callback(mod, :commands, [])
+    Enum.each(commands, fn {name, _c} ->
+      Registry.unregister(Tau.Commands.Registry, name)
+    end)
+
+    skills = safe_call_callback(mod, :skills, [])
+    Enum.each(skills, fn {name, _path} ->
+      Registry.unregister(Tau.Skills.Registry, name)
+    end)
+  end
+end
+```
+
+`try_tool_name/1` is updated analogously (or called via `safe_call_callback` with `:name`).
+No changes to `info` map, `load_entry/1`, `register_module/1`, `do_unload/1`, or
+`unload_entry/2`.
+
+## Tradeoffs
+
+### Strengths
+
+- Minimal diff: only `unload_module/1` and a new private helper change; four functions
+  deleted (the four `try/rescue` blocks), one added.
+- No refactoring of the `info` map or the load path — zero risk of perturbing load
+  behaviour.
+- Directly and explicitly satisfies acceptance-criterion requirements (a) and (b) with
+  named module and callback in every log/telemetry event.
+- Reusable helper reduces duplication immediately; the pattern is obviously applicable to
+  `try_tool_name/1` as well.
+- Incremental: can be merged independently of any other loader change.
+
+### Weaknesses
+
+- Does NOT satisfy acceptance criterion (c) in the case of a module that was successfully
+  loaded (callbacks returned non-empty lists) and subsequently became broken via a partial
+  hot-reload or dependency unload. In that failure mode, `safe_call_callback` returns `[]`
+  and the prior registry entries remain.
+- Relies on the implicit assumption that a broken module's broken callbacks returned empty
+  lists at load time — an assumption that does not hold for hot-reload scenarios (D-124),
+  which are the primary use case of `unload_module/1`.
+- The accepted criterion explicitly requires "no residual registry entries for the
+  registrations that were recorded at load time" — this proposal fails that bar for the
+  hot-reload case even though it passes for fresh-compile-error cases.
+
+### Costs
+
+- Smallest possible diff: ~20 lines changed, ~4 lines added.
+- No test-surface impact on `state.loaded` shape.
+- Risk of false confidence: logs and telemetry fire, but residual entries may still exist
+  after unload of a broken-but-previously-registered module.
+
+## Dependencies
+
+- None. No external or inter-module dependencies added.
+
+## Confidence
+
+low — the proposal satisfies (a) and (b) of the acceptance criterion but is structurally
+unable to satisfy (c) for the hot-reload scenario that is the stated motivation of the
+problem. Confidence in this being the right fix is low; confidence in the implementation
+itself is high. This proposal is most useful if the problem statement's acceptance
+criterion (c) is relaxed to "best-effort" for hot-reload.
+
+## Prior art / references
+
+- `crash_safe_register/2` telemetry and logging pattern (lines 296–349) — directly modelled.
+- OTP `:logger` conventions: log at the severity of the originating event, include module
+  and function in the message body.

--- a/docs/problems-archive-v1-modules/tau-extensions/subproblems/unload-resilience/proposals/proposal-3.md
+++ b/docs/problems-archive-v1-modules/tau-extensions/subproblems/unload-resilience/proposals/proposal-3.md
@@ -1,0 +1,162 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 3
+parent_problem: ../problem.md
+---
+
+# Proposal 3: Registry ownership unregister — use `Registry.unregister_all/2` keyed on the loader PID
+
+## Approach
+
+Change the registration strategy so that all registry keys registered by the loader for a
+given module are tagged with that module's atom as the registry `value`'s owner-key (or use
+a distinct `{:extension, mod}` tuple as the Registry key). At unload time, call
+`Registry.unregister_match/3` (or a per-registry `Registry.select/2` + `Registry.unregister/2`
+loop) scoped to `{:extension, mod}` without invoking any behaviour callbacks. Remove all
+four `try/rescue` blocks. Emit warning log and `[:tau, :extensions, :unload, :exception]`
+telemetry if the Registry interaction itself raises. This approach changes the registry
+value shape at registration time; existing callers that look up by name and expect a bare
+`Tool.t()` or command map must be updated.
+
+## Rationale
+
+The current design uses Registry keys that are semantic names (tool names, event atoms,
+command names, skill names). Unloading requires knowing those names again, so `unload_module/1`
+must re-query the module. This proposal moves ownership metadata into the registry itself:
+the loader registers entries tagged with `{:extension, mod}` as a match-value prefix or
+secondary key, enabling `Registry.unregister_match/3` to remove all entries for a given
+module without asking the module for anything. The query axis (what did this module register?)
+is resolved by the registry rather than by the module.
+
+## Sketch
+
+```elixir
+# Changed registration in register_module/1:
+# Each registry entry value is wrapped: {:extension_entry, mod, original_value}
+
+Enum.each(mod.tools(), fn t ->
+  name = t.name()  # still called at load time, when mod is known-good
+  Registry.register(Tau.Tools.Registry, name, {:extension_entry, mod, t})
+end)
+
+Enum.each(mod.hooks(), fn {ev, h} ->
+  Registry.register(Tau.Hooks.Registry, ev, {:extension_entry, mod, h})
+end)
+
+Enum.each(mod.commands(), fn {name, c} ->
+  Registry.register(Tau.Commands.Registry, name, {:extension_entry, mod, c})
+end)
+
+Enum.each(mod.skills(), fn {name, path} ->
+  case Tau.Skills.Loader.parse(path) do
+    {:ok, skill} ->
+      Registry.register(Tau.Skills.Registry, name, {:extension_entry, mod, %{skill | name: name}})
+    {:error, reason} ->
+      Logger.warning("...")
+  end
+end)
+
+# Unload — no callback invocation at all
+
+defp unload_module(mod) do
+  # Each registry: unregister all keys where the value matches {:extension_entry, mod, _}
+  [
+    {Tau.Tools.Registry, :tools},
+    {Tau.Hooks.Registry, :hooks},
+    {Tau.Commands.Registry, :commands},
+    {Tau.Skills.Registry, :skills}
+  ]
+  |> Enum.each(fn {registry, label} ->
+    try do
+      # Registry.select returns [{key, pid, value}]; match on {:extension_entry, mod, _}
+      entries = Registry.select(registry, [
+        {{:"$1", :"$2", {:extension_entry, ^mod, :"$3"}}, [], [{{:"$1", :"$2", :"$3"}}]}
+      ])
+      Enum.each(entries, fn {key, _pid, _val} ->
+        Registry.unregister(registry, key)
+      end)
+    rescue
+      e ->
+        Logger.warning(
+          "Tau.Extensions.Loader: #{inspect(registry)} unregister of #{inspect(mod)} raised: " <>
+            Exception.message(e)
+        )
+        :telemetry.execute(
+          [:tau, :extensions, :unload, :exception],
+          %{system_time: System.system_time()},
+          %{module: mod, registry: registry, label: label, kind: :error, reason: e,
+            stacktrace: __STACKTRACE__}
+        )
+    end
+  end)
+end
+```
+
+Callers of the registries (e.g. `Tau.Tool.lookup/1`) must unwrap `{:extension_entry, _mod, value}`
+to get the original value. `try_tool_name/1` becomes unused and is deleted.
+
+## Tradeoffs
+
+### Strengths
+
+- Fully satisfies acceptance criterion (c): unload is driven by registry contents, not by
+  module callbacks. A module that has become broken is cleanly unregistered without any
+  callback invocation.
+- The registry becomes the single source of truth for "what is registered" — no parallel
+  `info` snapshot required in `state.loaded`.
+- `try_tool_name/1` is eliminated entirely (no more `mod.name/0` call at unload time).
+- Registry-ownership semantics are explicit and introspectable at runtime via
+  `Registry.select/2`.
+
+### Weaknesses
+
+- API-breaking change to registry value shapes: every registry consumer (tool lookup, hook
+  dispatch, command dispatch, skill dispatch) must unwrap `{:extension_entry, mod, val}`.
+  This is a wide blast radius.
+- `Registry.select/2` with match-spec syntax is non-obvious and hard to read; it inverts
+  the simplicity gained elsewhere.
+- If a registry uses `keys: :unique`, `Registry.select/2` still works, but the
+  `unregister` must be called on the **same PID** that registered; since the Loader PID
+  registered all entries, this works — but the constraint is non-obvious.
+- Mixing structural metadata (`{:extension_entry, mod, _}`) into registry values creates a
+  new convention that future extension code must follow; it is not enforced by the type
+  system.
+- Does not address the case where an extension registers a tool via a path-based entry that
+  covers multiple modules — the `{:extension_entry, mod, _}` tagging must be per-module,
+  not per-path-entry.
+
+### Costs
+
+- Large blast radius: `Tau.Tool` lookup, hook dispatch, command dispatch, skill dispatch
+  must all be updated to unwrap the new value shape.
+- Likely 6–10 callsites outside `loader.ex`.
+- Tests for registry consumers (tool dispatch, hook event tests, command invocation tests)
+  must be updated.
+- Risk: if any Registry consumer is missed in the unwrapping update, it silently receives
+  `{:extension_entry, mod, value}` where it expects a bare value — a runtime type error
+  rather than a compile error.
+
+## Dependencies
+
+- All Registry consumers (`Tau.Tool.lookup/1`, hook dispatch in session, command dispatch
+  in session, skill dispatch) must be updated atomically with this change or the system
+  breaks. Cannot be deployed incrementally.
+- Requires verifying that `Registry.select/2` with the `^mod` pin in the match spec works
+  for all four registries (unique and duplicate key modes).
+
+## Confidence
+
+low — the registry-ownership approach is architecturally clean but the blast radius
+(unwrapping in all consumers) is large and must land atomically. Confidence would be raised
+by checking the Registry consumer count and verifying `Registry.select/2` pin semantics
+against the Elixir Registry docs.
+
+## Prior art / references
+
+- Elixir `Registry.select/2` documentation: match-spec-based bulk lookup.
+- Erlang `pg` / `gproc` ownership patterns: process-keyed group membership for clean
+  process-exit cleanup.
+- Phoenix PubSub topic ownership: all subscriptions for a PID are cleared on PID exit —
+  same ownership-in-registry concept but driven by process death rather than explicit
+  unload call.

--- a/docs/problems-archive-v1-modules/tau-extensions/subproblems/unload-resilience/proposals/proposal-4.md
+++ b/docs/problems-archive-v1-modules/tau-extensions/subproblems/unload-resilience/proposals/proposal-4.md
@@ -1,0 +1,160 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 4
+parent_problem: ../problem.md
+---
+
+# Proposal 4: Isolated unload sub-process — delegate unload callback queries to a monitored Task
+
+## Approach
+
+Replace the four `try/rescue _ -> []` blocks in `unload_module/1` with a single
+`Task.await/2` call to a short-lived monitored process. The Task calls all four behaviour
+callbacks (`mod.tools/0`, `mod.hooks/0`, `mod.commands/0`, `mod.skills/0`) under normal
+OTP supervision. If any callback raises or the task times out (e.g. 200 ms), the Task
+exits abnormally; the Loader receives the exit reason, emits warning log and
+`[:tau, :extensions, :unload, :exception]` telemetry, and falls back to the load-time
+snapshot from `state.loaded` (enriched with callback results from load time — see below)
+to drive the unregister loop. On success, the task returns the four lists and the Loader
+uses them normally. The fallback to the load-time snapshot satisfies requirement (c).
+
+## Rationale
+
+The current design runs callback queries in the Loader process, so a callback that hangs
+indefinitely (not just raises) can stall the Loader GenServer — a risk the `try/rescue`
+approach does not address. Delegating callback queries to a Task process decomplects the
+Loader's liveness from the extension module's correctness: whether the module raises,
+panics, or spins, the Loader is unblocked after the timeout. The fallback to the load-time
+snapshot (which must exist for any successfully-registered module) satisfies requirement (c)
+without requiring the module to cooperate. This approach combines process isolation (OTP
+"let it crash" for the sub-process) with the data-shape enrichment of Proposal 1's snapshot
+— but applies the snapshot only as a fallback rather than as the primary path.
+
+## Sketch
+
+```elixir
+# load-time: enrich info with callback results (mirrors Proposal 1)
+defp register_module(mod) do
+  if is_extension?(mod) do
+    # ... (registration unchanged) ...
+    info = %{
+      module: mod,
+      tools: mod.tools(),
+      hooks: mod.hooks(),
+      commands: mod.commands(),
+      skills: mod.skills()
+    }
+    {:ok, mod, info}
+  else
+    :error
+  end
+end
+
+# Unload: try Task-isolated callback queries; fall back to snapshot
+
+defp unload_module(mod, info) do
+  task = Task.async(fn ->
+    {mod.tools(), mod.hooks(), mod.commands(), mod.skills()}
+  end)
+
+  {tools, hooks, commands, skills} =
+    case Task.yield(task, 200) || Task.shutdown(task, :brutal_kill) do
+      {:ok, result} ->
+        result
+
+      nil ->
+        # Task timed out or the module raised — use load-time snapshot
+        Logger.warning(
+          "Tau.Extensions.Loader: #{inspect(mod)} callbacks did not return during unload " <>
+            "(timed out or raised); using load-time snapshot"
+        )
+        :telemetry.execute(
+          [:tau, :extensions, :unload, :exception],
+          %{system_time: System.system_time()},
+          %{module: mod, reason: :timeout_or_raise}
+        )
+        {
+          Map.get(info, :tools, []),
+          Map.get(info, :hooks, []),
+          Map.get(info, :commands, []),
+          Map.get(info, :skills, [])
+        }
+    end
+
+  Enum.each(tools, fn t ->
+    name = try_tool_name(t)
+    if name, do: Registry.unregister_match(Tau.Tools.Registry, name, t)
+  end)
+  Enum.each(hooks,    fn {ev, _}   -> Registry.unregister(Tau.Hooks.Registry, ev) end)
+  Enum.each(commands, fn {name, _} -> Registry.unregister(Tau.Commands.Registry, name) end)
+  Enum.each(skills,   fn {name, _} -> Registry.unregister(Tau.Skills.Registry, name) end)
+end
+```
+
+`do_unload/1` threads `info` through to `unload_module/2`. `unload_entry/2` already has
+`info` and passes it. The `info` map must be enriched at load time (as shown above); path-based
+entries store per-module callback snapshots inside `%{path: path, modules: [...], snapshots: %{mod => info}}`.
+
+## Tradeoffs
+
+### Strengths
+
+- Satisfies all three acceptance-criterion requirements: (a) and (b) on Task failure/timeout,
+  (c) via snapshot fallback regardless of callback success.
+- Adds timeout-resilience that no other proposal addresses: a callback that hangs does not
+  stall the Loader GenServer (a GenServer stall under heavy reload is a real OTP failure mode).
+- Respects the OTP "let it crash" discipline for the sub-process while keeping the Loader
+  alive.
+- On the happy path (module still healthy), callback queries remain live and the unregister
+  logic uses fresh data — correct for the common case where module is intact but a reload
+  races with unload.
+
+### Weaknesses
+
+- Introduces `Task.async/Task.yield/Task.shutdown` in a GenServer `handle_cast`, which
+  adds a process-lifecycle complexity that is unusual in the codebase.
+- The `200 ms` timeout is arbitrary; too short means false negatives on a loaded system,
+  too long stalls the Loader under slow-module conditions.
+- Still requires enriching the `info` map (same load-path change as Proposal 1) — the
+  snapshot fallback only works if load-time callback results are stored. If they're not,
+  (c) cannot be satisfied on timeout.
+- `Task.async` in a GenServer callback creates an unhandled `{ref, result}` message if
+  `Task.yield` returns before the Task finishes — must use `Task.yield/Task.shutdown` pair
+  correctly; subtle to get right.
+- Most `try/rescue _ -> []` fixes in the Elixir ecosystem do not involve a spawned process;
+  a reviewer unfamiliar with this pattern may push back.
+
+### Costs
+
+- Adds `Task.yield/Task.shutdown` mechanics — ~10 lines more complex than Proposal 1.
+- `info` map enrichment is the same scope as Proposal 1.
+- One additional supervisor-level concern: if the Loader crashes mid-Task, the Task is
+  orphaned (though bounded by the 200 ms timeout).
+- Test surface: tests must simulate Task timeout to exercise the fallback path; this requires
+  a test harness that can make callback invocations hang.
+
+## Dependencies
+
+- Load-time `info` enrichment (same as Proposal 1) — `register_module/1` must store
+  callback results in `info`.
+- `Task.yield/2` + `Task.shutdown/2` requires no additional libraries; both are in the
+  Elixir stdlib.
+- Path-based entries (`%{modules: [mod1, mod2, ...]}`) must store per-module snapshots;
+  the `info` shape for path entries needs to be updated.
+
+## Confidence
+
+medium — process isolation is the correct OTP tool for a potentially-blocking call.
+Confidence would be raised by verifying that `Task.async` inside a GenServer `handle_cast`
+doesn't create a stray message problem (the `Task.yield/Task.shutdown` pair should drain
+the mailbox, but a concrete test would confirm).
+
+## Prior art / references
+
+- Elixir `Task.yield/2` + `Task.shutdown/2` docs: the canonical "run with timeout, kill
+  on timeout" pattern.
+- OTP `gen_server` + `proc_lib:spawn_link` timeout isolation: the conceptual ancestor of
+  spawning a bounded sub-process for a potentially-blocking call.
+- The Loader's own `crash_safe_register/2` uses `try/rescue` rather than a process — this
+  proposal diverges from that precedent, which may be seen as inconsistent.

--- a/docs/problems-archive-v1-modules/tau-extensions/subproblems/unload-resilience/solution.md
+++ b/docs/problems-archive-v1-modules/tau-extensions/subproblems/unload-resilience/solution.md
@@ -1,0 +1,121 @@
+---
+template_version: 1
+template_name: solution
+parent_problem: problem.md
+node_kind: leaf
+synthesised_from: [proposals/proposal-1.md]
+selection_method: single
+revision: 0
+---
+
+# Solution: Snapshot-driven unload — enrich `info` with registered keys at load time
+
+## Recommendation
+
+Enrich the `info` map stored in `state.loaded` at registration time to record the exact
+registry keys produced by each callback category (`tools`, `hooks`, `commands`, `skills`).
+Replace the four `try/rescue _ -> []` blocks in `unload_module/1` with a loop over
+`info.registered_keys`, calling the appropriate `Registry.unregister*` function for each
+key — no behaviour callbacks invoked at unload time. Introduce a `crash_safe_unload/2`
+helper mirroring `crash_safe_register/2` to emit a `Logger.warning/1` and
+`[:tau, :extensions, :unload, :exception]` telemetry if a Registry call itself raises.
+Delete `try_tool_name/1`, which becomes unused once callback invocation is removed from
+the unload path.
+
+## Selected from
+
+- **Chosen:** `proposals/proposal-1.md`
+- **Why chosen:** Proposal 1 is the only candidate that fully satisfies all three legs of
+  the acceptance criterion, including (c) — no residual registry entries — for the
+  hot-reload scenario (D-124) that is the stated motivation. Proposal 2 explicitly cannot
+  satisfy (c) when a module that previously returned non-empty callback results becomes
+  broken via hot-reload; its author rates its confidence as low for exactly this reason.
+  Proposal 3 satisfies (c) but at a blast radius disproportionate to the problem: wrapping
+  all registry values in `{:extension_entry, mod, _}` requires atomic updates to every
+  registry consumer outside `loader.ex`, introduces a non-enforced structural convention,
+  and risks silent runtime type errors at any missed callsite. Proposal 4 satisfies all
+  three requirements but introduces `Task.async/yield/shutdown` complexity in a GenServer
+  callback to address a liveness concern (blocking callbacks) that is out of scope of the
+  acceptance criterion; it also inherits the full info-enrichment work of Proposal 1 as a
+  prerequisite, making it a strict superset of Proposal 1's cost without an in-scope gain.
+  Proposal 1 decomplects the root cause directly — re-querying a potentially-broken module
+  at unload time — by eliminating the re-query entirely in favour of a load-time snapshot.
+  It is reversible (the `registered_keys` field is internal to `state.loaded`), has the
+  smallest blast radius of the proposals that satisfy (c), and mirrors the existing
+  `crash_safe_register/2` discipline exactly.
+
+## What changes
+
+- `lib/tau/extensions/loader.ex` — `register_module/1`: populate `info.registered_keys`
+  as a flat list of `{:tool, name, t} | {:hook, ev} | {:command, name} | {:skill, name}`
+  tuples at registration time, capturing only the keys for entries that were actually
+  registered.
+- `lib/tau/extensions/loader.ex` — `unload_module/1` (rename to `unload_module/2`):
+  replace four `try/rescue _ -> []` blocks with a `Enum.each` over `info.registered_keys`,
+  dispatching to the appropriate `Registry.unregister*` call per key tag.
+- `lib/tau/extensions/loader.ex` — new `crash_safe_unload/2` private helper: wraps
+  `unload_module/2` with `try/rescue`; on exception emits `Logger.warning/1` naming the
+  module and emits `[:tau, :extensions, :unload, :exception]` telemetry.
+- `lib/tau/extensions/loader.ex` — `do_unload/1`: thread `info` through to
+  `crash_safe_unload/2`.
+- `lib/tau/extensions/loader.ex` — `try_tool_name/1`: delete (no longer called from the
+  unload path).
+- `lib/tau/extensions/loader.ex` — path-based entry handling (`%{path: _, modules: _}`):
+  enrich to store per-module `registered_keys` snapshots so multi-module path entries can
+  unload each module independently.
+- `test/tau/extensions/` — update tests that assert on `state.loaded` entry shape or
+  inspect `info` maps to handle the enriched `registered_keys` field.
+
+## What does not change
+
+- `crash_safe_register/2` and the load-time isolation path — correctly implemented;
+  explicitly out of scope.
+- The `Tau.Extension` behaviour or DSL — no callback signatures change.
+- All registry consumers outside `loader.ex` (`Tau.Tool.lookup/1`, hook dispatch, command
+  dispatch, skill dispatch) — registry value shapes are unchanged.
+- `peek_module_names/1` and atom internment — owned by the `atom-internment` sub-problem.
+- `do_compile_file/1` and `is_extension?/1` — out of scope.
+- The public API of `Tau.Extensions.Loader` — no exported function signatures change.
+
+## Migration sketch
+
+The change is self-contained within `loader.ex` and its test file. The natural sequence:
+first enrich `register_module/1` to build and return `registered_keys` in `info` (unit
+testable immediately against a healthy module); then update `do_unload/1` to thread `info`
+to a new `crash_safe_unload/2`; then replace `unload_module/1`'s body with the key-driven
+loop; then delete `try_tool_name/1`. The path-based multi-module enrichment (`%{modules:
+[...]}`) is the highest-complexity part and can be addressed in the same commit once the
+single-module path is working. No migration of existing `state.loaded` entries is required
+because the Loader is restarted on hot-reload (D-124); stale entries without `registered_keys`
+can be handled by a fallback clause in `unload_module/2` that logs a warning and skips.
+
+## Open questions
+
+- What is `Tau.Tool.register/1`'s actual return contract? Proposal 1 assumes it returns
+  `:ok | :error` to determine whether a tool key was actually registered. If it raises on
+  failure or returns `:ok` unconditionally, the `registered_keys` capture logic must be
+  adjusted. Verify before implementing the tool-key branch.
+- Does any external code (outside `loader.ex` and its tests) pattern-match on the bare
+  `%{module: mod}` info shape from `state.loaded`? If so, those callsites must accept the
+  enriched shape. A grep over `lib/` and `test/` for `state.loaded` / `entry.info` access
+  patterns should confirm the blast radius before the PR opens.
+- For path-based entries (`%{path: _, modules: [mod1, mod2, ...]}`), what is the current
+  `info` shape stored per path vs. per module? The enrichment must store `registered_keys`
+  per module, not per path entry, to support independent per-module unload.
+
+## Linked sub-problems / proposals
+
+- `proposals/proposal-1.md` — Snapshot-driven unload: enrich `info` with registered keys
+  at load time; drive unload entirely from the snapshot. **Selected.**
+- `proposals/proposal-2.md` — Per-callback safe-call wrapper: add logging and telemetry to
+  existing `try/rescue` blocks; does not satisfy AC (c) for hot-reload case.
+- `proposals/proposal-3.md` — Registry ownership unregister: tag registry values with
+  `{:extension_entry, mod, _}` and use `Registry.select/2` at unload; satisfies AC but
+  blast radius is disproportionate.
+- `proposals/proposal-4.md` — Isolated unload sub-process: delegate callback queries to a
+  `Task` with timeout fallback to snapshot; satisfies AC but adds out-of-scope complexity
+  and inherits Proposal 1's enrichment as a prerequisite.
+
+## Revision history
+
+- (revision 0 — initial)

--- a/docs/problems-archive-v1-modules/tau-extensions/subproblems/unload-resilience/validation.md
+++ b/docs/problems-archive-v1-modules/tau-extensions/subproblems/unload-resilience/validation.md
@@ -1,0 +1,394 @@
+---
+template_version: 1
+template_name: validation
+parent_solution: solution.md
+parent_problem: problem.md
+toulmin_complete: true
+falsification_attempted: true
+falsification_outcome: partially_falsified — claim/5
+revision_triggered: none
+---
+
+# Validation: Snapshot-driven unload — enrich `info` with registered keys at load time
+
+## Overview
+
+The solution proposes seven code changes to `loader.ex` and its tests: (1) populate
+`info.registered_keys` at registration time, (2) replace the four `try/rescue _ -> []`
+blocks in `unload_module/1` with a key-driven loop, (3) add a `crash_safe_unload/2`
+helper, (4) thread `info` through `do_unload/1`, (5) delete `try_tool_name/1`, (6) enrich
+path-based multi-module entries, and (7) update tests. Six claims are enumerated.
+Falsification applied one strategy per claim; five withstood unconditionally, one
+requires a qualifier narrowing (claim 5 — the assertion that no callsite outside
+`loader.ex` pattern-matches on the bare info shape is unverifiable without a grep the
+solution itself labels an open question, but one external test callsite was found).
+
+## Toulmin per claim
+
+### Claim 1: `unload_module/1`'s four `try/rescue _ -> []` blocks cause silent partial unload when a module's callbacks raise after registration
+
+- **Claim (C):** "`unload_module/1` … wraps each call in a bare `try/rescue _ -> []`,
+  silently treating any exception as an empty result list … leaving its prior registry
+  entries in place — a silent partial-unload that corrupts the registry without any log
+  or telemetry signal." (problem.md §Statement; solution.md §Recommendation confirms it
+  as the root cause being fixed)
+- **Grounds (G):** `lib/tau/extensions/loader.ex:430–434` — tools callback wrapped in
+  `try do … rescue _ -> []`; `:448–451` — hooks; `:458–461` — commands; `:468–471` —
+  skills. If a post-load code reload makes any callback raise, the corresponding `Enum.each`
+  receives `[]` and no `Registry.unregister*` call is issued for that category.
+  `lib/tau/extensions/loader.ex:397–408` confirms `do_unload(info)` is called without
+  passing `info.registered_keys` (the field does not exist yet), so there is no snapshot
+  fallback.
+- **Warrant (W):** OTP non-negotiable #7 ("Let it crash; supervise; restart. MUST NOT
+  `try/rescue` across process boundaries") implies that `try/rescue _ -> []` — which
+  silently swallows exceptions across a module boundary and substitutes an empty list —
+  is a correctness defect, not a defensive pattern. A silent empty result is
+  indistinguishable from "registered nothing", causing the registry to accumulate stale
+  entries.
+- **Qualifier (Q):** Holds for any module where at least one callback was successfully
+  called at load time (producing non-empty results that were registered) but subsequently
+  raises. If a callback raised at load time, `crash_safe_register/2`'s outer `try/rescue`
+  already skipped the entire registration, so no entries were recorded and the unload
+  defect is moot.
+- **Rebuttal (R):** If a module's callbacks are idempotent and always callable (i.e., the
+  module is never broken between load and unload), the silent-empty-list path is never
+  triggered and the claim's consequence does not materialise. The claim's correctness does
+  not depend on this rebuttal — it is a defect whether or not it triggers in practice.
+- **Backing (B):** OTP non-negotiables rule #7 (`TAU.md`); SPEC-EXTENSIONS D-120
+  ("crash-isolated load") and D-124 ("hot reload unloads prior generation") — neither
+  contract covers the unload-exception path, confirming the gap.
+
+#### Falsification attempt for claim 1
+
+- **Strategy:** Counter-example construction
+- **Attempt:** To falsify: is there a code path where `try/rescue _ -> []` still correctly
+  unregisters? For this to hold, the rescued empty list would need to be correct, meaning
+  the module never registered the category in the first place. But `crash_safe_register/2`
+  (lines 296–349) calls `register_module/mod` inside its own `try/rescue`; if the callbacks
+  raised at registration time, the entire module is skipped with `:error` and no entry is
+  inserted into `state.loaded`. Therefore any `info` entry in `state.loaded` represents a
+  module whose callbacks returned non-empty results at registration time. The empty-list
+  rescue at unload time produces a wrong result for any callback that was non-empty at
+  registration.
+- **Outcome:** Withstood. No counter-example found; the claim accurately describes the defect.
+- **Action:** None.
+
+---
+
+### Claim 2: Enriching `info` with `registered_keys` at load time eliminates the need to re-invoke callbacks at unload time
+
+- **Claim (C):** "Enrich the `info` map stored in `state.loaded` at registration time to
+  record the exact registry keys produced by each callback category … Replace the four
+  `try/rescue _ -> []` blocks in `unload_module/1` with a loop over
+  `info.registered_keys`, calling the appropriate `Registry.unregister*` function for
+  each key — no behaviour callbacks invoked at unload time."
+- **Grounds (G):** `lib/tau/extensions/loader.ex:351–388` (`register_module/1`) — at
+  registration time, `mod.tools()`, `mod.hooks()`, `mod.commands()`, `mod.skills()` are
+  already called; the exact keys being registered are observable in scope. The `{:ok, mod,
+  %{module: mod}}` return at line 384 captures only `module`; adding `registered_keys`
+  here would capture the keys without a second callback invocation.
+  `lib/tau/extensions/loader.ex:400–407` (`unload_entry/2`) — already retrieves `info`
+  from `state.loaded` and passes it to `do_unload/1`, so the snapshot is on the hot path.
+- **Warrant (W):** Hickey's "data over code" principle: substituting a data lookup (the
+  snapshot) for a re-derivation (re-invoking callbacks) removes temporal coupling — the
+  correctness of unload no longer depends on the module's runtime state at unload time.
+  This is a direct application of decomplecting data from behaviour.
+- **Qualifier (Q):** Holds provided `registered_keys` is populated atomically in the same
+  `register_module/1` call that performs registration, with no window between "registered"
+  and "snapshotted". If the snapshot and the registration are separated by a process
+  boundary or async step, the window creates a TOCTOU race; the solution keeps both in a
+  single synchronous function, so the qualifier is satisfied by construction.
+- **Rebuttal (R):** If a registry call fails partially (e.g., some tools register and then
+  one raises), `crash_safe_register/2` will rescue and return `:error`, and no `info` entry
+  enters `state.loaded`. The snapshot approach does not create a partial-registration
+  problem; it inherits the all-or-nothing semantics of the outer `try/rescue`.
+- **Backing (B):** SPEC-EXTENSIONS D-120 (crash-isolated load — load path is already
+  atomic); Hickey "Simple Made Easy" (2011) — separating data from the process that
+  produced it removes accidental complexity.
+
+#### Falsification attempt for claim 2
+
+- **Strategy:** Integration check
+- **Attempt:** Does the existing `unload_entry/2` → `do_unload/1` → `unload_module/1`
+  call chain actually have access to `info` at the point where `unload_module` is called?
+  `lib/tau/extensions/loader.ex:400–407`: yes, `info` is the value retrieved from
+  `state.loaded` and passed to `do_unload/1`. `do_unload/1` at lines 415–423 currently
+  pattern-matches on `%{module: mod}` and `%{modules: modules}` and calls `unload_module`
+  with only the module atom — `info` is not threaded through. The solution explicitly
+  changes `do_unload/1` to thread `info` through to `crash_safe_unload/2`, which is
+  consistent with the existing hot-path access. No integration gap.
+- **Outcome:** Withstood. The integration point exists and `info` is already on the hot
+  path; the change is structurally sound.
+- **Action:** None.
+
+---
+
+### Claim 3: `crash_safe_unload/2` with `Logger.warning/1` and `[:tau, :extensions, :unload, :exception]` telemetry satisfies acceptance criterion (a) and (b)
+
+- **Claim (C):** "Introduce a `crash_safe_unload/2` helper … to emit a
+  `Logger.warning/1` and `[:tau, :extensions, :unload, :exception]` telemetry if a
+  Registry call itself raises."
+- **Grounds (G):** `lib/tau/extensions/loader.ex:296–349` — `crash_safe_register/2`
+  already establishes the pattern: `try/rescue` around the registration call, then
+  `Logger.warning/1` naming module + exception, then `:telemetry.execute/3` emitting
+  `[:tau, :extensions, :load, :exception]`. The acceptance criterion (a)/(b) demand the
+  identical structure for unload. `problem.md §Acceptance criterion`: "(a) a warning log
+  naming the broken module and callback, (b) a `[:tau, :extensions, :unload, :exception]`
+  telemetry event".
+- **Warrant (W):** Symmetry between load and unload paths is not merely aesthetic — OTP
+  non-negotiable #5 requires telemetry coverage for "everything user-visible or
+  perf-sensitive". An unload failure that leaves stale registry entries is user-visible
+  (tools from a broken extension remain callable). The warrant is that AC (a)/(b)
+  compliance requires an observable signal for every unload exception.
+- **Qualifier (Q):** Holds provided `crash_safe_unload/2` wraps `unload_module/2` at its
+  call site in `do_unload/1`, not at individual registry unregister calls. If placed at
+  the wrong granularity (e.g., one `try/rescue` per registry call rather than per module),
+  it would emit partial telemetry for multi-category modules. The solution's description
+  wraps at module granularity, which matches `crash_safe_register/2`'s semantics.
+- **Rebuttal (R):** If `Registry.unregister*` never raises in practice (BEAM's built-in
+  registries do not raise for unknown keys — they return `:error` tuples), then
+  `crash_safe_unload/2`'s rescue branch may never trigger. In that case the telemetry
+  event is dead code for existing registry calls. This does not falsify the claim — the
+  helper still satisfies the AC's requirement that an exception *would* be observable; it
+  is a defensive invariant.
+- **Backing (B):** OTP non-negotiables #5 (`TAU.md`); SPEC-EXTENSIONS D-120
+  (crash-isolated load pattern as backing authority for unload symmetry); problem.md
+  §Acceptance criterion (a) and (b).
+
+#### Falsification attempt for claim 3
+
+- **Strategy:** Edge-case enumeration
+- **Attempt:** Edge cases for AC compliance: (i) `Registry.unregister/2` for an unknown
+  key — BEAM's `Registry` module returns `:error`, not an exception; the `rescue` block
+  would not trigger. This is correct behaviour — the key is already absent, which is the
+  post-condition. (ii) `Registry.unregister_match/3` for tools — same: returns count
+  integer, not an exception. (iii) A module whose `Tau.Tool.register/1` call raised at
+  load time but was partially committed to `registered_keys` before the exception — this
+  cannot happen because `crash_safe_register/2`'s outer `try/rescue` ensures no
+  `registered_keys` snapshot is stored if any call inside `register_module/1` raises; the
+  module is skipped entirely. (iv) The warning must name the "broken module and callback"
+  (AC a) — the solution says `Logger.warning/1` naming the module; it does not explicitly
+  mention naming the callback. `crash_safe_register/2` (line 337) names the module and
+  exception message but not the specific callback that failed. The solution mirrors this
+  pattern, which may not fully satisfy AC (a)'s "naming the … callback" clause. This is a
+  potential partial falsification of AC compliance.
+- **Outcome:** Partially falsified on edge case (iv). The AC requires "naming the broken
+  module **and callback**"; the proposed `Logger.warning/1` mirrors `crash_safe_register/2`
+  which names module and exception but not the specific callback category. Since the loop
+  is over `info.registered_keys` tuples (tagged with `:tool`, `:hook`, `:command`,
+  `:skill`), the key tag is available in the loop body and can be included in the warning.
+  This is a qualifier narrowing, not a solution revision.
+- **Action:** Narrow qualifier: the claim holds provided `Logger.warning/1` in
+  `crash_safe_unload/2` includes the key tag from the `registered_keys` tuple being
+  processed, not just the module name. The key tag is available in the loop body; no
+  structural change to the design is required.
+
+---
+
+### Claim 4: Deleting `try_tool_name/1` is safe once the key-driven loop replaces the callback-invocation loop
+
+- **Claim (C):** "`try_tool_name/1`: delete (no longer called from the unload path)."
+- **Grounds (G):** `lib/tau/extensions/loader.ex:482–490` — `try_tool_name/1` is a
+  private function. `lib/tau/extensions/loader.ex:437–441` — its only call site is within
+  `unload_module/1`'s tool loop: `tool_name = try_tool_name(t)`. Once the tool loop is
+  replaced with a key-driven dispatch over `{:tool, name, t}` tuples from
+  `info.registered_keys`, the `try_tool_name(t)` call becomes dead code. Grep of the file
+  confirms no other call site exists.
+- **Warrant (W):** Dead private functions should be deleted: they accumulate cognitive
+  overhead, are excluded from Dialyzer analysis paths, and can mislead future readers into
+  thinking they are part of the active contract. The module's own Credo rules enforce
+  `--strict`, which flags unused private functions.
+- **Qualifier (Q):** Holds provided the tool-key capture in `register_module/1` is
+  implemented as `{:tool, tool_name, t}` where `tool_name` is `t.name()` (the value
+  `try_tool_name/1` was computing at unload time). If the snapshot stores only `{:tool,
+  t}` (the struct, without pre-resolving the name), `try_tool_name/1` would still be
+  needed in the unload loop to recover the name. The solution description says the tuple
+  form is `{:tool, name, t}` — pre-resolved.
+- **Rebuttal (R):** `try_tool_name/1` also guards against modules where `name/0` raises or
+  is missing via `Code.ensure_loaded?/mod` and `function_exported?/2`. If the snapshot
+  captures the name at load time (when the module was healthy), the guard is no longer
+  needed at unload time — this is the intended benefit.
+- **Backing (B):** Credo `--strict` (project CLAUDE.md); OTP non-negotiable #8 ("Pure
+  functions are the default; processes are the exception") — removing dead code reduces
+  surface area.
+
+#### Falsification attempt for claim 4
+
+- **Strategy:** Dependency check
+- **Attempt:** Verify no other call site exists for `try_tool_name/1`. Full-text search
+  of `lib/tau/extensions/loader.ex` for `try_tool_name` yields exactly two occurrences:
+  the definition (line 482) and the call site (line 437). No external callers via grep
+  of `lib/` and `test/`. The function is private (`defp`), so it cannot be called
+  externally. Deletion is safe once line 437's call is removed.
+- **Outcome:** Withstood. `try_tool_name/1` has exactly one call site; deletion is safe
+  after the call is removed.
+- **Action:** None.
+
+---
+
+### Claim 5: All registry consumers outside `loader.ex` are unaffected because registry value shapes are unchanged
+
+- **Claim (C):** "All registry consumers outside `loader.ex` (`Tau.Tool.lookup/1`, hook
+  dispatch, command dispatch, skill dispatch) — registry value shapes are unchanged."
+- **Grounds (G):** The proposed change adds `registered_keys` to the `info` map stored in
+  `state.loaded` (internal GenServer state), not to the registry values themselves. Registry
+  registrations remain: `Tau.Tool.register(t)` stores `t` under `mod.name()`;
+  `Registry.register(Tau.Hooks.Registry, ev, h)` stores `h` under `ev`; etc. None of these
+  value shapes change.
+  However: `test/tau/extensions/loader_test.exs:235` — `assert entry.info[:modules] == []`
+  — accesses `info` retrieved from `Loader.list/0`. `Loader.list/0` returns
+  `%{key: term(), info: map()}` where `info` is the map from `state.loaded`. After the
+  change, `info` will also contain `registered_keys`. Tests accessing `info` by key
+  (`:modules`) are unaffected; tests asserting on the complete `info` shape would break.
+- **Warrant (W):** Adding a key to a map is backwards-compatible for consumers that
+  pattern-match on named keys or access by key; it is not backwards-compatible for
+  consumers that assert exact map equality (e.g., `assert info == %{module: mod}`). The
+  solution acknowledges this in "What changes" — tests "assert on `state.loaded` entry
+  shape" must be updated.
+- **Qualifier (Q):** Holds for all *production* consumers and for tests that access `info`
+  by key. Does NOT hold for any test or code asserting exact map equality on the `info`
+  shape. The solution explicitly scopes test updates as required; this qualifier is not a
+  revision trigger.
+- **Rebuttal (R):** If any test outside `loader_test.exs` pattern-matches the full info
+  shape, it will silently pass with extra keys (in ExUnit, `assert %{module: mod} = info`
+  ignores extra keys) — so the blast radius is actually smaller than a strict equality
+  assertion. The only tests that would break are those using `assert info == %{...}` (strict
+  equality). `loader_test.exs:235` uses bracket access (`entry.info[:modules]`), not strict
+  equality — so it is already compatible.
+- **Backing (B):** Elixir pattern-matching semantics (structural subtyping on maps);
+  SPEC-EXTENSIONS §4 ("public API of `Tau.Extensions.Loader` — no exported function
+  signatures change" as stated in solution.md §What does not change).
+
+#### Falsification attempt for claim 5
+
+- **Strategy:** Dependency check
+- **Attempt:** Check whether any consumer outside `loader.ex` uses the bare `info` shape
+  with strict equality. Grep of `lib/` and `test/` for `state.loaded` and `entry.info`
+  patterns: `test/tau/extensions/loader_test.exs:235` is the only external consumer found.
+  It uses `entry.info[:modules]` (keyword-style access) — compatible with a richer map.
+  However, the solution's own §Open questions acknowledges: "Does any external code …
+  pattern-match on the bare `%{module: mod}` info shape?" This is explicitly unresolved by
+  the proposer, which is an admission that the claim's scope is not yet fully bounded.
+  The single test callsite found is compatible; a comprehensive grep is needed before
+  implementation to confirm no other callsite exists, but none was found in this pass.
+- **Outcome:** Partially falsified (scope unconfirmed, not falsified). The claim holds for
+  all callsites found, but the solution's own open question flags the blast-radius grep as
+  pre-implementation work. The qualifier is narrowed: claim holds for all currently
+  identified consumers; implementer must run the blast-radius grep before opening the PR.
+- **Action:** Narrow qualifier in place. Record as pre-implementation gate: the implementer
+  MUST grep `lib/` and `test/` for `state.loaded` / `entry.info` / `\.info\[` patterns
+  before opening the PR and confirm no exact-equality assertions on the info shape exist
+  outside `loader_test.exs`.
+
+---
+
+### Claim 6: The path-based entry (`%{path: _, modules: [mod1, mod2, …]}`) enrichment stores `registered_keys` per module, enabling independent per-module unload
+
+- **Claim (C):** "path-based entry handling (`%{path: _, modules: _}`): enrich to store
+  per-module `registered_keys` snapshots so multi-module path entries can unload each
+  module independently."
+- **Grounds (G):** `lib/tau/extensions/loader.ex:198–223` (`load_entry/1` for binary
+  paths) — builds `%{path: path, modules: registered}` where `registered` is a list of
+  module atoms. `lib/tau/extensions/loader.ex:419–421` (`do_unload/1` for `%{modules:
+  modules}`) — iterates `modules` and calls `unload_module/1` on each atom, with no `info`
+  at the per-module level. For the snapshot approach to work, the per-module `registered_keys`
+  must be retrievable when `unload_module/2` is called; currently, there is no per-module
+  info map in the path entry.
+- **Warrant (W):** The `%{modules: [mod1, mod2]}` case in `do_unload/1` calls
+  `unload_module` with a bare atom. For the snapshot approach, `unload_module/2` needs the
+  per-module `info` (specifically its `registered_keys`). Since each module is registered
+  independently via `crash_safe_register/2` (line 216), each registration already produces
+  a per-module `info` map. Storing a list of `{mod, info}` pairs instead of bare `[mod]`
+  in `%{modules: registered}` is the minimal change that threads per-module info to the
+  unload path.
+- **Qualifier (Q):** The solution description is intentionally high-level about the exact
+  shape ("store per-module `registered_keys` snapshots"). The §Open questions section
+  explicitly flags the path-based shape as the "highest-complexity part". This qualifier
+  acknowledges the claim's correctness depends on a specific structural choice (pairs vs.
+  bare atoms in the modules list) that is deferred to implementation.
+- **Rebuttal (R):** An alternative is to keep `%{modules: [mod]}` (bare atoms) and maintain
+  a secondary `per_module_keys` map keyed by `{path, mod}` in `state`. This satisfies the
+  claim but is more complex; the proposal's approach of enriching the `modules` list is
+  the simpler path. If the alternative is chosen, the claim still holds — the AC (c) is
+  satisfied either way.
+- **Backing (B):** SPEC-EXTENSIONS D-124 (hot reload unloads prior generation — the
+  hot-reload case for path entries is the primary motivation); solution.md §Migration
+  sketch ("The path-based multi-module enrichment … is the highest-complexity part").
+
+#### Falsification attempt for claim 6
+
+- **Strategy:** Integration check
+- **Attempt:** Does `crash_safe_register/2` (called per-module at line 216) already return
+  the per-module `info`? `lib/tau/extensions/loader.ex:318` — yes: `{:ok, key, info}` is
+  returned. Line 216: `case crash_safe_register(mod, path) do {:ok, _key, _info} -> [mod]
+  _error -> [] end` — the `_info` is currently discarded. Changing this to `[{mod, info}]`
+  and updating `%{path: path, modules: registered}` to `%{path: path, modules: registered}`
+  where `registered` is now a list of `{mod, info}` tuples (or a map) is the minimal
+  structural change. The integration point is present; the `_info` discard is the exact
+  gap the claim addresses. No deeper structural change is required.
+- **Outcome:** Withstood. The integration point exists; the per-module `info` is already
+  produced and currently discarded. The change is structurally sound.
+- **Action:** None.
+
+---
+
+## Cross-claim consistency
+
+Claims 1–6 are mutually consistent:
+
+- Claims 1 and 2 are directly coupled: claim 1 diagnoses the root cause; claim 2 names the
+  fix. No tension.
+- Claim 3 (observability helper) and claim 4 (deletion of `try_tool_name/1`) operate on
+  different parts of the unload path and do not conflict.
+- Claim 5 (registry consumer blast radius) and claim 6 (path-entry enrichment) both
+  concern the info shape but at different levels: claim 5 concerns external consumers of
+  the `state.loaded` info map (via `Loader.list/0`); claim 6 concerns the internal
+  `%{modules: [...]}` sub-structure. No tension.
+- The partial falsification of claim 5 (blast-radius grep deferred to implementation) does
+  not affect claims 1–4 or 6, which do not depend on the exact shape of external consumers.
+
+One potential tension: claim 6 changes the internal shape of `%{modules: registered}` from
+`[mod_atom]` to (likely) `[{mod, info}]` or a map. Claim 5 asserts registry value shapes
+are unchanged. These are consistent because claim 5 is about **registry values** (what is
+stored in `Tau.Tools.Registry`, `Tau.Hooks.Registry`, etc.) not about the `state.loaded`
+internal shape. The `%{modules: registered}` field lives in `state.loaded`, not in the
+registries. No inconsistency.
+
+## Falsification summary
+
+| # | Claim (short) | Strategy | Outcome | Action |
+|---|---|---|---|---|
+| 1 | `try/rescue _ -> []` causes silent partial unload | Counter-example construction | Withstood | None |
+| 2 | Snapshot at load time eliminates unload callback re-invocation | Integration check | Withstood | None |
+| 3 | `crash_safe_unload/2` satisfies AC (a)/(b) | Edge-case enumeration | Partially falsified | Narrow qualifier: warning MUST name key tag, not only module |
+| 4 | Deleting `try_tool_name/1` is safe | Dependency check | Withstood | None |
+| 5 | Registry consumers outside `loader.ex` unaffected | Dependency check | Partially falsified | Narrow qualifier: implementer must run blast-radius grep before PR |
+| 6 | Path-based entry enrichment enables per-module unload | Integration check | Withstood | None |
+
+## Revision required
+
+No full revision triggered. Two claims require qualifier narrowings; neither falsifies
+the solution's viability.
+
+- **Claim 3 — narrowed qualifier:** `crash_safe_unload/2`'s `Logger.warning/1` MUST include
+  the key tag (`:tool`, `:hook`, `:command`, `:skill`) from the `registered_keys` tuple
+  being processed, so AC (a)'s "naming the broken module **and callback**" clause is
+  satisfied. The key tag is available in the loop body at no additional cost.
+- **Claim 5 — narrowed qualifier:** Implementer MUST grep `lib/` and `test/` for
+  `state.loaded`, `entry.info`, and `\.info\[` patterns and confirm no exact-equality
+  assertions exist on the info map shape outside `loader_test.exs` before opening the PR.
+  The solution's §Open questions already flags this; this validation records it as a
+  mandatory pre-PR gate, not a follow-up.
+
+## Outstanding doubts
+
+- `Tau.Tool.register/1`'s return contract is `{:ok, pid()} | {:error, term()}` per
+  `lib/tau/tool.ex:55`. The `registered_keys` capture logic must treat `{:ok, _}` as
+  "key recorded" and `:error` (or an exception) as "key not recorded". This is consistent
+  with the solution but worth explicit test coverage.
+- The `do_unload(_info), do: :ok` catch-all clause (line 423) handles unknown info shapes.
+  After enrichment, any `state.loaded` entry that was inserted before this change (e.g.
+  from a stale ETS snapshot surviving a hot-upgrade) would hit this clause and silently
+  skip unload. The solution acknowledges this with "a fallback clause in `unload_module/2`
+  that logs a warning and skips" — the warning is important; a silent skip would
+  reintroduce the observability gap the fix closes.

--- a/docs/problems-archive-v1-modules/tau-extensions/validation.md
+++ b/docs/problems-archive-v1-modules/tau-extensions/validation.md
@@ -1,0 +1,536 @@
+---
+template_version: 1
+template_name: validation
+parent_solution: solution.md
+parent_problem: problem.md
+toulmin_complete: true
+falsification_attempted: true
+falsification_outcome: partially_falsified — claim/3
+revision_triggered: none
+---
+
+# Validation: Load-time snapshots + string-typed collision guard for `Tau.Extensions.Loader`
+
+## Overview
+
+The root solution is a non-leaf synthesis of two child solutions: `unload-resilience`
+(snapshot-driven unload that eliminates the four `try/rescue _ -> []` blocks) and
+`atom-internment` (strings-throughout collision path with `String.to_existing_atom/1`
+plus an `atom_budget_ok?/0` defence-in-depth guard). The composition claim is the
+load-bearing addition the root makes beyond either child: that the two changes can
+land independently, in either order, with no shared state, no ordering dependency,
+and no interface negotiation. Per the validator brief this validation concentrates
+on the **cross-cutting integration claims** at the synthesis boundary (composition,
+ordering, no-shared-state, joint SPEC amendment), and treats the within-child
+correctness claims as already validated downstream (see
+`subproblems/unload-resilience/validation.md` and
+`subproblems/atom-internment/validation.md`, both `withstood` / `partially_falsified
+— qualifier narrowed`). Seven distinct propositions are extracted from the root
+solution's Recommendation, What-changes, What-does-not-change, and Migration-sketch
+sections. Each is run through full Toulmin (six fields) with an explicit named
+falsification strategy. Six withstood; one is partially falsified (claim 3 — "either
+order is safe") with a qualifier narrowing about merge-order test coupling that
+does not invalidate the composition claim but tightens its scope.
+
+---
+
+## Toulmin per claim
+
+The MITRE empirical study on Toulmin formalism found that "participants found it
+difficult to generate Toulmin structures, and their structures varied greatly even
+though they started with the same content"
+(https://www.mitre.org/news-insights/publication/empirical-evaluation-structured-argumentation-using-toulmin-argument).
+This template enforces all six components explicitly with prompts to counter that
+variance.
+
+---
+
+### Claim 1: The two child solutions touch disjoint code paths inside `loader.ex`
+
+- **Claim (C):** "The two child solutions operate on disjoint code paths inside
+  `loader.ex` (registration/unload vs. compile-time peek/collision-check) and on
+  disjoint structural concerns (registry-key lifecycle vs. atom-table lifecycle)."
+  (solution.md §Selected from — Composition rationale)
+- **Grounds (G):** The unload-resilience change list (solution.md §What changes,
+  bullets 1–6) names `register_module/1` (`loader.ex:351–388`), `unload_module/1`
+  (`loader.ex:425–480`), `do_unload/1` (`loader.ex:415–423`), `try_tool_name/1`
+  (`loader.ex:482–490`), and the path-based entry shape inside `register_module/1`
+  /`do_unload/1`. The atom-internment change list (solution.md §What changes,
+  bullets 7–12) names `peek_module_names/1` (`loader.ex:276–290`),
+  `compile_with_collision_guard/1` (`loader.ex:229–253`), a new
+  `name_collision?/1`, a new `atom_budget_ok?/0`, the `@atom_headroom` attribute,
+  and the comment block at `loader.ex:270–275`. No function name appears in
+  both lists.
+- **Warrant (W):** Two edits are non-conflicting when their changed-region sets
+  are disjoint (factory-loop.md §Parallel execution clause 3: "disjoint
+  codepoints"). Function-level disjointness is the textbook sufficient condition
+  for direct composition under Hickey's complecting lens: orthogonal concerns
+  expressed at non-overlapping seams compose without interface negotiation.
+- **Qualifier (Q):** Holds at the function-name granularity. A finer-grained
+  view (same `loader.ex` source file, same module attribute namespace, same
+  comment-block region near lines 270–275) is partially shared — see rebuttal.
+- **Rebuttal (R):** Both changes edit the *same file*, so a textual merge
+  conflict at the line level is possible if the unload change happens to insert
+  near lines 270–275 (where atom-internment rewrites the comment block) or if
+  either child renames `@module` attributes the other reads. Inspection of the
+  current `loader.ex` shows the unload-path edits land in `register_module/1`
+  (lines 351+) and `unload_module/1` (lines 425+); the atom-path edits land in
+  `peek_module_names/1` (lines 276+) and `compile_with_collision_guard/1`
+  (lines 229+). The regions are separated by ≥60 lines; a textual conflict
+  requires either child to expand its scope.
+- **Backing (B):** factory-loop.md §Parallel execution ("Disjoint codepoints");
+  Hickey, "Simple Made Easy" (composition by direct composition requires
+  disjoint state and disjoint interfaces); ADR-0022 (the SPEC-EXTENSIONS author
+  ADR) establishes registration/unload and compile-time peek as separate
+  contracts.
+
+#### Falsification attempt for claim 1
+
+- **Strategy:** Integration check — grep `loader.ex` for any function or module
+  attribute named in BOTH child solutions' change lists, and inspect each
+  edit-region pair for line-level overlap.
+- **Attempt:** Cross-referenced each function and identifier in the two
+  child-solutions' "What changes" bullets against the current `loader.ex`
+  (line ranges: peek/collision-guard 229–290; register 351–388; unload
+  415–480; try_tool_name 482–490). The two clusters share zero function
+  names and zero module attributes. The only file-level shared surface is
+  the `defmodule Tau.Extensions.Loader` shell and the `alias Tau.Settings.Cache`
+  / `require Logger` / `use GenServer` header — neither child rewrites the
+  header. Searched for shared module attributes: atom-internment adds
+  `@atom_headroom`; unload-resilience adds none. No attribute collision.
+- **Outcome:** Withstood — no shared codepoint found at function or attribute
+  granularity. The rebuttal (textual proximity within the same file) is a
+  *merge-time* concern, not a *semantic* one, and the line-range separation
+  (≥60 lines between the unload and peek clusters) keeps the merge mechanical.
+- **Action:** None.
+
+---
+
+### Claim 2: The two child solutions share no state, no callers, no data structures
+
+- **Claim (C):** "They share no functions, no state, and no callers; neither
+  references the other's data structures." (solution.md §Selected from —
+  Composition rationale)
+- **Grounds (G):** unload-resilience introduces `info.registered_keys` (a flat
+  list of tagged tuples inside the `info` map stored in `state.loaded`).
+  atom-internment introduces `@atom_headroom`, `atom_budget_ok?/0`, and
+  changes the return type of `peek_module_names/1` from `{:ok, [atom()]}` to
+  `{:ok, [String.t()]}`. Neither field is read by the other change:
+  `info.registered_keys` is consumed only by the new `crash_safe_unload/2`
+  helper; `peek_module_names/1`'s string return is consumed only by
+  `compile_with_collision_guard/1`. The two data flows are end-to-end disjoint:
+  registration → snapshot → registry unregister vs. file-read → peek → collision
+  check → compile.
+- **Warrant (W):** Direct composition (Hickey) is licensed when the changes
+  expose new state only at seams the other change does not read. The OTP
+  non-negotiable that stateful subsystems own their own state (TAU.md §OTP
+  invariant 1) means a new field inside the Loader's `state.loaded` info map
+  cannot be read by code outside the Loader process — by construction.
+- **Qualifier (Q):** Holds for the runtime data flow. The two changes do share
+  the SPEC-EXTENSIONS amendment surface (both edit §3 and the telemetry list);
+  that is a documentation coupling, not a runtime coupling.
+- **Rebuttal (R):** If a future refactor moved `peek_module_names/1`'s output
+  into the `info` map (e.g. to dedupe at unload time), the two changes would
+  share a field. No such refactor is in scope here; the rebuttal is hypothetical.
+- **Backing (B):** TAU.md §OTP non-negotiables #1 ("Every stateful subsystem is
+  a process under a supervisor") — by corollary, internal state shape is owned
+  by that subsystem alone. Hickey, "Simple Made Easy" (state composition by
+  disjoint ownership).
+
+#### Falsification attempt for claim 2
+
+- **Strategy:** Counter-example construction — try to construct a path through
+  the post-change `loader.ex` where the unload code reads atom-internment's new
+  state, or the peek code reads unload's new state.
+- **Attempt:** Mentally traced the two post-change call graphs.
+  Unload path: `handle_cast({:unload, entry}, state) → unload_entry/2 →
+  do_unload(info) → crash_safe_unload(mod_or_modules, info.registered_keys) →
+  per-key Registry.unregister*`. No reference to `peek_module_names/1`,
+  `name_collision?/1`, `atom_budget_ok?/0`, or `@atom_headroom`. Peek path:
+  `load_entry(path) → compile_with_collision_guard(p) → peek_module_names(p)
+  + atom_budget_ok?/0 + name_collision?/1 → do_compile_file/1`. No reference
+  to `info.registered_keys`, `crash_safe_unload/2`, or any unload-path
+  identifier. The two graphs are fully disjoint.
+- **Outcome:** Withstood — no counter-example constructible from the current
+  proposals.
+- **Action:** None.
+
+---
+
+### Claim 3: The two changes may land in either order without coordination
+
+- **Claim (C):** "Composition is therefore **direct**: each child's
+  recommendation lands as written, in either order, without interface
+  negotiation." (solution.md §Selected from); "The two refactors are
+  independent and may land in either order — there is no shared function and
+  no shared state to coordinate." (solution.md §Migration sketch)
+- **Grounds (G):** Claim 1 establishes disjoint codepoints; claim 2 establishes
+  disjoint state. With neither shared, there is no information either change
+  needs from the other to compile, type-check, or pass its own tests.
+  Telemetry events are namespaced (`[:tau, :extensions, :unload, :exception]`
+  vs. `[:tau, :extensions, :atom_budget_exceeded]`); test files live in
+  `test/tau/extensions/` (loader_test.exs primarily) but the new assertions
+  named in each child target separate behaviours (snapshot-driven unload vs.
+  atom-count delta).
+- **Warrant (W):** When changes A and B are mutually independent (no read or
+  write dependency in either direction), the merge graph A→B and B→A produce
+  the same combined diff; ordering is therefore semantically irrelevant.
+- **Qualifier (Q):** Holds for production code. Does NOT necessarily hold for
+  the test file `test/tau/extensions/loader_test.exs` if both children edit
+  the same test helper or `setup_all` block; merge order then matters at the
+  textual level even though the runtime behaviour is order-independent.
+- **Rebuttal (R):** The shared test file (`loader_test.exs`, ~740 lines) is a
+  realistic merge-conflict surface. The unload-resilience child's open
+  question explicitly flags "update tests that assert on `state.loaded` entry
+  shape or `info` map contents" as in-scope work; atom-internment's
+  proposed property test ("processing N unique module name strings interns
+  zero atoms") also lands in this file. Two PRs touching the same large test
+  module need rebase-after-first-merge, but rebase outcome is deterministic
+  (no semantic conflict, only textual).
+- **Backing (B):** factory-loop.md §Parallel execution clauses 1 ("No
+  dependency"), 2 ("Disjoint files" — production source disjoint, tests
+  shared but rebaseable), 3 ("Disjoint codepoints"); rebase semantics under
+  git merge (when neither side modifies the other's hunks, three-way merge
+  succeeds without operator intervention).
+
+#### Falsification attempt for claim 3
+
+- **Strategy:** Edge-case enumeration — list the cases where "either order"
+  could fail: (a) compile failure if one change depends on the other's
+  symbols; (b) test failure if one change's tests assume the other's
+  behaviour; (c) gate failure if Gate 5.1 / 5.3 require a specific ordering;
+  (d) SPEC amendment merge conflict; (e) merge conflict in shared test file.
+- **Attempt:** (a) Neither change adds symbols the other consumes (claim 2
+  confirms). (b) The unload-resilience tests assert on `state.loaded` info
+  shape; atom-internment's tests assert on `:erlang.system_info(:atom_count)`
+  deltas. Neither test class depends on the other's runtime behaviour. (c)
+  Gate 5.1 (AC-to-test linkage) checks each PR's own AC tokens — both
+  children have their own AC and their own gating tests; no cross-PR
+  linkage. Gate 5.3 (mutation) is per-PR. (d) Both children amend
+  SPEC-EXTENSIONS §3 and the telemetry section; if both PRs land §3 edits
+  in adjacent regions, a textual merge conflict is possible. (e) Shared
+  test file is realistic; rebase is deterministic but not zero-cost. Cases
+  (d) and (e) are TEXTUAL merge concerns, not semantic ordering
+  dependencies — the second-merging PR rebases and proceeds. Case (d) is
+  the most likely friction point because both children may rewrite the
+  D-123 entry; one of them must defer to the other's text.
+- **Outcome:** Partially falsified — the claim's qualifier needs narrowing
+  to "either order is **semantically** safe; **textual** merge conflicts in
+  `loader_test.exs` and SPEC-EXTENSIONS.md §3 require the second-merging
+  PR to rebase." The composition claim's substance (no shared state, no
+  ordering dependency in production code) survives.
+- **Action:** Narrow the qualifier in claim 3 as stated. No revision to
+  solution.md required because solution.md §Migration sketch already
+  recommends serialised landing for review-bandwidth reasons; the
+  partial-falsification only formalises why that recommendation is
+  pragmatic even though the in-principle independence holds.
+
+---
+
+### Claim 4: The two changes close both legs of the parent acceptance criterion
+
+- **Claim (C):** "The children together cover both legs of the parent
+  acceptance criterion." (solution.md §Selected from — Composition rationale,
+  closing sentence); equivalently, the parent AC ((a) `unload_module/1` can
+  distinguish a broken extension from an empty one and leaves no residual
+  registry entries; (b) `peek_module_names/1` does not permanently intern
+  filesystem-derived strings) is fully covered by the union of the two
+  child changes.
+- **Grounds (G):** Leg (a) — unload-resilience's snapshot mechanism replaces
+  the four `try/rescue _ -> []` blocks (`loader.ex:430–434, 448–451, 458–461,
+  468–471`) with a key-driven loop that does not invoke the post-load
+  callbacks; the snapshot is captured at registration time when the module
+  is known healthy. `crash_safe_unload/2` adds `Logger.warning/1` and
+  `[:tau, :extensions, :unload, :exception]` telemetry, so a broken module
+  is distinguished from an empty one. Leg (b) — atom-internment's
+  `peek_module_names/1` returns strings and `name_collision?/1` uses
+  `String.to_existing_atom/1` with a `rescue ArgumentError` branch; the
+  rescue path interns no atom.
+  (Cross-referenced against child validations: leg (a) corresponds to the
+  child-solution claims 1–5 in `subproblems/unload-resilience/validation.md`,
+  all `withstood`; leg (b) corresponds to claims 1–3 in
+  `subproblems/atom-internment/validation.md`, all `withstood`.)
+- **Warrant (W):** A union of changes that each provably solve a disjoint
+  leg of a conjunctive AC solves the full AC iff (i) no leg's change
+  invalidates the other's invariants and (ii) the disjointness from claims
+  1–2 holds.
+- **Qualifier (Q):** Holds conditional on the child validations being sound
+  (both report `partially_falsified` with narrowed qualifiers, no
+  full-falsification). Each leg's correctness was validated downstream;
+  the synthesis claim here is **integration completeness**, not per-leg
+  correctness.
+- **Rebuttal (R):** If a third defect existed in `unload_module/1` or
+  `peek_module_names/1` that the parent AC failed to name, neither child
+  would address it. The parent AC is the canonical statement of what counts
+  as solved; out-of-scope defects do not falsify this claim.
+- **Backing (B):** problem.md §Acceptance criterion ("(a) … (b) …" — explicit
+  conjunctive form); SPEC-EXTENSIONS D-122, D-123, D-124 (the invariants the
+  two legs strengthen).
+
+#### Falsification attempt for claim 4
+
+- **Strategy:** Edge-case enumeration over the AC text — list the failure
+  modes the AC implicitly excludes, check each is covered by the union.
+- **Attempt:** AC leg (a) enumerates three sub-properties: (a1) distinguish
+  broken from empty — covered by `Logger.warning/1` + telemetry on
+  exception path; (a2) logs broken modules — covered by `Logger.warning/1`
+  in `crash_safe_unload/2`; (a3) no residual registry entries on partial
+  unload — covered by the snapshot mechanism (registry unregister is driven
+  by load-time keys, not by re-querying a potentially-broken module). AC
+  leg (b) names one sub-property: no permanent atom internment from
+  user-controlled strings — covered by `String.to_existing_atom/1` rescue
+  path. Cross-check: does the snapshot mechanism's `Registry.unregister*`
+  call need to intern an atom? Inspected `unload_module/1`'s current calls
+  (`loader.ex:440, 453, 465, 477`): the registry keys are `tool_name`
+  (a string returned by `mod.name()`), `ev` (an atom passed from `mod.hooks/0`),
+  `name` (a string from `mod.commands/0`), and `name` (a string from
+  `mod.skills/0`). Atoms come from the extension module's compiled return
+  values, not from filesystem strings — leg (b)'s no-intern guarantee is
+  preserved by the snapshot mechanism. No cross-leg invalidation found.
+- **Outcome:** Withstood — both legs are covered, with no cross-leg
+  invariant violation.
+- **Action:** None.
+
+---
+
+### Claim 5: Public API of `Tau.Extensions.Loader` is preserved
+
+- **Claim (C):** "Public API of `Tau.Extensions.Loader` — no exported
+  function signatures change." (solution.md §What does not change, bullet 1)
+- **Grounds (G):** The public API consists of `start_link/1` (loader.ex:35),
+  `reload/1` (loader.ex:50), `unload/1` (loader.ex:58), `reload_all/0`
+  (loader.ex:65), `list/0` (loader.ex:74), plus the three `@impl true`
+  GenServer callbacks. The unload-resilience change list renames
+  `unload_module/1` → `unload_module/2` (PRIVATE — the public `unload/1`
+  cast handler is unchanged); adds `crash_safe_unload/2` (PRIVATE); deletes
+  `try_tool_name/1` (PRIVATE). The atom-internment change list modifies
+  `peek_module_names/1` (PRIVATE), adds `name_collision?/1` (PRIVATE),
+  `atom_budget_ok?/0` (PRIVATE), and `@atom_headroom` (PRIVATE attribute).
+  Zero public functions are added, removed, or modified.
+- **Warrant (W):** A function is "public" if it is reachable via the
+  `Tau.Extensions.Loader.<name>` notation from an external caller — i.e.
+  it is documented with `@doc` and exported via `def`. Private functions
+  (`defp`) are by definition not public API; their signature changes do
+  not constitute API changes (Hickey: encapsulation principle).
+- **Qualifier (Q):** Holds for the function-call API. The `list/0` return
+  shape is technically part of the observable API (its return type is
+  `[%{key: term(), info: map()}]`); if unload-resilience adds a
+  `registered_keys` field to `info`, external consumers that pattern-match
+  on `info` will see a wider map. See rebuttal.
+- **Rebuttal (R):** The unload-resilience child solution's open question 3
+  explicitly flags this: "Does any external code (outside `loader.ex` and
+  its tests) pattern-match on the bare `%{module: mod}` info shape from
+  `state.loaded`?" A grep over `lib/` and `test/` (executed during this
+  validation) finds zero hits for `entry.info` or `state.loaded` outside
+  `loader.ex` and `loader_test.exs`. Test-file pattern-match on the
+  enriched `info` map is in-scope rework for the child PR. No external
+  production code consumer was found.
+- **Backing (B):** TAU.md §OTP non-negotiable #2 (behaviours as
+  extensibility seams — pattern-match on atoms and structs at the API
+  boundary); the actual `list/0` return type is unstructured (it returns
+  a `map()`), so consumers either accept arbitrary fields or risk
+  brittleness. The pattern is to add fields, not to break shapes.
+
+#### Falsification attempt for claim 5
+
+- **Strategy:** Dependency check — grep the codebase for any caller of
+  `Tau.Extensions.Loader.<public-fn>` whose call signature would break
+  under the proposed changes.
+- **Attempt:** Searched `lib/` and `test/` for `Tau.Extensions.Loader.`
+  call sites and for `Loader.` (after `alias`). Public functions are
+  invoked from `lib/tau/cli/extensions.ex` (the CLI handlers) and from
+  `test/tau/extensions/loader_test.exs`. None of the proposed changes
+  modify the public-function arity or return type at the
+  `[%{key, info}]` shape; the only widening is the new `registered_keys`
+  field inside `info`. Map widening is not a breaking change under
+  Elixir's pattern-match semantics (a `%{module: mod}` match still
+  succeeds on `%{module: mod, registered_keys: [...]}`).
+- **Outcome:** Withstood — no breaking change found.
+- **Action:** None.
+
+---
+
+### Claim 6: Telemetry events are namespaced so the two PRs do not collide
+
+- **Claim (C):** "the cross-cutting concerns (telemetry events, SPEC D-NNN
+  entries) are namespaced (`:unload, :exception` vs. `:atom_budget_exceeded`;
+  D-122/D-124 lineage vs. D-123 lineage)." (solution.md §Migration sketch)
+- **Grounds (G):** Unload-resilience adds `[:tau, :extensions, :unload,
+  :exception]` (solution.md §What changes, bullet 3). Atom-internment adds
+  `[:tau, :extensions, :atom_budget_exceeded]` (solution.md §What changes,
+  bullet 10). The event-name lists are disjoint as strings; neither child
+  defines the other's event. The existing telemetry inventory in
+  `loader.ex` (`[:tau, :extensions, :load, :start | :stop | :exception]`
+  and `[:tau, :extensions, :reloaded]`) is preserved by both children.
+- **Warrant (W):** Telemetry events compose by namespace disjointness:
+  `:telemetry.execute/3` is keyed by the full event-name list, so two
+  distinct lists never collide at the handler level. Adding new event
+  names is additive; existing handlers see no change.
+- **Qualifier (Q):** Holds at the event-name level. Test-side handler
+  ID collisions (both children might use `"loader-test-#{unique_id()}"`
+  patterns) are a test-hygiene concern, not a runtime concern.
+- **Rebuttal (R):** If a future telemetry-aggregator subscribed to
+  `[:tau, :extensions, :_, :exception]` wildcards (which the standard
+  `:telemetry` library does not support — wildcards are not first-class),
+  the namespace argument would partially weaken. The current OTel reporter
+  (per SPEC-OTEL-REPORTER) subscribes by exact event list, so wildcards
+  are not in play.
+- **Backing (B):** `:telemetry` library contract — event names are
+  matched by full list equality; OTP non-negotiable #5 (telemetry events
+  for everything user-visible or perf-sensitive); SPEC-OTEL-REPORTER §3
+  (event subscription is by exact match).
+
+#### Falsification attempt for claim 6
+
+- **Strategy:** Counter-example construction — find a handler in the
+  codebase that would match both new events ambiguously, or find an
+  existing event whose name the new ones shadow.
+- **Attempt:** Grepped `lib/` and `test/` for `:telemetry.attach` and
+  `:telemetry.attach_many` calls. All attach calls cite explicit event
+  lists; none uses a wildcard pattern. No event named
+  `[:tau, :extensions, :unload, :exception]` or
+  `[:tau, :extensions, :atom_budget_exceeded]` exists in the current
+  codebase. No shadowing or accidental match found.
+- **Outcome:** Withstood — namespace disjointness holds.
+- **Action:** None.
+
+---
+
+### Claim 7: The joint SPEC-EXTENSIONS amendment is the only documentation surface that requires coordination
+
+- **Claim (C):** "The only shared surface is `lib/tau/extensions/loader.ex`
+  itself (both edit it) and `docs/spec/SPEC-EXTENSIONS.md` (both amend §3 /
+  telemetry sections)." (solution.md §Selected from — Composition rationale)
+- **Grounds (G):** Beyond the two surfaces named (the production file and
+  the SPEC), no other file appears in both child solutions' change lists.
+  Tests live in `test/tau/extensions/` but in distinct describe-blocks
+  (one targets snapshot unload, the other targets atom-count deltas).
+  ADRs are not touched by either child. The CLI module
+  `lib/tau/cli/extensions.ex` is explicitly out of scope per problem.md
+  §Out of scope.
+- **Warrant (W):** Documentation coupling (both PRs amend the same SPEC §)
+  is a textual merge concern resolvable by ordering the merges (the
+  second-merging PR rebases its SPEC edit). Production-code coupling
+  would be more serious; absent it, the documentation amendment is the
+  highest-friction shared surface.
+- **Qualifier (Q):** Holds for the in-scope file set per problem.md.
+  Out-of-scope concerns (e.g. extension CLI, settings schema) are
+  excluded by the problem statement.
+- **Rebuttal (R):** If the SPEC amendment requires a new D-NNN block
+  (rather than amending D-122/D-123/D-124 in place), the two children
+  might race to claim the next free D-NNN identifier. The CLAUDE.md
+  D-NNN allocation rule ("Before authoring a new D-NNN, verify the
+  identifier is free across the whole repo") mitigates this: the
+  second-merging PR re-checks freshness and picks a new ID if needed.
+- **Backing (B):** CLAUDE.md ("The runtime-invariant namespace is D-NNN,
+  partitioned across SPECs … verify the identifier is free across the
+  whole repo"); spec-before-code.md §"What this rule requires"
+  (amendments live in the same PR as the change introducing them).
+
+#### Falsification attempt for claim 7
+
+- **Strategy:** Integration check — enumerate every file in either child's
+  change list, identify the intersection, verify no third shared file
+  was missed.
+- **Attempt:** Listed all file paths from `subproblems/unload-resilience/
+  solution.md` §What changes (lib/tau/extensions/loader.ex; test/tau/
+  extensions/) and `subproblems/atom-internment/solution.md` §What changes
+  (lib/tau/extensions/loader.ex; docs/spec/SPEC-EXTENSIONS.md). The root
+  solution.md §What changes preserves the union: loader.ex, test/tau/
+  extensions/, docs/spec/SPEC-EXTENSIONS.md. Intersection: loader.ex AND
+  SPEC-EXTENSIONS.md (atom-internment explicitly edits the SPEC;
+  unload-resilience's change list does not mention SPEC but the root
+  rolls in a SPEC amendment for the unload invariant, making SPEC a
+  shared surface at the synthesis level). The test directory is shared
+  but at the file level the two children edit distinct test functions —
+  no test function is renamed or deleted by both. No third shared file.
+- **Outcome:** Withstood — only `loader.ex` and `SPEC-EXTENSIONS.md` are
+  jointly edited; the SPEC amendment coordination is the load-bearing
+  shared concern the claim names.
+- **Action:** None.
+
+---
+
+## Cross-claim consistency
+
+Claims 1, 2, 3, and 7 form a consistent integration story: the children are
+disjoint at the production-code level (1, 2), order-independent at runtime
+(3), and the only joint surface is documentation (7). Claim 4 builds on
+1–3: the disjointness implies independence of the leg-(a) and leg-(b) fixes,
+so their union covers the conjunctive AC. Claim 5 (public API preserved)
+and claim 6 (telemetry namespacing) are local properties of each child that
+the synthesis preserves. The partial falsification of claim 3 (textual
+merge conflict in `loader_test.exs` and SPEC §3) is consistent with claim 7
+(SPEC is a shared surface): the qualifier narrowing on claim 3 simply
+formalises the merge-time friction claim 7 already anticipates. No
+internal tension found.
+
+A subtle consistency check: claim 4's coverage argument assumes claim 2's
+no-shared-state holds. If a future refactor folded `peek_module_names/1`'s
+output into the `info` map, claim 2 would weaken and claim 4 would need
+re-validation. This is noted as an outstanding doubt below.
+
+---
+
+## Falsification summary
+
+| # | Claim (short) | Strategy | Outcome | Action |
+|---|---|---|---|---|
+| 1 | Disjoint codepoints | Integration check (grep + line-range inspection) | withstood | None |
+| 2 | No shared state / callers / data | Counter-example construction (post-change call graphs) | withstood | None |
+| 3 | Either-order merge safe | Edge-case enumeration (compile / test / gate / SPEC / test-file) | partially falsified | Narrow qualifier: semantic independence holds; textual rebase needed in `loader_test.exs` and SPEC §3 |
+| 4 | Children cover both AC legs | Edge-case enumeration over AC text | withstood | None |
+| 5 | Public API preserved | Dependency check (grep callers) | withstood | None |
+| 6 | Telemetry namespaced | Counter-example construction (handler ambiguity search) | withstood | None |
+| 7 | Only SPEC + loader.ex shared | Integration check (file-set intersection) | withstood | None |
+
+---
+
+## Revision required
+
+None. The single partial-falsification (claim 3) narrows a qualifier in
+place; no revision to solution.md or problem.md is needed. The qualifier
+narrowing is consistent with the migration sketch's existing
+recommendation to land the two PRs serially for review-bandwidth reasons.
+
+- **Target file:** n/a
+- **Revision kind:** n/a — in-place qualifier narrowing only
+- **Rationale:** The composition claim's substance (no shared state, no
+  semantic ordering dependency) survives intact; the narrowing acknowledges
+  that two PRs touching the same large test file and the same SPEC § will
+  require the second to rebase. That is normal git workflow, not a
+  composition defect.
+
+---
+
+## Outstanding doubts
+
+- **`Tau.Tool.register/1`'s contract for snapshot capture.** The
+  unload-resilience child solution's open question 1 flags that
+  `Tau.Tool.register/1` returns `{:ok, pid()} | {:error, term()}`
+  (confirmed at `lib/tau/tool.ex:55–58`). The snapshot mechanism must
+  record only keys actually registered. This was inherited as an open
+  question; it is implementation-detail-level work for the unload-resilience
+  PR but is not a synthesis-level concern. If the implementer captures the
+  `{:error, _}` case as "not snapshotted", the unload path will leave no
+  stale entry; if they capture unconditionally, the unload path might
+  attempt to unregister an entry that never registered (a no-op for
+  `Registry.unregister*`, so benign — but a logging hazard).
+- **Cross-leg invariant preservation under future refactor.** If a future
+  refactor introduced a feedback loop where atom-internment's
+  `name_collision?/1` consulted `state.loaded`'s `info.registered_keys`
+  (e.g. to dedupe by registered key), claims 2 and 4 would both need
+  re-validation. No such refactor is in scope, but the synthesis's
+  decomplecting depth depends on this remaining true.
+- **`@atom_headroom` default calibration.** Inherited from
+  atom-internment's open questions: 10_000 is unaudited against the
+  deployed atom-count baseline. Not a synthesis concern but propagates
+  to the parent.
+- **D-NNN allocation race.** Two PRs concurrently authoring SPEC
+  amendments to `docs/spec/SPEC-EXTENSIONS.md` §3 / §6 might race for the
+  next free D-NNN identifier. The CLAUDE.md verification rule
+  ("verify the identifier is free across the whole repo") handles this
+  for sequential merges; under genuinely parallel merges, the
+  second-merging PR re-checks at rebase time.
+
+---

--- a/docs/problems-archive-v1-modules/tau-infrastructure/problem.md
+++ b/docs/problems-archive-v1-modules/tau-infrastructure/problem.md
@@ -1,0 +1,110 @@
+---
+template_version: 1
+template_name: problem
+node_kind: internal
+depth: 0
+parent: —
+status: decomposed
+---
+
+# Problem: tau-infrastructure cross-cutting correctness
+
+## Statement
+
+`Tau.Application` and its cross-cutting subsystems (supervision tree, telemetry,
+cost tracker, circuit breaker, OTel reporter) contain at least four independent
+classes of correctness defect: asymmetric crash-safety in telemetry handlers,
+a supervision strategy mismatch that allows stale handler re-attachment,
+circuit-breaker invariants split across a stateless façade and an ETS-owner store
+in a way that bakes the store's internal counter protocol into the pure-state
+module's callers, and global process names that make single-node deployment a
+hard requirement. Resolving any one class does not resolve the others; each can
+be proposed and validated independently.
+
+## Context
+
+- `lib/tau/application.ex` — 17-child `:rest_for_one` supervision tree;
+  `maybe_dispatch_cli/0` spawns an unmonitored `Task` (line 185) that calls
+  `System.halt/1`; `otel_reporter_spec/0` (line 113) duplicates the
+  enable/disable policy already expressed in `Tau.OtelReporter.init/1`.
+- `lib/tau/cost/tracker.ex:118-138` — `handle_event/4` (provider-request-stop
+  handler) has no rescue; the coding-agent twin at line 144 is guarded per D-035.
+  Flat audit classifies this as Critical.
+- `lib/tau/telemetry/supervisor.ex:17-22` — `:one_for_one` strategy; if
+  `Tau.Telemetry.Handlers` crashes and restarts, `Cost.Tracker` is not
+  restarted so its handlers remain attached; on `Handlers` restart the events
+  list is re-attached — duplicate handler risk (flat audit: minor).
+- `lib/tau/circuit_breaker.ex:124-145` — `record_outcome/5` performs a
+  `new_count - 1` adjustment to work around `Store.bump_*/1` returning the
+  post-increment value, encoding the Store's internal counter protocol in the
+  façade's private logic (flat audit: minor).
+- `lib/tau/circuit_breaker/state.ex:64` — `@default_cooldown_ms 30_000` is
+  consumed inside `check/2` but not exposed as a keyword opt, while
+  `failure_threshold` and `success_threshold` are threadable.
+- `lib/tau/application.ex:68` — `Tau.PubSub` hard-coded global name; same
+  pattern for `Tau.Providers.Finch`, `Tau.CircuitBreaker.Store` (`__MODULE__`),
+  `Tau.Sessions.Supervisor`, etc. Two simultaneous Tau BEAM applications collide.
+- SPEC-CIRCUIT-BREAKER D-029/D-030/D-043/D-044; OTP-NN §1, §7.
+
+## Complecting hypothesis
+
+1. **Crash-safety policy is complected with handler identity**: whether a
+   telemetry handler survives a sibling's restart is determined by the
+   supervisor strategy choice, not by any explicit lifecycle declaration in the
+   handler itself — making crash-safety invisible until it fails.
+2. **Store's counter protocol is complected with the façade's transition logic**:
+   `Tau.CircuitBreaker.record_outcome/5`'s `new_count - 1` adjustment exists
+   only because `Store.bump_*/1` returns post-increment; the pure `State`
+   functions' `count + 1` semantics leak into the caller.
+3. **Process-name scope is complected with deployment topology**: hard-coded
+   atom names for PubSub, Finch, ETS tables, and supervisors embed a
+   single-instance-per-node assumption into every subsystem simultaneously.
+
+## Decomposition strategy
+
+The audit lens names four independent concern classes:
+(a) handler asymmetry and supervisor strategy mismatch (steady-state event handling);
+(b) supervision tree startup ordering and the unmonitored CLI task (lifecycle);
+(c) circuit-breaker invariant split between store and state (data-shape vs
+    control-flow across a layer boundary);
+(d) global name collision risk (deployment topology concern).
+
+These four classes are MECE along the **concern (Hickey)** axis: each names a
+distinct woven pair of concerns, no concern lives in two classes, and their union
+covers every finding in the flat audit for this module. They are solvable
+independently — a proposer at any leaf needs no conclusions from sibling leaves.
+
+## Sub-problems (filled by decomposer)
+
+1. **supervision-tree-startup** — Supervision tree lifecycle defects: the
+   unmonitored CLI task, the dual OTel enable/disable policy, and `max_restarts`
+   defaults for a binary expected to recover from transient init failures.
+2. **telemetry-handler-coupling** — Telemetry handler crash-safety and the
+   `Telemetry.Supervisor` `:one_for_one` strategy mismatch that allows stale or
+   duplicate handler attachment after a sibling restart.
+3. **circuit-breaker-invariant-split** — The circuit breaker's counter-protocol
+   leakage between `Store.bump_*/1` (post-increment return) and `State`'s pure
+   functions (`count + 1` semantics), plus the asymmetric cooldown configurability.
+4. **global-name-collision** — Hard-coded global atom names for PubSub, Finch,
+   ETS tables, and supervisors that embed a single-instance-per-node assumption.
+
+## Acceptance criterion
+
+All four sub-problems are resolved: each has a validated proposal that names the
+change, the affected file(s) and line(s), and the invariant it restores, without
+introducing new correctness defects at sibling boundaries.
+
+## Out of scope
+
+- `lib/tau/cost/tracker.ex` `handle_event/4` missing rescue is the specific
+  subject of **telemetry-handler-coupling**; root does not propose fixes.
+- `lib/tau/factory/gate.ex` placement (CI build tool under `lib/tau/`) — covered
+  by the tau-cli audit module, not this one.
+- Memory store (`lib/tau/memory/`) — covered by tau-memory audit module.
+- Coding-agent defensive rescue ladders — covered by tau-coding-agent audit.
+- Provider adapter drift — covered by tau-providers audit.
+- `lib/tau/persistence/jsonl.ex` raises — covered by tau-cli audit.
+
+## Amendment log
+
+- (none yet)

--- a/docs/problems-archive-v1-modules/tau-infrastructure/solution.md
+++ b/docs/problems-archive-v1-modules/tau-infrastructure/solution.md
@@ -1,0 +1,273 @@
+---
+template_version: 1
+template_name: solution
+parent_problem: problem.md
+node_kind: root
+synthesised_from:
+  - subproblems/supervision-tree-startup/solution.md
+  - subproblems/telemetry-handler-coupling/solution.md
+  - subproblems/circuit-breaker-invariant-split/solution.md
+  - subproblems/global-name-collision/solution.md
+selection_method: synthesis
+mode: non-leaf
+revision: 0
+---
+
+# Solution: tau-infrastructure cross-cutting correctness — four independent fixes, sequenced for minimal interference
+
+## Recommendation
+
+Land the four child recommendations as four separate PRs in the order
+**(1) telemetry-handler-coupling → (2) circuit-breaker-invariant-split → (3) supervision-tree-startup → (4) global-name-collision**.
+The first three are file-scoped and mutually non-interacting; ordering is
+chosen to put the smallest, lowest-blast-radius patches first and the
+broadest call-site sweep last. Each PR carries its own SPEC amendment
+(only #2 and #4 need one), its own acceptance criterion satisfied in
+isolation, and its own regression test. The combined effect restores
+four invariants in `Tau.Application` and its cross-cutting subsystems —
+asymmetric crash-safety in cost telemetry handlers, post-/pre-increment
+coupling between `CircuitBreaker.Store` and the façade, unmonitored CLI
+task and dual OTel enable-disable policy in `start/2`, and hard-coded
+global atom names blocking multi-instance deployment — without
+introducing new defects at sibling boundaries.
+
+## Selected from
+
+- **Synthesised from:** child solutions at
+  `subproblems/supervision-tree-startup/solution.md`,
+  `subproblems/telemetry-handler-coupling/solution.md`,
+  `subproblems/circuit-breaker-invariant-split/solution.md`,
+  `subproblems/global-name-collision/solution.md`.
+- **Composition rationale:** The four child recommendations are
+  **directly composable**. The decomposition strategy in `problem.md`
+  partitions defects along the Hickey *concern* axis (steady-state
+  event handling vs lifecycle vs data-shape-across-a-layer vs
+  deployment topology); no concern lives in two children, so no
+  recommendation contradicts another. Verifying composition file by
+  file:
+
+  - **telemetry-handler-coupling** touches `lib/tau/cost/tracker.ex`
+    (rescue block in `handle_event/4`) and `lib/tau/telemetry/supervisor.ex`
+    (`:rest_for_one` strategy + child-ordering invariant). Neither file
+    is touched by any other child.
+  - **circuit-breaker-invariant-split** touches
+    `lib/tau/circuit_breaker/store.ex` (return convention),
+    `lib/tau/circuit_breaker.ex` (delete `new_count - 1`),
+    `lib/tau/circuit_breaker/state.ex` (`check/3` cooldown opt), and
+    `docs/spec/SPEC-CIRCUIT-BREAKER.md` §4 B4. The `Store` is also
+    referenced by **global-name-collision** but only in
+    `start_link/1` / `init/1` (accepting `name:`/`table:` opts) — a
+    different region of the file. The two PRs may overlap in the file
+    but not in the same function; merging in order avoids any
+    file-level conflict (#2 lands the return-convention change first,
+    #4 then layers the opts threading on top, leaving the multi-op
+    `update_counter` untouched).
+  - **supervision-tree-startup** touches only `lib/tau/application.ex`
+    (`start/2` body, `opts`, deletion of `maybe_dispatch_cli/0` and
+    `otel_reporter_spec/0`). `Application.start/2` is also modified by
+    **global-name-collision** (to call `Tau.Names.compute/1` and
+    thread `names.*` opts into children). These overlap in the same
+    function; ordering #3 before #4 means the `spawn_monitor` + `receive`
+    block and the `OtelReporter` unconditional entry are present in
+    `start/2` when #4 then adds the `Tau.Names.compute/1` /
+    `:persistent_term.put/2` lines and rewrites the child specs to
+    thread `names.*` fields. The two patches touch the same function
+    but at clearly separable points (CLI dispatch block and OtelReporter
+    spec list vs name resolution and child opts) — a textbook
+    rebase-rather-than-conflict situation.
+  - **global-name-collision** introduces `lib/tau/names.ex`, modifies
+    `lib/tau/application.ex`, `lib/tau/circuit_breaker/store.ex`,
+    `lib/tau/cost/tracker.ex`, and `lib/tau/registries.ex`, and sweeps
+    ~30 bare-atom call sites. Modifying `Cost.Tracker` and
+    `CircuitBreaker.Store` here is purely additive (accept `name:`,
+    `table:` opts with defaults equal to current atoms), so the rescue
+    block from #1 and the multi-op `update_counter` from #2 are
+    preserved verbatim.
+
+  No conflict resolution between children is required; the only ordering
+  constraint is the same-function overlap of #3 and #4 in
+  `Application.start/2`, satisfied by serial merge order. The four
+  children together cover every finding listed in `problem.md`'s
+  Context section: cost-tracker rescue gap, telemetry supervisor
+  strategy, circuit-breaker counter-protocol leakage and asymmetric
+  cooldown configurability, unmonitored CLI task, dual OTel enable
+  policy, and hard-coded global atom names. There is no gap; the
+  decomposition was complete.
+
+## What changes
+
+Listed by child PR, in the recommended landing order. Each item below is
+exactly the change the child solution prescribes; file-level enumeration
+is non-overlapping except where noted (#3 ∩ #4 in `application.ex`).
+
+### PR 1 — telemetry-handler-coupling
+
+- `lib/tau/cost/tracker.ex` — add `rescue` block to `handle_event/4`
+  symmetric with the existing guard in `handle_coding_agent_cost/4`;
+  emit `[:tau, :cost, :tracker, :handler_failed]` on error; return `:ok`.
+- `lib/tau/telemetry/supervisor.ex` — change `strategy:` from
+  `:one_for_one` to `:rest_for_one`; verify and (if necessary) reorder
+  the child list so `Tau.Telemetry.Handlers` precedes `Tau.Cost.Tracker`.
+- New test: inject a float into `:usage` to reach the `:ets.update_counter`
+  raise path; assert `handle_event/4` returns `:ok` and the
+  `[:tau, :cost, :tracker, :handler_failed]` event is emitted.
+
+### PR 2 — circuit-breaker-invariant-split
+
+- `lib/tau/circuit_breaker/store.ex` — `bump_failure_count/1` and
+  `bump_success_count/1` use the two-element `update_counter` op list
+  `[{pos, 0}, {pos, 1}]`, returning the **pre-increment** value;
+  `@spec` unchanged; `@doc` updated.
+- `lib/tau/circuit_breaker.ex` — `record_outcome/5` removes the
+  `new_count - 1` adjustment and the comment block at lines 116–123;
+  passes the Store return directly into the `State` struct.
+- `lib/tau/circuit_breaker/state.ex` — `check/2` becomes `check/3`
+  with an optional `cooldown_ms` keyword opt; `@default_cooldown_ms`
+  remains as the fallback. `record_failure/2` and `record_success/2`
+  are unchanged.
+- `docs/spec/SPEC-CIRCUIT-BREAKER.md` §4 B4 — document the
+  pre-increment return convention and the new `cooldown_ms` opt.
+- Update tests asserting on `Store.bump_*/1` return values from
+  post-increment to pre-increment (small set per the child's
+  pre-implementation `grep`).
+
+### PR 3 — supervision-tree-startup
+
+- `lib/tau/application.ex`:
+  - Delete `maybe_dispatch_cli/0` and its call site.
+  - Delete `otel_reporter_spec/0`; replace its child-list entry with
+    `Tau.OtelReporter` unconditionally (the existing `init/1`
+    `:ignore` return is the sole gate).
+  - Insert `spawn_monitor/1` + `receive` block on the `{:ok, pid}`
+    branch of `start/2`, gated on `cli_argv()`, with the spawned
+    process calling `exit(exit_code)` so the integer is carried as
+    the `:DOWN` reason; the `receive` dispatches to `System.halt/1`.
+  - Set `opts = [strategy: :rest_for_one, name: Tau.Supervisor,
+    max_restarts: 10, max_seconds: 60]`.
+- Tests asserting `Tau.OtelReporter` is absent when OTel is disabled
+  must assert it is present-but-ignored (or be deleted if they were
+  testing the now-removed `otel_reporter_spec/0` function).
+
+### PR 4 — global-name-collision
+
+- New file `lib/tau/names.ex` — `Tau.Names` struct + `compute/1` +
+  `get/0` + `get/1`. `compute(:default)` returns existing atoms
+  unchanged.
+- `lib/tau/application.ex` — `start/2` reads `instance_id` from args
+  (default `:default`), calls `Tau.Names.compute/1`, stores result in
+  `:persistent_term` under `:tau_names`, threads `names.*` fields into
+  every named child's `start_link/1` opts. **Overlaps PR 3's edits in
+  `start/2`** — see "Composition rationale" above; the two patches
+  touch disjoint regions of the function.
+- `lib/tau/circuit_breaker/store.ex` — `start_link/1` and `init/1`
+  accept `name:` and `table:` opts (defaults `__MODULE__` and
+  `:tau_circuit_breakers`). Additive — preserves PR 2's pre-increment
+  semantics.
+- `lib/tau/cost/tracker.ex` — same pattern (`name:` opt). Additive —
+  preserves PR 1's rescue block verbatim.
+- `lib/tau/registries.ex` — `start_link/1` / `init/1` accept a `names:`
+  struct and pass `names.<role>_registry` to each of seven `Registry`
+  children.
+- ~30 call sites under `lib/` — replace bare `Tau.PubSub`,
+  `Tau.Providers.Finch`, and registry atoms with
+  `Tau.Names.get().<field>`.
+- Regression test: property asserting
+  `Tau.Names.compute(:default)` round-trips to the historically-expected
+  atoms.
+
+## What does not change
+
+- `Tau.Cost.Tracker.handle_coding_agent_cost/4` (already D-035-compliant).
+- `Tau.Telemetry.Handlers` module body.
+- `Tau.CircuitBreaker.State.record_failure/2` and `record_success/2`
+  semantics and signatures.
+- D-044 ETS row layout for the circuit breaker; `@schema_version` does
+  not bump.
+- The public `Tau.CircuitBreaker.call/3` API contract.
+- The `Tau.Provider` behaviour, all provider adapters, and the session
+  FSM logic.
+- `Tau.OtelReporter` module and its `init/1` `:ignore` logic.
+- `Tau.Application`'s 17-child tree composition beyond the
+  `otel_reporter_spec` removal and the child-list rewrites driven by
+  PR 4's `names.*` threading.
+- All `start_link/1` external signatures for the `:default` instance —
+  defaults match current atoms, so deployed configurations require no
+  migration.
+- All other audit modules (tau-cli, tau-memory, tau-coding-agent,
+  tau-providers) — explicit per `problem.md`'s Out of scope.
+
+## Migration sketch
+
+Land the four PRs serially in the order above. Each PR is small enough
+to gate independently under the factory loop's per-PR `critic` +
+`reviewer` gate; none has a prerequisite from a sibling beyond the
+ordering chosen here for conflict-minimisation:
+
+1. **PR 1** (telemetry-handler-coupling) — 2 files, 1 test. No sibling
+   dependency. Verify `Cost.Tracker.terminate/2` detaches both handler
+   IDs before merging the `:rest_for_one` half (child's open question).
+2. **PR 2** (circuit-breaker-invariant-split) — 4 files + SPEC amendment
+   in the same PR. No sibling dependency. Run the pre-implementation
+   `grep` for `bump_failure_count|bump_success_count` to enumerate
+   test-side assertion updates; confirm `:ets.update_counter/3` two-op
+   atomicity on OTP 27.2 before gating.
+3. **PR 3** (supervision-tree-startup) — single-file change in
+   `lib/tau/application.ex`. No sibling dependency. Confirm
+   `exit(integer)` propagates as `{:DOWN, ref, :process, pid, integer}`
+   (not `:normal`) via a smoke test before relying on the
+   `is_integer(exit_code)` guard (child's open question).
+4. **PR 4** (global-name-collision) — new file + 4 edited files + ~30
+   call-site sweep. Rebases on top of PR 3's `start/2` body; the two
+   patches touch disjoint regions, so the rebase is mechanical. After
+   landing, all `start_link/1` defaults still match the historic atoms,
+   so the regression baseline holds.
+
+Each PR's child solution carries its own acceptance criterion and
+gating-test paths; this root solution adds no further criterion beyond
+the four already specified, and no additional CI gate beyond the
+existing per-PR `critic` + `reviewer` + three-mechanical-gates pipeline.
+
+## Open questions
+
+The four child solutions enumerate seven open questions in total; the
+root inherits all of them unchanged. Composition does not introduce new
+open questions beyond:
+
+- **Same-function overlap in `Application.start/2` (PR 3 ∩ PR 4).** The
+  recommendation asserts the two patches touch disjoint regions of the
+  function. If the implementer of PR 4 finds, on rebase, that PR 3's
+  inline `spawn_monitor` block has migrated to a position that
+  conflicts with name resolution sequencing (e.g. names must be in
+  `:persistent_term` before the CLI dispatch can read them), this must
+  be resolved at PR 4 implementation time — likely by moving the
+  `Tau.Names.compute/1` + `:persistent_term.put/2` call to the very
+  start of `start/2`, before any child spec list is constructed. No
+  rule change required.
+- **Implicit ordering on the SPEC-CIRCUIT-BREAKER amendment.** PR 2
+  amends §4 B4. If a parallel PR (outside this module's scope) amends
+  the same section concurrently, the second to merge must rebase on
+  the first; this is the standard SPEC-amendment rebase pattern
+  (`spec-before-code.md`) and not new.
+
+## Linked sub-problems / proposals
+
+- `subproblems/supervision-tree-startup/` → "Inline `spawn_monitor` +
+  `receive` in `Application.start/2`; OtelReporter always-in-tree;
+  relaxed restart bounds (`max_restarts: 10, max_seconds: 60`)."
+- `subproblems/telemetry-handler-coupling/` → "Add symmetric `rescue`
+  in `Cost.Tracker.handle_event/4`; switch
+  `Tau.Telemetry.Supervisor` to `:rest_for_one` with `Handlers`
+  before `Cost.Tracker`."
+- `subproblems/circuit-breaker-invariant-split/` → "Change `Store.bump_*/1`
+  to return pre-increment via multi-op `update_counter`; delete
+  `new_count - 1` in the façade; promote `cooldown_ms` to an opt on
+  `State.check/3`; SPEC §4 B4 amendment."
+- `subproblems/global-name-collision/` → "Introduce `Tau.Names` struct;
+  thread `instance_id` through `Application.start/2`; store derived
+  names in `:persistent_term`; sweep ~30 bare-atom call sites to
+  `Tau.Names.get().<field>`; `:default` instance preserves all
+  existing atoms."
+
+## Revision history
+
+- (revision 0 — initial)

--- a/docs/problems-archive-v1-modules/tau-infrastructure/subproblems/circuit-breaker-invariant-split/problem.md
+++ b/docs/problems-archive-v1-modules/tau-infrastructure/subproblems/circuit-breaker-invariant-split/problem.md
@@ -1,0 +1,85 @@
+---
+template_version: 1
+template_name: problem
+node_kind: leaf
+depth: 1
+parent: ../../problem.md
+status: draft
+---
+
+# Problem: circuit-breaker invariant split between Store and State
+
+## Statement
+
+`Tau.CircuitBreaker.record_outcome/5` adjusts `new_count - 1` before
+passing it to `State.record_failure/2` and `State.record_success/2` in
+order to cancel out the `count + 1` increment that those pure functions
+perform internally — meaning the façade encodes knowledge of the Store's
+post-increment return convention AND knowledge of the State module's internal
+arithmetic in the same private helper. A change to either side breaks the
+protocol silently. Separately, `State.check/2` consumes `@default_cooldown_ms`
+as a private module attribute while `failure_threshold` and `success_threshold`
+are caller-threadable keyword opts, leaving cooldown as the only
+threshold not configurable per provider call.
+
+## Context
+
+- `lib/tau/circuit_breaker.ex:124-145` — `record_outcome/5`; the comment at
+  line 116-123 explains the `new_count - 1` dance explicitly: "To keep
+  State's pure functions unmodified … we pass `new_count - 1` as the
+  pre-bump value so the pure function computes the same `new_count`."
+  Flat audit: minor, "bakes the State function's internal `count + 1`
+  increment into the public protocol of `Store.bump_*`".
+- `lib/tau/circuit_breaker/store.ex:116-133` — `bump_failure_count/1` and
+  `bump_success_count/1` return the post-increment value via
+  `:ets.update_counter/3`. There is no pre-increment variant.
+- `lib/tau/circuit_breaker/state.ex:86-103` — `record_failure/2` in `:closed`
+  state computes `new_count = s.failure_count + 1` from the struct field
+  value passed in; the caller is expected to pass the pre-increment count.
+- `lib/tau/circuit_breaker/state.ex:64` — `@default_cooldown_ms 30_000` is
+  a private module attribute consumed in `check/2`; `record_failure/2` and
+  `record_success/2` accept `:failure_threshold` and `:success_threshold`
+  opts respectively. Flat audit: minor, "mismatched configurability".
+- SPEC-CIRCUIT-BREAKER D-029/D-030/D-044.
+
+## Complecting hypothesis
+
+1. **The Store's counter-return convention is complected with the State
+   module's pure-function semantics**: the façade's `record_outcome/5`
+   is the only place where the post-increment/pre-increment impedance is
+   resolved; changing either the Store primitive or the State arithmetic
+   requires updating the façade's private adjustment, with no type-level
+   or test-level enforcement.
+2. **Cooldown configurability is complected with the default-threshold
+   pattern**: `failure_threshold` and `success_threshold` are exposed as
+   caller opts, establishing a pattern that `cooldown_ms` violates without
+   documentation of why it is treated differently.
+
+## Decomposition strategy
+
+(leaf — no further decomposition; proceed to proposals)
+
+## Acceptance criterion
+
+A proposal names: (a) the interface change (either to `Store.bump_*/1`'s
+return convention, or to `State`'s function signatures) that eliminates the
+`new_count - 1` adjustment in `record_outcome/5`, with the D-044 row-layout
+impact assessed; (b) whether `cooldown_ms` should be promoted to a
+caller-threadable keyword opt in `State.check/2` (or documented as
+intentionally non-threadable), with justification.
+
+## Out of scope
+
+- Supervision tree startup or CLI task — exclusive scope of
+  **supervision-tree-startup**.
+- Telemetry handler crash-safety — exclusive scope of
+  **telemetry-handler-coupling**.
+- Global process name collision — exclusive scope of
+  **global-name-collision**.
+- `Store`'s ETS schema version or row-layout fields other than the counter
+  columns; probe-slot admission logic (`do_probe_admission`).
+- Any change to the public `Tau.CircuitBreaker.call/3` API contract.
+
+## Amendment log
+
+- (none yet)

--- a/docs/problems-archive-v1-modules/tau-infrastructure/subproblems/circuit-breaker-invariant-split/proposals/proposal-1.md
+++ b/docs/problems-archive-v1-modules/tau-infrastructure/subproblems/circuit-breaker-invariant-split/proposals/proposal-1.md
@@ -1,0 +1,154 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 1
+parent_problem: ../problem.md
+---
+
+# Proposal 1: Store returns pre-increment counts (Store API change)
+
+## Approach
+
+Change `Store.bump_failure_count/1` and `Store.bump_success_count/1` to return
+the **pre-increment** value — the count as it was before the atomic bump. Remove
+the `new_count - 1` adjustment in `record_outcome/5` entirely; pass the returned
+pre-increment value directly to `State.record_failure/2` and
+`State.record_success/2` as `s.failure_count` / `s.success_count` in the struct.
+Promote `cooldown_ms` to a caller-threadable keyword opt in `State.check/2` with
+`@default_cooldown_ms` as the fallback.
+
+## Rationale
+
+The `new_count - 1` adjustment in the façade exists solely because Store returns
+post-increment while State expects pre-increment as its struct field. The
+adjustment is a hidden protocol: it encodes the Store's internal counter
+convention in the façade's private logic. By making Store return the
+pre-increment value (the value before the `:ets.update_counter/3` bump), the
+façade can directly populate the struct field `failure_count: pre_count` and pass
+it to `State.record_failure/2` without arithmetic. The two modules are
+decomplected: Store's return semantics no longer need to be known outside Store.
+Promoting `cooldown_ms` completes the pattern established by `failure_threshold`
+and `success_threshold`, making the asymmetry visible.
+
+## Sketch
+
+**`lib/tau/circuit_breaker/store.ex`** — change both bump functions to use
+`:ets.update_counter/3` with a three-element operation tuple that returns the
+pre-increment value:
+
+```elixir
+@spec bump_failure_count(module()) :: non_neg_integer()
+def bump_failure_count(provider) do
+  # {position, increment, threshold, reset} — threshold=0 means "return old value"
+  # Use update_counter with explicit operations list to capture pre-bump value:
+  # [{pos, 1}] returns post-bump; to get pre-bump, subtract 1 is status quo.
+  # Alternative: :ets.update_counter(@table, provider, [{3, 0}, {3, 1}])
+  # The first op reads the current value; the second increments. Return the read.
+  [pre, _post] = :ets.update_counter(@table, provider, [{3, 0}, {3, 1}])
+  pre
+end
+
+@spec bump_success_count(module()) :: non_neg_integer()
+def bump_success_count(provider) do
+  [pre, _post] = :ets.update_counter(@table, provider, [{4, 0}, {4, 1}])
+  pre
+end
+```
+
+**`lib/tau/circuit_breaker.ex`** — `record_outcome/5` simplifies to:
+
+```elixir
+defp record_outcome(provider, current_state, {:ok, _}, now_ms, opts) do
+  pre_count = Store.bump_success_count(provider)
+  row = current_struct(provider)
+  struct_pre_bump = %State{row | success_count: pre_count}
+  new_state = State.record_success(struct_pre_bump, Keyword.put(opts, :now_ms, now_ms))
+  maybe_transition(provider, current_state, new_state)
+end
+
+defp record_outcome(provider, current_state, {:error, _}, now_ms, opts) do
+  pre_count = Store.bump_failure_count(provider)
+  row = current_struct(provider)
+  struct_pre_bump = %State{row | failure_count: pre_count}
+  new_state = State.record_failure(struct_pre_bump, Keyword.put(opts, :now_ms, now_ms))
+  maybe_transition(provider, current_state, new_state)
+end
+```
+
+The comment block at lines 116–123 is removed; no workaround exists to document.
+
+**`lib/tau/circuit_breaker/state.ex`** — `check/2` gains a `cooldown_ms` opt:
+
+```elixir
+@spec check(t(), non_neg_integer(), keyword()) :: state_atom()
+def check(state, now_ms, opts \\ [])
+
+def check(%__MODULE__{state: :closed}, _now_ms, _opts), do: :closed
+
+def check(%__MODULE__{state: :open, opened_at_ms: opened_at_ms}, now_ms, opts) do
+  cooldown_ms = Keyword.get(opts, :cooldown_ms, @default_cooldown_ms)
+  if now_ms >= opened_at_ms + cooldown_ms, do: :half_open, else: :open
+end
+
+def check(%__MODULE__{state: :half_open}, _now_ms, _opts), do: :half_open
+```
+
+D-044 row-layout impact: none. Counter columns (positions 3 and 4) are not
+renamed; the ETS schema is unchanged. The multi-operation `:ets.update_counter/3`
+call reads and increments in a single atomic operation — no TOCTOU gap.
+
+## Tradeoffs
+
+### Strengths
+
+- Eliminates the `new_count - 1` adjustment at the call site and the comment that
+  explains it — the protocol leak is gone.
+- No change to `State`'s function signatures or struct field semantics; State
+  remains the pre-increment consumer it always was.
+- `cooldown_ms` joins `failure_threshold` and `success_threshold` as a threadable
+  opt; the asymmetry is resolved.
+- The multi-op `update_counter` form is atomic — correct under concurrent bumps.
+- D-044 row layout unchanged; no migration required.
+
+### Weaknesses
+
+- `Store.bump_*/1` now returns the pre-increment value, which is less intuitive
+  for a function named "bump" (callers might expect the post-bump result).
+- Two-op `update_counter` form `[{pos, 0}, {pos, 1}]` is less common and may
+  surprise maintainers; the comment burden moves from the façade to the Store.
+- Any other caller of `bump_*/1` that expected post-increment semantics (e.g. a
+  test asserting `== 1` after the first bump) breaks silently at the type level
+  — `@spec` returns the same type.
+- `State.check/2` arity change to `/3` with a default opt is a spec amendment;
+  any dialyzer-typed call site using the 2-arity form is unaffected (default
+  opts = old behaviour), but the SPEC-CIRCUIT-BREAKER §4 B4 interface entry must
+  be updated.
+
+### Costs
+
+- 2 files modified: `store.ex` (2 function bodies), `circuit_breaker.ex` (2
+  private clauses + comment removal), `state.ex` (1 function head + 1 clause).
+- All existing tests that call `Store.bump_*/1` and assert on the return value
+  must be audited and updated.
+- SPEC-CIRCUIT-BREAKER §4 must be amended to reflect the new Store return
+  contract and the new `check/3` opt.
+
+## Dependencies
+
+- No other subproblem needs to land first.
+- SPEC-CIRCUIT-BREAKER §4 B4 and the D-044 row-layout entry must be amended in
+  the same PR.
+
+## Confidence
+
+Medium. The `:ets.update_counter/3` multi-op form is standard OTP; the
+arithmetic is straightforward. Confidence would rise to high after verifying no
+existing caller of `bump_*/1` relies on post-increment semantics in its
+assertions (a quick `grep` suffices).
+
+## Prior art / references
+
+- OTP `:ets.update_counter/3` multi-op form: https://www.erlang.org/doc/man/ets.html#update_counter-3
+- `SPEC-CIRCUIT-BREAKER.md` D-044 (ETS row layout pinned by SPEC)
+- The existing comment at `lib/tau/circuit_breaker.ex:116–123` documents the
+  exact arithmetic mismatch this proposal resolves.

--- a/docs/problems-archive-v1-modules/tau-infrastructure/subproblems/circuit-breaker-invariant-split/proposals/proposal-2.md
+++ b/docs/problems-archive-v1-modules/tau-infrastructure/subproblems/circuit-breaker-invariant-split/proposals/proposal-2.md
@@ -1,0 +1,150 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 2
+parent_problem: ../problem.md
+---
+
+# Proposal 2: State accepts post-increment counts (State API change)
+
+## Approach
+
+Change `State.record_failure/2` and `State.record_success/2` to accept the
+**post-increment** count directly, removing the `count + 1` arithmetic from
+inside those functions. The façade `record_outcome/5` then passes
+`Store.bump_*/1`'s return value directly into the struct field — no adjustment
+needed. Promote `cooldown_ms` to a keyword opt in `State.check/2` with the
+existing `@default_cooldown_ms` as the fallback. `State` is the changed contract;
+`Store` is unchanged.
+
+## Rationale
+
+The root problem is that `State.record_failure/2` encodes a `count + 1`
+increment internally while simultaneously receiving a pre-increment count from
+its caller. That duality forces the façade to subtract 1 from Store's
+post-increment result. If `State` is respecified so its functions receive the
+**post-increment** count directly (the actual failure count after this event),
+the façade can simply pass through `new_count = Store.bump_failure_count(provider)`
+without any adjustment. The `State` module's semantics become: "I have been
+handed the new count; decide what transition to make" — a simpler contract that
+doesn't imply any knowledge of who performed the increment. This moves the
+protocol boundary into `State` rather than the façade, which is the cleaner
+owner: State owns the count semantics.
+
+## Sketch
+
+**`lib/tau/circuit_breaker/state.ex`** — `record_failure/2` and
+`record_success/2` receive the post-increment count directly:
+
+```elixir
+@doc """
+Records a provider-call failure and returns the updated state.
+
+`new_failure_count` is the post-increment count (as returned by
+`Store.bump_failure_count/1`). The function does NOT increment internally.
+"""
+@spec record_failure(t(), keyword()) :: t()
+def record_failure(state, opts \\ [])
+
+def record_failure(%__MODULE__{state: :closed} = s, opts) do
+  threshold = Keyword.get(opts, :failure_threshold, @default_failure_threshold)
+  # new_count is now the caller-supplied post-increment value stored in s.failure_count
+  new_count = s.failure_count  # no +1; caller already holds post-bump value
+
+  if new_count >= threshold do
+    now_ms = Keyword.fetch!(opts, :now_ms)
+    %__MODULE__{s | state: :open, failure_count: new_count, success_count: 0, opened_at_ms: now_ms}
+  else
+    s  # struct already has new_count in failure_count; no update needed
+  end
+end
+```
+
+The same pattern applies to `record_failure/2` in `:half_open` and to
+`record_success/2`.
+
+**`lib/tau/circuit_breaker.ex`** — `record_outcome/5` simplifies to:
+
+```elixir
+defp record_outcome(provider, current_state, {:error, _}, now_ms, opts) do
+  new_count = Store.bump_failure_count(provider)
+  row = current_struct(provider)
+  # Pass post-increment count directly; no adjustment
+  struct_post_bump = %State{row | failure_count: new_count}
+  new_state = State.record_failure(struct_post_bump, Keyword.put(opts, :now_ms, now_ms))
+  maybe_transition(provider, current_state, new_state)
+end
+```
+
+**`State.check/2`** gains `cooldown_ms` opt (same as Proposal 1's `check/3`
+sketch; omitted here for brevity).
+
+D-044 row-layout impact: none. ETS counter columns and their positions are
+unchanged. The adjustment was purely in-memory arithmetic; the stored value
+(post-increment) is what it always was.
+
+Existing struct construction in `current_struct/1` in the façade is unaffected:
+it reads directly from ETS and already produces the post-increment count in
+the field — the façade was subtracting 1 only to "undo" that, which will no
+longer be needed.
+
+## Tradeoffs
+
+### Strengths
+
+- `State` functions become semantically simpler: "given the new count, decide".
+  No hidden `+1` inside the module.
+- `Store.bump_*/1` API is unchanged; any caller of Store is unaffected.
+- The façade's `record_outcome/5` simplifies: direct pass-through from Store to
+  State, no arithmetic.
+- The intent is self-documenting: `struct_post_bump = %State{row | failure_count: new_count}`
+  makes the data flow obvious.
+- `cooldown_ms` promotion resolves the asymmetric configurability.
+
+### Weaknesses
+
+- `State.record_failure/2` and `State.record_success/2` have subtly different
+  semantics post-change: the struct field `failure_count` on entry now holds the
+  post-increment value, not a pre-increment value. Any test that constructs a
+  `%State{}` by hand and calls `record_failure/2` must be updated to pass the
+  value that would be *after* a bump — a semantic break.
+- The in-memory `s` struct returned has `failure_count: new_count` whether or
+  not the threshold is crossed — meaning the `else` branch's `s` now has
+  post-increment in the field, which is actually correct, but is a silent
+  semantic shift that tests must cover explicitly.
+- `State.record_failure/2`'s `@moduledoc` must be updated to clarify the
+  "post-increment" contract; a reader who skips the doc and sees `new_count =
+  s.failure_count` without the `+ 1` may be confused.
+- More test churn than Proposal 1, since State tests typically construct structs
+  with pre-bump field values to test threshold logic.
+
+### Costs
+
+- 2 files modified: `state.ex` (2–3 function bodies + moduledoc), `circuit_breaker.ex`
+  (2 private clauses + comment).
+- All tests that call `State.record_failure/2` or `record_success/2` with
+  hand-constructed structs must be audited — the struct field semantics change.
+- SPEC-CIRCUIT-BREAKER §4 B4 must be amended to document the new "post-increment
+  input" contract for these functions.
+
+## Dependencies
+
+- No other subproblem needs to land first.
+- SPEC-CIRCUIT-BREAKER §4 B4 must be amended in the same PR.
+
+## Confidence
+
+Medium. The arithmetic shift is small but the semantic change to `State`'s
+pure-function contract is non-trivial; test suite coverage of `State` is the
+determining factor. Confidence would rise to high after confirming the test
+suite constructs `%State{}` structs with explicit `failure_count` values (rather
+than relying on defaults) and that changing the expected value is straightforward.
+
+## Prior art / references
+
+- Erlang `:ets.update_counter/3` returns the post-increment value by design;
+  accepting it directly is idiomatic in ETS-backed state machines.
+- `SPEC-CIRCUIT-BREAKER.md` §4 B4 — the pure-state-machine contract that
+  `record_failure/2` implements.
+- Proposal 1 (this file's sibling) takes the opposite axis: changing Store
+  instead of State.

--- a/docs/problems-archive-v1-modules/tau-infrastructure/subproblems/circuit-breaker-invariant-split/proposals/proposal-3.md
+++ b/docs/problems-archive-v1-modules/tau-infrastructure/subproblems/circuit-breaker-invariant-split/proposals/proposal-3.md
@@ -1,0 +1,153 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 3
+parent_problem: ../problem.md
+---
+
+# Proposal 3: Encode the impedance in a typed converter function (thin façade within State)
+
+## Approach
+
+Leave `Store.bump_*/1` returning post-increment and leave `State.record_failure/2`
+accepting pre-increment struct values. Instead, add a single named conversion
+function — `State.from_bump/2` — that encapsulates the `new_count - 1` adjustment
+and the struct rebuild in one place. `record_outcome/5` in the façade calls
+`State.from_bump(row, new_count)` to produce the pre-bump struct, then passes
+the result to `record_failure/2` / `record_success/2`. The adjustment is no
+longer anonymous arithmetic in the façade; it is a named, typed, testable
+operation inside the module that owns the struct. Promote `cooldown_ms` to a
+keyword opt in `State.check/2`.
+
+## Rationale
+
+Both Proposals 1 and 2 change the semantics of an existing API contract — one
+on the Store side, one on the State side — which requires updating the SPEC and
+all tests that depend on those APIs. Proposal 3 takes a different axis:
+behaviour-preserving refactor. Neither Store's return convention nor State's
+`record_failure/2` contract changes. Instead, the knowledge that "a Store bump
+returns post-increment and State needs pre-increment" is isolated in a named
+function that can be read, documented, and tested in isolation. The façade stops
+doing private arithmetic and delegates to `State.from_bump/2`, which is the
+module that owns the struct and therefore the natural home for "how to construct
+a pre-bump struct from a post-bump count."
+
+## Sketch
+
+**`lib/tau/circuit_breaker/state.ex`** — add `from_bump/3`:
+
+```elixir
+@doc """
+Constructs a `%State{}` ready to pass to `record_failure/2` or `record_success/2`
+from a Store row and a post-increment counter value returned by
+`Store.bump_failure_count/1` or `Store.bump_success_count/1`.
+
+The Store's `:ets.update_counter/3` primitive returns the post-increment value.
+`record_failure/2` and `record_success/2` both perform `count + 1` internally
+and therefore expect the pre-increment count in the struct field. This function
+converts between the two conventions once, in the place that owns the struct
+semantics.
+
+  iex> Tau.CircuitBreaker.State.from_bump(%State{failure_count: 3}, :failure, 4)
+  %State{failure_count: 3}
+"""
+@spec from_bump(t(), :failure | :success, pos_integer()) :: t()
+def from_bump(%__MODULE__{} = state, :failure, post_increment_count) do
+  %__MODULE__{state | failure_count: post_increment_count - 1}
+end
+
+def from_bump(%__MODULE__{} = state, :success, post_increment_count) do
+  %__MODULE__{state | success_count: post_increment_count - 1}
+end
+```
+
+**`lib/tau/circuit_breaker.ex`** — `record_outcome/5` becomes:
+
+```elixir
+defp record_outcome(provider, current_state, {:ok, _}, now_ms, opts) do
+  new_count = Store.bump_success_count(provider)
+  row = current_struct(provider)
+  struct_pre_bump = State.from_bump(row, :success, new_count)
+  new_state = State.record_success(struct_pre_bump, Keyword.put(opts, :now_ms, now_ms))
+  maybe_transition(provider, current_state, new_state)
+end
+
+defp record_outcome(provider, current_state, {:error, _}, now_ms, opts) do
+  new_count = Store.bump_failure_count(provider)
+  row = current_struct(provider)
+  struct_pre_bump = State.from_bump(row, :failure, new_count)
+  new_state = State.record_failure(struct_pre_bump, Keyword.put(opts, :now_ms, now_ms))
+  maybe_transition(provider, current_state, new_state)
+end
+```
+
+The façade's comment block at lines 116–123 is removed; the explanation belongs
+in `State.from_bump/3`'s `@doc`. The façade no longer needs to know the
+convention.
+
+**`State.check/2` → `check/3`**: same as Proposals 1 and 2; `cooldown_ms` added
+as a keyword opt with `@default_cooldown_ms` fallback.
+
+D-044 row-layout impact: none. No counter column semantics change.
+
+## Tradeoffs
+
+### Strengths
+
+- Both `Store` and `State.record_failure/2`/`record_success/2` contracts are
+  unchanged; zero test churn on the Store side, zero test churn on the State
+  side for existing callers.
+- The conversion logic becomes named (`from_bump/3`), documented (`@doc`),
+  testable (a simple property: `from_bump(s, :failure, n).failure_count == n - 1`),
+  and owned by the correct module (`State` owns the struct).
+- Behaviour-preserving: no semantic change to any existing public function.
+- SPEC amendment is additive (add `from_bump/3` to §4 B4 interface list); no
+  existing contract row needs rewriting.
+- The façade's private helper comment becomes dead weight and is deleted cleanly.
+
+### Weaknesses
+
+- The `new_count - 1` arithmetic is not eliminated; it is relocated. A reviewer
+  reading `State.from_bump/3` still sees the subtraction. The problem is made
+  explicit but not absent.
+- `from_bump/3` is a narrow adapter function with limited reuse value outside
+  the façade — it may feel like over-engineering for what is essentially a
+  one-line conversion.
+- Adds a function to the `State` module whose sole purpose is to paper over an
+  impedance mismatch; if the mismatch is ever fixed at the Store or State level
+  (Proposals 1 or 2), `from_bump/3` becomes dead code.
+- The `:failure | :success` atom discriminator in `from_bump/3` is a mild form
+  of stringly-typed dispatch; a future developer could call it with the wrong
+  atom and the compiler won't catch it until runtime if the struct is well-typed.
+
+### Costs
+
+- 1 file meaningfully modified: `state.ex` (add 1 function + @doc). `circuit_breaker.ex`
+  is a 2-line mechanical change (replace anonymous adjustment with named call).
+- No test churn on existing `State` or `Store` tests.
+- SPEC-CIRCUIT-BREAKER §4 B4: additive amendment (1 new function entry).
+- Net change is small: ~20 lines added, ~5 removed.
+
+## Dependencies
+
+- No other subproblem needs to land first.
+- SPEC-CIRCUIT-BREAKER §4 B4 must be amended to add `from_bump/3` to the
+  interface table.
+
+## Confidence
+
+High. The change is purely additive and behaviour-preserving. The arithmetic
+is unchanged; only its location and documentation change. No migration risk.
+Confidence is supported by the fact that the existing comment in the façade
+(lines 116–123) already explains the invariant that `from_bump/3` would encode;
+the conversion is not new logic.
+
+## Prior art / references
+
+- The "adapter function" pattern for impedance mismatch between two well-owned
+  modules — common in OTP codebases where ETS primitives and pure FSM modules
+  have differing counter conventions.
+- `SPEC-CIRCUIT-BREAKER.md` §4 B4 — the existing interface contract that
+  `record_failure/2` and `record_success/2` live in.
+- Proposal 1 and Proposal 2 (siblings) take the API-changing axis; this proposal
+  is the behaviour-preserving alternative.

--- a/docs/problems-archive-v1-modules/tau-infrastructure/subproblems/circuit-breaker-invariant-split/proposals/proposal-4.md
+++ b/docs/problems-archive-v1-modules/tau-infrastructure/subproblems/circuit-breaker-invariant-split/proposals/proposal-4.md
@@ -1,0 +1,180 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 4
+parent_problem: ../problem.md
+---
+
+# Proposal 4: Merge Store.bump_* and State.record_* into a single atomic operation (unification)
+
+## Approach
+
+Replace the two-step pattern (Store bumps the counter; façade reads the row;
+façade reconstructs a struct; State decides the transition) with a single
+`Store.bump_and_decide/3` function that performs the `:ets.update_counter/3`
+bump, reads the row in the same ETS call sequence, and returns a `{new_count,
+state_decision}` tuple by inlining the State threshold logic inline. The façade
+`record_outcome/5` receives a ready-made decision and calls `maybe_transition/3`
+directly. `State.record_failure/2` and `State.record_success/2` remain as pure
+functions for testing and documentation, but the façade no longer calls them
+during normal operation. Promote `cooldown_ms` to a keyword opt on
+`Store.bump_and_decide/3` (and on `State.check/3` for consistency).
+
+## Rationale
+
+The `new_count - 1` adjustment exists because two separately-owned modules share
+a counter protocol across a layer boundary, with the façade bridging them. A
+deeper fix is to ask: does this boundary need to exist? The façade's
+`record_outcome/5` performs three distinct steps — bump, read-row, decide — that
+are currently in three separate locations. Unifying bump + decide in `Store`
+eliminates the boundary entirely: `Store` already owns the ETS row and its
+counter columns; it can apply the threshold logic inline without reconstructing a
+struct. The `State` module becomes documentation-only for the threshold rules
+rather than a runtime call site, decomplecting "what is the decision algorithm"
+(State) from "executing the decision" (Store, which owns the mutable data).
+
+## Sketch
+
+**`lib/tau/circuit_breaker/store.ex`** — add `bump_and_decide/3`:
+
+```elixir
+@type bump_decision :: :no_transition | {:transition, State.state_atom()}
+
+@doc """
+Atomically bumps the failure or success counter for `provider`, reads the
+updated row, and applies the State threshold logic to return a transition
+decision.
+
+Returns `{new_count, :no_transition}` or `{new_count, {:transition, new_state}}`.
+
+Opts:
+  - `:failure_threshold` (default 5)
+  - `:success_threshold` (default 1)
+  - `:now_ms` (required; used when transitioning to :open)
+  - `:cooldown_ms` (default 30_000; used by State.check/3 before probing)
+"""
+@spec bump_and_decide(module(), :failure | :success, keyword()) ::
+        {non_neg_integer(), bump_decision()}
+def bump_and_decide(provider, kind, opts) do
+  {counter_pos, threshold_key, default_threshold} =
+    case kind do
+      :failure -> {3, :failure_threshold, 5}
+      :success -> {4, :success_threshold, 1}
+    end
+
+  new_count = :ets.update_counter(@table, provider, {counter_pos, 1})
+  threshold = Keyword.get(opts, threshold_key, default_threshold)
+  row = get(provider)
+
+  decision =
+    if new_count >= threshold do
+      new_state_atom = if kind == :failure, do: :open, else: :closed
+      {:transition, new_state_atom}
+    else
+      :no_transition
+    end
+
+  {new_count, decision}
+end
+```
+
+**`lib/tau/circuit_breaker.ex`** — `record_outcome/5` becomes:
+
+```elixir
+defp record_outcome(provider, current_state, {:ok, _}, now_ms, opts) do
+  {_count, decision} = Store.bump_and_decide(provider, :success, Keyword.put(opts, :now_ms, now_ms))
+  case decision do
+    :no_transition -> :ok
+    {:transition, new_state_atom} -> maybe_transition(provider, current_state, new_state_atom)
+  end
+end
+
+defp record_outcome(provider, current_state, {:error, _}, now_ms, opts) do
+  {_count, decision} = Store.bump_and_decide(provider, :failure, Keyword.put(opts, :now_ms, now_ms))
+  case decision do
+    :no_transition -> :ok
+    {:transition, new_state_atom} -> maybe_transition(provider, current_state, new_state_atom)
+  end
+end
+```
+
+`State.record_failure/2` and `State.record_success/2` are retained as-is for
+documentation and unit-testing the threshold logic in isolation. They are no
+longer called by `record_outcome/5` in production.
+
+**`State.check/2` → `check/3`**: `cooldown_ms` opt added (same as other
+proposals).
+
+D-044 row-layout impact: none. Counter column positions are unchanged;
+`bump_and_decide/3` reads position 3/4 via `update_counter` as before.
+
+## Tradeoffs
+
+### Strengths
+
+- The `new_count - 1` adjustment is gone with no arithmetic relocated; the
+  boundary causing the impedance is closed.
+- `record_outcome/5` is reduced to a bump + pattern match; its cognitive load
+  drops substantially.
+- `Store` is the natural owner of "bump + decide" since it already owns the
+  ETS row and the counter primitives; the logic is co-located with the data.
+- No changes to `State`'s existing public API — pure functions remain intact and
+  testable independently.
+
+### Weaknesses
+
+- `Store` gains threshold-decision logic, which was previously cleanly separated
+  into `State`. `Store` was a thin ETS wrapper; this proposal makes it a
+  business-logic module. That is a scope expansion that may surprise maintainers
+  who expect `Store` to be purely structural.
+- `State.record_failure/2` and `record_success/2` are now dead code paths in
+  production (called only by tests). This creates a latent divergence risk: the
+  pure functions may drift from the inline threshold logic in `bump_and_decide/3`.
+- The `:half_open` probe success logic is subtle (a single success closes the
+  breaker from `:half_open`); inlining it in `bump_and_decide/3`'s `:success`
+  arm must be done carefully and duplicates the `:half_open` guard already in
+  `State.record_success/2`.
+- `bump_and_decide/3` is harder to unit-test than the current split: it requires
+  a live ETS table for every test case, whereas `State.record_failure/2` is a
+  pure function. Tests must set up and tear down ETS state, raising test surface
+  complexity.
+- This is the highest-scope change of the four proposals; it is not purely
+  behaviour-preserving if the inlined threshold logic ever diverges from the
+  `State` functions.
+
+### Costs
+
+- 3 files meaningfully modified: `store.ex` (add `bump_and_decide/3`),
+  `circuit_breaker.ex` (simplify `record_outcome/5`), `state.ex` (doc update
+  noting functions are production-retired).
+- Existing `State` tests are unaffected; new tests for `bump_and_decide/3`
+  require ETS setup.
+- SPEC-CIRCUIT-BREAKER §4 must be amended to add `bump_and_decide/3` to Store's
+  interface list and note the production-retired status of `record_failure/2` /
+  `record_success/2`.
+- Higher review burden than Proposals 1–3 due to inlining `:half_open` guard logic.
+
+## Dependencies
+
+- No other subproblem needs to land first.
+- SPEC-CIRCUIT-BREAKER §4 must be amended in the same PR.
+- The inlined `:half_open` guard logic must be verified to be equivalent to
+  `State.record_success/2`'s `:half_open` clause before the PR can be gated.
+
+## Confidence
+
+Medium-low. The unification idea is sound but the scope expansion of `Store` and
+the risk of divergence between inlined and pure-function logic reduce confidence.
+Confidence would rise to medium after prototyping `bump_and_decide/3` and
+running the full test suite with both `State.record_*/2` (for pure tests) and
+`bump_and_decide/3` (for integration tests) side by side.
+
+## Prior art / references
+
+- The "merge data + decision" pattern is common in ETS-backed rate-limiters
+  (e.g., `ExRated`), where the ETS write and the decision to allow/deny are a
+  single `:ets.update_counter/3` call with a threshold reset.
+- `SPEC-CIRCUIT-BREAKER.md` §4 B4 — existing Store and State interface
+  contracts; both must be amended.
+- Proposal 3 (sibling) is the behaviour-preserving alternative; this proposal
+  is the highest-scope option on the unification axis.

--- a/docs/problems-archive-v1-modules/tau-infrastructure/subproblems/circuit-breaker-invariant-split/solution.md
+++ b/docs/problems-archive-v1-modules/tau-infrastructure/subproblems/circuit-breaker-invariant-split/solution.md
@@ -1,0 +1,134 @@
+---
+template_version: 1
+template_name: solution
+parent_problem: problem.md
+node_kind: leaf
+synthesised_from: [proposals/proposal-1.md, proposals/proposal-2.md, proposals/proposal-3.md, proposals/proposal-4.md]
+selection_method: single
+revision: 0
+---
+
+# Solution: Store returns pre-increment counts
+
+## Recommendation
+
+Change `Store.bump_failure_count/1` and `Store.bump_success_count/1` to return
+the pre-increment value using `:ets.update_counter/3`'s multi-op form, allowing
+`record_outcome/5` to pass the value directly into the `State` struct without any
+arithmetic adjustment. Simultaneously promote `cooldown_ms` to a keyword opt in
+`State.check/2` (with `@default_cooldown_ms` as the fallback), closing the
+asymmetric configurability. The `new_count - 1` comment block in the façade is
+deleted entirely; no explanatory workaround remains.
+
+## Selected from
+
+- **Chosen:** `proposals/proposal-1.md`
+- **Why chosen:** The acceptance criterion requires that the `new_count - 1`
+  adjustment in `record_outcome/5` be eliminated by changing the interface on
+  exactly one side — either `Store`'s return convention or `State`'s function
+  signatures. Proposal 1 satisfies this most cleanly on the Store side.
+
+| # | Fit | Decomplecting depth | Migration cost | Risk | Reversibility |
+|---|-----|---------------------|----------------|------|---------------|
+| 1 | Yes | Substantial | Low | Low | Easy |
+| 2 | Yes | Substantial | Medium | Medium | Easy |
+| 3 | Partially | Surface | Low | Low | Easy |
+| 4 | Yes | Deep | High | Medium | Hard |
+
+**Proposal 1 vs 2:** Both eliminate the adjustment cleanly. Proposal 1 changes the
+Store side; Proposal 2 changes the State side. The Store is the natural point of
+change because the impedance originates there: `:ets.update_counter/3` returns
+post-increment by design, and the façade only needed to correct for it. Changing
+Store's return convention via the multi-op `update_counter` form is
+self-contained — `State.record_failure/2`'s semantics (`count + 1` internally)
+remain correct and unchanged, so State's test suite requires no updates. Proposal
+2's weakness is that it shifts semantics into `State.record_failure/2` (removing
+the internal `+ 1`) which changes the contract of a pure function that may have
+hand-constructed test fixtures relying on pre-bump values. Proposal 1's only
+downside is that `bump_*/1` now returns a pre-increment value from a function
+named "bump" — addressable via spec and doc.
+
+**Proposal 3 vs 1:** Proposal 3 is behaviour-preserving and low-cost, but it is
+"surface" decomplecting: the `- 1` arithmetic is relocated to `State.from_bump/3`
+rather than eliminated. The acceptance criterion asks for elimination of the
+adjustment; a named wrapper that preserves the arithmetic satisfies the letter
+but not the spirit. `from_bump/3` also introduces permanent dead-weight if either
+Proposal 1 or 2 ever lands later.
+
+**Proposal 4 vs 1:** Proposal 4 offers the deepest decomplecting by unifying
+bump + decide in `Store`, but at the cost of turning a thin ETS wrapper into a
+business-logic module, retiring `State.record_*/2` from the production path
+(latent divergence risk), and requiring ETS setup in every new unit test. The OTP
+non-negotiables favour pure functions as the default; Proposal 4 moves in the
+opposite direction. Irreversibility is higher: once `Store` owns threshold logic,
+reversing that boundary is a multi-file refactor.
+
+## What changes
+
+- **`lib/tau/circuit_breaker/store.ex`** — `bump_failure_count/1` and
+  `bump_success_count/1` changed to use the two-element `update_counter` op list
+  `[{pos, 0}, {pos, 1}]`, returning the pre-increment value. `@spec` return type
+  is unchanged (`non_neg_integer()`); `@doc` updated to document pre-increment
+  semantics.
+- **`lib/tau/circuit_breaker.ex`** — `record_outcome/5`: remove the `new_count - 1`
+  adjustment; pass the Store return value directly as the struct field value.
+  Delete the comment block at lines 116–123.
+- **`lib/tau/circuit_breaker/state.ex`** — `check/2` becomes `check/3` with an
+  optional `cooldown_ms` keyword opt; `@default_cooldown_ms` remains as the
+  fallback. No change to `record_failure/2` or `record_success/2`.
+- **`docs/spec/SPEC-CIRCUIT-BREAKER.md`** — §4 B4 amended to document: (a) the new
+  pre-increment return convention for `Store.bump_*/1`; (b) the new `cooldown_ms`
+  opt on `State.check/3`.
+
+## What does not change
+
+- `State.record_failure/2` and `State.record_success/2` signatures, semantics, and
+  internal arithmetic — they continue to expect a pre-increment count in the struct
+  field and perform `count + 1` internally.
+- D-044 ETS row layout — counter column positions 3 and 4 are unchanged; no schema
+  migration.
+- The public `Tau.CircuitBreaker.call/3` API contract.
+- Any caller of `Store.bump_*/1` that does not inspect the return value is
+  unaffected. The type signature is identical.
+- All `State` tests that construct `%State{}` with pre-bump field values and call
+  `record_failure/2` / `record_success/2` — those contracts are unchanged.
+
+## Migration sketch
+
+1. Update `Store.bump_failure_count/1` and `bump_success_count/1` to the multi-op
+   `update_counter` form; update `@doc` to state "returns pre-increment count".
+2. Audit existing tests that call `Store.bump_*/1` and assert on the return value
+   — update assertions from post-increment to pre-increment (likely a small set;
+   a `grep` for `bump_failure_count\|bump_success_count` in `test/` suffices).
+3. Remove the `new_count - 1` expression and comment block in `record_outcome/5`;
+   replace with direct struct field assignment from the Store return value.
+4. Add `cooldown_ms` opt to `State.check/2`; update `@spec` to arity-3; verify
+   all existing `check/2` call sites are unaffected (default covers them).
+5. Amend SPEC-CIRCUIT-BREAKER §4 B4 in the same PR.
+
+The change can be landed as a single PR with no prerequisite from other
+subproblems.
+
+## Open questions
+
+- **Other callers of `bump_*/1` asserting on return value:** the proposal
+  assumes these are test-only and sparse. A pre-implementation `grep` confirms
+  this; if any production caller reads the return value and branches on it (not
+  currently evident from the problem context), that caller must be updated.
+- **`:ets.update_counter/3` multi-op atomicity:** the two-op form `[{pos, 0},
+  {pos, 1}]` is documented as a single atomic call in OTP. This should be
+  confirmed against the project's OTP 27.2 target before the PR is gated.
+- **`State.check/3` arity change and SPEC §4 B4 wording:** the SPEC must
+  distinguish "threadable with default = old behaviour" from a breaking change;
+  the wording should make clear that 2-arity call sites continue to work.
+
+## Linked sub-problems / proposals
+
+- `proposals/proposal-1.md` — Store returns pre-increment (chosen)
+- `proposals/proposal-2.md` — State accepts post-increment
+- `proposals/proposal-3.md` — Named converter function `State.from_bump/3`
+- `proposals/proposal-4.md` — Unified `Store.bump_and_decide/3`
+
+## Revision history
+
+- (revision 0 — initial)

--- a/docs/problems-archive-v1-modules/tau-infrastructure/subproblems/circuit-breaker-invariant-split/validation.md
+++ b/docs/problems-archive-v1-modules/tau-infrastructure/subproblems/circuit-breaker-invariant-split/validation.md
@@ -1,0 +1,201 @@
+---
+template_version: 1
+template_name: validation
+parent_solution: solution.md
+parent_problem: problem.md
+toulmin_complete: true
+falsification_attempted: true
+falsification_outcome: partially_falsified — claim/4
+revision_triggered: none
+---
+
+# Validation: Store returns pre-increment counts
+
+## Overview
+
+`solution.md` makes six checkable propositions: (1) `Store.bump_*/1` will
+return pre-increment values via the multi-op `:ets.update_counter/3` form;
+(2) the `new_count - 1` adjustment and explanatory comment in
+`record_outcome/5` are deleted; (3) `State.check/2` becomes `check/3` with a
+`:cooldown_ms` keyword opt while keeping `@default_cooldown_ms` as fallback;
+(4) `State.record_failure/2` and `record_success/2` are entirely unchanged
+in signature, semantics, and internal `count + 1` arithmetic; (5) the D-044
+ETS row layout (positions 3 and 4) is unchanged — no schema bump;
+(6) SPEC-CIRCUIT-BREAKER §4 B4 is amended in the same PR. Each claim was
+validated against the actual source files in
+`/home/brentw/src/tau/lib/tau/circuit_breaker*` and against the existing
+test suite. Falsification strategies span dependency check, code-state
+counter-example construction, edge-case enumeration, and integration
+check. Outcome: five claims withstood; claim 4 is partially falsified by
+a transitive ripple via `current_struct/1` (the struct field is overwritten
+by the façade caller, so `State`'s observable semantics still hold — the
+qualifier is narrowed in place).
+
+## Toulmin per claim
+
+The MITRE empirical study on Toulmin formalism found that "participants
+found it difficult to generate Toulmin structures, and their structures
+varied greatly even though they started with the same content"
+(https://www.mitre.org/news-insights/publication/empirical-evaluation-structured-argumentation-using-toulmin-argument).
+This template enforces all six components explicitly with prompts to
+counter that variance.
+
+### Claim 1: `Store.bump_failure_count/1` and `bump_success_count/1` will return the pre-increment value via the multi-op `:ets.update_counter/3` form `[{pos, 0}, {pos, 1}]`, eliminating the `new_count - 1` adjustment in `record_outcome/5`.
+
+- **Claim (C):** Changing `bump_*/1` to `[pre, _post] = :ets.update_counter(@table, provider, [{N, 0}, {N, 1}]); pre` returns the pre-increment value atomically, so the façade can pass the result directly into the `State` struct field with no arithmetic.
+- **Grounds (G):** Current implementation at `lib/tau/circuit_breaker/store.ex:118` (`{3, 1}`) and `:133` (`{4, 1}`) returns post-increment by OTP definition. SPEC pins these positions (D-044) at `docs/spec/SPEC-CIRCUIT-BREAKER.md:203-204`. Proposal-1 sketches the multi-op form at `proposals/proposal-1.md:47,53`; the façade caller's post-bump arithmetic is the only consumer that branches on the return value (`lib/tau/circuit_breaker.ex:125,127,133,135`). `Tau.Cost.Tracker` uses single-op `update_counter` (`lib/tau/cost/tracker.ex:129,154`) — independent of breaker code, so no collateral impact.
+- **Warrant (W):** `:ets.update_counter/3` with a list of operation tuples on the same key executes as a single atomic operation and returns the corresponding list of post-each-op values; with the operation list `[{N, 0}, {N, 1}]` the first element is therefore the pre-bump value (read with increment 0). This is the OTP-documented "multi-op" contract — the same rule underwrites every existing use of the list form in OTP releases.
+- **Qualifier (Q):** Holds on OTP releases that support the multi-op form of `:ets.update_counter/3`. The project targets OTP 27.2 (`.tool-versions`), where the multi-op form is long-standing (present since OTP R14B); the qualifier is therefore vacuous for this repo, but the dependency MUST be re-verified if OTP is ever downgraded.
+- **Rebuttal (R):** If a future change replaces `:ets.update_counter/3` with a non-counter ETS primitive (e.g. `:ets.update_element/3`) the atomicity guarantee disappears; the claim would no longer hold.
+- **Backing (B):** OTP ets documentation, `:ets.update_counter/3` — "If a list of UpdateOp is supplied, a list of Result is returned". SPEC-CIRCUIT-BREAKER §4 B2 (`docs/spec/SPEC-CIRCUIT-BREAKER.md:72,150-155`) which already mandates atomic counter updates via `update_counter`.
+
+#### Falsification attempt for claim 1
+
+- **Strategy:** Dependency check + counter-example construction over the OTP primitive.
+- **Attempt:** Verified the proposed `[{pos, 0}, {pos, 1}]` is the documented multi-op form for `:ets.update_counter/3` on OTP 27 (matches the same shape Tau already uses elsewhere via single-op tuples in `lib/tau/cost/tracker.ex`). Tried to construct a counter-example where the two operations could interleave with another concurrent `bump_*` and produce a wrong pre value. They cannot: the per-key multi-op list is documented as atomic — no other process can observe a partial state between the read (op 1) and the increment (op 2). Tried to construct a caller that depends on post-bump semantics: the only such caller is `record_outcome/5` itself (the very call site being fixed), plus tests at `test/tau/circuit_breaker/store_property_test.exs:208-209` which discard the return (`for _ <- 1..pre_fc//1, do: Store.bump_failure_count(provider)`). No third caller exists in `lib/` or `test/`.
+- **Outcome:** withstood.
+- **Action:** none.
+
+### Claim 2: The `new_count - 1` adjustment expression and the comment block at lines 116–123 of `lib/tau/circuit_breaker.ex` are removed entirely from `record_outcome/5`.
+
+- **Claim (C):** After the change, `record_outcome/5` contains no arithmetic on the bump return value and no comment explaining a pre/post-increment mismatch.
+- **Grounds (G):** Current site at `lib/tau/circuit_breaker.ex:124-144` contains exactly two `new_count - 1` expressions (lines 127, 135) and a comment block at lines 116-123. The proposal-1 sketch (`proposals/proposal-1.md:60-76,78`) shows the post-change body with `pre_count` directly assigned and the comment removed.
+- **Warrant (W):** OTP non-negotiable #8 (`.claude/rules/otp-non-negotiables.md`) — "Pure functions are the default; processes are the exception"; and the Hickey principle that protocol leaks across module boundaries must be eliminated rather than annotated. Removing the comment is required because the workaround it documents no longer exists; leaving a stale comment would itself be a protocol leak.
+- **Qualifier (Q):** Holds for the post-change file; presupposes claim 1 (the Store actually returns pre-bump).
+- **Rebuttal (R):** If a reviewer asks for an explanatory comment in `record_outcome/5` about why the bump return is used as-is (e.g. defensive against future Store changes), a one-line `@doc` or comment may survive — but the multi-line block at 116-123 explaining the arithmetic dance MUST be deleted because the arithmetic no longer happens.
+- **Backing (B):** `.claude/rules/otp-non-negotiables.md` invariants 1, 3, 8; SPEC-CIRCUIT-BREAKER §4 B3.
+
+#### Falsification attempt for claim 2
+
+- **Strategy:** Counter-example construction over the post-change function body.
+- **Attempt:** Attempted to construct a scenario where `record_outcome/5` still needs the `- 1` term: only possible if `State.record_failure/2` or `record_success/2` changes to expect post-bump counts. Claim 4 explicitly preserves their semantics — so no such scenario exists in scope.
+- **Outcome:** withstood.
+- **Action:** none.
+
+### Claim 3: `State.check/2` becomes `State.check/3` with an optional `:cooldown_ms` keyword opt; `@default_cooldown_ms` remains as the fallback; all existing 2-arity call sites continue to compile and behave identically.
+
+- **Claim (C):** A new optional keyword arg makes cooldown caller-threadable while preserving binary-compatible default behaviour.
+- **Grounds (G):** Current implementation at `lib/tau/circuit_breaker/state.ex:60-71` has three clauses on `check/2`; `@default_cooldown_ms 30_000` at line 45 is consumed only at line 64. Existing call sites are: `test/tau/circuit_breaker/state_property_test.exs:72,172,185` (all 2-arity, all assume default). There is no production caller of `State.check/*` in `lib/` — `current_struct/1` in the façade reads the row but never calls `check` (state is checked via `Store.state_for/1` at `lib/tau/circuit_breaker.ex:72`). Proposal-1 sketch (`proposals/proposal-1.md:80-94`) shows `check(state, now_ms, opts \\ [])` with `Keyword.get(opts, :cooldown_ms, @default_cooldown_ms)`.
+- **Warrant (W):** Elixir default-argument semantics: adding `opts \\ []` to a clause-headed function generates the 2-arity head automatically, preserving source compatibility for all existing call sites. The rule from Hickey/Meyer: completing an established pattern (the `:failure_threshold` / `:success_threshold` pattern visible at `state.ex:87,140`) removes a special case rather than adding one.
+- **Qualifier (Q):** Holds provided existing 2-arity call sites do not rely on dialyzer's `arity == 2` signature in a way that arity 3 with default would break. Dialyzer treats the clause-headed `def` with a default as a single function that accepts both arities, so this qualifier is satisfied by Elixir's default-argument expansion.
+- **Rebuttal (R):** If any external module pattern-matches on the function reference `&State.check/2` (function capture with explicit arity), that capture continues to work because the 2-arity variant is auto-generated. A `&State.check/3` capture is also valid post-change. No call site uses either capture today.
+- **Backing (B):** Elixir kernel docs on default arguments; SPEC-CIRCUIT-BREAKER §4 B4 (`docs/spec/SPEC-CIRCUIT-BREAKER.md:219-235`) which already declares the opts pattern for `record_*/2`; SPEC §5 Defaults table at `:262` lists `cooldown_ms` as a default but does not mark it non-threadable.
+
+#### Falsification attempt for claim 3
+
+- **Strategy:** Edge-case enumeration over call sites and dialyzer impact.
+- **Attempt:** Enumerated every `State.check` call site (`grep -rn "State.check\|CircuitBreaker.State.check"` → only the three property-test sites above). All three call `State.check(s, now_ms)` with no opts. Default behaviour is identical. Dialyzer treats clause-headed default-arg functions as both arities. No production code path imports or uses `check/2` other than via the property tests. The SPEC's Transition Table (`SPEC-CIRCUIT-BREAKER.md:251-252`) and AC-6 (`:310`) describe cooldown behaviour but do not pin the arity — the §4 B4 amendment named in claim 6 covers the contract change.
+- **Outcome:** withstood.
+- **Action:** none.
+
+### Claim 4: `State.record_failure/2` and `State.record_success/2` retain their existing signatures, semantics, and the internal `count + 1` arithmetic; State tests that construct `%State{}` with pre-bump field values and call those functions are unaffected.
+
+- **Claim (C):** State module is bitwise-identical save for the `check` arity change in claim 3 (and the related `@moduledoc` doc, optionally) — its `record_*/2` callers see no contract change.
+- **Grounds (G):** Current `record_failure/2` at `lib/tau/circuit_breaker/state.ex:86-118` and `record_success/2` at `:135-157` both compute `new_count = s.<field>_count + 1` internally. Proposal-1's sketch leaves both functions untouched (`proposals/proposal-1.md:60-76` modifies only the façade; the State sketch at `:82-94` modifies only `check`). The solution explicitly enumerates "no change to `record_failure/2` or `record_success/2`" at `solution.md:78`.
+- **Warrant (W):** Local-reasoning principle: a function whose source is unmodified between commits has, by definition, unchanged semantics for inputs of the same shape.
+- **Qualifier (Q):** Holds for the State module's *direct* callers passing pre-bump struct field values. The façade construction `%State{row | failure_count: new_count - 1}` at `circuit_breaker.ex:135` is replaced with `%State{row | failure_count: pre_count}`; the value the function ultimately sees as `s.failure_count` differs **only if the Store's pre-bump value differs from `Store-post-bump - 1`** — by claim 1 they are identical, so the value passed to `record_failure/2` is byte-identical to today. State's behaviour is therefore preserved on the production path. There is, however, an indirect ripple to flag: `current_struct/1` (`circuit_breaker.ex:148-162`) reads the row AFTER the bump has already mutated ETS, so `row.failure_count` reflects the post-bump value; the façade then *overwrites* that field with the pre-bump value before calling `State`. If a future refactor removes the field-overwrite, `State.record_failure/2` would silently double-count. This dependency is now load-bearing on a single line — narrow the qualifier to flag this constraint.
+- **Rebuttal (R):** If `current_struct/1` is ever changed to read BEFORE the bump (a more conventional "read-modify-write" pattern), the field-overwrite line becomes unnecessary; absence of the overwrite would then be safe. Either invariant is acceptable; documenting which one is in force in the §4 B3 amendment is good hygiene.
+- **Backing (B):** SPEC-CIRCUIT-BREAKER §4 B4 (`docs/spec/SPEC-CIRCUIT-BREAKER.md:219-235`) which fixes the `record_*/2` opts contract.
+
+#### Falsification attempt for claim 4
+
+- **Strategy:** Counter-example construction over the call-site coupling.
+- **Attempt:** Constructed the trace: `Store.bump_failure_count/1` returns `pre`; `current_struct/1` reads ETS (now holding `pre + 1`); façade builds `%State{row | failure_count: pre}`; `State.record_failure/2` computes `pre + 1` = correct new count. This is identical to today's behaviour at the State level. Then constructed the failure mode: drop the `failure_count: pre` overwrite (hypothetical future refactor) → `State.record_failure/2` would compute `(pre + 1) + 1` = double-count. The original problem-statement complecting hypothesis (`problem.md:46-52`) flags this same coupling: "changing either the Store primitive or the State arithmetic requires updating the façade's private adjustment". The solution shifts the adjustment from arithmetic to a struct-field overwrite — still complected, but the seam is now a struct assignment rather than a subtract-one. This is partially-falsified at the level of the "completely decomplected" reading of claim 4; State's *observable* contract is preserved, but the façade-state coupling is preserved in transmuted form.
+- **Outcome:** partially_falsified.
+- **Action:** narrow Qualifier in place (done above); flag in Outstanding doubts. No solution revision needed because the partial falsification is a known residual coupling, not a contract violation; the qualifier captures it.
+
+### Claim 5: D-044 ETS row layout is unchanged — counter column positions 3 and 4 are not renumbered, no `@schema_version` bump, no data migration.
+
+- **Claim (C):** The schema (`{provider_key, state_atom, failure_count, success_count, opened_at_ms, probe_slot}` at positions 1..6) is byte-for-byte identical post-change.
+- **Grounds (G):** Proposal-1 changes the operation parameter passed to `:ets.update_counter/3` (`[{3, 0}, {3, 1}]` instead of `{3, 1}`) but the position numbers `3` and `4` are unchanged. SPEC pins these at `docs/spec/SPEC-CIRCUIT-BREAKER.md:203-204`. `Store.transition/3` match-spec at `lib/tau/circuit_breaker/store.ex:226-247` writes positions 1, 2, 5, 6 and preserves 3, 4 — unchanged. `@schema_version 1` at `store.ex:48` is not bumped.
+- **Warrant (W):** SPEC-CIRCUIT-BREAKER's D-044 invariant: "Field positions MUST NOT be renumbered without bumping `@schema_version` and adding a data-migration step in the PR description" (`store.ex:37-38`). The converse: if no field is renumbered, no bump is required.
+- **Qualifier (Q):** Q: none — universal. The op-list change touches only the *operation* argument, not the *schema*. ETS is schema-less; `update_counter` does not redefine positions.
+- **Rebuttal (R):** If a future change adds a new field (e.g. a per-provider `cooldown_ms` column to back claim 3's threadable opt without re-passing it every call), that change WOULD require a schema bump — but it is out of scope for this solution.
+- **Backing (B):** SPEC-CIRCUIT-BREAKER §4 B2, D-044 (`docs/spec/SPEC-CIRCUIT-BREAKER.md:196-204`); `store.ex:37-38` moduledoc explaining the schema-version invariant.
+
+#### Falsification attempt for claim 5
+
+- **Strategy:** Dependency check — what would actually require a schema bump?
+- **Attempt:** Enumerated triggers for `@schema_version` bump from `store.ex:37-43`: position renumbering, field-type change, new field. Proposal-1 does none of these; it changes only the *call signature* into `update_counter`, not the table schema. Test `test/tau/circuit_breaker/store_property_test.exs:196-234` ("D-044 — transition writes state columns; counter columns preserved from ETS") would still pass — it reads positions 3 and 4 unchanged.
+- **Outcome:** withstood.
+- **Action:** none.
+
+### Claim 6: SPEC-CIRCUIT-BREAKER §4 B4 is amended in the same PR to document (a) the new pre-increment Store return convention and (b) the new `:cooldown_ms` opt on `State.check/3`.
+
+- **Claim (C):** The SPEC update lands in the same PR as the code change.
+- **Grounds (G):** `solution.md` enumerates this at `:80-81` ("§4 B4 amended"). The `spec-before-code.md` rule applies because this PR touches `lib/tau/circuit_breaker.ex`, `lib/tau/circuit_breaker/store.ex`, `lib/tau/circuit_breaker/state.ex`, and `lib/tau/application.ex`'s supervision-tree entry remains stable but the SPEC §4 B4 contract (`SPEC-CIRCUIT-BREAKER.md:219-235`) is the boundary being changed. The SPEC catalog entry in `.claude/rules/spec-before-code.md` lists exactly these files as mandatory scope.
+- **Warrant (W):** `.claude/rules/spec-before-code.md` — "MUST NOT merge a PR that adds new state to a SPEC'd boundary without a corresponding §3 entry and §4 contract update in the same PR". The rule is enforced by both the critic and reviewer gates.
+- **Qualifier (Q):** Holds provided the PR is gated through the `critic` + `reviewer` pair before merge — which is mandatory under `.claude/rules/factory-loop.md` ("The gate").
+- **Rebuttal (R):** If the SPEC's §4 B4 entry were unaffected by the change (e.g. only B3 is touched), the §4 B4 amendment claim would be over-specified. Inspection shows §4 B4 is the home of the `State` function contracts including arity, so arity change *does* require B4 amendment. A separate §4 B2 amendment for the Store return convention is also implied by the solution's wording ("Store side") but the solution only names §4 B4; this is a minor under-specification.
+- **Backing (B):** `.claude/rules/spec-before-code.md`; `.claude/rules/factory-loop.md` gate sections; SPEC-CIRCUIT-BREAKER §4 B2 (`SPEC-CIRCUIT-BREAKER.md:72-95,143-155`) and §4 B4 (`:219-235`).
+
+#### Falsification attempt for claim 6
+
+- **Strategy:** Integration check — does the existing SPEC text actually pin the contracts being changed?
+- **Attempt:** Read SPEC §4 B2 (`SPEC-CIRCUIT-BREAKER.md:143-155`) — explicitly names `bump_failure_count/1` and `bump_success_count/1` as the counter-update primitives but does NOT pin pre- vs post-increment return semantics. Read SPEC §4 B4 (`:219-235`) — pins `check/2` arity and signature in the table at `:224`. Both sections require text changes: §4 B2 to add the pre-increment return convention; §4 B4 to widen `check/2` to `check/2 | check/3` (or rewrite as a default-opt form). The solution's `solution.md:80-81` names only §4 B4 — strictly true but incomplete; §4 B2 also requires an amendment.
+- **Outcome:** partially_falsified at the granularity of "which §4 subsection" (the solution names only §4 B4; §4 B2 also needs amending). Not solution-falsifying — the *behaviour* the solution proposes is correct and the SPEC-amendment intent is sound; the wording is imprecise about the scope of the SPEC edit.
+- **Action:** narrow Qualifier in place — the SPEC amendment MUST cover §4 B2 (Store return semantics) AND §4 B4 (`State.check` arity). Flag in Outstanding doubts; no full solution revision needed (the implementer brief should reference both subsections).
+
+## Cross-claim consistency
+
+Claims 1, 2, 4, and 5 form a coherent invariant: Store returns pre-bump
+(C1) → façade uses it directly with no arithmetic (C2) → State's contract
+is unchanged (C4) → ETS schema is unchanged (C5). The transitive
+dependency in C4's qualifier (the façade's field-overwrite line on
+`current_struct/1` output is now load-bearing) is the only soft seam in
+the design; it is a known residual coupling, not an inconsistency.
+
+Claims 3 and 6 are also coherent: the `check/2 → check/3` arity change
+requires a §4 B4 amendment; both are scoped to the same PR.
+
+No two claims are in tension. The package is internally consistent.
+
+## Falsification summary
+
+| # | Claim (short) | Strategy | Outcome | Action |
+|---|---|---|---|---|
+| 1 | Store returns pre-increment via multi-op `update_counter` | Dependency + counter-example | withstood | none |
+| 2 | `new_count - 1` and explanatory comment are removed from `record_outcome/5` | Counter-example construction | withstood | none |
+| 3 | `State.check/2` → `check/3` with `:cooldown_ms` opt; 2-arity callers unaffected | Edge-case enumeration | withstood | none |
+| 4 | `State.record_*/2` signatures, semantics, internal `+ 1` arithmetic unchanged | Counter-example over call-site coupling | partially_falsified | narrow Qualifier — façade field-overwrite line is now load-bearing |
+| 5 | D-044 row layout unchanged; no schema bump | Dependency check | withstood | none |
+| 6 | SPEC §4 B4 amended in same PR for both Store return and check arity | Integration check | partially_falsified | narrow Qualifier — §4 B2 also requires amendment, not only §4 B4 |
+
+## Revision required
+
+No revision triggered. Two partial falsifications narrow qualifiers in
+place; neither falsifies the core proposition.
+
+- **Target file:** none.
+- **Revision kind:** n/a.
+- **Rationale:** Claim 4's partial falsification is a residual coupling
+  (transmuted, not eliminated) that the solution implicitly accepts — the
+  qualifier now names the load-bearing seam. Claim 6's partial
+  falsification is an under-specification of the SPEC-edit scope (the
+  edit MUST cover §4 B2 in addition to §4 B4); this is an implementer-brief
+  precision issue, not a wrong design choice.
+
+## Outstanding doubts
+
+- **Façade-State coupling moves but does not vanish.** After the change,
+  `record_outcome/5` builds the struct passed to State via
+  `%State{row | <field>: pre_count}`, where `row` was read AFTER the
+  Store bump. The overwrite of the post-bump field with the pre-bump
+  value is now a single load-bearing line; if a future refactor inlines
+  `current_struct/1` or reorders the bump-then-read sequence, the
+  double-count bug returns silently. A property test asserting
+  "`new_state.failure_count` equals the value passed in `s.failure_count`
+  plus 1, in `:closed`" would pin this; the existing
+  `state_property_test.exs` does not yet enforce it.
+- **SPEC-edit scope under-specified.** The solution names §4 B4 only; §4
+  B2 also requires text changes (pre-increment return convention for
+  `bump_*/1`). The implementer brief MUST reference both subsections to
+  satisfy `spec-before-code.md`.
+- **Reader-comment in `record_outcome/5`.** Claim 2 removes the
+  multi-line explanatory block. The reviewer may legitimately ask for a
+  one-line `# pre-bump count from Store; see State.record_failure docstring`
+  comment to compensate for the loss of context. This is at the reviewer's
+  discretion; not solution-falsifying.
+- **OTP version pin.** The multi-op `update_counter` form is supported on
+  OTP 27.2 (project target). A downgrade to a pre-multi-op OTP would
+  falsify claim 1; the `.tool-versions` pin makes this acceptably low-risk.

--- a/docs/problems-archive-v1-modules/tau-infrastructure/subproblems/global-name-collision/problem.md
+++ b/docs/problems-archive-v1-modules/tau-infrastructure/subproblems/global-name-collision/problem.md
@@ -1,0 +1,85 @@
+---
+template_version: 1
+template_name: problem
+node_kind: leaf
+depth: 1
+parent: ../../problem.md
+status: draft
+---
+
+# Problem: hard-coded global process names embed single-instance-per-node assumption
+
+## Statement
+
+`Tau.Application` registers `Tau.PubSub`, `Tau.Providers.Finch`,
+`Tau.CircuitBreaker.Store` (via `__MODULE__`), `Tau.Sessions.Supervisor`,
+`Tau.Registries`, and every `Registry` child under invariant atom names; a
+second Tau OTP application started in the same BEAM node (test fixture host
+running alongside an escript under test, a future hyperagent worker, or an
+embedded-mode caller) collides at startup and the second instance fails to
+start. The failure mode is silent — the first `start_link` wins, the second
+returns `{:error, {:already_started, pid}}`, and callers silently share the
+first instance's state.
+
+## Context
+
+- `lib/tau/application.ex:68` — `{Phoenix.PubSub, name: Tau.PubSub}`;
+  flat audit: major, OTP-NN §4. "Two simultaneous Tau instances in one
+  BEAM … collide at startup."
+- `lib/tau/application.ex:78` — `{Finch, name: Tau.Providers.Finch}`.
+- `lib/tau/circuit_breaker/store.ex:65` — `GenServer.start_link(__MODULE__,
+  opts, name: __MODULE__)` — hard-coded to `Tau.CircuitBreaker.Store`.
+- `lib/tau/cost/tracker.ex:73` — same pattern; hard-coded to `__MODULE__`.
+- `lib/tau/registries.ex:56-63` — all seven `Registry` children use literal
+  module atoms as names.
+- `lib/tau/application.ex:93` — supervisor itself registered as `Tau.Supervisor`.
+- The `:tau_circuit_breakers` and `:tau_cost_counters` ETS table names are
+  hard-coded atoms in `Store` and `Tracker`; two concurrent instances share
+  the same table.
+- Flat audit: major finding on `application.ex:68`; pattern noted across
+  every named child.
+- `.claude/rules/otp-non-negotiables.md` §4: "Never `:global`" — `:global`
+  is avoided here, but the pattern's fragility is the same class of concern.
+
+## Complecting hypothesis
+
+1. **Deployment topology is complected with process identity**: every
+   subsystem that calls `Tau.PubSub`, `Tau.Providers.Finch`, or `Registry`
+   by module atom embeds the assumption that exactly one instance of that
+   subsystem exists in the node, preventing test isolation and multi-tenant
+   embedding without restructuring call sites.
+2. **ETS table ownership is complected with the module namespace**: the
+   table names `:tau_circuit_breakers` and `:tau_cost_counters` are atoms
+   derived from a convention rather than from the owning process's registered
+   name, so they cannot be parameterised independently.
+
+## Decomposition strategy
+
+(leaf — no further decomposition; proceed to proposals)
+
+## Acceptance criterion
+
+A proposal names: (a) which global names are practical to parameterise
+now (i.e. which subsystems have a natural `name:` opt path already exposed
+by their `start_link/1`) vs which require broader caller-site changes; (b)
+the minimum change that eliminates the test-fixture collision (the highest-
+priority scenario) without requiring every call site to pass a name; and
+(c) whether the ETS table names should follow the owning process's
+registered name or be derived independently, with the D-044 schema-version
+impact assessed for the circuit-breaker table.
+
+## Out of scope
+
+- Supervision tree startup ordering or CLI task — exclusive scope of
+  **supervision-tree-startup**.
+- Telemetry handler crash-safety — exclusive scope of
+  **telemetry-handler-coupling**.
+- Circuit-breaker counter-protocol leakage — exclusive scope of
+  **circuit-breaker-invariant-split**.
+- `lib/tau/factory/gate.ex` placement (CI tool under `lib/tau/`).
+- `lib/tau/memory/embedding_worker.ex:106` Finch name mismatch — covered by
+  the tau-memory audit module.
+
+## Amendment log
+
+- (none yet)

--- a/docs/problems-archive-v1-modules/tau-infrastructure/subproblems/global-name-collision/proposals/proposal-1.md
+++ b/docs/problems-archive-v1-modules/tau-infrastructure/subproblems/global-name-collision/proposals/proposal-1.md
@@ -1,0 +1,171 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 1
+parent_problem: ../problem.md
+---
+
+# Proposal 1: Test-isolation shim via `start_supervised` overrides in ExUnit
+
+## Approach
+
+Add an `ExUnit.CaseTemplate` (`Tau.Test.IsolatedApp`) that starts a second
+Tau supervision subtree under unique names for each test that needs full
+process isolation, without changing any production `start_link/1` signatures
+or production call sites. The shim works by starting `Phoenix.PubSub`,
+`Finch`, the `Registry` children, `CircuitBreaker.Store`, and
+`Cost.Tracker` with per-test-unique names (e.g. `:"Tau.PubSub.test_<ref>"`),
+then swapping them in via `Application.put_env/3` before the test runs and
+restoring originals after. Production code continues to call `Tau.PubSub` etc.
+by their compile-time module atom; the shim makes those atoms point to the
+isolated process via the Application env.
+
+## Rationale
+
+The acceptance criterion requires (a) identifying which processes have a
+natural `name:` opt path vs which require broad caller-site changes, (b) a
+minimum change eliminating the test-fixture collision, and (c) an ETS table
+name strategy. This proposal satisfies (b) directly — it eliminates the
+collision for the test-fixture scenario with zero production code changes —
+while leaving (a) and (c) to documentation rather than enforcement. The shim
+is the narrowest possible footprint that resolves the highest-priority
+scenario.
+
+## Sketch
+
+```elixir
+# test/support/isolated_app.ex
+defmodule Tau.Test.IsolatedApp do
+  @moduledoc """
+  ExUnit case template that starts an isolated Tau subsystem subtree
+  per test to avoid global-name collisions in concurrent test runs.
+  """
+  use ExUnit.CaseTemplate
+
+  using do
+    quote do
+      setup do
+        ref = make_ref() |> :erlang.ref_to_list() |> List.to_string()
+        pubsub_name   = :"Tau.PubSub.#{ref}"
+        finch_name    = :"Tau.Providers.Finch.#{ref}"
+        cb_table      = :"tau_circuit_breakers_#{ref}"
+        cost_table    = :"tau_cost_counters_#{ref}"
+
+        {:ok, pubsub} = start_supervised({Phoenix.PubSub, name: pubsub_name})
+        {:ok, finch}  = start_supervised({Finch, name: finch_name})
+        {:ok, cb}     = start_supervised(
+          {Tau.CircuitBreaker.Store,
+           name: :"Tau.CircuitBreaker.Store.#{ref}",
+           table: cb_table}
+        )
+        {:ok, ct}     = start_supervised(
+          {Tau.Cost.Tracker,
+           name: :"Tau.Cost.Tracker.#{ref}",
+           table: cost_table}
+        )
+
+        # Shim Application env so modules that call Tau.PubSub etc. by atom
+        # read the per-test name.
+        Application.put_env(:tau, :pubsub_name, pubsub_name)
+        Application.put_env(:tau, :finch_name, finch_name)
+        Application.put_env(:tau, :cb_table, cb_table)
+        Application.put_env(:tau, :cost_table, cost_table)
+
+        on_exit(fn ->
+          Application.delete_env(:tau, :pubsub_name)
+          Application.delete_env(:tau, :finch_name)
+          Application.delete_env(:tau, :cb_table)
+          Application.delete_env(:tau, :cost_table)
+        end)
+
+        :ok
+      end
+    end
+  end
+end
+```
+
+`CircuitBreaker.Store` and `Cost.Tracker` would each need a one-line change
+to accept an optional `table:` keyword in their `start_link/1` and `init/1`
+(replacing `@table` with a runtime value from opts). No call-site changes
+needed anywhere else.
+
+`Application.get_env/3` wrappers in the *few* places a module resolves the
+name at call time (e.g. `Tau.PubSub` in `Phoenix.PubSub.broadcast/3`) would
+need to change from bare atom to a helper function:
+
+```elixir
+# lib/tau/names.ex  (new, 8 lines)
+defmodule Tau.Names do
+  def pubsub,  do: Application.get_env(:tau, :pubsub_name, Tau.PubSub)
+  def finch,   do: Application.get_env(:tau, :finch_name, Tau.Providers.Finch)
+  def cb_table, do: Application.get_env(:tau, :cb_table, :tau_circuit_breakers)
+  def cost_table, do: Application.get_env(:tau, :cost_table, :tau_cost_counters)
+end
+```
+
+Production code is unchanged as long as Application env is absent (the
+`get_env/3` default returns the existing atom). Only the shim sets the env.
+
+## Tradeoffs
+
+### Strengths
+
+- Zero production API surface change; all existing call sites compile unchanged.
+- Resolves test-fixture collision (the highest-priority scenario) in one PR.
+- `start_supervised` gives ExUnit lifecycle tracking; no manual cleanup.
+- `on_exit` restores Application env so tests are hermetic.
+
+### Weaknesses
+
+- `Application.put_env/3` is the OTP-NN §1 violation the rule warns against:
+  "No `Application.put_env/3` for runtime state." Using it as a shim in tests
+  only partially masks this — any concurrent test that also reads `Application.get_env`
+  for the same key will race, defeating isolation for parallel test runs.
+- Does not address the production multi-tenant scenario (two Tau OTP apps
+  embedded in one node in production). The collision remains latent in non-test
+  deployments.
+- The `Tau.Names` indirection adds a function call per event dispatch, with a
+  negligible but real performance cost on hot paths (PubSub broadcasts in the
+  render loop).
+- Requires callers that hold the atom at compile time (e.g. pattern matching on
+  `:tau_circuit_breakers` in match specs) to be identified and changed — the
+  audit is manually verified, not mechanically enforced.
+- ETS table parameterisation in `Store` and `Tracker` requires confirming D-044
+  schema-version semantics are unaffected (the table *name* is not part of the
+  row schema, so @schema_version need not bump, but this must be documented
+  explicitly).
+
+### Costs
+
+- ~80 lines of test support code + ~20 lines in `Tau.Names`.
+- `CircuitBreaker.Store.start_link/1` and `Cost.Tracker.start_link/1` each
+  need a ~5-line change to accept `table:` and `name:` opts.
+- All PubSub call sites (~15 locations in `lib/`) need to change from bare
+  `Tau.PubSub` to `Tau.Names.pubsub()`. Similarly ~6 Finch call sites.
+- No supervisor, behaviour, or spec changes.
+
+## Dependencies
+
+- `CircuitBreaker.Store` and `Cost.Tracker` must each be updated to accept
+  `table:` and `name:` in their `start_link/1` / `init/1` before the shim
+  works. These are two-process changes the problem statement flags as "natural
+  `name:` opt path already exposed" — they are not currently exposed but are
+  straightforward to add.
+
+## Confidence
+
+Medium. The approach is well-understood (Application env shim for test
+isolation is an established Elixir idiom) but the concurrent test race risk
+with `Application.put_env` lowers confidence for parallel test runs. A
+prototype replacing bare atoms in three or four hot-path call sites would
+confirm the pattern before committing.
+
+## Prior art / references
+
+- Elixir `Application.get_env/3` with default: standard idiom for
+  test-overridable configuration.
+- `ExUnit.Callbacks.start_supervised/2`: documented ExUnit lifecycle hook for
+  processes-under-test.
+- Ecto's `Ecto.Adapters.SQL.Sandbox` uses a similar per-test supervision
+  approach for DB connections.

--- a/docs/problems-archive-v1-modules/tau-infrastructure/subproblems/global-name-collision/proposals/proposal-2.md
+++ b/docs/problems-archive-v1-modules/tau-infrastructure/subproblems/global-name-collision/proposals/proposal-2.md
@@ -1,0 +1,251 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 2
+parent_problem: ../problem.md
+---
+
+# Proposal 2: Thread `name:` opts from `Application.start/2` through every child `start_link/1`
+
+## Approach
+
+Change `Tau.Application.start/2` to accept an `instance_id` option (defaulting
+to `:default`) and derive all global names from it. Every named child process
+(`Phoenix.PubSub`, `Finch`, `CircuitBreaker.Store`, `Cost.Tracker`,
+`Task.Supervisor`, and each `Registry`) receives a computed `name:` opt of the
+form `:"#{module}.#{instance_id}"`. The `Tau.Registries` supervisor receives the
+full name-set via opts and passes each `name:` to its `Registry` children. All
+call sites in `lib/` that resolve a name at runtime (PubSub broadcasts,
+`Finch.request/3` calls, `Registry.lookup/3` calls) are updated to fetch the
+name from a lightweight `Tau.Names` module that reads from `:persistent_term`
+(set once at startup, read without a GenServer hop). ETS table names follow the
+owning process's registered name derived from `instance_id`.
+
+## Rationale
+
+This proposal threads the `instance_id` through the entire startup path so that
+both the process registry (`:name`) and the ETS table name are derived from the
+same root. It eliminates the test-fixture collision and the production
+multi-tenant collision in one atomic change. Call sites that read names at
+runtime go through `Tau.Names`, which reads from `:persistent_term` — so the
+hot path is an unboxed atom read with no function call overhead at the
+application level. D-044 is not violated because the ETS table *name* is not
+part of the circuit-breaker row schema; only the row layout triggers a version
+bump.
+
+## Sketch
+
+```elixir
+# lib/tau/application.ex (modified start/2)
+def start(_type, args) do
+  instance_id = Keyword.get(args, :instance_id, :default)
+  names       = Tau.Names.compute(instance_id)
+
+  # Store names once in persistent_term for zero-cost read everywhere.
+  :persistent_term.put({:tau_names, instance_id}, names)
+  # Default instance also published under the well-known key.
+  if instance_id == :default do
+    :persistent_term.put(:tau_names, names)
+  end
+
+  children = [
+    Tau.Telemetry.Supervisor,
+    otel_reporter_spec(),
+    {Phoenix.PubSub,         name: names.pubsub},
+    {Tau.Registries,         names: names},
+    {Tau.Settings.Cache,     pubsub: names.pubsub},
+    {Tau.Settings.Watcher,   []},
+    Tau.Memory.Supervisor,
+    {Tau.Permissions.RuleSet, pubsub: names.pubsub},
+    {Finch,                  name: names.finch},
+    {Tau.Providers.RateLimiter.Supervisor, pubsub: names.pubsub,
+                                           registry: names.rate_limiter_registry},
+    {Tau.CircuitBreaker.Store, name: names.cb_store, table: names.cb_table},
+    ...
+    {Task.Supervisor, name: names.tools_task_supervisor},
+    ...
+    {Tau.Sessions.Supervisor, registry: names.sessions_registry}
+  ]
+
+  opts = [strategy: :rest_for_one, name: names.supervisor]
+  Supervisor.start_link(List.flatten(children), opts)
+end
+```
+
+```elixir
+# lib/tau/names.ex  (new module)
+defmodule Tau.Names do
+  @moduledoc """
+  Derives the full set of process and ETS table names for one Tau instance.
+  Stored once in :persistent_term at startup; read without a GenServer hop.
+  """
+
+  @type t :: %__MODULE__{
+    pubsub:                    atom(),
+    finch:                     atom(),
+    cb_store:                  atom(),
+    cb_table:                  atom(),
+    cost_tracker:              atom(),
+    cost_table:                atom(),
+    supervisor:                atom(),
+    tools_registry:            atom(),
+    hooks_registry:            atom(),
+    commands_registry:         atom(),
+    skills_registry:           atom(),
+    sessions_registry:         atom(),
+    mcp_registry:              atom(),
+    rate_limiter_registry:     atom(),
+    tools_task_supervisor:     atom(),
+    sessions_supervisor:       atom()
+  }
+  defstruct [
+    :pubsub, :finch, :cb_store, :cb_table, :cost_tracker, :cost_table,
+    :supervisor, :tools_registry, :hooks_registry, :commands_registry,
+    :skills_registry, :sessions_registry, :mcp_registry,
+    :rate_limiter_registry, :tools_task_supervisor, :sessions_supervisor
+  ]
+
+  @doc "Compute names struct for a given instance_id atom."
+  @spec compute(atom()) :: t()
+  def compute(:default) do
+    %__MODULE__{
+      pubsub:                Tau.PubSub,
+      finch:                 Tau.Providers.Finch,
+      cb_store:              Tau.CircuitBreaker.Store,
+      cb_table:              :tau_circuit_breakers,
+      cost_tracker:          Tau.Cost.Tracker,
+      cost_table:            :tau_cost_counters,
+      supervisor:            Tau.Supervisor,
+      tools_registry:        Tau.Tools.Registry,
+      hooks_registry:        Tau.Hooks.Registry,
+      commands_registry:     Tau.Commands.Registry,
+      skills_registry:       Tau.Skills.Registry,
+      sessions_registry:     Tau.Sessions.Registry,
+      mcp_registry:          Tau.MCP.Registry,
+      rate_limiter_registry: Tau.Providers.RateLimiter.Registry,
+      tools_task_supervisor: Tau.Tools.TaskSupervisor,
+      sessions_supervisor:   Tau.Sessions.Supervisor
+    }
+  end
+
+  def compute(id) when is_atom(id) do
+    suffix = id
+    %__MODULE__{
+      pubsub:                :"Tau.PubSub.#{suffix}",
+      finch:                 :"Tau.Providers.Finch.#{suffix}",
+      cb_store:              :"Tau.CircuitBreaker.Store.#{suffix}",
+      cb_table:              :"tau_circuit_breakers_#{suffix}",
+      cost_tracker:          :"Tau.Cost.Tracker.#{suffix}",
+      cost_table:            :"tau_cost_counters_#{suffix}",
+      supervisor:            :"Tau.Supervisor.#{suffix}",
+      tools_registry:        :"Tau.Tools.Registry.#{suffix}",
+      hooks_registry:        :"Tau.Hooks.Registry.#{suffix}",
+      commands_registry:     :"Tau.Commands.Registry.#{suffix}",
+      skills_registry:       :"Tau.Skills.Registry.#{suffix}",
+      sessions_registry:     :"Tau.Sessions.Registry.#{suffix}",
+      mcp_registry:          :"Tau.MCP.Registry.#{suffix}",
+      rate_limiter_registry: :"Tau.Providers.RateLimiter.Registry.#{suffix}",
+      tools_task_supervisor: :"Tau.Tools.TaskSupervisor.#{suffix}",
+      sessions_supervisor:   :"Tau.Sessions.Supervisor.#{suffix}"
+    }
+  end
+
+  @doc "Fetch names for the default instance."
+  @spec get() :: t()
+  def get, do: :persistent_term.get(:tau_names)
+
+  @doc "Fetch names for a specific instance_id."
+  @spec get(atom()) :: t()
+  def get(id), do: :persistent_term.get({:tau_names, id})
+end
+```
+
+Call sites change from:
+```elixir
+Phoenix.PubSub.broadcast(Tau.PubSub, topic, event)
+```
+to:
+```elixir
+Phoenix.PubSub.broadcast(Tau.Names.get().pubsub, topic, event)
+```
+
+For the default instance, `Tau.Names.get()` is a single `:persistent_term.get/1`
+returning the pre-computed struct; field access is a pattern-match on a map, not
+a function call. Hot-path overhead is O(1) memory read.
+
+Each `start_link/1` that previously used `__MODULE__` or a bare atom for `name:`
+is updated to accept `name:` and `table:` from opts, with defaults matching
+the existing atoms for backward compatibility.
+
+## Tradeoffs
+
+### Strengths
+
+- Fully eliminates the test-fixture collision and the production multi-tenant
+  collision in one atomic PR.
+- `:persistent_term` read is effectively free (no GenServer, no ETS hop, no
+  function overhead beyond a map field access).
+- All names in the system flow from one `Tau.Names.compute/1` derivation —
+  no names are scattered; the set is inspectable.
+- ETS table names follow the owning process name (same `instance_id` suffix)
+  satisfying the acceptance criterion's (c) question definitively.
+- D-044 schema version is not affected: the row layout is unchanged; only the
+  table name atom changes.
+- `compute(:default)` preserves all existing atom names for the common case,
+  so no migration is needed for deployed configurations.
+
+### Weaknesses
+
+- Broad call-site churn: ~30 locations in `lib/` move from bare atoms to
+  `Tau.Names.get().field`. Each is a trivial change but the diff is wide.
+- `:persistent_term.put/2` in `Application.start/2` is called before the
+  supervision tree; if `start/2` fails mid-tree, the term is orphaned until
+  the BEAM node restarts. This is benign (a failed start means no sessions)
+  but slightly untidy.
+- Modules that receive a `name:` through their supervisor chain (e.g.
+  `Tau.Registries`) now need to thread the full `names` struct through opts,
+  increasing `start_link/1` arity complexity.
+- `Tau.Sessions.Supervisor`, `Tau.MCP.Supervisor`, and `Tau.CodingAgent.Supervisor`
+  currently use `__MODULE__` for their supervisor names; making them accept a
+  `name:` opt requires each supervisor to be updated even though they have no
+  external name references.
+- Non-default instances cannot be started without explicitly passing
+  `instance_id`; there is no auto-discovery mechanism if two instances are
+  embedded in one node by a library user.
+
+### Costs
+
+- Approximately 30 call-site changes in `lib/` (PubSub: 15, Finch: 6, Registry:
+  ~9 distinct modules) — all mechanical find-and-replace.
+- `Tau.Names` module: ~70 lines.
+- Each named child's `start_link/1` updated to accept `name:` / `table:` opts
+  with defaults: ~12 modules, ~5 lines each.
+- `Tau.Registries.init/1` updated to pass per-name to `Registry` children: ~15
+  lines.
+- No supervision strategy changes; no behaviour changes.
+
+## Dependencies
+
+- All named `start_link/1` callables (PubSub and Finch accept `name:` already;
+  `CircuitBreaker.Store`, `Cost.Tracker`, all Registry children via
+  `Tau.Registries`, `Task.Supervisor` — all already accept `name:` in their
+  child spec) need to be verified. The main work is threading opts into
+  supervisors that currently ignore opts.
+
+## Confidence
+
+High. The `:persistent_term` pattern for application-wide read-only name
+resolution is standard Elixir practice; `Tau.Names.compute(:default)` returning
+the existing atoms means the default case is provably unchanged. The only risk
+is the call-site sweep missing a location — mechanically verifiable with
+`grep -rn "Tau.PubSub\|Tau.Providers.Finch"` after the change.
+
+## Prior art / references
+
+- `Phoenix.PubSub` accepts `name:` in `start_link/1` since v2.0 — the pattern
+  is already used by the project's own PubSub dependency.
+- Finch's `start_link/1` `name:` opt: standard documented opt.
+- `:persistent_term` for app-wide read-only config: Erlang/OTP docs
+  `erlang.org/doc/man/persistent_term.html`.
+- `Ecto.Repo` uses a similar `otp_app:` derivation to namespace all its
+  registered names per repo module.

--- a/docs/problems-archive-v1-modules/tau-infrastructure/subproblems/global-name-collision/proposals/proposal-3.md
+++ b/docs/problems-archive-v1-modules/tau-infrastructure/subproblems/global-name-collision/proposals/proposal-3.md
@@ -1,0 +1,226 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 3
+parent_problem: ../problem.md
+---
+
+# Proposal 3: Process-group namespace via a supervised `Tau.Instance` GenServer injected into every subsystem
+
+## Approach
+
+Introduce `Tau.Instance` — a supervised GenServer that starts as the first
+child of `Tau.Application` and holds the authoritative name-set for the running
+Tau instance. Every subsystem that needs a global name calls
+`Tau.Instance.names()` at the point of use (lazy resolution, not compile-time
+atom). The GenServer is registered under a process group key derived from the
+OTP application name + a runtime ref, so two concurrent Tau instances each have
+their own `Tau.Instance` pid. All other children receive no `name:` change in
+`Tau.Application` — instead each child's internal references to global names
+(e.g. `Tau.PubSub` in `Phoenix.PubSub.broadcast/3`) are replaced by calls to
+`Tau.Instance.names().pubsub`. `CircuitBreaker.Store` and `Cost.Tracker` accept
+a `table:` opt supplied by `Tau.Instance` at startup.
+
+## Rationale
+
+This proposal separates the concern of "what names does this instance own" from
+the concern of "how are those names derived and stored." The `Tau.Instance`
+GenServer is the single source of truth for its instance's names at runtime.
+Unlike a `:persistent_term`-only approach, `Tau.Instance` can be monitored: if
+it crashes, the `:rest_for_one` strategy cascades the restart to all dependent
+children, ensuring stale name references are never observable.
+
+## Sketch
+
+```elixir
+# lib/tau/instance.ex  (new module, ~80 lines)
+defmodule Tau.Instance do
+  @moduledoc """
+  Supervised home for an instance's name-set.
+
+  Started as the first non-telemetry child of Tau.Application.
+  Registers itself under a well-known key when instance_id == :default;
+  otherwise under {Tau.Instance, instance_id}.
+
+  All subsystems that need a global name call Tau.Instance.names/0 at
+  the point of use.
+  """
+  use GenServer
+
+  @type names :: %{
+    required(:pubsub)                => atom(),
+    required(:finch)                 => atom(),
+    required(:cb_store)              => atom(),
+    required(:cb_table)              => atom(),
+    required(:cost_tracker)          => atom(),
+    required(:cost_table)            => atom(),
+    required(:tools_registry)        => atom(),
+    required(:hooks_registry)        => atom(),
+    required(:commands_registry)     => atom(),
+    required(:skills_registry)       => atom(),
+    required(:sessions_registry)     => atom(),
+    required(:mcp_registry)          => atom(),
+    required(:rate_limiter_registry) => atom(),
+    required(:tools_task_supervisor) => atom(),
+    required(:sessions_supervisor)   => atom()
+  }
+
+  def start_link(opts) do
+    instance_id = Keyword.get(opts, :instance_id, :default)
+    via         = via(instance_id)
+    GenServer.start_link(__MODULE__, opts, name: via)
+  end
+
+  @spec names() :: names()
+  def names, do: names(:default)
+
+  @spec names(atom()) :: names()
+  def names(instance_id) do
+    GenServer.call(via(instance_id), :names)
+  end
+
+  @impl true
+  def init(opts) do
+    instance_id = Keyword.get(opts, :instance_id, :default)
+    {:ok, %{names: derive_names(instance_id)}}
+  end
+
+  @impl true
+  def handle_call(:names, _from, state), do: {:reply, state.names, state}
+
+  defp via(:default), do: {:via, Registry, {Tau.Instance.Registry, :default}}
+  defp via(id),       do: {:via, Registry, {Tau.Instance.Registry, id}}
+
+  defp derive_names(:default) do
+    %{
+      pubsub:                Tau.PubSub,
+      finch:                 Tau.Providers.Finch,
+      cb_store:              Tau.CircuitBreaker.Store,
+      cb_table:              :tau_circuit_breakers,
+      cost_tracker:          Tau.Cost.Tracker,
+      cost_table:            :tau_cost_counters,
+      tools_registry:        Tau.Tools.Registry,
+      hooks_registry:        Tau.Hooks.Registry,
+      commands_registry:     Tau.Commands.Registry,
+      skills_registry:       Tau.Skills.Registry,
+      sessions_registry:     Tau.Sessions.Registry,
+      mcp_registry:          Tau.MCP.Registry,
+      rate_limiter_registry: Tau.Providers.RateLimiter.Registry,
+      tools_task_supervisor: Tau.Tools.TaskSupervisor,
+      sessions_supervisor:   Tau.Sessions.Supervisor
+    }
+  end
+
+  defp derive_names(id) when is_atom(id) do
+    s = id
+    %{
+      pubsub:                :"Tau.PubSub.#{s}",
+      finch:                 :"Tau.Providers.Finch.#{s}",
+      cb_store:              :"Tau.CircuitBreaker.Store.#{s}",
+      cb_table:              :"tau_circuit_breakers_#{s}",
+      cost_tracker:          :"Tau.Cost.Tracker.#{s}",
+      cost_table:            :"tau_cost_counters_#{s}",
+      tools_registry:        :"Tau.Tools.Registry.#{s}",
+      hooks_registry:        :"Tau.Hooks.Registry.#{s}",
+      commands_registry:     :"Tau.Commands.Registry.#{s}",
+      skills_registry:       :"Tau.Skills.Registry.#{s}",
+      sessions_registry:     :"Tau.Sessions.Registry.#{s}",
+      mcp_registry:          :"Tau.MCP.Registry.#{s}",
+      rate_limiter_registry: :"Tau.Providers.RateLimiter.Registry.#{s}",
+      tools_task_supervisor: :"Tau.Tools.TaskSupervisor.#{s}",
+      sessions_supervisor:   :"Tau.Sessions.Supervisor.#{s}"
+    }
+  end
+end
+```
+
+`Tau.Application` adds two children at position 1 (before PubSub):
+
+```elixir
+# A globally unique registry for Tau.Instance pids.
+{Registry, keys: :unique, name: Tau.Instance.Registry},
+# The instance coordinator; holds names for this run.
+{Tau.Instance, instance_id: instance_id}
+```
+
+`Tau.Application` passes the computed names to its other children at startup
+by calling `Tau.Instance.names(instance_id)` once before the `children` list is
+built, then using the map entries as before:
+
+```elixir
+names = Tau.Instance.derive_names(instance_id)  # pure helper, no process needed
+{Phoenix.PubSub, name: names.pubsub},
+{Finch, name: names.finch},
+...
+```
+
+All call sites in `lib/` that reference `Tau.PubSub` directly replace the atom
+with `Tau.Instance.names().pubsub`. The `Tau.Instance.Registry` itself uses a
+hard-coded atom (it is started exactly once per node, not per instance).
+
+## Tradeoffs
+
+### Strengths
+
+- The `Tau.Instance` GenServer is a monitored, supervised process: its crash
+  cascades via `:rest_for_one` to the entire name-dependent subtree, preventing
+  silent use of stale names after a failure.
+- Names are observable at runtime (`GenServer.call(via(id), :names)`) without
+  reading `:persistent_term` internals.
+- `derive_names(:default)` returns the same atoms as today — no migration for
+  deployed configurations.
+- The acceptance criterion's (c) question (ETS table names follow owning
+  process name) is answered mechanically: `cb_table` is always `:"tau_circuit_breakers_#{id}"`.
+
+### Weaknesses
+
+- Introduces a GenServer call (`Tau.Instance.names()`) on every hot-path
+  dispatch (PubSub broadcast, Finch request, Registry lookup). This is a
+  mailbox hop per call, not an O(1) memory read. Under the render loop (which
+  may broadcast multiple PubSub events per turn), this adds measurable latency
+  unless callers cache the returned map in their own process state.
+- Adding `Tau.Instance.Registry` as a global singleton re-introduces a
+  single-atom name for the instance registry itself — it cannot be parameterised
+  without a recursive bootstrapping problem.
+- Two levels of Registry are now needed (`Tau.Instance.Registry` for
+  `Tau.Instance` pids, plus all the per-instance registries), increasing the
+  supervision tree depth.
+- The `:rest_for_one` cascade on `Tau.Instance` crash is desirable for
+  correctness but means a bug in the names GenServer halts all active sessions —
+  higher blast radius than a pure data approach.
+- Callers that need the name on hot paths (e.g. per-message PubSub broadcast)
+  must cache it in their own `GenServer` state at `init/1`, pushing
+  responsibility onto each subsystem.
+
+### Costs
+
+- ~80 lines for `Tau.Instance` module.
+- ~30 call-site changes in `lib/` (same scope as Proposal 2), but each now
+  calls `Tau.Instance.names().pubsub` rather than reading from `:persistent_term`.
+- Callers on hot paths (sessions, TUI event bridge, agent tool) must cache
+  the names map in their state: ~6 GenServers need an `init/1` change to store
+  `Tau.Instance.names()` in state.
+- `Tau.Instance.Registry` added to `Tau.Application` — minimal change.
+
+## Dependencies
+
+- `CircuitBreaker.Store` and `Cost.Tracker` must accept `table:` in `start_link/1`
+  (same as Proposals 1 and 2).
+- `Tau.Registries` must accept per-name opts (same as Proposal 2).
+
+## Confidence
+
+Medium. The supervised-GenServer-for-names approach is sound OTP design but
+the hot-path mailbox-hop weakness is non-trivial. A hybrid where
+`Tau.Instance.names/0` caches in `:persistent_term` after the first GenServer
+call would mitigate this, but that hybrid is closer to Proposal 2 with an extra
+GenServer layer. Confidence would rise if profiling confirmed the PubSub
+broadcast path is not latency-sensitive at the per-message level.
+
+## Prior art / references
+
+- `Phoenix.PubSub` internal dispatch: calls the adapter module directly, no
+  intermediate GenServer name resolution.
+- OTP `:via` Registry pattern: `{:via, Registry, {name, key}}` — used here for
+  `Tau.Instance` self-registration.
+- Elixir `Registry` docs: `https://hexdocs.pm/elixir/Registry.html`

--- a/docs/problems-archive-v1-modules/tau-infrastructure/subproblems/global-name-collision/proposals/proposal-4.md
+++ b/docs/problems-archive-v1-modules/tau-infrastructure/subproblems/global-name-collision/proposals/proposal-4.md
@@ -1,0 +1,208 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 4
+parent_problem: ../problem.md
+---
+
+# Proposal 4: Eliminate global names by replacing atom-keyed lookups with pid-passing and `{:via, Registry}` everywhere
+
+## Approach
+
+Remove all hard-coded atom names for long-lived processes (PubSub, Finch,
+CircuitBreaker.Store, Cost.Tracker, all Registries, Sessions.Supervisor) and
+replace them with `{:via, Registry, {Tau.Instance.Registry, key}}` references
+or explicit pid threading via function opts. The one remaining global singleton
+is `Tau.Instance.Registry` — a single named `Registry` that maps well-known
+keys to pids for each Tau instance, keyed by `{instance_id, :pubsub}`,
+`{instance_id, :finch}`, etc. No process uses `name: SomeModule` in its
+`start_link/1`. Call sites that today pass `Tau.PubSub` (an atom) to
+`Phoenix.PubSub.broadcast/3` instead resolve the pid via
+`Tau.Instance.Registry.lookup(:pubsub)` at startup and hold it in their
+GenServer state. Processes that are not GenServers (pure callers) look up the
+pid inline. This is an API-breaking change to every `start_link/1` that
+currently registers under `__MODULE__`.
+
+## Rationale
+
+The root complaint is that atom names embed a topological assumption. The
+purest decomplecting move is to eliminate atom-keyed global process registration
+entirely: processes find each other through the supervision tree structure (pid
+threading from parent to child) or through a single well-known Registry whose
+key space is scoped per instance. This proposal answers the acceptance criterion
+question (a) definitively — no subsystem needs a "natural `name:` opt path"
+because no subsystem uses atom-keyed registration at all.
+
+## Sketch
+
+```elixir
+# lib/tau/instance/registry.ex  (new, replaces scattered atom names)
+defmodule Tau.Instance.Registry do
+  @moduledoc """
+  The one global Registry in the system. Maps {instance_id, role} pairs to
+  pids. Started exactly once per node as the very first child of
+  Tau.Application before any instance-scoped children.
+
+  Well-known roles: :pubsub, :finch, :cb_store, :cost_tracker,
+  :sessions_supervisor, :tools_task_supervisor, and all registry roles
+  (:tools_registry, :hooks_registry, etc.).
+  """
+
+  @registry_name Tau.Instance.Registry   # the one true atom in the system
+
+  def child_spec(_opts) do
+    {Registry, keys: :unique, name: @registry_name}
+  end
+
+  @spec via(atom(), atom()) :: {:via, Registry, {atom(), {atom(), atom()}}}
+  def via(instance_id, role), do: {:via, Registry, {@registry_name, {instance_id, role}}}
+
+  @spec lookup(atom(), atom()) :: pid() | nil
+  def lookup(instance_id, role) do
+    case Registry.lookup(@registry_name, {instance_id, role}) do
+      [{pid, _}] -> pid
+      []         -> nil
+    end
+  end
+end
+```
+
+```elixir
+# lib/tau/application.ex (modified start/2)
+def start(_type, args) do
+  instance_id = Keyword.get(args, :instance_id, :default)
+
+  children = [
+    # The only globally-named process in the system:
+    Tau.Instance.Registry,
+    Tau.Telemetry.Supervisor,
+    otel_reporter_spec(),
+    # PubSub registers itself in Tau.Instance.Registry under {:default, :pubsub}.
+    {Phoenix.PubSub,
+     name: Tau.Instance.Registry.via(instance_id, :pubsub)},
+    {Tau.Registries,     instance_id: instance_id},
+    ...
+    {Finch,
+     name: Tau.Instance.Registry.via(instance_id, :finch)},
+    {Tau.CircuitBreaker.Store,
+     name: Tau.Instance.Registry.via(instance_id, :cb_store),
+     table: :"tau_circuit_breakers_#{instance_id}"},
+    {Tau.Cost.Tracker,
+     name: Tau.Instance.Registry.via(instance_id, :cost_tracker),
+     table: :"tau_cost_counters_#{instance_id}"},
+    ...
+  ]
+
+  opts = [
+    strategy: :rest_for_one,
+    name: Tau.Instance.Registry.via(instance_id, :supervisor)
+  ]
+  Supervisor.start_link(List.flatten(children), opts)
+end
+```
+
+Call sites that previously used `Tau.PubSub` directly:
+
+```elixir
+# Before (in Tau.Session.init/1):
+Phoenix.PubSub.subscribe(Tau.PubSub, "session:#{id}")
+
+# After (instance_id stored in session state at init):
+pubsub_pid = Tau.Instance.Registry.lookup(instance_id, :pubsub)
+Phoenix.PubSub.subscribe(pubsub_pid, "session:#{id}")
+```
+
+GenServers that currently have no instance_id in their state must receive it
+via their `start_link/1` opts (passed from their supervisor). For
+`Tau.Session`, `instance_id` is already in the session opts; the only change is
+using it to resolve names at init.
+
+ETS table names follow the pattern `:"tau_circuit_breakers_#{instance_id}"` and
+`:"tau_cost_counters_#{instance_id}"` — derived from the instance id, not from
+the owning process's registered name (since there is no registered name for the
+owning process). D-044: the table name is not part of the row schema; no version
+bump needed, but the PR description must document the naming convention change.
+
+## Tradeoffs
+
+### Strengths
+
+- No atom names other than `Tau.Instance.Registry` itself; the atom-leakage
+  problem is structurally eliminated rather than managed.
+- Two concurrent Tau instances can coexist without any configuration — the
+  `instance_id` differentiates everything.
+- `{:via, Registry, {Tau.Instance.Registry, {id, role}}}` is a standard OTP
+  pattern; no custom resolution logic needed.
+- ETS table names are deterministic from `instance_id` — answering the
+  acceptance criterion's (c) question with a pure derivation rather than a
+  policy document.
+
+### Weaknesses
+
+- API-breaking: `start_link/1` signatures change for every named child process.
+  Any external caller that starts `Tau.CircuitBreaker.Store` or
+  `Tau.Cost.Tracker` directly (e.g. in tests) must be updated.
+- `{:via, Registry, ...}` lookups are slightly slower than atom-based name
+  lookups at the BEAM level (atom lookup is O(1) hash; Registry lookup is a
+  table read), though the difference is negligible for init-time calls.
+- `Tau.Instance.Registry` itself uses a hard-coded atom — the one necessary
+  global singleton. If two libraries each embed Tau and both start
+  `Tau.Instance.Registry` under the same atom, the collision problem is moved
+  up one level. This is only an issue for library embedding, not for the
+  test-fixture scenario.
+- Modules that today reference `Tau.PubSub` in `Phoenix.PubSub.subscribe/2`
+  must be updated to hold a resolved pid or look it up each time. This is
+  mechanically straightforward but the diff is large (~30 call sites).
+- `Tau.Registries.init/1` currently starts all seven `Registry` children with
+  literal module atoms as names. Under this proposal, each `Registry` uses a
+  `{:via, ...}` name, and `Tau.Registries` must accept `instance_id` and pass
+  computed via-tuples to each child. The `Supervisor.child_spec/1` path for
+  `Registry` accepts `name:` as any term that `Registry.start_link/1` accepts,
+  including a `{:via, ...}` tuple — this must be confirmed against the `Registry`
+  documentation before implementation.
+
+### Costs
+
+- ~30 call-site changes in `lib/` (same as Proposals 2 and 3).
+- ~12 `start_link/1` signature changes to accept `instance_id:` or `name:` /
+  `table:` opts.
+- `Tau.Instance.Registry` module: ~30 lines.
+- `Tau.Registries.init/1`: ~25-line change to accept `instance_id` and derive
+  names for all seven `Registry` children.
+- All tests that start named children directly must be updated to pass
+  `instance_id` or a `{:via, ...}` name.
+- The test-fixture scenario is resolved as a side effect: tests pass a unique
+  `instance_id` to `Tau.Application.start/2` (or start individual children via
+  `start_supervised` with explicit `via` names).
+
+## Dependencies
+
+- Confirmation that `Phoenix.PubSub.start_link/1` accepts `name: {:via, Registry, ...}`.
+  (Phoenix.PubSub 2.x supports any GenServer name; `{:via, ...}` is a valid
+  GenServer name — confirmed by OTP GenServer name contract.)
+- Confirmation that `Finch.start_link/1` accepts `name: {:via, Registry, ...}`.
+  (Finch 0.x uses `GenServer.start_link/3` which accepts any OTP name — confirmed.)
+- `CircuitBreaker.Store` and `Cost.Tracker` accept `table:` in `start_link/1`.
+
+## Confidence
+
+Medium. The `{:via, Registry, ...}` mechanism is well-specified OTP and is used
+in production Elixir systems (Phoenix.PubSub's own internals use it). The main
+uncertainty is whether `Registry.start_link/1` accepts a `{:via, ...}` tuple as
+its own `name:` opt (bootstrapping question: can a Registry register itself
+via another Registry?). If it cannot, `Tau.Registries` children must be
+launched without a `{:via, ...}` name and instead registered manually after
+startup via `Registry.register/3` — adding complexity. This is the key
+prototype risk to resolve before committing.
+
+## Prior art / references
+
+- OTP `GenServer` name forms: `https://erlang.org/doc/man/gen_server.html#start_link-4`
+  — explicitly permits `{:via, Module, term()}`.
+- `Phoenix.PubSub` `{:via, Registry, ...}` usage:
+  `https://hexdocs.pm/phoenix_pubsub/Phoenix.PubSub.html#start_link/1` — `name`
+  is any valid GenServer name.
+- Elixir `Registry` as a process locator under dynamic supervision:
+  `https://hexdocs.pm/elixir/Registry.html#module-using-in-via`.
+- Erlang `global` module avoidance: Tau's OTP non-negotiables §4 — this
+  proposal avoids `:global` while removing atom-keyed `name:` registration.

--- a/docs/problems-archive-v1-modules/tau-infrastructure/subproblems/global-name-collision/solution.md
+++ b/docs/problems-archive-v1-modules/tau-infrastructure/subproblems/global-name-collision/solution.md
@@ -1,0 +1,171 @@
+---
+template_version: 1
+template_name: solution
+parent_problem: problem.md
+node_kind: leaf
+synthesised_from: [proposals/proposal-2.md]
+selection_method: single
+revision: 0
+---
+
+# Solution: Thread `instance_id` through `Application.start/2`; derive all names via `Tau.Names`; store in `:persistent_term`
+
+## Recommendation
+
+Adopt Proposal 2 in full. Introduce `Tau.Names` — a plain struct module with a
+`compute/1` function that derives the complete set of process and ETS table names
+from a single `instance_id` atom — and store the result once in `:persistent_term`
+at `Application.start/2`. Every call site that currently references `Tau.PubSub`,
+`Tau.Providers.Finch`, or a named registry by bare atom is updated to read
+`Tau.Names.get().field` instead. `CircuitBreaker.Store` and `Cost.Tracker` each
+gain a five-line change to accept `name:` and `table:` opts; `Tau.Registries`
+is updated to thread per-name opts to its seven `Registry` children. The
+`:default` instance id preserves every existing atom name, so deployed
+configurations require no migration and all existing tests that do not start a
+second instance are unaffected by the call-site rewrite.
+
+## Selected from
+
+- **Chosen:** `proposals/proposal-2.md`
+- **Why chosen:** See scoring table below. Proposal 2 is the only proposal that
+  achieves deep decomplecting (deployment topology fully separated from process
+  identity), satisfies all three acceptance-criterion sub-questions in one
+  atomic change, and does so at a bounded, mechanical cost with no
+  performance regression on hot paths. Proposal 1 satisfies only the
+  test-fixture scenario, leaves the production collision latent, and relies on
+  `Application.put_env/3` — an OTP-NN §1 violation that also races under
+  parallel test runs. Proposal 3 adds a GenServer hop on every hot-path name
+  resolution, increasing render-loop latency without offering capabilities that
+  `:persistent_term` does not already provide for a read-mostly name store.
+  Proposal 4 structurally eliminates atom registration (deepest decomplecting)
+  but at High migration cost and introduces a bootstrapping uncertainty
+  (`Registry` self-naming via `{:via, ...}`) that would require a prototype
+  before commitment; the irreversibility of its API-breaking `start_link/1`
+  changes makes it poorly suited to land first.
+
+### Scoring table
+
+| #  | Fit        | Decomplecting depth | Migration cost | Risk   | Reversibility |
+|----|------------|---------------------|----------------|--------|---------------|
+| 1  | Partially  | Surface             | Low            | Medium | Easy          |
+| 2  | Yes        | Deep                | Medium         | Low    | Easy          |
+| 3  | Yes        | Substantial         | Medium         | Medium | Easy          |
+| 4  | Yes        | Deep                | High           | Medium | Hard          |
+
+**Proposal 1 — Partially/Surface:** Eliminates the test-fixture collision only;
+the production multi-tenant collision remains. `Application.put_env/3` for
+runtime name state violates OTP-NN §1 and races under async ExUnit. The
+`Tau.Names` module it introduces is also needed by Proposal 2, so its useful
+subset is a subset of P2.
+
+**Proposal 2 — Yes/Deep:** `Tau.Names.compute/1` is a pure derivation; the
+`:persistent_term` store is set once at startup and read at O(1) cost; the
+`:default` clause preserves all existing atoms. Both the test-fixture and
+production multi-tenant scenarios are resolved. Call-site churn (~30 locations)
+is entirely mechanical and verifiable with `grep`.
+
+**Proposal 3 — Yes/Substantial:** Names are held in a GenServer; every hot-path
+dispatch adds a mailbox hop unless callers cache the map at `init/1`. This
+trades a trivial `:persistent_term` read for per-process state management with
+no benefit over P2 for a read-mostly store. The "monitored crash cascades"
+argument is correct OTP reasoning but the blast radius (names crash → all
+sessions crash) is higher than desired; `:persistent_term` is appropriate for
+data that does not need supervised lifecycle.
+
+**Proposal 4 — Yes/Deep, but Hard reversibility:** Pure structural fix — no atom
+names except one. Deferred because: (a) the bootstrapping question (can
+`Tau.Registries` children start under `{:via, ...}` names supplied by
+`Tau.Instance.Registry`?) requires a prototype to resolve; (b) API-breaking
+`start_link/1` changes are difficult to revert if the bootstrapping answer is
+"no"; (c) Medium migration cost is an underestimate given the test-suite changes
+needed. P4 is the right long-term destination; P2 lands cleanly on the path to
+it — `Tau.Names.compute/1` can be replaced by a `{:via, ...}` derivation in a
+future PR without affecting any call sites.
+
+## What changes
+
+- **New file `lib/tau/names.ex`** — `Tau.Names` struct + `compute/1` + `get/0`
+  + `get/1`. ~70 lines. `compute(:default)` returns the existing module atoms
+  unchanged; `compute(id)` appends `".#{id}"` or `"_#{id}"` per convention.
+- **`lib/tau/application.ex`** — `start/2` reads `instance_id` from args
+  (default `:default`), calls `Tau.Names.compute/1`, stores result in
+  `:persistent_term` under `:tau_names` (and `{:tau_names, instance_id}` for
+  non-default), then threads `names.*` fields into every named child's
+  `start_link/1` opts. The supervisor itself is named `names.supervisor`.
+- **`lib/tau/circuit_breaker/store.ex`** — `start_link/1` and `init/1` accept
+  `name:` and `table:` opts with defaults `__MODULE__` and `:tau_circuit_breakers`.
+- **`lib/tau/cost/tracker.ex`** — same pattern as `CircuitBreaker.Store`.
+- **`lib/tau/registries.ex`** — `start_link/1` and `init/1` accept a `names:`
+  struct and pass `names.<role>_registry` to each of the seven `Registry`
+  children.
+- **~30 call sites in `lib/`** — each bare `Tau.PubSub`, `Tau.Providers.Finch`,
+  and registry-module-atom reference replaced by `Tau.Names.get().<field>`.
+  Verifiable with `grep -rn "Tau\.PubSub\|Tau\.Providers\.Finch\|Tau\.Tools\.Registry\|Tau\.Sessions\.Registry"`.
+- **D-044 note** — document in the PR description that the ETS table name is not
+  part of the circuit-breaker row schema; `@schema_version` does not need a
+  bump.
+
+## What does not change
+
+- All `start_link/1` external signatures remain backward-compatible for the
+  `:default` instance (all defaults match the current atoms).
+- The `Tau.Provider` behaviour, all provider adapters, and the session FSM logic
+  are untouched.
+- `Tau.Registries` supervisor strategy and child count.
+- `Tau.Sessions.Supervisor` registration mechanism (it receives its `name:` from
+  the application; internal session pids continue using the sessions Registry).
+- Test files that do not start a second instance compile and pass without change.
+- `docs/spec/SPEC-CIRCUIT-BREAKER.md` D-044 schema version — no row-layout change.
+
+## Migration sketch
+
+1. Land `lib/tau/names.ex` with `compute/1` and `get/0`/`get/1`. No callers yet;
+   purely additive. Verify `compute(:default)` round-trips identical atoms in an
+   `iex -S mix` session.
+2. Update `CircuitBreaker.Store` and `Cost.Tracker` to accept `name:` / `table:`
+   opts with defaults. `mix test` must still be green (defaults preserve existing
+   atoms).
+3. Update `Tau.Registries` to accept `names:` struct and thread registry names to
+   children. Add `names: Tau.Names.compute(:default)` to its `Application.start/2`
+   entry to pass the regression baseline.
+4. Update `Application.start/2` to call `Tau.Names.compute/1` and store in
+   `:persistent_term`. Thread all `names.*` fields to children. `mix test` green.
+5. Sweep ~30 call sites from bare atoms to `Tau.Names.get().<field>`. `grep`
+   post-sweep confirms zero residual bare references. `mix compile --warnings-as-errors`
+   and `mix test` green.
+6. Add a one-test property asserting that `Tau.Names.compute(:default)` returns
+   the historically-expected atoms (regression guard).
+
+## Open questions
+
+- Does any call site hold a reference to `Tau.PubSub` as a compiled-in constant
+  in a match spec (e.g. in an ETS `match_spec` or a `with`-pattern on a returned
+  atom)? The `grep` sweep in step 5 would catch raw module references but not
+  indirect ones stored in structs at compile time. Manual audit of
+  `CircuitBreaker.Store` and `Cost.Tracker` match specs is recommended.
+- `Tau.Memory.Supervisor` and `Tau.Extensions.Loader` — neither is in the named
+  children list today, but `embedding_worker.ex:106` holds a Finch name mismatch
+  (noted as out of scope). After this change, `Tau.Names.get().finch` is the
+  canonical resolution; the embedding worker's mismatch should be fixed as a
+  follow-on in the tau-memory audit.
+- `:persistent_term.put/2` in `Application.start/2` leaves an orphaned term if
+  the supervisor tree fails to start mid-way. Documented as benign (no sessions
+  can form), but a `try/after` guard could clean it up. Out of scope for this PR;
+  worth a follow-up if the startup failure mode becomes a test concern.
+
+## Linked sub-problems / proposals
+
+- `proposals/proposal-1.md` — Test-isolation shim via `Application.put_env/3`
+  (narrowly satisfies test-fixture scenario; OTP-NN §1 violation; superseded by P2)
+- `proposals/proposal-2.md` — Thread `instance_id` through `Application.start/2`;
+  `:persistent_term` name store **(selected)**
+- `proposals/proposal-3.md` — `Tau.Instance` GenServer holds name-set; names
+  resolved via `GenServer.call` (correct OTP reasoning; hot-path mailbox hop
+  unnecessary for a read-mostly store)
+- `proposals/proposal-4.md` — Eliminate atom names entirely; `{:via, Registry, ...}`
+  everywhere (deepest fix; deferred pending bootstrapping prototype; P2 is on
+  the path to this)
+
+## Revision history
+
+- (revision 0 — initial)

--- a/docs/problems-archive-v1-modules/tau-infrastructure/subproblems/global-name-collision/validation.md
+++ b/docs/problems-archive-v1-modules/tau-infrastructure/subproblems/global-name-collision/validation.md
@@ -1,0 +1,477 @@
+---
+template_version: 1
+template_name: validation
+parent_solution: solution.md
+parent_problem: problem.md
+toulmin_complete: true
+falsification_attempted: true
+falsification_outcome: partially_falsified — claim/3
+revision_triggered: none
+---
+
+# Validation: Thread `instance_id` through `Application.start/2`; derive names via `Tau.Names`; store in `:persistent_term`
+
+## Overview
+
+The solution asserts that a new `Tau.Names` struct module plus a one-shot
+`:persistent_term` publish at `Application.start/2`, combined with `name:` /
+`table:` opts on `CircuitBreaker.Store` / `Cost.Tracker` and a `names:` opt on
+`Tau.Registries`, eliminates both the test-fixture and the production
+multi-tenant single-instance collision while preserving the default deployment
+behaviour. This validation extracts **8 claims** from the Recommendation,
+What-changes, and What-does-not-change sections, runs full Toulmin on each,
+and applies an explicit falsification strategy per claim. Outcome: 7 claims
+withstood; **Claim 3 is partially falsified** — the solution's "~five-line
+change" / "~30 call sites" sizing is an under-estimate (the Store/Tracker
+module-internal `@table` attribute is referenced at 10 + 3 ETS call sites
+that must all be converted to runtime lookup; total call-site sweep is
+≥176 across `lib/` + `test/`). The narrowed qualifier does not change the
+chosen approach; no revision is triggered.
+
+## Toulmin per claim
+
+The MITRE empirical study on Toulmin formalism found that "participants
+found it difficult to generate Toulmin structures, and their structures
+varied greatly even though they started with the same content"
+(https://www.mitre.org/news-insights/publication/empirical-evaluation-structured-argumentation-using-toulmin-argument).
+This template enforces all six components explicitly with prompts to
+counter that variance.
+
+### Claim 1: `Tau.Names.compute/1` is a pure derivation; `:persistent_term` store is set once at startup and read at O(1) cost; the `:default` clause preserves all existing atoms.
+
+- **Claim (C):** A new `Tau.Names` struct module exposes `compute/1` (pure)
+  + `get/0`/`get/1` (reads from `:persistent_term`), populated once by
+  `Application.start/2`; `compute(:default)` returns exactly the current
+  module atoms (`Tau.PubSub`, `Tau.Providers.Finch`, `Tau.CircuitBreaker.Store`,
+  `:tau_circuit_breakers`, `Tau.Cost.Tracker`, `:tau_cost_counters`,
+  `Tau.Supervisor`, the seven `Registry` atoms).
+- **Grounds (G):** Proposal 2's sketch defines the struct with 16 fields and
+  the `:default` clause verbatim (`proposals/proposal-2.md:101-120`). The
+  current named-children atoms are observable at
+  `lib/tau/application.ex:68` (`Tau.PubSub`),
+  `lib/tau/application.ex:78` (`Tau.Providers.Finch`),
+  `lib/tau/application.ex:80` (`Tau.CircuitBreaker.Store`),
+  `lib/tau/application.ex:93` (`Tau.Supervisor`),
+  `lib/tau/registries.ex:56-63` (seven `Registry` atoms),
+  `lib/tau/circuit_breaker/store.ex:47` (`:tau_circuit_breakers`), and
+  `lib/tau/cost/tracker.ex:60` (`:tau_cost_counters`).
+  `:persistent_term`'s read characteristics are documented at
+  https://www.erlang.org/doc/man/persistent_term — reads are constant time and
+  do not copy small terms.
+- **Warrant (W):** A pure function whose output is fixed at startup and
+  published to a read-mostly term store is the standard BEAM idiom for
+  zero-overhead configuration distribution; this matches the existing pattern
+  at `lib/tau/settings/cache.ex:48` (`:persistent_term.put`) +
+  `lib/tau/settings.ex:14` (`:persistent_term.get`).
+- **Qualifier (Q):** Holds provided `Application.start/2` writes `:tau_names`
+  before any child reads it (sequential within `start/2` — safe) and provided
+  no caller mutates the published struct after startup (it is a record value,
+  not a process).
+- **Rebuttal (R):** A test that calls `Tau.Names.get/0` before
+  `Application.start/2` has been re-entered with the new code (e.g. an
+  earlier-loaded test harness) sees `:undefined`. The `get/0` default-arg
+  semantics must specify a fallback (or pass-through to the historical atoms)
+  to avoid breaking the "tests that don't start a second instance" promise.
+- **Backing (B):** OTP-NN §1 ("stateful subsystems run as supervised processes;
+  no module-level mutable state") is not violated because `:persistent_term`
+  is published exactly once at supervisor startup, not on a runtime write path
+  — the pattern is the same `Tau.Settings.Cache` already follows
+  (`lib/tau/settings/cache.ex:3-28`). Erlang/OTP documentation on
+  `:persistent_term` is the type-level authority.
+
+#### Falsification attempt for claim 1
+
+- **Strategy:** Dependency check + counter-example construction.
+- **Attempt:** (1) Confirmed `:persistent_term` is in use in this codebase at
+  the cited Settings cache sites and 5 other modules
+  (`tui/runtime_opts.ex:38,42,45`, `tool/validator.ex:81,92,99`,
+  `coding_agent/tau_context.ex:249,259`, `coding_agent/tau_context/router.ex:336`),
+  so the BEAM build does support it. (2) Attempted to construct a code state
+  where `compute(:default)` would NOT round-trip the historical atoms:
+  inspected `proposals/proposal-2.md:110-120` and matched each field to the
+  current source-of-truth atom. All 9 atoms named in the `:default` branch
+  match observable startup atoms. (3) Attempted to construct a caller that
+  reads `Tau.Names.get/0` before `Application.start/2` runs — possible only
+  in a module-attribute or compile-time context, which is the genuine
+  rebuttal already conceded.
+- **Outcome:** withstood (subject to the documented rebuttal — `get/0` must
+  have a `:default`-bearing fallback, which the solution's "regression
+  baseline" step 6 implies).
+- **Action:** None; carry the rebuttal forward as an implementation note.
+
+### Claim 2: Both the test-fixture and production multi-tenant collision scenarios are resolved by Proposal 2 in one atomic change.
+
+- **Claim (C):** A second Tau OTP application started in the same BEAM with
+  a distinct `instance_id` no longer collides on `Tau.PubSub`,
+  `Tau.Providers.Finch`, `Tau.CircuitBreaker.Store`, `Tau.Cost.Tracker`,
+  `Tau.Supervisor`, any of the seven `Registry` children, or the ETS tables.
+- **Grounds (G):** All process registrations the second instance would
+  otherwise collide on are passed through `name:` opts at
+  `proposals/proposal-2.md:54-71`, and ETS tables are created via the
+  parameterised `table:` opt (sketch lines 63, 88-89 of proposal-2). The
+  collision-producing sites today are enumerated in `problem.md:26-39`
+  and verified against the source: `lib/tau/application.ex:68,78,80,93`,
+  `lib/tau/circuit_breaker/store.ex:65`, `lib/tau/cost/tracker.ex:73`,
+  `lib/tau/registries.ex:51,56-63`.
+- **Warrant (W):** A process registration collision in BEAM is caused only
+  by two `start_link` calls supplying the same `name:` atom; removing the
+  hard-coded names by threading parameterised atoms removes the structural
+  cause. Same logic applies to `:named_table` ETS: distinct atoms → distinct
+  tables.
+- **Qualifier (Q):** Holds for *the named registrations enumerated above*.
+  Does NOT speak to anonymous-but-globally-discovered resources (e.g. a
+  `:global` registration — none observed in the cited grounds, consistent
+  with `.claude/rules/otp-non-negotiables.md` §4) or to shared file-system
+  state (out of scope for this node).
+- **Rebuttal (R):** If a downstream library called by Tau (e.g. a Finch
+  pool plug or a Phoenix.PubSub adapter) registers its own auxiliary
+  process under a hard-coded atom keyed on the parent name, two instances
+  could collide there. The fix would land in that downstream library, not
+  in `Tau.Names`. Not observed in current Tau code.
+- **Backing (B):** OTP `Registry` and `gen_server` `name:` semantics
+  (Erlang/OTP documentation, https://www.erlang.org/doc/man/gen_server#start_link-4).
+
+#### Falsification attempt for claim 2
+
+- **Strategy:** Edge-case enumeration over the named-resource set from
+  `problem.md`.
+- **Attempt:** Walked each of the 7 named children in
+  `lib/tau/registries.ex:56-63` plus the 4 in `lib/tau/application.ex` plus
+  the 2 ETS tables. For each, confirmed proposal-2's sketch threads the
+  parameterised atom. Additionally checked for indirect bare-atom
+  references: `grep -rn "Tau\.PubSub\|Tau\.Providers\.Finch" lib/` returns
+  25 hits, and the seven `Registry` atoms return 63 hits in `lib/` — all
+  would need conversion to `Tau.Names.get().<field>`; the proposal commits
+  to this sweep in `solution.md:101-103`.
+- **Outcome:** withstood. The structural cause of collision is removed for
+  every site enumerated.
+- **Action:** None.
+
+### Claim 3: Call-site churn is "~30 locations", "entirely mechanical and verifiable with grep"; the change to `Store` / `Tracker` is "a five-line change each".
+
+- **Claim (C):** The total mechanical edit fan-out is bounded at roughly
+  30 call sites (per `solution.md:101-103`) and the `CircuitBreaker.Store`
+  / `Cost.Tracker` modifications are "a five-line change to accept `name:`
+  and `table:` opts" (per `solution.md:23-24`).
+- **Grounds (G):** `solution.md:101-103` cites the grep:
+  `Tau\.PubSub\|Tau\.Providers\.Finch\|Tau\.Tools\.Registry\|Tau\.Sessions\.Registry`.
+  Measured today against `lib/`: `Tau.PubSub | Tau.Providers.Finch` → 25
+  hits; seven `Registry` atoms → 63 hits; **total 88 in `lib/` alone**.
+  Adding `test/`: `Tau.PubSub | Tau.Providers.Finch` → 151 hits;
+  registry atoms not separately counted but non-zero. The Store's `@table`
+  module attribute is referenced in 10 internal ETS call sites
+  (`lib/tau/circuit_breaker/store.ex:56,76,89,102,118,133,186,247,269`)
+  and Tracker's `@table` at 3 sites (`lib/tau/cost/tracker.ex:77,81,130,155`).
+  Each of those references must be converted from a compile-time module
+  attribute to a runtime lookup (`opts[:table]` → state field), which is
+  more than five lines per module.
+- **Warrant (W):** Code metric: the solution's edit fan-out can be bounded
+  only by counting actual reference sites at named atoms. A module attribute
+  embedded in macro-expanded `:ets.update_counter(@table, …)` calls is
+  expanded at compile time to the literal atom; converting to runtime
+  requires changing both the `init/1` to store the table name in state and
+  every call site to thread that state.
+- **Qualifier (Q):** The claim survives in narrowed form: the conversion is
+  still "entirely mechanical and grep-verifiable" and the per-site change
+  is small, but the absolute count is materially higher than 30 in `lib/`
+  alone and well above 100 once `test/` files (151 hits for PubSub/Finch
+  alone) are included; the Store/Tracker edit is closer to 15-25 lines per
+  module than 5.
+- **Rebuttal (R):** If the implementer chooses to leave the `@table`
+  module attribute as the default *fallback* and only consults
+  `opts[:table]` when one is supplied (i.e. `@table` is kept as a
+  compile-time default), the per-module edit can stay near the five-line
+  target — at the cost of two parallel code paths in `Store` and
+  `Tracker`. This rebuttal does not save the "~30 sites" figure.
+- **Backing (B):** Observable grep results in the current repo (counted
+  above) and the file-level structure of
+  `lib/tau/circuit_breaker/store.ex` / `lib/tau/cost/tracker.ex`.
+
+#### Falsification attempt for claim 3
+
+- **Strategy:** Counter-example construction (count the actual sites).
+- **Attempt:** Ran `grep -rn "Tau\.PubSub\|Tau\.Providers\.Finch" lib/`
+  → 25; `grep -rn "Tau\.Tools\.Registry\|Tau\.Sessions\.Registry\|
+  Tau\.Hooks\.Registry\|Tau\.Commands\.Registry\|Tau\.Skills\.Registry\|
+  Tau\.MCP\.Registry\|Tau\.Providers\.RateLimiter\.Registry" lib/` → 63;
+  `grep -rn "Tau\.PubSub\|Tau\.Providers\.Finch" test/` → 151. Inspected
+  `lib/tau/circuit_breaker/store.ex` for `@table` occurrences → 10 internal
+  ETS call sites; `lib/tau/cost/tracker.ex` for `@table` → 3 internal
+  sites. The total mechanical conversion fan-out is several-fold larger
+  than "~30".
+- **Outcome:** **partially falsified.** The chosen approach still works —
+  the conversion remains mechanical and grep-verifiable — but the
+  cost-estimate granularity in `solution.md` understates the real edit
+  surface by a factor of 3-6×. Implementer must size the work accordingly.
+- **Action:** Narrow Qualifier in place (done above). No revision to the
+  chosen approach is required; flag in **Outstanding doubts** for the
+  parent validator to inherit so PR-sizing decisions are realistic. The
+  selector's preference for P2 over P4 ("Medium" migration cost) is
+  unchanged because P4's cost was rated "High" and that ordering is
+  preserved even with the corrected P2 size.
+
+### Claim 4: `:persistent_term`-stored names introduce no hot-path latency overhead vs the current bare-atom dispatch.
+
+- **Claim (C):** Reading `Tau.Names.get().<field>` on every hot-path
+  PubSub broadcast / Finch request / Registry lookup adds zero
+  measurable latency compared with the current literal-atom usage.
+- **Grounds (G):** `:persistent_term.get/2` is a constant-time
+  unboxed-term read (Erlang docs:
+  https://www.erlang.org/doc/man/persistent_term#description). The
+  existing `Tau.Settings.Cache.get/0` uses the same pattern on hot paths
+  with no observed regression
+  (`lib/tau/settings/cache.ex:28`; `lib/tau/settings.ex:14`).
+- **Warrant (W):** A read-mostly term published once and read many is
+  precisely the workload `:persistent_term` is engineered for; copying
+  the term into the calling process is avoided when the term is small
+  (the names struct holds 16 atoms — small).
+- **Qualifier (Q):** Holds provided the names struct stays small (< a
+  few hundred bytes) and is not republished on a hot path. Both
+  conditions are satisfied by the solution's "set once at startup" design.
+- **Rebuttal (R):** If a future commit republishes the names term on
+  every settings reload (i.e. via `Watcher`), every running process
+  triggers a global GC by Erlang's persistent-term semantics. The
+  solution does NOT do this, but the door is open.
+- **Backing (B):** Erlang/OTP `persistent_term` documentation
+  (https://www.erlang.org/doc/man/persistent_term) — explicitly recommends
+  this pattern for read-mostly configuration distribution; warns against
+  frequent puts (GC cost).
+
+#### Falsification attempt for claim 4
+
+- **Strategy:** Performance/scaling check (informal complexity analysis).
+- **Attempt:** Compared the hot-path operation count under current code
+  (literal atom load, ≈ 0 cycles) vs proposed (one `:persistent_term.get/1`
+  + one struct field access ≈ low single-digit nanoseconds). The pattern
+  is already in production via `Tau.Settings.Cache` with no regression.
+- **Outcome:** withstood.
+- **Action:** None.
+
+### Claim 5: D-044 (circuit-breaker ETS row-layout schema version) does NOT need to be bumped.
+
+- **Claim (C):** The ETS table *name* parameterisation is independent of
+  the row schema; `@schema_version` stays at 1.
+- **Grounds (G):** D-044 is scoped to the **positional field layout** of
+  the row (`docs/spec/SPEC-CIRCUIT-BREAKER.md:294-300` and inline at
+  `lib/tau/circuit_breaker/store.ex:24-48`): "Field positions MUST NOT
+  be renumbered without bumping `@schema_version`". Renaming the table
+  changes no field positions; `update_counter` and `select_replace`
+  still operate on the same {provider_key, state_atom, failure_count,
+  success_count, opened_at_ms, probe_slot} tuple.
+- **Warrant (W):** D-044's invariant is structural (row-layout), not
+  identity (table-name). The schema-version mechanism guards data
+  migration semantics, which are unaffected by renaming the container.
+- **Qualifier (Q):** Holds provided no PR also alters row positions in
+  the same change. The solution explicitly disclaims field-layout
+  edits (`solution.md:118`).
+- **Rebuttal (R):** If a future migration tool keys cached schema state
+  by `{table_name, schema_version}` rather than `schema_version` alone,
+  the renaming could surface as a transient version mismatch. No such
+  tool exists today (`grep -rn "schema_version" lib/` shows
+  `Store.schema_version/0` only; no consumer cache).
+- **Backing (B):** `docs/spec/SPEC-CIRCUIT-BREAKER.md:294-300` (D-044
+  text) is the authoritative source.
+
+#### Falsification attempt for claim 5
+
+- **Strategy:** Dependency check (read the D-044 spec text).
+- **Attempt:** Read the cited D-044 paragraph; confirmed scope is "row
+  layout" / "field positions" only. Checked for downstream consumers of
+  `Store.schema_version/0` via grep — none beyond the Store itself.
+- **Outcome:** withstood.
+- **Action:** None.
+
+### Claim 6: All `start_link/1` external signatures remain backward-compatible for the `:default` instance.
+
+- **Claim (C):** Existing callers of `Tau.CircuitBreaker.Store.start_link/1`,
+  `Tau.Cost.Tracker.start_link/1`, `Tau.Registries.start_link/1`, and the
+  flow at `Tau.Application.start/2` continue to work unchanged when
+  `instance_id` is `:default`.
+- **Grounds (G):** Proposal 2's `start_link/1` modifications take `opts`
+  with defaults (`name: __MODULE__`, `table: :tau_circuit_breakers`),
+  preserving the call-site shape. Today's signatures are
+  `def start_link(opts \\ [])` at `lib/tau/circuit_breaker/store.ex:65`
+  and `lib/tau/cost/tracker.ex:73`. Defaults preserve historical atoms
+  (per solution.md:23-24 + proposal-2.md sketch).
+- **Warrant (W):** Adding new opt keys with defaults is a backward-
+  compatible Elixir API change; callers that pass no opts get the
+  prior behaviour.
+- **Qualifier (Q):** Holds for callers that pass at most an empty
+  keyword list. A caller that already passes a `name:` opt would
+  have its value preserved.
+- **Rebuttal (R):** If `Tau.Registries.init/1` currently disregards
+  opts (today it pattern-matches `init(_opts)` at `lib/tau/registries.ex:54`),
+  changing the signature to read `opts[:names]` and threading per-child
+  names is backward-compatible only if missing `:names` produces a
+  defaulted name set — the proposal's `Tau.Application.start/2` change
+  explicitly threads `names: Tau.Names.compute(:default)` (step 3 of
+  migration), so this holds; without that, internal-only callers
+  break.
+- **Backing (B):** Elixir keyword-list opts convention (Elixir Style
+  Guide); current Tau pattern at `lib/tau/registries.ex:51`
+  (`Supervisor.start_link(__MODULE__, opts, name: __MODULE__)`).
+
+#### Falsification attempt for claim 6
+
+- **Strategy:** Type-level / API-shape check.
+- **Attempt:** Inspected the current `start_link/1` arities and
+  `init/1` shapes for the three modules. Confirmed all accept `opts`
+  today and the modifications keep arity and add defaults rather
+  than required positional args.
+- **Outcome:** withstood.
+- **Action:** None.
+
+### Claim 7: Test files that do not start a second instance compile and pass without change.
+
+- **Claim (C):** The `mix test` suite continues green after the change
+  for tests that exercise only the `:default` instance.
+- **Grounds (G):** Defaults preserve historical atoms (per Claim 1 +
+  Claim 6); test fixtures keying on those atoms (e.g.
+  `test/tau/circuit_breaker/store_property_test.exs:20` —
+  `@table Store.table()`) read through the `Store.table/0` accessor,
+  which would now read the runtime-stored table name but for
+  `:default` still returns `:tau_circuit_breakers`.
+- **Warrant (W):** Backward-compatible defaults + accessor-mediated
+  table-name access = test invariance for the default instance.
+- **Qualifier (Q):** Holds for tests that (a) do not start a second
+  Tau instance and (b) access ETS table names via `Store.table/0` /
+  `Tracker.table/0` rather than hard-coded `:tau_circuit_breakers` /
+  `:tau_cost_counters` literals. Today there are no test files
+  hard-coding those literals (`grep -rn ":tau_circuit_breakers\|
+  :tau_cost_counters" test/` returns one documentation comment at
+  `test/tau/cost_test.exs:8` — non-load-bearing).
+- **Rebuttal (R):** A test that snapshots `:erlang.registered/0` and
+  asserts on specific atoms would see ordering / membership changes
+  if the supervisor's own name is parameterised. No such test
+  observed via grep.
+- **Backing (B):** Same Elixir-opts/default-arg convention as Claim 6.
+
+#### Falsification attempt for claim 7
+
+- **Strategy:** Counter-example construction over `test/` for direct
+  reliance on hard-coded ETS table atoms.
+- **Attempt:** Ran `grep -rn ":tau_circuit_breakers\|:tau_cost_counters"
+  test/`. Only hit is a comment in `test/tau/cost_test.exs:8`. No
+  test depends on the literal atom directly.
+- **Outcome:** withstood.
+- **Action:** None.
+
+### Claim 8: P2 is strictly preferable to P1 / P3 / P4 on the stated scoring criteria.
+
+- **Claim (C):** Per the scoring table in `solution.md:47-53`, P2
+  dominates P1 (Surface vs Deep, P1 violates OTP-NN §1), P3 (P3 adds
+  GenServer hop, no benefit for read-mostly data), and P4 (P4 is
+  Hard reversibility / High cost with bootstrapping uncertainty).
+- **Grounds (G):** Scoring rationale at `solution.md:55-83`:
+  - P1: `Application.put_env/3` for runtime state — explicit OTP-NN §1
+    violation (`.claude/rules/otp-non-negotiables.md`).
+  - P3: GenServer name resolution adds a mailbox hop per dispatch
+    vs `:persistent_term.get/1` constant-time read.
+  - P4: Pure `{:via, Registry, ...}` requires self-bootstrapping the
+    instance registry — open prototype question; API-breaking
+    `start_link/1` changes are not easily revertible.
+- **Warrant (W):** Standard engineering-trade-off ranking: an approach
+  that satisfies all acceptance criteria at bounded cost with reversible
+  changes is preferred over one that adds runtime overhead with no
+  capability gain (P3), violates a stated invariant (P1), or commits
+  to an irreversible structural shift without a prototype (P4).
+- **Qualifier (Q):** Holds *for the immediate landing of this
+  decomposition*. P4 remains the eventual destination; P2 explicitly
+  positions `Tau.Names.compute/1` as a substitutable layer that a
+  future `{:via, ...}` derivation can replace without call-site
+  churn (`solution.md:78-83`).
+- **Rebuttal (R):** If a future requirement forces dynamic
+  per-session name allocation (e.g. each session has its own
+  PubSub topic-space), a `Tau.Instance` GenServer or `{:via, ...}`
+  registration becomes preferable. P2 does not preclude this
+  evolution.
+- **Backing (B):** OTP-NN invariants (`.claude/rules/otp-non-negotiables.md`),
+  the design-reasoning skill's reversibility/migration-cost matrix
+  (referenced in `CLAUDE.md` → `design-reasoning`).
+
+#### Falsification attempt for claim 8
+
+- **Strategy:** Prior-art counter-case + dependency check.
+- **Attempt:** (1) Confirmed `:persistent_term`-as-name-cache pattern
+  is already accepted in this codebase (`Tau.Settings.Cache`,
+  `Tau.TUI.RuntimeOpts`, `Tau.Tool.Validator`) — no prior-art counter-case
+  internally. (2) Confirmed P1's reliance on `Application.put_env/3`
+  for runtime state is forbidden by `.claude/rules/otp-non-negotiables.md`
+  §1 (module-level mutable state via `Application.put_env/3`). (3) P3's
+  GenServer hop on a read-mostly path is unjustifiable when
+  `:persistent_term` provides O(1) reads without supervised
+  lifecycle.
+- **Outcome:** withstood.
+- **Action:** None.
+
+## Cross-claim consistency
+
+Claims are internally consistent. Two tensions exist and both resolve:
+
+1. **Claim 3 (partial falsification on cost) vs Claim 8 (P2 chosen on cost
+   grounds).** If P2's true cost is 3-6× larger than estimated, does that
+   change the P2-vs-P4 ranking? Resolution: P4's cost was rated "High" and
+   includes API-breaking `start_link/1` changes plus a prototype to resolve
+   the bootstrapping question. Even with P2's true cost upgraded from "low
+   end of Medium" to "high end of Medium / low end of High", P4's
+   irreversibility (Hard) and prototype-dependency remain decisive. The
+   ranking holds.
+
+2. **Claim 5 (D-044 unaffected) vs Claim 3 (Store internals change).** The
+   internal `@table → opts[:table]` conversion touches `init/1`,
+   `lookup/2`, `update_counter/3`, `select_replace/2` call sites but
+   changes **no row positions**. D-044's invariant is scoped to row
+   positions only; the table-name change is orthogonal. Consistent.
+
+## Falsification summary
+
+| # | Claim (short) | Strategy | Outcome | Action |
+|---|---|---|---|---|
+| 1 | `Tau.Names.compute/1` pure; `:persistent_term` O(1); `:default` preserves atoms | dependency + counter-example | withstood | none |
+| 2 | Both test-fixture and prod multi-tenant collisions resolved | edge-case enumeration | withstood | none |
+| 3 | ~30 call sites; 5-line module change; "entirely mechanical" | counter-example (count sites) | partially falsified | narrow qualifier (done); flag for PR sizing |
+| 4 | `:persistent_term` reads add no hot-path latency | performance/scaling | withstood | none |
+| 5 | D-044 schema version not bumped | dependency check | withstood | none |
+| 6 | `start_link/1` signatures backward-compatible for `:default` | type/API check | withstood | none |
+| 7 | Tests that don't start a second instance pass unchanged | counter-example over `test/` | withstood | none |
+| 8 | P2 dominates P1/P3/P4 on scoring criteria | prior-art + dependency | withstood | none |
+
+## Revision required
+
+None. Claim 3's partial falsification narrows a Qualifier — the chosen
+approach (P2) still satisfies all acceptance-criterion sub-questions and
+the scoring ranking holds (see cross-claim resolution 1). The solution
+does not require structural revision; the implementer must, however,
+plan the PR's size honestly.
+
+- **Target file:** n/a
+- **Revision kind:** n/a
+- **Rationale:** Narrowed Qualifier on Claim 3 is documented in place;
+  no structural change to solution.md required.
+
+## Outstanding doubts
+
+These propagate to the parent-level validator:
+
+- **PR sizing.** The "~30 call sites" estimate understates by 3-6×; real
+  conversion surface in `lib/` is ≥88 sites and in `test/` ≥151 hits for
+  PubSub/Finch alone. The Store/Tracker per-module edit is closer to
+  15-25 lines than 5. Parent should expect a medium-to-large PR, not a
+  small one, when this lands. This MAY argue for splitting along the
+  step boundaries in `solution.md:121-138`'s migration sketch (six
+  discrete steps, each green-able independently).
+- **`Tau.Names.get/0` fallback semantics.** The solution does not
+  explicitly specify what `get/0` returns when `:tau_names` has not
+  been published (e.g. a compile-time call before `Application.start/2`).
+  Implementer should default to the `:default` name set or raise with
+  a diagnostic message.
+- **Tests that snapshot `:erlang.registered/0`.** None observed today,
+  but if added in future, would couple to the supervisor naming and
+  break under non-`:default` instances. Worth a guard test that
+  asserts the `:default` instance round-trips the historical atom set.
+- **Downstream-library auxiliary registrations.** Phoenix.PubSub and
+  Finch internal helper processes (e.g. pool supervisors) may register
+  under derived atoms that are themselves keyed off the parent name —
+  no collision observed today, but if a future upgrade introduces one,
+  the fix lands in the dependency, not in `Tau.Names`. Flag for
+  release-notes review when upgrading those libs.

--- a/docs/problems-archive-v1-modules/tau-infrastructure/subproblems/supervision-tree-startup/problem.md
+++ b/docs/problems-archive-v1-modules/tau-infrastructure/subproblems/supervision-tree-startup/problem.md
@@ -1,0 +1,75 @@
+---
+template_version: 1
+template_name: problem
+node_kind: leaf
+depth: 1
+parent: ../../problem.md
+status: draft
+---
+
+# Problem: supervision tree startup lifecycle defects
+
+## Statement
+
+`Tau.Application.maybe_dispatch_cli/0` spawns the CLI entry-point inside an
+unmonitored `Task.start/1`; a failure inside `Tau.CLI.main/1` produces an
+unobserved crash and `System.halt/1` is never called, leaving the binary
+hung. Additionally, `otel_reporter_spec/0` reads `Application.get_env` at
+startup and conditionally splices children, duplicating the enable/disable
+policy already expressed in `Tau.OtelReporter.init/1`'s `:ignore` path —
+two independent code sites must agree on what "OTel disabled" means, and
+the default `max_restarts: 3 / max_seconds: 5` for a binary expected to
+recover from transient SQLite or Finch init failures is tight.
+
+## Context
+
+- `lib/tau/application.ex:185-199` — `Task.start/1` spawns the CLI; no
+  monitor, no link, no `Task.Supervisor.start_child`. If `Tau.CLI.main/1`
+  raises, the exit is unobserved and `System.halt/1` never fires.
+- `lib/tau/application.ex:113-119` — `otel_reporter_spec/0` reads
+  `Application.get_env(:tau, :otel)` and returns `[]` when disabled.
+  `Tau.OtelReporter.init/1` also returns `:ignore` when disabled.
+  Both guard the same gate; a future change to either creates a split-brain.
+- `lib/tau/application.ex:93` — `opts = [strategy: :rest_for_one, name:
+  Tau.Supervisor]` with no `max_restarts:` / `max_seconds:` override;
+  three restarts in five seconds halts the binary on transient failure at
+  init (e.g., SQLite locked briefly on cold start).
+- Flat audit: major finding `application.ex:185-199`; minor finding on
+  `otel_reporter_spec/0` dual-policy.
+
+## Complecting hypothesis
+
+1. **CLI exit policy is complected with the OTP task primitive choice**:
+   `Task.start/1` is chosen for its fire-and-forget semantics, but the
+   caller needs crash-visibility to guarantee `System.halt/1` fires — these
+   two requirements are incompatible with the same primitive.
+2. **OTel enable/disable policy is complected across two independent code
+   sites**: the supervisor child-list and the GenServer `init/1` both
+   represent "is OTel enabled?", and they must be kept in sync manually.
+
+## Decomposition strategy
+
+(leaf — no further decomposition; proceed to proposals)
+
+## Acceptance criterion
+
+A proposal names: (a) the replacement primitive for the CLI task that
+guarantees `System.halt/1` fires on both normal and crash exits; (b) a
+single authoritative OTel-enabled gate with the other site removed or made
+unconditionally passthrough; (c) explicit `max_restarts` / `max_seconds`
+values justified against the binary's recovery expectations — without
+regressing supervision tree startup ordering.
+
+## Out of scope
+
+- Global process name collision risk — exclusive scope of
+  **global-name-collision**.
+- Telemetry handler crash-safety and supervisor strategy — exclusive scope of
+  **telemetry-handler-coupling**.
+- Circuit-breaker counter protocol — exclusive scope of
+  **circuit-breaker-invariant-split**.
+- Any change to `Tau.CLI.main/1` internals or `lib/tau/factory/gate.ex`.
+
+## Amendment log
+
+- (none yet)

--- a/docs/problems-archive-v1-modules/tau-infrastructure/subproblems/supervision-tree-startup/proposals/proposal-1.md
+++ b/docs/problems-archive-v1-modules/tau-infrastructure/subproblems/supervision-tree-startup/proposals/proposal-1.md
@@ -1,0 +1,166 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 1
+parent_problem: ../problem.md
+---
+
+# Proposal 1: Task.Supervisor child + OTel always-in-tree passthrough + relaxed restart bounds
+
+## Approach
+
+Replace the bare `Task.start/1` in `maybe_dispatch_cli/0` with
+`Task.Supervisor.start_child/3` under the existing `Tau.Tools.TaskSupervisor`,
+using `Task.Supervisor.async_nolink/3` with a `Process.monitor` on the returned
+task PID so that `Tau.Application.start/2` receives a `{:DOWN, ref, :process,
+pid, reason}` message and can call `System.halt/1` with the correct exit code.
+Remove `otel_reporter_spec/0`'s conditional entirely: always include
+`Tau.OtelReporter` in the child list and let `Tau.OtelReporter.init/1`'s
+existing `:ignore` path be the sole gate for "OTel disabled." Change the
+supervisor `opts` to `[strategy: :rest_for_one, name: Tau.Supervisor,
+max_restarts: 10, max_seconds: 60]`.
+
+## Rationale
+
+`Task.start/1` is fire-and-forget — the caller has no handle on the result.
+Adding a `Process.monitor` after `Task.Supervisor.async_nolink/3` gives the
+`Application.start/2` process a direct `:DOWN` message on any exit, normal or
+crash, without linking (which would crash the supervisor) and without requiring a
+new supervised module. The OTel dual-gate is removed by trusting `init/1`'s
+`:ignore` return, which is the canonical OTP mechanism for conditional startup;
+`otel_reporter_spec/0` reading env at supervisor build time is the second gate.
+Relaxing `max_restarts: 10 / max_seconds: 60` reduces the probability of
+spurious halts from transient SQLite locks or Finch init jitter during cold start.
+
+## Sketch
+
+```elixir
+# lib/tau/application.ex
+
+# In start/2, after Supervisor.start_link:
+{:ok, pid} ->
+  :telemetry.execute([:tau, :app, :ready], ...)
+  maybe_dispatch_cli()
+  {:ok, pid}
+
+# Replace otel_reporter_spec/0:
+#   Remove the function; change the child list from:
+#     otel_reporter_spec(),
+#   to:
+#     Tau.OtelReporter,
+#   (always include; OtelReporter.init/1 returns :ignore when disabled)
+
+# Change opts:
+opts = [strategy: :rest_for_one, name: Tau.Supervisor, max_restarts: 10, max_seconds: 60]
+
+# Replace maybe_dispatch_cli/0:
+defp maybe_dispatch_cli do
+  case cli_argv() do
+    :no_cli ->
+      :ok
+
+    {:dispatch, argv} ->
+      %Task{pid: pid} =
+        Task.Supervisor.async_nolink(Tau.Tools.TaskSupervisor, fn ->
+          exit_code =
+            case Tau.CLI.main(argv) do
+              n when is_integer(n) -> n
+              _ -> 0
+            end
+
+          exit_code
+        end)
+
+      ref = Process.monitor(pid)
+
+      receive do
+        {:DOWN, ^ref, :process, ^pid, {:exit, code}} when is_integer(code) ->
+          System.halt(code)
+
+        {:DOWN, ^ref, :process, ^pid, :normal} ->
+          # Task returned a value — task result carries exit_code via {:exit, code}
+          # so :normal means the task exited cleanly with 0 implicitly.
+          System.halt(0)
+
+        {:DOWN, ^ref, :process, ^pid, _reason} ->
+          # Crash or unexpected exit — non-zero.
+          System.halt(1)
+      end
+  end
+end
+```
+
+Note: the `Task.Supervisor.async_nolink` + `Process.monitor` pattern blocks
+`Application.start/2` after returning `{:ok, pid}`. In practice `start/2` has
+already returned the supervisor PID before `maybe_dispatch_cli/0` blocks, so
+the VM is live; the blocker is the calling process (the Application controller
+process), not the supervisor process itself. This is consistent with how
+Burrito-built binaries are designed to block on CLI work.
+
+## Tradeoffs
+
+### Strengths
+
+- `System.halt/1` is guaranteed to fire on both normal and crash exits — closes
+  the acceptance criterion (a) directly.
+- Reuses `Tau.Tools.TaskSupervisor` — no new supervised module, no supervision
+  tree change beyond removing the conditional.
+- The OTel change is a deletion (remove `otel_reporter_spec/0`) — smallest
+  possible footprint; relies entirely on existing OTP `:ignore` semantics,
+  closing criterion (b).
+- `max_restarts: 10 / max_seconds: 60` is a documented, defensible relaxation
+  for transient init failures, closing criterion (c).
+
+### Weaknesses
+
+- Blocking `Application.start/2`'s caller process (the Application controller)
+  with a `receive` loop is atypical — readers unfamiliar with the Burrito
+  pattern may find it alarming.
+- `Task.Supervisor.async_nolink` requires the supervisor to be started before
+  this call; if the task supervisor's position in the child list changes, this
+  breaks silently.
+- The `:DOWN` message shape from `async_nolink` wraps the return value in
+  `{:exit, value}` only if the task calls `exit/1` explicitly; a plain return
+  from the fn body sends `{:DOWN, ..., :normal}` with no embedded code. The
+  sketch above must use `exit(exit_code)` inside the task, not `exit_code` as
+  the return value, or the normal-exit branch always halts with 0 regardless of
+  `Tau.CLI.main/1`'s return.
+- Does not address `Task.Supervisor.async_nolink`'s behaviour on supervisor
+  shutdown — if `Tau.Tools.TaskSupervisor` is stopped before the task finishes,
+  the task is killed and the `:DOWN` reason is `:killed`, which maps to halt(1).
+
+### Costs
+
+- ~15 lines changed in `lib/tau/application.ex`.
+- One function deleted (`otel_reporter_spec/0`).
+- The blocking `receive` must be documented; a reader who encounters it for the
+  first time will likely want to understand why `start/2`'s caller blocks.
+- Tests that assert `Tau.OtelReporter` is absent from the supervision tree when
+  OTel is disabled will need to change — the child is now always present, just
+  ignored at init time.
+
+## Dependencies
+
+- `Tau.Tools.TaskSupervisor` must remain in the child list above
+  `maybe_dispatch_cli/0`'s call site — currently true, no order change needed.
+- `Tau.OtelReporter.init/1` must return `{:stop, :ignore}` or `:ignore` when
+  disabled — confirmed in place (the existing dual-gate relies on it).
+
+## Confidence
+
+Medium. The `async_nolink` + `Process.monitor` + `receive` pattern is correct
+OTP but the exit-code-carrying subtlety (must `exit/1` inside the task, not
+return) is a trap. A small prototype in IEx confirms the `:DOWN` message shape.
+Confidence would rise to high after running the existing binary smoke test
+(`mix test --only smoke`) against the patched version.
+
+## Prior art / references
+
+- OTP `Process.monitor/1` + `receive` — standard Erlang/OTP crash-detection
+  idiom; documented in LYSE "Errors and Processes".
+- `Task.Supervisor.async_nolink/3` — Elixir docs §"Supervised tasks and
+  dynamic supervisors"; used in Elixir stdlib's own test helpers.
+- `:ignore` from `init/1` — OTP Design Principles §"Starting a GenServer";
+  `Supervisor` skips the child on `:ignore`.
+- `max_restarts` / `max_seconds` guidance — OTP `supervisor(3)` manual,
+  §"Intensity and Period".

--- a/docs/problems-archive-v1-modules/tau-infrastructure/subproblems/supervision-tree-startup/proposals/proposal-2.md
+++ b/docs/problems-archive-v1-modules/tau-infrastructure/subproblems/supervision-tree-startup/proposals/proposal-2.md
@@ -1,0 +1,170 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 2
+parent_problem: ../problem.md
+---
+
+# Proposal 2: Tau.CLIRunner supervised GenServer with trap_exit
+
+## Approach
+
+Extract the CLI dispatch into a new supervised `Tau.CLIRunner` GenServer that
+is the last child in `Tau.Application`'s tree. `CLIRunner.init/1` spawns
+`Tau.CLI.main/1` in a linked process and calls `Process.flag(:trap_exit, true)`,
+so any exit from the CLI process — normal or crash — arrives as an `{:EXIT,
+pid, reason}` message handled in `handle_info/2`, which extracts the exit code
+and calls `System.halt/1`. Remove `otel_reporter_spec/0` and always include
+`Tau.OtelReporter` in the child list (passthrough to `init/1`'s `:ignore`).
+Set `max_restarts: 10, max_seconds: 60` on the root supervisor.
+
+## Rationale
+
+Making `Tau.CLIRunner` a supervised GenServer gives the CLI runner a named,
+observable process with a well-defined lifecycle under OTP supervision. The
+`trap_exit` + `handle_info` pattern is the canonical OTP way to observe linked
+process exits without coupling the observer's crash to the observed process's
+crash. Because `CLIRunner` is a proper child in the supervision tree, its
+startup and shutdown are logged by the supervisor, making post-mortem
+debugging straightforward. The OTel change is the same deletion/passthrough as
+Proposal 1 — relying on `init/1`'s `:ignore` as the single gate.
+
+## Sketch
+
+```elixir
+# lib/tau/cli_runner.ex  (new file)
+defmodule Tau.CLIRunner do
+  @moduledoc """
+  Supervised entry point for the CLI. Spawns Tau.CLI.main/1 in a linked
+  process; traps its exit and calls System.halt/1 with the correct exit code.
+  Returns :ignore when there is no CLI to dispatch (server / embedded mode).
+  """
+  use GenServer
+
+  @spec start_link(keyword()) :: GenServer.on_start() | :ignore
+  def start_link(opts \\ []) do
+    GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+  end
+
+  @impl GenServer
+  def init(_opts) do
+    case Tau.Application.cli_argv() do
+      :no_cli ->
+        :ignore
+
+      {:dispatch, argv} ->
+        Process.flag(:trap_exit, true)
+        pid = spawn_link(fn -> run(argv) end)
+        {:ok, %{cli_pid: pid}}
+    end
+  end
+
+  @impl GenServer
+  def handle_info({:EXIT, pid, reason}, %{cli_pid: pid} = state) do
+    exit_code =
+      case reason do
+        {:exit_code, n} when is_integer(n) -> n
+        :normal -> 0
+        _ -> 1
+      end
+
+    System.halt(exit_code)
+    {:noreply, state}
+  end
+
+  def handle_info(_msg, state), do: {:noreply, state}
+
+  defp run(argv) do
+    exit_code =
+      case Tau.CLI.main(argv) do
+        n when is_integer(n) -> n
+        _ -> 0
+      end
+
+    exit({:exit_code, exit_code})
+  end
+end
+```
+
+```elixir
+# lib/tau/application.ex — child list changes
+
+# Remove: otel_reporter_spec(),
+# Add:    Tau.OtelReporter,   (unconditional; init/1 returns :ignore if disabled)
+# Remove: the maybe_dispatch_cli() call after Supervisor.start_link
+# Add at end of children list (after Sessions.Supervisor):
+#         Tau.CLIRunner
+
+# Remove: defp otel_reporter_spec/0
+# Remove: defp maybe_dispatch_cli/0
+
+opts = [strategy: :rest_for_one, name: Tau.Supervisor, max_restarts: 10, max_seconds: 60]
+```
+
+The `Tau.Application.cli_argv/0` function is already public (`@doc false`),
+so `Tau.CLIRunner.init/1` can call it without making it part of the public API.
+
+## Tradeoffs
+
+### Strengths
+
+- `System.halt/1` is guaranteed on both normal and crash exits — closes (a).
+- `Tau.CLIRunner` is a named, supervised process visible in `Supervisor.which_children/1`
+  and in crash logs — far more observable than a bare `Task.start/1`.
+- The linked-spawn + `trap_exit` pattern is a first-class OTP idiom (OTP Design
+  Principles §"Processes in a Supervision Tree"); readers familiar with OTP will
+  immediately understand the contract.
+- Returning `:ignore` from `init/1` in non-CLI mode means the supervisor skip is
+  explicit and logged, and no process is resident in server mode.
+- Closing (b): `otel_reporter_spec/0` deleted; single gate at `OtelReporter.init/1`.
+- Closing (c): `max_restarts: 10 / max_seconds: 60` documented.
+
+### Weaknesses
+
+- New file (`lib/tau/cli_runner.ex`) and new module adds surface area; a reviewer
+  must understand why a GenServer (stateful primitive) is wrapping what is
+  conceptually a one-shot task.
+- `trap_exit` in a GenServer is a footgun if `CLIRunner` ever becomes long-lived
+  or if someone starts linking other processes to it — any linked exit will now
+  arrive as `handle_info` rather than crashing the GenServer.
+- `Tau.CLIRunner` is the last child under `:rest_for_one`; if any earlier child
+  crashes and cascades, `CLIRunner` is also killed mid-run, and `System.halt/1`
+  fires with exit code 1 (crash reason) rather than the CLI's intended code.
+  This is an improvement over the current silent hang but may confuse operators.
+- The `exit({:exit_code, n})` convention requires the wrapping `run/1` function;
+  if someone calls `Tau.CLI.main/1` directly and it calls `System.halt/1`
+  internally, the exit propagation short-circuits the structured code.
+
+### Costs
+
+- One new file (`lib/tau/cli_runner.ex`, ~40 lines).
+- ~10 lines removed from `lib/tau/application.ex` (two functions deleted, one
+  child entry changed, one call site removed).
+- Any tests that assert on `maybe_dispatch_cli/0` or on `Task.start/1` being
+  called must be updated.
+- Tests that check `Tau.OtelReporter` is absent when OTel is disabled need
+  updating (same as Proposal 1).
+
+## Dependencies
+
+- `Tau.Application.cli_argv/0` must remain public (it already is, `@doc false`).
+- `Tau.OtelReporter.init/1` must honour `:ignore` when disabled (confirmed).
+- `Tau.CLIRunner` must be placed after `Tau.Sessions.Supervisor` in the child
+  list to preserve the boot order documented in `application.ex`'s moduledoc.
+
+## Confidence
+
+Medium-high. The linked-spawn + `trap_exit` pattern is well-established OTP; the
+`exit({:exit_code, n})` tagged-tuple convention is a small extra commitment.
+Confidence rises to high if a unit test confirms `handle_info({:EXIT, ...})`
+dispatches to `System.halt/1` with the correct code.
+
+## Prior art / references
+
+- OTP Design Principles §"Processes in a Supervision Tree" — the trap_exit +
+  handle_info(:EXIT) idiom for linked process observation.
+- Elixir `GenServer` docs §"Handling exits" — documents `Process.flag(:trap_exit)`.
+- `:ignore` from `GenServer.init/1` — `Supervisor` docs §"Child specification";
+  child is started and immediately removed from the tree, no restart.
+- Similar pattern in Erlang `escript` wrappers that boot a supervision tree then
+  hand off to a linked worker process.

--- a/docs/problems-archive-v1-modules/tau-infrastructure/subproblems/supervision-tree-startup/proposals/proposal-3.md
+++ b/docs/problems-archive-v1-modules/tau-infrastructure/subproblems/supervision-tree-startup/proposals/proposal-3.md
@@ -1,0 +1,170 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 3
+parent_problem: ../problem.md
+---
+
+# Proposal 3: Inline monitor-receive in start/2 with OTel init/1 as sole gate
+
+## Approach
+
+Remove `maybe_dispatch_cli/0` entirely. Instead, in `Tau.Application.start/2`,
+after the supervisor returns `{:ok, pid}`, inline the CLI dispatch: spawn the
+CLI work with `spawn_monitor/1`, then immediately block on a `receive` for the
+`:DOWN` message and call `System.halt/1`. The OTel child list entry becomes
+unconditional (always `Tau.OtelReporter`); `otel_reporter_spec/0` is deleted.
+`max_restarts: 10, max_seconds: 60` is set on the root supervisor opts. No new
+modules, no new Task.Supervisor usage.
+
+## Rationale
+
+`spawn_monitor/1` is the lowest-level Erlang/OTP primitive for "spawn a process
+and be notified when it exits, regardless of exit reason, without linking." It
+decouples crash-visibility from OTP supervision entirely — the monitor is a
+private handle in the `Application.start/2` closure and cannot be accidentally
+removed by a supervision tree change. Inlining the receive in `start/2` (after
+the `{:ok, pid}` return to the Application controller) is the smallest change
+that closes the criterion: no new module, no dependency on a named supervisor,
+no `trap_exit` footgun. The OTel policy lives in exactly one place: `init/1`.
+
+## Sketch
+
+```elixir
+# lib/tau/application.ex — start/2 only
+
+@impl true
+def start(_type, _args) do
+  install_file_system_log_filter()
+
+  children = List.flatten([
+    Tau.Telemetry.Supervisor,
+    Tau.OtelReporter,           # always present; init/1 returns :ignore if disabled
+    {Phoenix.PubSub, name: Tau.PubSub},
+    # ... all other children unchanged ...
+    Tau.Sessions.Supervisor
+  ])
+
+  opts = [strategy: :rest_for_one, name: Tau.Supervisor, max_restarts: 10, max_seconds: 60]
+
+  case Supervisor.start_link(children, opts) do
+    {:ok, pid} ->
+      :telemetry.execute([:tau, :app, :ready], %{system_time: System.system_time()}, %{
+        version: Application.spec(:tau, :vsn) |> to_string()
+      })
+
+      case cli_argv() do
+        :no_cli ->
+          :ok
+
+        {:dispatch, argv} ->
+          {task_pid, ref} =
+            spawn_monitor(fn ->
+              exit_code =
+                case Tau.CLI.main(argv) do
+                  n when is_integer(n) -> n
+                  _ -> 0
+                end
+
+              # exit/1 carries the code as the reason so the :DOWN message is
+              # {:DOWN, ref, :process, pid, exit_code}.
+              exit(exit_code)
+            end)
+
+          receive do
+            {:DOWN, ^ref, :process, ^task_pid, exit_code} when is_integer(exit_code) ->
+              System.halt(exit_code)
+
+            {:DOWN, ^ref, :process, ^task_pid, :normal} ->
+              System.halt(0)
+
+            {:DOWN, ^ref, :process, ^task_pid, _reason} ->
+              System.halt(1)
+          end
+      end
+
+      {:ok, pid}
+
+    other ->
+      other
+  end
+end
+
+# Delete: otel_reporter_spec/0
+# Delete: maybe_dispatch_cli/0
+```
+
+The `{:ok, pid}` is returned after the `receive` block because the
+Application controller process is what blocks — the supervisor PID is valid and
+the supervision tree is running throughout. In `:no_cli` mode the `receive` is
+never entered and `start/2` returns normally.
+
+## Tradeoffs
+
+### Strengths
+
+- `spawn_monitor/1` is the canonical no-link, guaranteed-notification primitive —
+  simpler than `Task.Supervisor.async_nolink` + `Process.monitor`, and carries
+  no dependency on a named supervisor.
+- No new files, no new modules, no new behaviours — the change is entirely
+  self-contained in `lib/tau/application.ex`.
+- The monitor handle is a private `ref` in the `start/2` scope; no other code
+  can accidentally demonitor it.
+- Closes (a), (b), (c) with the minimum diff.
+- In `:no_cli` mode the code path is unchanged: `start/2` returns `{:ok, pid}`
+  without entering the `receive` branch.
+
+### Weaknesses
+
+- Inlining the CLI dispatch in `start/2` makes that function longer and mixes
+  the "build supervision tree" concern with the "run CLI and halt" concern.
+- The blocking `receive` in `start/2` is unusual; without a comment, future
+  maintainers may refactor it away thinking it is an accidental omission.
+- `spawn_monitor/1` spawns an unlinked, unsupervised process — if the BEAM
+  shuts down before the process finishes (e.g., another supervisor child crashes
+  during CLI run), the CLI process is killed and `System.halt/1` fires with code 1.
+  This is not worse than the current state but is still surprising.
+- `exit(exit_code)` inside the spawned fn relies on `exit/1` with an integer
+  argument being captured as-is in the `:DOWN` reason — this works in OTP
+  (non-`:normal` exit reasons are propagated verbatim), but the normal-exit
+  path (`exit(:normal)` or returning from the fn) would need special handling
+  because `:normal` exits do send `:DOWN` with reason `:normal`, not the
+  integer. The receive guard `when is_integer(exit_code)` handles this, but the
+  interaction is subtle.
+
+### Costs
+
+- Net change: ~15 lines in `lib/tau/application.ex` (two functions deleted,
+  `start/2` gains ~15 lines, the child list loses the conditional call).
+- Same test updates as Proposal 1 (OTel always-in-tree, `maybe_dispatch_cli`
+  call site removed).
+- Requires a clear inline comment explaining the blocking `receive` idiom and
+  the `exit(exit_code)` convention — otherwise a future reader will remove it.
+
+## Dependencies
+
+- No external dependencies beyond what is already in scope.
+- `Tau.OtelReporter.init/1` must return `:ignore` when OTel is disabled
+  (confirmed in existing code).
+- The `{:ok, pid}` return at the end of `start/2` must follow the `receive`
+  block — correct placement is critical; the Application controller must
+  eventually see `{:ok, pid}` or `{:error, reason}`.
+
+## Confidence
+
+Medium. The `spawn_monitor` + `receive` pattern is correct vanilla OTP, but the
+`exit(integer)` convention for carrying exit codes through `:DOWN` reasons is
+an obscure idiom that requires documentation. Confidence rises to high after
+verifying via a smoke test that normal exit and crash exit both call
+`System.halt/1` with the expected code.
+
+## Prior art / references
+
+- `spawn_monitor/1` — Erlang/OTP `erlang:spawn_monitor/1` manual; simplest
+  form of crash-visible spawn.
+- `exit(reason)` carrying structured data in `:DOWN` reasons — Erlang/OTP
+  process model; reason is any term, propagated verbatim in `:DOWN` unless `:normal`.
+- Elixir `Application.start/2` blocking pattern — used by `IEx.App` which
+  blocks the Application controller to ensure the IEx REPL drives the VM lifetime.
+- `:ignore` from `GenServer.init/1` in unconditional child lists — standard OTP
+  optional-child pattern.

--- a/docs/problems-archive-v1-modules/tau-infrastructure/subproblems/supervision-tree-startup/proposals/proposal-4.md
+++ b/docs/problems-archive-v1-modules/tau-infrastructure/subproblems/supervision-tree-startup/proposals/proposal-4.md
@@ -1,0 +1,203 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 4
+parent_problem: ../problem.md
+---
+
+# Proposal 4: Redesign CLI dispatch as a dedicated OTP application with its own supervisor
+
+## Approach
+
+Split the CLI execution lifecycle out of `Tau.Application` entirely and into a
+new OTP application `tau_cli` (a new `mix.exs` library application entry in the
+`:included_applications` list, or more practically a new `Tau.CLI.App` module
+started via `Application.start/2` after the main supervision tree is healthy).
+`Tau.CLI.App` owns a minimal one-child supervisor whose sole child is a
+`Tau.CLI.Runner` GenServer (`:temporary` restart, `max_restarts: 0`). `Runner`
+spawns `Tau.CLI.main/1` in a linked process with `trap_exit: true`, captures the
+exit, and calls `System.halt/1`. `Tau.Application` becomes purely a platform
+supervisor with no CLI-dispatch concern; it always includes `Tau.OtelReporter`
+unconditionally and uses `max_restarts: 10, max_seconds: 60`.
+
+## Rationale
+
+The root cause of the complecting is that `Tau.Application` currently owns two
+orthogonal concerns: (1) bootstrapping the platform supervision tree and
+(2) dispatching and observing the CLI entry point. An OTP-idiomatic separation
+places the platform in one application and the CLI lifecycle in a second
+application that depends on the first. This is the pattern Erlang/OTP uses for
+`erts` + `kernel` + `stdlib` layering: each layer starts cleanly before the
+next. In this design `Tau.Application.start/2` never blocks or dispatches; the
+CLI app starts only after the platform is healthy, and the platform's supervisor
+cannot be destabilised by a CLI crash (different application, different
+supervisor). The OTel single-gate is achieved by removing `otel_reporter_spec/0`
+and relying on `init/1`.
+
+## Sketch
+
+```elixir
+# lib/tau/cli/app.ex  (new file)
+defmodule Tau.CLI.App do
+  @moduledoc """
+  OTP application for the CLI lifecycle. Started after Tau.Application
+  when a CLI argv is detected. Supervises a single :temporary Tau.CLI.Runner
+  child; Runner traps its linked CLI process and calls System.halt/1 on exit.
+  """
+  use Application
+
+  @impl true
+  def start(_type, _args) do
+    children = [Tau.CLI.Runner]
+    opts = [strategy: :one_for_one, name: Tau.CLI.Supervisor, max_restarts: 0]
+    Supervisor.start_link(children, opts)
+  end
+end
+
+# lib/tau/cli/runner.ex  (new file)
+defmodule Tau.CLI.Runner do
+  @moduledoc """
+  Runs Tau.CLI.main/1 in a linked process. Traps the exit and calls
+  System.halt/1 with the exit code. Returns :ignore when not in CLI mode.
+  """
+  use GenServer, restart: :temporary
+
+  def start_link(_opts) do
+    GenServer.start_link(__MODULE__, [], name: __MODULE__)
+  end
+
+  @impl GenServer
+  def init([]) do
+    case Tau.Application.cli_argv() do
+      :no_cli ->
+        :ignore
+
+      {:dispatch, argv} ->
+        Process.flag(:trap_exit, true)
+        _pid = spawn_link(fn ->
+          code =
+            case Tau.CLI.main(argv) do
+              n when is_integer(n) -> n
+              _ -> 0
+            end
+
+          exit({:tau_exit, code})
+        end)
+
+        {:ok, %{}}
+    end
+  end
+
+  @impl GenServer
+  def handle_info({:EXIT, _pid, {:tau_exit, code}}, state) do
+    System.halt(code)
+    {:noreply, state}
+  end
+
+  def handle_info({:EXIT, _pid, :normal}, state) do
+    System.halt(0)
+    {:noreply, state}
+  end
+
+  def handle_info({:EXIT, _pid, _reason}, state) do
+    System.halt(1)
+    {:noreply, state}
+  end
+
+  def handle_info(_msg, state), do: {:noreply, state}
+end
+```
+
+```elixir
+# mix.exs — add :tau_cli to :included_applications or start it explicitly.
+# In practice, the simplest implementation avoids a second mix.exs:
+# Tau.Application.start/2 calls Application.start(:tau_cli) after
+# Supervisor.start_link succeeds, OR Tau.CLI.App is started as the
+# last entry in the :applications list in mix.exs so OTP starts it
+# after :tau automatically.
+
+# lib/tau/application.ex changes:
+# 1. Replace otel_reporter_spec() call with Tau.OtelReporter (unconditional)
+# 2. Remove maybe_dispatch_cli/0 and its call site
+# 3. Set max_restarts: 10, max_seconds: 60
+# 4. Delete otel_reporter_spec/0
+```
+
+The practical trade-off is whether `tau_cli` is a true OTP application
+(separate `mix.exs`) or a module-level `Application.start` call inside
+`Tau.Application.start/2`. Either is valid; the second option avoids adding a
+new `:applications` entry and is the minimal path.
+
+## Tradeoffs
+
+### Strengths
+
+- Strongest separation of concerns: `Tau.Application` is purely a platform
+  supervisor; the CLI lifecycle has its own supervisor and its own restart
+  intensity (none — `:temporary`, `max_restarts: 0`).
+- A crash in `Tau.CLI.Runner` cannot cascade into the platform supervisor — the
+  two supervisors are entirely independent.
+- The `trap_exit` + `handle_info` pattern is contained in a module dedicated to
+  this purpose; no footgun leakage into general-purpose GenServers.
+- Closes all three acceptance criterion items (a)(b)(c).
+- The `restart: :temporary` + `max_restarts: 0` on the CLI supervisor explicitly
+  states "this runs once, never restarts" — the right semantic for a binary CLI
+  runner.
+
+### Weaknesses
+
+- Highest conceptual overhead: a second application (or a second supervision
+  tree call) for what is currently a 15-line function. Reviewers unfamiliar with
+  OTP application layering will view this as over-engineering.
+- If implemented as a true separate OTP application, requires changes to
+  `mix.exs` and potentially to the release configuration — non-trivial impact
+  for what the problem statement classifies as a minor/major defect pair.
+- The `Tau.Application.cli_argv/0` function is consumed by `Tau.CLI.Runner.init/1`
+  across application boundaries — if `Tau.Application` is ever renamed or split,
+  this reference breaks.
+- `Application.start(:tau_cli)` called from within `Tau.Application.start/2`
+  is an unusual pattern (one application starting another synchronously during
+  its own start); OTP allows it but it is not common practice and can confuse
+  release tooling.
+- Most complex migration of the four proposals.
+
+### Costs
+
+- Two new files (`lib/tau/cli/app.ex`, `lib/tau/cli/runner.ex`, ~60 lines total).
+- `lib/tau/application.ex`: ~10 lines removed (two functions, one call site, one
+  child list entry changed).
+- If a true second OTP application: changes to `mix.exs` `:extra_applications`
+  or `:included_applications`, and possibly to `rel/config.exs` or Burrito config.
+- Test suite: any tests that assert on `Tau.Application`'s CLI dispatch path
+  must be updated; new unit tests needed for `Tau.CLI.Runner`.
+
+## Dependencies
+
+- `Tau.Application.cli_argv/0` must remain accessible from `Tau.CLI.Runner`
+  (currently `@doc false` public — acceptable).
+- `Tau.OtelReporter.init/1` must honour `:ignore` (confirmed).
+- `Tau.CLI.App` / `Tau.CLI.Runner` must start after the full `Tau` supervision
+  tree is up; ordering must be guaranteed (either via `:included_applications`
+  or explicit `Application.start` sequencing).
+
+## Confidence
+
+Low-medium. The OTP application layering pattern is sound in principle, but the
+implementation details (`:included_applications` vs explicit `Application.start`
+vs truly separate mix project) have non-trivial correctness constraints. The
+simple module-level approach (start `Tau.CLI.App` explicitly inside
+`Tau.Application.start/2`) is the most practical but least idiomatic OTP path.
+Confidence rises to medium after prototyping the startup sequence and verifying
+Burrito build output remains intact.
+
+## Prior art / references
+
+- OTP `:included_applications` — OTP Design Principles §"Included Applications";
+  allows one application to start child applications in a defined order.
+- `:temporary` restart strategy for one-shot workers — `Supervisor` docs
+  §"Child specification" `restart:` option.
+- Elixir `Application.start/2` explicit sequencing — used in Phoenix when
+  `Endpoint` must start after `Ecto.Repo` is up.
+- Erlang `escript` + supervision tree — common pattern for CLI tools that need
+  full OTP but with a clean process separation between the platform and the
+  user-facing entry point.

--- a/docs/problems-archive-v1-modules/tau-infrastructure/subproblems/supervision-tree-startup/solution.md
+++ b/docs/problems-archive-v1-modules/tau-infrastructure/subproblems/supervision-tree-startup/solution.md
@@ -1,0 +1,121 @@
+---
+template_version: 1
+template_name: solution
+parent_problem: problem.md
+node_kind: leaf
+synthesised_from: [proposals/proposal-3.md]
+selection_method: single
+revision: 0
+---
+
+# Solution: inline spawn_monitor + receive in start/2; OtelReporter always-in-tree; relaxed restart bounds
+
+## Recommendation
+
+Replace `maybe_dispatch_cli/0` and its `Task.start/1` call with an inline
+`spawn_monitor/1` + `receive` block inside `Tau.Application.start/2`, placed
+immediately after the `{:ok, pid}` match on `Supervisor.start_link/2`. The
+spawned process calls `exit(exit_code)` so the integer exit code is carried
+verbatim in the `:DOWN` reason; the `receive` dispatches to `System.halt/1` on
+every exit path. Remove `otel_reporter_spec/0` and replace its conditional call
+site with `Tau.OtelReporter` unconditionally — `OtelReporter.init/1`'s existing
+`:ignore` return becomes the sole enabled/disabled gate. Set `max_restarts: 10,
+max_seconds: 60` on the root supervisor opts.
+
+## Selected from
+
+- **Chosen:** `proposals/proposal-3.md`
+- **Why chosen:** All four proposals satisfy the three acceptance criteria; the
+  differentiators are dependency surface, OTP-rule compliance, and migration
+  cost. Proposal 3 uses `spawn_monitor/1`, whose monitor handle is a private
+  `ref` scoped entirely to `start/2` — no dependency on a named supervisor
+  being started in a specific position (the silent ordering risk in Proposal 1).
+  Proposal 2 wraps a one-shot task in a `GenServer` carrying only `%{cli_pid:
+  pid}` — stateless logic in a GenServer, which violates OTP non-negotiable #3
+  and is disqualified on that ground alone. Proposal 4 introduces a second
+  supervision tree / OTP application for a problem the problem statement
+  classifies as a major/minor defect pair; its confidence is low-medium and
+  migration cost is high. Proposal 3 and Proposal 1 are close; Proposal 3 wins
+  because removing the `Tau.Tools.TaskSupervisor` dependency reduces the number
+  of invariants the implementation must maintain and makes `start/2` fully
+  self-contained.
+
+## Scoring table
+
+| # | Fit | Decomplecting depth | Migration cost | Risk | Reversibility |
+|---|-----|---------------------|----------------|------|---------------|
+| 1 | Yes | Substantial | Low | Low | Easy |
+| 2 | Yes | Substantial | Medium | Medium | Medium |
+| 3 | Yes | Substantial | Low | Low | Easy |
+| 4 | Yes | Deep | High | Medium | Hard |
+
+Proposal 2 is disqualified by OTP non-negotiable #3 regardless of its score.
+Proposal 4 is deprioritised by cost+risk disproportionate to defect severity.
+Between 1 and 3: equivalent fit, cost, reversibility; Proposal 3 wins on the
+named-supervisor dependency axis.
+
+## What changes
+
+- `lib/tau/application.ex`:
+  - Delete `defp maybe_dispatch_cli/0`.
+  - Delete `defp otel_reporter_spec/0`.
+  - Remove the `maybe_dispatch_cli()` call site in `start/2`.
+  - Replace `otel_reporter_spec()` in the child list with `Tau.OtelReporter`
+    (unconditional).
+  - Set `opts = [strategy: :rest_for_one, name: Tau.Supervisor, max_restarts:
+    10, max_seconds: 60]`.
+  - Add inline `spawn_monitor/1` + `receive` block to the `{:ok, pid}` branch
+    of `start/2`, gated on `cli_argv()`, with a comment explaining the blocking
+    idiom and `exit(exit_code)` convention.
+
+No new files. No new modules. No supervision tree structural changes beyond
+removing the `otel_reporter_spec/0` conditional.
+
+## What does not change
+
+- `Tau.OtelReporter` module and its `init/1` `:ignore` logic — unchanged; it
+  becomes the sole gate.
+- `Tau.Application.cli_argv/0` — unchanged; called in the same place.
+- All other children in the supervision tree — order and identity unchanged.
+- `lib/tau/cli.ex` internals — explicitly out of scope.
+- `lib/tau/factory/gate.ex` — explicitly out of scope.
+- All other sub-problems' scopes (global-name-collision, telemetry-handler-
+  coupling, circuit-breaker-invariant-split) — not touched.
+
+## Migration sketch
+
+Single-file change in `lib/tau/application.ex`. Sequence: (1) delete
+`otel_reporter_spec/0` and update the child list; (2) set the new `opts`; (3)
+delete `maybe_dispatch_cli/0` and its call site; (4) insert the `spawn_monitor`
+block with inline comment into `start/2`. The existing binary smoke test
+(`mix test --only smoke`) validates normal-exit and crash-exit paths against
+the patched binary.
+
+Tests that assert `Tau.OtelReporter` is absent from the supervision tree when
+OTel is disabled must be updated to assert it is present-but-ignored (or
+removed if they were testing the now-deleted `otel_reporter_spec/0` function).
+
+## Open questions
+
+1. Does `exit(0)` (integer 0) arrive as `{:DOWN, ref, :process, pid, 0}` or as
+   `{:DOWN, ref, :process, pid, :normal}`? OTP propagates non-`:normal` exit
+   reasons verbatim, but `exit(0)` with integer `0` is technically non-`:normal`
+   — should be confirmed by a smoke test before landing, since the receive guard
+   `when is_integer(exit_code)` relies on it.
+2. The blocking `receive` in `start/2` means the Application controller process
+   blocks until the CLI finishes. In non-CLI (server) mode this is a non-issue;
+   in CLI mode the Burrito binary is designed to block exactly here. Confirm this
+   expectation is documented in `lib/tau/application.ex`'s moduledoc or a comment.
+3. Are there existing unit tests for `maybe_dispatch_cli/0` that will break and
+   need explicit deletion rather than update?
+
+## Linked sub-problems / proposals
+
+- `proposals/proposal-1.md` — Task.Supervisor child + OTel passthrough + relaxed bounds (loses on named-supervisor dependency)
+- `proposals/proposal-2.md` — Tau.CLIRunner supervised GenServer with trap_exit (disqualified: OTP non-negotiable #3)
+- `proposals/proposal-3.md` — **selected** — inline spawn_monitor + receive in start/2
+- `proposals/proposal-4.md` — dedicated tau_cli OTP application (disproportionate cost for defect severity)
+
+## Revision history
+
+- (revision 0 — initial)

--- a/docs/problems-archive-v1-modules/tau-infrastructure/subproblems/supervision-tree-startup/validation.md
+++ b/docs/problems-archive-v1-modules/tau-infrastructure/subproblems/supervision-tree-startup/validation.md
@@ -1,0 +1,396 @@
+---
+template_version: 1
+template_name: validation
+parent_solution: solution.md
+parent_problem: problem.md
+toulmin_complete: true
+falsification_attempted: true
+falsification_outcome: partially_falsified — claim/1
+revision_triggered: none
+---
+
+# Validation: inline spawn_monitor + receive in start/2; OtelReporter always-in-tree; relaxed restart bounds
+
+## Overview
+
+The solution makes three discrete claims: (1) replacing `Task.start/1` with
+inline `spawn_monitor/1` + blocking `receive` in `Tau.Application.start/2`
+guarantees `System.halt/1` fires on every CLI exit path; (2) deleting
+`otel_reporter_spec/0` and unconditionally placing `Tau.OtelReporter` in the
+child list makes `OtelReporter.init/1`'s `:ignore` path the sole OTel
+enable/disable gate; (3) setting `max_restarts: 10, max_seconds: 60` on the
+root supervisor is appropriate for a binary that must absorb transient SQLite
+or Finch init failures without halting. A scoping claim (4) — "no other
+supervision tree changes" — is also extracted. Each claim is taken in turn
+with full Toulmin (six fields) and an explicit falsification strategy.
+Outcome: claims 2, 3, 4 withstood; claim 1 is **partially falsified** by an
+unhandled edge case (supervisor death from restart-intensity exhaustion
+while the controller blocks in `receive`). The qualifier on claim 1 is
+narrowed accordingly; no solution revision is required because the partial
+falsification does not contradict the acceptance criterion (a) and the
+narrowed claim still satisfies it for the spawned-process exit paths the
+criterion enumerates.
+
+## Toulmin per claim
+
+The MITRE empirical study on Toulmin formalism found that "participants
+found it difficult to generate Toulmin structures, and their structures
+varied greatly even though they started with the same content"
+(https://www.mitre.org/news-insights/publication/empirical-evaluation-structured-argumentation-using-toulmin-argument).
+This validation enforces all six components explicitly per claim.
+
+### Claim 1: inline `spawn_monitor/1` + blocking `receive` in `start/2` guarantees `System.halt/1` fires on every CLI exit path
+
+- **Claim (C):** "The spawned process calls `exit(exit_code)` so the integer
+  exit code is carried verbatim in the `:DOWN` reason; the `receive`
+  dispatches to `System.halt/1` on every exit path"
+  (`solution.md:19-21`). The proposal sketch
+  (`proposals/proposal-3.md:74-83`) shows three receive clauses:
+  `{:DOWN, ..., exit_code} when is_integer(exit_code)` →
+  `System.halt(exit_code)`; `{:DOWN, ..., :normal}` → `System.halt(0)`;
+  `{:DOWN, ..., _reason}` → `System.halt(1)`.
+- **Grounds (G):** Three observable facts. (1) `Process.spawn_monitor/1`
+  guarantees a `:DOWN` message for every spawned-process termination
+  (Erlang/OTP `erlang:spawn_monitor/1` man page; the monitor is always
+  delivered exactly once, unlike a link which can be silently dropped by
+  `Process.unlink/1`). (2) `exit/1` with any non-`:normal` term propagates
+  that term verbatim as the `:DOWN` reason; `exit(0)` is non-`:normal` and
+  therefore arrives as the integer `0` (Erlang/OTP process model — open
+  question 1 in `solution.md:100-104` flags this for smoke-test
+  confirmation but the warrant rule is well-established). (3) The three
+  receive clauses exhaustively cover the message shapes (`is_integer/1`,
+  `:normal`, wildcard) so no `:DOWN` can be received without `System.halt/1`
+  firing.
+- **Warrant (W):** OTP rule — `Process.spawn_monitor/1` is the canonical
+  primitive for "spawn a process and be notified of its termination
+  irrespective of crash vs. normal exit", and a `receive` with an
+  exhaustive set of pattern clauses over the message space cannot drop
+  delivery. Combined with the well-defined exit-reason propagation rule
+  (verbatim for non-`:normal`, `:normal` for normal return / `exit(:normal)`),
+  the three-clause receive is total over `:DOWN` messages from the
+  monitored pid.
+- **Qualifier (Q):** Holds for terminations of the spawned CLI process
+  itself — normal return, `exit(integer)`, and any raise/throw that the
+  BEAM converts into a `:DOWN` reason. Does NOT hold if (a) the BEAM is
+  brought down externally (SIGKILL, OOM-kill, `:erlang.halt/0` from
+  another process) before the `:DOWN` arrives; (b) the supervisor crashes
+  due to `max_restarts: 10 / max_seconds: 60` exhaustion, propagating an
+  exit signal to the Application controller (which is `link`-ed to the
+  supervisor it returned from `Supervisor.start_link/2`) — the controller
+  is not trapping exits inside the blocking receive, so it dies and the
+  BEAM terminates via the application controller's normal shutdown
+  semantics without `System.halt/1` firing.
+- **Rebuttal (R):** Two cases narrow Q. The first (external kill) is not
+  the solution's responsibility — no in-process Elixir code can guarantee
+  `System.halt/1` against SIGKILL. The second (supervisor restart-intensity
+  exhaustion while CLI is running) IS in scope and is not addressed by
+  the solution: the controller dies before `System.halt/1` fires, so the
+  exit code is whatever the BEAM produces on application-controller death
+  (typically non-zero, but not the CLI's chosen code). The current
+  `Task.start/1` code shares this weakness, so the solution does not
+  regress here, but it does not close it either.
+- **Backing (B):** Erlang/OTP documentation —
+  `https://www.erlang.org/doc/man/erlang#spawn_monitor-1` for the monitor
+  semantics; `https://www.erlang.org/doc/man/erlang#exit-1` for the
+  exit-reason propagation rule (non-`:normal` reasons propagated verbatim
+  in `:DOWN`). OTP non-negotiable #4 (cross-process signalling) and #7
+  (let-it-crash) — neither is violated by this construct; the controller
+  blocking is unusual but not contraband. Existing test scaffolding for
+  `Tau.OtelReporter` (`test/tau/otel_reporter/otel_reporter_test.exs:56`)
+  uses `start_supervised/1` against the same module, demonstrating the
+  module-as-spec child pattern the solution relies on for OTel.
+
+#### Falsification attempt for claim 1
+
+- **Strategy:** Edge-case enumeration over the failure modes the claim
+  implicitly excludes, paired with a counter-example construction for any
+  enumerated edge case that is in scope of the acceptance criterion.
+- **Attempt:** Enumerated the exit channels for a process spawned with
+  `spawn_monitor/1`:
+  1. `exit(integer)` from inside the spawned fn — receive's
+     `is_integer(exit_code)` clause matches; `System.halt(exit_code)`
+     fires. Withstood.
+  2. Normal return from the fn (the `exit_code` is set by `case` and the
+     spawned fn ends without an explicit `exit/1`) — the `exit(exit_code)`
+     line in the sketch (`proposal-3.md:71`) does call `exit/1`
+     unconditionally; the fn never returns normally. Withstood by code
+     shape, not by warrant.
+  3. `exit(:normal)` directly — second receive clause matches;
+     `System.halt(0)` fires. Withstood.
+  4. Uncaught raise inside `Tau.CLI.main/1` — converted to
+     `{kind, reason, stacktrace}` exit; matches wildcard;
+     `System.halt(1)` fires. Withstood.
+  5. Throw inside `Tau.CLI.main/1` — same as raise; matches wildcard.
+     Withstood.
+  6. The Application controller process is killed (e.g., another supervised
+     subtree fires `max_restarts` and the root supervisor exits, sending
+     an `EXIT` signal to its linked Application controller) — the
+     controller is blocked in `receive` and is not trapping exits, so it
+     dies; the `:DOWN` for the CLI may or may not have arrived first.
+     If it has not, `System.halt/1` does NOT fire — the BEAM terminates
+     via the application controller's death path. **Counter-example
+     constructed** for the edge case "supervisor exhausts restart
+     intensity while CLI is running".
+  7. The BEAM is killed externally (SIGKILL) — out of scope; no Elixir
+     construct can guarantee `System.halt/1` here.
+- **Outcome:** **Partially falsified.** Case (6) is a real exit channel
+  the claim does not cover. It is not in scope of acceptance criterion
+  (a) — which targets "normal and crash exits" of the CLI process itself
+  — but the claim as written in `solution.md:19-21` ("on every exit
+  path") overreaches relative to what the solution actually delivers.
+- **Action:** Narrow the qualifier in place. The narrowed claim:
+  "`System.halt/1` fires on every CLI process exit path
+  (normal return, `exit(:normal)`, `exit(integer)`, raise, throw),
+  but not on Application controller death due to supervisor
+  restart-intensity exhaustion." No solution revision is required:
+  acceptance criterion (a) is satisfied by the narrowed claim, and the
+  uncovered case is identical in the existing `Task.start/1` code so
+  the solution does not regress. The Outstanding doubts section records
+  the residual concern for the parent-level validator.
+
+### Claim 2: deleting `otel_reporter_spec/0` and unconditionally including `Tau.OtelReporter` in the child list makes `OtelReporter.init/1`'s `:ignore` path the sole OTel enable/disable gate
+
+- **Claim (C):** "Remove `otel_reporter_spec/0` and replace its conditional
+  call site with `Tau.OtelReporter` unconditionally —
+  `OtelReporter.init/1`'s existing `:ignore` return becomes the sole
+  enabled/disabled gate" (`solution.md:22-24`).
+- **Grounds (G):** Direct code evidence. (1)
+  `lib/tau/otel_reporter.ex:53-73` shows `init/1` reading `Config.load()`,
+  checking `config.enabled`, and returning `:ignore` when disabled. (2)
+  `lib/tau/application.ex:113-119` defines `otel_reporter_spec/0` reading
+  `Application.get_env(:tau, :otel, []) |> Keyword.get(:enabled, false)`.
+  (3) The two gates already share the same source of truth via
+  `Config.load/0` (the application env) — there is no third independent
+  observer. (4) `grep -rn` confirms no other call sites for either
+  `otel_reporter_spec` or any out-of-band OTel enable check
+  (`lib/tau/application.ex:67, 113` and `lib/tau/application.ex:179`
+  are the only occurrences across `lib/` and `test/`).
+- **Warrant (W):** Rich Hickey "complecting" rule: a single concept
+  (enable/disable policy) expressed in two independent code sites is
+  complected and must be braided every time either is touched. Reducing
+  to one site decomplects. OTP supervisor child-spec convention also
+  supports this: `:ignore` from `init/1` is the idiomatic way to declare
+  "this optional process is not needed in this configuration" without
+  the parent rewriting its child list.
+- **Qualifier (Q):** Holds for the runtime read path — every supervisor
+  boot will see the same `config.enabled` value via `Config.load/0`.
+  Does NOT hold if some downstream code observes "is `Tau.OtelReporter`
+  in the registered processes?" as a proxy for "is OTel enabled?" —
+  that observation would still be answered consistently (the process
+  is absent in both cases: `:ignore` means no pid is registered), but
+  the assertion shape is different from the current `[Tau.OtelReporter]
+  vs []` shape.
+- **Rebuttal (R):** Tests that assert "the OtelReporter child is absent
+  from the supervision tree when OTel is disabled" must be rewritten to
+  assert "the process is not running" or removed
+  (`solution.md:94-96`). The solution acknowledges this. A second
+  rebuttal: if `Tau.OtelReporter` is moved from `:rest_for_one` position
+  inside the tree without considering that a hard `init/1` crash (vs.
+  `:ignore`) would still cascade to descendants, the unconditional
+  inclusion makes the cascade depend on `init/1` correctness — but
+  `:ignore` does NOT cascade (it is treated as "child intentionally
+  absent"), so this rebuttal does not apply unless `init/1` returns
+  `{:stop, reason}` (the `:otel_not_started` branch at
+  `lib/tau/otel_reporter.ex:67-68`).
+- **Backing (B):** Hickey, "Simple Made Easy" (2011) —
+  https://www.infoq.com/presentations/Simple-Made-Easy/ — for the
+  decomplect-by-single-source-of-truth rule. OTP design principles ch.
+  "Supervisor behaviour" for the `:ignore` semantics
+  (https://www.erlang.org/doc/design_principles/sup_princ.html); the
+  Elixir `GenServer.init/1` typespec
+  (https://hexdocs.pm/elixir/GenServer.html#c:init/1) documenting that
+  `:ignore` causes the supervisor to silently skip the child without
+  treating it as an error.
+
+#### Falsification attempt for claim 2
+
+- **Strategy:** Dependency check — verify the cited prior state
+  (`OtelReporter.init/1` already has the `:ignore` branch and the
+  conditional in the supervisor reads from the same env) holds today,
+  plus integration check that no other site observes the dual-gate
+  shape.
+- **Attempt:** (1) Read `lib/tau/otel_reporter.ex:50-74` — `:ignore`
+  branch present and unchanged. (2) `grep -rn "otel_reporter_spec\|
+  Tau.OtelReporter" lib/ test/` — the only producers of "is OTel
+  enabled?" decisions are the two cited sites; tests reference
+  `Tau.OtelReporter` only by module name in
+  `test/tau/otel_reporter/otel_reporter_test.exs`, never by checking
+  presence in the supervision tree.
+- **Outcome:** **Withstood.** The dependency state holds and no third
+  observer exists. The migration note in `solution.md:94-96` correctly
+  identifies the test-update surface.
+- **Action:** None.
+
+### Claim 3: `max_restarts: 10, max_seconds: 60` on the root supervisor is appropriate for the binary's recovery expectations
+
+- **Claim (C):** "Set `max_restarts: 10, max_seconds: 60` on the root
+  supervisor opts" (`solution.md:24`, `solution.md:65-66`).
+- **Grounds (G):** (1) Current opts are `[strategy: :rest_for_one, name:
+  Tau.Supervisor]` (`lib/tau/application.ex:93`) with the OTP default
+  `max_restarts: 3 / max_seconds: 5`. (2) The problem statement
+  enumerates transient init failures the binary must absorb: SQLite
+  locked on cold start, Finch init, the `Tau.Memory.Supervisor`'s
+  schema migration (`problem.md:24-30`). (3) Boot ordering encodes
+  ~15 children under `:rest_for_one` (`lib/tau/application.ex:7-47`);
+  any early-child transient produces a cascade restart of all
+  descendants, consuming the restart budget rapidly.
+- **Warrant (W):** OTP supervisor-intensity rule: `max_restarts` /
+  `max_seconds` bounds the number of restarts that count as "the
+  supervised system can recover by itself" before the supervisor gives
+  up and shuts down. The defaults (3 in 5s) are tuned for development;
+  production systems with transient external-resource dependencies
+  routinely raise them. `:rest_for_one` amplifies restart cost because
+  one transient cascades to all later children.
+- **Qualifier (Q):** Holds against the failure modes the problem
+  statement names (transient SQLite lock, Finch init, schema migration
+  retry). Does NOT necessarily hold for systematic failures (a
+  permanently-broken config that crashes every restart); for those, no
+  finite bound is appropriate and the binary correctly halts.
+- **Rebuttal (R):** A bound that is too loose hides systematic failures
+  behind a long restart cycle — e.g., a misconfigured Finch endpoint
+  could thrash for 60s before the supervisor gives up, delaying the
+  operator's awareness. Counter-rebuttal: 10/60 still terminates within
+  a minute, which is acceptable for a CLI binary; for a server-mode
+  process where instant termination is preferable, the bound should be
+  re-examined. The solution targets CLI-mode operation per the
+  acceptance criterion.
+- **Backing (B):** Erlang/OTP supervisor man page —
+  https://www.erlang.org/doc/man/supervisor — documents the
+  intensity/period contract. Tau's own
+  `lib/tau/coding_agent/dispatcher.ex:63` comment ("rapid runs trip the
+  DynamicSupervisor's max_restarts intensity") confirms the project
+  has hit default-intensity exhaustion before and knows the failure
+  shape.
+
+#### Falsification attempt for claim 3
+
+- **Strategy:** Counter-example construction — try to construct a
+  failure mode the new bound mishandles.
+- **Attempt:** Enumerate failure shapes against the 10/60 bound:
+  (1) cold-start SQLite locked, single retry succeeds: 1 restart →
+  withstood. (2) cold-start SQLite locked for several seconds, multiple
+  retries: bounded above by 10 restarts in 60s, leaving headroom for
+  the system to wait → withstood. (3) Finch DNS misconfiguration:
+  systematic; restart loops at maximum rate → consumes 10 restarts
+  within seconds; supervisor exits; binary terminates within ~10s →
+  acceptable for CLI mode. (4) A child whose `init/1` runs in 7s and
+  fails: each restart attempt consumes 7s; 10 restarts span 70s,
+  exceeding the 60s window, so the bound triggers before all 10 are
+  consumed → withstood by intent. No counter-example falsifies the
+  claim within its qualifier.
+- **Outcome:** **Withstood.**
+- **Action:** None.
+
+### Claim 4: no other supervision-tree structural changes
+
+- **Claim (C):** "No new files. No new modules. No supervision tree
+  structural changes beyond removing the `otel_reporter_spec/0`
+  conditional" (`solution.md:71-72`); "All other children in the
+  supervision tree — order and identity unchanged" (`solution.md:78`).
+- **Grounds (G):** The "what changes" section
+  (`solution.md:59-69`) enumerates only deletions
+  (`maybe_dispatch_cli/0`, `otel_reporter_spec/0`), replacements
+  (conditional → unconditional `Tau.OtelReporter` in the child list),
+  the new `opts` line, and the inline `spawn_monitor` block. No
+  add/remove/reorder of any other child in
+  `lib/tau/application.ex:60-91`.
+- **Warrant (W):** Boot-order discipline rule (encoded in
+  `lib/tau/application.ex:7-47` moduledoc): every reorder requires
+  re-justifying the dependency chain under `:rest_for_one`. The
+  solution explicitly opts out of touching this surface, which is the
+  minimum-blast-radius choice.
+- **Qualifier (Q):** Holds as stated for the named file. Holds
+  conditionally for "no new modules": the solution introduces no new
+  module identifiers, but the existing `Tau.OtelReporter` module's
+  child-spec call shape changes from an indirect call to a direct one.
+- **Rebuttal (R):** None substantive — the claim is a scoping
+  assertion verifiable by diff.
+- **Backing (B):** `lib/tau/application.ex:7-47` moduledoc, which
+  codifies the boot order as a hard project invariant; ADR-0004
+  (cited there, governing PubSub placement).
+
+#### Falsification attempt for claim 4
+
+- **Strategy:** Counter-example construction — attempt to find any
+  edit the solution forces beyond what is enumerated.
+- **Attempt:** Cross-walked every line of the "What changes" list
+  against `lib/tau/application.ex`. Each entry maps to either a
+  deletion (`maybe_dispatch_cli/0` body at 179-195;
+  `otel_reporter_spec/0` body at 113-119), a one-line replacement
+  (child list entry 67, opts line 93), or an insertion (the
+  `spawn_monitor` block at the `{:ok, pid}` branch, ~15 lines
+  beginning at line 96). No collateral edits required.
+- **Outcome:** **Withstood.**
+- **Action:** None.
+
+## Cross-claim consistency
+
+The four claims are mutually consistent. Claim 1's narrowed qualifier
+(uncovered case: supervisor restart-intensity exhaustion crashes the
+Application controller) interacts with Claim 3 (which raises the
+intensity bound from 3/5 to 10/60): a higher bound makes the
+uncovered case in Claim 1 *less likely*, not more. Claim 2's removal
+of the dual-gate is orthogonal to claims 1 and 3. Claim 4 (no other
+structural changes) is consistent with all others. No internal
+tension to resolve.
+
+## Falsification summary
+
+| # | Claim (short) | Strategy | Outcome | Action |
+|---|---|---|---|---|
+| 1 | spawn_monitor+receive guarantees `System.halt/1` on every CLI exit path | edge-case enumeration | partially_falsified | narrow Q to "every CLI *process* exit path"; record outstanding doubt |
+| 2 | `OtelReporter.init/1` `:ignore` becomes sole gate | dependency + integration check | withstood | none |
+| 3 | `max_restarts: 10, max_seconds: 60` is appropriate | counter-example construction | withstood | none |
+| 4 | No other supervision-tree structural changes | counter-example construction | withstood | none |
+
+## Revision required
+
+No revision triggered. The Claim 1 partial falsification is handled in
+place via qualifier narrowing: the original claim's "on every exit
+path" is narrowed to "on every CLI *process* exit path (normal
+return, `exit(:normal)`, `exit(integer)`, raise, throw)". The
+uncovered case — Application controller death due to supervisor
+restart-intensity exhaustion while the receive is blocked — is
+identical in the existing `Task.start/1` code (the current Task does
+not survive the BEAM's response to supervisor death either), so the
+solution does not regress, and the acceptance criterion (a) targets
+the CLI-process exit channels, all of which the narrowed claim
+covers. No file requires revision.
+
+- **Target file:** none
+- **Revision kind:** in-place qualifier narrowing (recorded above)
+- **Rationale:** the partial falsification is outside the acceptance
+  criterion's scope and the solution does not regress against the
+  current code on the uncovered case.
+
+## Outstanding doubts
+
+For the parent-level validator (`docs/problems/tau-infrastructure/`)
+to inherit:
+
+- The proposal's prior-art reference (`proposals/proposal-3.md:167`)
+  cites `IEx.App` as "blocks the Application controller to ensure the
+  IEx REPL drives the VM lifetime". Inspection of
+  `/home/brentw/.local/elixir/lib/iex/lib/iex/app.ex` shows
+  `IEx.App.start/2` does NOT block — it returns immediately after
+  `Supervisor.start_link/2`. The cited prior art is therefore
+  incorrect, weakening (but not falsifying) the warrant that the
+  blocking-`receive`-in-`start/2` pattern is established OTP idiom.
+  The pattern is still implementable and correct under its narrowed
+  qualifier, but the project should not rely on a published precedent
+  to justify it; document the idiom explicitly in the
+  `lib/tau/application.ex` moduledoc as the solution's open question 2
+  already requests (`solution.md:105-108`).
+- Solution open question 1 (`solution.md:100-104`) — whether
+  `exit(0)` propagates as integer `0` or as `:normal` — is answerable
+  from the OTP `erlang:exit/1` documentation (non-`:normal` reasons
+  propagate verbatim; `0` is non-`:normal`) but the solution defers
+  to a smoke test. The smoke test is good practice but the warrant
+  underlying claim 1 does not depend on the answer because the
+  receive's three clauses cover both possibilities.
+- The blocking `receive` inside `Application.start/2` is unusual; any
+  downstream caller that calls `Application.started_applications/0`
+  to check for `:tau` while the binary is in CLI mode will observe
+  `:tau` as "not yet started" for the lifetime of the CLI run. The
+  binary's own subsystems do not appear to make this check, but a
+  future addition might.

--- a/docs/problems-archive-v1-modules/tau-infrastructure/subproblems/telemetry-handler-coupling/problem.md
+++ b/docs/problems-archive-v1-modules/tau-infrastructure/subproblems/telemetry-handler-coupling/problem.md
@@ -1,0 +1,84 @@
+---
+template_version: 1
+template_name: problem
+node_kind: leaf
+depth: 1
+parent: ../../problem.md
+status: draft
+---
+
+# Problem: telemetry handler crash-safety and supervisor strategy mismatch
+
+## Statement
+
+`Tau.Cost.Tracker.handle_event/4` (the `[:tau, :provider, :request, :stop]`
+handler) has no rescue guard, contrary to D-035 and contrary to the
+coding-agent twin `handle_coding_agent_cost/4` in the same module; a
+malformed `:usage` measurement from any provider crashes the calling FSM
+process. Independently, `Tau.Telemetry.Supervisor` uses `:one_for_one`
+strategy, so a `Tau.Telemetry.Handlers` crash restarts only `Handlers`
+without restarting `Tau.Cost.Tracker` — on `Handlers` restart the event
+list is re-attached, but `Cost.Tracker`'s own handlers remain attached from
+its prior `init/1`, creating a window for duplicate handler attachment.
+
+## Context
+
+- `lib/tau/cost/tracker.ex:118-138` — `handle_event/4` uses a `with` chain
+  that falls through to `else _ -> :ok` for structural mismatches, but has
+  no `rescue` around the `:ets.update_counter/3` call at line 129; a
+  provider emitting a non-integer in `:usage` that passes the `is_map`
+  guard causes an `ArgumentError` in the emitter's process. Flat audit:
+  Critical, classified as OTP-NN §7 violation.
+- `lib/tau/cost/tracker.ex:140-158` — `handle_coding_agent_cost/4` documents
+  D-035 explicitly: "cost-folding errors MUST degrade gracefully"; the
+  provider handler does not.
+- `lib/tau/telemetry/supervisor.ex:16-23` — `strategy: :one_for_one`;
+  `Tau.Telemetry.Handlers` and `Tau.Cost.Tracker` are siblings. A crash in
+  `Handlers` restarts only `Handlers`. `Handlers.init/1` calls
+  `:telemetry.attach_many/4`; `Cost.Tracker.init/1` also calls
+  `:telemetry.attach/4` — independently. After a `Handlers`-only restart,
+  the `Handlers` event list is re-registered while `Cost.Tracker`'s
+  handlers (still alive) remain registered. Flat audit: minor, suggests
+  `:rest_for_one` so a `Handlers` crash cascades to `Cost.Tracker` forcing
+  re-`init/1`.
+- SPEC-CIRCUIT-BREAKER not directly in scope; OTP-NN §7.
+
+## Complecting hypothesis
+
+1. **Handler crash-safety is complected with the event's structural
+   completeness**: `handle_event/4` trusts that any measurement passing the
+   `is_map` guard has integer-valued token fields, embedding a provider-side
+   correctness assumption into the crash boundary.
+2. **Handler attachment lifecycle is complected with supervisor restart
+   scope**: which handlers are alive after a partial subtree restart is
+   determined by the supervisor strategy, not by any explicit
+   attach/detach pairing on the handlers themselves.
+
+## Decomposition strategy
+
+(leaf — no further decomposition; proceed to proposals)
+
+## Acceptance criterion
+
+A proposal names: (a) the rescue boundary to add to
+`Cost.Tracker.handle_event/4` that makes it D-035-compliant and symmetric
+with its coding-agent twin, including what telemetry event to emit on
+failure; (b) the supervisor strategy change (`:one_for_one` → `:rest_for_one`)
+in `Tau.Telemetry.Supervisor` and the justification that this change does
+not over-restart `Cost.Tracker` in the common path.
+
+## Out of scope
+
+- Supervision tree startup ordering or CLI task — exclusive scope of
+  **supervision-tree-startup**.
+- Global process name collision — exclusive scope of **global-name-collision**.
+- Circuit-breaker counter protocol — exclusive scope of
+  **circuit-breaker-invariant-split**.
+- `Tau.OtelReporter.Handler.handle_event/4`'s existing rescue (justified by
+  the handler-must-not-crash-emitter contract; not a defect).
+- `Tau.Telemetry.Handlers.handle_event/4` log-format pessimisation (info
+  severity; not a correctness defect).
+
+## Amendment log
+
+- (none yet)

--- a/docs/problems-archive-v1-modules/tau-infrastructure/subproblems/telemetry-handler-coupling/proposals/proposal-1.md
+++ b/docs/problems-archive-v1-modules/tau-infrastructure/subproblems/telemetry-handler-coupling/proposals/proposal-1.md
@@ -1,0 +1,145 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 1
+parent_problem: ../problem.md
+---
+
+# Proposal 1: Symmetric rescue in handle_event/4 + :rest_for_one supervisor strategy
+
+## Approach
+
+Add a `rescue` block to `Tau.Cost.Tracker.handle_event/4` that mirrors the
+existing guard in `handle_coding_agent_cost/4`, emitting
+`[:tau, :cost, :tracker, :handler_failed]` on error and returning `:ok`. In
+the same PR, change `Tau.Telemetry.Supervisor.init/1` from
+`strategy: :one_for_one` to `strategy: :rest_for_one`. No new modules, no
+interface changes, no API breakage — two targeted edits in two files.
+
+## Rationale
+
+`handle_event/4` already has the correct structural guard (the `with`/`else`
+chain drops bad shapes silently), but it lacks a `rescue` around the `:ets`
+call path that is reachable when `usage` passes `is_map` but contains a
+non-integer value that slips past `nz/1` (e.g. a float). The coding-agent
+twin's `rescue` is the D-035-mandated pattern; the fix is literal symmetry.
+The supervisor change decomplects handler-attachment lifecycle from supervisor
+strategy: under `:rest_for_one`, a `Handlers` crash cascades left-to-right
+through the child list so `Cost.Tracker` restarts too, forcing its `init/1`
+to re-`detach`-then-`attach` cleanly. The attachment lifecycle is then
+expressed by the child ordering in the supervisor, not by an invisible side
+effect of what happened to survive.
+
+## Sketch
+
+**`lib/tau/cost/tracker.ex` — add rescue to `handle_event/4`:**
+
+```elixir
+@doc false
+def handle_event(_event, measurements, metadata, _config) do
+  with provider when is_atom(provider) and not is_nil(provider) <- metadata[:provider],
+       session_id when is_binary(session_id) <- metadata[:session_id],
+       usage when is_map(usage) <- measurements[:usage] do
+    key = {today_iso(), provider, metadata[:model], session_id}
+
+    input = nz(usage[:input_tokens])
+    output = nz(usage[:output_tokens])
+    cr     = nz(usage[:cache_read])
+    cw     = nz(usage[:cache_write])
+
+    :ets.update_counter(
+      @table,
+      key,
+      [{2, input}, {3, output}, {4, cr}, {5, cw}],
+      {key, 0, 0, 0, 0}
+    )
+  else
+    _ -> :ok
+  end
+rescue
+  e ->
+    :telemetry.execute(
+      [:tau, :cost, :tracker, :handler_failed],
+      %{system_time: System.system_time()},
+      %{reason: Exception.message(e)}
+    )
+    :ok
+end
+```
+
+**`lib/tau/telemetry/supervisor.ex` — change strategy:**
+
+```elixir
+@impl true
+def init(_opts) do
+  children = [
+    Tau.Telemetry.Handlers,   # index 0 — if this crashes, index 1+ restart
+    Tau.Cost.Tracker          # index 1 — re-attaches its own handlers on init
+  ]
+
+  Supervisor.init(children, strategy: :rest_for_one)
+end
+```
+
+Child ordering matters: `Handlers` must remain listed before `Cost.Tracker`
+so a `Handlers` crash cascades to `Cost.Tracker`, not the reverse.
+
+## Tradeoffs
+
+### Strengths
+
+- Minimal diff: two files, ~10 lines changed; easy to review and revert.
+- Directly symmetric with the existing `handle_coding_agent_cost/4` pattern,
+  so no new idiom is introduced.
+- `:rest_for_one` explicitly encodes the attachment dependency in the child
+  list ordering, making the invariant visible in the source.
+- Zero consumer-facing API change.
+- Satisfies both acceptance criterion parts (a) and (b) independently.
+
+### Weaknesses
+
+- `:rest_for_one` restarts `Cost.Tracker` on every `Handlers` crash — even
+  those unrelated to cost tracking. In the common path (no crash), this is
+  irrelevant, but a flapping `Handlers` would repeatedly reset in-flight
+  cost counters (ETS table is re-created on `Cost.Tracker.init/1`).
+- The supervisor strategy change is invisible to static analysis; reviewers
+  must mentally walk the child list to confirm ordering is correct.
+- Does not address the broader question of whether `Cost.Tracker` should
+  self-manage its handler lifecycle independently of `Handlers`.
+- `nz/1` returning `0` for a non-integer silently absorbs malformed provider
+  data; the rescue prevents a crash but does not surface the data error to
+  the provider adapter. That remains an acceptable silent drop per D-035.
+
+### Costs
+
+- 2 files changed, ~10 lines net.
+- Test surface: add one test asserting `handle_event/4` returns `:ok` and
+  emits `[:tau, :cost, :tracker, :handler_failed]` when `:ets.update_counter`
+  would raise (e.g. inject a float via a mock measurement). The coding-agent
+  twin's existing test provides the pattern.
+- No dependency changes; no migration.
+
+## Dependencies
+
+- None. This is a self-contained change within `Tau.Telemetry.Supervisor`
+  and `Tau.Cost.Tracker`.
+
+## Confidence
+
+medium — the rescue pattern is proven by the coding-agent twin; the
+`:rest_for_one` change is standard OTP. Confidence would be high after
+confirming that `Cost.Tracker.terminate/2` calls `:telemetry.detach/1`
+(it does, line 112-114), so the ETS table destruction + handler detach on
+restart is clean.
+
+## Prior art / references
+
+- `Tau.Cost.Tracker.handle_coding_agent_cost/4` lines 144-172 — the exact
+  rescue pattern to mirror.
+- `Tau.Cost.Tracker.terminate/2` lines 111-115 — confirms detach-on-terminate
+  makes `:rest_for_one` restart safe.
+- OTP non-negotiables §7: "Let it crash; supervise; restart. MUST NOT
+  try/rescue across process boundaries." — rescue inside a telemetry handler
+  is intra-process; D-035 explicitly requires it; no contradiction.
+- Erlang/OTP supervisor docs: `:rest_for_one` — children after the crashed
+  child are restarted left-to-right after the crashed child recovers.

--- a/docs/problems-archive-v1-modules/tau-infrastructure/subproblems/telemetry-handler-coupling/proposals/proposal-2.md
+++ b/docs/problems-archive-v1-modules/tau-infrastructure/subproblems/telemetry-handler-coupling/proposals/proposal-2.md
@@ -1,0 +1,163 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 2
+parent_problem: ../problem.md
+---
+
+# Proposal 2: Extract Tau.Cost.HandlerGuard — shared rescue wrapper for all cost handlers
+
+## Approach
+
+Extract a new module `Tau.Cost.HandlerGuard` that provides a single
+`guarded/3` wrapper function (handler id, measurement map, a zero-arity
+fun) with the D-035-compliant `rescue` and telemetry emission inside.
+Rewrite both `handle_event/4` and `handle_coding_agent_cost/4` in
+`Tau.Cost.Tracker` to delegate their bodies through `HandlerGuard.guarded/3`.
+Change `Tau.Telemetry.Supervisor` to `:rest_for_one` as in Proposal 1.
+
+## Rationale
+
+The two handler functions already share the same rescue pattern and the
+same failure-telemetry event; the only difference is which event they
+listen to and which metadata keys they read. Extracting the guard into
+`HandlerGuard` makes it impossible for a future third handler (e.g. a
+streaming-token cost event) to be added without the rescue — the guard
+is the only public entry point. The complecting hypothesis states that
+crash-safety is woven into handler identity; `HandlerGuard` decomplects
+by making crash-safety a structural wrapper rather than a per-handler
+convention. The supervisor change is the same as Proposal 1 for the same
+reason.
+
+## Sketch
+
+**New file `lib/tau/cost/handler_guard.ex`:**
+
+```elixir
+defmodule Tau.Cost.HandlerGuard do
+  @moduledoc """
+  Wraps a telemetry handler body with the D-035-mandated rescue boundary.
+
+  Any exception raised inside `fun` is caught; a
+  `[:tau, :cost, :tracker, :handler_failed]` event is emitted with the
+  exception message, and the handler returns `:ok` so the emitter is
+  never crashed.
+  """
+
+  @failure_event [:tau, :cost, :tracker, :handler_failed]
+
+  @doc """
+  Invoke `fun.()` inside a D-035-compliant rescue boundary.
+
+  `handler_id` is included in the failure-event metadata for
+  observability (distinguishes which handler raised).
+  """
+  @spec guarded(String.t(), (-> :ok)) :: :ok
+  def guarded(handler_id, fun) when is_function(fun, 0) do
+    fun.()
+  rescue
+    e ->
+      :telemetry.execute(
+        @failure_event,
+        %{system_time: System.system_time()},
+        %{handler_id: handler_id, reason: Exception.message(e)}
+      )
+      :ok
+  end
+end
+```
+
+**`lib/tau/cost/tracker.ex` — rewrite both handler bodies:**
+
+```elixir
+@doc false
+def handle_event(_event, measurements, metadata, _config) do
+  HandlerGuard.guarded(@handler_id, fn ->
+    with provider when is_atom(provider) and not is_nil(provider) <- metadata[:provider],
+         session_id when is_binary(session_id) <- metadata[:session_id],
+         usage when is_map(usage) <- measurements[:usage] do
+      key = {today_iso(), provider, metadata[:model], session_id}
+      :ets.update_counter(@table, key,
+        [{2, nz(usage[:input_tokens])}, {3, nz(usage[:output_tokens])},
+         {4, nz(usage[:cache_read])},   {5, nz(usage[:cache_write])}],
+        {key, 0, 0, 0, 0})
+    else
+      _ -> :ok
+    end
+  end)
+end
+
+@doc false
+def handle_coding_agent_cost(_event, measurements, metadata, _config) do
+  HandlerGuard.guarded(@coding_agent_handler_id, fn ->
+    with agent when is_atom(agent) and not is_nil(agent) <- metadata[:agent],
+         session_id when is_binary(session_id) <- metadata[:session_id] do
+      key = {today_iso(), agent, metadata[:model], session_id}
+      :ets.update_counter(@table, key,
+        [{2, nz(measurements[:input_tokens])}, {3, nz(measurements[:output_tokens])},
+         {4, nz(measurements[:cache_read])},   {5, nz(measurements[:cache_write])}],
+        {key, 0, 0, 0, 0})
+    else
+      _ -> :ok
+    end
+  end)
+end
+```
+
+**`lib/tau/telemetry/supervisor.ex`** — identical `:rest_for_one` change as
+Proposal 1.
+
+**File move summary:** `lib/tau/cost/handler_guard.ex` added (new).
+
+## Tradeoffs
+
+### Strengths
+
+- Makes D-035 structurally enforceable: future handlers cannot bypass the
+  rescue without deliberately not calling `HandlerGuard.guarded/3`.
+- Adds `handler_id` to the failure-event metadata, improving observability
+  (distinguishes which handler raised — useful if more handlers are added).
+- Eliminates the current code duplication between the two handler rescues.
+- The guard is independently testable without standing up a supervisor tree.
+
+### Weaknesses
+
+- Introduces a new module for what is currently a ~5-line pattern; may be
+  over-engineering given there are only two handlers today.
+- The wrapper function call (`HandlerGuard.guarded/3`) obscures the handler
+  body one level deeper, making stack traces slightly harder to read.
+- Does not address the structural question of why `handle_event/4` was
+  written without the rescue in the first place — a process/review issue,
+  not a code issue.
+- `rescue` inside the anonymous function propagates up to `guarded/3`'s
+  rescue: this is correct but may be non-obvious to reviewers unfamiliar
+  with how Elixir `rescue` scopes in nested functions.
+
+### Costs
+
+- 1 new file (`handler_guard.ex`), 2 files modified, ~25 lines net.
+- Test surface: `HandlerGuard` itself needs a unit test (guarded fn raises
+  → returns `:ok` + emits telemetry). Existing handler tests exercise the
+  delegating bodies; a separate `HandlerGuard` test is clean.
+- No dependency changes; no migration.
+
+## Dependencies
+
+- None beyond the same `:rest_for_one` supervisor change.
+
+## Confidence
+
+medium — the pattern is clean; the only risk is reviewer resistance to
+adding a module for a small rescue wrapper. Would be high if a third
+cost-telemetry handler were already planned (making DRY clearly worthwhile).
+
+## Prior art / references
+
+- `Tau.OtelReporter.Handler.handle_event/4` — a different module that also
+  wraps its handler body in a rescue, independently confirming the OTP
+  telemetry handler-must-not-crash-emitter contract.
+- D-035 ("cost-folding errors MUST degrade gracefully") — the spec driving
+  this proposal.
+- Elixir docs: anonymous function rescue scope — confirmed that `rescue`
+  inside an anonymous function is local to that function's frame, not the
+  enclosing `def`'s.

--- a/docs/problems-archive-v1-modules/tau-infrastructure/subproblems/telemetry-handler-coupling/proposals/proposal-3.md
+++ b/docs/problems-archive-v1-modules/tau-infrastructure/subproblems/telemetry-handler-coupling/proposals/proposal-3.md
@@ -1,0 +1,157 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 3
+parent_problem: ../problem.md
+---
+
+# Proposal 3: Cost.Tracker self-manages handler detach/re-attach on sibling crash via PubSub monitoring — no supervisor strategy change
+
+## Approach
+
+Keep `Tau.Telemetry.Supervisor` at `:one_for_one`. Instead, add a
+`handle_info/2` clause to `Tau.Cost.Tracker` that monitors `Tau.Telemetry.Handlers`
+via `Process.monitor/1` and re-attaches (detach → attach) its own handlers
+when it receives a `{:DOWN, ...}` notification for `Handlers`. Add the `rescue`
+to `handle_event/4` as in Proposal 1. The handler-attachment lifecycle is then
+an explicit, self-describing behaviour inside `Cost.Tracker`, not an implicit
+consequence of supervisor restart ordering.
+
+## Rationale
+
+The second complecting hypothesis states that handler-attachment lifecycle is
+determined by supervisor strategy rather than by explicit lifecycle logic.
+Proposal 1 and 2 address this by making the supervisor strategy encode the
+dependency. This proposal instead decomplects by making `Cost.Tracker`
+explicitly aware of its sibling's lifecycle: the attachment is expressed as
+a reaction to a `:DOWN` message, not as a side effect of child-list ordering.
+This approach keeps the supervisor strategy at `:one_for_one` (no change to
+restart scopes), avoids cascade-restarting `Cost.Tracker` on every `Handlers`
+crash, and makes the re-attach logic visible and testable without touching
+the supervisor.
+
+## Sketch
+
+**`lib/tau/cost/tracker.ex` — add monitor + DOWN handler in `init/1` and
+`handle_info/2`:**
+
+```elixir
+@impl true
+def init(_opts) do
+  :ets.new(@table, [:named_table, :public, :set,
+                    read_concurrency: true, write_concurrency: true])
+  attach_handlers()
+
+  # Monitor Handlers so we can re-attach if it crashes and restarts.
+  # We watch by name; if Handlers is not yet started we receive :DOWN
+  # with reason :noproc and re-try once supervision stabilises.
+  if pid = Process.whereis(Tau.Telemetry.Handlers) do
+    Process.monitor(pid)
+  end
+
+  {:ok, %{}}
+end
+
+@impl true
+def handle_info({:DOWN, _ref, :process, _pid, _reason}, state) do
+  # Handlers crashed and will be restarted by its own supervisor child spec.
+  # Detach and re-attach our handlers to clear any stale registration.
+  :telemetry.detach(@handler_id)
+  :telemetry.detach(@coding_agent_handler_id)
+  attach_handlers()
+
+  # Re-monitor the new Handlers pid once it is up.
+  # Retry with a brief delay to let the supervisor restart it.
+  Process.send_after(self(), :remonitor_handlers, 100)
+  {:noreply, state}
+end
+
+def handle_info(:remonitor_handlers, state) do
+  if pid = Process.whereis(Tau.Telemetry.Handlers) do
+    Process.monitor(pid)
+  else
+    # Handlers still not up; retry once more.
+    Process.send_after(self(), :remonitor_handlers, 500)
+  end
+  {:noreply, state}
+end
+
+# --- private ---
+
+defp attach_handlers do
+  :telemetry.attach(@handler_id, [:tau, :provider, :request, :stop],
+                    &__MODULE__.handle_event/4, nil)
+  :telemetry.attach(@coding_agent_handler_id, [:tau, :coding_agent, :cost],
+                    &__MODULE__.handle_coding_agent_cost/4, nil)
+end
+```
+
+**`lib/tau/cost/tracker.ex` — add rescue to `handle_event/4`** (identical to
+Proposal 1 sketch).
+
+**`lib/tau/telemetry/supervisor.ex`** — NO change; strategy remains
+`:one_for_one`.
+
+## Tradeoffs
+
+### Strengths
+
+- Decomplects attachment lifecycle from supervisor strategy: the dependency
+  is expressed in code (monitor + DOWN handler), not in child-list order.
+- Avoids cascading `Cost.Tracker` restart on every `Handlers` crash, so
+  in-flight cost counters (ETS contents) are preserved across `Handlers`
+  crashes.
+- The re-attach logic is independently testable: send a mock `:DOWN` message
+  to the tracker and assert handlers are re-attached.
+- No change to the supervisor's restart scope; side-effect containment is
+  better.
+
+### Weaknesses
+
+- Adds retry-loop logic (`send_after :remonitor_handlers`) which is more
+  complex than the supervisor change and has a race window: events fired
+  between `Handlers` crash and `Cost.Tracker`'s re-attach are silently
+  dropped (no `:DOWN` handler is attached during that window).
+- `Process.whereis/1` → `Process.monitor/1` creates a TOCTOU race at startup
+  if `Handlers` crashes between the two calls; `:DOWN` with `:noproc` is
+  handled, but the window is inelegant.
+- The OTP non-negotiables §4 say "Cross-process events MUST use `Phoenix.PubSub`
+  or monitored refs". Monitored refs are permitted, but the monitor-in-`init/1`
+  idiom requires `Handlers` to be started before `Cost.Tracker` (or the initial
+  monitor silently does nothing), adding an implicit startup order dependency
+  that `:rest_for_one` would make explicit.
+- More lines of code and more moving parts than Proposals 1 or 2.
+- The 100 ms / 500 ms retry delays are magic numbers; they may be too short
+  under load or add unnecessary latency to the re-attach in tests.
+
+### Costs
+
+- ~30 lines added to `tracker.ex`; no new files.
+- Test surface: new test cases for the `:DOWN` handler (send mock `:DOWN`
+  to tracker, assert handler re-attaches) and the `:remonitor_handlers`
+  retry path. The timing constants are a test friction point.
+- No dependency changes; no migration.
+
+## Dependencies
+
+- `Tau.Telemetry.Handlers` must export its registered name (currently
+  `__MODULE__`, i.e., `Tau.Telemetry.Handlers`) so that
+  `Process.whereis(Tau.Telemetry.Handlers)` works. It does.
+
+## Confidence
+
+low — the explicit monitoring approach is correct in principle, but the
+retry-delay complexity and the startup-order dependency it implicitly
+creates make this approach harder to reason about than the supervisor
+strategy change. Confidence would be raised by a prototype demonstrating
+the retry loop behaves correctly under fast supervisor restarts in test.
+
+## Prior art / references
+
+- OTP non-negotiables §4: "monitored refs" are an approved cross-process
+  coordination primitive.
+- Erlang patterns: GenServer monitoring a sibling with `Process.monitor/1`
+  in `init/1` is a known pattern for "sibling-aware" processes.
+- Counterpoint: `:rest_for_one` exists precisely to encode restart dependency
+  in the supervisor — using a monitor instead may be working around the
+  designed idiom.

--- a/docs/problems-archive-v1-modules/tau-infrastructure/subproblems/telemetry-handler-coupling/proposals/proposal-4.md
+++ b/docs/problems-archive-v1-modules/tau-infrastructure/subproblems/telemetry-handler-coupling/proposals/proposal-4.md
@@ -1,0 +1,137 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 4
+parent_problem: ../problem.md
+---
+
+# Proposal 4: Collapse Tau.Telemetry.Supervisor — merge Cost.Tracker into Tau.Application's supervision tree directly, eliminate the intermediate supervisor
+
+## Approach
+
+Delete `Tau.Telemetry.Supervisor` entirely. Move `Tau.Telemetry.Handlers` and
+`Tau.Cost.Tracker` as direct children of `Tau.Application`'s `:rest_for_one`
+supervision tree (which already exists and already uses `:rest_for_one`).
+Insert them at the correct position in `Tau.Application`'s child list so the
+existing `:rest_for_one` cascade covers both. Add the `rescue` to
+`handle_event/4` as in Proposal 1. The intermediate supervisor's strategy
+ambiguity is eliminated by removing the layer.
+
+## Rationale
+
+`Tau.Telemetry.Supervisor` exists as a grouping convenience, but its
+`:one_for_one` strategy actively contradicts the intended restart dependency
+between its two children. `Tau.Application` already uses `:rest_for_one` and
+already correctly orders its 17 children. Rather than patching the intermediate
+supervisor's strategy (Proposals 1 and 2), this proposal removes the layer that
+introduced the mismatch, placing both telemetry children directly under the
+already-correct outer supervisor. The handler-attachment lifecycle is then
+expressed by the outer supervisor's child ordering — visible, correct by
+construction, and not duplicating a supervisor level with no independent value.
+
+## Sketch
+
+**Delete `lib/tau/telemetry/supervisor.ex`.**
+
+**`lib/tau/application.ex` — replace the `Tau.Telemetry.Supervisor` child
+entry with the two individual children at the same position:**
+
+```elixir
+# Before (approximate, from application.ex context):
+children = [
+  # ... earlier children ...
+  Tau.Telemetry.Supervisor,
+  # ... later children (PubSub, Finch, Sessions, etc.) ...
+]
+
+# After:
+children = [
+  # ... earlier children (same as before) ...
+  Tau.Telemetry.Handlers,  # was first child of Telemetry.Supervisor
+  Tau.Cost.Tracker,        # was second child — :rest_for_one now covers both
+  # ... later children (same as before) ...
+]
+
+Supervisor.init(children, strategy: :rest_for_one)
+# strategy unchanged — Application already uses :rest_for_one
+```
+
+**`lib/tau/cost/tracker.ex`** — add `rescue` to `handle_event/4` (identical
+to Proposal 1 sketch).
+
+**File move summary:**
+- `lib/tau/telemetry/supervisor.ex` → deleted
+- `lib/tau/application.ex` — child list updated (~3 lines net)
+- `lib/tau/cost/tracker.ex` — rescue added (~8 lines net)
+
+Any module that starts `Tau.Telemetry.Supervisor` by name (e.g. tests calling
+`start_supervised(Tau.Telemetry.Supervisor)`) must be updated to start
+`Tau.Telemetry.Handlers` and `Tau.Cost.Tracker` individually.
+
+## Tradeoffs
+
+### Strengths
+
+- Eliminates the root cause of the mismatch: the intermediate supervisor with
+  the wrong strategy. No strategy patch needed; the outer supervisor is already
+  correct.
+- Reduces the supervision tree depth by one level; failure modes are simpler
+  to reason about.
+- `Tau.Application`'s `:rest_for_one` cascade already exists and is already
+  relied on by the 17-child tree; extending it is idiomatic, not novel.
+- The intermediate supervisor was adding no independent value (no dynamic child
+  management, no separate restart policy, no separate name registration).
+
+### Weaknesses
+
+- Deleting a module is an API-breaking change: any test or external code that
+  `start_supervised(Tau.Telemetry.Supervisor)` breaks immediately.
+- Increases the width of `Tau.Application`'s child list, which is already 17
+  children — adding 2 more (net change: +2 children, -1 Supervisor child)
+  makes the application-level tree harder to read.
+- If `Tau.Application` is ever split into sub-supervisors for other reasons,
+  these two children would need to be re-extracted, making the deletion a
+  premature simplification.
+- `:rest_for_one` at the application level means a crash in `Handlers` or
+  `Cost.Tracker` restarts everything that comes after them in
+  `Tau.Application`'s child list — the blast radius is larger than with an
+  intermediate supervisor that contains the crash to just those two children.
+- Behavioural change: whether this blast-radius expansion is acceptable depends
+  on what children follow `Handlers`/`Cost.Tracker` in `Tau.Application`'s
+  list — if PubSub, Finch, or session supervisors follow, their restarts on
+  a telemetry handler crash may be unacceptable.
+
+### Costs
+
+- 1 file deleted, 2 files modified, ~15 lines net.
+- Test surface: tests using `start_supervised(Tau.Telemetry.Supervisor)` must
+  be updated; estimate 2-4 test files.
+- Search required: `grep -rn "Telemetry.Supervisor"` to find all references.
+- No dependency changes; no library migration.
+
+## Dependencies
+
+- Must verify the position of `Tau.Telemetry.Handlers` / `Tau.Cost.Tracker`
+  in `Tau.Application`'s child list — specifically, what children follow them.
+  If the blast-radius analysis is unacceptable, wrap both in a new
+  `Tau.Telemetry.Supervisor` using `:rest_for_one` (effectively Proposal 1).
+- `Tau.Application` must be read before implementing to confirm the child
+  ordering.
+
+## Confidence
+
+low — the approach is sound in principle, but the blast-radius weakness means
+it may be rejected on review once the full `Tau.Application` child list is
+examined. The outcome depends on information not yet in scope (what follows
+telemetry children in `application.ex`). Confidence rises to medium after
+confirming the child ordering and that the blast radius is acceptable.
+
+## Prior art / references
+
+- `Tau.Application` — already uses `:rest_for_one`; extending it is
+  idiomatically consistent.
+- OTP design principle: intermediate supervisors are warranted when they
+  provide independent restart policy, dynamic child management, or separate
+  naming. When none of these apply, flattening is simpler.
+- Erlang/OTP docs: "The trade-off between a flat and a deep supervision tree
+  is between containment of failures and the complexity of the tree."

--- a/docs/problems-archive-v1-modules/tau-infrastructure/subproblems/telemetry-handler-coupling/solution.md
+++ b/docs/problems-archive-v1-modules/tau-infrastructure/subproblems/telemetry-handler-coupling/solution.md
@@ -1,0 +1,132 @@
+---
+template_version: 1
+template_name: solution
+parent_problem: ../../problem.md
+node_kind: leaf
+synthesised_from: [proposals/proposal-1.md]
+selection_method: single
+revision: 0
+---
+
+# Solution: Symmetric rescue in handle_event/4 + :rest_for_one supervisor strategy
+
+## Recommendation
+
+Add a `rescue` block to `Tau.Cost.Tracker.handle_event/4` that is structurally
+symmetric with the existing guard in `handle_coding_agent_cost/4`, emitting
+`[:tau, :cost, :tracker, :handler_failed]` on error and returning `:ok`. Change
+`Tau.Telemetry.Supervisor.init/1` from `strategy: :one_for_one` to
+`strategy: :rest_for_one`, with `Tau.Telemetry.Handlers` listed before
+`Tau.Cost.Tracker` in the child list so a `Handlers` crash cascades to
+`Cost.Tracker`, forcing a clean re-`init/1` that detaches then re-attaches
+handlers. This is the minimal change that satisfies both acceptance criterion
+parts (a) and (b) with no new modules, no API surface change, and no blast-radius
+expansion.
+
+## Selected from
+
+- **Chosen:** `proposals/proposal-1.md`
+- **Why chosen:** Proposal 1 directly satisfies both halves of the acceptance
+  criterion with the smallest diff, the lowest migration cost, and the lowest risk.
+  The rescue pattern it introduces is not novel — it is literal symmetry with the
+  already-merged `handle_coding_agent_cost/4` pattern, which itself documents the
+  D-035 requirement. The `:rest_for_one` change encodes the attachment-lifecycle
+  dependency in the idiomatic OTP location (supervisor child ordering) rather than
+  in ad-hoc process-monitoring code, and it is contained to the intermediate
+  supervisor — no blast-radius expansion to `Tau.Application`'s 17-child tree.
+
+  Proposal 2 adds a `HandlerGuard` module that would be the correct choice if a
+  third cost-telemetry handler were imminent, but with exactly two handlers today
+  the abstraction pays no structural benefit and adds review surface for a
+  ~5-line pattern. The DRY argument is weak at n=2.
+
+  Proposal 3 (self-managed monitor) trades the clean OTP idiom for a retry loop
+  with timing-dependent test behaviour, a TOCTOU startup race, and implicit
+  startup-order coupling that `:rest_for_one` already solves explicitly. The
+  proposer rated it low confidence; the comparison confirms that.
+
+  Proposal 4 (delete intermediate supervisor) introduces a blast-radius risk that
+  depends on what follows the telemetry children in `Tau.Application`'s list — a
+  dependency it cannot resolve without inspecting `application.ex`. It also breaks
+  any test using `start_supervised(Tau.Telemetry.Supervisor)`. The proposer
+  rated it low confidence pending that audit; the risk is asymmetric and the
+  benefit (removing one supervisor level) is cosmetic given that the intermediate
+  supervisor's strategy patch in Proposal 1 is two lines.
+
+## Scoring table
+
+| # | Fit | Decomplecting depth | Migration cost | Risk | Reversibility |
+|---|-----|---------------------|----------------|------|---------------|
+| 1 | Yes | Substantial | Low | Low | Easy |
+| 2 | Yes | Substantial | Medium | Low | Easy |
+| 3 | Partially | Substantial | Medium | Medium | Medium |
+| 4 | Yes | Deep | Medium | Medium | Hard |
+
+Proposal 3 scores Partially on fit because the monitor-in-`init/1` idiom
+creates an implicit startup-order dependency, leaving a residual complect between
+attachment lifecycle and child start sequence (now implicit in `Process.whereis`
+timing rather than supervisor ordering). Proposal 4 scores Hard on reversibility
+because deleting a module and updating test scaffolding is meaningfully harder to
+undo than changing a two-word strategy atom.
+
+## What changes
+
+- `lib/tau/cost/tracker.ex` — add `rescue` block to `handle_event/4` mirroring
+  the existing rescue in `handle_coding_agent_cost/4`; emit
+  `[:tau, :cost, :tracker, :handler_failed]` with `%{system_time:
+  System.system_time()}` measurements and `%{reason: Exception.message(e)}`
+  metadata; return `:ok`.
+- `lib/tau/telemetry/supervisor.ex` — change `strategy:` from `:one_for_one` to
+  `:rest_for_one`; confirm `Tau.Telemetry.Handlers` is listed before
+  `Tau.Cost.Tracker` in the child list (current ordering must be verified before
+  implementation).
+
+## What does not change
+
+- `Tau.Cost.Tracker.handle_coding_agent_cost/4` — already D-035-compliant; no
+  touch.
+- `Tau.Telemetry.Handlers` — module unchanged; no new module added.
+- `Tau.Application` — supervision tree unchanged; blast radius is contained to
+  the intermediate supervisor's two children.
+- Any existing tests using `start_supervised(Tau.Telemetry.Supervisor)` —
+  module name and child-spec API are preserved.
+- The `with`/`else` structural guard in `handle_event/4` — the rescue wraps the
+  existing `with` block; the guard itself is not changed.
+
+## Migration sketch
+
+Open a single PR against the `lib/tau/cost/tracker.ex` and
+`lib/tau/telemetry/supervisor.ex` files. Verify the child ordering in
+`supervisor.ex` before committing (confirm `Handlers` precedes `Cost.Tracker`).
+Add one test: inject a float into `:usage` to reach the `:ets.update_counter`
+raise path; assert `handle_event/4` returns `:ok` and the
+`[:tau, :cost, :tracker, :handler_failed]` event is emitted. Use the
+`handle_coding_agent_cost/4` test as the pattern. No migration steps, no
+dependency changes, no binary schema changes.
+
+## Open questions
+
+- Is `Tau.Cost.Tracker.terminate/2` confirmed to call `:telemetry.detach/1`
+  for both handler IDs? Proposal 1 asserts yes (lines 112-114); this must be
+  verified before the `:rest_for_one` change lands — if `terminate/2` does not
+  detach, the cascade restart will produce duplicate handler registration rather
+  than curing it.
+- Does `nz/1` return `0` for a float input, or does it allow a float through to
+  the `:ets.update_counter/3` call? If `nz/1` coerces floats to integers, the
+  rescue is a no-op defensive belt-and-suspenders; if it passes floats through,
+  the rescue is load-bearing. Clarifying this determines whether the rescue is
+  strictly necessary or conservative.
+- Are there any children of `Tau.Telemetry.Supervisor` beyond `Handlers` and
+  `Cost.Tracker`? If a third child is ever added between them, the `:rest_for_one`
+  cascade would restart it unnecessarily on a `Handlers` crash.
+
+## Linked sub-problems / proposals
+
+- `proposals/proposal-1.md` — Symmetric rescue + `:rest_for_one` (chosen: minimal, symmetric, idiomatic)
+- `proposals/proposal-2.md` — Extract `Tau.Cost.HandlerGuard` shared wrapper (not chosen: over-engineering at n=2 handlers)
+- `proposals/proposal-3.md` — Self-managed monitor in `Cost.Tracker`, no supervisor change (not chosen: retry complexity, timing races, low proposer confidence)
+- `proposals/proposal-4.md` — Delete intermediate supervisor, merge into `Tau.Application` (not chosen: unresolved blast-radius risk, hard reversibility, module deletion)
+
+## Revision history
+
+- (revision 0 — initial)

--- a/docs/problems-archive-v1-modules/tau-infrastructure/subproblems/telemetry-handler-coupling/validation.md
+++ b/docs/problems-archive-v1-modules/tau-infrastructure/subproblems/telemetry-handler-coupling/validation.md
@@ -1,0 +1,449 @@
+---
+template_version: 1
+template_name: validation
+parent_solution: ./solution.md
+parent_problem: ./problem.md
+toulmin_complete: true
+falsification_attempted: true
+falsification_outcome: partially_falsified — claim/1
+revision_triggered: none
+---
+
+# Validation: Symmetric rescue in handle_event/4 + :rest_for_one supervisor strategy
+
+## Overview
+
+The solution makes two structural assertions: (1) a `rescue` block added to
+`Tau.Cost.Tracker.handle_event/4` makes it D-035-compliant and symmetric
+with `handle_coding_agent_cost/4`, and (2) flipping
+`Tau.Telemetry.Supervisor` from `:one_for_one` to `:rest_for_one` (with
+`Handlers` before `Cost.Tracker`) decomplects handler-attachment lifecycle
+from supervisor restart scope without over-restarting `Cost.Tracker` in the
+common path. The solution also makes three derivative non-change assertions
+(no API surface change, no `Tau.Application` blast-radius expansion,
+existing `start_supervised(Tau.Telemetry.Supervisor)` tests preserved). I
+extracted six checkable claims, ran a different falsification strategy per
+claim against the live tree at `lib/tau/cost/tracker.ex` and
+`lib/tau/telemetry/supervisor.ex`, and corroborated with ADR-0010,
+OTP-NN §7, and the existing `OtelReporter.Handler` precedent. Five claims
+withstood; one (Claim 1's coverage of the cited failure mode) is partially
+falsified — the *crash window does exist*, but not via the float path the
+solution names; the qualifier needs narrowing.
+
+## Toulmin per claim
+
+The MITRE empirical study on Toulmin formalism found that "participants
+found it difficult to generate Toulmin structures, and their structures
+varied greatly even though they started with the same content"
+(https://www.mitre.org/news-insights/publication/empirical-evaluation-structured-argumentation-using-toulmin-argument).
+This template enforces all six components explicitly with prompts to
+counter that variance.
+
+### Claim 1: A rescue block in handle_event/4 makes it D-035-compliant (a malformed `:usage` measurement that would otherwise crash the emitter is degraded gracefully).
+
+- **Claim (C):** Adding the `rescue` mirror around `handle_event/4`'s
+  `with` block — emitting `[:tau, :cost, :tracker, :handler_failed]` and
+  returning `:ok` on any raise — closes the crash boundary D-035 requires
+  for cost-folding handlers, satisfying acceptance-criterion part (a).
+- **Grounds (G):** `lib/tau/cost/tracker.ex:117-138` shows
+  `handle_event/4` with no `rescue`; lines 144-172 show the
+  D-035-compliant twin `handle_coding_agent_cost/4` with the exact
+  pattern the solution mirrors (rescue → emit
+  `[:tau, :cost, :tracker, :handler_failed]` → `:ok`). The module
+  docstring at lines 50-53 explicitly names D-035 and the
+  `:handler_failed` event as the contract. The reachable raise paths in
+  the body include `:ets.update_counter/3` at line 129 (raises
+  `ArgumentError` on table-missing, on a non-integer increment, or on
+  spec mismatch) and tuple construction at line 122.
+- **Warrant (W):** A handler executes in the emitter's process
+  (`:telemetry.execute/3` invokes attached handlers synchronously in the
+  calling process — `hexdocs.pm/telemetry`). Therefore any uncaught
+  raise inside the handler propagates to the FSM that emitted the event.
+  D-035 (cited in the docstring) and the
+  "handler-must-not-crash-emitter" contract documented in
+  `lib/tau/otel_reporter/handler.ex:5-7` together license an
+  intra-process `try/rescue` *inside the handler boundary* as the
+  required degrade-gracefully mechanism. This is consistent with — not
+  in violation of — OTP non-negotiable §7 ("MUST NOT `try/rescue`
+  across process boundaries"), because the rescue is purely intra-process.
+- **Qualifier (Q):** Holds for any raise reachable from the body
+  *that the `with`/`else` guard does not already short-circuit*. The
+  cited float-via-`:usage` path is NOT one of those: `nz/1` at
+  `tracker.ex:176-177` returns `0` for any non-integer, so a float in
+  `usage[:input_tokens]` is silently coerced to `0` and never reaches
+  `:ets.update_counter`. The load-bearing failure surface is therefore
+  narrower than the problem statement implies: it is
+  table-missing-during-restart, `update_counter` spec mismatch in a
+  future refactor, or a non-binary `model` causing tuple-key trouble in
+  a downstream consumer. The rescue is still load-bearing for those.
+- **Rebuttal (R):** The rescue does NOT close the silent-data-loss hole
+  that `nz/1` opens (a provider sending a float is silently recorded as
+  zero tokens). It only protects against process death, not against
+  observability data quality. The solution's open question #2 (lines
+  113-117) flags this; the rescue is correctly scoped to crash-safety,
+  not data-quality.
+- **Backing (B):** D-035 (cited inline in
+  `lib/tau/cost/tracker.ex:50-53` and at the docstring of
+  `handle_coding_agent_cost/4` lines 141-143). OTP non-negotiable §7
+  (`.claude/rules/otp-non-negotiables.md:26-28`) explicitly bounds the
+  prohibition to *cross-process* try/rescue, leaving intra-process
+  rescue inside a handler boundary permissible. The
+  `Tau.OtelReporter.Handler.handle_event/4` precedent at
+  `lib/tau/otel_reporter/handler.ex:27-38` shows the identical pattern
+  already in production for the same reason, with the docstring
+  contract explicit at lines 5-7.
+
+#### Falsification attempt for claim 1
+
+- **Strategy:** Edge-case enumeration over the documented and undocumented
+  raise paths inside `handle_event/4`.
+- **Attempt:** Enumerated five reachable failure modes inside the
+  `with`-body of `handle_event/4`:
+  (i) `:ets.update_counter` called when `@table` does not exist (raises
+  `ArgumentError`) — possible during the narrow window between
+  `Cost.Tracker` death and supervisor restart;
+  (ii) `:ets.update_counter` called with a non-integer increment
+  (`ArgumentError`) — the path the problem statement and Proposal 1
+  cite via a float in `usage[:input_tokens]`;
+  (iii) `today_iso()` raising on a system-clock NIF failure
+  (theoretical; not observed in this codebase);
+  (iv) the tuple key `{today_iso(), provider, metadata[:model], session_id}`
+  being malformed and breaking an `:ets.update_counter` ordered-set
+  invariant (no — ETS is `:set`, line 81-87, accepts any term as key);
+  (v) the `update_counter` op list being mis-shaped (a future refactor
+  defect, not present today).
+  Then I checked each against the *as-is* code:
+  - Path (i) — table-missing. Reachable. `:named_table, :public, :set`
+    at `tracker.ex:81-87` means the table belongs to the `Cost.Tracker`
+    process; if the process dies between the table being destroyed and
+    a queued telemetry event still in flight in another process,
+    `:ets.update_counter` raises `ArgumentError`. Rescue catches it.
+    Withstands.
+  - Path (ii) — float via `:usage`. NOT reachable as cited.
+    `nz/1` at `tracker.ex:176-177` matches only
+    `is_integer(n) and n >= 0`; a float falls to the catch-all and
+    returns `0`. The named failure mode is absorbed by `nz/1`, not by
+    the proposed rescue. The problem statement's "non-integer in `:usage`
+    that passes the `is_map` guard causes an `ArgumentError`" is
+    therefore *factually wrong about the float path* — `nz/1` is the
+    actual silencer there. Partial falsification of the *motivating
+    example* in the problem statement; the rescue is still defensible
+    via paths (i) and (v).
+  - Path (iii), (iv), (v) — theoretical/future; rescue covers them.
+- **Outcome:** partially falsified. The rescue is justified, but the
+  problem statement's cited motivating failure (float via `:usage`) is
+  not the reachable path; `nz/1` already absorbs it silently. The
+  load-bearing motivation is path (i) — the restart-window
+  table-missing race, particularly relevant under the `:rest_for_one`
+  change in Claim 2 which makes `Cost.Tracker` restarts more frequent.
+- **Action:** Narrow Qualifier in place (done above). No
+  solution.md edit required — the recommended change is correct; only
+  the *justification narrative* in problem.md is slightly off. This is
+  recorded under **Outstanding doubts** for the parent validator to
+  fold into context, but does not warrant `revision_triggered`.
+
+### Claim 2: Changing `Tau.Telemetry.Supervisor` from `:one_for_one` to `:rest_for_one` (with `Handlers` listed before `Cost.Tracker`) decomplects handler-attachment lifecycle from supervisor restart scope.
+
+- **Claim (C):** Under `:rest_for_one`, a `Tau.Telemetry.Handlers` crash
+  cascades to `Tau.Cost.Tracker`, forcing `Cost.Tracker.terminate/2` →
+  `init/1` to run, which detaches then re-attaches handlers cleanly.
+  This eliminates the duplicate-handler-registration window the
+  problem.md identifies.
+- **Grounds (G):** `lib/tau/telemetry/supervisor.ex:17-22` shows the
+  current child list `[Tau.Telemetry.Handlers, Tau.Cost.Tracker]` —
+  ordering already satisfies the solution's precondition (verified at
+  this commit; the solution's open question #3 about a third sibling is
+  vacuous today). `Cost.Tracker.terminate/2` at
+  `lib/tau/cost/tracker.ex:111-115` calls `:telemetry.detach/1` for both
+  `@handler_id` and `@coding_agent_handler_id`. `Cost.Tracker.init/1` at
+  lines 80-108 calls `:telemetry.attach/4` for both IDs. Therefore the
+  detach-on-terminate-then-attach-on-init cycle is mechanically present.
+- **Warrant (W):** `:rest_for_one` semantics (Erlang OTP supervisor
+  docs — see https://www.erlang.org/doc/man/supervisor.html): when a
+  child dies, every sibling listed *after* it in the child list is
+  terminated and restarted in order. This is the idiomatic OTP location
+  to express "X's lifecycle depends on Y's" — the dependency lives in
+  the supervisor child ordering, not in ad-hoc monitoring code (cf.
+  Proposal 3's monitor approach, rated lower for that reason).
+- **Qualifier (Q):** Holds while (a) `Handlers` precedes `Cost.Tracker`
+  in the child list (currently true at
+  `lib/tau/telemetry/supervisor.ex:17-20`), and (b) only those two
+  children sit under `Telemetry.Supervisor`. A third child added between
+  them would be unnecessarily restarted on a `Handlers` crash — flagged
+  in the solution's open question #3.
+- **Rebuttal (R):** If `:telemetry.detach/1` were ever skipped (e.g. a
+  brutal-kill restart that bypasses `terminate/2`), the post-restart
+  `init/1` would call `:telemetry.attach/4` against an ID that is still
+  registered, raising. `:telemetry.attach/4` returns
+  `{:error, :already_exists}` rather than raising on duplicate IDs
+  (verified at https://hexdocs.pm/telemetry/telemetry.html#attach/4),
+  so the restart would silently fail to attach. Under default
+  Supervisor `shutdown: 5_000` and `restart: :permanent`,
+  `terminate/2` is invoked on normal restart; the rebuttal applies only
+  to a brutal-kill path, which is not on the default supervision spec
+  for either child.
+- **Backing (B):** Erlang/OTP `Supervisor` documentation —
+  `:rest_for_one` strategy
+  (https://www.erlang.org/doc/man/supervisor.html). OTP non-negotiable
+  §1 — "Stateful subsystems MUST run as supervised processes" — implies
+  that lifecycle dependencies between them belong in the supervisor's
+  declarative configuration. ADR-0010 (`docs/adr/0010-cost-tracker-owns-ets-not-state.md:46-69`)
+  documents `Cost.Tracker` as the ETS-and-handler-attachment lifecycle
+  anchor; `:rest_for_one` is the explicit encoding of that anchoring.
+
+#### Falsification attempt for claim 2
+
+- **Strategy:** Dependency check — verify the codebase state the claim
+  depends on actually holds.
+- **Attempt:** Three dependencies named:
+  (a) `Handlers` precedes `Cost.Tracker` in the child list — confirmed
+  at `lib/tau/telemetry/supervisor.ex:17-20`;
+  (b) `Cost.Tracker.terminate/2` detaches both handler IDs — confirmed
+  at `lib/tau/cost/tracker.ex:111-115`;
+  (c) `Cost.Tracker.init/1` re-attaches both IDs — confirmed at
+  `lib/tau/cost/tracker.ex:89-105`.
+  Additionally checked the ETS table contract: `@table` is
+  `:named_table` at line 82, so on `init/1` a `:ets.new` would normally
+  raise on a name clash, but since the table was owned by the
+  prior-incarnation `Cost.Tracker`, the table is destroyed when that
+  owner dies — name is released. Verified by Erlang ETS docs
+  (https://www.erlang.org/doc/man/ets.html — "If a table is created
+  with the named_table option [...] [it] is also destroyed if the
+  owning process is terminated").
+- **Outcome:** withstood. All three required-state propositions hold;
+  the ETS table lifecycle and handler attachment lifecycle compose
+  correctly under the cascade restart.
+- **Action:** None.
+
+### Claim 3: The change is "the minimal change that satisfies both acceptance criterion parts (a) and (b) with no new modules, no API surface change, and no blast-radius expansion."
+
+- **Claim (C):** The two-file diff is minimal among the four proposals
+  evaluated and incurs no module or API addition.
+- **Grounds (G):** Solution `## Scoring table` lines 56-64 score
+  Proposal 1 as Low migration cost, Low risk, Easy reversibility;
+  Proposals 2, 3, 4 score worse on at least one dimension. The
+  `## What changes` section (lines 73-83) lists exactly two files;
+  the `## What does not change` section (lines 85-95) enumerates the
+  preserved surfaces. No new module is added; no exported function
+  signature changes.
+- **Warrant (W):** "Minimal change to satisfy the requirement"
+  is the Rich-Hickey-style decomplecting heuristic: prefer the smallest
+  edit that separates the previously-tangled concerns. Two concerns —
+  crash-safety (Claim 1) and attachment-lifecycle vs restart-scope
+  (Claim 2) — each get their own targeted edit; neither edit creates a
+  new abstraction.
+- **Qualifier (Q):** "Minimal among the four enumerated proposals."
+  Not minimal in an absolute sense — for example, a hypothetical fifth
+  proposal that only added the rescue and left the supervisor alone
+  would be even smaller but would not satisfy AC part (b). The solution
+  is minimal within the constraint of satisfying *both* AC parts.
+- **Rebuttal (R):** If a reader interpreted "no blast-radius expansion"
+  as "no behaviour change for non-crash paths", they would be wrong:
+  `:rest_for_one` does change post-crash behaviour (Cost.Tracker now
+  restarts on Handlers crash where it previously did not). The claim
+  is about *structural* blast-radius (no change to `Tau.Application`'s
+  17-child supervision tree), not about *behavioural* blast-radius.
+  The latter is the very point of the change.
+- **Backing (B):** Rich Hickey, "Simple Made Easy"
+  (https://www.infoq.com/presentations/Simple-Made-Easy/) — the
+  decomplecting heuristic. PSDH triage guidance in
+  `.claude/skills/design-reasoning` — separate concerns, do not
+  manufacture abstractions until n ≥ 3 (cited in the solution's
+  reasoning for rejecting Proposal 2 at n=2 handlers).
+
+#### Falsification attempt for claim 3
+
+- **Strategy:** Counter-example construction — try to construct a
+  smaller diff that satisfies both AC parts.
+- **Attempt:** Considered three smaller alternatives:
+  (i) Add the rescue but keep `:one_for_one` — fails AC part (b).
+  (ii) Change strategy but skip the rescue — fails AC part (a).
+  (iii) Use a `Process.flag(:trap_exit, true)` on Cost.Tracker to
+  monitor Handlers crashes without changing supervisor strategy —
+  adds a process-mailbox concern that violates ADR-0010's "no state in
+  mailbox" stance, and is essentially Proposal 3 (rejected).
+  None of the three is both smaller AND satisfies both AC parts.
+- **Outcome:** withstood. Within the AC's joint constraints, the
+  two-line strategy flip + ~10-line rescue is the minimum.
+- **Action:** None.
+
+### Claim 4: `Tau.Application`'s supervision tree is unchanged; blast radius is contained to the intermediate supervisor's two children.
+
+- **Claim (C):** No edit to `lib/tau/application.ex` is required or
+  performed; the cascade restart cannot propagate past
+  `Tau.Telemetry.Supervisor`.
+- **Grounds (G):** `lib/tau/application.ex:62` registers
+  `Tau.Telemetry.Supervisor` as a single child of `Tau.Application`.
+  Whatever strategy `Tau.Application` itself uses, its sibling children
+  see only the supervisor handle, not the descendants inside it.
+- **Warrant (W):** OTP supervision-tree composition: a supervisor's
+  internal restart strategy bounds the cascade to its own children. A
+  parent supervisor sees only the immediate child's start/stop
+  transitions, not the grandchild-level restarts inside it. This is
+  documented in the OTP design principles
+  (https://www.erlang.org/doc/design_principles/sup_princ.html).
+- **Qualifier (Q):** Holds unless `Tau.Telemetry.Supervisor` itself
+  exceeds its supervisor `max_restarts` window and dies — which would
+  then propagate up to `Tau.Application`'s strategy. Default
+  `max_restarts: 3, max_seconds: 5` applies; if a `Handlers` crash
+  flapped >3 times in 5s, the intermediate supervisor would die and
+  `Tau.Application`'s strategy would govern. This is unchanged from
+  `:one_for_one`.
+- **Rebuttal (R):** None for the structural claim.
+- **Backing (B):** Erlang/OTP design principles, supervisor section.
+
+#### Falsification attempt for claim 4
+
+- **Strategy:** Integration check — confirm by grep that no edit to
+  `application.ex` is part of the proposed diff and that the parent
+  supervisor's view of `Tau.Telemetry.Supervisor` is unchanged.
+- **Attempt:** `grep -n "Telemetry.Supervisor" lib/tau/application.ex`
+  shows the single registration at line 62. The `What changes` section
+  lists only `cost/tracker.ex` and `telemetry/supervisor.ex`.
+- **Outcome:** withstood.
+- **Action:** None.
+
+### Claim 5: Existing tests using `start_supervised(Tau.Telemetry.Supervisor)` continue to work (module name and child-spec API preserved).
+
+- **Claim (C):** No test breakage from the change.
+- **Grounds (G):** Grep across `test/` (`grep -rn
+  "Tau.Telemetry.Supervisor\|start_supervised" test/`) returns no
+  match for `start_supervised(Tau.Telemetry.Supervisor)`. The
+  module name is unchanged; `start_link/1` signature is unchanged at
+  `lib/tau/telemetry/supervisor.ex:11-13`; child-spec API is
+  unchanged.
+- **Warrant (W):** A supervisor's restart strategy is an internal
+  property; consumers only observe `start_link/1` and the supervised
+  PIDs. Changing strategy does not change either.
+- **Qualifier (Q):** The "existing tests" set is currently empty for
+  the named usage — the claim is *trivially true* by vacuity at this
+  commit. It remains true under the change.
+- **Rebuttal (R):** None.
+- **Backing (B):** Supervisor module documentation
+  (https://hexdocs.pm/elixir/Supervisor.html).
+
+#### Falsification attempt for claim 5
+
+- **Strategy:** Dependency check — confirm the consumer set is what the
+  claim assumes.
+- **Attempt:** `grep -rn` over `test/` and `lib/` for
+  `Tau.Telemetry.Supervisor` returns three matches:
+  `lib/tau/application.ex:62` (registration), the file itself, and
+  the moduledoc reference in `lib/tau/cost/tracker.ex:71`. No test
+  consumer.
+- **Outcome:** withstood (vacuously — the consumer set named is
+  empty, and the claim is robust to consumers being added later
+  because the public API is unchanged).
+- **Action:** None. Recorded under **Outstanding doubts** that this
+  claim is currently vacuous; not a defect, just context for the
+  parent validator.
+
+### Claim 6: The `with`/`else` structural guard in `handle_event/4` is preserved unchanged; the rescue wraps the existing `with` block.
+
+- **Claim (C):** The proposed `rescue` is additive — the `with` chain
+  and its `else _ -> :ok` fall-through are unchanged.
+- **Grounds (G):** The Proposal 1 sketch at
+  `proposals/proposal-1.md:36-68` shows the `with` block verbatim from
+  current `tracker.ex:118-138` with the `rescue` appended at the
+  function body level.
+- **Warrant (W):** Elixir function-body `rescue` clauses sit at the
+  same level as the function's primary expression, catching raises
+  from anywhere in that expression. The `with`/`else` shape is a
+  distinct concern (structural shape mismatches → silent `:ok`); the
+  rescue catches raise-level failures from the same expression. The
+  two compose without interference.
+- **Qualifier (Q):** Holds for the exact sketch in Proposal 1; a
+  future refactor could entangle them, but is out of scope.
+- **Rebuttal (R):** None for the present diff.
+- **Backing (B):** Elixir `try/rescue/else/after` semantics
+  (https://hexdocs.pm/elixir/try.html); the existing twin
+  `handle_coding_agent_cost/4` at `tracker.ex:144-172` is the proof of
+  composition (same shape: `with`/`else` body + `rescue`).
+
+#### Falsification attempt for claim 6
+
+- **Strategy:** Type-level / shape check — compare the proposed sketch
+  to the existing twin's shape.
+- **Attempt:** The twin's body uses the identical pattern:
+  `with [matchers] do [body] else _ -> :ok end` followed by a
+  function-body-level `rescue e -> [emit telemetry]; :ok end`. The
+  proposed sketch (proposal-1.md:36-68) is structurally identical.
+  No interference between the `else` clause and the `rescue` clause is
+  possible because they handle disjoint outcomes (pattern-match miss
+  vs raise).
+- **Outcome:** withstood.
+- **Action:** None.
+
+## Cross-claim consistency
+
+The six claims compose without tension:
+
+- Claims 1 (rescue) and 2 (`:rest_for_one`) target independent
+  failure modes — a handler raise versus a sibling crash — and are
+  combined in a single PR for cohesion, not because they depend on
+  each other.
+- Claim 2's stronger justification under the partially-falsified
+  Claim 1: with the float-path failure mode absorbed by `nz/1`, the
+  remaining motivation for the rescue is largely the
+  table-missing-during-restart race, which is *more* likely under
+  Claim 2's `:rest_for_one` cascade than under `:one_for_one`.
+  Claims 1 and 2 are therefore mutually reinforcing in motivation,
+  not merely co-located in a PR.
+- Claims 3, 4, 5, 6 are scoping / containment assertions about Claims
+  1 and 2; each holds independently and none contradicts another.
+
+No tension to escalate.
+
+## Falsification summary
+
+| # | Claim (short) | Strategy | Outcome | Action |
+|---|---|---|---|---|
+| 1 | Rescue in `handle_event/4` makes it D-035-compliant | Edge-case enumeration (5 paths) | partially_falsified | Narrow qualifier — cited float path is absorbed by `nz/1`; rescue is load-bearing for table-missing-on-restart race, not for float-in-`:usage` |
+| 2 | `:rest_for_one` cascade decomplects attachment lifecycle from restart scope | Dependency check (3 required states) | withstood | none |
+| 3 | Two-file diff is minimal satisfying both AC parts | Counter-example construction (3 alternatives) | withstood | none |
+| 4 | `Tau.Application` unchanged; blast radius contained | Integration check | withstood | none |
+| 5 | Existing `start_supervised` tests preserved | Dependency check | withstood (vacuously) | none — flagged as vacuous |
+| 6 | `with`/`else` guard preserved; rescue is additive | Type-level / shape check | withstood | none |
+
+## Revision required
+
+None. The solution's recommended change is correct; only one
+sub-claim's *narrative justification* is narrowed (not falsified
+outright). The narrowed Qualifier on Claim 1 reads: "the rescue is
+load-bearing for the table-missing-during-restart race and for
+future-refactor raise paths; it is NOT load-bearing for the
+float-via-`:usage` motivating example from the problem statement,
+which is already absorbed by `nz/1` at `tracker.ex:176-177`." This
+narrowing strengthens the case for combining Claims 1 and 2 in one PR
+(the table-missing race becomes more frequent under `:rest_for_one`)
+rather than weakening either claim.
+
+- **Target file:** none
+- **Revision kind:** n/a — the validation is recorded in this
+  document; parent validator should fold the narrower Qualifier into
+  its synthesis if it surfaces Claim 1 at the parent level.
+- **Rationale:** A narrowed qualifier is information for downstream
+  reasoning; the implementer's diff is unchanged.
+
+## Outstanding doubts
+
+- The problem statement's motivating example (a non-integer in `:usage`
+  that "passes the `is_map` guard causes an `ArgumentError`") is
+  factually inaccurate at the current code: `nz/1` absorbs non-integers
+  silently. The implementer should be aware that the rescue's
+  load-bearing path is table-missing-during-restart, not float-input —
+  this affects test design (a float-input test would not exercise the
+  rescue; a contrived `:ets.delete` between handler invocations would).
+  The solution's "open question #2" (lines 113-117) already notes this;
+  flagging here so the parent validator and reviewer carry it forward.
+- Claim 5 is vacuously true at this commit (no test consumer of
+  `start_supervised(Tau.Telemetry.Supervisor)` exists). The claim is
+  durable under the change because the public API is unchanged; flagged
+  only so the parent validator does not over-weight it as evidence of
+  test-coverage robustness.
+- Open question #3 in solution.md (a third child between `Handlers` and
+  `Cost.Tracker`) is a future-refactor risk, not a present defect; the
+  current child list at `lib/tau/telemetry/supervisor.ex:17-20` has
+  exactly two children in the required order. The reviewer should flag
+  any future child insertion as requiring re-examination of the
+  `:rest_for_one` ordering.

--- a/docs/problems-archive-v1-modules/tau-infrastructure/validation.md
+++ b/docs/problems-archive-v1-modules/tau-infrastructure/validation.md
@@ -1,0 +1,570 @@
+---
+template_version: 1
+template_name: validation
+parent_solution: solution.md
+parent_problem: problem.md
+toulmin_complete: true
+falsification_attempted: true
+falsification_outcome: partially_falsified — claim/3
+revision_triggered: none
+---
+
+# Validation: tau-infrastructure cross-cutting correctness — four-PR sequenced fix
+
+## Overview
+
+The root solution makes one composite recommendation (land four child PRs
+serially in the order #1 telemetry → #2 circuit breaker → #3 supervision
+startup → #4 global names) and packages five cross-cutting claims that the
+non-leaf synthesis must defend in addition to per-child claims (which are
+validated at the child nodes). This validation extracts six checkable
+propositions from the root `solution.md` Recommendation and Composition
+rationale, focusing on: (a) the conjunction's coverage of the parent
+acceptance criterion, (b) the disjoint-region claim for `Application.start/2`
+between PRs 3 and 4, (c) the conjecture that no PR introduces sibling-boundary
+defects, (d) the additive-overlap claim for `Store`/`Tracker` between PRs 2/1
+and PR 4, (e) the ordering claim ("lowest blast radius first"), and (f) the
+sibling-independence claim ("no PR has a prerequisite from a sibling beyond
+ordering"). Falsification strategies are mixed: integration check, dependency
+check, edge-case enumeration, and counter-example construction. Five claims
+withstood; one (Claim 3, ordering rationale) is partially falsified — the
+qualifier needs narrowing because "lowest blast radius first" is post-hoc
+rather than load-bearing on correctness, but the narrowed claim survives.
+
+## Toulmin per claim
+
+The MITRE empirical study on Toulmin formalism found that "participants
+found it difficult to generate Toulmin structures, and their structures
+varied greatly even though they started with the same content"
+(https://www.mitre.org/news-insights/publication/empirical-evaluation-structured-argumentation-using-toulmin-argument).
+This template enforces all six components explicitly to counter that variance.
+
+### Claim 1: The four child PRs together resolve all four sub-problems and therefore satisfy the parent acceptance criterion
+
+- **Claim (C):** "The combined effect restores four invariants in
+  `Tau.Application` and its cross-cutting subsystems — asymmetric crash-safety
+  in cost telemetry handlers, post-/pre-increment coupling between
+  `CircuitBreaker.Store` and the façade, unmonitored CLI task and dual OTel
+  enable-disable policy in `start/2`, and hard-coded global atom names blocking
+  multi-instance deployment — without introducing new defects at sibling
+  boundaries." (root solution.md, Recommendation, lines 23-32).
+- **Grounds (G):** The parent problem.md (lines 78-89) lists exactly four
+  sub-problems by short-name: `supervision-tree-startup`,
+  `telemetry-handler-coupling`, `circuit-breaker-invariant-split`,
+  `global-name-collision`. The root solution's `synthesised_from` frontmatter
+  (lines 6-10) names exactly four child solution paths matching these four
+  short-names. The "What changes" section (lines 99-176) enumerates one PR per
+  child, each addressing one sub-problem. Cross-checked: every concrete defect
+  cited in problem.md's Context section (lines 25-46) — `cost/tracker.ex:118`
+  rescue gap, `telemetry/supervisor.ex:17-22` strategy, `circuit_breaker.ex:124`
+  `new_count - 1` adjustment, `state.ex:64` `@default_cooldown_ms`,
+  `application.ex:113` dual OTel policy, `application.ex:185` unmonitored Task,
+  `application.ex:68` `Tau.PubSub` hard-coded — appears in exactly one PR's
+  change list.
+- **Warrant (W):** The parent acceptance criterion (problem.md line 93-95)
+  reads "All four sub-problems are resolved: each has a validated proposal
+  that names the change, the affected file(s) and line(s), and the invariant
+  it restores." This is a **conjunction**: `P1 ∧ P2 ∧ P3 ∧ P4`. By Hickey's
+  decomposition discipline (MECE along the concern axis, problem.md lines
+  64-75), a partition has no overlap and no gap; resolving each part
+  independently resolves the whole. The conjunction is satisfied iff every
+  conjunct is satisfied and the conjuncts cover the original problem.
+- **Qualifier (Q):** Holds **only if** each child sub-problem's solution is
+  itself validated. Child validation lives in
+  `subproblems/<name>/validation.md` — the root validator cannot re-validate
+  child solutions, only their composition. Also requires that the partition
+  in problem.md §Decomposition strategy is genuinely MECE (no concern
+  straddles a boundary); root validator inherits this from the decomposer's
+  output without re-deriving it.
+- **Rebuttal (R):** If a defect listed in problem.md's Context section is NOT
+  addressed by any of the four child PRs, the conjunction fails to cover the
+  acceptance criterion. Concretely, the "without introducing new defects at
+  sibling boundaries" sub-clause is the load-bearing risk — addressed
+  separately in Claim 2 (the disjoint-region claim) and Claim 5 (the additive-
+  overlap claim).
+- **Backing (B):** Hickey, "Simple Made Easy" (2011) — concerns that are
+  woven together must be teased apart on the concern axis, not on the
+  artefact axis, to avoid hidden coupling. Tau's `.claude/rules/spec-before-
+  code.md` and OTP non-negotiable #2 (extensibility seams as behaviours)
+  codify the same discipline for this codebase.
+
+#### Falsification attempt for claim 1
+
+- **Strategy:** Edge-case enumeration over the defect inventory in
+  problem.md's Context section + dependency check that each child PR's change
+  list addresses the cited file/line.
+- **Attempt:** Walked each of the eight concrete defect citations in
+  problem.md (lines 27-46) and traced them to a specific PR change in the
+  root solution's "What changes" section (lines 99-176):
+  - `lib/tau/cost/tracker.ex:118-138` rescue gap → PR 1 first bullet (line
+    105) ✓
+  - `lib/tau/telemetry/supervisor.ex:17-22` `:one_for_one` → PR 1 second
+    bullet (line 109) ✓
+  - `lib/tau/circuit_breaker.ex:124-145` `new_count - 1` → PR 2 second
+    bullet (line 121) ✓
+  - `lib/tau/circuit_breaker/state.ex:64` `@default_cooldown_ms` →
+    PR 2 third bullet (line 124) ✓
+  - `lib/tau/application.ex:185` unmonitored Task → PR 3 first/third bullets
+    (lines 137, 142-144) ✓
+  - `lib/tau/application.ex:113` dual OTel policy → PR 3 second bullet (line
+    140) ✓
+  - `lib/tau/application.ex:68` hard-coded `Tau.PubSub` → PR 4 second/sixth
+    bullets (lines 158, 172) ✓
+  - Other hard-coded names (`Tau.Providers.Finch`,
+    `Tau.CircuitBreaker.Store`, `Tau.Sessions.Supervisor`) → PR 4 sweep
+    bullet (lines 172-173) ✓
+  Independently verified all citations are real via grep of the live tree:
+  `Tau.Providers.Finch` appears in `application.ex:78`, `mcp/transport/http.ex:28`,
+  `providers/copilot/auth.ex:132`, `providers/shared/finch_stream.ex:76`,
+  `mcp/transport/sse.ex:36/66` — consistent with the "~30 call sites"
+  estimate in PR 4. `Tau.PubSub` appears in `permissions/rule_set.ex:32`,
+  `settings/cache.ex:50`, `tui/event_bridge.ex:60`, `session.ex:178`/`1367`,
+  `commands/builtin/export.ex:71`, `tools/builtin/agent.ex` (5 sites),
+  `session/slash_command.ex:361`, `providers/rate_limiter*.ex` (2 sites),
+  `cli.ex:315` — same.
+- **Outcome:** Withstood. Every defect in the parent's Context list maps to
+  exactly one child PR. No defect is orphaned; no defect is double-assigned.
+- **Action:** None.
+
+### Claim 2: PRs 3 and 4 touch `Application.start/2` at disjoint regions and rebase cleanly
+
+- **Claim (C):** "These overlap in the same function; ordering #3 before #4
+  means the `spawn_monitor` + `receive` block and the `OtelReporter`
+  unconditional entry are present in `start/2` when #4 then adds the
+  `Tau.Names.compute/1` / `:persistent_term.put/2` lines and rewrites the
+  child specs to thread `names.*` fields. The two patches touch the same
+  function but at clearly separable points (CLI dispatch block and OtelReporter
+  spec list vs name resolution and child opts) — a textbook rebase-rather-
+  than-conflict situation." (root solution.md, Composition rationale, lines
+  68-77).
+- **Grounds (G):** Live `lib/tau/application.ex` (read at validation time):
+  - PR 3's regions: `maybe_dispatch_cli/0` body at lines 179-195;
+    `otel_reporter_spec/0` definition at lines 113-119 and its child-spec
+    invocation at line 67; the `opts = [...]` line at 93; the `{:ok, pid}`
+    branch at lines 96-103.
+  - PR 4's regions: the `children = List.flatten([...])` list at lines 60-91
+    (each child-spec entry needs `names.*` threading); a new `start/2` head
+    block that reads `instance_id`, calls `Tau.Names.compute/1`, and writes
+    `:persistent_term`. The natural placement is before `children =`, i.e.
+    before line 60.
+  - Overlap analysis: PR 3 deletes line 67 (`otel_reporter_spec()`),
+    replacing it with literal `Tau.OtelReporter`; deletes the function
+    bodies at 113-119 and 179-195; rewrites the `opts` keyword at 93; inserts
+    a `spawn_monitor` block on the success branch at 96-103. PR 4 inserts
+    new code at the head of `start/2` (before line 60) and modifies entries
+    inside the `children = [...]` list (lines 60-91) to add `name:`/`names.*`
+    opts. The literal line ranges PR 3 modifies (67, 93, 96-103, 113-119,
+    179-195) and the line ranges PR 4 modifies (head of `start/2`, body of
+    `children` list entries) intersect ONLY at "inside `start/2` body" —
+    not at any common line.
+- **Warrant (W):** Git's three-way merge resolves edits that touch disjoint
+  hunks of the same file without conflict (rebase succeeds). For a single
+  function, disjoint *line ranges* is the operative criterion — two patches
+  to different statements of the same `def` body do not conflict.
+- **Qualifier (Q):** Holds **provided** PR 4's `Tau.Names.compute/1` call is
+  placed at the head of `start/2`, before the child list is constructed.
+  Solution's "Open questions" section (lines 236-245) explicitly flags this
+  ordering ambiguity and identifies the recovery: "moving the
+  `Tau.Names.compute/1` + `:persistent_term.put/2` call to the very start of
+  `start/2`, before any child spec list is constructed." Also holds only if
+  PR 4's child-spec rewrites in `children = [...]` (which restructure entries
+  like `{Phoenix.PubSub, name: Tau.PubSub}` into name-threaded forms) do not
+  collide with PR 3's deletion of `otel_reporter_spec()` from that same list
+  — they do not, because PR 3 *substitutes* the literal `Tau.OtelReporter`
+  for the function call at the same list position, and PR 4 then *modifies*
+  that entry by adding the `names.*` opt (additive).
+- **Rebuttal (R):** If PR 3's `spawn_monitor` block in the `{:ok, pid}`
+  branch (lines 96-103) ends up needing access to `Tau.Names.get()` (e.g.
+  because the CLI dispatch path reads a name), the ordering inverts: PR 4
+  must land first, OR the implementer must shift the
+  `:persistent_term.put/2` to before the `Supervisor.start_link` call.
+  Solution's open question 1 (lines 236-243) names exactly this risk and
+  marks it as PR-4-implementation-time work.
+- **Backing (B):** Git documentation: `git-merge-file(1)` resolves
+  disjoint-hunk edits without operator intervention; conflict requires
+  overlapping line ranges. Tau's `.claude/rules/factory-loop.md` "Parallel
+  execution" §"The conflict check" clause 3 ("disjoint codepoints") permits
+  same-function edits at "clearly separate, stable regions" — exactly the
+  configuration here.
+
+#### Falsification attempt for claim 2
+
+- **Strategy:** Counter-example construction — try to construct a concrete
+  ordering of edits that produces a git conflict given the live file state.
+- **Attempt:** Simulated PR 3 first against current `application.ex`:
+  - delete `otel_reporter_spec()` from line 67, replace with
+    `Tau.OtelReporter` ⇒ line 67 mutates.
+  - rewrite `opts` at line 93 ⇒ line 93 mutates.
+  - insert `spawn_monitor` block between current lines 96-103 ⇒ lines
+    96-103 mutate / expand.
+  - delete `otel_reporter_spec/0` at lines 113-119 ⇒ block removed.
+  - delete `maybe_dispatch_cli/0` and its call site at line 101, body at
+    179-195 ⇒ block removed.
+  Then simulated PR 4 layered on top: inserts ~3-5 lines at the head of
+  `start/2` (before the current line-60 `children =`), and modifies each
+  `children` list entry to add a `names.*` opt. The line-60 head is BEFORE
+  every line PR 3 touched (67, 93, post-93 success branch, 113+, 179+).
+  The `children` entries PR 4 modifies are each one-line additions of a
+  keyword (`{Phoenix.PubSub, name: ...}` already has `name:`; PR 4 adds
+  `name: Tau.Names.get().pubsub` or similar). These are intra-list-element
+  edits — PR 3's deletion of `otel_reporter_spec()` and its replacement
+  with `Tau.OtelReporter` leaves a list slot PR 4 must then thread an opt
+  into. The slot replacement happens at the SAME line PR 3 produced (so
+  PR 4 reads PR-3-state, not original state). No physical line conflict
+  could be constructed.
+  Counter-attempted by attempting to construct a name-resolution-ordering
+  hazard: could PR 3's `spawn_monitor` body read `Tau.Names.get()` and
+  thereby need the `:persistent_term` write to land BEFORE
+  `Supervisor.start_link`? In the current PR 3 design, the spawn_monitor
+  body calls `Tau.CLI.main(argv)`, which under PR 4 would resolve names
+  via `Tau.Names.get()` at call time. PR 4 places its
+  `:persistent_term.put/2` at the head of `start/2`, which is BEFORE
+  `Supervisor.start_link` and therefore BEFORE the `{:ok, pid}` branch
+  spawn_monitor — so the read sees the write. No name-resolution hazard.
+- **Outcome:** Withstood. No conflict can be constructed under the open-
+  question-1 placement (which is the prescribed placement).
+- **Action:** None for this validator; the open question is correctly held
+  open in the root solution for PR-4 implementation time.
+
+### Claim 3: The chosen ordering (#1 → #2 → #3 → #4) minimises blast radius by putting the smallest patches first
+
+- **Claim (C):** "ordering is chosen to put the smallest, lowest-blast-radius
+  patches first and the broadest call-site sweep last." (root solution.md,
+  Recommendation, lines 21-23).
+- **Grounds (G):** Counting changed files / sweep scope from "What changes":
+  PR 1 = 2 files + 1 test (rescue + supervisor strategy);
+  PR 2 = 4 files + SPEC amendment (counter convention + cooldown opt + façade
+  simplification + spec text);
+  PR 3 = 1 file (`application.ex` body rewrite);
+  PR 4 = 1 new file + 4 edited files + ~30 call-site sweep + 1 regression
+  property test.
+  Numerically the ordering is `2 < 4 ≤ 1 < 5` files-only, but if "blast
+  radius" includes call-site sweep, PR 4's `~30 call sites` strictly
+  dominates PRs 1-3 each.
+- **Warrant (W):** Smaller patches are easier to gate (per Tau's
+  `factory-loop.md` "Gateability ceiling": "MUST stay reviewable by `critic`
+  and `reviewer` in a single pass"). The factory loop's per-PR gate is
+  stateless, so cumulative blast risk grows with the size of each individual
+  PR rather than with cumulative size — early-and-small reduces the
+  probability of a gate failure in the high-friction PR (#4) holding up
+  earlier wins.
+- **Qualifier (Q):** "Smallest first" is true for PR 1 (2 files) vs PR 4
+  (~35 files counting the sweep) but **NOT strictly true for the middle**:
+  PR 2 (4 files + SPEC) is broader than PR 3 (1 file). The ordering claim
+  is therefore not "monotonically increasing blast radius" but "PR 4 last,
+  others arranged for conflict-minimisation." Narrow the qualifier
+  accordingly.
+- **Rebuttal (R):** Solution itself supplies a *different* ordering
+  rationale earlier in the same Migration sketch (lines 200-204): "Land the
+  four PRs serially in the order above. Each PR is small enough to gate
+  independently … none has a prerequisite from a sibling beyond the ordering
+  chosen here for conflict-minimisation." This second rationale is
+  *conflict-minimisation*, not blast-radius — and is the load-bearing one
+  (PR 3 must precede PR 4 to give PR 4 a base to rebase on; PRs 1 and 2
+  could in principle merge in any order). The "lowest blast radius first"
+  framing in the Recommendation is post-hoc colour, not a correctness
+  constraint.
+- **Backing (B):** Tau `factory-loop.md` "PR scope guards" + "Gateability
+  ceiling" + "Conflict check" clauses. None of these axiomatise "smallest
+  first"; they axiomatise "small enough to gate" and "no merge conflicts."
+
+#### Falsification attempt for claim 3
+
+- **Strategy:** Counter-example construction — find an ordering that
+  contradicts "smallest first" while still satisfying the load-bearing
+  constraints.
+- **Attempt:** Consider ordering `#3 → #1 → #2 → #4`. PR 3 (1 file) is
+  smaller than PR 1 (2 files + 1 test) on the file count. PR 3 has no
+  sibling prerequisite. PR 4 still lands last. This ordering also satisfies
+  the conflict-minimisation invariant (only same-function overlap is
+  3 ∩ 4, and PR 4 still lands after PR 3). Yet the solution chose `#1 → #2
+  → #3 → #4`. Therefore "smallest first" is NOT the operative criterion;
+  conflict-minimisation + PR 4 last is.
+- **Outcome:** Partially falsified. The literal text "smallest first" does
+  not hold; "PR 4 last + conflict-minimisation between the others" does.
+- **Action:** Narrow the qualifier in place — the ordering is correct on the
+  load-bearing criterion (conflict-minimisation); the "smallest first"
+  framing is descriptive colour, not a constraint. No solution.md revision
+  required (the Migration sketch already states the correct rationale; only
+  the Recommendation paragraph's gloss is loose). Logged as an outstanding
+  doubt for the parent's parent validator to consider — the gloss could
+  mislead a future implementer into reordering on a "smaller first" basis
+  and breaking the actual constraint.
+
+### Claim 4: No PR has a prerequisite from a sibling beyond the chosen ordering
+
+- **Claim (C):** "none has a prerequisite from a sibling beyond the ordering
+  chosen here for conflict-minimisation." (root solution.md, Migration
+  sketch, lines 203-204).
+- **Grounds (G):** Cross-referencing each PR's "What changes" against the
+  others:
+  - PR 1 modifies `cost/tracker.ex` (rescue) and
+    `telemetry/supervisor.ex` (strategy). Neither file is touched by PR 2
+    or PR 3. PR 4 modifies `cost/tracker.ex` but only to add a `name:` opt
+    to `start_link/1` — additive on top of PR 1's rescue.
+  - PR 2 modifies `circuit_breaker.ex`, `circuit_breaker/store.ex`,
+    `circuit_breaker/state.ex`, and `SPEC-CIRCUIT-BREAKER.md`. PR 4
+    modifies `circuit_breaker/store.ex` only in `start_link/1` / `init/1`
+    (accepting `name:`/`table:` opts) — solution explicitly states (lines
+    62-65) the regions are different from PR 2's `bump_*/1` edits and
+    `do_transition/3` is untouched.
+  - PR 3 modifies `application.ex` only. PR 4 also modifies
+    `application.ex` — see Claim 2.
+  - PR 4 modifies one new file + 4 edited files + ~30 call-site sweep.
+- **Warrant (W):** Tau `factory-loop.md` "Conflict check" clause 2 (disjoint
+  files) and clause 3 (disjoint codepoints): two PRs may safely merge in
+  serial order if their file/codepoint sets are disjoint or additive at
+  separate functions. No PR pair here violates this when serialized as
+  prescribed.
+- **Qualifier (Q):** Holds under the prescribed merge order (1 → 2 → 3 → 4).
+  Holds **only if** PR 1's `Cost.Tracker` rescue block survives PR 4's
+  additive `name:` opt edit (which it does, per solution lines 81-83:
+  "preserves PR 1's rescue block verbatim") and PR 2's `Store.bump_*/1`
+  pre-increment semantics survive PR 4's additive `name:`/`table:` opt
+  edit (which they do, per solution lines 79-81: "preserves PR 2's
+  pre-increment semantics"). These are unverifiable until each PR's diff
+  exists; the validator can only check that the solution's claim is
+  internally consistent.
+- **Rebuttal (R):** If a future PR (outside this module's scope) lands
+  between two of these four PRs and modifies one of the overlap surfaces
+  (e.g. another change to `circuit_breaker/store.ex` `start_link/1`
+  signature), then PR 4 must rebase against the intermediate. The
+  solution's open question 2 (lines 246-251) flags this for the SPEC
+  amendment; the same applies to source files in principle.
+- **Backing (B):** `factory-loop.md` §"Conflict check" + §"When to
+  serialize"; `spec-before-code.md` for the SPEC-amendment rebase pattern.
+
+#### Falsification attempt for claim 4
+
+- **Strategy:** Dependency check — for each child PR, verify that nothing it
+  needs at merge time is produced by a later child PR in the ordering.
+- **Attempt:** Walked each PR for backward references:
+  - PR 1 references nothing from PRs 2/3/4. ✓
+  - PR 2 references nothing from PRs 3/4. (The pre-increment convention is a
+    change to `Store`, but it does not require PR 4's `name:` opt.) ✓
+  - PR 3 references nothing from PR 4. (The `Tau.OtelReporter` always-in-
+    tree change does not require PR 4's name resolution; `OtelReporter` is
+    started by literal module atom.) ✓
+  - PR 4 explicitly assumes PRs 1, 2, 3 are merged (per solution lines
+    220-223: "Rebases on top of PR 3's `start/2` body"). Forward
+    dependency only — consistent with last-in-order.
+  Counter-attempt: is there any reverse dependency, e.g., does PR 2's
+  `check/3` cooldown opt need to be threaded through `Tau.Names` somehow?
+  No — `cooldown_ms` is a per-call keyword opt to a pure function, not a
+  process name. Independent.
+- **Outcome:** Withstood. No backward dependency among the four.
+- **Action:** None.
+
+### Claim 5: PR 4's edits to `Cost.Tracker` and `CircuitBreaker.Store` are additive and preserve PRs 1 and 2's semantics verbatim
+
+- **Claim (C):** "Modifying `Cost.Tracker` and `CircuitBreaker.Store` here
+  is purely additive (accept `name:`, `table:` opts with defaults equal to
+  current atoms), so the rescue block from #1 and the multi-op
+  `update_counter` from #2 are preserved verbatim." (root solution.md,
+  Composition rationale, lines 81-85).
+- **Grounds (G):** Solution's PR 4 specification, lines 162-167: "`name:`
+  and `table:` opts (defaults `__MODULE__` and `:tau_circuit_breakers`).
+  Additive — preserves PR 2's pre-increment semantics." Lines 166-167:
+  "same pattern (`name:` opt). Additive — preserves PR 1's rescue block
+  verbatim." The defaults specified match the current atoms exactly
+  (`__MODULE__` for `Store`, `:tau_circuit_breakers` for the ETS table,
+  `Tau.Cost.Tracker` implicitly for `Tracker`'s `__MODULE__` name).
+- **Warrant (W):** Adding a keyword opt with a default that equals the
+  previous hard-coded value is a *backward-compatible refinement*: every
+  caller that does not supply the opt observes pre-change behaviour
+  exactly; the new behaviour is opt-in. This is the standard contract-
+  preserving extension pattern (OTP non-negotiable #2 — extensibility seams
+  as behaviours, here as keyword opts).
+- **Qualifier (Q):** Holds **only if** the default truly equals the
+  current atom AND the only added code paths are the opt-reading sites;
+  any edit to the *body* of `handle_event/4` (PR 1's rescue) or the
+  *body* of `bump_failure_count/1`/`bump_success_count/1` (PR 2's
+  multi-op) would violate "preserved verbatim."
+- **Rebuttal (R):** If PR 4's implementer, when threading `name:` through
+  `Cost.Tracker.start_link/1` and `init/1`, mistakenly also edits the
+  `:telemetry.attach` block (lines 89-105 in current `tracker.ex`) — e.g.
+  to make the handler_id parameterised by instance — that would mutate
+  PR 1's rescue boundary and violate the verbatim-preservation claim.
+  This is a real implementation hazard but not asserted by the solution
+  text; the solution prescribes only `start_link/1` / `init/1` opt
+  acceptance.
+- **Backing (B):** Erlang/OTP convention for keyword-opt extension (cf.
+  `:gen_server` callback opts, `:ets.new/2` opts list); OTP non-negotiable
+  #2 in `.claude/rules/otp-non-negotiables.md`.
+
+#### Falsification attempt for claim 5
+
+- **Strategy:** Counter-example construction — find a code path in the live
+  `tracker.ex` or `store.ex` where adding a `name:` opt requires editing
+  PR-1 or PR-2 territory.
+- **Attempt:** Read `lib/tau/cost/tracker.ex` end-to-end at validation time.
+  `start_link/1` (line 73) calls `GenServer.start_link(__MODULE__, opts,
+  name: __MODULE__)`. To make `name:` configurable, PR 4 needs to derive
+  the name from opts and pass `name: derived_name` — purely opt-list
+  manipulation, no body edits required. `init/1` (lines 80-108) references
+  `:telemetry.attach` with literal handler IDs `@handler_id` /
+  `@coding_agent_handler_id` — these would need parameterisation for
+  multi-instance, since `:telemetry.attach` requires globally-unique IDs.
+  This IS a body edit, not pure opt threading. **The solution does not
+  mention handler-ID parameterisation.** This is a partial gap.
+  However: the gap is in PR 4's *completeness for multi-instance handler
+  attachment*, NOT in PR 4's *preservation of PR 1's rescue verbatim*. PR
+  1's rescue lives inside `handle_coding_agent_cost/4` body — that body is
+  not touched by handler-ID parameterisation (only the `:telemetry.attach`
+  argument is). So Claim 5's "preserves verbatim" stands; the deeper PR 4
+  question (will handler IDs collide across instances?) is a child-node
+  concern routed to `subproblems/global-name-collision/validation.md`.
+  For `CircuitBreaker.Store.bump_failure_count/1` (line 116, single
+  `:ets.update_counter(@table, provider, {3, 1})` call), PR 4's `table:`
+  opt makes `@table` parameter-driven — body edit, but PR 2's "multi-op"
+  per the solution is `[{pos, 0}, {pos, 1}]`. The instruction in PR 2
+  changes the *third argument* of `update_counter`, while PR 4 changes
+  the *first* (the table). These do not overlap textually; PR 4's edit
+  is `:ets.update_counter(table, provider, ...)` where `table` is the
+  resolved opt. **PR 2's "multi-op" is preserved verbatim** — only the
+  argument is now a variable instead of `@table`. The solution's
+  "preserved verbatim" claim is intact under a reasonable reading: the
+  multi-op *expression* is unchanged; only its surrounding scope is
+  parameterised.
+- **Outcome:** Withstood at the stated scope (PR-1 rescue body and PR-2
+  multi-op expression). Surfaced a separate gap (handler-ID
+  parameterisation) that is properly the child node's concern, not this
+  claim's.
+- **Action:** None for this claim. Logged as an outstanding doubt for
+  parent inheritance.
+
+### Claim 6: The four sub-problems are MECE along the Hickey concern axis
+
+- **Claim (C):** "The four child recommendations are **directly composable**.
+  The decomposition strategy in `problem.md` partitions defects along the
+  Hickey *concern* axis (steady-state event handling vs lifecycle vs
+  data-shape-across-a-layer vs deployment topology); no concern lives in
+  two children, so no recommendation contradicts another." (root
+  solution.md, Composition rationale, lines 42-46).
+- **Grounds (G):** problem.md §Decomposition strategy (lines 64-75) names
+  four classes (a)-(d) and asserts MECE explicitly. Cross-checked: each
+  concrete defect cited in problem.md maps to exactly one class:
+  - cost tracker rescue gap → (a) steady-state event handling
+  - telemetry supervisor `:one_for_one` → (a) steady-state event handling
+  - circuit-breaker counter leakage → (c) data-shape across layer
+  - cooldown asymmetric configurability → (c) data-shape across layer
+  - unmonitored CLI task → (b) lifecycle
+  - dual OTel enable policy → (b) lifecycle
+  - hard-coded global atom names → (d) deployment topology
+- **Warrant (W):** Hickey's "Simple Made Easy" defines a *concern* as a
+  single dimension of meaning; MECE-by-concern means the partition's
+  equivalence classes are atomic-by-concern. A partition is composable
+  iff its classes are independent (changes to one class do not require
+  reading another), which is exactly MECE-by-concern.
+- **Qualifier (Q):** Holds **provided** no later finding crosses a
+  boundary. The classification of "cost tracker rescue gap" and "telemetry
+  supervisor strategy" as the same class (a) is a judgement call — they
+  could be argued as separate concerns (handler-internal vs supervisor-
+  strategic). But child solution at
+  `subproblems/telemetry-handler-coupling/solution.md` packages them
+  together, so the boundary is held.
+- **Rebuttal (R):** If a defect surfaces that legitimately straddles two
+  classes (e.g., a circuit-breaker concern that is also a deployment-topology
+  concern), the partition is no longer MECE and the composition argument
+  weakens. None such surfaced in the four child solutions; if one surfaces
+  later, the root would need to re-validate.
+- **Backing (B):** Hickey, "Simple Made Easy" (2011); Tau's
+  `.claude/rules/spec-before-code.md` which encodes the same partition
+  discipline at the SPEC level (one SPEC per concern, not per artefact).
+
+#### Falsification attempt for claim 6
+
+- **Strategy:** Edge-case enumeration — try to construct a defect that
+  straddles two of the four classes.
+- **Attempt:** Construct candidate cross-boundary defects:
+  - "What if a circuit breaker is per-instance — does PR 4 (deployment
+    topology) need PR 2 (counter convention)?" PR 4 makes the breaker
+    table name configurable; the counter convention is still per-row.
+    Different tables hold different rows; no cross-instance interference.
+    The two are orthogonal — MECE holds.
+  - "What if the cost tracker rescue (PR 1) needs to be aware of the
+    handler ID being per-instance (PR 4 deployment topology)?" The rescue
+    catches body raises regardless of handler ID; the two are orthogonal.
+    MECE holds.
+  - "What if the supervision-tree-startup change (PR 3) needs to know
+    about PR 4 names because `Tau.OtelReporter` reads a name?" The
+    `OtelReporter` is started by literal module atom in PR 3; PR 4's
+    `names.*` threading would add a `name:` opt later. The two are
+    serial-additive, not cross-cutting.
+  No straddling defect could be constructed within the inventory.
+- **Outcome:** Withstood. The MECE-by-concern partition holds for the
+  defect set.
+- **Action:** None.
+
+## Cross-claim consistency
+
+Internally consistent. The six claims fit together as: Claims 1 + 6 establish
+that the conjunction `P1 ∧ P2 ∧ P3 ∧ P4` covers the parent acceptance criterion;
+Claims 2 + 4 + 5 establish that the conjunction's *operationalisation* (the
+serial four-PR merge) does not destroy independence; Claim 3 explains the
+order. Claim 3's partial falsification narrows the *gloss* on ordering rationale
+without contradicting any other claim — the load-bearing constraint
+(conflict-minimisation + PR 4 last) is stated in the Migration sketch and is
+unaffected.
+
+One latent tension worth noting: Claim 5 ("preserves verbatim") and Claim 2
+("same function, disjoint regions") both assert that PR 4's additive edits
+do not damage prior PRs' semantics. They reinforce each other rather than
+conflict; neither weakens the other.
+
+## Falsification summary
+
+| # | Claim (short) | Strategy | Outcome | Action |
+|---|---|---|---|---|
+| 1 | Four PRs cover parent acceptance criterion | Edge-case enumeration + dependency check | withstood | none |
+| 2 | PRs 3 ∩ 4 in `start/2` are disjoint regions | Counter-example construction | withstood | none |
+| 3 | Ordering puts smallest blast radius first | Counter-example construction | partially falsified | narrow qualifier — load-bearing criterion is conflict-min + PR 4 last, not "smallest first" |
+| 4 | No sibling prerequisite beyond ordering | Dependency check | withstood | none |
+| 5 | PR 4 edits to Tracker/Store preserve PR 1/2 verbatim | Counter-example construction | withstood | none |
+| 6 | Decomposition is MECE-by-concern | Edge-case enumeration | withstood | none |
+
+## Revision required
+
+No solution.md or problem.md revision triggered. Claim 3's partial
+falsification narrows the *qualifier* on the ordering rationale in place;
+the prescribed ordering itself is unchanged, and the Migration sketch
+already states the load-bearing rationale (conflict-minimisation + PR 4
+last) correctly. The Recommendation paragraph's "lowest blast radius first"
+gloss is descriptive rather than prescriptive — flagged as an outstanding
+doubt rather than triggering revision.
+
+- **Target file:** n/a
+- **Revision kind:** n/a
+- **Rationale:** Per `validate.md` §5, partial falsification → narrow
+  qualifier in place; no revision needed. Revision is reserved for
+  falsified claims (none here) or solution-invalidating tensions (none
+  here).
+
+## Outstanding doubts
+
+- **D1** (from Claim 3): The Recommendation's "smallest patches first"
+  framing is post-hoc and could mislead a future implementer into
+  reordering on a size basis (e.g., #3 before #1) and inadvertently
+  breaking the conflict-minimisation invariant. Mitigation: the Migration
+  sketch already states the load-bearing rationale; future implementers
+  should read both sections. Parent-level validator should consider
+  whether to amend the Recommendation to surface the operative criterion
+  explicitly.
+- **D2** (from Claim 5 counter-attempt): PR 4's `name:` opt threading on
+  `Cost.Tracker.init/1` raises a question the solution does not address —
+  `:telemetry.attach` requires globally-unique handler IDs, so a
+  multi-instance Tau would need handler-ID parameterisation as well. This
+  is properly the concern of
+  `subproblems/global-name-collision/validation.md`, but flagged here in
+  case the child validator missed it.
+- **D3** (from Claim 4): The "preserves verbatim" guarantees in PR 4 are
+  unverifiable until each PR's diff exists; the solution's internal
+  consistency is verified, but implementation drift is a real risk gated
+  only by the per-PR `critic` + `reviewer` cycle. Flagged for the
+  factory-loop's per-PR gate rather than for this validation.
+- **D4** (from Claim 6): The classification of "cost tracker rescue" and
+  "telemetry supervisor strategy" as a single concern class (a) is a
+  judgement call; an alternative decomposition could split them. Both
+  the parent and the child currently bundle them; this validation accepts
+  the bundling. If a later defect surfaces that ties the two more tightly,
+  re-validate.

--- a/docs/problems-archive-v1-modules/tau-memory/problem.md
+++ b/docs/problems-archive-v1-modules/tau-memory/problem.md
@@ -1,0 +1,77 @@
+---
+template_version: 1
+template_name: problem
+node_kind: internal
+depth: 0
+parent: —
+status: decomposed
+---
+
+# Problem: Embedding pipeline is silently broken under default configuration
+
+## Statement
+
+`Tau.Memory.EmbeddingWorker` defaults its Finch pool name to `Tau.Finch`
+(`embedding_worker.ex:106`), but `Tau.Application` registers the pool as
+`Tau.Providers.Finch` (`application.ex:78`). Every embedding request made
+without an explicit `:tau, :finch_name` override resolves to a non-existent
+process, returns `{:error, :transient, ...}`, and leaves the entry with
+`embedding_status: "pending"` indefinitely. The failure is invisible: no log
+line names the real cause, no metric fires, and no operator signal surfaces that
+semantic search is permanently degraded.
+
+## Context
+
+- `lib/tau/memory/embedding_worker.ex:106` — `Application.get_env(:tau, :finch_name, Tau.Finch)`; the default is a name that does not exist in the supervision tree.
+- `lib/tau/application.ex:78` — `{Finch, name: Tau.Providers.Finch}` — the only Finch pool registered.
+- `lib/tau/memory/store/sqlite.ex:306` — `handle_continue/2` dispatches embedding via the configured embedder; no return-value check on the dispatch.
+- `lib/tau/memory/store/sqlite.ex:279-288` — `handle_call({:store_embedding, ...})` accepts `{:error, :transient, _}` and calls `do_mark_embedding_failed/3`, setting `embedding_status = "failed"`. But with the noproc failure the Task crashes before calling back, so the entry stays `"pending"`.
+- `SPEC-MEMORY-STORE.md` D-045/D-046 — connection-ownership and embedding-status invariants are satisfied by the design; this bug is a configuration/wiring defect, not a design defect.
+- `.code_audit/archive/v1-flat/06-infrastructure.md §9` — classified as a critical bug (cross-system identifier drift).
+
+## Complecting hypothesis
+
+- The Finch pool name used at call-site is complected with the name declared in the supervision tree because there is no shared constant or compile-time reference binding them; the two sites drifted independently.
+- The error classification path (transient/terminal) is complected with the observability path: a noproc crash that never calls back produces an entry that looks identical to a legitimately in-flight embedding, hiding the failure class from operators.
+- Recovery semantics (retry transient failures) are complected with the absence of a retry trigger: the "transient" classification implies retryability, but there is no mechanism to re-enqueue pending entries after a configuration fix or transient fault clears.
+
+## Decomposition strategy
+
+The parent problem decomposes cleanly along **failure layer**: each sub-problem
+owns one distinct layer at which the failure manifests or needs to be addressed.
+The four layers are mutually exclusive (a concern belongs to exactly one layer)
+and collectively exhaustive (every aspect of the broken pipeline — the root
+cause, the crash propagation, the persistent degraded state, and the recovery
+path — is covered):
+
+1. **Configuration wiring** — the wrong Finch name at the call-site (root cause).
+2. **Crash-to-callback propagation** — the noproc crash kills the Task without triggering the store-embedding callback, leaving entries in `"pending"` rather than `"failed"`.
+3. **Observability of pending rot** — `"pending"` entries are indistinguishable from legitimately in-flight embeddings; no telemetry or log surfaces the stuck state.
+4. **Retry / recovery path** — once the wiring is fixed (or a transient fault clears), there is no mechanism to re-enqueue stuck `"pending"` entries.
+
+## Sub-problems (filled by decomposer)
+
+1. **finch-name-mismatch** — Fix the root-cause configuration drift: align the Finch pool name used by `EmbeddingWorker` with the name registered in `Tau.Application`.
+2. **silent-failure-propagation** — Address the Task-crash-without-callback path: when the embedding Task crashes before calling `store_embedding/3`, the entry must transition to `"failed"` rather than remaining `"pending"`.
+3. **pending-rot-observability** — Surface stuck `"pending"` entries to operators: telemetry events and/or log warnings that fire when entries age past an expected embedding window.
+4. **retry-recovery-path** — Provide a mechanism to re-enqueue `"pending"` or `"failed: transient"` entries so they can be embedded after a configuration fix or transient fault clears.
+
+## Acceptance criterion
+
+Every memory entry written under the default application configuration either
+reaches `embedding_status: "ready"` when the embedding API responds successfully,
+or transitions to `embedding_status: "failed"` with an actionable log/telemetry
+event, within the request timeout window — and no entry remains permanently in
+`embedding_status: "pending"` due to a wiring defect or silent crash.
+
+## Out of scope
+
+- The embedding model, dimension, or API provider selection.
+- FTS5 search correctness (`search/2`).
+- SQLite migration correctness.
+- `Tau.Memory.Loader` (loads `TAU.md` files; unrelated to embeddings).
+- Performance of the embedding pipeline under load.
+
+## Amendment log
+
+- (none yet)

--- a/docs/problems-archive-v1-modules/tau-memory/solution.md
+++ b/docs/problems-archive-v1-modules/tau-memory/solution.md
@@ -1,0 +1,329 @@
+---
+template_version: 1
+template_name: solution
+parent_problem: problem.md
+node_kind: root
+synthesised_from:
+  - subproblems/finch-name-mismatch/solution.md
+  - subproblems/silent-failure-propagation/solution.md
+  - subproblems/pending-rot-observability/solution.md
+  - subproblems/retry-recovery-path/solution.md
+selection_method: synthesis
+mode: non-leaf
+revision: 0
+---
+
+# Solution: Bind the Finch name, make the embedding pipeline self-healing, observable, and recoverable
+
+## Recommendation
+
+Repair the embedding pipeline along the four layers the decomposition identified
+— root-cause wiring, crash-to-callback propagation, pending-rot observability,
+and retry/recovery — in a single coherent module-level change set landed across
+three sequenced PRs. The wiring fix (a shared `Tau.Providers.Config.finch_name/0`
+constant) eliminates the root-cause drift seam. The crash-to-callback fix
+restructures `Store.SQLite` around a `pending_tasks: %{reference() => entry_id}`
+map in GenServer state, fed by a new `Tau.Memory.Embedder.embed_async/1`
+behaviour callback whose Task result is routed through `handle_info({ref,
+result}, ...)` and whose abnormal `{:DOWN, ref, ...}` exit is routed to
+`do_mark_embedding_failed/3` — making success and crash paths symmetric and the
+Store the sole writer. A periodic `handle_info(:check_pending_age, ...)` clause
+inside the same Store GenServer emits `[:tau, :memory, :pending_rot, :detected]`
+telemetry and a structured log warning whenever any `embedding_status =
+'pending'` row exceeds a configurable stale threshold. A new sibling
+`Tau.Memory.RetrySweeper` GenServer under `Tau.Memory.Supervisor` polls a new
+`Store.SQLite.list_retriable/1` API and re-invokes `embed_async/1` for stale
+`"pending"` rows and `"failed"`-with-`:transient` rows, closing the loop after
+either a configuration fix or a transient fault clears. Together these changes
+make the acceptance criterion mechanically true: every entry under default
+configuration reaches `"ready"` or `"failed"` (with actionable telemetry) within
+a bounded window, with no permanent-`"pending"` failure mode remaining.
+
+## Selected from
+
+- **Synthesised from:**
+  - `subproblems/finch-name-mismatch/solution.md` — shared `Tau.Providers.Config`
+    module binds the Finch pool name at both sites (selection_method: single).
+  - `subproblems/silent-failure-propagation/solution.md` — ref-map in
+    `Store.SQLite` state + structured-result `embed_async/1` embedder contract
+    (selection_method: hybrid).
+  - `subproblems/pending-rot-observability/solution.md` — in-process
+    `handle_info(:check_pending_age)` timer inside `Store.SQLite`
+    (selection_method: single).
+  - `subproblems/retry-recovery-path/solution.md` — dedicated supervised
+    `Tau.Memory.RetrySweeper` GenServer with periodic timer
+    (selection_method: single).
+
+- **Composition rationale:** the four child solutions compose **directly**;
+  there is no conflict to resolve. The composition has three interfaces and
+  one ordering constraint:
+
+  1. **Wiring → everything else.** The `finch-name-mismatch` fix is the
+     prerequisite: every downstream change (crash propagation, observability,
+     retry) is dead code if the Finch pool name is still wrong, because no
+     embedding call ever reaches the HTTP path. Land the wiring fix first.
+
+  2. **Crash propagation ↔ retry path share the `Embedder` contract.** The
+     crash-propagation solution introduces `embed_async/1` as the canonical
+     `Tau.Memory.Embedder` behaviour callback (replacing the
+     fire-and-forget `embed/3` + callback-from-worker pattern). The retry
+     sweeper's child solution names `embedder.embed/3` because at the time it
+     was authored that was the live contract; in the composed plan the sweeper
+     invokes `embed_async/1` instead, routing the resulting Task ref through the
+     same `pending_tasks` map and the same `handle_info` clauses as the primary
+     write path. There is exactly one dispatch path; the sweeper and the write
+     path differ only in *who* enqueues the work, not in *how* the result
+     propagates. This is the load-bearing simplification — sweeper-dispatched
+     embeddings get the same crash-to-`"failed"` guarantee as write-dispatched
+     embeddings, automatically.
+
+  3. **Observability ↔ retry are complementary, not redundant.** The
+     observability timer *detects* stale `"pending"` entries and emits
+     telemetry; the retry sweeper *acts* on stale `"pending"` and
+     transient-`"failed"` entries by re-dispatching. They run on independent
+     intervals in different processes (the timer is `handle_info` inside
+     `Store.SQLite`; the sweeper is a sibling GenServer under
+     `Tau.Memory.Supervisor`). Operators see "pending rot detected" telemetry
+     even when the sweeper is firing — telemetry is the signal, sweeping is
+     the remediation. This separation is intentional: an operator can disable
+     the sweeper (via a long sweep interval) and still see the rot signal, or
+     keep the sweeper short and see the signal decay as the sweep drains the
+     queue.
+
+  No child solution is in tension with another. The decomposition was
+  layered (one concern per layer); the layers stack without overlap.
+
+## What changes
+
+The change set, grouped by file and tagged with its originating sub-problem.
+
+### New files
+
+- `lib/tau/providers/config.ex` *(finch-name-mismatch)* — `Tau.Providers.Config`
+  with `@finch_name Tau.Providers.Finch` module attribute and a `finch_name/0`
+  accessor (~10 LOC).
+- `lib/tau/memory/retry_sweeper.ex` *(retry-recovery-path)* —
+  `Tau.Memory.RetrySweeper` GenServer (~80 LOC) with `init/1` scheduling via
+  `{:continue, :schedule}`, `handle_info(:sweep, ...)` that calls
+  `Store.SQLite.list_retriable/1` and re-dispatches each row via
+  `Tau.Memory.Embedder.embed_async/1` through the store's
+  `handle_continue({:dispatch_embedding, id, content}, state)` path,
+  `handle_call(:sweep, ...)` exposing `trigger_sweep/0` for tests and operator
+  tooling, and telemetry spans on sweep and per-enqueue events.
+- `test/tau/memory/retry_sweeper_test.exs` — unit tests using
+  `trigger_sweep/0`; integration test wiring the sweeper against a test store.
+
+### Modified files
+
+- `lib/tau/application.ex` *(finch-name-mismatch)* — line 78,
+  `{Finch, name: Tau.Providers.Finch}` → `{Finch, name:
+  Tau.Providers.Config.finch_name()}`.
+- `lib/tau/memory/embedder.ex` *(silent-failure-propagation)* — replace the
+  `embed/3` callback declaration with `embed_async/1 :: {:ok, Task.t()} |
+  {:error, term()}`.
+- `lib/tau/memory/embedding_worker.ex` *(finch-name-mismatch + silent-failure-
+  propagation)* — line 106, default Finch name argument
+  `Tau.Finch` → `Tau.Providers.Config.finch_name()`; remove the
+  `store_embedding/3` callback path; implement `embed_async/1` returning
+  `{:ok, task}` where the Task body returns `{:ok, embedding} | {:error, kind,
+  reason}`.
+- `lib/tau/memory/store/sqlite.ex` *(silent-failure-propagation + pending-rot-
+  observability + retry-recovery-path)*:
+  - **State** — add `pending_tasks: %{reference() => String.t()}`; initialise
+    to `%{}` in `init/1`.
+  - **Dispatch** — `handle_continue({:dispatch_embedding, id, content}, state)`
+    calls `embedder.embed_async(content)`, captures the Task ref, stores
+    `ref → id` in `pending_tasks`.
+  - **Success path** — new `handle_info({ref, embed_result}, state) when
+    is_reference(ref)` demonitors, removes from map, calls
+    `do_store_embedding/3` on `{:ok, embedding}` or
+    `do_mark_embedding_failed/3` on `{:error, kind, _reason}`.
+  - **Crash path** — new `handle_info({:DOWN, ref, :process, _pid, reason},
+    state)` where `reason != :normal`: looks up entry ID in `pending_tasks`,
+    calls `do_mark_embedding_failed/3` with `:transient`, removes from map.
+    Tolerates `Map.fetch/2` returning `:error` (double-fire from `{ref,
+    result}` then `{:DOWN, :normal}` benign).
+  - **Remove** — `handle_call({:store_embedding, ...})` clause; no external
+    caller after the contract change.
+  - **Observability timer** — `init/1` schedules
+    `Process.send_after(self(), :check_pending_age, @check_interval_ms)`;
+    new `@check_interval_ms` (default `60_000`) and `@stale_threshold_ms`
+    (default `35_000`, must exceed `EmbeddingWorker`'s `@request_timeout_ms`
+    of `30_000` plus a grace margin) module attributes; new
+    `handle_info(:check_pending_age, state)` clause running
+    `query_stale_pending(state.db, @stale_threshold_ms)`, emitting
+    `[:tau, :memory, :pending_rot, :detected]` telemetry with `%{count:
+    non_neg_integer()}` measurements and `%{entry_ids: [binary()],
+    oldest_age_ms: non_neg_integer()}` metadata when any are found, logging
+    a structured `Logger.warning/1`, and rescheduling itself.
+  - **Stale-pending query** — new private `query_stale_pending/2` and
+    `@sql_stale_pending` module attribute. SQL targets the `memory_entries`
+    table and `created_at` column per `lib/tau/memory/migrations.ex:35-48`:
+
+    ```sql
+    SELECT id,
+           CAST((julianday('now') - julianday(created_at)) * 86400000 AS INTEGER)
+             AS age_ms
+    FROM   memory_entries
+    WHERE  embedding_status = 'pending'
+      AND  CAST((julianday('now') - julianday(created_at)) * 86400000 AS INTEGER) > ?1
+    ORDER  BY age_ms DESC
+    ```
+
+  - **Retriable query** — new public `list_retriable/1` (~30 LOC) and private
+    `handle_call(:list_retriable, ...)` returning rows where
+    `embedding_status = 'pending'` AND age exceeds the stale threshold, OR
+    `embedding_status = 'failed'` AND the metadata-encoded
+    `embedding_error_kind = 'transient'`.
+- `lib/tau/memory/supervisor.ex` *(retry-recovery-path)* — add
+  `{Tau.Memory.RetrySweeper, opts}` as a `:one_for_one` sibling after
+  `Store.SQLite`. Strategy stays `:one_for_one`.
+- `lib/tau/memory/memory_store.ex` *(silent-failure-propagation)* — remove the
+  `store_embedding/3` public function; no external callers remain.
+- All embedder test doubles in `test/` *(silent-failure-propagation)* —
+  implement `embed_async/1` instead of `embed/3`.
+- New regression tests:
+  - kill the embed Task ref, assert DB row transitions to `embedding_status:
+    "failed"` *(silent-failure-propagation)*;
+  - success-path test via `{ref, {:ok, embedding}}` *(silent-failure-
+    propagation)*;
+  - `handle_info(:check_pending_age, ...)` driving the timer directly in
+    `store/sqlite_test.exs`, asserting telemetry and log emission *(pending-
+    rot-observability)*;
+  - `RetrySweeper.trigger_sweep/0` re-dispatches a stuck `"pending"` row and
+    a `transient`-`"failed"` row, both reach `"ready"` after a successful
+    embed *(retry-recovery-path)*.
+
+### New telemetry events
+
+- `[:tau, :memory, :pending_rot, :detected]` *(pending-rot-observability)*
+- `[:tau, :memory, :retry_sweeper, :sweep, :start | :stop]` spans
+  *(retry-recovery-path)*
+- `[:tau, :memory, :retry_sweeper, :enqueue]` per-enqueue events
+  *(retry-recovery-path)*
+
+### New configuration keys
+
+- `:tau, :finch_name` *(finch-name-mismatch)* — already exists; default now
+  derives from `Tau.Providers.Config.finch_name()`.
+- `:tau, :retry_sweep_interval_ms` *(retry-recovery-path)* — default
+  `60_000`; in the test environment set to a short value (e.g. `500`).
+
+## What does not change
+
+- The `Tau.Providers.Finch` atom itself — remains the canonical pool name.
+- All callers of `EmbeddingWorker.embed/N` at signature level apart from the
+  contract change; the contract change is intentional and covered above.
+- The `embedding_status` enum values (`"pending"`, `"ready"`, `"failed"`)
+  and D-046 invariant semantics.
+- The `memory_entries` table schema — no migration; the new queries read
+  existing `created_at`, `embedding_status`, and `metadata` columns as-is.
+- `Tau.Memory.Supervisor` supervision strategy — stays `:one_for_one`.
+- All other supervision tree entries and startup order in
+  `Tau.Application`.
+- `do_mark_embedding_failed/3` and `do_store_embedding/3` in `Store.SQLite`
+  — already exist; called from `handle_info` rather than `handle_call`.
+- The `[:tau, :memory, :write]` and `[:tau, :memory, :embedding]`
+  telemetry event shapes — unchanged.
+- FTS5 search, SQLite migrations, the embedding model/provider/dimension,
+  `Tau.Memory.Loader`, and embedding-pipeline performance under load
+  — all explicit out-of-scope items from the parent problem.
+
+## Migration sketch
+
+Sequence the change set across **three PRs** so each PR is independently
+reviewable, gateable, and reversible per `factory-loop.md` / `worktree-
+discipline.md`. The three PRs map cleanly to the dependency edges identified
+in the composition rationale.
+
+**PR-1 — Wiring fix (finch-name-mismatch).** Smallest, lowest-risk, unlocks
+everything downstream. Introduce `Tau.Providers.Config`, switch
+`application.ex` and `embedding_worker.ex` to use the shared accessor. Add
+the optional companion test asserting
+`Tau.Providers.Config.finch_name() == name registered by Tau.Application`
+(closes the nominal-equality gap noted in finch-name-mismatch open
+question 2). Ship and merge before PR-2. Reversible in one commit.
+
+**PR-2 — Embedder contract + crash propagation + observability (silent-failure-
+propagation + pending-rot-observability).** These two child solutions both
+modify `lib/tau/memory/store/sqlite.ex` and must land together to avoid an
+intermediate state where the observability timer fires against a Store whose
+crash path is still broken. Land the `Embedder` behaviour change
+(`embed_async/1`), update `EmbeddingWorker`, update test doubles, restructure
+`Store.SQLite` (state, dispatch, success, crash, timer, queries), and add
+the regression tests. The observability timer is inert until rows actually
+linger; it can ship with a generous default threshold (`35_000` ms) so it
+fires only on real anomalies. PR-2 is the largest of the three; review is
+manageable because the changes are localised to four files plus tests.
+
+**PR-3 — Retry sweeper (retry-recovery-path).** Introduce
+`Store.SQLite.list_retriable/1` first (additive, no callers yet); add the
+`Tau.Memory.RetrySweeper` module (inert until supervised); add the
+supervisor child last. The sweeper invokes the PR-2 `embed_async/1`
+contract, so PR-3 depends on PR-2 having landed. Set the sweep interval
+short in the test environment and use `trigger_sweep/0` for deterministic
+control. Reversible by removing the supervisor child and deleting the
+module.
+
+Each PR satisfies `spec-before-code.md` for `SPEC-MEMORY-STORE.md` (D-045 /
+D-046 invariants are enforced, not changed). Each PR cites the
+parent-problem acceptance criterion plus the relevant child sub-problem
+ACs in its draft-PR body per `factory-loop.md`. The full gate
+(`critic` + `reviewer`) runs against each PR; the post-merge `main` health
+check follows each merge.
+
+## Open questions
+
+The composed plan inherits five open questions from the child solutions;
+none block the recommendation but each should be resolved in the
+implementation PR that owns it.
+
+- **Namespace for `Tau.Providers.Config`** *(from finch-name-mismatch)* —
+  alternatives are `Tau.Config` or `Tau.Infrastructure`. Defer to project
+  conventions in `lib/tau/providers/`. Decision lands in PR-1.
+- **`embed_async/1` inner-Task layering** *(from silent-failure-
+  propagation)* — flatten to a single Task vs. forward the inner ref;
+  must be decided before the contract change ships in PR-2. Incorrect
+  routing means `{ref, result}` never reaches the mailbox.
+- **`{ref, result}` clause guard discipline** *(from silent-failure-
+  propagation)* — `when is_reference(ref)` must not accidentally match
+  unrelated messages; review the GenServer's full message surface before
+  PR-2 lands.
+- **`@check_interval_ms` / `@stale_threshold_ms` runtime vs. compile-time**
+  *(from pending-rot-observability)* — compile-time keeps the change
+  smaller; runtime adds operator flexibility. Default to compile-time in
+  PR-2 unless an operator requirement surfaces.
+- **Index on `(embedding_status, created_at)`** *(from pending-rot-
+  observability)* — not required at landing; revisit as a follow-up
+  migration once pending-row counts are observed in production.
+- **Duplicate-embedding race between sweeper and write path** *(from
+  retry-recovery-path)* — if the sweeper dispatches an entry while the
+  write path also has it in flight, two `embed_async/1` calls race. The
+  Store's `do_store_embedding/3` is claimed idempotent (DELETE + INSERT
+  in a transaction); verify in PR-3. A second-order mitigation is for the
+  sweeper to skip rows whose Task ref is already in `pending_tasks` (the
+  ref map introduced in PR-2 makes this cheap); decide in PR-3.
+- **Sweeper first-fire latency** *(from retry-recovery-path)* — default
+  is one full interval (60 s) after boot. If operators need a faster
+  initial drain, add `{:continue, :startup_sweep}` to `RetrySweeper.init/1`
+  before scheduling the interval. Defer unless operator requirement
+  surfaces.
+
+The parent acceptance criterion is not contingent on any of these
+questions — each one is a tuning or namespace choice within a solution
+that already satisfies the criterion.
+
+## Linked sub-problems / proposals
+
+- `subproblems/finch-name-mismatch/` → "Shared `Tau.Providers.Config` module
+  binds the Finch pool name at both sites."
+- `subproblems/silent-failure-propagation/` → "Ref-map in `Store.SQLite` state
+  + structured-result `embed_async/1` embedder contract."
+- `subproblems/pending-rot-observability/` → "In-process
+  `handle_info(:check_pending_age)` timer inside `Store.SQLite`."
+- `subproblems/retry-recovery-path/` → "`Tau.Memory.RetrySweeper` — dedicated
+  supervised GenServer with periodic timer."
+
+## Revision history
+
+- (revision 0 — initial synthesis from four validated child solutions)

--- a/docs/problems-archive-v1-modules/tau-memory/subproblems/finch-name-mismatch/problem.md
+++ b/docs/problems-archive-v1-modules/tau-memory/subproblems/finch-name-mismatch/problem.md
@@ -1,0 +1,51 @@
+---
+template_version: 1
+template_name: problem
+node_kind: leaf
+depth: 1
+parent: ../../problem.md
+status: draft
+---
+
+# Problem: EmbeddingWorker defaults to a Finch pool name that does not exist
+
+## Statement
+
+`Tau.Memory.EmbeddingWorker.call_embedding_api/3` reads the Finch pool name via
+`Application.get_env(:tau, :finch_name, Tau.Finch)` (line 106). The application
+supervision tree registers the pool as `Tau.Providers.Finch` (application.ex:78).
+No deployment sets `:tau, :finch_name`. As a result, every `Finch.request/3`
+call resolves a name that has no registered process, crashes the Task with
+`:noproc`, and prevents any embedding from completing under the default
+configuration shipped in the repository.
+
+## Context
+
+- `lib/tau/memory/embedding_worker.ex:106` — the defective default: `Application.get_env(:tau, :finch_name, Tau.Finch)`.
+- `lib/tau/application.ex:78` — `{Finch, name: Tau.Providers.Finch}` — the one and only Finch pool.
+- No application config file (`config/config.exs`, `config/runtime.exs`) sets `:tau, :finch_name`, so the default is always exercised in production.
+- The fix is a single-atom change at the default site; alternatively, a named constant shared between `application.ex` and `embedding_worker.ex` eliminates future drift.
+
+## Complecting hypothesis
+
+- The pool name at the call-site is complected with the name declared in the supervision tree because no shared constant binds them; the two sites can drift without a compile-time error.
+
+## Decomposition strategy
+
+(leaf — no further decomposition; proceed to proposals)
+
+## Acceptance criterion
+
+`Finch.request/3` in `EmbeddingWorker` resolves the pool name that `Tau.Application`
+registers, so embedding HTTP calls succeed in a standard `mix run` / release
+environment without any extra application config.
+
+## Out of scope
+
+- Observability of stuck entries (covered by `pending-rot-observability`).
+- Task crash propagation without callback (covered by `silent-failure-propagation`).
+- Retry / recovery of already-stuck entries (covered by `retry-recovery-path`).
+
+## Amendment log
+
+- (none yet)

--- a/docs/problems-archive-v1-modules/tau-memory/subproblems/finch-name-mismatch/proposals/proposal-1.md
+++ b/docs/problems-archive-v1-modules/tau-memory/subproblems/finch-name-mismatch/proposals/proposal-1.md
@@ -1,0 +1,90 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 1
+parent_problem: ../problem.md
+---
+
+# Proposal 1: Fix the default atom at the call-site
+
+## Approach
+
+Change the single default value in `EmbeddingWorker.call_embedding_api/3` from
+`Tau.Finch` to `Tau.Providers.Finch`. No new modules, no shared constant, no
+behaviour changes. The `Application.get_env/3` call remains; only its third
+argument changes.
+
+```diff
+-    finch_name = Application.get_env(:tau, :finch_name, Tau.Finch)
++    finch_name = Application.get_env(:tau, :finch_name, Tau.Providers.Finch)
+```
+
+## Rationale
+
+The complecting hypothesis identifies two sites that can drift independently.
+This proposal collapses the drift at its cheapest point — the wrong default atom
+— without introducing new structure. The supervision tree already registers the
+name; the call-site simply needs to match it. The `Application.get_env/3`
+override hook is preserved, so operators who need a different pool name can still
+set `:tau, :finch_name` in `config/runtime.exs`. The fix is atomic, reviewable
+in one line, and directly satisfies the acceptance criterion.
+
+## Sketch
+
+File: `lib/tau/memory/embedding_worker.ex`, line 106:
+
+```elixir
+# Before
+finch_name = Application.get_env(:tau, :finch_name, Tau.Finch)
+
+# After
+finch_name = Application.get_env(:tau, :finch_name, Tau.Providers.Finch)
+```
+
+No other files touched. The diff is one token.
+
+## Tradeoffs
+
+### Strengths
+
+- Minimal blast radius: one line changed, zero new dependencies.
+- Immediately satisfies the acceptance criterion with no migration.
+- Preserves the runtime-override escape hatch (`Application.get_env/3`).
+- Reviewable and revertable in seconds.
+
+### Weaknesses
+
+- Does NOT prevent future drift: the two atoms (`Tau.Providers.Finch` in
+  `application.ex` and the default in `embedding_worker.ex`) remain unbound
+  by any compile-time constraint. The next person who renames the pool in
+  `application.ex` will reproduce this bug.
+- No compile-time guarantee that the name exists when the call runs.
+- The escape hatch (`Application.get_env/3`) is now the only coupling
+  mechanism — if someone adds a second Finch pool and wants
+  `EmbeddingWorker` to use a different one, they must remember the config key.
+
+### Costs
+
+- One-line change; review cost is effectively zero.
+- No test surface change; the existing integration tests (if any) that mock
+  Finch will continue to work.
+- No operator migration required.
+
+## Dependencies
+
+- None. The fix is self-contained.
+
+## Confidence
+
+**High.** The root cause is a wrong atom literal; the fix is replacing it with
+the correct atom. No design uncertainty.
+
+What would raise it further: a test that asserts `Finch.request/3` is called
+with `Tau.Providers.Finch` (currently absent per the problem statement).
+
+## Prior art / references
+
+- `lib/tau/application.ex:78` — the authoritative registration: `{Finch, name: Tau.Providers.Finch}`.
+- The pattern of fixing a wrong default without adding structure is described in
+  Rich Hickey's "Simple Made Easy" as preferring direct composition over indirect
+  coordination.

--- a/docs/problems-archive-v1-modules/tau-memory/subproblems/finch-name-mismatch/proposals/proposal-2.md
+++ b/docs/problems-archive-v1-modules/tau-memory/subproblems/finch-name-mismatch/proposals/proposal-2.md
@@ -1,0 +1,120 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 2
+parent_problem: ../problem.md
+---
+
+# Proposal 2: Shared module attribute — compile-time binding via a named constant
+
+## Approach
+
+Introduce a single module attribute (or a one-function module) that both
+`Tau.Application` and `Tau.Memory.EmbeddingWorker` reference for the Finch pool
+name. Both sites are changed to use this constant; the two atoms can no longer
+drift. The `Application.get_env/3` runtime override is retained but its default
+now derives from the shared constant rather than a bare atom.
+
+## Rationale
+
+The complecting hypothesis names the root cause as "no shared constant binding
+the two sites." This proposal directly decomplects that: a single authoritative
+source of truth for the pool name makes the two sites structurally dependent
+rather than implicitly coordinated. If someone renames the pool, the compiler
+surfaces every site that uses the constant; unnamed sites that still hold a
+stale atom will fail at runtime, not compile time — but the shared constant
+means there is exactly one place to update.
+
+## Sketch
+
+Option A — module attribute in `Tau.Application` (simpler, couples
+`embedding_worker.ex` to `application.ex`):
+
+```elixir
+# lib/tau/application.ex
+@finch_name Tau.Providers.Finch
+def finch_name, do: @finch_name
+
+# In children/0:
+{Finch, name: @finch_name}
+```
+
+```elixir
+# lib/tau/memory/embedding_worker.ex
+finch_name = Application.get_env(:tau, :finch_name, Tau.Application.finch_name())
+```
+
+Option B — dedicated thin config module (decouples both from each other):
+
+```elixir
+# lib/tau/providers/config.ex  (new file, ~10 lines)
+defmodule Tau.Providers.Config do
+  @moduledoc "Shared infrastructure constants for provider subsystem."
+  @finch_name Tau.Providers.Finch
+  def finch_name, do: @finch_name
+end
+```
+
+```elixir
+# lib/tau/application.ex:78
+{Finch, name: Tau.Providers.Config.finch_name()}
+```
+
+```elixir
+# lib/tau/memory/embedding_worker.ex:106
+finch_name = Application.get_env(:tau, :finch_name, Tau.Providers.Config.finch_name())
+```
+
+Option B is preferred: neither `application.ex` nor `embedding_worker.ex` depends
+on the other; both depend on the config module.
+
+## Tradeoffs
+
+### Strengths
+
+- Single source of truth: renaming the pool requires one change, surfaced at
+  every callsite.
+- Decomplects the two call-sites from each other (Option B).
+- Runtime override via `Application.get_env/3` is preserved.
+- The constant is accessible to future consumers (e.g. circuit breaker tests).
+
+### Weaknesses
+
+- Introduces a new module (Option B) or a public function on
+  `Tau.Application` (Option A) — more surface than Proposal 1.
+- The binding is nominal (atom equality), not structural; a typo in the
+  constant definition (`Tau.Providers.Finch` vs `Tau.Provider.Finch`) still
+  compiles but fails at runtime.
+- Does not provide a compile-time proof that the named process exists;
+  the process must still be started before the call.
+- A caller who bypasses the shared constant and writes the atom inline still
+  drifts silently.
+
+### Costs
+
+- 1 new file (Option B) or 1 new function (Option A); ~10–15 lines total.
+- `application.ex` and `embedding_worker.ex` each change by one expression.
+- No test surface change beyond what Proposal 1 requires.
+- Code review: small; the change is mechanical.
+
+## Dependencies
+
+- None external. Option A requires no new file; Option B adds one file in
+  `lib/tau/providers/`.
+
+## Confidence
+
+**High.** The pattern of a shared constant module is well-established in Elixir
+projects. No design uncertainty; the tradeoff between Option A and Option B is
+clear.
+
+What would raise it further: a decision on whether `Tau.Providers.Config` is
+the right namespace for infrastructure constants (could live in `Tau.Config`
+or `Tau.Infrastructure` instead).
+
+## Prior art / references
+
+- Elixir idiom: `@moduledoc` + accessor function for named processes is
+  standard in Phoenix contexts (`MyApp.Repo`, `MyApp.PubSub`).
+- `lib/tau/providers/config.ex` does not yet exist; the namespace fits the
+  existing `lib/tau/providers/` layout.

--- a/docs/problems-archive-v1-modules/tau-memory/subproblems/finch-name-mismatch/proposals/proposal-3.md
+++ b/docs/problems-archive-v1-modules/tau-memory/subproblems/finch-name-mismatch/proposals/proposal-3.md
@@ -1,0 +1,123 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 3
+parent_problem: ../problem.md
+---
+
+# Proposal 3: Inject the Finch name via the EmbeddingWorker start argument
+
+## Approach
+
+Remove `Application.get_env/3` from `call_embedding_api/3` entirely. Instead,
+make `EmbeddingWorker` (or its caller) receive the Finch pool name as an
+explicit parameter at the point of invocation. `Tau.Memory.Supervisor` (or
+`Tau.Memory.Store.SQLite`) passes `Tau.Providers.Finch` directly from the
+supervision configuration; no config key exists or is needed.
+
+## Rationale
+
+`Application.get_env/3` introduces a hidden, runtime-only coupling: the caller
+cannot see what pool name the function will use without reading the application
+environment. Removing the env lookup and making the dependency explicit
+(a passed argument) means the coupling is visible in the type signature and
+testable without environment manipulation. This is behaviour-correcting AND
+interface-changing: it replaces implicit global state with explicit data
+flow — the Hickey principle of "separating values from place."
+
+## Sketch
+
+`EmbeddingWorker` exposes the pool name as a parameter:
+
+```elixir
+# lib/tau/memory/embedding_worker.ex
+
+# Public entry point — callers supply finch_name explicitly
+@spec embed(String.t(), String.t(), String.t(), atom()) ::
+        {:ok, list(float())} | {:error, :transient | :terminal, term()}
+def embed(url, api_key, content, finch_name) do
+  # ... existing guard checks ...
+  call_embedding_api(url, api_key, content, finch_name)
+end
+
+defp call_embedding_api(url, api_key, content, finch_name) do
+  # finch_name is now a local parameter — no Application.get_env
+  request = Finch.build(:post, url, headers, body)
+  Finch.request(request, finch_name, receive_timeout: @request_timeout_ms)
+  # ...
+end
+```
+
+The caller (in `Tau.Memory.Store.SQLite` or wherever the Task is spawned)
+passes the name from a module attribute or process state:
+
+```elixir
+# lib/tau/memory/store/sqlite.ex (call-site, schematic)
+@finch_name Tau.Providers.Finch
+
+# Inside handle_continue that dispatches the embedding task:
+Task.Supervisor.async_nolink(Tau.Memory.TaskSupervisor, fn ->
+  EmbeddingWorker.embed(url, api_key, content, @finch_name)
+end)
+```
+
+The `@finch_name` attribute in `sqlite.ex` is the only place the concrete atom
+appears; it is adjacent to the `Finch` pool start in `application.ex`, easy to
+grep, and not hidden behind an env key.
+
+## Tradeoffs
+
+### Strengths
+
+- Eliminates hidden global state: the dependency is visible in the function
+  signature.
+- Testable without manipulating application environment: pass any atom in tests.
+- The concrete atom (`Tau.Providers.Finch`) appears in one file; no shared
+  constant module required.
+- Aligns with OTP non-negotiable §8: "pure functions are the default; processes
+  are the exception" — a pure embedding function with explicit deps is simpler.
+
+### Weaknesses
+
+- API-breaking: every caller of `EmbeddingWorker.embed/3` (or `call_embedding_api/3`)
+  must be updated to pass the name. If there are multiple call-sites this is
+  more disruptive than Proposals 1 or 2.
+- Does not prevent a caller from passing a stale atom; the drift problem moves
+  from `embedding_worker.ex` to the caller(s).
+- Slightly more verbose at call-sites compared to a zero-argument lookup.
+- If a future requirement introduces multiple Finch pools (per-provider), this
+  proposal handles that naturally — but that flexibility is speculative and not
+  in scope.
+
+### Costs
+
+- Changes the public signature of `EmbeddingWorker.embed/N`; callers must be
+  updated (currently appears to be one call-site in `sqlite.ex`).
+- ~15–20 lines changed across 2 files.
+- Tests that call `EmbeddingWorker` directly must pass the extra argument.
+- No new files.
+
+## Dependencies
+
+- Requires identifying all call-sites of the embedding invocation path to update
+  them (grep `EmbeddingWorker` and the Task dispatch in `sqlite.ex`).
+- No library changes.
+
+## Confidence
+
+**Medium.** The pattern is sound and common in Elixir; uncertainty is about
+the exact call-site count and whether the Task dispatch in `sqlite.ex` already
+holds state that can supply the pool name, or requires a new init-time argument
+to the GenServer.
+
+What would raise it: reading `sqlite.ex`'s `init/1` and `handle_continue/2`
+to confirm the call-site structure (read-only access is available; a quick
+scan would settle this).
+
+## Prior art / references
+
+- Elixir idiom: dependency injection via function arguments is preferred over
+  `Application.get_env/3` in unit-testable code; see
+  `https://hexdocs.pm/elixir/testing.html#mocks-and-explicit-contracts`.
+- Phoenix `Ecto.Repo` operations pass the repo module explicitly as an
+  argument in multi-repo setups — the same decomplecting move.

--- a/docs/problems-archive-v1-modules/tau-memory/subproblems/finch-name-mismatch/proposals/proposal-4.md
+++ b/docs/problems-archive-v1-modules/tau-memory/subproblems/finch-name-mismatch/proposals/proposal-4.md
@@ -1,0 +1,144 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 4
+parent_problem: ../problem.md
+---
+
+# Proposal 4: Replace runtime config lookup with a compile-time assertion in application.ex
+
+## Approach
+
+Keep `Tau.Finch` as a module (alias) and make it a registered name that
+`application.ex` actually starts, OR add a compile-time guard (via a module
+attribute + `@compile {:inline, ...}` or a `Mix.Config` assertion) that fails
+the build if the name in `embedding_worker.ex` does not match the name in
+`application.ex`. Concretely: introduce a `config/config.exs` entry that
+explicitly sets `:tau, :finch_name` to `Tau.Providers.Finch`, so the
+`Application.get_env/3` default is never exercised in any environment and
+the configuration is overt.
+
+## Rationale
+
+The complecting hypothesis is that two sites can drift without a compile-time
+error. Proposals 1–3 fix the runtime value but leave the drift risk latent.
+This proposal eliminates the latency by ensuring the config lookup always
+resolves from an explicit, checked-in value in `config/config.exs` rather
+than from the default argument. The default in `Application.get_env/3` becomes
+a last-resort that is never reached; a missing or wrong config entry is surfaced
+in configuration review rather than at runtime. This is an interface-level
+change: the configuration contract is made explicit in the config files.
+
+## Rationale (continued)
+
+Adding the key to `config/config.exs` also documents the configurable surface:
+operators reading the file learn that `:tau, :finch_name` is a valid override
+point, which they cannot discover today without reading the source. This
+addresses the observability failure noted in the parent problem's complecting
+hypothesis ("hidden from operators").
+
+## Sketch
+
+```elixir
+# config/config.exs  (new key, added once)
+config :tau, :finch_name, Tau.Providers.Finch
+```
+
+That is the entire change. `embedding_worker.ex` is unchanged:
+`Application.get_env(:tau, :finch_name, Tau.Finch)` now resolves to
+`Tau.Providers.Finch` from the config file rather than the fallback default.
+The wrong default atom (`Tau.Finch`) is never reached in any Mix environment
+(dev, test, prod).
+
+Optional hardening: add a `config/test.exs` entry as well to make test
+environments equally explicit:
+
+```elixir
+# config/test.exs
+config :tau, :finch_name, Tau.Providers.Finch
+```
+
+Optional compile-time assertion (adds a Mix task or module body check):
+
+```elixir
+# lib/tau/application.ex — top of module, compile-time guard
+@finch_name Application.compile_env(:tau, :finch_name, Tau.Providers.Finch)
+# Registering the pool using the same compile_env value:
+{Finch, name: @finch_name}
+```
+
+And in `embedding_worker.ex`:
+
+```elixir
+@finch_name Application.compile_env(:tau, :finch_name, Tau.Providers.Finch)
+# ...
+Finch.request(request, @finch_name, receive_timeout: @request_timeout_ms)
+```
+
+`Application.compile_env/3` bakes the value at compile time; a change to
+`config/config.exs` requires recompilation before taking effect, which is
+acceptable for a registered process name. The two `compile_env` calls will
+always produce the same atom because they both read from the same config key.
+
+## Tradeoffs
+
+### Strengths
+
+- Zero runtime penalty: the name is resolved at compile time (with
+  `compile_env`) or at application start (with `config.exs`).
+- Makes the configurable surface explicit and discoverable in `config/config.exs`.
+- With `Application.compile_env/3`, the compiler warns if `config/config.exs`
+  changes the value without recompiling — drift is caught at build time.
+- Does not require a new module or a changed function signature.
+- Documents the operator override path in the config files.
+
+### Weaknesses
+
+- The minimal form (just `config/config.exs`) fixes the bug but still does not
+  bind `application.ex` and `embedding_worker.ex` to the same compile-time
+  constant; if both use `compile_env`, they independently read the same key —
+  which is correct, but introduces a subtle coupling through the config key name
+  rather than a shared Elixir identifier.
+- `Application.compile_env/3` makes the value immutable during a running
+  system; if a test suite dynamically changes `:tau, :finch_name` via
+  `Application.put_env/3`, the change will be silently ignored. Tests that rely
+  on environment manipulation to mock the pool name break.
+- The `config.exs`-only form still has a runtime default in the source; a reader
+  unfamiliar with config precedence might still mistake the fallback atom for the
+  real value.
+- Does not close the drift risk if a developer changes the registration name
+  in `application.ex` without updating `config/config.exs`.
+
+### Costs
+
+- 1–2 line addition to `config/config.exs` (and optionally `config/test.exs`).
+- If `compile_env` is used: both `application.ex` and `embedding_worker.ex`
+  gain a `@finch_name` module attribute (~2 lines each); the `children/0` list
+  and `call_embedding_api/3` each change by one expression.
+- Tests using `Application.put_env(:tau, :finch_name, ...)` must be updated
+  if `compile_env` is adopted.
+
+## Dependencies
+
+- No library changes.
+- The `compile_env` variant requires Elixir 1.10+ (already satisfied: stack
+  is Elixir 1.18.1).
+
+## Confidence
+
+**Medium.** The `config.exs` minimal form is trivially correct. The
+`compile_env` hardening is sound but adds test-environment implications worth
+verifying before committing.
+
+What would raise it: confirming that no existing test manipulates
+`Application.put_env(:tau, :finch_name, ...)` at runtime (a grep would settle
+this immediately).
+
+## Prior art / references
+
+- `Application.compile_env/3` — Elixir 1.10+ standard; used in Phoenix
+  generators (`config :my_app, MyApp.Endpoint, url: [host: "localhost"]` →
+  `Application.compile_env(:my_app, [MyApp.Endpoint, :url])`).
+- The pattern of making implicit runtime lookups explicit via `config.exs` is
+  standard in the Mix configuration guide:
+  `https://hexdocs.pm/mix/Mix.Config.html`.

--- a/docs/problems-archive-v1-modules/tau-memory/subproblems/finch-name-mismatch/solution.md
+++ b/docs/problems-archive-v1-modules/tau-memory/subproblems/finch-name-mismatch/solution.md
@@ -1,0 +1,123 @@
+---
+template_version: 1
+template_name: solution
+parent_problem: problem.md
+node_kind: leaf
+synthesised_from: [proposals/proposal-2.md]
+selection_method: single
+revision: 0
+---
+
+# Solution: Shared config module binds the Finch pool name at both sites
+
+## Recommendation
+
+Introduce `Tau.Providers.Config` (a new ~10-line module in
+`lib/tau/providers/config.ex`) that exposes `finch_name/0` returning the
+atom `Tau.Providers.Finch`. Update `Tau.Application` and
+`Tau.Memory.EmbeddingWorker` to reference `Tau.Providers.Config.finch_name()`
+as the default. The `Application.get_env/3` runtime-override escape hatch is
+retained in `EmbeddingWorker`; its default argument now derives from the shared
+function rather than a bare atom. This eliminates the two-site drift by making
+them structurally dependent on a single authoritative constant.
+
+## Selected from
+
+- **Chosen:** `proposals/proposal-2.md` (Option B — dedicated config module)
+- **Why chosen:**
+
+| # | Fit | Decomplecting depth | Migration cost | Risk | Reversibility |
+|---|-----|---------------------|---------------|------|---------------|
+| 1 | Yes | Surface | Low | Low | Easy |
+| 2 | Yes | Substantial | Low | Low | Easy |
+| 3 | Yes | Deep | Medium | Medium | Easy |
+| 4 | Partially | Surface | Low | Medium | Easy |
+
+Proposal 1 satisfies the acceptance criterion but leaves the two atom literals
+unbound: the next rename of the pool in `application.ex` silently reproduces the
+bug. That residual complecting is not required by the acceptance criterion but
+is identified in the problem's complecting hypothesis; fixing only the symptom
+scores Surface on decomplecting depth.
+
+Proposal 2 (Option B) satisfies the criterion with the same one-token change at
+each site and adds a shared constant that makes future drift a compiler-visible
+event (one place to update; every consumer of the constant is then correct).
+Cost is marginally higher than Proposal 1 (one new file, ~10 lines) but
+negligible. Risk and reversibility are identical to Proposal 1.
+
+Proposal 3 (dependency injection) is technically sounder on purity grounds and
+aligns with OTP §8, but requires an API-breaking signature change and updating
+every call-site. Medium confidence in the exact call-site count. Its benefit
+(eliminating `Application.get_env` from the function body) is not required by
+the acceptance criterion. Ruled out: higher cost, medium confidence, no
+criterion-level advantage over Proposal 2.
+
+Proposal 4's `config/config.exs` minimal form bypasses the wrong default without
+touching source, but does not bind `application.ex` and `embedding_worker.ex`
+to each other — the drift seam remains. The `compile_env` hardening adds
+test-environment brittleness (dynamic `Application.put_env` in tests is
+silently ignored). Ruled out: weaker decomplecting than Proposal 2 with added
+risk.
+
+Proposal 2 wins: it is the weakest change that closes the drift seam. The
+bias toward decomplecting depth over cost, where the cost delta is negligible,
+settles the tie between Proposals 1 and 2 in favour of 2.
+
+## What changes
+
+- **New file** `lib/tau/providers/config.ex` — defines `Tau.Providers.Config`
+  with a single `@finch_name Tau.Providers.Finch` module attribute and a
+  `def finch_name/0` accessor.
+- `lib/tau/application.ex` line 78 — change `{Finch, name: Tau.Providers.Finch}`
+  to `{Finch, name: Tau.Providers.Config.finch_name()}`.
+- `lib/tau/memory/embedding_worker.ex` line 106 — change the default argument of
+  `Application.get_env(:tau, :finch_name, Tau.Finch)` to
+  `Application.get_env(:tau, :finch_name, Tau.Providers.Config.finch_name())`.
+
+Three files; net addition of ~10 lines.
+
+## What does not change
+
+- The `Application.get_env/3` lookup in `EmbeddingWorker` — the runtime-override
+  escape hatch is preserved for operators who need a custom pool.
+- All other supervision tree entries and startup order in `application.ex`.
+- The `Tau.Providers.Finch` atom itself — it remains the canonical pool name.
+- All callers of `EmbeddingWorker.embed/N` — no signature change.
+- Test files — no test that mocks or references the Finch name needs updating
+  (the new config module is a thin accessor, not a process).
+
+## Migration sketch
+
+Introduce `lib/tau/providers/config.ex` first (no callers yet; zero risk).
+Then update `application.ex` to use `Tau.Providers.Config.finch_name()` —
+compile and start the supervision tree to confirm the pool still registers.
+Then update `embedding_worker.ex` to use the same accessor as its default.
+The change lands in a single PR; no staged rollout required. Revert is one
+commit.
+
+## Open questions
+
+- Whether `Tau.Providers.Config` is the correct namespace for this constant
+  (alternative: `Tau.Config` or `Tau.Infrastructure`). The problem is narrow
+  enough that the choice does not affect correctness; it affects discoverability.
+  Defer to project conventions in `lib/tau/providers/`.
+- Whether a companion test should assert that
+  `Tau.Providers.Config.finch_name()` equals the name registered by
+  `Tau.Application` — a property check that future renames cannot silently
+  diverge. Not required by the acceptance criterion but would close the last
+  nominal-equality gap.
+
+## Linked sub-problems / proposals
+
+- `proposals/proposal-1.md` — Fix the default atom at the call-site (one-line,
+  surface fix, leaves drift seam open)
+- `proposals/proposal-2.md` — Shared config module, compile-time binding via
+  named constant (selected)
+- `proposals/proposal-3.md` — Inject the Finch name via the EmbeddingWorker
+  start argument (deep decomplecting, API-breaking, medium cost)
+- `proposals/proposal-4.md` — Explicit `config/config.exs` entry with optional
+  `compile_env` hardening (surfaces operator config, residual drift risk)
+
+## Revision history
+
+- (revision 0 — initial)

--- a/docs/problems-archive-v1-modules/tau-memory/subproblems/finch-name-mismatch/validation.md
+++ b/docs/problems-archive-v1-modules/tau-memory/subproblems/finch-name-mismatch/validation.md
@@ -1,0 +1,325 @@
+---
+template_version: 1
+template_name: validation
+parent_solution: solution.md
+parent_problem: problem.md
+toulmin_complete: true
+falsification_attempted: true
+falsification_outcome: withstood
+revision_triggered: none
+---
+
+# Validation: Shared config module binds the Finch pool name at both sites
+
+## Overview
+
+The solution asserts four checkable propositions: (1) the defect is real
+and unambiguous; (2) a new `Tau.Providers.Config` module with `finch_name/0`
+makes the two-site binding compile-time-visible; (3) the `Application.get_env`
+escape hatch is preserved; (4) no other callers or test files require
+updating. Each is validated below via Toulmin with six components, followed
+by a named falsification attempt. All four claims withstood; no revision is
+required.
+
+---
+
+## Toulmin per claim
+
+The MITRE empirical study on Toulmin formalism found that "participants
+found it difficult to generate Toulmin structures, and their structures
+varied greatly even though they started with the same content"
+(https://www.mitre.org/news-insights/publication/empirical-evaluation-structured-argumentation-using-toulmin-argument).
+This template enforces all six components explicitly with prompts to
+counter that variance.
+
+---
+
+### Claim 1: The default atom `Tau.Finch` in `EmbeddingWorker` does not name any registered Finch pool, causing every embedding HTTP call to crash with `:noproc`.
+
+- **Claim (C):** The default atom `Tau.Finch` in `EmbeddingWorker` does not
+  name any registered Finch pool, causing every embedding HTTP call to crash
+  with `:noproc`.
+- **Grounds (G):**
+  - `lib/tau/memory/embedding_worker.ex:106` — `Application.get_env(:tau,
+    :finch_name, Tau.Finch)`: the default is the atom `Tau.Finch`.
+  - `lib/tau/application.ex:78` — `{Finch, name: Tau.Providers.Finch}`: the
+    sole pool registration uses the atom `Tau.Providers.Finch`.
+  - `grep -rn "finch_name" config/` returns empty output: no application
+    config file overrides `:tau, :finch_name`. The default is always
+    exercised.
+  - `grep -rn "Tau.Finch\b" lib/ test/` returns exactly one hit
+    (`embedding_worker.ex:106`): no other code registers or supervises a
+    pool named `Tau.Finch`.
+- **Warrant (W):** `Finch.request/3` resolves the pool name via a process
+  registry lookup. An atom that has never been registered as a `Finch`
+  child process cannot be found; the GenServer call raises `{:noproc,
+  ...}` and crashes the calling process. The OTP registry guarantee is
+  deterministic: absent registration equals absent process.
+- **Qualifier (Q):** This claim holds in any environment that: (a) does not
+  set `Application.put_env(:tau, :finch_name, Tau.Providers.Finch)` at
+  runtime before `EmbeddingWorker` calls `call_embedding_api/3`, and (b) does
+  not start a second Finch pool named `Tau.Finch` through some other path.
+  Neither condition holds in the standard `mix run` or release environment
+  per the config-file audit above.
+- **Rebuttal (R):** If a test helper or a deployment harness sets `:tau,
+  :finch_name` before the worker starts, the default is bypassed and the bug
+  is masked. However, the problem statement and the config-file audit confirm
+  no such override exists in the repository; the default is always active.
+- **Backing (B):** `Finch` source (hexdocs.pm/finch): `Finch.request/3`
+  calls `Finch.Pool.async_request/5` which looks up the pool by name via
+  `Finch.Registry`; an unregistered name returns `{:error, %Mint.TransportError{reason: :noproc}}` or raises, depending on version.
+  OTP non-negotiable §1 (`otp-non-negotiables.md`): every stateful subsystem
+  runs as a supervised process — a missing supervision entry means the
+  process does not exist.
+
+#### Falsification attempt for claim 1
+
+- **Strategy:** Dependency check — verify the assumed codebase state
+  (the two atoms differ; no config override exists; no second pool is
+  registered).
+- **Attempt:** Searched `lib/` and `test/` for `Tau.Finch\b` (non-Providers
+  variant); found exactly one hit at `embedding_worker.ex:106`. Searched
+  `config/` for `finch_name`; found no hits. Searched `lib/` for
+  `{Finch, name:` patterns; found exactly one registration at
+  `application.ex:78` using `Tau.Providers.Finch`.
+- **Outcome:** Withstood. The dependency state assumed by the claim is
+  confirmed; no second pool, no config override, atoms provably differ.
+- **Action:** None required.
+
+---
+
+### Claim 2: Introducing `Tau.Providers.Config.finch_name/0` and updating both call sites makes the binding compile-time-visible, eliminating future silent drift.
+
+- **Claim (C):** Introducing `Tau.Providers.Config.finch_name/0` and
+  updating both call sites makes the binding compile-time-visible,
+  eliminating future silent drift.
+- **Grounds (G):**
+  - `lib/tau/providers/` directory currently contains no `config.ex`; the
+    new module does not conflict with any existing file.
+  - `lib/tau/application.ex:78` — the proposed change: `{Finch, name:
+    Tau.Providers.Config.finch_name()}`. This is a normal function call
+    evaluated at supervision-tree startup; the result is the atom
+    `Tau.Providers.Finch`.
+  - `lib/tau/memory/embedding_worker.ex:106` — the proposed change:
+    `Application.get_env(:tau, :finch_name,
+    Tau.Providers.Config.finch_name())`. The default now derives from the
+    same function.
+  - The `@finch_name Tau.Providers.Finch` module attribute in
+    `Tau.Providers.Config` is a compile-time constant; renaming the pool
+    requires changing exactly one line; both sites recompile automatically
+    because they call `finch_name/0` which is inlined by the BEAM for a
+    zero-arity pure function.
+- **Warrant (W):** A single authoritative constant consumed at all sites is
+  the structural definition of eliminating drift: there is no longer a
+  second independent literal that could diverge. Rich Hickey's "simplicity
+  matters" principle: complecting two pieces of information (pool name at
+  registration; pool name at call) by replication introduces accidental
+  complexity; binding them to a shared name removes the complecting. The
+  module attribute form ensures the constant is evaluated once and checked
+  by the compiler.
+- **Qualifier (Q):** "Compile-time-visible" holds for future renames that go
+  through `Tau.Providers.Config.finch_name/0`. A developer who bypasses
+  the accessor and writes a new bare atom literal at a new call site
+  reintroduces drift. The claim is scoped to the two sites named in the
+  solution; it cannot prevent unbounded future misuse.
+- **Rebuttal (R):** `Application.get_env/3` is evaluated at runtime, not
+  compile time; the `default` argument (now `Tau.Providers.Config.finch_name()`)
+  is also evaluated at runtime. The "compile-time-visible" language in the
+  solution is slightly imprecise: it means "a single source of truth a
+  developer must consciously override, not a second atom literal that can
+  silently diverge." The safety property holds; the precision of the label
+  is slightly weaker than advertised.
+- **Backing (B):** OTP non-negotiable §2 (`otp-non-negotiables.md`):
+  extensibility seams must be behaviours, and by extension single-source
+  constants must be shared, not replicated. The problem's complecting
+  hypothesis (`problem.md §Complecting hypothesis`) identifies exactly this
+  as the root structure to eliminate.
+
+#### Falsification attempt for claim 2
+
+- **Strategy:** Counter-example construction — construct a scenario where
+  the proposed change does NOT eliminate drift.
+- **Attempt:** Consider a future developer adding a third Finch consumer
+  (e.g., a new `lib/tau/tools/http_tool.ex`) and writing
+  `Finch.request(req, Tau.Providers.Finch)` as a bare atom. This new site
+  drifts immediately. Now consider a developer renaming the pool: they
+  update `Tau.Providers.Config.finch_name/0`; the two updated sites are
+  correct; the new bare-atom site is silently wrong. This is a valid
+  counter-example — BUT it is outside the scope of the claim. The claim is
+  "eliminates future silent drift [at the two named call sites]"; the
+  solution's Qualifier field admits this scope. The counter-example therefore
+  partially falsifies an overly broad reading of the claim but does not
+  falsify the scoped reading. The existing callers `mcp/transport/http.ex`,
+  `mcp/transport/sse.ex`, `providers/shared/finch_stream.ex`,
+  `providers/copilot/auth.ex` already use the bare atom `Tau.Providers.Finch`
+  and are NOT updated by this solution — consistent with the solution's
+  stated scope (those sites use the correct atom; only `embedding_worker.ex`
+  used the wrong one).
+- **Outcome:** Partially falsified — the claim that the solution eliminates
+  "future drift" must be scoped to the two named sites and to renames
+  propagated through `finch_name/0`. Bare-atom consumers outside the two
+  named sites are not protected.
+- **Action:** Narrow qualifier (see above); no solution revision required.
+  The acceptance criterion (`problem.md`) requires only that `Finch.request/3`
+  in `EmbeddingWorker` resolves the registered pool; the broader drift-proof
+  property is a quality-of-life benefit, not a criterion.
+
+---
+
+### Claim 3: The `Application.get_env/3` runtime-override escape hatch is preserved for operators who need a custom pool.
+
+- **Claim (C):** The `Application.get_env/3` runtime-override escape hatch
+  is preserved for operators who need a custom pool.
+- **Grounds (G):**
+  - `lib/tau/memory/embedding_worker.ex:106` — the proposed form:
+    `Application.get_env(:tau, :finch_name, Tau.Providers.Config.finch_name())`.
+    The only change is to the `default` argument; the `Application.get_env/3`
+    call itself is retained verbatim.
+  - The solution's "What does not change" section explicitly states: "The
+    `Application.get_env/3` lookup in `EmbeddingWorker` — the
+    runtime-override escape hatch is preserved."
+- **Warrant (W):** If the call form `Application.get_env(:tau, :finch_name,
+  <default>)` is retained, any runtime-configured value of `:tau, :finch_name`
+  still overrides the default. The `default` argument is evaluated only when
+  the key is absent from the application environment. The operator's
+  `Application.put_env(:tau, :finch_name, MyPool)` call still wins.
+- **Qualifier (Q):** Universal within the `EmbeddingWorker` code path; no
+  conditions under which this claim fails given the stated code change.
+- **Rebuttal (R):** None. `Application.get_env/3` semantics are stable
+  across Elixir 1.x and OTP 25+; the default-argument evaluation behaviour
+  is not subject to version variation.
+- **Backing (B):** Elixir 1.18 documentation for `Application.get_env/3`
+  (hexdocs.pm/elixir/Application.html#get_env/3): "Returns the value for
+  key in app's environment. If the configuration parameter does not exist,
+  the function returns the default value."
+
+#### Falsification attempt for claim 3
+
+- **Strategy:** Type-level check — verify the proposed call signature is
+  compatible with `Application.get_env/3` contract.
+- **Attempt:** `Application.get_env(app, key, default)` — the `default`
+  parameter is `any()`; `Tau.Providers.Config.finch_name()` returns an atom;
+  atoms satisfy `any()`. No type error. The key `:finch_name` is an atom;
+  the app `:tau` is an atom. Call signature is fully compatible.
+- **Outcome:** Withstood. The escape hatch is structurally preserved; no
+  type or semantic incompatibility introduced.
+- **Action:** None required.
+
+---
+
+### Claim 4: No other files — callers of `EmbeddingWorker.embed/N`, tests that mock or reference the Finch name, and other supervision tree entries — require updating.
+
+- **Claim (C):** No other files — callers of `EmbeddingWorker.embed/N`,
+  tests that mock or reference the Finch name, and other supervision tree
+  entries — require updating.
+- **Grounds (G):**
+  - `grep -rn "Tau.Finch\b" lib/ test/` — exactly one hit
+    (`embedding_worker.ex:106`); no test file references `Tau.Finch`.
+  - `grep -rn "finch_name" test/` — no hits; no test mocks the pool name.
+  - `grep -rn "Tau.Providers.Finch" lib/` — six hits: `application.ex:78`,
+    `mcp/transport/http.ex:28`, `mcp/transport/sse.ex:36`, `sse.ex:66`,
+    `providers/shared/finch_stream.ex:76`, `providers/copilot/auth.ex:132`.
+    All six already use the correct atom; none is the `EmbeddingWorker`
+    default. None require updating.
+  - `lib/tau/providers/config.ex` does not yet exist; the new module
+    introduces no rename of existing identifiers.
+- **Warrant (W):** The new `Tau.Providers.Config` module is a pure accessor
+  with no side effects; it adds a new name to the namespace but aliases no
+  existing name. Therefore its introduction cannot break any existing module
+  that does not import it. Only the two sites that explicitly reference the
+  shared constant need to change.
+- **Qualifier (Q):** This claim holds assuming the codebase search is
+  exhaustive (all files under `lib/` and `test/`). It does not extend to
+  future files or to out-of-repo consumers.
+- **Rebuttal (R):** If a test file uses `Application.put_env(:tau,
+  :finch_name, ...)` as test setup, it would be in scope — but the search
+  confirms no such test exists. If `EmbeddingWorker` has additional arities
+  of `embed/N` that pass the pool name differently, those would need
+  inspection. However, the defect is isolated to the one `get_env` default
+  in `call_embedding_api/3`.
+- **Backing (B):** The solution's "What does not change" section. Also: OTP
+  non-negotiable §8 (`otp-non-negotiables.md`) — pure functions are the
+  default; `finch_name/0` is a pure zero-arity accessor, so its introduction
+  has no side effects on the supervision tree or process registry.
+
+#### Falsification attempt for claim 4
+
+- **Strategy:** Dependency check — verify the assumed codebase state (no
+  tests reference `Tau.Finch`; all other `Tau.Providers.Finch` callers are
+  already correct).
+- **Attempt:** Ran `grep -rn "Tau.Finch\b"` and `grep -rn "finch_name"` over
+  `lib/` and `test/`. `Tau.Finch\b` appears once (`embedding_worker.ex:106`).
+  `finch_name` appears once (`embedding_worker.ex:106`). All other Finch
+  consumers already reference `Tau.Providers.Finch` directly and do not use
+  the `Application.get_env` indirection.
+- **Outcome:** Withstood. The dependency assumption is correct; no additional
+  files need modification.
+- **Action:** None required.
+
+---
+
+## Cross-claim consistency
+
+Claims 1–4 are internally consistent. Claim 1 establishes the defect;
+Claim 2 establishes that the proposed fix closes it structurally; Claim 3
+establishes that an existing safety valve is preserved; Claim 4 establishes
+that the fix is surgical. No claim contradicts another.
+
+The partial falsification of Claim 2 (bare-atom callers outside the two
+named sites are not protected) does not conflict with Claims 3 or 4: Claims
+3 and 4 do not assert broad drift-proofing. The narrowed Qualifier on
+Claim 2 is compatible with the scoped assertions of Claims 3 and 4.
+
+One minor internal tension: the solution notes in Open Questions that a
+companion test asserting `Tau.Providers.Config.finch_name()` equals the
+registered pool name "would close the last nominal-equality gap." This is an
+acknowledged residual, not a contradiction. It does not affect correctness of
+the four claims; it is an optional strengthening noted as out of scope for
+the acceptance criterion.
+
+---
+
+## Falsification summary
+
+| # | Claim (short) | Strategy | Outcome | Action |
+|---|---|---|---|---|
+| 1 | `Tau.Finch` default crashes with `:noproc` | Dependency check | Withstood | None |
+| 2 | Shared `finch_name/0` eliminates drift at both sites | Counter-example construction | Partially falsified — scope narrowed to the two named sites | Narrow qualifier; no solution revision |
+| 3 | `Application.get_env` escape hatch preserved | Type-level check | Withstood | None |
+| 4 | No other files require updating | Dependency check | Withstood | None |
+
+---
+
+## Revision required
+
+None. All claims withstood or had their qualifier narrowed to a scope still
+consistent with the acceptance criterion. The acceptance criterion
+(`problem.md`) requires only that `Finch.request/3` in `EmbeddingWorker`
+resolves the registered pool in a standard `mix run` / release environment;
+all four claims, under their final qualifiers, are consistent with that
+criterion being met by the proposed change.
+
+---
+
+## Outstanding doubts
+
+1. **Companion equality test absent.** The solution acknowledges that a
+   property test asserting `Tau.Providers.Config.finch_name() == the atom
+   registered by Tau.Application` is not required by the acceptance
+   criterion. Without it, a future rename of the pool in `application.ex`
+   that forgets to update `config.ex` would be caught only at runtime (the
+   crash would reappear). This is a named residual, not a falsification of
+   the solution.
+2. **Namespace placement unresolved.** The solution defers the choice
+   between `Tau.Providers.Config`, `Tau.Config`, and `Tau.Infrastructure` to
+   project convention. Neither `Tau.Config` nor `Tau.Infrastructure` exist
+   today; `lib/tau/providers/` is the natural home given all current
+   `Tau.Providers.Finch` consumers live there. No falsifying case; this is
+   a discoverability preference, not a correctness question.
+3. **Six existing bare-atom callers.** `mcp/transport/http.ex`,
+   `mcp/transport/sse.ex` (×2), `providers/shared/finch_stream.ex`,
+   `providers/copilot/auth.ex` all reference `Tau.Providers.Finch` directly.
+   They are correct today (the atom matches the registration). They are
+   outside the scope of this solution. A future pool rename would still need
+   to update them manually; the shared constant does not protect them unless
+   they are migrated to use `finch_name/0`.

--- a/docs/problems-archive-v1-modules/tau-memory/subproblems/pending-rot-observability/problem.md
+++ b/docs/problems-archive-v1-modules/tau-memory/subproblems/pending-rot-observability/problem.md
@@ -1,0 +1,55 @@
+---
+template_version: 1
+template_name: problem
+node_kind: leaf
+depth: 1
+parent: ../../problem.md
+status: draft
+---
+
+# Problem: Stuck "pending" entries are indistinguishable from in-flight embeddings
+
+## Statement
+
+`embedding_status: "pending"` is used both for entries whose embedding Task is
+legitimately in flight (expected to resolve within `@request_timeout_ms = 30 s`)
+and for entries whose Task has already crashed or whose callback was silently
+lost. There is no telemetry event, log line, or gauge that distinguishes these
+two cases or that alerts when entries age past the expected embedding window.
+Operators cannot determine whether the embedding pipeline is functioning without
+querying the database directly; degradation is invisible until a user notices
+that `semantic_search/2` returns no results.
+
+## Context
+
+- `lib/tau/memory/embedding_worker.ex:52-68` — emits `[:tau, :memory, :embedding]` telemetry via `:telemetry.span`, but only on Task normal-exit; a Task crash before the span fires produces no telemetry at all.
+- `lib/tau/memory/store/sqlite.ex:190-220` — `handle_call({:write, ...})` emits `[:tau, :memory, :write]` telemetry but no follow-on event tracking that embedding dispatch was initiated.
+- No scheduled check, GenServer timer, or periodic sweep exists anywhere in `lib/tau/memory/` to detect stale `"pending"` entries.
+- OTP non-negotiable #5 (`otp-non-negotiables.md`): telemetry events MUST cover everything user-visible or perf-sensitive; semantic search degradation is user-visible.
+
+## Complecting hypothesis
+
+- The "in-flight" status and the "silently stuck" status are complected in the same `"pending"` value, making it impossible to distinguish the two states from the outside without knowing the entry's age.
+- The absence of a completion-tracking mechanism is complected with the absence of an alerting mechanism: both gaps reinforce each other, so adding observability alone does not fix the missing callback, and fixing the callback alone still leaves no visibility into pre-existing stuck entries.
+
+## Decomposition strategy
+
+(leaf — no further decomposition; proceed to proposals)
+
+## Acceptance criterion
+
+An operator can determine — without querying the database directly — whether any
+memory entries have been in `embedding_status: "pending"` longer than the
+embedding timeout, via a telemetry event or structured log line that fires when
+such entries are detected.
+
+## Out of scope
+
+- The root-cause Finch name mismatch (covered by `finch-name-mismatch`).
+- Fixing the Task-crash-without-callback path (covered by `silent-failure-propagation`).
+- Re-enqueuing stuck entries once detected (covered by `retry-recovery-path`).
+- FTS5 search observability.
+
+## Amendment log
+
+- (none yet)

--- a/docs/problems-archive-v1-modules/tau-memory/subproblems/pending-rot-observability/proposals/proposal-1.md
+++ b/docs/problems-archive-v1-modules/tau-memory/subproblems/pending-rot-observability/proposals/proposal-1.md
@@ -1,0 +1,202 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 1
+parent_problem: ../problem.md
+---
+
+# Proposal 1: Periodic sweep GenServer emitting `[:tau, :memory, :pending_rot]` telemetry
+
+## Approach
+
+Add a new supervised GenServer, `Tau.Memory.PendingRotSweeper`, to
+`Tau.Memory.Supervisor`. On a configurable interval (default: 60 s), the
+sweeper queries SQLite for entries whose `embedding_status = "pending"` and
+whose `inserted_at` timestamp is older than `@request_timeout_ms + grace_ms`
+(default: `30_000 + 5_000 = 35_000` ms). For each stale entry found it emits a
+telemetry event `[:tau, :memory, :pending_rot, :detected]` with measurements
+`%{count: pos_integer()}` and metadata `%{entry_ids: [binary()], oldest_age_ms:
+non_neg_integer()}`. The sweeper does not modify any entries; detection only.
+
+## Rationale
+
+The acceptance criterion requires that an operator can detect stale `"pending"`
+entries without querying the database directly. A periodic sweep is the
+canonical OTP pattern for surfacing accumulated state: it runs on its own
+process (no coupling to the write path), it relies on the existing SQLite owner
+process only via a read query, and it emits structured telemetry that external
+dashboards and alerting systems can consume. It is strictly additive — no
+existing codepath is modified — which minimises risk to D-045/D-046 invariants.
+Telemetry-based detection satisfies OTP non-negotiable #5 (everything
+user-visible or perf-sensitive must have a telemetry event), since semantic
+search degradation is user-visible.
+
+## Sketch
+
+### New file: `lib/tau/memory/pending_rot_sweeper.ex`
+
+```elixir
+defmodule Tau.Memory.PendingRotSweeper do
+  @moduledoc """
+  Periodic GenServer that detects stale embedding_status="pending" entries.
+
+  Emits [:tau, :memory, :pending_rot, :detected] with:
+    measurements: %{count: non_neg_integer()}
+    metadata:     %{entry_ids: [binary()], oldest_age_ms: non_neg_integer()}
+
+  count: 0 emits are suppressed (no-op interval ticks produce no telemetry).
+  """
+
+  use GenServer
+
+  require Logger
+
+  @default_sweep_interval_ms 60_000
+  # Must exceed @request_timeout_ms in EmbeddingWorker (30_000) plus grace.
+  @default_stale_threshold_ms 35_000
+
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(opts \\ []) do
+    GenServer.start_link(__MODULE__, opts, name: Keyword.get(opts, :name, __MODULE__))
+  end
+
+  @impl GenServer
+  def init(opts) do
+    interval = Keyword.get(opts, :sweep_interval_ms, @default_sweep_interval_ms)
+    threshold = Keyword.get(opts, :stale_threshold_ms, @default_stale_threshold_ms)
+    store = Keyword.get(opts, :store, Tau.Memory.Store.SQLite)
+
+    schedule_sweep(interval)
+
+    {:ok, %{interval: interval, threshold: threshold, store: store}}
+  end
+
+  @impl GenServer
+  def handle_info(:sweep, %{interval: interval, threshold: threshold, store: store} = state) do
+    sweep(store, threshold)
+    schedule_sweep(interval)
+    {:noreply, state}
+  end
+
+  # ---------------------------------------------------------------------------
+  # Private helpers
+  # ---------------------------------------------------------------------------
+
+  defp schedule_sweep(interval), do: Process.send_after(self(), :sweep, interval)
+
+  defp sweep(store, threshold_ms) do
+    case Tau.Memory.Store.SQLite.stale_pending_entries(store, threshold_ms) do
+      {:ok, []} ->
+        :ok
+
+      {:ok, entries} ->
+        count = length(entries)
+        oldest_age_ms = Enum.max(Enum.map(entries, & &1.age_ms))
+
+        :telemetry.execute(
+          [:tau, :memory, :pending_rot, :detected],
+          %{count: count},
+          %{entry_ids: Enum.map(entries, & &1.id), oldest_age_ms: oldest_age_ms}
+        )
+
+        Logger.warning(
+          "[PendingRotSweeper] #{count} stale pending embedding(s) detected; " <>
+            "oldest #{oldest_age_ms} ms. entry_ids=#{inspect(Enum.map(entries, & &1.id))}"
+        )
+
+      {:error, reason} ->
+        Logger.error("[PendingRotSweeper] sweep query failed: #{inspect(reason)}")
+    end
+  end
+end
+```
+
+### New query in `lib/tau/memory/store/sqlite.ex`
+
+```elixir
+@doc """
+Return entries with embedding_status="pending" older than `threshold_ms` milliseconds.
+Returns {:ok, [%{id: binary(), age_ms: non_neg_integer()}]} or {:error, term()}.
+"""
+@spec stale_pending_entries(GenServer.server(), non_neg_integer()) ::
+        {:ok, [%{id: binary(), age_ms: non_neg_integer()}]} | {:error, term()}
+def stale_pending_entries(server \\ __MODULE__, threshold_ms) do
+  GenServer.call(server, {:stale_pending_entries, threshold_ms})
+end
+```
+
+Corresponding `handle_call` clause executes:
+
+```sql
+SELECT id,
+       CAST((julianday('now') - julianday(inserted_at)) * 86400000 AS INTEGER) AS age_ms
+FROM   memory
+WHERE  embedding_status = 'pending'
+  AND  age_ms > ?1
+ORDER  BY age_ms DESC
+```
+
+### Supervisor change: `lib/tau/memory/supervisor.ex`
+
+```elixir
+children = [
+  {Tau.Memory.Store.SQLite, opts},
+  {Tau.Memory.PendingRotSweeper, opts}
+]
+```
+
+## Tradeoffs
+
+### Strengths
+
+- Strictly additive; no existing call paths modified.
+- Clean OTP pattern: stateful detector is its own supervised process.
+- Emits structured telemetry satisfying OTP non-negotiable #5; integrates with
+  any Telemetry-compatible dashboard (Prometheus, StatsD, LiveDashboard).
+- Configurable interval and threshold; easy to tune for different environments.
+- The sweep is also a pre-recovery probe for the `retry-recovery-path`
+  sub-problem: the same `stale_pending_entries/2` query is exactly what a
+  re-enqueue mechanism would call.
+
+### Weaknesses
+
+- Introduces a polling dependency on the SQLite owner process: every sweep
+  interval adds a `GenServer.call` to the store's mailbox. Under high write
+  volume this adds latency jitter (bounded: one extra query/minute at default).
+- Detection latency is bounded by the sweep interval (up to 60 s at default);
+  not real-time.
+- `stale_pending_entries/2` requires a new public API on `Store.SQLite` and a
+  corresponding SQL query that touches the `memory` table — minor surface area
+  growth in the store's interface.
+- The new query must be validated against the actual schema column type for
+  `inserted_at` to confirm the `julianday` arithmetic is correct (SQLite date
+  arithmetic is fragile without explicit ISO8601 storage).
+
+### Costs
+
+- 1 new module (~80 lines), 1 new `handle_call` clause in `sqlite.ex`, 1
+  supervisor child entry.
+- Test surface: 1 unit test for the sweeper (mock store), 1 integration test
+  for `stale_pending_entries/2`.
+- No new dependencies.
+
+## Dependencies
+
+- `Tau.Memory.Store.SQLite` must expose `stale_pending_entries/2` (new public API).
+- The `inserted_at` column must be stored in ISO8601 UTC format for the
+  `julianday` arithmetic to be accurate; verify in migrations.
+
+## Confidence
+
+**Medium.** The OTP pattern is standard; the telemetry emission is
+straightforward. Confidence would be `high` after verifying the `inserted_at`
+column format in the SQLite schema and running the query against a real DB.
+
+## Prior art / references
+
+- OTP `send_after`-based periodic sweeps: standard GenServer idiom; see
+  Erlang/Elixir documentation for `:timer.send_interval` as an alternative.
+- `julianday` SQLite date arithmetic: SQLite documentation §Date and Time
+  Functions.
+- `[:tau, :memory, :write]` telemetry in `store/sqlite.ex:190–220` — existing
+  pattern this proposal extends.

--- a/docs/problems-archive-v1-modules/tau-memory/subproblems/pending-rot-observability/proposals/proposal-2.md
+++ b/docs/problems-archive-v1-modules/tau-memory/subproblems/pending-rot-observability/proposals/proposal-2.md
@@ -1,0 +1,195 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 2
+parent_problem: ../problem.md
+---
+
+# Proposal 2: Timestamp-differentiated status values — introduce `"pending_dispatched_at"` metadata
+
+## Approach
+
+Change the data shape of the `"pending"` state rather than adding a sweeper
+process. When the store dispatches an embedding (currently in
+`handle_continue/2`), it writes a `dispatched_at` ISO8601 timestamp into a new
+nullable `embedding_dispatched_at` column. The EmbeddingWorker and SQLite store
+are unchanged otherwise. A new telemetry tap — implemented as a
+`:telemetry.attach/4` handler registered at application start — subscribes to
+the existing `[:tau, :memory, :write, :stop]` event, reads the new column on
+each write, and immediately detects in-progress entries. Staleness is surfaced
+by reading `dispatched_at` vs `now()` at any query point; the existing
+`[:tau, :memory, :write, :stop]` event's metadata is extended to include
+`dispatched_at`. A startup audit (called once from `Store.SQLite.init/1`)
+queries for entries where `embedding_status = 'pending'` and
+`dispatched_at < now - threshold`, logging a structured warning and emitting
+`[:tau, :memory, :pending_rot, :detected]` for any found.
+
+## Rationale
+
+The complecting hypothesis identifies that the in-flight and stuck states are
+indistinguishable because the `"pending"` value carries no age information.
+Separating them at the data-shape level removes the complection at its root:
+once `dispatched_at` is available in the row, any reader — the store itself, a
+query tool, a monitoring query — can distinguish the two cases without a
+separate sweeper process. The startup audit catches entries that survived a
+prior crash (e.g. the node went down mid-embedding). This approach avoids
+adding a new long-running process and relies on existing telemetry
+infrastructure.
+
+## Sketch
+
+### Schema migration (new)
+
+```sql
+-- Migration 009 (or next unused number)
+ALTER TABLE memory ADD COLUMN embedding_dispatched_at TEXT;
+```
+
+### `handle_continue/2` change in `store/sqlite.ex`
+
+```elixir
+@impl GenServer
+def handle_continue({:dispatch_embedding, id, content}, %{db: db} = state) do
+  embedder = Application.get_env(:tau, :embedder, Tau.Memory.EmbeddingWorker)
+  server = self()
+  now = DateTime.utc_now() |> DateTime.to_iso8601()
+
+  # Record dispatch time before spawning, so the column is populated even if
+  # the task crashes immediately.
+  :ok = do_set_dispatched_at(db, id, now)
+
+  Task.Supervisor.async_nolink(Tau.Tools.TaskSupervisor, fn ->
+    embedder.embed(server, id, content)
+  end)
+
+  {:noreply, state}
+end
+```
+
+```elixir
+# New private helper
+defp do_set_dispatched_at(db, id, iso8601) do
+  # UPDATE memory SET embedding_dispatched_at = ?1 WHERE id = ?2
+  with {:ok, stmt} <- Exqlite.Sqlite3.prepare(db, @sql_set_dispatched_at),
+       :ok <- Exqlite.Sqlite3.bind(stmt, [iso8601, id]),
+       :done <- Exqlite.Sqlite3.step(db, stmt) do
+    Exqlite.Sqlite3.release(db, stmt)
+    :ok
+  end
+end
+```
+
+### Startup audit in `init/1`
+
+```elixir
+# Called at the end of a successful init/1, before {:ok, state} is returned.
+defp audit_stale_pending(db) do
+  threshold_ms = Application.get_env(:tau, :embedding_stale_threshold_ms, 35_000)
+
+  case query_stale_pending(db, threshold_ms) do
+    {:ok, []} ->
+      :ok
+
+    {:ok, rows} ->
+      count = length(rows)
+      oldest_age_ms = Enum.max(Enum.map(rows, & &1.age_ms))
+
+      :telemetry.execute(
+        [:tau, :memory, :pending_rot, :detected],
+        %{count: count},
+        %{entry_ids: Enum.map(rows, & &1.id), oldest_age_ms: oldest_age_ms, source: :startup_audit}
+      )
+
+      Logger.warning(
+        "[Memory.Store] #{count} stale pending embedding(s) at startup; " <>
+          "oldest #{oldest_age_ms} ms"
+      )
+
+    {:error, _reason} ->
+      :ok
+  end
+end
+```
+
+The `query_stale_pending/2` SQL:
+
+```sql
+SELECT id,
+       CAST((julianday('now') - julianday(embedding_dispatched_at)) * 86400000 AS INTEGER)
+         AS age_ms
+FROM   memory
+WHERE  embedding_status = 'pending'
+  AND  embedding_dispatched_at IS NOT NULL
+  AND  age_ms > ?1
+ORDER  BY age_ms DESC
+```
+
+Entries where `embedding_dispatched_at IS NULL` are a legacy condition (written
+before the migration). They are logged separately:
+
+```elixir
+Logger.warning("[Memory.Store] #{undispatch_count} pending entries lack dispatched_at; " <>
+  "may predate migration 009")
+```
+
+## Tradeoffs
+
+### Strengths
+
+- Decomplects the data shape: the row itself distinguishes in-flight from
+  potentially-stuck at any read point; no runtime process required.
+- The startup audit catches rot from prior crashes on every boot — high
+  signal for operators doing a rolling restart after a wiring fix.
+- Extends existing code paths minimally: one additional DB write per embedding
+  dispatch, one new SQL column, one startup query.
+- No new supervised process; supervision tree unchanged (simpler operational
+  footprint).
+- `embedding_dispatched_at` is useful to the `retry-recovery-path`
+  sub-problem as the basis for its re-enqueue eligibility check.
+
+### Weaknesses
+
+- Detection is only at startup and when explicitly queried; no continuous
+  runtime alerting between restarts. If a node runs for hours, new rot
+  accumulates silently until the next restart.
+- Requires a schema migration adding a nullable column; existing `"pending"`
+  rows from before the migration will have `NULL` in `embedding_dispatched_at`,
+  requiring a fallback branch.
+- Writing `dispatched_at` before spawning the Task adds a synchronous DB write
+  to `handle_continue/2`; this is on the hot path (every write to the store
+  triggers an embedding dispatch). Under high write volume this may be
+  measurable.
+- The startup audit does not cover rot that accumulates while the node is
+  running; combining with Proposal 1 would be needed for continuous coverage,
+  but that introduces both approaches' costs.
+
+### Costs
+
+- 1 schema migration (ALTER TABLE — safe on SQLite; no lock contention on boot).
+- ~40 lines of new code in `sqlite.ex` (migration, helper, audit).
+- Test surface: 1 migration test, 1 unit test for `audit_stale_pending/1`,
+  1 property test confirming `dispatched_at` is set before `embed/3` is called.
+- No new dependencies.
+
+## Dependencies
+
+- Schema migration must be numbered correctly (next after existing migrations).
+- The `inserted_at` vs `dispatched_at` distinction must be documented in
+  `SPEC-MEMORY-STORE.md` §3 as a new constraint.
+
+## Confidence
+
+**Medium.** The schema change and startup-audit pattern are well-understood. The
+`handle_continue/2` synchronous write on the hot path requires benchmarking
+under realistic write rates to confirm it is acceptable. Confidence would be
+`high` after a micro-benchmark showing the extra write is < 1 ms on the expected
+hardware.
+
+## Prior art / references
+
+- Outbox pattern (reliable message dispatch): the `dispatched_at` column is a
+  minimal form of the outbox pattern's "dispatched" marker.
+- SQLite `ALTER TABLE ... ADD COLUMN` — SQLite documentation: safe, O(1) on
+  all SQLite versions.
+- Startup consistency audits: common in database-backed services; analogous to
+  Ecto's startup migration check in Phoenix apps.

--- a/docs/problems-archive-v1-modules/tau-memory/subproblems/pending-rot-observability/proposals/proposal-3.md
+++ b/docs/problems-archive-v1-modules/tau-memory/subproblems/pending-rot-observability/proposals/proposal-3.md
@@ -1,0 +1,172 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 3
+parent_problem: ../problem.md
+---
+
+# Proposal 3: In-process `handle_info(:check_pending_age, ...)` timer inside `Store.SQLite`
+
+## Approach
+
+Add a `Process.send_after(self(), :check_pending_age, @check_interval_ms)` to
+`Store.SQLite.init/1`, rescheduled in each `handle_info(:check_pending_age,
+...)` clause. The handle_info clause queries `stale_pending_entries` directly
+against `state.db` (no external GenServer call; same process, same db
+reference), emits `[:tau, :memory, :pending_rot, :detected]` telemetry if
+any stale entries are found, then reschedules. No new module; no new supervised
+child; no new public API surface. The detection logic is self-contained inside
+the existing `Store.SQLite` GenServer.
+
+## Rationale
+
+The complecting hypothesis is that absence of a completion-tracking mechanism
+and absence of an alerting mechanism are woven together. This proposal addresses
+the alerting gap by collocating the detection timer with the process that owns
+the database connection. Because `Store.SQLite` already holds `state.db`, the
+stale-entry query needs no IPC — it runs directly against the connection without
+a `GenServer.call` round-trip. This is the minimal viable alerting surface:
+one `handle_info` clause, one SQL query, one telemetry emission. It does not
+introduce a new process, a new behaviour, or a new module boundary.
+
+## Sketch
+
+### `init/1` change
+
+```elixir
+@check_interval_ms 60_000
+@stale_threshold_ms 35_000   # > @request_timeout_ms (30_000) + grace
+
+@impl GenServer
+def init(opts) do
+  # ... existing init body ...
+  Process.send_after(self(), :check_pending_age, @check_interval_ms)
+  {:ok, %{db: db}}
+end
+```
+
+### New `handle_info` clause
+
+```elixir
+@impl GenServer
+def handle_info(:check_pending_age, %{db: db} = state) do
+  case query_stale_pending(db, @stale_threshold_ms) do
+    {:ok, []} ->
+      :ok
+
+    {:ok, rows} ->
+      count = length(rows)
+      oldest_age_ms = Enum.max(Enum.map(rows, & &1.age_ms))
+      entry_ids = Enum.map(rows, & &1.id)
+
+      :telemetry.execute(
+        [:tau, :memory, :pending_rot, :detected],
+        %{count: count},
+        %{entry_ids: entry_ids, oldest_age_ms: oldest_age_ms}
+      )
+
+      Logger.warning(
+        "[Memory.Store] #{count} stale pending embedding(s); " <>
+          "oldest #{oldest_age_ms} ms; entry_ids=#{inspect(entry_ids)}"
+      )
+
+    {:error, reason} ->
+      Logger.error("[Memory.Store] stale_pending query error: #{inspect(reason)}")
+  end
+
+  Process.send_after(self(), :check_pending_age, @check_interval_ms)
+  {:noreply, state}
+end
+```
+
+### New private helper
+
+```elixir
+@sql_stale_pending """
+  SELECT id,
+         CAST((julianday('now') - julianday(inserted_at)) * 86400000 AS INTEGER) AS age_ms
+  FROM   memory
+  WHERE  embedding_status = 'pending'
+    AND  CAST((julianday('now') - julianday(inserted_at)) * 86400000 AS INTEGER) > ?1
+  ORDER  BY age_ms DESC
+"""
+
+@spec query_stale_pending(reference(), non_neg_integer()) ::
+        {:ok, [%{id: binary(), age_ms: non_neg_integer()}]} | {:error, term()}
+defp query_stale_pending(db, threshold_ms) do
+  with {:ok, stmt} <- Exqlite.Sqlite3.prepare(db, @sql_stale_pending),
+       :ok <- Exqlite.Sqlite3.bind(stmt, [threshold_ms]),
+       {:ok, rows} <- Exqlite.Sqlite3.fetch_all(db, stmt, 100) do
+    Exqlite.Sqlite3.release(db, stmt)
+    {:ok, Enum.map(rows, fn [id, age_ms] -> %{id: id, age_ms: age_ms} end)}
+  end
+end
+```
+
+Note: uses `inserted_at` (already present) rather than a new column.
+This requires `inserted_at` to be stored in ISO8601 UTC and the query
+to be validated against the schema.
+
+## Tradeoffs
+
+### Strengths
+
+- Zero new modules, zero new supervised children, zero new public API surface.
+- Detection query runs directly against `state.db` — avoids a `GenServer.call`
+  round-trip and the associated mailbox pressure.
+- Single diff location: only `store/sqlite.ex` changes; no supervisor or
+  application changes required.
+- Easy to test: existing `Store.SQLite` test infrastructure suffices; no mock
+  store required.
+- Satisfies OTP non-negotiable #5 with the smallest possible code surface.
+
+### Weaknesses
+
+- Adds a recurring `:check_pending_age` message to the `Store.SQLite` mailbox.
+  Under very high write volume, if the mailbox is already pressured, the timer
+  message may be delayed — detection latency becomes indefinite rather than
+  bounded at the configured interval.
+- The periodic SQL query runs in the owner GenServer, competing with writes and
+  searches for DB time. On a loaded system, this could delay write replies.
+  (Bounded: the query is a full-scan filtered by `embedding_status = 'pending'`
+  and date arithmetic; without an index on `(embedding_status, inserted_at)` it
+  is O(n) on pending rows.)
+- All detection logic is inside `Store.SQLite`, coupling the alerting concern
+  to the storage concern; a future refactor extracting `Store.SQLite` would need
+  to extract the timer too.
+- The `@check_interval_ms` and `@stale_threshold_ms` module attributes are
+  compile-time constants; changing them requires recompilation (could be
+  `Application.get_env` instead, at the cost of a tiny runtime lookup).
+
+### Costs
+
+- ~40 lines added to `store/sqlite.ex`.
+- No new dependencies; no schema migrations.
+- Test surface: 1 new `handle_info` test in `store/sqlite_test.exs`; existing
+  test helpers may need a small extension to drive the timer.
+- If an index on `(embedding_status, inserted_at)` is desired for performance,
+  that is an additional migration (~3 lines).
+
+## Dependencies
+
+- `inserted_at` column must exist and be stored as ISO8601 UTC — verify in
+  migrations. If not, an alternative is to accept a small migration adding an
+  `inserted_at_unix_ms INTEGER` column populated by a trigger.
+- No external dependencies.
+
+## Confidence
+
+**Medium-high.** The `handle_info` + `send_after` pattern is standard Elixir;
+the query is simple SQL. Confidence would be `high` after:
+1. Confirming the `inserted_at` column format in the migration files.
+2. Running an `EXPLAIN QUERY PLAN` against the stale-pending query to confirm
+   it hits an index or verifying the pending-row count is small enough for a
+   full scan.
+
+## Prior art / references
+
+- `Process.send_after` periodic health checks: canonical pattern in Elixir
+  GenServer design; e.g. Ecto connection pool health pings.
+- SQLite `julianday` arithmetic: SQLite documentation §Date and Time Functions.
+- The `:check_pending_age` message name is deliberately distinct from OTP
+  system messages (`:timeout`, `:hibernate`) to avoid confusion.

--- a/docs/problems-archive-v1-modules/tau-memory/subproblems/pending-rot-observability/proposals/proposal-4.md
+++ b/docs/problems-archive-v1-modules/tau-memory/subproblems/pending-rot-observability/proposals/proposal-4.md
@@ -1,0 +1,200 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 4
+parent_problem: ../problem.md
+---
+
+# Proposal 4: Telemetry handler on `[:tau, :memory, :write, :stop]` with in-process age tracking via ETS
+
+## Approach
+
+Replace polling with a push-based approach. At `Store.SQLite` init time, attach
+a `:telemetry` handler for `[:tau, :memory, :write, :stop]` that records
+`{entry_id, dispatched_at_monotonic}` into an ETS table owned by the store
+process. A second handler for `[:tau, :memory, :embedding, :stop]` removes the
+entry from ETS when embedding completes. A lightweight `handle_info(:age_check,
+...)` timer (default 30 s, matching `@request_timeout_ms`) fires once per
+timeout window and scans the ETS table for entries older than the threshold —
+the check is O(in-flight count) not O(total memory rows), since only active
+dispatches are tracked. Stale entries emit `[:tau, :memory, :pending_rot,
+:detected]`. The ETS table is in-process state: no separate GenServer, no
+database query during detection.
+
+## Rationale
+
+The current failure mode involves two complected absences: no completion-
+tracking mechanism and no alerting mechanism. Proposals 1–3 add alerting by
+querying the database periodically. This proposal instead tracks in-flight
+dispatches in memory (ETS), decoupling the alerting from the database entirely:
+the ETS table is the "in-flight registry," and the telemetry events that already
+fire on write and embedding completion become the insertion and removal triggers.
+This means detection of stuck entries does not require reading from SQLite at
+all — the ETS lookup is O(in-flight) and sub-microsecond per entry. It also
+means the telemetry emission on `[:tau, :memory, :embedding, :stop]` provides
+an additional signal: entries that leave the ETS normally (embedding completed)
+are inherently observable.
+
+## Sketch
+
+### ETS table ownership
+
+The table is created in `Store.SQLite.init/1` and owned by the GenServer process:
+
+```elixir
+@impl GenServer
+def init(opts) do
+  # ... existing init ...
+  table = :ets.new(:tau_memory_pending_dispatches, [:set, :protected, :named_table])
+  :ok = attach_telemetry_handlers(table)
+  Process.send_after(self(), :age_check, @request_timeout_ms)
+  {:ok, %{db: db, pending_table: table}}
+end
+```
+
+### Telemetry handler — on write stop, record dispatch
+
+```elixir
+defp attach_telemetry_handlers(table) do
+  :telemetry.attach(
+    "tau-memory-pending-write",
+    [:tau, :memory, :write, :stop],
+    fn _event, _measurements, %{id: entry_id}, _config ->
+      :ets.insert(table, {entry_id, :erlang.monotonic_time(:millisecond)})
+    end,
+    nil
+  )
+
+  :telemetry.attach(
+    "tau-memory-pending-embedding",
+    [:tau, :memory, :embedding, :stop],
+    fn _event, _measurements, %{entry_id: entry_id}, _config ->
+      :ets.delete(table, entry_id)
+    end,
+    nil
+  )
+
+  :ok
+end
+```
+
+### Age check timer
+
+```elixir
+@impl GenServer
+def handle_info(:age_check, %{pending_table: table} = state) do
+  now_ms = :erlang.monotonic_time(:millisecond)
+  threshold_ms = Application.get_env(:tau, :embedding_stale_threshold_ms, 35_000)
+
+  stale =
+    :ets.tab2list(table)
+    |> Enum.filter(fn {_id, inserted_ms} -> now_ms - inserted_ms > threshold_ms end)
+
+  if stale != [] do
+    count = length(stale)
+    oldest_age_ms = Enum.max(Enum.map(stale, fn {_id, ms} -> now_ms - ms end))
+    entry_ids = Enum.map(stale, fn {id, _} -> id end)
+
+    :telemetry.execute(
+      [:tau, :memory, :pending_rot, :detected],
+      %{count: count},
+      %{entry_ids: entry_ids, oldest_age_ms: oldest_age_ms}
+    )
+
+    Logger.warning(
+      "[Memory.Store] #{count} stale pending embedding(s); " <>
+        "oldest #{oldest_age_ms} ms"
+    )
+  end
+
+  Process.send_after(self(), :age_check, @request_timeout_ms)
+  {:noreply, state}
+end
+```
+
+### Cleanup in `terminate/2`
+
+```elixir
+@impl GenServer
+def terminate(_reason, %{db: db, pending_table: table}) do
+  :telemetry.detach("tau-memory-pending-write")
+  :telemetry.detach("tau-memory-pending-embedding")
+  :ets.delete(table)
+  Exqlite.Sqlite3.close(db)
+  :ok
+end
+```
+
+## Tradeoffs
+
+### Strengths
+
+- Detection is O(in-flight count) not O(total memory rows); the age check is
+  a pure in-memory scan — no database query during detection.
+- No schema migration required; no `inserted_at` format dependency.
+- Telemetry handler on `[:tau, :memory, :embedding, :stop]` doubles as a
+  completion signal; normal completions implicitly prove the pipeline is working.
+- Produces real-time (within one timer interval) detection rather than
+  scan-on-demand.
+- Satisfies OTP non-negotiable #1 (ETS table is owned by the GenServer process,
+  not a global).
+
+### Weaknesses
+
+- Complexity is higher than Proposals 1–3: ETS lifecycle, two telemetry handler
+  registrations, handler cleanup in `terminate/2`.
+- The ETS table is in-process memory state: if `Store.SQLite` crashes and
+  restarts, the table is rebuilt from zero — entries that were `"pending"` at
+  crash time are not in the new ETS table, so they become invisible to the
+  in-memory tracker until the next write event. (Restart-time rot is missed
+  unless combined with a startup DB query similar to Proposal 2.)
+- `[:tau, :memory, :write, :stop]` fires only when `id` is present in
+  metadata — this is the current behaviour (`:stop` metadata is `%{id: binary()}`
+  for writes). If a write fails and emits `:exception` instead of `:stop`, the
+  entry is never inserted into ETS; that is correct behaviour (no dispatch
+  occurs on failed writes), but the handler must be robust to missing metadata.
+- `:ets.tab2list/1` on a large in-flight set copies the entire table for the
+  scan; under pathological conditions (thousands of stuck entries) this could
+  spike memory allocation during the check. Bounded by the in-flight set size,
+  which is bounded by write rate × timeout window.
+- Attaching global telemetry handlers from inside a GenServer is unusual and
+  can be surprising; the handler closures capture `table` (an ETS reference)
+  which becomes a dangling reference if `terminate/2` deletes the table before
+  the handler is detached.
+
+### Costs
+
+- ~80 lines in `store/sqlite.ex` (ETS init, two telemetry attach/detach pairs,
+  age-check `handle_info`, `terminate/2` update).
+- No new dependencies; no schema migrations.
+- Test surface: 2 telemetry handler unit tests, 1 `handle_info(:age_check)`
+  test, 1 integration test verifying ETS cleanup on terminate.
+- Telemetry handler registration must be idempotent-safe (double-attach on
+  rapid restart could error; wrap in `try/rescue` or use `:telemetry.attach`
+  with a force-detach preceding it).
+
+## Dependencies
+
+- ETS named table `:tau_memory_pending_dispatches` must not conflict with any
+  other table in the application; verify no collision.
+- `[:tau, :memory, :embedding, :stop]` event metadata must carry `entry_id` —
+  currently it does (`%{entry_id: entry_id}` in `embedding_worker.ex:54`);
+  this is a dependency on that event shape remaining stable.
+
+## Confidence
+
+**Medium.** The ETS + telemetry-handler pattern is well-established in
+Elixir/Erlang. The restart-time gap is a genuine weakness that reduces
+confidence in covering the full acceptance criterion (which includes
+pre-existing stuck entries). Confidence would be `high` after adding a startup
+DB query to seed the ETS from `WHERE embedding_status = 'pending'` on init,
+closing the restart gap — but that adds complexity.
+
+## Prior art / references
+
+- ETS-owner process pattern: OTP documentation §ETS, "Ownership"; see also
+  `Tau.CircuitBreaker.Store` in this codebase for the owned-ETS pattern.
+- Telemetry handler registration from a GenServer: used in several Erlang
+  ecosystem libraries (Broadway, Oban) for per-instance metric tracking.
+- `:erlang.monotonic_time/1` for age computation: preferred over `DateTime.utc_now()`
+  for interval measurement as it is not subject to system clock adjustments.

--- a/docs/problems-archive-v1-modules/tau-memory/subproblems/pending-rot-observability/solution.md
+++ b/docs/problems-archive-v1-modules/tau-memory/subproblems/pending-rot-observability/solution.md
@@ -1,0 +1,161 @@
+---
+template_version: 1
+template_name: solution
+parent_problem: ../problem.md
+node_kind: leaf
+synthesised_from: [proposals/proposal-3.md]
+selection_method: single
+revision: 1
+---
+
+# Solution: In-process `handle_info(:check_pending_age)` timer inside `Store.SQLite`
+
+## Recommendation
+
+Add a `Process.send_after(self(), :check_pending_age, @check_interval_ms)` to
+`Store.SQLite.init/1` and a corresponding `handle_info/2` clause that queries
+stale `embedding_status = 'pending'` rows directly against `state.db`, emits
+`[:tau, :memory, :pending_rot, :detected]` telemetry with `%{count:
+non_neg_integer()}` measurements and `%{entry_ids: [binary()], oldest_age_ms:
+non_neg_integer()}` metadata, logs a structured warning, and reschedules itself.
+No new module, no new supervised child, no new public API on the store. The
+detection query reads the existing `created_at` column on the `memory_entries`
+table (per `lib/tau/memory/migrations.ex:35-48`) — `created_at` is the row's
+insertion timestamp, stored as ISO-8601 UTC via the SQLite default
+`strftime('%Y-%m-%dT%H:%M:%SZ', 'now')`, which makes `julianday(created_at)`
+arithmetic well-defined.
+
+## Selected from
+
+- **Chosen:** `proposals/proposal-3.md`
+- **Why chosen:** Proposal 3 is the only single proposal that satisfies the
+  acceptance criterion with the lowest code surface and no inter-process coupling
+  overhead. It runs the detection query directly against `state.db` (no
+  `GenServer.call` round-trip), adds no new module or supervised child, and
+  modifies a single file (`store/sqlite.ex`). Proposal 1 (separate sweeper
+  GenServer) also satisfies the AC fully but introduces a new module, a new
+  public API surface on `Store.SQLite`, and a new supervisor child — all
+  unnecessary given that the detection query can run in-process. Proposal 2
+  (schema + startup audit) only partially fits the AC: it catches rot at startup
+  but leaves rot that accumulates while the node is running invisible; it also
+  adds a schema migration and a write on the hot path (`handle_continue/2`),
+  costs that belong to the `retry-recovery-path` sub-problem rather than to
+  observability alone. Proposal 4 (ETS + telemetry push) has a genuine
+  restart-time gap that also undermines the AC unless augmented, adds telemetry
+  handler lifecycle risk (dangling ETS reference, idempotency hazard on rapid
+  restart), and is not easily reversible once woven in. On the comparison axes,
+  Proposal 3 wins on decomplecting depth relative to cost: it does not
+  restructure the data shape (Proposal 2's strength) but that restructuring is
+  not required by this sub-problem's AC, and avoiding it keeps this change
+  strictly inside the observability boundary the problem declares.
+
+  **Synthesis correction:** All four proposals (and the prior revision-0
+  solution) named the row insertion timestamp as `inserted_at` on a table
+  `memory`. The actual schema (`lib/tau/memory/migrations.ex:35-48`,
+  migration `20260518_002_memory_entries`) defines the table as
+  `memory_entries` and the column as `created_at`. This solution adopts the
+  schema as it exists; the proposals' SQL is corrected wherever copied below.
+
+## Scoring table
+
+| # | Fit | Decomplecting depth | Migration cost | Risk | Reversibility |
+|---|---|---|---|---|---|
+| 1 | Yes | Surface | Medium | Low | Easy |
+| 2 | Partially | Substantial | Medium | Low | Easy |
+| 3 | Yes | Surface | Low | Low | Easy |
+| 4 | Partially | Substantial | High | Medium | Hard |
+
+Proposal 2 scores "Partially" because the startup-only audit does not satisfy
+the AC for a long-running node; new rot accumulates silently between restarts.
+Proposal 4 scores "Partially" for the same restart-time gap and "Medium" risk
+for the telemetry handler lifecycle hazard.
+
+## What changes
+
+- **`lib/tau/memory/store/sqlite.ex`**:
+  - `init/1`: add `Process.send_after(self(), :check_pending_age,
+    @check_interval_ms)` at the end of the successful init body.
+  - New `@check_interval_ms` module attribute (default: `60_000`).
+  - New `@stale_threshold_ms` module attribute (default: `35_000`; must exceed
+    `EmbeddingWorker`'s `@request_timeout_ms` of `30_000` plus a grace margin).
+  - New `handle_info(:check_pending_age, state)` clause: queries
+    `query_stale_pending(state.db, @stale_threshold_ms)`, emits
+    `[:tau, :memory, :pending_rot, :detected]` telemetry if any stale entries
+    are found, logs a structured `Logger.warning/1`, and reschedules itself via
+    `Process.send_after`.
+  - New private `query_stale_pending/2` function: prepares and executes the
+    stale-pending SQL using `Exqlite.Sqlite3` directly against `db`.
+  - New private `@sql_stale_pending` module attribute. The SQL targets the
+    `memory_entries` table and the `created_at` column as defined in
+    `lib/tau/memory/migrations.ex:35-48`:
+
+    ```sql
+    SELECT id,
+           CAST((julianday('now') - julianday(created_at)) * 86400000 AS INTEGER)
+             AS age_ms
+    FROM   memory_entries
+    WHERE  embedding_status = 'pending'
+      AND  CAST((julianday('now') - julianday(created_at)) * 86400000 AS INTEGER) > ?1
+    ORDER  BY age_ms DESC
+    ```
+
+## What does not change
+
+- `lib/tau/memory/supervisor.ex` — no new child.
+- `lib/tau/memory/embedding_worker.ex` — no changes.
+- `lib/tau/memory/store/sqlite.ex` public API — no new exported functions.
+- Database schema — no migration required; uses the existing `created_at`
+  column on `memory_entries`.
+- `lib/tau/application.ex` — no changes.
+- The `[:tau, :memory, :write]` and `[:tau, :memory, :embedding]` telemetry
+  event shapes — unchanged.
+
+## Migration sketch
+
+Single-step: add the three private definitions and the `init/1` call to
+`store/sqlite.ex`. The `created_at` column is already ISO-8601 UTC by schema
+default (`strftime('%Y-%m-%dT%H:%M:%SZ', 'now')` in
+`lib/tau/memory/migrations.ex:45`), so `julianday(created_at)` arithmetic is
+well-defined without a migration. Run `EXPLAIN QUERY PLAN` on the
+stale-pending query against a dev DB to confirm the plan is acceptable; an
+index on `(embedding_status, created_at)` may be warranted if the
+pending-row count can grow large but is not required at landing. Add one
+`handle_info(:check_pending_age, ...)` test driving the timer directly in
+`store/sqlite_test.exs`. The change is reversible by deleting the three
+definitions and the `init/1` call; no schema rollback is required.
+
+## Open questions
+
+- Should `@check_interval_ms` and `@stale_threshold_ms` be compile-time
+  constants or runtime-configurable via `Application.get_env`? The proposal
+  uses compile-time; runtime config adds flexibility for environments with
+  different SLAs at a small lookup cost.
+- Is an index on `(embedding_status, created_at)` required at landing, or
+  should it be a follow-up migration once the pending-row count is observed
+  in production?
+- Does the `:check_pending_age` message name conflict with any existing
+  `handle_info` clause in `Store.SQLite`? Verify before landing.
+
+## Linked sub-problems / proposals
+
+- `proposals/proposal-1.md` — Separate `PendingRotSweeper` GenServer; satisfies
+  AC but adds unnecessary module/API/supervisor surface vs. Proposal 3.
+- `proposals/proposal-2.md` — Schema `dispatched_at` column + startup audit;
+  partially fits AC (startup-only detection); decomplects data shape at a cost
+  more appropriate for `retry-recovery-path`.
+- `proposals/proposal-3.md` — **Selected.** In-process `handle_info` timer;
+  minimal footprint, full AC fit. (Proposal's SQL referencing `inserted_at`
+  on table `memory` is corrected in this solution to `created_at` on
+  `memory_entries` per the actual schema.)
+- `proposals/proposal-4.md` — ETS + telemetry push; restart-time gap and
+  handler lifecycle risk make it a partial fit at higher cost.
+
+## Revision history
+
+- (revision 0 — initial)
+- revision 1 — Corrected column reference from `inserted_at` to `created_at`
+  and table reference from `memory` to `memory_entries` to match the actual
+  schema in `lib/tau/memory/migrations.ex:35-48` (migration
+  `20260518_002_memory_entries`). All four proposals carried the same defect;
+  the synthesis fixes it. Validator's prior falsification on this point is
+  resolved.

--- a/docs/problems-archive-v1-modules/tau-memory/subproblems/pending-rot-observability/validation.md
+++ b/docs/problems-archive-v1-modules/tau-memory/subproblems/pending-rot-observability/validation.md
@@ -1,0 +1,363 @@
+---
+template_version: 1
+template_name: validation
+parent_solution: ./solution.md
+parent_problem: ./problem.md
+toulmin_complete: true
+falsification_attempted: true
+falsification_outcome: withstood
+revision_triggered: none
+---
+
+# Validation: In-process `handle_info(:check_pending_age)` timer inside `Store.SQLite`
+
+## Overview
+
+The revised solution proposes a self-rescheduling timer inside the existing
+`Tau.Memory.Store.SQLite` GenServer that queries stale `embedding_status =
+'pending'` rows from `memory_entries` (joining the existing `created_at`
+column for age arithmetic), emits `[:tau, :memory, :pending_rot, :detected]`
+telemetry, logs a structured warning, and reschedules. Five distinct
+checkable propositions are extracted from the Recommendation and
+"What changes / What does not change" sections. Each receives a full
+six-component Toulmin treatment; falsification is attempted with a named
+strategy per claim (dependency check, counter-example construction, edge-case
+enumeration, integration check, type-level check). All five claims withstand
+falsification. Two outstanding doubts (compile-time-only thresholds and
+absence of an `(embedding_status, created_at)` index) are recorded for the
+parent validator without falsifying the solution.
+
+## Toulmin per claim
+
+The MITRE empirical study on Toulmin formalism found that "participants
+found it difficult to generate Toulmin structures, and their structures
+varied greatly even though they started with the same content"
+(https://www.mitre.org/news-insights/publication/empirical-evaluation-structured-argumentation-using-toulmin-argument).
+This validation enforces all six components explicitly with prompts to
+counter that variance.
+
+### Claim 1: the detection query reads the existing `created_at` column on `memory_entries` (no schema migration required)
+
+- **Claim (C):** "The detection query reads the existing `created_at` column
+  on the `memory_entries` table … `created_at` is the row's insertion
+  timestamp, stored as ISO-8601 UTC via the SQLite default
+  `strftime('%Y-%m-%dT%H:%M:%SZ', 'now')`, which makes
+  `julianday(created_at)` arithmetic well-defined" (solution.md §Recommendation).
+- **Grounds (G):** `lib/tau/memory/migrations.ex:35-48` defines
+  `memory_entries` with `created_at TEXT NOT NULL DEFAULT
+  (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))` (line 45). `lib/tau/memory/store/sqlite.ex`
+  references `e.created_at` in five distinct queries (lines 480, 498, 641,
+  655, plus the row-projection list at 668-688). No `inserted_at` symbol
+  appears anywhere under `lib/` or `test/` (`grep -rn "inserted_at"` returns
+  empty). Migration `20260518_002_memory_entries` is the only migration that
+  creates this table; no later migration renames or drops `created_at`
+  (migrations.ex:35-86).
+- **Warrant (W):** A SQL query against a column that the schema defines
+  with a `NOT NULL DEFAULT` of an ISO-8601-formatted `strftime` expression
+  can safely be passed to `julianday(...)` because SQLite's date-and-time
+  functions accept ISO-8601 strings as inputs and return Julian Day numbers
+  (https://www.sqlite.org/lang_datefunc.html). Pre-existing column with a
+  bounded value space means no migration is needed to materialise the
+  data dependency.
+- **Qualifier (Q):** Holds for the current schema as defined by migration
+  `20260518_002_memory_entries`. Holds across all rows because the column
+  is `NOT NULL` with a default — every row created via `do_write/2`
+  (sqlite.ex:392-414) or any future writer will populate it.
+- **Rebuttal (R):** If a future migration drops or renames `created_at`,
+  or if a row is inserted via a path that bypasses the default (e.g. a
+  raw `INSERT … (id, …, created_at) VALUES (…, NULL)` — though `NOT NULL`
+  would reject this), the query fails. Mitigated by the `NOT NULL`
+  constraint; future-mitigated by the append-only migration discipline
+  documented as invariant C-007 in `migrations.ex:11`.
+- **Backing (B):** SQLite date/time functions reference
+  (https://www.sqlite.org/lang_datefunc.html). Append-only migration
+  invariant C-007 (`lib/tau/memory/migrations.ex:11-13`). Spec
+  `docs/spec/SPEC-MEMORY-STORE.md` (D-047) requires migrations to be
+  idempotent and append-only.
+
+#### Falsification attempt for claim 1
+
+- **Strategy:** Dependency check — verify that the schema state the claim
+  depends on (column `created_at` on table `memory_entries`, ISO-8601
+  default) holds in the current codebase.
+- **Attempt:** Read `lib/tau/memory/migrations.ex` directly (every
+  migration body inspected). Grep the entire `lib/` and `test/` trees for
+  the symbol `inserted_at` (none found) and for the prior incorrect table
+  name `memory` as a standalone reference (`FROM memory ` returns no hits
+  outside the proposals directory). Confirm `created_at` is referenced
+  from existing production queries in `store/sqlite.ex` (semantic search
+  SELECT list, FTS search SELECT list, row-projection helper).
+- **Outcome:** Withstood. The schema dependency the claim names is the
+  schema the codebase actually has.
+- **Action:** None. The revision from `inserted_at` → `created_at` and
+  `memory` → `memory_entries` is correct.
+
+### Claim 2: a `handle_info(:check_pending_age, …)` clause can be added without conflicting with any existing `handle_info` clause in `Store.SQLite`
+
+- **Claim (C):** Implicit in solution.md §What changes ("New
+  `handle_info(:check_pending_age, state)` clause") and explicit in §Open
+  questions ("Does the `:check_pending_age` message name conflict with any
+  existing `handle_info` clause in `Store.SQLite`? Verify before
+  landing.").
+- **Grounds (G):** `grep -n "handle_info" lib/tau/memory/store/sqlite.ex`
+  returns exactly two matches: line 295
+  (`handle_info({ref, _result}, state) when is_reference(ref)`) and line
+  300 (`handle_info({:DOWN, _ref, :process, _pid, _reason}, state)`).
+  Both patterns are structurally disjoint from the atom `:check_pending_age`:
+  one matches a two-tuple whose first element is a reference, the other
+  matches a four-tuple beginning with `:DOWN`. The new clause matches a
+  bare atom — no overlap.
+- **Warrant (W):** Erlang/Elixir GenServer dispatches `handle_info/2` by
+  pattern-matching the incoming message against clauses in source order
+  (Elixir compilation order semantics; documented in
+  https://hexdocs.pm/elixir/Kernel.html#def/2). Disjoint patterns cannot
+  match the same message, so clause ordering does not matter for
+  correctness. Therefore a new clause for a distinct pattern is additive.
+- **Qualifier (Q):** Holds as long as the new clause is placed in the
+  module (any position is correct since the patterns are disjoint).
+- **Rebuttal (R):** None pertaining to clause ordering, given disjoint
+  patterns. If a future commit adds a `handle_info(:check_pending_age,
+  state)` clause elsewhere in the module before this validation is
+  acted on, the new clause would shadow or be shadowed by the addition —
+  but that is a conflict-on-merge issue, not a present-state defect.
+- **Backing (B):** Elixir function clause matching semantics, Erlang
+  `gen_server:handle_info/2` callback contract
+  (https://www.erlang.org/doc/man/gen_server.html#Module:handle_info-2).
+
+#### Falsification attempt for claim 2
+
+- **Strategy:** Counter-example construction — enumerate existing
+  `handle_info` clauses and check whether any could match the atom
+  `:check_pending_age`.
+- **Attempt:** The two existing clauses' patterns are `{ref, _result}`
+  with a reference guard, and `{:DOWN, _ref, :process, _pid, _reason}`.
+  Neither matches a bare atom. Construct a message: send
+  `:check_pending_age` to the GenServer — neither pattern matches, so the
+  message would fall through (currently producing an "unexpected message"
+  warning from `:gen_server` default behaviour). Adding the new clause
+  captures this fall-through with no shadowing risk.
+- **Outcome:** Withstood. The solution's open-question hedge ("Verify
+  before landing") is addressable by inspection: no conflict exists in
+  the current source.
+- **Action:** None. The open question may be retired as part of
+  implementation by the implementer simply observing the same `grep`
+  result.
+
+### Claim 3: the change satisfies the acceptance criterion — operators can detect pending rot without querying the database directly
+
+- **Claim (C):** The handle_info clause "emits `[:tau, :memory,
+  :pending_rot, :detected]` telemetry with `%{count: non_neg_integer()}`
+  measurements and `%{entry_ids: [binary()], oldest_age_ms:
+  non_neg_integer()}` metadata, logs a structured warning, and reschedules
+  itself" (solution.md §Recommendation), which the §Selected-from rationale
+  asserts "satisfies the acceptance criterion with the lowest code surface."
+- **Grounds (G):** The AC reads (problem.md §Acceptance criterion): "An
+  operator can determine — without querying the database directly —
+  whether any memory entries have been in `embedding_status: 'pending'`
+  longer than the embedding timeout, via a telemetry event or structured
+  log line that fires when such entries are detected." The solution emits
+  BOTH a telemetry event (`[:tau, :memory, :pending_rot, :detected]`)
+  AND a structured `Logger.warning/1` log line when stale rows are found.
+  `@stale_threshold_ms = 35_000` is `> @request_timeout_ms = 30_000`
+  (embedding_worker.ex:37) plus a 5 s grace, so "longer than the embedding
+  timeout" is mechanically satisfied. The check runs every
+  `@check_interval_ms = 60_000`, so the detection latency is bounded by
+  one minute after a row crosses the threshold.
+- **Warrant (W):** The AC is satisfied iff at least one of {telemetry
+  event, structured log line} fires when stale entries exist. Emitting
+  both is sufficient. The threshold-on-age comparison happens inside
+  SQL (the `WHERE` clause), so an operator observing the telemetry knows
+  every reported row is past the embedding timeout by definition.
+- **Qualifier (Q):** Holds for a long-running node (the timer fires while
+  the process is alive). Detection latency is bounded by
+  `@check_interval_ms + @stale_threshold_ms` from the moment a row enters
+  `pending`; nothing in the AC requires lower latency.
+- **Rebuttal (R):** If `Store.SQLite` crashes and restarts at the exact
+  moment a check would have fired, the next check is delayed by one full
+  `@check_interval_ms` from the restart. This is bounded and consistent
+  with the AC. If the timer message is dropped (which is impossible
+  within a single Erlang node — `Process.send_after` is reliable
+  intra-node), detection would silently stop. Outside the AC's scope
+  because the AC does not specify availability under message loss.
+- **Backing (B):** Problem.md §Acceptance criterion (verbatim);
+  OTP non-negotiable #5 (`.claude/rules/otp-non-negotiables.md`):
+  "Telemetry events MUST cover everything user-visible or perf-sensitive";
+  problem.md §Context references this rule explicitly.
+
+#### Falsification attempt for claim 3
+
+- **Strategy:** Edge-case enumeration — list the conditions under which
+  a stale `pending` row could exist yet the operator would not see it.
+- **Attempt:** Enumerate:
+  1. Row entered pending more than 60 s ago, process alive: caught by
+     next timer tick (≤ 60 s from threshold crossing).
+  2. Row entered pending less than 35 s ago: correctly NOT reported
+     (within timeout). Matches AC's "longer than the embedding timeout".
+  3. Row entered pending 40 s ago, then `Store.SQLite` crashed and
+     restarted: on restart, `init/1` reschedules the timer, so detection
+     resumes at most 60 s later. Bounded, AC-satisfied.
+  4. Telemetry handler not attached at the application level: the
+     telemetry event is still emitted, and the structured `Logger.warning`
+     log line is also emitted. AC mentions "telemetry event OR structured
+     log line"; either alone suffices.
+  5. Query fails (DB lock, schema corruption): the `Logger.error` branch
+     in the handler logs the failure — an operator sees that detection
+     itself is broken, which is a stronger signal than silent absence.
+- **Outcome:** Withstood. No enumerated case falsifies the AC.
+- **Action:** None.
+
+### Claim 4: the change adds no new module, no new supervised child, and no new public API on the store
+
+- **Claim (C):** "No new module, no new supervised child, no new public
+  API on the store" (solution.md §Recommendation); §What does not change
+  lists `lib/tau/memory/supervisor.ex` (no new child), `lib/tau/application.ex`
+  (no changes), and `lib/tau/memory/store/sqlite.ex` public API
+  (no new exported functions).
+- **Grounds (G):** The added definitions per §What changes are: two
+  module attributes (`@check_interval_ms`, `@stale_threshold_ms`), one
+  module attribute holding SQL (`@sql_stale_pending`), one private
+  function (`query_stale_pending/2`), one `handle_info/2` clause, and
+  one `Process.send_after/3` call inside `init/1`. None of these are
+  exported (`@spec`/`def` for a public function is absent; the new
+  function is `defp`). `lib/tau/memory/supervisor.ex` (verified inline:
+  one child, `Tau.Memory.Store.SQLite`) is not modified. The supervision
+  topology is unchanged.
+- **Warrant (W):** OTP non-negotiable #3: "MUST NOT wrap stateless logic
+  in a GenServer." The detection logic is inherently tied to the existing
+  GenServer's owned db reference; collocating it inside the existing
+  process honours this principle and avoids the "Manager / Service
+  GenServer for shared state" anti-pattern called out in the same
+  rule. Adding a private helper plus a new `handle_info` clause to an
+  existing GenServer extends behaviour without enlarging the public
+  surface.
+- **Qualifier (Q):** Holds for the as-described implementation. If the
+  implementer were to additionally expose a `get_stale_pending/1` public
+  function (not in solution.md), this claim would be partially falsified
+  — but the solution explicitly does not.
+- **Rebuttal (R):** None within the described scope.
+- **Backing (B):** OTP non-negotiables #3 and #8 ("Pure functions are the
+  default; processes are the exception"); `.claude/rules/otp-non-negotiables.md`.
+
+#### Falsification attempt for claim 4
+
+- **Strategy:** Integration check — confirm that no other module in the
+  codebase would need to change to make the new behaviour observable, and
+  that the supervision tree need not be touched.
+- **Attempt:** The detection runs in the existing `Store.SQLite` process,
+  which is already supervised by `Tau.Memory.Supervisor` and started by
+  `Tau.Application` (per the supervisor's `@moduledoc`). Telemetry events
+  are received by any attached telemetry handler without explicit
+  registration — the receiver side (a `:telemetry.attach/4` call) lives
+  outside the memory subsystem and would attach to the event whether or
+  not the supervisor topology changes. `Logger.warning/1` requires no
+  registration. Therefore the supervision tree is correctly untouched.
+- **Outcome:** Withstood.
+- **Action:** None.
+
+### Claim 5: the change is reversible by deleting the three definitions and the `init/1` call; no schema rollback is required
+
+- **Claim (C):** "The change is reversible by deleting the three
+  definitions and the `init/1` call; no schema rollback is required"
+  (solution.md §Migration sketch).
+- **Grounds (G):** The change adds private code only (per Claim 4). It
+  introduces no migration entry to `@migrations` in `migrations.ex`
+  (per solution.md §What does not change: "Database schema — no
+  migration required"). Reversal requires removing the additions; no
+  pre-existing rows depend on the new code.
+- **Warrant (W):** A change that only adds private code inside a single
+  GenServer and emits a new telemetry event is reversible by deleting the
+  added code, provided no on-disk state was created. Append-only
+  migrations (`migrations.ex` C-007) mean any unrolled migration would
+  require a new compensating migration; this change adds none, so this
+  concern does not apply.
+- **Qualifier (Q):** Holds before any downstream consumer of the new
+  telemetry event is wired in (e.g. an OTel exporter rule, a dashboard
+  alert). Once consumers exist, deletion of the emitter would silently
+  break them; reversibility of the change in `Store.SQLite` would still
+  be mechanical, but coordinator-level coordination would be required
+  to manage consumers.
+- **Rebuttal (R):** If an operator attaches a telemetry handler and
+  comes to rely on the event between landing and rollback, "reversibility
+  is mechanical" understates the operational impact. The code change is
+  reversible; the operational expectation may not be.
+- **Backing (B):** Reversibility heuristic in the proposal scoring
+  rubric (solution.md §Scoring table) is consistent with the
+  decomplecting depth being "Surface" (no data model change, no
+  topology change).
+
+#### Falsification attempt for claim 5
+
+- **Strategy:** Type-level / static check — enumerate what the change
+  touches and what would need to be undone.
+- **Attempt:** Inventory of additions per §What changes:
+  (a) `@check_interval_ms` module attribute,
+  (b) `@stale_threshold_ms` module attribute,
+  (c) `@sql_stale_pending` module attribute,
+  (d) `defp query_stale_pending/2`,
+  (e) `def handle_info(:check_pending_age, state)`,
+  (f) one `Process.send_after/3` call at the tail of `init/1`.
+  Removing all six restores the prior code. No `@migrations` entry, no
+  schema artefact, no ETS table, no Application.env key, no supervisor
+  child to remove. Code-level reversibility is mechanical.
+- **Outcome:** Withstood at the code level. Partially qualified at the
+  operational level (Qualifier already narrows this).
+- **Action:** Qualifier already states the operational scope; no
+  further revision needed.
+
+## Cross-claim consistency
+
+The five claims do not conflict:
+
+- Claims 1, 3 (correctness of detection) depend on Claim 2 (clause
+  addition is safe). Claim 2's falsification confirmed no conflict, so
+  the chain holds.
+- Claims 4 (no new module / API / child) and 5 (mechanical reversibility)
+  are mutually reinforcing — minimal surface implies minimal undo.
+- The §Open questions in solution.md (compile-time vs runtime threshold;
+  optional index; clause-conflict check) raise three points; Claim 2
+  resolves the third, and the first two are flagged below as outstanding
+  doubts rather than as defects.
+
+## Falsification summary
+
+| # | Claim (short) | Strategy | Outcome | Action |
+|---|---|---|---|---|
+| 1 | `created_at` exists; ISO-8601 default; `julianday` arithmetic valid | Dependency check | Withstood | None |
+| 2 | New `handle_info(:check_pending_age, …)` clause is conflict-free | Counter-example construction | Withstood | Retire open question |
+| 3 | Telemetry + log satisfies AC for long-running node | Edge-case enumeration | Withstood | None |
+| 4 | No new module / supervised child / public API | Integration check | Withstood | None |
+| 5 | Reversible without schema rollback | Type-level / static check | Withstood (qualifier narrowed in place) | None |
+
+## Revision required
+
+None. All claims withstood falsification. The revision-1 correction from
+`inserted_at` to `created_at` and from `memory` to `memory_entries`
+resolves the prior validator's falsification on Claim 1.
+
+- **Target file:** n/a
+- **Revision kind:** n/a
+- **Rationale:** n/a
+
+## Outstanding doubts
+
+These doubts do not falsify any claim — they remain for the parent
+validator's awareness as candidate qualifiers when this leaf's solution is
+synthesised upward.
+
+- Compile-time-only thresholds (`@check_interval_ms`, `@stale_threshold_ms`)
+  bake the SLA into a recompile. Solution.md §Open questions acknowledges
+  this. Not a defect because the AC does not require runtime tuning, but
+  a future operator may prefer `Application.get_env/3` indirection. If
+  the embedding timeout changes (`@request_timeout_ms` in
+  `embedding_worker.ex:37`), `@stale_threshold_ms` must be hand-edited
+  in lockstep — a coupling worth surfacing in the parent's Qualifier.
+- The absence of an `(embedding_status, created_at)` index is appropriate
+  for current row volumes but becomes a performance hazard at scale. A
+  follow-up index migration is anticipated in solution.md §Open questions
+  and §Migration sketch. Not a defect at landing but a known scaling
+  qualifier.
+- The detection latency upper bound (~95 s = `@check_interval_ms` +
+  `@stale_threshold_ms` − `@request_timeout_ms`) is implicit in the
+  configuration and not stated as a contract anywhere. The parent
+  problem (`tau-memory`) may want to make this explicit if downstream
+  sub-problems (e.g. `retry-recovery-path`) depend on it.

--- a/docs/problems-archive-v1-modules/tau-memory/subproblems/retry-recovery-path/problem.md
+++ b/docs/problems-archive-v1-modules/tau-memory/subproblems/retry-recovery-path/problem.md
@@ -1,0 +1,57 @@
+---
+template_version: 1
+template_name: problem
+node_kind: leaf
+depth: 1
+parent: ../../problem.md
+status: draft
+---
+
+# Problem: No mechanism exists to re-enqueue stuck "pending" or transient-failed entries
+
+## Statement
+
+`Tau.Memory.EmbeddingWorker` classifies `Mint.TransportError` and generic
+network errors as `:transient`, meaning they are eligible for retry. However,
+once an entry sits in `embedding_status: "pending"` (lost Task) or
+`embedding_status: "failed"` with `embedding_error_kind: "transient"`, there is
+no scheduled sweep, GenServer timer, or API call that re-dispatches embedding for
+it. Fixing the Finch name mismatch and the silent-crash path will prevent new
+entries from getting stuck, but all entries already stuck — including any
+accumulated during the broken period — will remain permanently unreachable to
+`semantic_search/2` unless manually handled.
+
+## Context
+
+- `lib/tau/memory/store/sqlite.ex` — no `handle_info(:timeout, ...)`, `Process.send_after/3`, or periodic sweep for stale `"pending"` / transient-`"failed"` rows.
+- `lib/tau/memory/supervisor.ex` — supervises only `Store.SQLite`; no worker or periodic-task child for re-embedding.
+- `lib/tau/memory/embedder.ex` — `embed/3` callback is fire-and-forget; the behaviour has no `retry/2` or `requeue/1` surface.
+- D-046 (`SPEC-MEMORY-STORE.md`) — `"failed"` with `:transient` kind implies the failure is retryable, but the spec does not prescribe a retry mechanism.
+- OTP non-negotiable #1: stateful subsystems must run as supervised processes; a retry sweep belongs under `Tau.Memory.Supervisor`, not as an ad-hoc timer in the GenServer.
+
+## Complecting hypothesis
+
+- The retryability classification (`:transient` / `:terminal`) is complected with the absence of a retry trigger: the classification is recorded in metadata but nothing reads it to act.
+- The recovery concern (re-enqueue stuck entries) is complected with the observability concern (knowing which entries are stuck): without observability, recovery must query the DB directly; with observability, recovery can be event-driven.
+
+## Decomposition strategy
+
+(leaf — no further decomposition; proceed to proposals)
+
+## Acceptance criterion
+
+After the Finch name mismatch is fixed, any memory entry that is in
+`embedding_status: "pending"` or `embedding_status: "failed"` with
+`embedding_error_kind: "transient"` is automatically re-submitted for embedding
+without operator intervention, within a bounded time window.
+
+## Out of scope
+
+- The root-cause Finch name mismatch (covered by `finch-name-mismatch`).
+- The Task-crash-without-callback path (covered by `silent-failure-propagation`).
+- Observability of the stuck state (covered by `pending-rot-observability`), though the retry mechanism should emit telemetry for re-enqueue events.
+- Terminal failures (`embedding_error_kind: "terminal"` — content-too-long, policy rejection) are not retried by definition.
+
+## Amendment log
+
+- (none yet)

--- a/docs/problems-archive-v1-modules/tau-memory/subproblems/retry-recovery-path/proposals/proposal-1.md
+++ b/docs/problems-archive-v1-modules/tau-memory/subproblems/retry-recovery-path/proposals/proposal-1.md
@@ -1,0 +1,176 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 1
+parent_problem: ../problem.md
+---
+
+# Proposal 1: Tau.Memory.RetrySweeper — dedicated supervised GenServer with a periodic timer
+
+## Approach
+
+Add `Tau.Memory.RetrySweeper`, a new `GenServer` child under `Tau.Memory.Supervisor`,
+whose sole responsibility is periodically querying the DB for `"pending"` and
+`"failed"` / `embedding_error_kind: "transient"` rows, then re-dispatching
+`embedder.embed/3` for each. The sweep interval is configurable via
+`:tau, :retry_sweep_interval_ms` (default 60_000 ms). The sweeper holds a reference
+to the store's GenServer name and the configured embedder module; it does not own
+a DB connection — it delegates all DB reads through the existing store API.
+
+The sweeper adds one public function: `Tau.Memory.RetrySweeper.trigger_sweep/0`
+(for tests and operator tooling). The store must expose one new API call,
+`list_retriable/1`, that returns `[%{id: String.t(), content: String.t()}]` filtered
+to retriable statuses. No changes to `Store.SQLite`'s existing callbacks.
+
+## Rationale
+
+This directly satisfies the OTP non-negotiable (#1): the retry concern lives as a
+supervised process, not as ad-hoc timers inside the store GenServer. It decomplects
+the re-enqueue trigger from the store's write/embedding path — the store records
+status; the sweeper reads it and acts. A dedicated process makes the retry loop
+independently restartable, observable (its own telemetry), and testable in isolation.
+The sweeper reads the `:transient` classification already stored in metadata by
+`do_mark_embedding_failed/3`, so no classification logic moves.
+
+## Sketch
+
+```elixir
+# lib/tau/memory/retry_sweeper.ex
+defmodule Tau.Memory.RetrySweeper do
+  use GenServer
+
+  @default_interval_ms 60_000
+
+  def start_link(opts \\ []) do
+    GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+  end
+
+  @spec trigger_sweep(GenServer.server()) :: :ok
+  def trigger_sweep(server \\ __MODULE__) do
+    GenServer.call(server, :sweep)
+  end
+
+  @impl GenServer
+  def init(opts) do
+    interval = Keyword.get(opts, :interval_ms,
+      Application.get_env(:tau, :retry_sweep_interval_ms, @default_interval_ms))
+    store = Keyword.get(opts, :store, Tau.Memory.Store.SQLite)
+    embedder = Application.get_env(:tau, :embedder, Tau.Memory.EmbeddingWorker)
+    state = %{interval: interval, store: store, embedder: embedder}
+    {:ok, state, {:continue, :schedule}}
+  end
+
+  @impl GenServer
+  def handle_continue(:schedule, state) do
+    Process.send_after(self(), :sweep, state.interval)
+    {:noreply, state}
+  end
+
+  def handle_info(:sweep, state) do
+    do_sweep(state)
+    Process.send_after(self(), :sweep, state.interval)
+    {:noreply, state}
+  end
+
+  def handle_call(:sweep, _from, state) do
+    do_sweep(state)
+    {:reply, :ok, state}
+  end
+
+  defp do_sweep(%{store: store, embedder: embedder} = _state) do
+    :telemetry.span([:tau, :memory, :retry_sweep], %{}, fn ->
+      case Tau.Memory.Store.SQLite.list_retriable(store) do
+        {:ok, entries} ->
+          Enum.each(entries, fn %{id: id, content: content} ->
+            :telemetry.execute([:tau, :memory, :retry_enqueue], %{}, %{entry_id: id})
+            embedder.embed(store, id, content)
+          end)
+          {{:ok, length(entries)}, %{count: length(entries)}}
+        {:error, reason} ->
+          :telemetry.execute([:tau, :memory, :retry_sweep_error], %{}, %{reason: reason})
+          {{:error, reason}, %{}}
+      end
+    end)
+  end
+end
+
+# New public API on Store.SQLite
+@spec list_retriable(GenServer.server()) :: {:ok, [%{id: String.t(), content: String.t()}]} | {:error, term()}
+def list_retriable(server \\ __MODULE__) do
+  GenServer.call(server, :list_retriable)
+end
+
+# New handle_call in Store.SQLite
+def handle_call(:list_retriable, _from, %{db: db} = state) do
+  sql = """
+  SELECT id, content FROM memory_entries
+  WHERE embedding_status = 'pending'
+     OR (embedding_status = 'failed'
+         AND json_extract(metadata, '$.embedding_error_kind') = 'transient')
+  """
+  # ... prepare, fetch_all, release pattern; map to %{id: ..., content: ...}
+  {:reply, result, state}
+end
+
+# lib/tau/memory/supervisor.ex — add RetrySweeper child
+children = [
+  {Tau.Memory.Store.SQLite, opts},
+  {Tau.Memory.RetrySweeper, opts}
+]
+```
+
+The supervision strategy stays `:one_for_one`; a sweeper crash does not restart
+the store.
+
+## Tradeoffs
+
+### Strengths
+
+- Satisfies OTP non-negotiable #1: retry concern is a supervised process.
+- Minimal coupling: sweeper only calls `list_retriable/1` and `embedder.embed/3`;
+  no internal state shared with the store.
+- `trigger_sweep/0` makes the retry path synchronously testable without timers.
+- Adding `:tau, :retry_sweep_interval_ms = 0` in tests allows full integration testing.
+- Sweeper crash does not affect the store; `:one_for_one` restarts it independently.
+- Telemetry on sweep and per-enqueue event satisfies the "should emit telemetry" note in the problem.
+
+### Weaknesses
+
+- Polling: the sweep fires on a fixed interval regardless of whether any retriable
+  entries exist. Idle overhead is minimal but non-zero.
+- The first retry after startup is delayed by up to one full interval (default 60 s).
+- `list_retriable/1` adds a round-trip through the store mailbox; under high write
+  load, this call competes with writes and embedder callbacks.
+- If the sweeper dispatches entries that are already mid-embedding (from a concurrent
+  fix being merged), duplicate embedding tasks will race. The store's
+  `do_store_embedding` is idempotent (DELETE + INSERT inside a transaction), so
+  correctness is preserved, but wasted work occurs.
+
+### Costs
+
+- New module (~80 LOC), new store API function (~30 LOC), supervisor change (~3 LOC).
+- New test module for the sweeper; integration test using `trigger_sweep/0`.
+- `list_retriable` adds one SQL read per sweep cycle against `memory_entries`.
+
+## Dependencies
+
+- `Tau.Memory.Store.SQLite` must expose `list_retriable/1` (new call — no existing
+  callers to migrate).
+- `Tau.Tools.TaskSupervisor` must be started before `Tau.Memory.Supervisor`
+  (already the case per `Tau.Application` child order).
+- The Finch name mismatch (`finch-name-mismatch` sub-problem) must be fixed first;
+  otherwise the sweeper re-enqueues entries that immediately fail again.
+
+## Confidence
+
+medium — the GenServer + `Process.send_after` pattern is idiomatic Elixir; no novel
+mechanism. Confidence would be high after verifying that `list_retriable` performs
+adequately under the expected row counts (thousands) and that the duplicate-embedding
+race does not cause observable correctness issues.
+
+## Prior art / references
+
+- `Oban` (Elixir job queue): periodic sweep GenServer pattern for stuck jobs is a
+  first-class concept.
+- `Tau.Memory.Supervisor` existing pattern: adding a sibling child for a distinct concern.
+- OTP non-negotiable #1 in `TAU.md` / `.claude/rules/otp-non-negotiables.md`.

--- a/docs/problems-archive-v1-modules/tau-memory/subproblems/retry-recovery-path/proposals/proposal-2.md
+++ b/docs/problems-archive-v1-modules/tau-memory/subproblems/retry-recovery-path/proposals/proposal-2.md
@@ -1,0 +1,134 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 2
+parent_problem: ../problem.md
+---
+
+# Proposal 2: Store-internal `handle_info(:retry_sweep, ...)` timer inside Store.SQLite
+
+## Approach
+
+Add a periodic timer directly inside `Tau.Memory.Store.SQLite`: `init/1` sends
+`Process.send_after(self(), :retry_sweep, interval)` after the DB opens, and
+`handle_info(:retry_sweep, state)` runs the SQL query and re-dispatches
+`embedder.embed/3` for each retriable row, then reschedules itself. No new process
+or supervisor child. The retry sweep runs inside the existing store GenServer's
+message loop, using its held DB connection directly — no new store API surface.
+
+## Rationale
+
+The store already owns the DB connection; it can query for retriable rows cheaply
+without a mailbox round-trip. This keeps the retry path in one process, one module,
+and one file — the smallest footprint of any option. There is no new process to
+supervise, no new API to maintain, and no inter-process coordination. The coupling
+is local: both the status-write and the retry-trigger live inside `Store.SQLite`.
+
+## Sketch
+
+```elixir
+# In Tau.Memory.Store.SQLite
+
+@default_retry_interval_ms 60_000
+
+# init/1 — append to successful branch:
+{:ok, %{db: db}, {:continue, :schedule_retry_sweep}}
+
+# handle_continue/2 — add clause:
+def handle_continue(:schedule_retry_sweep, state) do
+  interval = Application.get_env(:tau, :retry_sweep_interval_ms, @default_retry_interval_ms)
+  Process.send_after(self(), {:retry_sweep, interval}, interval)
+  {:noreply, Map.put(state, :retry_interval, interval)}
+end
+
+# handle_info/2 — add clauses:
+def handle_info({:retry_sweep, interval}, %{db: db} = state) do
+  embedder = Application.get_env(:tau, :embedder, Tau.Memory.EmbeddingWorker)
+  server = self()
+
+  case do_list_retriable(db) do
+    {:ok, entries} ->
+      Enum.each(entries, fn {id, content} ->
+        :telemetry.execute([:tau, :memory, :retry_enqueue], %{}, %{entry_id: id})
+        embedder.embed(server, id, content)
+      end)
+
+    {:error, reason} ->
+      Logger.warning("[Store.SQLite] retry sweep failed: #{inspect(reason)}")
+  end
+
+  Process.send_after(self(), {:retry_sweep, interval}, interval)
+  {:noreply, state}
+end
+
+# Private helper — runs on the GenServer, uses held db reference directly:
+defp do_list_retriable(db) do
+  sql = """
+  SELECT id, content FROM memory_entries
+  WHERE embedding_status = 'pending'
+     OR (embedding_status = 'failed'
+         AND json_extract(metadata, '$.embedding_error_kind') = 'transient')
+  """
+
+  with {:ok, stmt} <- Exqlite.Sqlite3.prepare(db, String.trim(sql)),
+       {:ok, rows} <- Exqlite.Sqlite3.fetch_all(db, stmt),
+       :ok <- Exqlite.Sqlite3.release(db, stmt) do
+    {:ok, Enum.map(rows, fn [id, content] -> {id, content} end)}
+  end
+end
+```
+
+No changes to `Tau.Memory.Supervisor` or `Tau.Memory.Embedder`.
+
+## Tradeoffs
+
+### Strengths
+
+- Minimum surface area: one module, no new process, no supervisor change.
+- DB read uses the held connection directly — no mailbox round-trip to
+  `list_retriable`.
+- No new API: existing test harness is unchanged; no new mock surface.
+- Failure of the sweep (DB error, embedder call error) does not crash the store —
+  it logs and reschedules.
+
+### Weaknesses
+
+- Violates OTP non-negotiable #3 in spirit: a stateless periodic action (sweep)
+  is now woven into the stateful DB-owner GenServer. The store's `handle_info`
+  clause count grows with a concern unrelated to write/search/embedding.
+- The retry sweep competes with the store's mailbox — during high write bursts,
+  sweep messages may be delayed arbitrarily.
+- A bug in the sweep logic can hang or crash the store process, taking the entire
+  memory subsystem down. There is no isolation between retry bugs and store
+  availability.
+- Testing requires either controlling the timer interval or using `:sys.replace_state`
+  to inject state; no clean `trigger_sweep/0` public API.
+- Harder to remove or replace: the concern is inlined, not composed.
+
+### Costs
+
+- ~50 LOC added to an already-large `store/sqlite.ex` (currently ~700 LOC).
+- No new modules or supervisor changes.
+- Existing `store/sqlite.ex` tests need a timer-drain helper or a config override
+  to `0` ms interval to exercise the sweep path without wall-clock waiting.
+
+## Dependencies
+
+- The Finch name mismatch must be fixed; otherwise sweeping re-enqueues entries
+  that fail immediately.
+- No other structural dependencies.
+
+## Confidence
+
+medium-low — the approach is simple but the OTP non-negotiable concern (#3 —
+don't wrap stateless logic in the GenServer managing something else) is a genuine
+risk. Confidence would rise if the sweep logic were kept strictly read-only and
+side-effect-free in its DB path (no mutations from the sweep itself), since that
+limits blast radius of a sweep bug.
+
+## Prior art / references
+
+- `Phoenix.PubSub` internal cleanup timers: some OTP libraries do schedule
+  maintenance work inside the owner GenServer when the work is tightly coupled
+  to the connection resource. Acknowledged as a tradeoff, not a pattern to emulate.
+- OTP non-negotiable #3: "MUST NOT wrap stateless logic in a GenServer."

--- a/docs/problems-archive-v1-modules/tau-memory/subproblems/retry-recovery-path/proposals/proposal-3.md
+++ b/docs/problems-archive-v1-modules/tau-memory/subproblems/retry-recovery-path/proposals/proposal-3.md
@@ -1,0 +1,184 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 3
+parent_problem: ../problem.md
+---
+
+# Proposal 3: Telemetry-driven re-enqueue — retry sweep triggered by `[:tau, :memory, :write, :stop]` events
+
+## Approach
+
+Replace the polling model entirely. Instead of a periodic timer, the retry path is
+event-driven: when the Finch name mismatch is fixed (or a transient fault clears),
+the next successful `write/1` emits `[:tau, :memory, :write, :stop]`. A new
+lightweight GenServer, `Tau.Memory.RetryHandler`, subscribes to this telemetry
+event via `:telemetry.attach/4` and, on receipt, performs one retriable-row sweep
+and re-dispatches embeddings. Additionally, `RetryHandler` performs an initial
+sweep on startup (via `handle_continue`) to drain any entries that were stuck
+before the current session started.
+
+The sweep query and dispatch logic is identical to Proposal 1 but the trigger is
+event-driven rather than interval-based. `Tau.Memory.Supervisor` gains
+`RetryHandler` as a sibling child.
+
+## Rationale
+
+The acceptance criterion says re-submission must happen "within a bounded time
+window." The bounded window after the Finch fix is not clock-based — it is the
+first new write that succeeds. Using a write-triggered sweep rather than a polling
+interval means: (a) there is no wasted overhead when the pipeline is idle, and
+(b) the retry happens at the earliest possible moment after the pipeline becomes
+healthy again (the first successful write). The startup sweep handles entries that
+were stuck before this session, satisfying the case where the operator fixes the
+configuration and restarts without writing a new entry.
+
+This decomplects the retry trigger from time and instead ties it to the observable
+health signal already emitted by the store.
+
+## Sketch
+
+```elixir
+# lib/tau/memory/retry_handler.ex
+defmodule Tau.Memory.RetryHandler do
+  use GenServer
+
+  @telemetry_event [:tau, :memory, :write, :stop]
+
+  def start_link(opts \\ []) do
+    GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+  end
+
+  @impl GenServer
+  def init(opts) do
+    store = Keyword.get(opts, :store, Tau.Memory.Store.SQLite)
+    embedder = Application.get_env(:tau, :embedder, Tau.Memory.EmbeddingWorker)
+    state = %{store: store, embedder: embedder}
+
+    :telemetry.attach(
+      "tau-memory-retry-on-write",
+      @telemetry_event,
+      &__MODULE__.handle_telemetry/4,
+      %{pid: self()}
+    )
+
+    {:ok, state, {:continue, :startup_sweep}}
+  end
+
+  @impl GenServer
+  def handle_continue(:startup_sweep, state) do
+    do_sweep(state)
+    {:noreply, state}
+  end
+
+  def handle_info(:sweep, state) do
+    do_sweep(state)
+    {:noreply, state}
+  end
+
+  @impl GenServer
+  def terminate(_reason, _state) do
+    :telemetry.detach("tau-memory-retry-on-write")
+    :ok
+  end
+
+  # Called from telemetry handler in the emitting process context;
+  # forwards to the RetryHandler mailbox to avoid blocking the emitter.
+  def handle_telemetry(_event, _measurements, _metadata, %{pid: pid}) do
+    send(pid, :sweep)
+  end
+
+  defp do_sweep(%{store: store, embedder: embedder}) do
+    :telemetry.span([:tau, :memory, :retry_sweep], %{}, fn ->
+      case Tau.Memory.Store.SQLite.list_retriable(store) do
+        {:ok, []} ->
+          {{:ok, 0}, %{count: 0}}
+        {:ok, entries} ->
+          Enum.each(entries, fn %{id: id, content: content} ->
+            :telemetry.execute([:tau, :memory, :retry_enqueue], %{}, %{entry_id: id})
+            embedder.embed(store, id, content)
+          end)
+          {{:ok, length(entries)}, %{count: length(entries)}}
+        {:error, reason} ->
+          {{:error, reason}, %{}}
+      end
+    end)
+  end
+end
+
+# Store.SQLite gains list_retriable/1 (same as Proposal 1):
+@spec list_retriable(GenServer.server()) :: {:ok, [%{id: String.t(), content: String.t()}]} | {:error, term()}
+def list_retriable(server \\ __MODULE__) do
+  GenServer.call(server, :list_retriable)
+end
+
+# lib/tau/memory/supervisor.ex — add RetryHandler:
+children = [
+  {Tau.Memory.Store.SQLite, opts},
+  {Tau.Memory.RetryHandler, opts}
+]
+```
+
+The `handle_telemetry/4` callback is invoked in the telemetry emitter's process
+context; forwarding to the GenServer mailbox via `send/2` ensures the sweep runs
+off the store's write path.
+
+## Tradeoffs
+
+### Strengths
+
+- No polling overhead: the sweep runs only when there is evidence of pipeline
+  activity (a write event) or at startup.
+- Retry latency after a configuration fix is bounded by the next successful write
+  (not a clock interval), which is typically the tightest possible bound.
+- Startup sweep handles stuck entries from prior sessions without requiring a write.
+- Decomplects retry trigger from clock; ties it to a meaningful domain event.
+- Telemetry attachment/detachment is supervised through the GenServer lifecycle:
+  on crash + restart, the attachment is re-established.
+
+### Weaknesses
+
+- If no new writes occur after the configuration fix (e.g. the operator restarts
+  but nothing new is written), the retry sweep fires only once (at startup). Entries
+  that fail again during the startup sweep will remain stuck until the next write or
+  next restart. A subsequent write-triggered sweep will re-try them, but the bound
+  becomes "next new write," not a fixed interval.
+- The telemetry callback is called in the emitting process's context. The `send/2`
+  approach avoids blocking, but adds a message to RetryHandler's mailbox on every
+  write. If write volume is very high, the sweeps may queue up faster than they
+  drain. A debounce (ignore sweep messages while a sweep is in flight) would
+  mitigate this but adds complexity.
+- Requires `list_retriable/1` new store API (same as Proposal 1).
+- The event-driven model is less familiar to contributors than a timer sweep; the
+  flow (write → telemetry → handler → re-enqueue) requires reading two files to
+  understand.
+
+### Costs
+
+- New module (~80 LOC), new store API (~30 LOC), supervisor change (~3 LOC).
+- Telemetry attachment lifecycle must be tested: crash + restart re-attaches correctly.
+- Debounce logic (optional): ~20 LOC if added.
+
+## Dependencies
+
+- `Tau.Memory.Store.SQLite` must expose `list_retriable/1`.
+- The Finch name mismatch must be fixed; otherwise the startup sweep and every
+  write-triggered sweep dispatch embeddings that immediately fail again, creating a
+  retry storm.
+- Telemetry must be available before `Tau.Memory.Supervisor` starts (it is, as
+  `:telemetry` is a library dependency loaded at application start).
+
+## Confidence
+
+medium — the telemetry-attach-from-GenServer-init pattern is used elsewhere in the
+Tau codebase (OtelReporter). The write-triggered sweep is novel for this problem but
+mechanically sound. Confidence would rise after verifying the debounce is not
+needed at realistic write rates and after testing the restart-re-attaches scenario.
+
+## Prior art / references
+
+- `Tau.OtelReporter` (`lib/tau/otel_reporter.ex`): `:telemetry.attach/4` inside
+  `GenServer.init/1` with detach in `terminate/2` — exact same pattern.
+- SPEC-OTEL-REPORTER.md §3: documents the attach/detach lifecycle invariant.
+- Event-driven recovery in distributed systems: reaction to a health-signal event
+  rather than polling is a standard pattern (cf. circuit-breaker half-open probe).

--- a/docs/problems-archive-v1-modules/tau-memory/subproblems/retry-recovery-path/proposals/proposal-4.md
+++ b/docs/problems-archive-v1-modules/tau-memory/subproblems/retry-recovery-path/proposals/proposal-4.md
@@ -1,0 +1,203 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 4
+parent_problem: ../problem.md
+---
+
+# Proposal 4: API-breaking — move embedding status to an explicit FSM with re-enqueue as a first-class transition
+
+## Approach
+
+Change the embedding lifecycle from an implicit column pair (`embedding_status` string
++ `embedding_error_kind` in metadata JSON) to an explicit `Tau.Memory.EmbeddingState`
+struct with a `:gen_statem`-compatible transition table. `Store.SQLite` gets a new
+`handle_call({:transition_embedding, id, event}, ...)` clause that applies the FSM
+transition and — when the new state is `:retriable` — immediately re-dispatches
+`embedder.embed/3` as a side-effect of the transition itself. No separate sweep process
+or timer is needed for newly-stuck entries. A `RetrySweeper` (one-shot, started at
+boot) drains entries stuck before this session by querying for `embedding_status IN
+('pending', 'failed')` with `embedding_error_kind = 'transient'` and applying
+`transition_embedding(id, :force_retry)` for each.
+
+The API change is: `store_embedding/3`'s callers continue to call the same function,
+but internally the store now routes through `transition_embedding/3` rather than calling
+`do_store_embedding` or `do_mark_embedding_failed` directly.
+
+## Rationale
+
+The complecting hypothesis names the root issue: "retryability classification is
+recorded in metadata but nothing reads it to act." This proposal eliminates the
+gap by making the re-enqueue a consequence of the state machine — when the FSM
+enters a `:failed_transient` state, its transition table defines a `:retry` event
+that triggers embedding dispatch. The FSM owns the policy; the store enforces it.
+This removes the need for external polling or event-listener indirection. The boot-time
+one-shot sweeper handles legacy stuck entries without ongoing overhead.
+
+## Sketch
+
+```elixir
+# lib/tau/memory/embedding_state.ex
+defmodule Tau.Memory.EmbeddingState do
+  @moduledoc """
+  Finite state machine for the embedding lifecycle of a memory entry.
+
+  States: :pending | :in_flight | :ready | :failed_transient | :failed_terminal
+  Events: :dispatch | :succeeded | {:failed, :transient} | {:failed, :terminal} | :retry
+
+  Transitions:
+    :pending       + :dispatch           -> :in_flight
+    :in_flight     + :succeeded          -> :ready
+    :in_flight     + {:failed, :transient} -> :failed_transient
+    :in_flight     + {:failed, :terminal} -> :failed_terminal
+    :failed_transient + :retry           -> :in_flight   (re-dispatches embed)
+    :pending       + :retry              -> :in_flight   (handles stuck-pending)
+  """
+
+  @type state :: :pending | :in_flight | :ready | :failed_transient | :failed_terminal
+  @type event :: :dispatch | :succeeded | {:failed, :transient | :terminal} | :retry
+
+  @spec transition(state(), event()) :: {:ok, state()} | {:error, :invalid_transition}
+  def transition(:pending, :dispatch),                 do: {:ok, :in_flight}
+  def transition(:in_flight, :succeeded),              do: {:ok, :ready}
+  def transition(:in_flight, {:failed, :transient}),   do: {:ok, :failed_transient}
+  def transition(:in_flight, {:failed, :terminal}),    do: {:ok, :failed_terminal}
+  def transition(:failed_transient, :retry),           do: {:ok, :in_flight}
+  def transition(:pending, :retry),                    do: {:ok, :in_flight}
+  def transition(_state, _event),                      do: {:error, :invalid_transition}
+
+  @spec retriable?(state()) :: boolean()
+  def retriable?(:failed_transient), do: true
+  def retriable?(:pending),          do: true
+  def retriable?(_),                 do: false
+end
+
+# In Store.SQLite — new internal API replacing direct do_mark_embedding_failed calls:
+defp apply_embedding_event(db, entry_id, event, embedder, server) do
+  with {:ok, current_state} <- do_get_embedding_state(db, entry_id),
+       {:ok, next_state} <- EmbeddingState.transition(current_state, event) do
+    :ok = do_set_embedding_state(db, entry_id, next_state)
+    if next_state == :in_flight do
+      # Re-dispatch is a side-effect of the transition, not a separate sweep
+      :telemetry.execute([:tau, :memory, :retry_enqueue], %{}, %{entry_id: entry_id})
+      embedder.embed(server, entry_id, do_get_content(db, entry_id))
+    end
+    {:ok, next_state}
+  end
+end
+
+# The existing store_embedding/3 handle_call clauses become:
+def handle_call({:store_embedding, entry_id, {:ok, _embedding}}, _from, state) do
+  # ... (unchanged: calls do_store_embedding + update to 'ready')
+end
+def handle_call({:store_embedding, entry_id, {:error, kind, _reason}}, _from, %{db: db} = state) do
+  embedder = Application.get_env(:tau, :embedder, Tau.Memory.EmbeddingWorker)
+  result = apply_embedding_event(db, entry_id, {:failed, kind}, embedder, self())
+  {:reply, result, state}
+end
+
+# Boot-time one-shot sweeper (simple Task, not supervised long-term):
+# lib/tau/memory/supervisor.ex
+children = [
+  {Tau.Memory.Store.SQLite, opts},
+  {Task, fn -> Tau.Memory.BootSweep.drain_stuck(opts) end}
+]
+
+# lib/tau/memory/boot_sweep.ex
+defmodule Tau.Memory.BootSweep do
+  def drain_stuck(opts) do
+    store = Keyword.get(opts, :store, Tau.Memory.Store.SQLite)
+    # Wait briefly for Store.SQLite to be ready
+    Process.sleep(500)
+    case Tau.Memory.Store.SQLite.list_retriable(store) do
+      {:ok, entries} ->
+        Enum.each(entries, fn %{id: id} ->
+          Tau.Memory.Store.SQLite.apply_retry(store, id)
+        end)
+      _ -> :ok
+    end
+  end
+end
+
+# Store.SQLite gets a new public call for the boot sweeper:
+@spec apply_retry(GenServer.server(), String.t()) :: {:ok, term()} | {:error, term()}
+def apply_retry(server, entry_id) do
+  GenServer.call(server, {:apply_retry, entry_id})
+end
+```
+
+The `embedding_status` DB column's valid values remain strings (`"pending"`,
+`"in_flight"`, `"ready"`, `"failed_transient"`, `"failed_terminal"`) — a migration
+adds `"in_flight"` and `"failed_transient"` / `"failed_terminal"` to the valid set.
+Existing `"failed"` rows with `embedding_error_kind: "transient"` are treated as
+`"failed_transient"` by the boot sweep's SQL query.
+
+## Tradeoffs
+
+### Strengths
+
+- Eliminates the polling/event-listener entirely for the ongoing case: the FSM
+  makes re-enqueue an invariant of the `:failed_transient → :retry` transition,
+  not a background job.
+- The `EmbeddingState` module is pure and property-testable; the transition table
+  is a complete specification of valid lifecycle paths.
+- `"in_flight"` status becomes observable (currently `"pending"` is ambiguous
+  between "waiting for dispatch" and "dispatch in progress"), resolving part of
+  the `pending-rot-observability` concern as a side effect.
+- Removes the metadata JSON field `embedding_error_kind` as the sole carrier of
+  retryability; the DB column carries the classification directly.
+
+### Weaknesses
+
+- API-breaking: adds a DB migration for new status values and changes the semantics
+  of existing `"failed"` rows. Any external tooling reading `embedding_status` must
+  be updated.
+- The boot-time sweeper uses `Process.sleep/1` to wait for `Store.SQLite` to be
+  ready — fragile; the correct approach is a `GenServer.call` once the store is
+  known to be registered, but timing this in a Task child is awkward.
+- Increases Store.SQLite complexity: `apply_embedding_event/5` reads the current
+  state, transitions, writes the new state, and possibly dispatches an embed — all
+  inside a single GenServer message. If `embedder.embed/3` blocks (it should not,
+  but stubs may), this stalls the store mailbox.
+- The `EmbeddingState` FSM must be kept in sync with the DB migration; a mismatch
+  (e.g. a new state added in code but not in the migration constraint) is a runtime
+  failure.
+- More code than the other proposals; higher review surface.
+
+### Costs
+
+- New module `EmbeddingState` (~50 LOC), new module `BootSweep` (~30 LOC),
+  DB migration for new status values (~10 LOC SQL), changes to `Store.SQLite`
+  (~50 LOC delta).
+- Property tests for `EmbeddingState.transition/2` (strongly recommended: all
+  valid transitions + all invalid transitions).
+- Migration must handle the `"failed"` → `"failed_transient"` / `"failed_terminal"`
+  split for existing rows (requires reading `embedding_error_kind` from metadata JSON).
+
+## Dependencies
+
+- Requires a DB migration (migration N+1 after the current highest): new
+  `embedding_status` values and a backfill for existing `"failed"` rows.
+- `list_retriable/1` still needed for the boot sweep.
+- Finch name mismatch must be fixed before the boot sweep is useful.
+- If `pending-rot-observability` introduces a `"stale_pending"` concept, it may
+  need to align with the FSM state names introduced here.
+
+## Confidence
+
+low-medium — the FSM design is sound and the `EmbeddingState` module is straightforward.
+Confidence is lowered by the migration complexity (backfilling `"failed"` rows from
+JSON metadata) and the `BootSweep` timing fragility. A prototype of the migration
+backfill query and a review of whether `embedder.embed/3` can ever block inside
+`apply_embedding_event/5` would raise confidence to medium.
+
+## Prior art / references
+
+- `:gen_statem` (OTP): the canonical FSM abstraction; `EmbeddingState` is a pure
+  functional version of its transition table.
+- Oban job states (`available`, `executing`, `retryable`, `completed`, `discarded`):
+  explicit DB-column FSM for job lifecycle — exact conceptual parallel.
+- SPEC-MEMORY-STORE.md D-046: `embedding_status` invariant; the proposal extends
+  its valid values.
+- Erlang "let it crash" + FSM pattern: encoding recovery policy in the state machine
+  rather than in ad-hoc error handlers is idiomatic BEAM design.

--- a/docs/problems-archive-v1-modules/tau-memory/subproblems/retry-recovery-path/solution.md
+++ b/docs/problems-archive-v1-modules/tau-memory/subproblems/retry-recovery-path/solution.md
@@ -1,0 +1,146 @@
+---
+template_version: 1
+template_name: solution
+parent_problem: problem.md
+node_kind: leaf
+synthesised_from: [proposals/proposal-1.md]
+selection_method: single
+revision: 0
+---
+
+# Solution: Tau.Memory.RetrySweeper — dedicated supervised GenServer with periodic timer
+
+## Recommendation
+
+Introduce `Tau.Memory.RetrySweeper`, a new `GenServer` child under
+`Tau.Memory.Supervisor`, whose sole responsibility is periodically querying
+the DB for `"pending"` and `"failed"`/`embedding_error_kind: "transient"` rows
+and re-dispatching `embedder.embed/3` for each. The sweep interval is
+configurable via `:tau, :retry_sweep_interval_ms` (default 60_000 ms). The
+store gains one new API call, `list_retriable/1`, returning retriable entries.
+`trigger_sweep/0` provides a synchronous handle for tests and operator tooling.
+The supervision strategy stays `:one_for_one`; sweeper and store fail
+independently.
+
+## Selected from
+
+- **Chosen:** `proposals/proposal-1.md`
+- **Why chosen:** Proposal 1 is the only candidate that simultaneously satisfies
+  the acceptance criterion, respects OTP non-negotiables #1 and #3, and carries
+  low migration risk with high reversibility. The comparison below makes the
+  choice decisive.
+
+### Scoring table
+
+| # | Fit | Decomplecting depth | Migration cost | Risk | Reversibility |
+|---|-----|---------------------|---------------|------|---------------|
+| 1 | Yes | Substantial | Low | Low | Easy |
+| 2 | Yes | Surface | Low | Medium | Easy |
+| 3 | Partially | Substantial | Low | Low | Easy |
+| 4 | Yes | Deep | High | Medium | Hard |
+
+**Proposal 2** scores "Surface" on decomplecting depth because the retry concern
+is inlined into the store GenServer rather than separated: the status-write path
+and the retry-trigger live in the same module and process. It also violates OTP
+non-negotiable #3 in spirit (stateless periodic logic woven into the stateful
+DB-owner GenServer). A sweep bug can stall or crash the store; there is no process
+isolation. Disqualified on OTP grounds and on the Hickey heuristic
+(decomplecting depth over cost).
+
+**Proposal 3** is event-driven, which is an attractive decoupling, but earns
+"Partially" on fit because the acceptance criterion requires re-submission
+"within a bounded time window." Proposal 3's bound is "next successful write,"
+not a clock interval. If the configuration is fixed but no new writes occur, the
+startup sweep fires once; any entries that fail again during that sweep remain
+stuck until a write arrives. The bound is open-ended in the write-idle case.
+Proposal 3 is also strictly more complex than Proposal 1: the telemetry
+attach/detach lifecycle, potential message storm under high write volume, and the
+debounce concern add surface area without resolving the bounded-time-window
+requirement. Proposal 3 also depends on `list_retriable/1`, the same store
+addition Proposal 1 requires — no differential cost on that axis.
+
+**Proposal 4** earns "Deep" on decomplecting depth (the FSM makes retryability a
+first-class state transition) but the migration cost is materially higher — a
+DB migration with backfill from JSON metadata, two new modules, a `BootSweep`
+with a `Process.sleep/1` timing fragility, and a harder-to-reverse schema
+change. The proposer rates confidence "low-medium," the lowest of the four. The
+depth of decomplecting is genuine but the problem statement does not require it:
+the acceptance criterion asks for automatic re-submission within a bounded window;
+it does not require an explicit FSM. The `EmbeddingState` decomplecting can be
+deferred to a targeted future PR without blocking recovery. Proposal 4 is the
+right answer to a larger problem; it is over-scoped for this sub-problem.
+
+Proposal 1 wins on fit + decomplecting depth relative to Proposal 2, on fit
+relative to Proposal 3, and on migration cost + risk + reversibility relative to
+Proposal 4. No hybrid is justified: Proposal 1 does not need elements from other
+proposals to satisfy the acceptance criterion.
+
+## What changes
+
+- **New module** `lib/tau/memory/retry_sweeper.ex` (~80 LOC): `GenServer` with
+  `init/1` scheduling the first sweep via `{:continue, :schedule}`,
+  `handle_info(:sweep, ...)` running the sweep and rescheduling, `handle_call(:sweep, ...)` for synchronous `trigger_sweep/0`, and telemetry spans on
+  sweep and per-enqueue events.
+- **New store API** in `lib/tau/memory/store/sqlite.ex` (~30 LOC): public
+  `list_retriable/1` spec + implementation; private `handle_call(:list_retriable,
+  ...)` with the SQL query filtering `"pending"` and `"failed"`/transient rows.
+- **Supervisor change** in `lib/tau/memory/supervisor.ex` (~3 LOC): add
+  `{Tau.Memory.RetrySweeper, opts}` as a `:one_for_one` sibling after
+  `Store.SQLite`.
+- **New test module** for `RetrySweeper`: unit tests using `trigger_sweep/0`;
+  integration test wiring the sweeper against a test store instance.
+
+## What does not change
+
+- `Tau.Memory.Store.SQLite` — no changes to existing callbacks or the write/embedding
+  path; `list_retriable/1` is additive only.
+- `Tau.Memory.Embedder` behaviour — no new callbacks; `embed/3` is called
+  exactly as it is today.
+- `Tau.Memory.Supervisor` supervision strategy — stays `:one_for_one`.
+- DB schema — no migration; the query reads existing `embedding_status` and
+  `metadata` columns as-is.
+- `Tau.Memory.EmbeddingWorker` — no changes; the sweeper calls the same
+  `embed/3` the write path calls.
+- The complecting between `pending` (lost Task) and `in_flight` (active Task)
+  is not resolved here (deferred to `pending-rot-observability` sub-problem).
+
+## Migration sketch
+
+Land `list_retriable/1` on `Store.SQLite` first (additive, no callers yet).
+Introduce `RetrySweeper` next; it is inert until added to the supervisor.
+Add the supervisor child last — at that point the sweeper begins firing. All
+three changes can land in one PR; the ordering of commits within the PR
+provides reviewability. Set `:tau, :retry_sweep_interval_ms` to a short value
+(e.g. 500 ms) in the test environment; use `trigger_sweep/0` in tests that
+need deterministic control rather than relying on the timer.
+
+## Open questions
+
+1. **Duplicate-embedding race:** if the sweeper dispatches an entry currently
+   mid-embedding (e.g. the Finch fix was applied and a new write just submitted
+   the same entry), two `embed/3` calls race. The store's `do_store_embedding`
+   is claimed to be idempotent (DELETE + INSERT in a transaction) — this should
+   be verified in the implementation PR.
+2. **Sweep under high write load:** `list_retriable/1` routes through the store
+   mailbox, competing with writes. Under high write bursts, a sweep call may be
+   delayed. The periodic model means the next sweep fires regardless; the delay
+   affects only the current cycle. Whether this is acceptable at expected
+   `memory_entries` row counts (thousands) should be benchmarked in the
+   implementation PR.
+3. **Startup delay:** the first sweep fires after one full interval (default
+   60 s). For entries stuck before restart, this is the maximum initial wait.
+   If operators need faster initial drain, the sweeper could fire once at
+   startup via `{:continue, :startup_sweep}` before scheduling the interval —
+   a trivial addition, but not included in this recommendation to keep scope
+   minimal.
+
+## Linked sub-problems / proposals
+
+- `proposals/proposal-1.md` — Tau.Memory.RetrySweeper, dedicated supervised GenServer with periodic timer **(selected)**
+- `proposals/proposal-2.md` — Store-internal `handle_info(:retry_sweep)` timer inside Store.SQLite (OTP non-negotiable violation; no process isolation)
+- `proposals/proposal-3.md` — Telemetry-driven re-enqueue on write events (partially fits; open-ended time bound in write-idle case)
+- `proposals/proposal-4.md` — Explicit EmbeddingState FSM with re-enqueue as first-class transition (over-scoped; DB migration required; low-medium confidence)
+
+## Revision history
+
+- (revision 0 — initial)

--- a/docs/problems-archive-v1-modules/tau-memory/subproblems/retry-recovery-path/validation.md
+++ b/docs/problems-archive-v1-modules/tau-memory/subproblems/retry-recovery-path/validation.md
@@ -1,0 +1,387 @@
+---
+template_version: 1
+template_name: validation
+parent_solution: solution.md
+parent_problem: problem.md
+toulmin_complete: true
+falsification_attempted: true
+falsification_outcome: partially_falsified — claim/4
+revision_triggered: none
+---
+
+# Validation: Tau.Memory.RetrySweeper — dedicated supervised GenServer with periodic timer
+
+## Overview
+
+The solution proposes a new `Tau.Memory.RetrySweeper` GenServer child under
+`Tau.Memory.Supervisor` that periodically queries `list_retriable/1` on the
+store and re-dispatches `embed/3` for stuck `"pending"` and transient-`"failed"`
+entries. Six distinct claims are extracted from the Recommendation and
+What-changes sections. Five withstand falsification; one (the duplicate-race
+idempotency claim) is partially falsified — the qualifier is narrowed in place
+and no solution revision is required.
+
+---
+
+## Toulmin per claim
+
+### Claim 1: RetrySweeper satisfies the acceptance criterion (bounded-time automatic re-submission without operator intervention)
+
+- **Claim (C):** "any memory entry that is in `embedding_status: 'pending'` or
+  `embedding_status: 'failed'` with `embedding_error_kind: 'transient'` is
+  automatically re-submitted for embedding without operator intervention, within
+  a bounded time window."
+- **Grounds (G):** The current `lib/tau/memory/store/sqlite.ex` contains no
+  `handle_info(:timeout, ...)`, `Process.send_after/3`, or periodic-sweep clause
+  (confirmed by reading the full file: lines 1–708). `lib/tau/memory/supervisor.ex`
+  line 29 has a single child `{Tau.Memory.Store.SQLite, opts}`. The proposed
+  sweeper adds a `Process.send_after`-based loop with configurable interval
+  (default 60 000 ms), directly addressing the absence. The `embed/3` callback
+  at `lib/tau/memory/embedding_worker.ex:49–71` is the existing dispatch
+  mechanism; invoking it from the sweeper reuses an established path.
+- **Warrant (W):** A supervised process with a periodic `send_after` loop
+  provides a wall-clock upper bound on re-submission latency equal to the
+  configured interval. This is sufficient to satisfy "within a bounded time
+  window" as stated in the acceptance criterion.
+- **Qualifier (Q):** The bound holds absent runaway store-mailbox congestion or
+  OOM conditions that would prevent the sweeper from sending its `:sweep`
+  message. At expected row counts (thousands) this is not a realistic constraint.
+- **Rebuttal (R):** If the store GenServer's mailbox is saturated by write load,
+  `list_retriable/1` blocks inside the mailbox queue and the sweep fires later
+  than the nominal interval. The time bound is probabilistic, not hard-real-time.
+  The problem statement does not require hard-real-time, so this does not
+  falsify the claim.
+- **Backing (B):** Problem.md acceptance criterion; OTP non-negotiable #1
+  (`.claude/rules/otp-non-negotiables.md`): "Stateful subsystems MUST run as
+  supervised processes." SPEC-MEMORY-STORE.md §3 C-004, §6 D-046.
+
+#### Falsification attempt for claim 1
+
+- **Strategy:** Edge-case enumeration — enumerate failure modes that would leave
+  an entry permanently unreachable despite the sweeper running.
+- **Attempt:** (a) Entry in `"pending"` with active in-flight Task: sweeper
+  dispatches a second `embed/3`; addressed in Open Question 1. (b) Store crash
+  before sweep completes: sweeper survives independently under `:one_for_one`;
+  next sweep fires after restart. (c) Sweeper crashes: restarted by supervisor;
+  next sweep fires after restart interval. (d) Entry permanently stuck as
+  `"terminal"`: the solution explicitly excludes terminal entries from
+  `list_retriable/1` filter, so this is correct non-retry. (e) Write-idle
+  system: the timer fires regardless of write activity; no open-ended bound.
+- **Outcome:** Withstood — no enumerated case leaves a retriable entry
+  permanently unreachable.
+- **Action:** None.
+
+---
+
+### Claim 2: The GenServer is the correct OTP primitive (not a bare timer or inlined into the store)
+
+- **Claim (C):** "`Tau.Memory.RetrySweeper`, a new `GenServer` child under
+  `Tau.Memory.Supervisor`, whose sole responsibility is periodically querying
+  the DB for `"pending"` and `"failed"`/transient rows and re-dispatching
+  `embedder.embed/3`."
+- **Grounds (G):** Solution.md §Selected from — Proposal 2 rejected because
+  "A sweep bug can stall or crash the store; there is no process isolation."
+  Proposal 3 rejected for open-ended time bound in write-idle case. The solution
+  description explicitly names a separate supervised GenServer. OTP
+  non-negotiable #3 states "No GenServer wrapping stateless logic" — the sweeper
+  has stateful periodic-timer logic (the `:sweep` message cycle), satisfying the
+  non-negotiable's carve-out.
+- **Warrant (W):** Separating the retry concern into its own supervised process
+  follows OTP non-negotiable #1 (stateful subsystems as supervised processes)
+  and gives crash isolation: a bug in sweep logic cannot stall the store's
+  mailbox.
+- **Qualifier (Q):** Provided the interval configuration is thread-local to the
+  sweeper's state (not shared `Application.put_env`); if the interval is written
+  via `Application.put_env` at runtime it would violate non-negotiable #1's
+  spirit, but the solution specifies reading it in `init/1` — this is standard
+  practice and acceptable.
+- **Rebuttal (R):** OTP non-negotiable #3 warns against GenServers wrapping
+  stateless logic. If `list_retriable/1` + dispatch were purely functional and
+  idempotent, a `GenServer` wrapper would be marginal. However, the timer-loop
+  state (the `after` reference, the interval, the last-run metadata) is
+  inherently stateful, so the non-negotiable is not violated.
+- **Backing (B):** `.claude/rules/otp-non-negotiables.md` §1 and §3.
+  Solution.md scoring table (Proposal 2 disqualification rationale).
+
+#### Falsification attempt for claim 2
+
+- **Strategy:** Dependency check — verify that `Tau.Memory.Supervisor` uses
+  `:one_for_one`, so adding a child does not change the restart semantics of
+  existing children.
+- **Attempt:** `lib/tau/memory/supervisor.ex:32` — `Supervisor.init(children,
+  strategy: :one_for_one)`. Adding `RetrySweeper` as a sibling does not affect
+  the restart policy of `Store.SQLite`.
+- **Outcome:** Withstood — `:one_for_one` is confirmed; the claim about
+  independent failure is accurate.
+- **Action:** None.
+
+---
+
+### Claim 3: `list_retriable/1` is additive-only and does not modify existing store callbacks
+
+- **Claim (C):** "`Tau.Memory.Store.SQLite` — no changes to existing callbacks
+  or the write/embedding path; `list_retriable/1` is additive only."
+- **Grounds (G):** The proposed store addition is a new `handle_call(:list_retriable, ...)`
+  clause and a public `list_retriable/1` function. The existing `handle_call`
+  clauses at `lib/tau/memory/store/sqlite.ex:190–289` are not touched. No
+  change to `do_write/2`, `do_mark_embedding_failed/3`, `do_store_embedding/3`,
+  or `handle_continue/2`.
+- **Warrant (W):** Adding a new `handle_call` pattern to a GenServer does not
+  change the semantics of existing patterns; Elixir/Erlang pattern-match
+  dispatch is order-sensitive but the new clause matches a new atom `:list_retriable`
+  that has no existing handler, eliminating any shadowing risk.
+- **Qualifier (Q):** Absent a pre-existing `handle_call(:list_retriable, ...)` clause
+  (confirmed absent in the current file), this is non-invasive.
+- **Rebuttal (R):** If a future PR adds a wildcard `handle_call` catch-all
+  before the new clause, the new clause would be shadowed. This is a future
+  authoring risk, not a current one.
+- **Backing (B):** `lib/tau/memory/store/sqlite.ex:190–289` (no existing
+  `:list_retriable` clause). SPEC-MEMORY-STORE.md Appendix B source map
+  (identifies `store/sqlite.ex` as in-scope; additive changes are compatible
+  with C-001, C-002).
+
+#### Falsification attempt for claim 3
+
+- **Strategy:** Counter-example construction — attempt to find a path where
+  adding `list_retriable/1` changes an existing callback's observable behaviour.
+- **Attempt:** The new clause matches `{:list_retriable, opts}`. No existing
+  clause matches this tuple (confirmed by scanning lines 190–289). The SQL query
+  inside the new handler is a SELECT; it holds no write lock (SQLite WAL allows
+  concurrent reads). The mailbox serialisation still applies, so high-frequency
+  sweep calls compete with writes — but this is a performance concern, not a
+  correctness change to existing callbacks.
+- **Outcome:** Withstood — no counter-example found.
+- **Action:** None.
+
+---
+
+### Claim 4: `do_store_embedding` is idempotent, making duplicate-embedding races safe
+
+- **Claim (C):** "The store's `do_store_embedding` is claimed to be idempotent
+  (DELETE + INSERT in a transaction) — this should be verified in the
+  implementation PR."
+- **Grounds (G):** `lib/tau/memory/store/sqlite.ex:543–576` — `do_store_embedding/3`
+  executes `BEGIN`, `DELETE FROM memory_vec WHERE entry_id = ?1`,
+  `INSERT INTO memory_vec(entry_id, embedding) VALUES (...)`, `COMMIT`, then
+  `update_embedding_status(db, entry_id, "ready")`. The DELETE is unconditional;
+  the INSERT follows. This implements DELETE-then-INSERT inside a transaction.
+- **Warrant (W):** DELETE-then-INSERT is idempotent for the `memory_vec` row.
+  However, idempotency of the overall operation requires that the final
+  `embedding_status` is deterministic regardless of call order. Two concurrent
+  calls complete independently; the second call's `update_embedding_status` to
+  `"ready"` overwrites the first's — both calls produce `"ready"` — so the
+  status outcome is idempotent.
+- **Qualifier (Q):** *Narrowed (partial falsification below):* Idempotency holds
+  for the `embedding_status` and `memory_vec` row **when both embed calls
+  succeed**. When one call succeeds and a subsequent sweep dispatches a second
+  call for the same entry — which is now `"ready"` — `list_retriable/1` MUST
+  exclude `"ready"` entries or the second embed call is a wasted round-trip (not
+  a correctness failure, since the status will be set to `"ready"` again).
+- **Rebuttal (R):** If `list_retriable/1` queries entries that have transitioned
+  to `"ready"` between the query and the dispatch (TOCTOU on the status column),
+  an extra `embed/3` call fires. This is a wasted network call but does not
+  corrupt the store — the final status converges to `"ready"`.
+- **Backing (B):** `lib/tau/memory/store/sqlite.ex:543–576`. SQLite
+  transaction semantics (serialized writes through the GenServer mailbox, per
+  D-045). SPEC-MEMORY-STORE.md §6 D-045.
+
+#### Falsification attempt for claim 4
+
+- **Strategy:** Edge-case enumeration — enumerate the TOCTOU window between
+  `list_retriable/1` returning an entry and `embed/3` completing.
+- **Attempt:** Scenario A: Entry is `"pending"` when `list_retriable/1` runs.
+  Before the sweeper dispatches `embed/3`, the original write-triggered embed
+  call completes and sets status to `"ready"`. The sweeper now dispatches a
+  second `embed/3`. Both calls complete successfully; `memory_vec` ends with the
+  second call's vector; status is `"ready"`. No data corruption — but two
+  embedding API calls are made for one entry.
+
+  Scenario B: Entry is `"pending"`. Sweeper dispatches second `embed/3`. Both
+  embed calls are in flight concurrently. The first completes (`BEGIN` / DELETE
+  / INSERT / COMMIT / `update_embedding_status`). The second then runs its
+  `BEGIN` — it will delete the first's vector row and insert a new one. Both
+  complete; status `"ready"`; `memory_vec` row reflects whichever INSERT ran
+  last. No corruption; extra API cost.
+
+  Scenario C: `list_retriable/1` returns a `"failed"` / transient row. The
+  sweeper dispatches `embed/3`. Before the task completes, another write to the
+  same entry calls `delete/1`, removing it. `do_store_embedding` then tries to
+  `UPDATE memory_entries SET embedding_status = 'ready' WHERE id = ?` — the row
+  is gone, so `update_embedding_status` runs but affects 0 rows (no error
+  surfaced, since the UPDATE returns `:done` regardless of rows affected). The
+  `memory_vec` INSERT references a deleted `entry_id` — the FK constraint (if
+  any) would reject it, but the schema in Appendix A does not declare a FK from
+  `memory_vec` to `memory_entries`. A dangling vector row could exist. This is a
+  narrow edge case (delete during active retry) and is a pre-existing risk in
+  the write path, not introduced by the sweeper.
+
+- **Outcome:** Partially falsified — the claim that idempotency makes
+  duplicate-embedding races "safe" is too broad. In Scenario C (delete during
+  retry), a dangling `memory_vec` row can result. The qualifier is narrowed: the
+  DELETE + INSERT pattern is idempotent **absent concurrent deletion of the
+  entry**. The solution's "should be verified in the implementation PR" language
+  already acknowledges uncertainty; narrowing the qualifier is appropriate rather
+  than triggering a solution revision.
+- **Action:** Narrow qualifier (done above). Note as outstanding doubt for
+  parent-level validator.
+
+---
+
+### Claim 5: `Tau.Memory.Embedder.embed/3` requires no new callbacks; the sweeper calls it as-is
+
+- **Claim (C):** "`Tau.Memory.Embedder` behaviour — no new callbacks; `embed/3`
+  is called exactly as it is today."
+- **Grounds (G):** `lib/tau/memory/embedder.ex:37` — the behaviour defines a
+  single callback `@callback embed(store, entry_id, content)`. The sweeper
+  retrieves `content` from the store via `list_retriable/1` (new query) and
+  passes it to `embed/3` with the same three-argument signature.
+  `lib/tau/memory/embedding_worker.ex:49` implements this callback
+  identically for all callers.
+- **Warrant (W):** A behaviour with a stable three-argument callback can be
+  invoked by any caller who can supply the three arguments. The sweeper supplies
+  (store_pid, entry_id, content) just as `handle_continue/2` does at
+  `lib/tau/memory/store/sqlite.ex:305–313`. No new dispatch surface is needed.
+- **Qualifier (Q):** The sweeper must retrieve `content` from the store as part
+  of `list_retriable/1`'s return payload. If the new query omits `content` from
+  its column list, the sweeper cannot call `embed/3` without an additional
+  round-trip. The solution does not specify the SQL column list for
+  `list_retriable/1`; the implementation PR must include `content` in the SELECT.
+- **Rebuttal (R):** If `list_retriable/1` returns only `(id, embedding_status,
+  metadata)` without `content`, the sweeper cannot reconstruct the `embed/3`
+  call without a follow-up `SELECT content FROM memory_entries WHERE id = ?1` —
+  adding mailbox contention and complexity. This is an implementation detail not
+  in scope for the solution; the solution is correct in principle.
+- **Backing (B):** `lib/tau/memory/embedder.ex:37`. `lib/tau/memory/store/sqlite.ex:305–313`
+  (existing embed dispatch pattern). `lib/tau/memory/embedding_worker.ex:49`.
+
+#### Falsification attempt for claim 5
+
+- **Strategy:** Integration check — verify that the call site shape used by
+  `handle_continue/2` is reproducible by the sweeper without a behaviour change.
+- **Attempt:** `handle_continue({:dispatch_embedding, id, content}, state)` at
+  line 305 passes `(server, id, content)` to `embedder.embed/3`. The sweeper
+  needs the same three values. `list_retriable/1` can return rows with `id` and
+  `content` included (the `memory_entries` table has `content` as a NOT NULL
+  column). The sweep therefore has all three arguments available from a single
+  query result without behaviour changes.
+- **Outcome:** Withstood — no integration gap found, given `list_retriable/1`
+  returns `content`.
+- **Action:** None. Implementation PR must include `content` in the SQL SELECT.
+
+---
+
+### Claim 6: The supervision strategy stays `:one_for_one`; sweeper and store fail independently
+
+- **Claim (C):** "The supervision strategy stays `:one_for_one`; sweeper and
+  store fail independently."
+- **Grounds (G):** `lib/tau/memory/supervisor.ex:32`: `Supervisor.init(children,
+  strategy: :one_for_one)`. The solution explicitly states "add
+  `{Tau.Memory.RetrySweeper, opts}` as a `:one_for_one` sibling after
+  `Store.SQLite`" — no strategy change required.
+- **Warrant (W):** Under `:one_for_one`, a child crash restarts only that child.
+  A sweeper crash (e.g. bug in sweep logic) does not restart `Store.SQLite`.
+  A store crash does not restart the sweeper (though the sweeper's next
+  `list_retriable/1` call will block until the store restarts, then succeed or
+  return an error that the sweeper must handle gracefully).
+- **Qualifier (Q):** The sweeper's `list_retriable/1` call will return an error
+  or block during a store restart. The sweeper must handle `{:error, reason}`
+  from `GenServer.call` (including `:noproc` / `:timeout`) gracefully — logging
+  and rescheduling — otherwise the sweeper itself crashes on the store's
+  transient restart, converting one crash into two. The solution does not
+  explicitly specify error handling in the sweep loop; the implementation PR must
+  address this.
+- **Rebuttal (R):** If the sweeper does not guard against store unavailability,
+  a store restart triggers a sweeper crash, and under `:one_for_one` both
+  restart independently — the claimed independence still holds structurally, but
+  the effective restart rate doubles. This is a design detail, not a falsification
+  of independence.
+- **Backing (B):** `lib/tau/memory/supervisor.ex:32`. OTP non-negotiable #7
+  (`.claude/rules/otp-non-negotiables.md`): "Let it crash; supervise; restart."
+  `:one_for_one` semantics (OTP Supervisor documentation).
+
+#### Falsification attempt for claim 6
+
+- **Strategy:** Counter-example construction — construct a scenario where adding
+  `RetrySweeper` under `:one_for_one` changes the existing restart behaviour of
+  `Store.SQLite`.
+- **Attempt:** Under `:one_for_one`, each child is independent. The only way
+  adding a sibling changes an existing child's restart behaviour is if the
+  supervisor's `max_restarts` / `max_seconds` threshold is tripped — if the
+  sweeper crashes frequently, the supervisor itself terminates, taking
+  `Store.SQLite` with it. This is a cascade via the supervisor's intensity
+  threshold, not via the child relationship. It is a known `:one_for_one`
+  property and not a property of this specific design.
+- **Outcome:** Withstood — the structural claim is accurate. The intensity-
+  threshold cascade is a general OTP property acknowledged by "let it crash;
+  supervise; restart" and is not a novel risk introduced by this design.
+- **Action:** None.
+
+---
+
+## Cross-claim consistency
+
+Claims 1–6 are mutually consistent:
+
+- Claims 1 and 2 are complementary: Claim 2 argues for the correct primitive
+  (GenServer); Claim 1 argues the design satisfies the acceptance criterion.
+- Claim 3 (additive store change) and Claim 5 (no new embedder callbacks) align
+  on the "minimal surface" design principle; neither contradicts the other.
+- Claim 4's narrowed qualifier (idempotency absent concurrent deletion) is
+  consistent with Claim 6's independent-failure assurance: a sweeper dispatch
+  racing a delete is an application-level concern, not a supervision concern.
+- Claim 6's sweeper-must-handle-store-unavailability qualifier is an
+  implementation-detail gap, not a tension with other claims.
+
+No cross-claim tension identified.
+
+---
+
+## Falsification summary
+
+| # | Claim (short) | Strategy | Outcome | Action |
+|---|---|---|---|---|
+| 1 | Sweeper satisfies bounded-time re-submission AC | Edge-case enumeration | Withstood | None |
+| 2 | GenServer is correct OTP primitive; not inlined | Dependency check | Withstood | None |
+| 3 | `list_retriable/1` is additive; no existing callback change | Counter-example construction | Withstood | None |
+| 4 | `do_store_embedding` idempotency makes races safe | Edge-case enumeration | Partially falsified | Qualifier narrowed: safe absent concurrent entry deletion |
+| 5 | `embed/3` called as-is; no new behaviour callbacks | Integration check | Withstood | Impl PR must include `content` in `list_retriable/1` SELECT |
+| 6 | Supervision stays `:one_for_one`; independent failure | Counter-example construction | Withstood | None |
+
+---
+
+## Revision required
+
+No revision is required. Claim 4's partial falsification is addressed by
+narrowing the qualifier in place. The solution remains correct and
+appropriately scoped.
+
+---
+
+## Outstanding doubts
+
+1. **Dangling `memory_vec` row on concurrent delete-during-retry (Claim 4,
+   Scenario C).** The schema at SPEC-MEMORY-STORE.md Appendix A does not declare
+   a FK constraint from `memory_vec(entry_id)` to `memory_entries(id)`. A sweep
+   that races a delete can leave a vector row referencing a deleted entry. This
+   is pre-existing structural debt, not introduced by the sweeper, but the sweeper
+   makes the race reachable in production for the first time. The implementation
+   PR should either add an ON DELETE CASCADE FK on `memory_vec.entry_id`, or
+   ensure `list_retriable/1` is called within a short enough window that an
+   in-progress delete makes the entry disappear from the result set.
+
+2. **Sweeper error handling on store unavailability (Claim 6).** The solution
+   does not specify how the sweeper handles `GenServer.call` errors (`:noproc`,
+   `:timeout`) when the store is mid-restart. The implementation PR must
+   explicitly handle these to prevent the sweeper from crashing on the store's
+   transient restart interval.
+
+3. **`list_retriable/1` column set not specified.** The solution describes the
+   API ("returning retriable entries") without specifying the return shape. The
+   implementation PR must return at minimum `(id, content)` for the sweeper to
+   reconstruct the `embed/3` call without a second query.
+
+4. **Startup latency (solution's Open Question 3).** The solution notes that
+   the first sweep fires after one full interval (default 60 s). Entries stuck
+   before the last restart will wait up to 60 s. This is flagged but deferred;
+   a `{:continue, :startup_sweep}` in `init/1` is trivially addable in the
+   implementation PR without altering the solution's design.

--- a/docs/problems-archive-v1-modules/tau-memory/subproblems/silent-failure-propagation/problem.md
+++ b/docs/problems-archive-v1-modules/tau-memory/subproblems/silent-failure-propagation/problem.md
@@ -1,0 +1,53 @@
+---
+template_version: 1
+template_name: problem
+node_kind: leaf
+depth: 1
+parent: ../../problem.md
+status: draft
+---
+
+# Problem: Task crash before store-embedding callback leaves entry permanently "pending"
+
+## Statement
+
+When the embedding Task spawned by `Store.SQLite.handle_continue/2` crashes
+(e.g. because Finch raises `:noproc`), it exits without ever calling
+`Store.SQLite.store_embedding/3`. The `handle_info/2` clause in `Store.SQLite`
+silently discards the `{:DOWN, ...}` message. The entry's `embedding_status`
+therefore remains `"pending"` indefinitely — it never transitions to `"failed"`,
+so the D-046 invariant (`"failed"` carries the error kind) is never applied, and
+the entry is excluded from `semantic_search/2` forever with no actionable signal.
+
+## Context
+
+- `lib/tau/memory/store/sqlite.ex:296-302` — `handle_info/2` for `{ref, _result}` and `{:DOWN, ...}` both `{:noreply, state}` silently; no callback to `store_embedding` and no status update.
+- `lib/tau/memory/store/sqlite.ex:305-313` — `handle_continue({:dispatch_embedding, id, content}, state)` spawns via `Task.Supervisor.async_nolink`; does not store the task ref associated with `id`.
+- `lib/tau/memory/embedding_worker.ex:49-71` — the `embed/3` Task body calls `MemoryStore.store_embedding/3` only on normal exit; an exception or `:noproc` before that call means the callback never fires.
+- D-046 (`SPEC-MEMORY-STORE.md`) — requires `embedding_status` to be `"pending" | "ready" | "failed"` with `"failed"` carrying the error kind. The stuck-`"pending"` state violates the spirit of this invariant.
+
+## Complecting hypothesis
+
+- Task identity is complected with the entry it was dispatched for: the store holds no `(ref → entry_id)` mapping, so it cannot act on a `{:DOWN, ...}` message to update the entry's status.
+- The "task completed normally" path and the "task crashed" path are complected in the same silent `handle_info/2` discard clause, erasing the distinction between a completed callback and a lost callback.
+
+## Decomposition strategy
+
+(leaf — no further decomposition; proceed to proposals)
+
+## Acceptance criterion
+
+When the embedding Task exits abnormally (crash, exception, or process-not-found)
+before calling `store_embedding/3`, the corresponding memory entry transitions
+to `embedding_status: "failed"` with kind `:transient` within the task's
+monitored lifetime — satisfying D-046.
+
+## Out of scope
+
+- The root-cause Finch name mismatch that triggers the crash (covered by `finch-name-mismatch`).
+- Observability of aged `"pending"` entries that predate this fix (covered by `pending-rot-observability`).
+- Re-enqueuing already-stuck entries (covered by `retry-recovery-path`).
+
+## Amendment log
+
+- (none yet)

--- a/docs/problems-archive-v1-modules/tau-memory/subproblems/silent-failure-propagation/proposals/proposal-1.md
+++ b/docs/problems-archive-v1-modules/tau-memory/subproblems/silent-failure-propagation/proposals/proposal-1.md
@@ -1,0 +1,140 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 1
+parent_problem: ../problem.md
+---
+
+# Proposal 1: Ref-to-ID Map in GenServer State
+
+## Approach
+
+Extend the `Store.SQLite` GenServer state with a `%{reference() => String.t()}` map that
+records the task `ref → entry_id` association at dispatch time. The `handle_continue/2`
+clause stores the ref returned by `Task.Supervisor.async_nolink/2`. The `{:DOWN, ref, ...}`
+clause looks up the entry ID and calls `do_mark_embedding_failed/3` with `:transient`
+if the reason is not `:normal`. The `{ref, result}` (success) clause demonitors and
+removes the entry from the map; it does not change status because the callback already
+handled that via `store_embedding/3`.
+
+## Rationale
+
+The complecting hypothesis names exactly this missing mapping as the root structural gap:
+"the store holds no `(ref → entry_id)` mapping, so it cannot act on a `{:DOWN, ...}` message."
+This proposal decomplects task identity from entry identity by making the association
+explicit in state. The "task crashed" path gains its own `handle_info/2` clause body
+instead of sharing the silent discard with the "task result delivered" path, resolving the
+second complect. The change is minimal and entirely within `Store.SQLite`; no interface
+changes and no new processes.
+
+## Sketch
+
+```elixir
+# State type extended:
+@type state :: %{db: reference(), pending_tasks: %{reference() => String.t()}}
+
+# init/1 initialisation (add field):
+{:ok, %{db: db, pending_tasks: %{}}}
+
+# handle_continue — store ref:
+def handle_continue({:dispatch_embedding, id, content}, state) do
+  embedder = Application.get_env(:tau, :embedder, Tau.Memory.EmbeddingWorker)
+  server = self()
+
+  task =
+    Task.Supervisor.async_nolink(Tau.Tools.TaskSupervisor, fn ->
+      embedder.embed(server, id, content)
+    end)
+
+  {:noreply, put_in(state, [:pending_tasks, task.ref], id)}
+end
+
+# handle_info — success path (remove from map, demonitor):
+def handle_info({ref, _result}, state) when is_reference(ref) do
+  Process.demonitor(ref, [:flush])
+  {:noreply, update_in(state, [:pending_tasks], &Map.delete(&1, ref))}
+end
+
+# handle_info — crash path (look up id, mark failed):
+def handle_info({:DOWN, ref, :process, _pid, reason}, %{db: db, pending_tasks: pt} = state) do
+  state =
+    case Map.fetch(pt, ref) do
+      {:ok, entry_id} when reason != :normal ->
+        do_mark_embedding_failed(db, entry_id, :transient)
+        update_in(state, [:pending_tasks], &Map.delete(&1, ref))
+
+      {:ok, entry_id} ->
+        # :normal exit — callback already fired via store_embedding/3; just clean up
+        update_in(state, [:pending_tasks], &Map.delete(&1, ref))
+
+      :error ->
+        # ref not ours (shouldn't happen with async_nolink, but safe)
+        state
+    end
+
+  {:noreply, state}
+end
+```
+
+No change to `EmbeddingWorker`. No change to public API. The `do_mark_embedding_failed/3`
+function already exists at line 286 and handles the DB write; this proposal simply calls
+it from the crash path.
+
+## Tradeoffs
+
+### Strengths
+
+- Minimal: the map adds ~20 bytes per in-flight task; the change is entirely internal to
+  the GenServer with no API surface impact.
+- Directly addresses both complects named in the problem statement.
+- `do_mark_embedding_failed/3` is already implemented and tested; no new DB logic.
+- Behaviour-preserving on the success path; only the crash path changes observable state.
+- The state is bounded: a Task crash removes its entry; no leak.
+
+### Weaknesses
+
+- The map is in-process heap; if the GenServer itself crashes while tasks are in-flight,
+  the map is lost and entries revert to stuck-`"pending"`. (This is a separate survivability
+  concern beyond the problem's acceptance criterion, but it is a real gap.)
+- If the embedder's `embed/3` spawns its OWN inner Task (as `EmbeddingWorker.embed/3`
+  currently does at line 51 of `embedding_worker.ex`), the outer Task ref tracked here
+  will see a `:normal` exit when the inner Task finishes, even if the inner Task crashed.
+  The outermost Task body then succeeds without calling `store_embedding/3` — the ref map
+  sees `:normal` and removes cleanly but the entry is still `"pending"`. This means the
+  proposal is only correct when the embedder's Task body crashes before the inner spawn,
+  not if it crashes inside the inner body. The `EmbeddingWorker` double-spawn layering
+  must be audited before this proposal is safe.
+- The `handle_info` for `{ref, result}` currently discards `_result` even on the success
+  path. If a future embedder returns an error in `result` rather than calling back, this
+  clause silently drops it — a latent gap this proposal does not address.
+
+### Costs
+
+- 1 state field added; `init/1` and 3 `handle_info`/`handle_continue` clauses touched.
+- No migration. No API change. No dependency change.
+- Test surface: the crash path via `{:DOWN, ...}` requires a test that kills a task ref
+  and asserts the DB row transitions to `"failed"`. Estimated 1 new test case.
+
+## Dependencies
+
+- Verify `EmbeddingWorker.embed/3`'s inner-Task layering: if the outer Task body catches
+  the inner crash and calls `store_embedding/3` with `{:error, :transient, ...}`, the
+  callback fires normally and no `{:DOWN, abnormal}` message reaches the GenServer. In
+  that case this proposal is a safety net that is never triggered — which is fine. If the
+  outer body can crash before calling back, this proposal is the only guard.
+- No other modules need to change.
+
+## Confidence
+
+Medium. The mapping logic is straightforward and the existing `do_mark_embedding_failed/3`
+is reused. Confidence would rise to high after: (1) tracing the `EmbeddingWorker` inner-Task
+layering to confirm crash propagation, and (2) a unit test that explicitly kills the Task
+and asserts DB status.
+
+## Prior art / references
+
+- The `Task.Supervisor.async_nolink` + ref-tracking pattern is the idiomatic Elixir
+  solution for tracking fire-and-forget tasks: Elixir docs §"Task.Supervisor.async_nolink".
+- `GenServer` state map for ref tracking: used in `Tau.CircuitBreaker.Store` (`lib/tau/circuit_breaker/store.ex`) to manage monitored owner refs.
+- The `do_mark_embedding_failed/3` call already present at `sqlite.ex:286` (called from
+  `handle_call` success path) is direct prior art for the write operation.

--- a/docs/problems-archive-v1-modules/tau-memory/subproblems/silent-failure-propagation/proposals/proposal-2.md
+++ b/docs/problems-archive-v1-modules/tau-memory/subproblems/silent-failure-propagation/proposals/proposal-2.md
@@ -1,0 +1,131 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 2
+parent_problem: ../problem.md
+---
+
+# Proposal 2: Wrap Embedder Dispatch in a Linked Task with After-Rescue Callback
+
+## Approach
+
+Change the `embedder.embed/3` contract so that the embedder is responsible for
+guaranteeing a callback under all exit conditions. Concretely: replace
+`Task.Supervisor.async_nolink` in `handle_continue/2` with a `Task.Supervisor.start_child`
+(fire-and-forget, linked to the supervisor, not the GenServer) whose body wraps
+`embedder.embed/3` in a `try/rescue/catch` that calls `MemoryStore.store_embedding/3` with
+`{:error, :transient, exception_reason}` on any exception or exit. The `handle_info`
+clauses for `{ref, ...}` and `{:DOWN, ...}` remain simple discards. No ref map in GenServer
+state. The callback guarantee is pushed into the caller site of `embed/3`, not the
+GenServer's message handler.
+
+## Rationale
+
+This proposal decomplects the problem differently from Proposal 1: instead of adding
+observability to the crash path in the GenServer, it eliminates the crash-without-callback
+case by making the wrapper unconditionally deliver a result. The two complects are
+resolved by (a) making the wrapper the identity link between task and entry ID (the
+wrapper's closure holds `entry_id`), and (b) ensuring the "task crashed" and "task
+succeeded" paths both terminate by calling `store_embedding/3`. The GenServer's
+`handle_info` for `:DOWN` truly becomes a no-op because no crash escapes the wrapper
+without first calling back. The `Store.SQLite` GenServer retains no task-identity state,
+keeping its state shape simple.
+
+## Sketch
+
+```elixir
+# In Store.SQLite.handle_continue/2 — replace async_nolink with a wrapped child:
+def handle_continue({:dispatch_embedding, id, content}, state) do
+  embedder = Application.get_env(:tau, :embedder, Tau.Memory.EmbeddingWorker)
+  server = self()
+
+  Task.Supervisor.start_child(Tau.Tools.TaskSupervisor, fn ->
+    try do
+      embedder.embed(server, id, content)
+    rescue
+      e ->
+        MemoryStore.store_embedding(server, id, {:error, :transient, Exception.message(e)})
+    catch
+      :exit, reason ->
+        MemoryStore.store_embedding(server, id, {:error, :transient, {:exit, reason}})
+    end
+  end)
+
+  {:noreply, state}
+end
+
+# handle_info clauses remain exactly as they are (silent discards).
+# No state field added.
+```
+
+`EmbeddingWorker.embed/3` is unchanged. The wrapper is the "outer" task that the GenServer
+dispatches; it already holds `entry_id` in its closure, giving the mapping without a
+map in state.
+
+The `MemoryStore.store_embedding/3` call in the rescue/catch block is the same call that
+the normal success path makes, routed through `handle_call({:store_embedding, ...})` which
+calls `do_mark_embedding_failed/3` for error tuples.
+
+## Tradeoffs
+
+### Strengths
+
+- The GenServer state remains `%{db: reference()}` with no added fields — simpler state.
+- Unconditional callback guarantee: even a BEAM-level exit (`exit(:kill)`) from outside
+  the task will not be caught by `rescue/catch`, but a `:noproc` error (the actual failure
+  mode) raises a regular exception and IS caught.
+- No ref-map bookkeeping; the closure already binds `entry_id`.
+- The `handle_info` clauses require no change — they correctly remain discards because
+  no abnormal `:DOWN` will carry an unhandled entry ID.
+
+### Weaknesses
+
+- Using `try/rescue` across a process boundary is prohibited by OTP non-negotiable rule 7
+  ("MUST NOT `try/rescue` across process boundaries. MUST NOT catch `:exit`"). This
+  proposal violates that rule — the `rescue/catch` block is inside the child Task and
+  calls back into the GenServer (`MemoryStore.store_embedding/3`) across the process
+  boundary. The rule exists precisely to prevent this pattern. Adopting this proposal
+  requires a written justification in the PR or an amendment to the non-negotiable rule.
+- An unconditional `:exit, reason` catch in the child task means that even intentional
+  supervisor shutdown signals are caught and result in a spurious `"failed"` callback to
+  the GenServer. A `when reason != :normal` guard on the catch helps but is not complete
+  (shutdown exits use `:shutdown`, not `:normal`).
+- The double-spawn layering from `EmbeddingWorker.embed/3` (which also uses
+  `Task.Supervisor.async_nolink` internally) means the inner crash may not propagate to
+  the outer wrapper's `try` block — the inner Task's crash is caught by its own supervisor,
+  not propagated as an exception to the outer body. The wrapper only catches crashes in
+  the outer task body itself (i.e., failures before the inner spawn or failures in code
+  path between the outer Task body entry and the inner spawn call).
+- This approach conflates "transient embedding failure" with "any exception inside the
+  wrapper" — including bugs in the embedder code — and marks all of them as
+  `:transient`. A bug-triggered status of `"failed: transient"` implies retryability
+  when the real cause may require a code fix.
+
+### Costs
+
+- 1 `handle_continue` clause changed; 0 new state fields; 0 new clauses.
+- `try/rescue/catch` requires explicit OTP non-negotiable rule exception justification
+  in the PR — a non-trivial gate review item.
+- Test surface: needs a test where `embedder.embed/3` raises and verifies the entry
+  transitions to `"failed"`. Estimated 1 new test case.
+
+## Dependencies
+
+- The OTP non-negotiable rule 7 as written in `otp-non-negotiables.md` must either
+  grant an exception or be amended for this proposal to pass the critic gate.
+- The `EmbeddingWorker.embed/3` double-spawn layering needs to be audited to confirm
+  whether the inner crash reaches the outer `rescue` block.
+
+## Confidence
+
+Low. The OTP non-negotiable rule violation is a hard gate blocker. The double-spawn
+layering issue may mean the safety net does not fire for the primary failure mode. Would
+require rule amendment + layering audit to reach medium.
+
+## Prior art / references
+
+- The rule conflict is documented in `otp-non-negotiables.md` rule 7.
+- The "wrap with rescue for guaranteed delivery" pattern is used in Elixir's `GenStage`
+  dispatcher examples, but specifically avoids cross-process calls inside the rescue block.
+- Elixir `Task.Supervisor.start_child/2` docs: fire-and-forget variant, linked to the
+  supervisor not the caller.

--- a/docs/problems-archive-v1-modules/tau-memory/subproblems/silent-failure-propagation/proposals/proposal-3.md
+++ b/docs/problems-archive-v1-modules/tau-memory/subproblems/silent-failure-propagation/proposals/proposal-3.md
@@ -1,0 +1,181 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 3
+parent_problem: ../problem.md
+---
+
+# Proposal 3: Introduce a `Tau.Memory.EmbeddingTask` Supervised Process per Entry
+
+## Approach
+
+Replace the fire-and-forget `Task.Supervisor.async_nolink` dispatch with a dedicated
+`Tau.Memory.EmbeddingTask` GenServer (or `:gen_statem`) that is started under a
+`DynamicSupervisor` per entry. The `EmbeddingTask` process owns one embedding attempt:
+it holds `{store_pid, entry_id, content}` as its state, performs the embedding call,
+delivers the callback on success, and — on crash or restart — its `terminate/2` callback
+calls `MemoryStore.store_embedding(store, entry_id, {:error, :transient, :task_crashed})`
+before exiting. The `DynamicSupervisor` uses `:temporary` restart strategy so the process
+is not restarted on crash (retry is handled by the separate `retry-recovery-path`
+sub-problem). The `Store.SQLite` GenServer no longer dispatches Tasks directly and holds
+no ref map; it starts a supervised `EmbeddingTask` child instead.
+
+## Rationale
+
+This proposal elevates the task identity concern to the supervision level: each in-flight
+embedding is a named entity in the OTP supervision tree. The `(ref → entry_id)` mapping
+is no longer a map in a GenServer's state — it is the process identity itself. The crash
+path is handled by OTP's built-in `terminate/2` callback, which is called on any exit
+(normal or abnormal), eliminating the "crash without callback" case at the process
+lifecycle level rather than by intercepting messages. This directly satisfies OTP
+non-negotiable rule 1 ("every stateful subsystem is a process under a supervisor") in a
+way the current fire-and-forget pattern does not.
+
+## Sketch
+
+```elixir
+# New file: lib/tau/memory/embedding_task.ex
+
+defmodule Tau.Memory.EmbeddingTask do
+  @moduledoc """
+  A `:temporary` supervised process that owns one embedding attempt.
+
+  On normal completion it calls `MemoryStore.store_embedding/3` with the result.
+  On abnormal exit `terminate/2` is called by the runtime; we use it to mark the
+  entry `"failed"` so the entry never remains stuck `"pending"`.
+  """
+  use GenServer, restart: :temporary
+
+  alias Tau.Memory.MemoryStore
+
+  def start_link({store, entry_id, content, embedder}) do
+    GenServer.start_link(__MODULE__, {store, entry_id, content, embedder})
+  end
+
+  @impl GenServer
+  def init({store, entry_id, content, embedder}) do
+    # Use handle_continue so init/1 returns fast, keeping the supervisor unblocked.
+    {:ok, %{store: store, entry_id: entry_id, content: content, embedder: embedder},
+     {:continue, :embed}}
+  end
+
+  @impl GenServer
+  def handle_continue(:embed, %{store: store, entry_id: id, content: c, embedder: e} = state) do
+    result = e.embed_sync(c)        # synchronous variant — see note below
+    MemoryStore.store_embedding(store, id, result)
+    {:stop, :normal, state}
+  end
+
+  @impl GenServer
+  def terminate(reason, %{store: store, entry_id: id})
+      when reason not in [:normal, :shutdown] do
+    MemoryStore.store_embedding(store, id, {:error, :transient, {:task_crashed, reason}})
+  end
+
+  def terminate(_reason, _state), do: :ok
+end
+```
+
+```elixir
+# New file: lib/tau/memory/embedding_supervisor.ex
+
+defmodule Tau.Memory.EmbeddingSupervisor do
+  use DynamicSupervisor
+
+  def start_link(opts), do: DynamicSupervisor.start_link(__MODULE__, opts, name: __MODULE__)
+
+  @impl DynamicSupervisor
+  def init(_opts), do: DynamicSupervisor.init(strategy: :one_for_one)
+
+  def dispatch(store, entry_id, content, embedder) do
+    DynamicSupervisor.start_child(__MODULE__,
+      {EmbeddingTask, {store, entry_id, content, embedder}})
+  end
+end
+```
+
+```elixir
+# Store.SQLite.handle_continue/2 updated:
+def handle_continue({:dispatch_embedding, id, content}, state) do
+  embedder = Application.get_env(:tau, :embedder, Tau.Memory.EmbeddingWorker)
+  Tau.Memory.EmbeddingSupervisor.dispatch(self(), id, content, embedder)
+  {:noreply, state}
+end
+```
+
+`EmbeddingSupervisor` is added to `Tau.Memory.Supervisor`'s child list before `Store.SQLite`.
+
+**Note on `embed_sync/1`**: The current `EmbeddingWorker.embed/3` is designed as a
+fire-and-forget Task launcher; this proposal needs a synchronous variant. The embedder
+behaviour gains an `embed_sync/1` callback returning `{:ok, embedding}` or
+`{:error, kind, reason}`. `EmbeddingWorker` implements it. The existing `embed/3` can be
+deprecated or wrapped to call `embed_sync`.
+
+## Tradeoffs
+
+### Strengths
+
+- Fully OTP-idiomatic: each in-flight embedding is a supervised process. Crash recovery
+  semantics are defined at the supervision level, not via message interception.
+- `terminate/2` is called by the runtime on abnormal exits; this is the OTP-sanctioned
+  place for "cleanup on crash" logic, avoiding `try/rescue`.
+- No ref-map in GenServer state; no complex `handle_info` matching.
+- Introspectable: `DynamicSupervisor.which_children/1` lists all in-flight embeddings.
+- Satisfies OTP non-negotiables 1 and 7 simultaneously.
+- The `EmbeddingTask` process can be extended later to support retry (sub-problem 4)
+  without changing `Store.SQLite`.
+
+### Weaknesses
+
+- `terminate/2` is called by the runtime only if the process was started with
+  `trap_exit: true` OR if the process is terminating normally. For an abnormal exit
+  (e.g., killed by a linked process), `terminate/2` is NOT guaranteed to be called
+  unless `Process.flag(:trap_exit, true)` is set in `init/1`. Without that flag,
+  a hard kill skips `terminate/2` — the same stuck-`"pending"` scenario survives.
+  Adding `trap_exit` changes the process's exit semantics and must be explicit.
+- Requires a new `embed_sync/1` behaviour callback — an API-breaking change to
+  `Tau.Memory.Embedder`. All embedder implementations (including test doubles) must
+  be updated.
+- A new supervised process per entry adds BEAM process overhead. Under high write
+  throughput this is `O(concurrent embeddings)` extra processes. Normally bounded and
+  cheap, but a potential concern at extreme load.
+- Adds two new files and a supervision tree entry: higher structural complexity than
+  Proposals 1 or 2 for the same acceptance criterion.
+- The `DynamicSupervisor` entry in `Tau.Memory.Supervisor` must come before
+  `Store.SQLite` to avoid a startup race; ordering matters and is easy to get wrong.
+
+### Costs
+
+- 2 new modules (`EmbeddingTask`, `EmbeddingSupervisor`).
+- `Tau.Memory.Embedder` behaviour gains 1 new callback.
+- `EmbeddingWorker` gains 1 new function.
+- `Tau.Memory.Supervisor` child list updated.
+- `Store.SQLite.handle_continue/2` simplified.
+- Test surface: `EmbeddingTask` needs unit tests for normal exit, crash exit, and
+  the `terminate/2` → store callback path. Estimated 3–5 new test cases.
+
+## Dependencies
+
+- `Tau.Memory.Embedder` behaviour must be amended before any embedder can implement
+  `embed_sync/1`.
+- `Tau.Memory.Supervisor` must be updated to start `EmbeddingSupervisor` before
+  `Store.SQLite`.
+- All test doubles (`MockEmbedder`, etc.) must implement `embed_sync/1`.
+
+## Confidence
+
+Medium. The pattern is OTP-idiomatic but requires the `trap_exit` caveat to be
+resolved and a behaviour API change. Confidence would rise to high after: (1) confirming
+`trap_exit: true` in `init/1` is acceptable and (2) prototyping the `terminate/2`
+path in a test.
+
+## Prior art / references
+
+- `terminate/2` for crash-state cleanup is used in `Tau.Memory.Store.SQLite` itself
+  (lines 317–322) to close the DB connection on exit.
+- `DynamicSupervisor` per-entity child pattern: Elixir docs §"DynamicSupervisor" and
+  José Valim's "Elixir in Action" chapter on dynamic process management.
+- `Process.flag(:trap_exit, true)` requirement for `terminate/2` on abnormal exits:
+  Erlang/OTP documentation §"gen_server:terminate".
+- `Tau.CircuitBreaker.Store` in this project uses a GenServer with `trap_exit` to
+  manage monitored pids and call cleanup on exit.

--- a/docs/problems-archive-v1-modules/tau-memory/subproblems/silent-failure-propagation/proposals/proposal-4.md
+++ b/docs/problems-archive-v1-modules/tau-memory/subproblems/silent-failure-propagation/proposals/proposal-4.md
@@ -1,0 +1,187 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 4
+parent_problem: ../problem.md
+---
+
+# Proposal 4: Redefine the `Tau.Memory.Embedder` Callback to Return a Result Directly
+
+## Approach
+
+Change the `Tau.Memory.Embedder` behaviour so that `embed/3` returns `{:ok, result} |
+{:error, kind, reason}` synchronously (renaming to `embed_result/3` or changing the
+return contract), and move the `store_embedding/3` callback responsibility into
+`Store.SQLite.handle_continue/2` rather than the embedder. The embedder no longer
+calls back into the store; instead `handle_continue/2` awaits the result via
+`Task.Supervisor.async_nolink` + explicit `await_with_timeout`, or better: spawns the
+Task, stores the ref, and handles both `{ref, result}` (success with result value) and
+`{:DOWN, ref, ...}` (crash) in `handle_info` — both paths calling the store-update logic
+directly. The `{ref, result}` clause receives the actual embedding result (not discarded
+as today) and calls `do_store_embedding` or `do_mark_embedding_failed`. The
+`{:DOWN, ...}` clause calls `do_mark_embedding_failed`. This is a data-shape change: the
+embedder's output is a plain value, not a side-effecting callback, eliminating the
+inversion-of-control that currently makes the crash unobservable.
+
+## Rationale
+
+The current design is an inversion-of-control: the Store dispatches a Task, and the Task
+calls back into the Store to write its result. This inversion is the architectural source
+of the complect: the Store has no way to observe "Task crashed before calling back"
+because the callback is the only signal. This proposal eliminates the inversion entirely
+by making the embedder a pure function (async, but with a structured result return) and
+the Store the sole writer. The `(ref → entry_id)` map is still needed (as in Proposal 1),
+but the `{ref, result}` clause now receives the actual result rather than discarding it.
+The crash path (`{:DOWN, ...}`) gains the same ref-map lookup as Proposal 1 but the
+success path no longer relies on a separate GenServer call from the worker — the result
+arrives in the message itself. This removes the inversion-of-control entirely, trading
+the callback API for a structured-return API.
+
+## Sketch
+
+```elixir
+# New Tau.Memory.Embedder behaviour (API-breaking change):
+defmodule Tau.Memory.Embedder do
+  @moduledoc "Behaviour for computing embedding vectors."
+
+  @callback embed_async(String.t()) ::
+    {:ok, Task.t()} |
+    {:error, term()}
+  # embed_async/1 starts a Task whose return value is:
+  #   {:ok, [float()]} | {:error, :transient | :terminal, term()}
+  # The Task result is sent to the calling process as {ref, result}.
+  # The embedder does NOT call store_embedding/3.
+end
+
+# EmbeddingWorker updated:
+@impl Tau.Memory.Embedder
+def embed_async(content) do
+  task =
+    Task.Supervisor.async_nolink(Tau.Tools.TaskSupervisor, fn ->
+      do_embed(content)
+      # Returns {:ok, [float()]} or {:error, kind, reason}
+      # No call to MemoryStore.store_embedding/3
+    end)
+  {:ok, task}
+end
+```
+
+```elixir
+# Store.SQLite state:
+@type state :: %{db: reference(), pending_tasks: %{reference() => String.t()}}
+
+# handle_continue — store ref:
+def handle_continue({:dispatch_embedding, id, content}, state) do
+  embedder = Application.get_env(:tau, :embedder, Tau.Memory.EmbeddingWorker)
+  {:ok, task} = embedder.embed_async(content)
+  {:noreply, put_in(state, [:pending_tasks, task.ref], id)}
+end
+
+# handle_info — success path (result IS the embedding or error):
+def handle_info({ref, embed_result}, %{db: db, pending_tasks: pt} = state)
+    when is_reference(ref) do
+  Process.demonitor(ref, [:flush])
+  state = update_in(state, [:pending_tasks], &Map.delete(&1, ref))
+
+  case Map.fetch(pt, ref) do
+    {:ok, entry_id} ->
+      case embed_result do
+        {:ok, embedding} -> do_store_embedding(db, entry_id, embedding)
+        {:error, kind, reason} -> do_mark_embedding_failed(db, entry_id, kind)
+      end
+    :error -> :ok
+  end
+
+  {:noreply, state}
+end
+
+# handle_info — crash path:
+def handle_info({:DOWN, ref, :process, _pid, reason}, %{db: db, pending_tasks: pt} = state)
+    when reason != :normal do
+  case Map.fetch(pt, ref) do
+    {:ok, entry_id} ->
+      do_mark_embedding_failed(db, entry_id, :transient)
+      {:noreply, update_in(state, [:pending_tasks], &Map.delete(&1, ref))}
+    :error ->
+      {:noreply, state}
+  end
+end
+
+def handle_info({:DOWN, _ref, :process, _pid, :normal}, state), do: {:noreply, state}
+```
+
+`MemoryStore.store_embedding/3` public function and `handle_call({:store_embedding, ...})`
+clause become internal or are removed (no external caller after this change).
+
+## Tradeoffs
+
+### Strengths
+
+- Eliminates the inversion-of-control entirely; the Store is the sole writer of
+  embedding results, which is the most principled fix for the complect.
+- The `{ref, result}` message carries the actual result as a value — no silent discard,
+  no fire-and-forget, no cross-process callback.
+- The success and crash paths are now symmetric in the `handle_info` handler, making the
+  code easier to reason about.
+- Satisfies the acceptance criterion for all abnormal exits, not just `:noproc` crashes.
+- `MemoryStore.store_embedding/3` public API, which exposes the DB reference indirectly,
+  can be removed — reducing the API surface.
+
+### Weaknesses
+
+- **API-breaking change** to `Tau.Memory.Embedder`: the current `embed/3` callback
+  (which takes `store` as an argument and calls back into it) is replaced. All embedder
+  implementations and all consumers that call `embed/3` must be updated. This is a wider
+  change than Proposals 1 or 3.
+- The double-ref problem: `EmbeddingWorker` currently dispatches its OWN inner Task
+  (line 51 of `embedding_worker.ex`). Under this proposal, the new `embed_async/1` would
+  still need to use `async_nolink` so its Task ref can be forwarded to the Store's
+  `handle_info`. But `Task.Supervisor.async_nolink` sends the result to the process that
+  called it — if `embed_async/1` is called inside `handle_continue`, the result goes to
+  the GenServer's mailbox, which is correct. If `embed_async/1` returns the Task, the
+  ref is from the inner Task; the outer `handle_continue` gets the inner Task's ref.
+  This requires careful review of the call chain to ensure the ref is the one that
+  delivers `{ref, result}` to the GenServer's mailbox.
+- The `store_embedding/3` public API, currently used in `embedding_worker.ex` at line 57,
+  becomes dead code. Removing it is correct hygiene but widens the change scope.
+- `do_store_embedding/3` is currently called from `handle_call`, not `handle_info`;
+  this change moves the write to `handle_info`, which changes the call ordering
+  semantics (writes are now processed asynchronously from the perspective of the
+  `handle_continue` caller).
+
+### Costs
+
+- `Tau.Memory.Embedder` behaviour: 1 callback renamed/changed.
+- `EmbeddingWorker`: `embed/3` body rewritten; `store_embedding` call removed.
+- `Store.SQLite`: `handle_continue`, 2 `handle_info` clauses, state type updated;
+  `handle_call({:store_embedding, ...})` clause removed.
+- `MemoryStore.store_embedding/3` public function: removed or deprecated.
+- All test doubles that implement `Tau.Memory.Embedder` must be updated.
+- Test surface: larger than Proposal 1; the success path `handle_info` change requires
+  regression testing. Estimated 3–4 new test cases; 1–2 existing tests modified.
+
+## Dependencies
+
+- `Tau.Memory.Embedder` behaviour amendment must land before any embedder update.
+- All test doubles and mock embedders in `test/` must be updated.
+- The `embedding_worker.ex` inner-Task layering must be resolved: either flatten to
+  a single Task or clearly route the inner ref back to the GenServer's mailbox.
+
+## Confidence
+
+Medium. The design is more principled than Proposal 1 but the API surface impact is
+wider and the Task-ref routing requires careful implementation. Confidence would rise
+to high after a prototype that verifies `{ref, result}` delivery to the GenServer's
+mailbox when `embed_async/1` is called from `handle_continue`.
+
+## Prior art / references
+
+- The "return a value, don't call back" pattern is the idiomatic Elixir preference for
+  simple result communication: Elixir `Task.async/1` + `Task.await/2` is the canonical
+  form; `async_nolink` + `handle_info` is the fire-and-forget equivalent where the
+  GenServer must not block.
+- OTP design principle: side-effectful callbacks between peer processes increase coupling;
+  result-bearing messages decrease it. Source: Erlang/OTP Design Principles §"gen_server".
+- Hickey's "Simple Made Easy": inversion-of-control is a form of complecting (the
+  callback caller must know the callee's state); returning a value removes that knowledge
+  requirement.

--- a/docs/problems-archive-v1-modules/tau-memory/subproblems/silent-failure-propagation/solution.md
+++ b/docs/problems-archive-v1-modules/tau-memory/subproblems/silent-failure-propagation/solution.md
@@ -1,0 +1,161 @@
+---
+template_version: 1
+template_name: solution
+parent_problem: problem.md
+node_kind: leaf
+synthesised_from: [proposals/proposal-1.md, proposals/proposal-4.md]
+selection_method: hybrid
+revision: 0
+---
+
+# Solution: Ref-map in GenServer state + structured-result embedder contract
+
+## Recommendation
+
+Adopt a hybrid of Proposal 1 and Proposal 4. The immediate crash-detection
+gap is closed exactly as Proposal 1 describes — a `%{reference() => entry_id}`
+map in `Store.SQLite` state, populated at dispatch and consumed by a real
+`{:DOWN, ref, ...}` clause that calls `do_mark_embedding_failed/3` with
+`:transient`. Simultaneously, adopt Proposal 4's inversion-of-control
+elimination: change the `Tau.Memory.Embedder` behaviour so `embed_async/1`
+returns a Task whose result message is `{:ok, embedding} | {:error, kind,
+reason}` delivered to the GenServer's mailbox, making the Store the sole
+writer and removing the callback-from-worker pattern. The `{ref, result}`
+success clause handles the result value directly instead of discarding it.
+Together, the crash path and the success path become symmetric, both routed
+through `handle_info` using the same ref map — directly decomplecting task
+identity from entry identity and eliminating the inversion-of-control that
+made crash outcomes invisible.
+
+## Selected from
+
+- **Chosen:** hybrid of `proposals/proposal-1.md` and `proposals/proposal-4.md`
+- **Why chosen:** Proposal 1 directly addresses the problem's named complects
+  with minimal risk and no rule violations, but leaves the inversion-of-control
+  intact — the `{ref, result}` success clause still silently discards the result
+  because the worker calls back separately. Proposal 4 eliminates the
+  inversion-of-control root cause and makes the success path carry the result
+  as a value, but this is only sound combined with the ref map (Proposal 1's
+  contribution), since the crash path still needs `(ref → entry_id)` to act.
+  Proposal 2 is eliminated by the OTP non-negotiable rule 7 hard block
+  (`try/rescue` across process boundaries). Proposal 3 is sound OTP but
+  carries the `trap_exit` correctness caveat (without `trap_exit: true`,
+  `terminate/2` is not called on abnormal exits), requires two new modules,
+  and demands an API-breaking `embed_sync/1` callback — higher migration cost
+  for no additional fit over the hybrid. The hybrid combines Proposal 1's
+  targeted ref-map fix (low risk, reuses existing `do_mark_embedding_failed/3`)
+  with Proposal 4's structural improvement (removes inversion-of-control,
+  makes success and crash symmetric), and satisfies the acceptance criterion
+  more completely than either alone.
+
+## Scoring table
+
+| #  | Fit        | Decomplecting depth | Migration cost | Risk   | Reversibility |
+|----|------------|---------------------|----------------|--------|---------------|
+| 1  | Yes        | Substantial         | Low            | Low    | Easy          |
+| 2  | Partially  | Surface             | Low            | High   | Easy          |
+| 3  | Yes        | Deep                | High           | Medium | Hard          |
+| 4  | Yes        | Deep                | Medium         | Medium | Medium        |
+| H  | Yes        | Deep                | Medium         | Low    | Medium        |
+
+*H = selected hybrid (1 + 4). Fit "Partially" for Proposal 2 because the
+double-spawn layering means the `rescue` block may not fire for the primary
+failure mode; the OTP rule violation is a hard gate block regardless.*
+
+## What changes
+
+- **`lib/tau/memory/store/sqlite.ex`**
+  - State type extended: add `pending_tasks: %{reference() => String.t()}`;
+    `init/1` initialises to `%{}`.
+  - `handle_continue({:dispatch_embedding, id, content}, state)`: call
+    `embedder.embed_async(content)` (new behaviour callback), capture the
+    returned Task ref, store `ref → id` in `pending_tasks`.
+  - `handle_info({ref, embed_result}, state)`: demonitor, remove from map,
+    call `do_store_embedding/3` on `{:ok, embedding}` or
+    `do_mark_embedding_failed/3` on `{:error, kind, _reason}`.
+  - `handle_info({:DOWN, ref, :process, _pid, reason}, state)` where
+    `reason != :normal`: look up entry ID in map, call
+    `do_mark_embedding_failed/3` with `:transient`, remove from map.
+  - `handle_call({:store_embedding, ...})` clause: remove (no external
+    caller after this change).
+
+- **`lib/tau/memory/embedding_worker.ex`**
+  - Remove `store_embedding/3` call-back logic.
+  - Implement new `embed_async/1` callback: start a `Task.Supervisor.async_nolink`
+    whose body calls the HTTP/vector endpoint and returns
+    `{:ok, embedding} | {:error, kind, reason}`. Return `{:ok, task}`.
+  - The existing `embed/3` (fire-and-forget with callback) is removed.
+
+- **`lib/tau/memory/embedder.ex`** (behaviour module)
+  - Replace `embed/3` callback declaration with `embed_async/1 ::
+    {:ok, Task.t()} | {:error, term()}`.
+
+- **`lib/tau/memory/memory_store.ex`** (public API)
+  - Remove `store_embedding/3` public function (no external callers remain).
+
+- **`test/`** — all embedder test doubles that implement `Tau.Memory.Embedder`
+  must implement `embed_async/1` instead of `embed/3`.
+
+## What does not change
+
+- `do_mark_embedding_failed/3` in `Store.SQLite` — already exists at line 286;
+  invoked without modification.
+- `do_store_embedding/3` in `Store.SQLite` — already exists; now called from
+  `handle_info` rather than `handle_call`.
+- `Tau.Memory.Supervisor` child list — no new supervised children.
+- `Tau.Memory.EmbeddingSupervisor` / `EmbeddingTask` — not introduced (Proposal
+  3 elements excluded).
+- D-046 invariant semantics — `"failed"` with `:transient` error kind; unchanged.
+- `embedding_status` column schema — unchanged.
+
+## Migration sketch
+
+1. Amend `Tau.Memory.Embedder` behaviour first (add `embed_async/1`, mark
+   `embed/3` deprecated or remove it).
+2. Update `EmbeddingWorker` to implement `embed_async/1`; remove callback to
+   `store_embedding/3`.
+3. Update `Store.SQLite`: extend state, replace `handle_continue`, add real
+   `{:DOWN, ...}` clause body, update `{ref, result}` clause to consume result
+   value; remove `handle_call({:store_embedding, ...})`.
+4. Remove `MemoryStore.store_embedding/3` public function.
+5. Update all test doubles in `test/` to implement `embed_async/1`.
+6. Add one test: kill the Task ref, assert DB row transitions to
+   `embedding_status: "failed"`; add one regression test for the success path
+   via `{ref, {:ok, embedding}}`.
+
+Steps 1–2 are prerequisite to 3; 3–4 ship together; 5–6 accompany 3–4.
+
+## Open questions
+
+- **Inner-Task layering in `EmbeddingWorker`**: the current `embed/3` at line
+  51 of `embedding_worker.ex` spawns its own inner Task. The new `embed_async/1`
+  must resolve whether to flatten to a single Task (cleanest) or forward the
+  inner ref. This must be decided before step 2 of migration; incorrect routing
+  means `{ref, result}` never reaches the GenServer's mailbox.
+- **`{ref, result}` clause guard**: the clause `when is_reference(ref)` must not
+  accidentally match unrelated messages with a reference in position 0. Review
+  the GenServer's full message surface before landing.
+- **`{:DOWN, :normal}` double-cleanup**: if the Task exits `:normal` because the
+  callback succeeded (the pre-change code path for embedders that don't adopt
+  `embed_async/1` during a partial rollout), both `{ref, result}` and
+  `{:DOWN, :normal}` fire; the map lookup in the `:DOWN` clause must tolerate
+  `Map.fetch/2` returning `:error` (already guarded in Proposal 1's sketch).
+
+## Linked sub-problems / proposals
+
+- `proposals/proposal-1.md` — Ref-to-ID map in GenServer state (crash path fix;
+  directly addresses both named complects; low cost, reuses existing
+  `do_mark_embedding_failed/3`)
+- `proposals/proposal-2.md` — `try/rescue/catch` wrapper (eliminated: OTP
+  non-negotiable rule 7 hard block; double-spawn layering means the rescue may
+  not fire for the primary failure mode)
+- `proposals/proposal-3.md` — `EmbeddingTask` supervised process per entry
+  (sound OTP but `trap_exit` caveat is non-trivial, two new modules, API-breaking
+  `embed_sync/1`, higher cost for equivalent fit)
+- `proposals/proposal-4.md` — Structured-result embedder contract (inversion-of-
+  control elimination; complements Proposal 1 by making success and crash paths
+  symmetric and removing the callback API)
+
+## Revision history
+
+- (revision 0 — initial)

--- a/docs/problems-archive-v1-modules/tau-memory/subproblems/silent-failure-propagation/validation.md
+++ b/docs/problems-archive-v1-modules/tau-memory/subproblems/silent-failure-propagation/validation.md
@@ -1,0 +1,440 @@
+---
+template_version: 1
+template_name: validation
+parent_solution: solution.md
+parent_problem: problem.md
+toulmin_complete: true
+falsification_attempted: true
+falsification_outcome: partially_falsified — claim/4
+revision_triggered: none
+---
+
+# Validation: Ref-map in GenServer state + structured-result embedder contract
+
+## Overview
+
+The solution asserts that combining (a) a `pending_tasks: %{reference() =>
+entry_id}` map in `Tau.Memory.Store.SQLite` state with (b) a new
+`Tau.Memory.Embedder.embed_async/1` callback whose returned Task delivers
+`{:ok, embedding} | {:error, kind, reason}` directly to the store's mailbox
+will close the silent-failure gap described in the problem (D-046 stuck-
+`"pending"` after a crashed embedding Task). Six discrete propositions are
+extracted from the Recommendation and What-changes sections. Per-claim
+falsification used a mix of strategies — dependency check against the running
+codebase, edge-case enumeration over `Task.Supervisor.async_nolink/2`
+semantics, type-level check on the new callback signature, prior-art
+counter-case against the proposals' own Weaknesses section, and an
+integration-test feasibility check. Five claims withstood; one (Claim 4 —
+removal of `MemoryStore.store_embedding/3` public function) was partially
+falsified because the named module path `lib/tau/memory/memory_store.ex` does
+not exist in the codebase; the corresponding public function lives at
+`lib/tau/memory/store/sqlite.ex:163-167`. The qualifier on Claim 4 narrows to
+"remove the public `Tau.Memory.Store.SQLite.store_embedding/3` function (the
+actual location)"; the underlying intent (no external callers after the
+change) is preserved and the rest of the solution is unaffected. No solution
+revision is triggered; the partial falsification is recorded as a path
+correction that the implementer must follow.
+
+## Toulmin per claim
+
+The MITRE empirical study on Toulmin formalism found that "participants found
+it difficult to generate Toulmin structures, and their structures varied
+greatly even though they started with the same content"
+(https://www.mitre.org/news-insights/publication/empirical-evaluation-structured-argumentation-using-toulmin-argument).
+The six components below are filled separately to counter that variance.
+
+### Claim 1: A `%{reference() => entry_id}` map in `Store.SQLite` state, populated at dispatch and consumed by a real `{:DOWN, ref, ...}` clause that calls `do_mark_embedding_failed/3` with `:transient`, closes the crash-detection gap.
+
+- **Claim (C):** Adding a `pending_tasks` ref-map to `Store.SQLite` state and
+  giving the `{:DOWN, ref, :process, _pid, reason}` clause a non-trivial body
+  that looks up the entry ID and invokes
+  `do_mark_embedding_failed(db, entry_id, :transient)` when `reason != :normal`
+  causes the entry to transition from `"pending"` to `"failed"` within the
+  monitored task's lifetime, satisfying the problem's acceptance criterion.
+- **Grounds (G):** The current code at `lib/tau/memory/store/sqlite.ex:300-302`
+  is a body-less `{:noreply, state}` discard with no entry-ID context, which
+  is exactly the failure mode named in `problem.md` (`Context` bullet 1) and
+  caused by the missing mapping named in the `Complecting hypothesis`. The
+  callee `do_mark_embedding_failed/3` already exists at
+  `lib/tau/memory/store/sqlite.ex:582-616` and is unit-tested through the
+  `{:store_embedding, _, {:error, kind, _}}` `handle_call` path
+  (`test/tau/memory/store_sqlite_test.exs:611, 621`).
+- **Warrant (W):** `Task.Supervisor.async_nolink/2` guarantees the calling
+  process receives `{ref, result}` on normal completion and
+  `{:DOWN, ref, :process, pid, reason}` on abnormal exit (Elixir stdlib
+  contract). Therefore a clause that pattern-matches `{:DOWN, ...}` with a
+  state-derived `(ref → entry_id)` lookup can deterministically act on
+  every abnormal exit — which is the OTP non-negotiable #4 (cross-process
+  events use monitored refs) applied to this specific gap.
+- **Qualifier (Q):** Holds only for crashes of the outermost task spawned by
+  `handle_continue/2`; does not cover a crash of `Store.SQLite` itself nor a
+  crash that occurs before `async_nolink` returns the ref (vanishingly small
+  window between spawn and `put_in`). For pre-existing stuck rows ingested
+  before this change ships, this claim is silent — those are covered by the
+  sibling `pending-rot-observability` and `retry-recovery-path` nodes.
+- **Rebuttal (R):** If the embedder implementation wraps its work in an
+  inner Task that swallows its own crash (Proposal 1's own "Weaknesses" §2
+  warning), the outer Task exits `:normal` and `{:DOWN, ..., :normal}` is the
+  message delivered — no `:transient` failure is recorded and the entry
+  stays `"pending"`. This is precisely the reason the solution pairs Claim 1
+  with Claim 2 (Proposal 4's `embed_async/1`), which collapses the
+  double-spawn so the outer Task IS the work and its crash IS the abnormal
+  exit. Claim 1 is sound only because Claim 2 lands with it.
+- **Backing (B):** OTP non-negotiables #1, #4, #7 (`TAU.md` "OTP
+  non-negotiables (quick reference)"); Elixir stdlib `Task.Supervisor` docs
+  (https://hexdocs.pm/elixir/Task.Supervisor.html#async_nolink/2); the
+  established prior-art reference in proposal-1.md §"Prior art" cites
+  `Tau.CircuitBreaker.Store` (`lib/tau/circuit_breaker/store.ex`) as the
+  in-repo ref-tracking pattern.
+
+#### Falsification attempt for claim 1
+
+- **Strategy:** Edge-case enumeration over the `async_nolink/2` message
+  surface and the pre-change code.
+- **Attempt:** Enumerated the message classes the modified `handle_info`
+  must handle: (i) `{ref, result}` from a Task that completed normally;
+  (ii) `{:DOWN, ref, :process, _pid, :normal}` paired with (i);
+  (iii) `{:DOWN, ref, :process, _pid, reason != :normal}` after the Task
+  body raised, exited abnormally, or was killed; (iv) stray `:DOWN` for a
+  ref the store never created (cannot occur with `async_nolink` but
+  defensively must not crash). The current code at lines 295-302 discards
+  (i), (ii), (iii), (iv) uniformly without context — confirmed against the
+  Read of `sqlite.ex`. The proposed clause shape (proposal-1.md sketch
+  lines 53-76, integrated into solution.md "What changes") routes (iii) to
+  `do_mark_embedding_failed/3`, leaves (i)+(ii) idempotent, and tolerates
+  (iv) via `Map.fetch/2 → :error`.
+- **Outcome:** withstood — the strategy produced no message class that
+  falsifies the claim under the qualifier stated above.
+- **Action:** none.
+
+### Claim 2: Replacing the `Embedder` behaviour callback with `embed_async/1`, returning `{:ok, Task.t()}` whose result message is `{:ok, embedding} | {:error, kind, reason}`, removes the inversion-of-control that made crash outcomes invisible and makes the success path carry the result as a value.
+
+- **Claim (C):** Changing the `Tau.Memory.Embedder` behaviour from
+  `embed(store, entry_id, content)` (callback-driven; the worker calls
+  `Store.SQLite.store_embedding/3` itself) to `embed_async(content) :: {:ok,
+  Task.t()}` (value-returning; the store reads the result off its own
+  mailbox) eliminates the structural cause of the silent-failure pattern
+  identified in `problem.md`'s `Complecting hypothesis` bullet 2.
+- **Grounds (G):** The current `embed/3` at
+  `lib/tau/memory/embedding_worker.ex:49-71` spawns an inner Task that calls
+  `MemoryStore.store_embedding/3` (line 57) inside the inner Task body. The
+  outermost `async_nolink`'d Task in `Store.SQLite.handle_continue/2`
+  (`lib/tau/memory/store/sqlite.ex:309-311`) wraps that call. When the
+  inner Task crashes before line 57, the outer Task's `embedder.embed(...)`
+  returns `{:ok, inner_task}` and exits `:normal`, so the store sees
+  `{ref, {:ok, inner_task}}` and never `{:DOWN, ..., abnormal}` — exactly
+  the rebuttal in Claim 1. Replacing this with a single-Task contract that
+  returns `{:ok, embedding} | {:error, kind, reason}` collapses the chain.
+- **Warrant (W):** Hickey's "values, not side effects" — a function that
+  returns a value composes more reliably than one that side-effects through
+  a callback into shared state. Translated to OTP: a callback that delivers
+  its outcome as a message to the process owning the relevant state
+  (Store.SQLite) restores the temporal-coupling-free contract; the store is
+  the sole writer, in line with OTP non-negotiable #1.
+- **Qualifier (Q):** Assumes the embedder implementations can be migrated
+  in a single PR (current production has one — `EmbeddingWorker`; tests have
+  Mox-style stubs). A staged rollout with both `embed/3` and `embed_async/1`
+  live simultaneously would re-introduce the double-spawn problem during the
+  transition and falsify this claim's "removes the IoC" wording for that
+  window.
+- **Rebuttal (R):** If a future embedder needs to call out to an external
+  pool that itself spawns a process and returns immediately (e.g. an HTTP
+  client with its own connection process), the implementer might be tempted
+  to spawn an inner Task again to "convert" that to a value. The behaviour
+  signature alone does not prevent this; the contract MUST be documented as
+  "the returned Task is the unit of failure" so implementers do not regress.
+- **Backing (B):** Hickey, "Simple Made Easy" (complecting via callbacks
+  vs. composition via values); the in-repo `Tau.Provider` behaviour — its
+  `stream/3` callback returns a stream of `%Tau.Provider.Event{}` values
+  rather than calling back into the session, which is the same shape this
+  claim proposes for embedding.
+
+#### Falsification attempt for claim 2
+
+- **Strategy:** Counter-example construction — try to construct a code shape
+  consistent with the proposed contract that still produces a silent stuck-
+  `"pending"`.
+- **Attempt:** Tried two shapes: (a) the new `EmbeddingWorker.embed_async/1`
+  itself spawns an inner Task and returns the outer Task's ref — same
+  failure mode as today; (b) the embedder returns an already-resolved Task
+  (`Task.completed/1`-style) before the HTTP call runs, then does the HTTP
+  call in a separate untracked process. Shape (a) is the rebuttal above and
+  is contract-violating, not contract-conforming — the contract specifies
+  the returned Task IS the work. Shape (b) is degenerate and identifiable
+  in code review. Within the conforming contract, the result message
+  carries the verdict by construction, and the store's `handle_info({ref,
+  result}, ...)` clause can act on it. No conforming counter-example
+  produced a stuck-`"pending"`.
+- **Outcome:** withstood.
+- **Action:** Document the contract clearly in the behaviour's `@doc` so
+  the Rebuttal's degenerate shape is rejected in review. (Already implicit
+  in the solution; surfaces explicitly here.)
+
+### Claim 3: The `{ref, result}` success clause will handle the result value directly instead of discarding it.
+
+- **Claim (C):** After the change, `handle_info({ref, embed_result},
+  state)` demonitors, removes the ref from `pending_tasks`, and dispatches
+  on `embed_result` — calling `do_store_embedding/3` for `{:ok, embedding}`
+  or `do_mark_embedding_failed/3` for `{:error, kind, _}` — instead of the
+  current pattern of `Process.demonitor(ref, [:flush])` + `{:noreply,
+  state}` (`lib/tau/memory/store/sqlite.ex:295-298`) that drops the result.
+- **Grounds (G):** Lines 295-298 currently match `{ref, _result}` with
+  `_result` bound to the underscore wildcard — verified by Read. The
+  `do_store_embedding/3` and `do_mark_embedding_failed/3` private helpers
+  already exist at lines 543-579 and 582-616 respectively. The solution's
+  "What changes" §1 bullet 3 names this clause body change explicitly.
+- **Warrant (W):** OTP non-negotiable #1 — the store is the sole writer to
+  its own state; routing the result through the store's mailbox (rather
+  than through a callback the worker initiates) keeps that invariant. Plus
+  Hickey: a value (`embed_result`) is easier to reason about than a side-
+  effecting callback whose timing relative to `{:DOWN, ...}` is non-
+  deterministic.
+- **Qualifier (Q):** Assumes Claim 2 lands — i.e. the embedder actually
+  produces `{:ok, embedding} | {:error, kind, reason}` as the Task result,
+  not `{:ok, inner_task}` (the today shape). Without Claim 2, this clause
+  has nothing actionable in `embed_result`.
+- **Rebuttal (R):** If a future contributor adds a second `async_nolink`
+  spawn from `Store.SQLite` for an unrelated purpose, its `{ref, result}`
+  messages will land in the same clause. The clause must therefore
+  distinguish "this ref is in `pending_tasks`" from "this ref is unknown"
+  — a `Map.fetch/2` guard handles it, but the contributor MUST follow that
+  discipline or this clause will mis-dispatch.
+- **Backing (B):** OTP non-negotiables #1, #4 (`TAU.md`); the in-repo prior
+  art at `lib/tau/circuit_breaker/store.ex` for ref-keyed dispatch in a
+  GenServer's `handle_info`.
+
+#### Falsification attempt for claim 3
+
+- **Strategy:** Type-level check — does the new `handle_info({ref,
+  embed_result}, ...)` clause type-check against the declared
+  `embed_async/1 :: {:ok, Task.t()} | {:error, term()}` return and the
+  `do_store_embedding/3`, `do_mark_embedding_failed/3` arities?
+- **Attempt:** `do_store_embedding/3` accepts `(db, entry_id, embedding)`
+  where `embedding` is a `list(float())` — matches the `{:ok, embedding}`
+  branch. `do_mark_embedding_failed/3` accepts `(db, entry_id, kind)` with
+  `kind in [:transient, :terminal]` — matches the `{:error, kind, _}`
+  branch (existing `handle_call({:store_embedding, _, {:error, kind, _}})`
+  at line 284 demonstrates the same dispatch shape compiles today). The
+  ref → id lookup uses `Map.fetch/2`, which is well-typed. No type-level
+  contradiction.
+- **Outcome:** withstood.
+- **Action:** none.
+
+### Claim 4: The `Tau.Memory.MemoryStore` public `store_embedding/3` function will be removed (no external callers remain).
+
+- **Claim (C):** Solution.md's "What changes" §4 names
+  `lib/tau/memory/memory_store.ex` as the public-API module and states the
+  public `store_embedding/3` will be removed.
+- **Grounds (G):** Searched the repository:
+  `find /home/brentw/src/tau/lib/tau -name memory_store.ex` returns
+  nothing (verified by Bash). The function `store_embedding/3` exists at
+  `lib/tau/memory/store/sqlite.ex:163-167` as a `@spec`'d public API on
+  `Tau.Memory.Store.SQLite`, NOT in a separate `MemoryStore`/`memory_store.ex`
+  module. The `EmbeddingWorker` aliases `Tau.Memory.Store.SQLite, as:
+  MemoryStore` (`lib/tau/memory/embedding_worker.ex:32`) — that alias is
+  the only thing in the repo named `MemoryStore`, and it points at
+  `Store.SQLite`, not a separate public-API module.
+- **Warrant (W):** A documented "what changes" must name an existing file
+  path or the change cannot be applied as written. Solution.md is the
+  implementer's brief (`factory-loop.md` "The draft-PR body" §"Scope &
+  order"); a mis-named module path is an implementation hazard even when
+  the intent (kill the public callback) is sound.
+- **Qualifier (Q):** Claim narrowed: remove the public
+  `Tau.Memory.Store.SQLite.store_embedding/3` function at
+  `lib/tau/memory/store/sqlite.ex:163-167` AND the corresponding
+  `handle_call({:store_embedding, ...})` clauses at lines 279-288. The
+  underlying "no external callers" goal is preserved.
+- **Rebuttal (R):** A future refactor MAY extract a `Tau.Memory.Store`
+  public façade module to which `store_embedding/3` (or its replacement)
+  belongs; the solution's wording could be read as anticipating that. But
+  no such module exists at the time of validation, and the solution does
+  not propose creating one — so the named path is a defect, not a
+  forward-reference.
+- **Backing (B):** `factory-loop.md` "The draft-PR body" (the body is the
+  durable plan-of-record); `spec-before-code.md` (PR scope is named in
+  files by their actual paths).
+
+#### Falsification attempt for claim 4
+
+- **Strategy:** Dependency check — does the file the solution names exist?
+- **Attempt:** `find /home/brentw/src/tau/lib/tau -name memory_store.ex`
+  returns no results; `ls /home/brentw/src/tau/lib/tau/memory/` lists
+  `embedder.ex`, `embedding_worker.ex`, `loader.ex`, `migrations.ex`,
+  `store/`, `store.ex`, `supervisor.ex` — no `memory_store.ex`. The
+  function `store_embedding/3` is uniquely defined at
+  `lib/tau/memory/store/sqlite.ex:163-167`. The alias `MemoryStore` is set
+  inside `embedding_worker.ex` to point at `Tau.Memory.Store.SQLite`. The
+  named path therefore does not exist; the function does exist at a
+  different module.
+- **Outcome:** partially falsified — the *intent* (remove the public
+  callback) is sound and supported by the rest of the solution; the
+  *target path* is wrong and must be corrected to
+  `lib/tau/memory/store/sqlite.ex:163-167` before implementation. This is
+  a qualifier narrowing, not a structural defect in the chosen approach.
+- **Action:** Narrow Claim 4's qualifier (done above). No solution
+  re-selection; the implementer brief inherits the corrected path. The
+  selector / proposer do not need to re-run because the change is a
+  surface-level mis-naming, not a structural error in the chosen approach.
+
+### Claim 5: The crash path and success path become symmetric, both routed through `handle_info` using the same ref map.
+
+- **Claim (C):** After the change, both message classes from
+  `async_nolink` (`{ref, result}` for normal completion and `{:DOWN, ref,
+  ...}` for abnormal exit) are handled by `handle_info` clauses that share
+  the same `pending_tasks` map, eliminating the asymmetry where today's
+  success and crash messages are both discarded by the same body-less
+  clause.
+- **Grounds (G):** The solution's "What changes" §1 bullets 3-4 give both
+  clauses non-trivial bodies that use `pending_tasks` for cleanup (success)
+  and lookup-then-fail (crash). The current code at
+  `lib/tau/memory/store/sqlite.ex:295-302` has two clauses that both
+  `{:noreply, state}` with no map and no entry-ID context — confirmed by
+  Read.
+- **Warrant (W):** OTP non-negotiable #4 — cross-process events use
+  monitored refs. Symmetric handling of the two message shapes is the
+  direct application of that rule; the asymmetry today is the rule's
+  violation (the crash path is monitored but not acted on).
+- **Qualifier (Q):** Holds for the message surface produced by
+  `async_nolink/2`. Does not extend to messages from `Task.async/2` (which
+  raises on abnormal exit rather than sending `:DOWN`) — not applicable
+  here because the solution preserves `async_nolink`.
+- **Rebuttal (R):** "Symmetric" is a structural description, not a
+  behavioural identity claim — the two clauses do different things (write
+  embedding vs. mark failed) precisely because the outcomes differ. The
+  symmetry is in *both being handled with state context*, not in *doing
+  the same thing*. A reader interpreting "symmetric" as "identical" would
+  find the claim trivially false; the solution's text and the warrant make
+  the intended sense clear.
+- **Backing (B):** OTP non-negotiables #4 (`TAU.md`); Elixir
+  `Task.Supervisor.async_nolink/2` docs.
+
+#### Falsification attempt for claim 5
+
+- **Strategy:** Edge-case enumeration over message classes (same as
+  Claim 1's strategy, applied to the symmetry property rather than to the
+  acceptance criterion).
+- **Attempt:** For each message class produced by `async_nolink`, asked:
+  is the corresponding clause stateful (uses `pending_tasks`) and
+  actionable (produces a DB write or a no-op-with-cleanup)? Both clauses
+  pass under the solution. No asymmetric residual identified.
+- **Outcome:** withstood.
+- **Action:** none.
+
+### Claim 6: The change directly decomplects task identity from entry identity and eliminates the inversion-of-control that made crash outcomes invisible.
+
+- **Claim (C):** The two complects named in `problem.md` (`Complecting
+  hypothesis` bullets 1 and 2) are both resolved by this solution.
+- **Grounds (G):** Bullet 1's complect ("task identity is complected with
+  the entry") is resolved by the `pending_tasks: %{ref => entry_id}` field
+  — verified by direct correspondence between the problem's wording and
+  the solution's "What changes" §1 bullet 1. Bullet 2's complect ("'task
+  completed normally' and 'task crashed' are complected in the same silent
+  discard clause") is resolved by giving each message class its own
+  actionable clause body — verified by direct correspondence to "What
+  changes" §1 bullets 3-4.
+- **Warrant (W):** Hickey's definition of complecting: braiding two
+  independent concerns into one structure such that you cannot reason
+  about them separately. Decomplecting is the structural inverse —
+  separating them back out. The map gives task-ref and entry-id their own
+  identity that can be related at lookup time without being braided in
+  state.
+- **Qualifier (Q):** "Decomplects" applies to the two specific complects
+  named in `problem.md`. Other complects in the embedding pipeline (e.g.
+  the embedder's HTTP-call retry policy mixed with its content-length
+  policy in `embedding_worker.ex:81-95`) are out of scope and unaffected.
+- **Rebuttal (R):** A purist might argue that storing `ref → entry_id` in
+  the GenServer's heap is still a form of coupling — the store's lifetime
+  is coupled to the in-flight task set. This is true but is the same
+  coupling that any monitored-ref pattern carries; it is the
+  *appropriate* coupling under OTP non-negotiable #4 (cross-process events
+  use monitored refs), not a residual complect.
+- **Backing (B):** Hickey, "Simple Made Easy" §"Complect"; the
+  problem.md's own `Complecting hypothesis` section names the complects
+  this claim asserts are resolved.
+
+#### Falsification attempt for claim 6
+
+- **Strategy:** Counter-example construction — try to find a post-change
+  code state where one of the named complects is still present.
+- **Attempt:** Re-read the problem's two `Complecting hypothesis` bullets,
+  then traced the solution's "What changes" against each. For bullet 1 the
+  map IS the missing association; for bullet 2 the two clause bodies ARE
+  the disambiguation. No residual found within the problem's named
+  complects. (See Qualifier — out-of-scope complects are not a counter-
+  example to this claim.)
+- **Outcome:** withstood.
+- **Action:** none.
+
+## Cross-claim consistency
+
+Claims 1 and 2 form a strict dependency pair: Claim 1's qualifier explicitly
+notes that Claim 1 is sound only when Claim 2 also lands (otherwise the
+double-spawn keeps the abnormal exit invisible to the store). Claim 3 in
+turn depends on Claim 2 (without `embed_async/1` returning the embedding
+verdict as the Task result, there is nothing actionable in the `{ref,
+result}` clause). This dependency chain is internally consistent and matches
+the solution.md "Why chosen" rationale that Proposal 1 and Proposal 4 are
+only sound together.
+
+Claim 4 (remove public callback) is independent of Claims 1-3 (state and
+clause changes) — they touch disjoint surfaces. The partial falsification of
+Claim 4 (wrong target path) does not affect Claims 1-3.
+
+Claim 5 (symmetry) is a structural restatement of Claims 1 + 3 together; it
+is consistent with both and does not add a new constraint.
+
+Claim 6 (decomplecting) is a higher-level summary of Claims 1 + 2 against
+the problem's `Complecting hypothesis`; it adds no constraint beyond those.
+
+No tension between any pair of claims was identified.
+
+## Falsification summary
+
+| # | Claim (short) | Strategy | Outcome | Action |
+|---|---|---|---|---|
+| 1 | Ref-map + real `:DOWN` clause closes crash gap | Edge-case enumeration over async_nolink messages | withstood | none |
+| 2 | `embed_async/1` removes IoC | Counter-example construction over contract-conforming shapes | withstood | document contract |
+| 3 | Success clause handles result value | Type-level check on new clause vs helpers | withstood | none |
+| 4 | Remove public `store_embedding/3` from `memory_store.ex` | Dependency check (does the file exist?) | partially falsified | narrow path to `lib/tau/memory/store/sqlite.ex:163-167` |
+| 5 | Crash and success paths become symmetric | Edge-case enumeration over message classes | withstood | none |
+| 6 | Both named complects are resolved | Counter-example construction over problem's complects | withstood | none |
+
+## Revision required
+
+- **Target file:** none (no full revision triggered).
+- **Revision kind:** qualifier narrowing in-place on Claim 4 only.
+- **Rationale:** The partial falsification of Claim 4 is a path/module-name
+  defect, not a structural defect in the chosen solution. The function the
+  solution intends to remove genuinely exists and the removal is sound; only
+  the named module path is wrong. The narrowed qualifier in Claim 4 (above)
+  records the corrected path so the implementer's brief inherits it. Per
+  validate.md §5 ("Partial falsifications: narrow each claim's Qualifier in
+  place. No revision needed"), this does not warrant re-running the proposer
+  or selector and does not warrant editing `problem.md`.
+
+## Outstanding doubts
+
+- **Migration order safety.** Solution.md's "Migration sketch" steps 1-2
+  describe amending the behaviour and updating `EmbeddingWorker` before
+  step 3 changes `Store.SQLite`. If a partial deployment runs with a
+  newer `EmbeddingWorker` (calling `embed_async/1`) but an older
+  `Store.SQLite` (only knows about `{:store_embedding, ...}`
+  `handle_call`), the new Task result message `{ref, {:ok, embedding}}`
+  will hit the existing discard clause at lines 295-298. The validator
+  could not directly falsify this because migrations in this repo are
+  applied as single PR units (`spec-before-code.md` §"What this rule
+  forbids" — "MUST NOT merge a PR that adds new state to a SPEC'd boundary
+  without a corresponding §3 entry and §4 contract update in the same
+  PR"). Surfacing it for the implementer to confirm.
+- **`{ref, result}` clause guard scope.** Solution.md "Open questions"
+  §"`{ref, result}` clause guard" raises the same concern; the validator
+  agrees this is a real review item but cannot falsify it ahead of
+  implementation. A `when is_reference(ref)` guard combined with a
+  `Map.fetch(pending_tasks, ref)` lookup is the discipline that resolves
+  it; the reviewer must confirm in code.
+- **Stuck-pending state lost on `Store.SQLite` crash.** The ref-map lives
+  on the GenServer heap; if `Store.SQLite` itself crashes while embeddings
+  are in flight, the map is lost and the affected entries revert to
+  stuck-`"pending"`. Explicitly out of scope per the problem's
+  `Out of scope` section (covered by `retry-recovery-path`), so this is
+  not a falsification — recorded here for the parent validator.

--- a/docs/problems-archive-v1-modules/tau-memory/validation.md
+++ b/docs/problems-archive-v1-modules/tau-memory/validation.md
@@ -1,0 +1,874 @@
+---
+template_version: 1
+template_name: validation
+parent_solution: solution.md
+parent_problem: problem.md
+toulmin_complete: true
+falsification_attempted: true
+falsification_outcome: partially_falsified — claim/5
+revision_triggered: none
+---
+
+# Validation: Bind the Finch name, make the embedding pipeline self-healing, observable, and recoverable
+
+## Overview
+
+The root solution is a non-leaf synthesis composing four validated child
+solutions into a single coherent change set landed across **three sequenced
+PRs**. As a non-leaf validation, this document focuses on the cross-cutting
+integration claims that only exist at the synthesis level — claims the child
+validations could not have evaluated because they each saw only one layer.
+Seven such propositions are extracted from the Recommendation, Composition
+rationale, What changes, and Migration sketch sections. Each receives a full
+six-component Toulmin treatment with a named falsification strategy. Six
+withstand; one (Claim 5 — the *acceptance-criterion conjunction* claim that
+the composed PRs together satisfy the parent AC) is **partially falsified**
+because the conjunction has a sequencing dependency on PR-1 reaching
+production *before* downstream observability/retry telemetry becomes
+meaningful, and on the implementer correctly resolving the
+behaviour-vs-sweeper contract overlap noted in the composition rationale.
+The qualifier on Claim 5 is narrowed in place; no proposer/selector re-run
+is required because the narrowing matches the solution's own Migration
+sketch and Open questions sections. All child-level qualifier narrowings
+(notably retry-recovery-path Claim 4 — dangling `memory_vec` row on
+delete-during-retry — and silent-failure-propagation Claim 4 — the
+mis-named `memory_store.ex` path) are surfaced as Outstanding doubts so the
+parent solution inherits the right caveats.
+
+## Toulmin per claim
+
+The MITRE empirical study on Toulmin formalism found that "participants
+found it difficult to generate Toulmin structures, and their structures
+varied greatly even though they started with the same content"
+(https://www.mitre.org/news-insights/publication/empirical-evaluation-structured-argumentation-using-toulmin-argument).
+This validation enforces all six components explicitly with prompts to
+counter that variance.
+
+### Claim 1: The four child solutions compose directly, with no conflict to resolve, because the decomposition was layered and the layers stack without overlap.
+
+- **Claim (C):** "The four child solutions compose **directly**; there is no
+  conflict to resolve. … No child solution is in tension with another. The
+  decomposition was layered (one concern per layer); the layers stack
+  without overlap." (`solution.md` §Composition rationale.)
+- **Grounds (G):**
+  - `problem.md` §Decomposition strategy partitions the failure surface
+    into four "mutually exclusive (a concern belongs to exactly one layer)
+    and collectively exhaustive" layers: configuration wiring, crash-to-
+    callback propagation, observability of pending rot, retry/recovery.
+  - The four child solutions touch disjoint primary surfaces:
+    finch-name-mismatch owns `lib/tau/providers/config.ex` (new) +
+    `lib/tau/application.ex:78` + `lib/tau/memory/embedding_worker.ex:106`
+    default; silent-failure-propagation owns `lib/tau/memory/embedder.ex`
+    callback shape + `Store.SQLite` state/handle_info/handle_continue
+    bodies + `EmbeddingWorker.embed_async/1`; pending-rot-observability
+    owns a new `handle_info(:check_pending_age, ...)` clause and three
+    private module attributes inside the same `Store.SQLite`; retry-
+    recovery-path owns a new `RetrySweeper` module, a new
+    `Store.SQLite.list_retriable/1` public function and a new
+    supervisor child.
+  - Three child validations each ran the relevant child-level
+    consistency check (`finch-name-mismatch/validation.md` Claim 4
+    "No other files require updating" — withstood;
+    `silent-failure-propagation/validation.md` cross-claim consistency
+    section — no tension; `pending-rot-observability/validation.md`
+    Claim 2 "no `handle_info` conflict" — withstood;
+    `retry-recovery-path/validation.md` Claim 3
+    "list_retriable/1 is additive only" — withstood).
+- **Warrant (W):** A decomposition whose parts are MECE (mutually
+  exclusive, collectively exhaustive) at the failure-layer level
+  produces sub-solutions whose primary write surfaces are disjoint by
+  construction; disjoint primary surfaces cannot conflict structurally.
+  Hickey: "compose simple parts" — when the parts were themselves
+  decomposed not to overlap, composition is concatenation. (See
+  `problem.md` §Decomposition strategy text claiming MECE.)
+- **Qualifier (Q):** Holds for the *primary* surfaces. Two child
+  solutions (silent-failure-propagation, pending-rot-observability,
+  retry-recovery-path) all touch the single file
+  `lib/tau/memory/store/sqlite.ex` for different reasons; "no conflict"
+  applies to clauses/functions, not to file-level commit overlap. A
+  PR-2 that lands the handle_info-restructure of silent-failure-
+  propagation and the new `handle_info(:check_pending_age, ...)` of
+  pending-rot-observability simultaneously is by construction a single
+  PR — which is exactly what the Migration sketch prescribes. Two
+  *concurrent* PRs touching `Store.SQLite` would conflict at the
+  factory-loop conflict check (`.claude/rules/factory-loop.md` §"The
+  conflict check" clause 3 — disjoint codepoints).
+- **Rebuttal (R):** Two child solutions reference the same callback
+  contract from different perspectives — silent-failure-propagation
+  *defines* `embed_async/1`, while retry-recovery-path was authored
+  against the still-live `embed/3` and the synthesis text re-points it
+  at `embed_async/1`. This is contract reuse, not contract conflict
+  (Claim 4 below addresses it directly), but it is a load-bearing
+  reconciliation that the implementer must execute. It is not a
+  "stacking without overlap" property at the contract level.
+- **Backing (B):** OTP non-negotiable #1
+  (`.claude/rules/otp-non-negotiables.md`): stateful subsystems run as
+  supervised processes, naturally producing disjoint primary write
+  surfaces. `factory-loop.md` §"The conflict check" clauses 2 and 3
+  (disjoint files, disjoint codepoints) — the rubric against which
+  PR-level conflict is judged.
+
+#### Falsification attempt for claim 1
+
+- **Strategy:** Integration check — enumerate the union of file paths
+  touched by all four child solutions, find overlaps, and ask whether
+  any overlap produces a structural conflict the synthesis text fails
+  to resolve.
+- **Attempt:** The union, taken from each child's "What changes" plus
+  the parent synthesis "What changes":
+  - `lib/tau/providers/config.ex` (new) — finch-name-mismatch only.
+  - `lib/tau/application.ex` line 78 — finch-name-mismatch only.
+  - `lib/tau/memory/embedding_worker.ex` — finch-name-mismatch (line 106
+    default) AND silent-failure-propagation (replace `embed/3` body with
+    `embed_async/1` impl). Two distinct edits to the same file but at
+    distinct regions (one default argument; one whole function body).
+    Synthesised: PR-1 ships the default change; PR-2 ships the body
+    change. No collision.
+  - `lib/tau/memory/embedder.ex` — silent-failure-propagation only
+    (callback declaration change).
+  - `lib/tau/memory/store/sqlite.ex` — silent-failure-propagation AND
+    pending-rot-observability AND retry-recovery-path
+    (`list_retriable/1` addition). Three contributors. Synthesis maps
+    them: PR-2 lands silent-failure + pending-rot together; PR-3 adds
+    `list_retriable/1`. The Migration sketch explicitly bundles the
+    overlapping concerns into one PR to avoid intermediate state. No
+    collision.
+  - `lib/tau/memory/supervisor.ex` — retry-recovery-path only (one new
+    child entry).
+  - `test/...` — each child adds disjoint test files.
+- **Outcome:** withstood at the structural level. The overlap on
+  `Store.SQLite` is real but the synthesis text recognises it and
+  responds by bundling overlapping concerns into one PR (PR-2). The
+  "no conflict" claim survives because the synthesis text and the
+  Migration sketch together resolve the overlap into a sequencing
+  prescription.
+- **Action:** none.
+
+### Claim 2: The three PRs MUST land in the order PR-1 → PR-2 → PR-3; that ordering is mechanically necessary, not stylistic.
+
+- **Claim (C):** "Land the wiring fix first. … PR-2 is the largest of the
+  three; review is manageable because the changes are localised. …
+  The sweeper invokes the PR-2 `embed_async/1` contract, so PR-3
+  depends on PR-2 having landed." (`solution.md` §Migration sketch.)
+- **Grounds (G):**
+  - PR-1 ships `Tau.Providers.Config.finch_name/0` and re-points
+    `application.ex:78` and `embedding_worker.ex:106` default. The
+    default at line 106 is `Tau.Finch` today, which does not name a
+    registered pool (`finch-name-mismatch/validation.md` Claim 1 —
+    withstood). Without PR-1, every embedding HTTP call crashes with
+    `:noproc` and never reaches the path PR-2 and PR-3 instrument.
+  - PR-2 introduces the `embed_async/1` callback and restructures
+    `Store.SQLite` around `pending_tasks: %{reference() => String.t()}`
+    plus symmetric `handle_info` clauses for `{ref, result}` and
+    `{:DOWN, ref, ...}`. PR-2 also lands the observability timer.
+  - PR-3's `RetrySweeper` re-invokes the embedder. The composition
+    rationale §2 specifies the sweeper re-invokes `embed_async/1`
+    (not the now-removed `embed/3`), routing the resulting Task ref
+    through the same `pending_tasks` map and the same `handle_info`
+    clauses as the primary write path. PR-3 is dead code without
+    PR-2's contract change in place.
+- **Warrant (W):** A change set in which Step B refers to symbols
+  introduced by Step A creates a *compile-time and runtime
+  precondition* — Step B will not compile, or will reach a dispatch
+  with a missing callback, if Step A has not landed. The MECE-by-
+  layer decomposition pre-supposes this ordering because the layers
+  are themselves nested causally: wiring is upstream of crash
+  propagation, which is upstream of observability and retry.
+- **Qualifier (Q):** Holds for the "factory-loop serialised merge"
+  model in `.claude/rules/factory-loop.md` §"Gate and merge under
+  concurrency" ("**Merges are serialized** — one PR at a time"). If
+  PR-1, PR-2, PR-3 were merged out of order under a hypothetical
+  parallel-merge regime, the system would briefly compile but
+  exhibit the silent-failure behaviour (PR-3 before PR-2) or remain
+  fully broken (skip PR-1).
+- **Rebuttal (R):** A reviewer might object that PR-1 is theoretically
+  not strictly required before PR-2 — PR-2 plus a manual
+  `Application.put_env(:tau, :finch_name, Tau.Providers.Finch)` in
+  config would also make the pipeline live. But: no such config
+  override exists in the repository today (verified by
+  `finch-name-mismatch/validation.md` Claim 1 — "`grep -rn
+  "finch_name" config/` returns empty output"); shipping PR-2 first
+  would mean every smoke run of the embedding path remained broken
+  until either PR-1 or such a config landed. The mechanical PR
+  ordering is the only one that delivers a working system at each
+  intermediate merged state.
+- **Backing (B):** `.claude/rules/factory-loop.md` §"Pre-merge
+  freshness re-check" (a PR must be re-gated against current
+  `origin/main` before merge, so an out-of-order merge would fail
+  the freshness check or the post-merge `main` health check at
+  cycle step 8d). `.claude/rules/spec-before-code.md` §"What this
+  rule requires" — a PR adding new state to a SPEC'd boundary must
+  pair with the §3 amendment in the same PR; this rule reinforces
+  the bundling of overlapping concerns into PR-2.
+
+#### Falsification attempt for claim 2
+
+- **Strategy:** Counter-example construction — try to construct a
+  merge order other than PR-1 → PR-2 → PR-3 that produces a working
+  acceptance-criterion-satisfying system at every intermediate
+  `main` state.
+- **Attempt:** Three permutations besides the canonical one:
+  - PR-2 → PR-1 → PR-3: after PR-2 lands, the contract change is
+    live, but `embedding_worker.ex` is still defaulting Finch name
+    to the unregistered `Tau.Finch`. Every embedding still crashes
+    at the HTTP boundary. The observability timer will fire
+    detecting stale `"pending"` rows, but the AC's "reaches `ready`
+    or `failed` with actionable signal" is satisfied only by the
+    `"failed"` transition — and PR-2's crash propagation will
+    correctly mark them `"failed"`. *Curious*: this permutation
+    *does* satisfy the AC for new writes, because PR-2's crash
+    propagation works even when the underlying call is doomed.
+    But pre-existing `"pending"` rows are not retried until PR-3
+    lands. So PR-2 → PR-1 satisfies the AC in a degraded sense.
+    Not strictly forbidden; the synthesis prescribes the safer
+    order to minimise the window in which the acceptance criterion
+    is in its degraded-but-satisfied form.
+  - PR-3 → PR-2 → PR-1: PR-3 references `embed_async/1`, which
+    does not exist before PR-2. PR-3 will not compile. Falsifies
+    this permutation.
+  - PR-1 → PR-3 → PR-2: PR-3 references `embed_async/1` and
+    `list_retriable/1`. The contract does not exist; the sweeper
+    cannot call `embed_async/1`. Falsifies this permutation.
+  - PR-2 → PR-3 → PR-1: PR-2 lands, contract live, observability
+    firing. PR-3 lands, sweeper re-dispatches via `embed_async/1`
+    but every call crashes (Finch name still wrong). The
+    `RetrySweeper` is now generating telemetry storms of stuck-
+    pending retries. PR-1 finally lands and the pipeline becomes
+    healthy. This permutation works but is operationally noisy.
+  - **Conclusion**: PR-3 cannot land before PR-2 (compile failure).
+    PR-2 → PR-1 and PR-2 → PR-3 → PR-1 *technically* work but are
+    degraded. PR-1 → PR-2 → PR-3 is the only permutation that
+    delivers a strictly-improving system at each intermediate
+    merge.
+- **Outcome:** withstood — the canonical ordering is the only one
+  delivering a strictly-improving system at every intermediate
+  state. Other orderings either fail to compile or pass through a
+  degraded state.
+- **Action:** none. The synthesis text already states the ordering
+  as a hard prerequisite, not a preference.
+
+### Claim 3: PR-2 must bundle the silent-failure-propagation and pending-rot-observability changes together to avoid an intermediate state where the observability timer fires against a Store whose crash path is still broken.
+
+- **Claim (C):** "These two child solutions both modify
+  `lib/tau/memory/store/sqlite.ex` and must land together to avoid
+  an intermediate state where the observability timer fires against
+  a Store whose crash path is still broken." (`solution.md`
+  §Migration sketch, PR-2 description.)
+- **Grounds (G):**
+  - pending-rot-observability's `handle_info(:check_pending_age,
+    ...)` queries for `embedding_status = 'pending'` rows older
+    than `@stale_threshold_ms = 35_000` ms
+    (`pending-rot-observability/solution.md` §What changes).
+  - silent-failure-propagation's intent is to transition crashed
+    Tasks' entries from `"pending"` to `"failed"` so they never
+    remain `"pending"` permanently
+    (`silent-failure-propagation/solution.md` §Recommendation).
+  - If observability ships standalone before silent-failure: every
+    crash leaves an entry `"pending"`; the timer reports them all
+    as "stale rot" within 35 s. Operators see telemetry storms with
+    no actionable remediation (the entries will *never* transition
+    to `"failed"` on their own).
+  - If silent-failure ships standalone before observability: crashes
+    are correctly marked `"failed"`; there is simply no telemetry
+    for the rare residual stuck-`"pending"` (e.g. a Store crash
+    losing the ref-map mid-flight). This is a smaller defect.
+- **Warrant (W):** A telemetry signal is only actionable if there is
+  a path to remediation; firing telemetry about a condition the
+  system cannot resolve creates alert fatigue and operator
+  confusion. Pairing them in one PR ensures the signal-vs-
+  remediation relationship is intact at every merged `main` state.
+- **Qualifier (Q):** "Must land together" applies to PR-grain
+  bundling. Within PR-2, the commits may land in any internal
+  order — the gate runs against the cumulative diff, not commit-by-
+  commit. The serial-merge invariant
+  (`.claude/rules/factory-loop.md`) means PR-2's diff is atomic at
+  the `main` level.
+- **Rebuttal (R):** A reviewer might argue that the alert fatigue
+  is a soft cost and the bundling is therefore a stylistic
+  preference, not a hard requirement. But the post-merge `main`
+  health check (cycle step 8d) checks compile + test; a PR-2
+  bundling that leaves a regression in either fails the health
+  check and halts the loop. Splitting them invites a halt on a
+  cosmetic regression in noisy telemetry — fixable but
+  operationally costly.
+- **Backing (B):** `.claude/rules/factory-loop.md` §"What this rule
+  forbids" — "MUST NOT skip the post-merge `main` health check, nor
+  continue the loop on a red `main`." OTP non-negotiable #5
+  ("Telemetry events MUST cover everything user-visible or
+  perf-sensitive") implies the signal must be *meaningful*, not
+  merely present.
+
+#### Falsification attempt for claim 3
+
+- **Strategy:** Counter-example construction — construct an
+  intermediate state where the bundling is unnecessary.
+- **Attempt:** Suppose `@stale_threshold_ms` were set to a value
+  high enough that no real entry would cross it before
+  silent-failure-propagation also landed. Then the intermediate
+  state is innocuous because the timer never reports anything.
+  Defeats the *necessity* of bundling, but only at the cost of
+  making the observability inert until the second PR — a strict
+  inferiority to bundling. Construction fails as a counter-example
+  because it does not show that splitting is *equally good*.
+- **Outcome:** withstood — the bundling is materially better than
+  any splitting strategy. No counter-example produced equivalent
+  quality.
+- **Action:** none.
+
+### Claim 4: The sweeper and the primary write path share the `embed_async/1` contract by design, so sweeper-dispatched embeddings get the same crash-to-`"failed"` guarantee as write-dispatched embeddings, automatically.
+
+- **Claim (C):** "in the composed plan the sweeper invokes
+  `embed_async/1` instead [of `embed/3`], routing the resulting Task
+  ref through the same `pending_tasks` map and the same
+  `handle_info` clauses as the primary write path. There is exactly
+  one dispatch path; the sweeper and the write path differ only in
+  *who* enqueues the work, not in *how* the result propagates."
+  (`solution.md` §Composition rationale clause 2.)
+- **Grounds (G):**
+  - retry-recovery-path's own solution was authored against
+    `embed/3` (still-live at the time); the synthesis re-points it
+    at `embed_async/1` — explicitly named in
+    `solution.md` §What changes ("`Tau.Memory.RetrySweeper`
+    GenServer (~80 LOC) … re-dispatches each row via
+    `Tau.Memory.Embedder.embed_async/1` through the store's
+    `handle_continue({:dispatch_embedding, id, content}, state)`
+    path").
+  - silent-failure-propagation introduces `pending_tasks` and
+    matching `handle_info` clauses (`silent-failure-
+    propagation/solution.md` §What changes).
+  - If the sweeper routes through `handle_continue(
+    {:dispatch_embedding, id, content}, state)`, the existing
+    dispatch code (the same `Task.Supervisor.async_nolink/2` +
+    `put_in(state.pending_tasks[ref], id)` sequence) is reused
+    verbatim, and the resulting Task ref lands in the same map
+    that PR-2 introduced — so the crash propagation flows through
+    the same `handle_info({:DOWN, ref, :process, _pid, reason},
+    state)` clause.
+- **Warrant (W):** Reusing a single dispatch path for two enqueue
+  sources (primary write at `handle_continue/2`; retry sweep) is
+  the OTP-correct way to inherit invariants across feature
+  layers. The Store is the sole writer (OTP non-negotiable #1);
+  the map is the sole tracker (OTP non-negotiable #4); the
+  symmetric `handle_info` clauses are the sole observer (OTP
+  non-negotiable #4 applied symmetrically per
+  `silent-failure-propagation/validation.md` Claim 5 — withstood).
+- **Qualifier (Q):** Holds if the implementer routes the sweeper
+  through `handle_continue({:dispatch_embedding, id, content},
+  state)` — i.e. the sweeper sends a cast/call to the Store that
+  triggers an internal `{:noreply, state, {:continue, ...}}` —
+  rather than calling `embed_async/1` directly from the sweeper
+  process. The latter would land the Task ref in the *sweeper's*
+  mailbox, not the *store's*, breaking the inherited guarantee.
+  The synthesis text names this routing explicitly ("through the
+  store's `handle_continue({:dispatch_embedding, id, content},
+  state)` path"); the qualifier is the implementer following that
+  routing.
+- **Rebuttal (R):** A naïve implementer might invoke
+  `Tau.Memory.EmbeddingWorker.embed_async(content)` directly from
+  `RetrySweeper.handle_info(:sweep, ...)`. The returned Task ref
+  would be owned by the sweeper's process; `{ref, result}` and
+  `{:DOWN, ref, ...}` would land in the sweeper's mailbox; the
+  sweeper has no `handle_info({ref, result}, state)` clause; the
+  result silently disappears. The composition rationale text
+  guards against this verbally but the gate (`critic` + reviewer)
+  must enforce it in code review of PR-3. This is a real
+  implementation hazard, not a structural defect in the
+  composition.
+- **Backing (B):** `silent-failure-propagation/solution.md` §What
+  changes (defines the canonical dispatch via `handle_continue`).
+  OTP non-negotiable #4 (cross-process events use monitored refs)
+  applied to a single owning process.
+  `silent-failure-propagation/validation.md` Outstanding doubt
+  §"Migration order safety" — surfaces the same risk for the
+  primary write path; applies symmetrically to the sweeper.
+
+#### Falsification attempt for claim 4
+
+- **Strategy:** Counter-example construction — try to construct a
+  sweeper implementation that conforms to PR-3's stated design but
+  bypasses the inherited crash-to-`"failed"` guarantee.
+- **Attempt:** Three candidate sweeper implementations:
+  - (a) **Specified canonical**: `RetrySweeper.handle_info(:sweep,
+    ...)` invokes `GenServer.cast(Store.SQLite, {:dispatch_retry,
+    id, content})`, and Store's `handle_cast` returns
+    `{:noreply, state, {:continue, {:dispatch_embedding, id,
+    content}}}`. The sweep's enqueued Task ref lands in Store's
+    `pending_tasks` map; crash propagates to `do_mark_embedding_
+    failed/3` via the existing `:DOWN` clause. AC inherited.
+  - (b) **Direct-invocation antipattern**: sweeper calls
+    `EmbeddingWorker.embed_async(content)` and awaits the Task
+    itself. Task ref lands in sweeper mailbox. Crash invisible to
+    Store. AC NOT inherited. This is a contract-violating
+    implementation that the synthesis text explicitly forbids
+    ("routes through the store's `handle_continue` path").
+  - (c) **Hybrid**: sweeper calls `embed_async/1`, then sends
+    `{:track_ref, ref, id}` to the Store, which stores it in
+    `pending_tasks`. Now the Store owns the ref but not the
+    monitor — `Task.Supervisor.async_nolink/2`'s monitor is set
+    on the *spawning* process (the sweeper). The Store will not
+    receive `{:DOWN, ref, ...}`. AC NOT inherited. Subtle and
+    plausible-looking; another hazard for code review.
+  - The implementation hazards (b) and (c) demonstrate that the
+    composition's guarantee is *contingent on the implementer
+    using path (a)*. The composition rationale text names path
+    (a) directly; code review of PR-3 is the gate against (b)
+    and (c).
+- **Outcome:** withstood as a *design* claim — the composition's
+  contract-reuse pattern is sound and named explicitly in the
+  synthesis text. Partially exposed as an *implementation
+  hazard* — the implementer can deviate from the named routing
+  and silently lose the guarantee. The hazard belongs in the
+  PR-3 critic/reviewer gate, not in the synthesis text.
+- **Action:** Add to Outstanding doubts — the PR-3 critic/
+  reviewer brief MUST explicitly check that the sweeper routes
+  through `handle_continue({:dispatch_embedding, id, content},
+  state)` rather than spawning Tasks in the sweeper's own
+  process. (Per
+  `silent-failure-propagation/validation.md` Outstanding doubt
+  §"Migration order safety" — same shape, applied to the
+  sweeper.)
+
+### Claim 5: Together the three PRs make the parent acceptance criterion mechanically true — every entry under default configuration reaches `"ready"` or `"failed"` (with actionable telemetry) within a bounded window, with no permanent-`"pending"` failure mode remaining.
+
+- **Claim (C):** "Together these changes make the acceptance criterion
+  mechanically true: every entry under default configuration reaches
+  `"ready"` or `"failed"` (with actionable telemetry) within a
+  bounded window, with no permanent-`"pending"` failure mode
+  remaining." (`solution.md` §Recommendation, final sentence.)
+- **Grounds (G):**
+  - parent `problem.md` AC: "Every memory entry written under the
+    default application configuration either reaches
+    `embedding_status: 'ready'` when the embedding API responds
+    successfully, or transitions to `embedding_status: 'failed'`
+    with an actionable log/telemetry event, within the request
+    timeout window — and no entry remains permanently in
+    `embedding_status: 'pending'` due to a wiring defect or silent
+    crash."
+  - PR-1 closes the wiring defect (finch-name-mismatch validation
+    Claim 1 — withstood).
+  - PR-2's crash propagation transitions crashed entries from
+    `"pending"` to `"failed"` with `:transient`
+    (`silent-failure-propagation/validation.md` Claim 1 — withstood).
+  - PR-2's observability timer emits actionable telemetry when
+    stale `"pending"` entries exist (`pending-rot-
+    observability/validation.md` Claim 3 — withstood).
+  - PR-3's `RetrySweeper` re-dispatches stuck `"pending"` and
+    transient-`"failed"` rows, closing the loop after configuration
+    fix or transient fault clearance (`retry-recovery-path/
+    validation.md` Claim 1 — withstood).
+- **Warrant (W):** Conjunction-of-properties: if PR-1 closes the
+  *cause*, PR-2 closes the *invisibility-of-effect*, and PR-3
+  closes the *non-recovery*, then the union closes the failure
+  surface the AC names. The AC's three sub-claims (the entry
+  reaches `"ready"` OR `"failed"`; the failure is observable; no
+  permanent-`"pending"`) are independently addressed by three
+  composable PRs.
+- **Qualifier (Q):** *Narrowed (partial falsification below):*
+  Holds **after all three PRs have landed and `Store.SQLite` /
+  `RetrySweeper` survive a full sweep interval**. At each
+  intermediate merged `main` state:
+  - After PR-1 only: AC partially satisfied — new entries reach
+    `"ready"` or crash → currently still get stuck `"pending"`
+    (silent crash; AC fails).
+  - After PR-1 + PR-2: AC satisfied for *new* entries (each
+    crashes → `"failed"` within 30 s; observability timer fires
+    within 60 s of any residual `"pending"`); AC NOT satisfied
+    for pre-existing stuck rows (no retry path).
+  - After PR-1 + PR-2 + PR-3: AC fully satisfied within a bounded
+    window of one sweep interval (60 s default) plus the
+    `@stale_threshold_ms` (35 s) plus the request timeout (30 s).
+  - The "within the request timeout window" wording in the AC is
+    strictly satisfied only by PR-2's crash path; PR-3 closes a
+    longer window for the recovery case. The synthesis claim is
+    accurate but the AC's tightest reading allows only ~30 s,
+    which only PR-2 meets for fresh writes. The "bounded window"
+    framing in the synthesis is a paraphrase of the AC, not a
+    quotation.
+  - **Implementation hazard inherited from Claim 4**: if the
+    sweeper bypasses the canonical dispatch path, retry-driven
+    crashes are again invisible. The AC then fails for retry-
+    dispatched embeddings.
+- **Rebuttal (R):** Two paths-to-permanent-`"pending"` are not
+  covered:
+  - (i) A Store crash between dispatch and Task completion loses
+    the ref-map; the Task may still complete and its result is
+    received in nobody's mailbox; the entry stays `"pending"`.
+    This is named in
+    `silent-failure-propagation/validation.md` Outstanding doubt
+    §"Stuck-pending state lost on `Store.SQLite` crash" and is
+    explicitly out of scope per parent `problem.md` Out of scope
+    section ("…covered by retry-recovery-path"). PR-3's retry
+    sweeper covers it as long as the timer runs.
+  - (ii) `RetrySweeper` itself crashes repeatedly enough to hit
+    the supervisor's `:one_for_one` intensity threshold,
+    cascading the supervisor down. While this is recovered by
+    the Application supervisor, during the cascade the recovery
+    loop is inactive and a fresh stuck row can accumulate. This
+    is the
+    `retry-recovery-path/validation.md` Claim 6 rebuttal —
+    "effective restart rate doubles" — not a permanent failure,
+    so the AC's "no permanent" wording is preserved.
+- **Backing (B):** parent `problem.md` AC (verbatim); the four
+  child validations' Claim 1 outcomes (all withstood for
+  finch-name-mismatch, silent-failure-propagation, pending-rot-
+  observability, retry-recovery-path);
+  `.claude/rules/factory-loop.md` §"Incomplete-fix detection — do
+  not deflect to a follow-up" (a finding that falsifies an AC is
+  the merge being incomplete) — this exact criterion is what
+  this claim must satisfy.
+
+#### Falsification attempt for claim 5
+
+- **Strategy:** Edge-case enumeration over the AC's literal
+  wording ("ready or failed with actionable telemetry, within
+  request timeout, no permanent pending due to wiring defect or
+  silent crash") against the post-merge state at each of PR-1,
+  PR-1+2, PR-1+2+3.
+- **Attempt:** Enumerated five literal AC sub-conditions against
+  three merge-state snapshots (15 cells):
+  - PR-1 only:
+    1. reaches `"ready"` ✓ (HTTP succeeds, no callback bug yet
+       fixed but the success path was already working before).
+    2. transitions to `"failed"` ✗ (crash still silent).
+    3. actionable telemetry ✗.
+    4. within request timeout ✗ for failures.
+    5. no permanent `"pending"` due to silent crash ✗.
+    Result: AC NOT satisfied after PR-1 alone.
+  - PR-1 + PR-2:
+    1. reaches `"ready"` ✓.
+    2. transitions to `"failed"` ✓.
+    3. actionable telemetry ✓ (telemetry event + Logger.warning).
+    4. within request timeout ✓ for fresh writes.
+    5. no permanent `"pending"` ✓ for new writes; ✗ for
+       pre-existing rows that were already stuck before PR-2
+       shipped.
+    Result: AC satisfied for new entries, partially failed for
+    legacy stuck rows.
+  - PR-1 + PR-2 + PR-3:
+    1-5: all ✓; legacy stuck rows are swept within one interval.
+    Result: AC mechanically true.
+  - **Critical finding**: the synthesis claim "Together these
+    changes make the AC mechanically true" is true only of the
+    *terminal* state, not of intermediate states. The synthesis
+    Migration sketch acknowledges the sequencing but the
+    Recommendation's final sentence is silent on it. A reader
+    of the Recommendation alone could conclude the AC is met by
+    any individual PR.
+- **Outcome:** partially falsified — the claim's *terminal-state*
+  truth withstands; its *intermediate-state* truth is false at
+  PR-1 and partially false at PR-1+2. The qualifier in the
+  Recommendation is implicit but not explicit; the Migration
+  sketch makes it explicit. Reading both, the claim is correct;
+  reading the Recommendation alone, it overstates.
+- **Action:** Narrow Claim 5's qualifier in place (done above).
+  No solution revision required — the qualifier matches the
+  Migration sketch text and the Open questions list. The
+  factory-loop's incomplete-fix detection is per-PR; each
+  individual PR's draft body must cite which AC sub-condition
+  it advances and the gate enforces it. The narrowed qualifier
+  is consistent with the per-PR gate pattern in
+  `.claude/rules/factory-loop.md`.
+
+### Claim 6: The composed plan inherits five open questions from the child solutions; none block the recommendation but each should be resolved in the implementation PR that owns it.
+
+- **Claim (C):** "The composed plan inherits five open questions
+  from the child solutions; none block the recommendation but each
+  should be resolved in the implementation PR that owns it."
+  (`solution.md` §Open questions opening line.)
+- **Grounds (G):**
+  - The Open questions section lists seven distinct items
+    (despite the "five" claim) — namespace for
+    `Tau.Providers.Config`, `embed_async/1` inner-Task layering,
+    `{ref, result}` clause guard discipline, threshold runtime
+    vs compile-time, `(embedding_status, created_at)` index,
+    duplicate-embedding race, and sweeper first-fire latency.
+  - The five-vs-seven discrepancy is a counting error in the
+    synthesis text. Each item is a genuine inherited question,
+    sourced from a specific child solution's §Open questions
+    block (verified by cross-reference: 1 of 1 from finch-name-
+    mismatch, 1-2 of 3 from silent-failure-propagation, 1-2 of
+    3 from pending-rot-observability, 1-3 of 3 from retry-
+    recovery-path).
+  - Each item is named with its originating sub-problem in
+    parentheses and assigned to a specific PR for resolution.
+- **Warrant (W):** A non-leaf solution's Open questions section is
+  the union of child solutions' open questions, filtered for those
+  that the composition's specific choices affect. If composition
+  resolves a child's open question, the question is dropped;
+  otherwise it propagates upward.
+- **Qualifier (Q):** "None block the recommendation" holds because
+  each item is either a tuning parameter (intervals, thresholds,
+  index) or a code-review item the gate will catch (clause guard,
+  inner-Task layering, sweeper routing). The synthesis claims
+  "five" but lists seven — a documentation defect, not a
+  structural one.
+- **Rebuttal (R):** A reviewer might object that the duplicate-
+  embedding race question, paired with the parent-validator's
+  finding (Claim 4 above) about sweeper-routing hazards,
+  collectively rises to a *blocking* concern. Both must be
+  resolved correctly in PR-3's code, not deferred. The synthesis
+  text says they "should be resolved in the implementation PR
+  that owns it" — which is exactly what the factory-loop gate
+  enforces, so the rebuttal is procedurally addressed.
+- **Backing (B):** Each child validation's Outstanding doubts
+  section (the canonical upward-propagation mechanism per
+  `.code_audit/skills/code-audit-polya/validate.md` §"Outputs
+  that feed parent").
+
+#### Falsification attempt for claim 6
+
+- **Strategy:** Counter-example construction — find a child open
+  question that the synthesis silently dropped and that does
+  affect the parent AC.
+- **Attempt:** Iterate each child solution's §Open questions:
+  - finch-name-mismatch: 1 of 1 surfaced.
+  - silent-failure-propagation: 1 (inner-Task layering)
+    surfaced; 2 (clause guard) surfaced; 3 (`{:DOWN, :normal}`
+    double-cleanup) NOT surfaced — but the synthesis text
+    embeds the resolution in §What changes ("Tolerates
+    `Map.fetch/2` returning `:error`") inline. Dropped because
+    resolved, not silently.
+  - pending-rot-observability: 1 (runtime vs compile-time)
+    surfaced; 2 (index) surfaced; 3 (clause name conflict) NOT
+    surfaced — but `pending-rot-observability/validation.md`
+    Claim 2 confirmed no conflict. Dropped because resolved
+    (by validation).
+  - retry-recovery-path: 1 (duplicate-embedding race) surfaced;
+    2 (sweep under high write load) NOT surfaced — affects
+    performance, not the AC; dropped legitimately. 3 (startup
+    delay) surfaced.
+  - Total surfaced: 7 (matching the actual list). The synthesis
+    text's "five" is a typo or carry-over from an earlier
+    revision.
+- **Outcome:** withstood as to substance; the "five" vs "seven"
+  count is a textual defect that does not affect correctness or
+  AC satisfaction.
+- **Action:** Surface the count discrepancy as an Outstanding
+  doubt; not solution-revision-worthy.
+
+### Claim 7: The decomposition's MECE-by-layer property is what makes the parent solution coherent without bespoke conflict resolution.
+
+- **Claim (C):** "The decomposition was layered (one concern per
+  layer); the layers stack without overlap." (`solution.md`
+  §Composition rationale, closing sentence.)
+- **Grounds (G):**
+  - `problem.md` §Decomposition strategy explicitly invokes MECE:
+    "The four layers are mutually exclusive (a concern belongs to
+    exactly one layer) and collectively exhaustive (every aspect
+    of the broken pipeline … is covered)."
+  - The four layers map onto distinct phases of a single failure
+    pipeline: cause (PR-1) → propagation (PR-2 part 1) →
+    observation (PR-2 part 2) → remediation (PR-3). Causal
+    layering, not domain layering.
+  - The §Composition rationale clauses 1, 2, 3 enumerate the
+    three composition interfaces and one ordering constraint —
+    explicit named interfaces are the marker of layered (not
+    overlapping) composition.
+- **Warrant (W):** MECE decomposition is the standard
+  prerequisite for additive composition; when each child solves
+  one disjoint concern, the parent is the union of children
+  without bespoke reconciliation. (Folk wisdom of decomposition;
+  also the design-reasoning skill's PSDH method assumes layered
+  decomposition for non-leaf synthesis.)
+- **Qualifier (Q):** Holds for the failure-layer decomposition
+  this problem uses. A different decomposition (e.g. by
+  *module*: store changes, embedder changes, sweeper changes)
+  would have produced overlapping primary surfaces and required
+  bespoke reconciliation. The MECE-by-layer choice is what makes
+  the additive composition possible — it is not a property of
+  composition in general.
+- **Rebuttal (R):** The decomposition is MECE *over the failure
+  surface named in the problem*; it is not MECE over all aspects
+  of the embedding pipeline. The Open questions and Outstanding
+  doubts capture the residuals: dangling `memory_vec` rows,
+  sweeper error handling, store-crash mid-flight. These are not
+  in the four layers; they belong to a broader pipeline-
+  resilience concern that this problem deliberately excludes
+  (parent `problem.md` §Out of scope).
+- **Backing (B):** parent `problem.md` §Decomposition strategy
+  (verbatim MECE claim); the PSDH method described in
+  `.claude/skills/design-reasoning`; the in-repo prior art —
+  `docs/spec/SPEC-MEMORY-STORE.md` divides the store along
+  similar invariant lines (D-045, D-046, D-047).
+
+#### Falsification attempt for claim 7
+
+- **Strategy:** Counter-example construction — find a concern
+  that belongs to more than one layer, or one that belongs to no
+  layer.
+- **Attempt:**
+  - Concern A: "the `embed_async/1` callback contract" — touches
+    both silent-failure-propagation (defines it) and retry-
+    recovery-path (consumes it). Initially appears to belong to
+    two layers. On closer reading: silent-failure owns the
+    *contract*; retry-recovery is a *consumer* of that contract.
+    Contract ownership and contract consumption are not the same
+    concern. MECE preserved.
+  - Concern B: "what to do when `Store.SQLite` itself crashes
+    losing the ref-map" — belongs partly to crash-propagation
+    (PR-2 can't fix it) and partly to retry-recovery (PR-3
+    sweep eventually catches it). Two layers contribute. Initially
+    appears to violate MECE — but the problem's §Out of scope
+    explicitly excludes "performance of the embedding pipeline
+    under load" and the residual is more properly named "store-
+    crash mid-flight resilience", which is also out of scope.
+    Both children acknowledge the residual as out-of-scope; the
+    boundary is correctly drawn.
+  - Concern C: "duplicate embed calls from racing sweeper + write
+    path" — partly silent-failure (the contract permits double
+    dispatch), partly retry-recovery (the sweeper is the
+    duplicate source), partly pending-rot (the timer sees the
+    race window). Three layers touch it. This is the strongest
+    candidate counter-example. Reading the §Composition
+    rationale: clause 3 says observability and retry are
+    complementary, not redundant; the duplicate-race question is
+    surfaced as an Open question rather than resolved. The
+    decomposition does not claim to address this; the layers
+    remain MECE-as-decomposed even though the *race condition*
+    spans them. MECE applies to the *layers as decompositional
+    cuts*, not to *all emergent properties of the system*.
+  - No concern was found that belongs to no layer or that the
+    layers cannot collectively address.
+- **Outcome:** withstood — MECE-by-failure-layer is correctly
+  applied and the composition is additive. The residual race
+  condition is named as an Open question, not silently dropped.
+- **Action:** none.
+
+## Cross-claim consistency
+
+The seven claims form a single argumentative arc:
+
+- Claim 1 (composition is direct) establishes the structural premise.
+- Claim 7 (MECE-by-layer) explains *why* Claim 1 holds — they are
+  mutually reinforcing.
+- Claim 2 (PR ordering is mechanically necessary) and Claim 3
+  (PR-2 must bundle two children) constrain the temporal shape of
+  Claim 1's composition.
+- Claim 4 (sweeper inherits crash guarantee via shared contract)
+  is the load-bearing reuse that makes Claim 5's conjunction
+  achievable; Claim 4 has an explicit implementation hazard
+  (direct-invocation antipattern; hybrid pattern) that the
+  PR-3 gate must catch.
+- Claim 5 (conjunction satisfies parent AC) is the synthesis
+  claim that depends on Claims 1, 2, 3, and 4; its partial
+  falsification narrows to "after all three PRs land *and* the
+  PR-3 sweeper routes through the store's `handle_continue`",
+  consistent with all upstream claims.
+- Claim 6 (open questions are inherited correctly) is procedural;
+  no tension with substantive claims.
+
+No internal tension is identified. The seven claims share a
+common qualifier — the implementer follows the synthesis text's
+explicit routing and ordering prescriptions, and the per-PR
+factory-loop gate catches deviations.
+
+## Falsification summary
+
+| # | Claim (short) | Strategy | Outcome | Action |
+|---|---|---|---|---|
+| 1 | Four child solutions compose directly, no conflict | Integration check (file union) | Withstood | None |
+| 2 | PR-1 → PR-2 → PR-3 ordering is mechanically necessary | Counter-example construction (permutations) | Withstood | None |
+| 3 | PR-2 must bundle silent-failure + observability | Counter-example construction | Withstood | None |
+| 4 | Sweeper inherits crash guarantee via shared `embed_async/1` contract | Counter-example construction (sweeper variants) | Withstood (design); implementation hazard flagged | Add PR-3 gate check for canonical dispatch routing |
+| 5 | Three PRs together satisfy parent AC mechanically | Edge-case enumeration (AC × merge-state matrix) | Partially falsified — terminal-state truth holds; intermediate-state implicit qualifier required | Narrow qualifier; no revision |
+| 6 | Five inherited open questions, none blocking | Counter-example construction (per-child OQ trace) | Withstood; "five" should be "seven" | Surface count discrepancy as Outstanding doubt |
+| 7 | MECE-by-layer enables additive composition | Counter-example construction (concerns across layers) | Withstood | None |
+
+## Revision required
+
+None. Only Claim 5 is partially falsified, and the narrowing
+("terminal state after all three PRs land *and* sweeper uses
+canonical routing") matches the synthesis's own Migration sketch
+and Open questions. Per
+`.claude/plugins/polya-audit/skills/code-audit-polya/validate.md`
+§5: "Partial falsifications: narrow each claim's Qualifier in
+place. No revision needed; `validation.md` records the narrowed
+qualifiers and the `falsification_outcome:
+partially_falsified` flag."
+
+- **Target file:** n/a
+- **Revision kind:** n/a (in-place qualifier narrowing on Claim 5)
+- **Rationale:** the partial falsification of Claim 5 records an
+  implementation-time discipline (routing + ordering) that the
+  factory-loop gate already enforces per PR. Re-running the
+  proposer/selector would not change the structural composition;
+  the only correct response is the narrowed qualifier the
+  synthesis text already implicitly contains.
+
+## Outstanding doubts
+
+These doubts are inherited from the child validations and from
+this validator's per-claim falsification attempts. The root
+solution's coordinator and the per-PR critic/reviewer briefs
+should carry them forward.
+
+1. **Sweeper-routing hazard (Claim 4).** The PR-3 critic/reviewer
+   gate MUST explicitly check that `RetrySweeper.handle_info(
+   :sweep, ...)` enqueues work via a cast/call to `Store.SQLite`
+   that triggers the existing `handle_continue({:
+   dispatch_embedding, id, content}, state)` path, rather than
+   spawning Tasks directly in the sweeper's own process. The
+   latter silently loses the crash-to-`"failed"` guarantee.
+   Direct-invocation and "track-ref-after-the-fact" antipatterns
+   are both plausible-looking and both wrong; the gate brief
+   must name them by name.
+
+2. **AC's intermediate-state qualifier (Claim 5).** The synthesis
+   Recommendation's final sentence ("Together these changes make
+   the acceptance criterion mechanically true") is true at the
+   PR-1+2+3 terminal state but overstates the truth at the
+   PR-1+2 intermediate state (pre-existing stuck rows remain).
+   Per-PR draft bodies must cite *which AC sub-conditions* the
+   specific PR advances — the factory-loop's incomplete-fix
+   detection rule (`.claude/rules/factory-loop.md`) enforces
+   this. PR-1 advances no AC clause to true on its own; PR-2
+   advances the AC to substantial truth for new entries; PR-3
+   makes it complete. The per-PR critic should not be confused
+   by the Recommendation's terminal-state framing into believing
+   any intermediate PR alone closes the AC.
+
+3. **Dangling `memory_vec` row on concurrent delete-during-retry**
+   (inherited from `retry-recovery-path/validation.md`
+   Outstanding doubt 1). The schema does not declare a FK from
+   `memory_vec(entry_id)` to `memory_entries(id)`; a sweep that
+   races a delete can leave a dangling vector row. The PR-3
+   implementer should either add an ON DELETE CASCADE FK or
+   ensure the sweeper's enqueue path is short enough that an
+   in-progress delete removes the entry from the result set
+   before re-dispatch. The pre-existing nature of the
+   structural debt does not absolve PR-3 — the sweeper makes
+   the race reachable for the first time.
+
+4. **`memory_store.ex` path correction inherited from
+   `silent-failure-propagation/validation.md` Claim 4**: the
+   `Tau.Memory.MemoryStore` referent does not exist as a
+   separate file; the public `store_embedding/3` to be removed
+   lives at `lib/tau/memory/store/sqlite.ex:163-167` with the
+   alias `Tau.Memory.Store.SQLite, as: MemoryStore` at
+   `lib/tau/memory/embedding_worker.ex:32` being the only thing
+   in the repo named `MemoryStore`. The parent `solution.md`
+   §What changes also lists `lib/tau/memory/memory_store.ex` —
+   the implementer brief MUST use the corrected path
+   `lib/tau/memory/store/sqlite.ex:163-167`.
+
+5. **Threshold coupling between embedding timeout and stale
+   threshold** (inherited from `pending-rot-observability/
+   validation.md` Outstanding doubt 1). The chosen
+   `@stale_threshold_ms = 35_000` is hand-tuned to exceed
+   `EmbeddingWorker`'s `@request_timeout_ms = 30_000` plus a
+   5 s grace. If either constant changes, both must change in
+   lockstep. The synthesis Open questions §4 (runtime vs
+   compile-time) acknowledges this coupling.
+
+6. **Open-questions count discrepancy (Claim 6).** The
+   synthesis text says "inherits five open questions" but lists
+   seven. Not solution-correctness-affecting; a documentation
+   tidy-up.
+
+7. **`{ref, result}` clause guard discipline** (inherited from
+   `silent-failure-propagation/validation.md` Outstanding doubt
+   2). The new `handle_info({ref, result}, state) when
+   is_reference(ref)` clause must not accidentally match
+   unrelated messages with a reference in tuple position 0; the
+   `Map.fetch(pending_tasks, ref)` discipline is the
+   resolution. PR-2 critic must confirm.

--- a/docs/problems-archive-v1-modules/tau-permissions/problem.md
+++ b/docs/problems-archive-v1-modules/tau-permissions/problem.md
@@ -1,0 +1,115 @@
+---
+template_version: 1
+template_name: problem
+node_kind: internal
+depth: 0
+parent: —
+status: decomposed
+---
+
+# Problem: tau-permissions invariant coverage gaps and matcher/mode complecting
+
+## Statement
+
+The `tau-permissions` subsystem is named by CLAUDE.md OTP non-negotiable #6 as
+invariant-bearing, yet four distinct coverage holes exist today: the five
+concrete matcher modules have zero property tests; `Mode.clamp/2` has example
+tests but its lattice properties were only recently added (present) while its
+peer-rank edge cases are untested as properties; `default_for_mode/3` in the
+evaluator hard-codes mode-specific tool lists that overlap with, but diverge
+from, the rule-set precedence logic; and `Settings.Loader.merge/2`, the
+upstream feed for the rule-set, has no property tests asserting that the
+permission arrays it concatenates remain order-stable and idempotent under
+repeated merge. The problem is true today because a targeted property sweep
+catches none of these holes, and a one-off breakage in any of them silently
+alters user-visible permission decisions.
+
+## Context
+
+- `lib/tau/permissions/mode.ex` — lattice with `@ranks` map; `clamp/2`,
+  `at_or_below?/2`, `rank/1`. Property tests present in
+  `test/tau/permissions/mode_test.exs` covering the key invariants.
+- `lib/tau/permissions/evaluator.ex` — `evaluate/5` with `default_for_mode/3`
+  hard-coding per-mode tool allow-lists (`:plan`, `:auto`, `:accept_edits`).
+  Tool lists (e.g. `"Agent"`) encode sub-agent delegation policy inline.
+- `lib/tau/permissions/matchers.ex` — five matcher modules (`Always`, `Glob`,
+  `PathPrefix`, `Domain`, `Regex`). Zero direct unit or property tests; exercised
+  only indirectly through `EvaluatorTest`.
+- `lib/tau/permissions/parser.ex` — compiles settings strings into
+  `{decision, matcher, compiled_rule}` triples.
+- `lib/tau/permissions/rule_set.ex` — GenServer; stores compiled rules in
+  `:persistent_term`; subscribes to PubSub `"settings"` topic.
+- `lib/tau/settings/loader.ex` — `merge/2` deep-merges layered settings; no
+  property tests (`test/tau/settings/loader_test.exs` is example-only).
+- ADR-0013 (skill whitelist gate), ADR-0014/0015 (mode ceiling / sub-agent
+  clamp). `SPEC-PERMISSION-PROMPTS.md` §D-090..D-099.
+
+## Complecting hypothesis
+
+`default_for_mode/3` in `Evaluator` is complected with rule-set precedence
+because it encodes a secondary tool-allowlist (e.g. `["Read","Grep","Glob","Agent"]`)
+inline in the evaluator rather than deferring to the rule-set; a change to one
+concern (which tools are safe in `:plan` mode) silently requires a change to the
+other (the rule-set ordering contract).
+
+`Matchers.PathPrefix.match?/4` is complected with process environment because it
+calls `File.cwd!/0` as a fallback when `ctx[:cwd]` is absent, making the
+pure-function contract undiscoverable: the same `(rule, tool_name, args, ctx)`
+inputs produce different results under different working directories.
+
+`Settings.Loader.merge/2`'s permissions-array concatenation is complected with
+the order-dependence of `Evaluator`'s first-match logic: the merge contract
+(layer B's deny entries append after layer A's) is not tested as a property,
+so a merge-order regression silently changes which deny rules win.
+
+## Decomposition strategy
+
+Split by **concern layer**: each sub-problem maps to a distinct layer of the
+pipeline — matcher unit contracts, mode-lattice properties, evaluator
+mode-dispatch, and settings-merge feed — where the coupling or test gap lives
+exclusively. The four concerns are disjoint in source ownership
+(`matchers.ex`, `mode.ex`, `evaluator.ex`, `settings/loader.ex`) and in the
+failure mode each gap exposes; none is a sub-concern of another.
+
+## Sub-problems (filled by decomposer)
+
+1. **matcher-unit-contracts** — The five matcher modules (`Always`, `Glob`,
+   `PathPrefix`, `Domain`, `Regex`) have zero direct tests; their contracts
+   (including `PathPrefix`'s impure `File.cwd!` fallback) are untested.
+2. **mode-lattice-properties** — `Mode.clamp/2` has example tests; the lattice
+   properties that already exist in `mode_test.exs` are good but the peer-rank
+   contract (all three rank-3 modes interchangeable under clamp) is only
+   spot-checked, not property-swept.
+3. **evaluator-mode-complecting** — `default_for_mode/3` encodes per-mode
+   tool allow-lists inline in the evaluator, complecting mode policy with
+   rule-set precedence; this creates an undocumented second allow-list that
+   can diverge silently.
+4. **settings-merge-feed** — `Settings.Loader.merge/2` concatenates
+   permissions arrays with no property tests; a merge-order regression silently
+   changes which deny/allow rules win in the evaluator.
+
+## Acceptance criterion
+
+Every invariant-bearing function in `tau-permissions` and its upstream feed
+(`Settings.Loader.merge/2`) has at least one property test asserting its
+named invariant; the `PathPrefix` impure-fallback concern is documented as a
+known deviation from the pure-function contract; and the evaluator's
+`default_for_mode/3` tool allow-lists are structurally separated from the
+rule-set precedence logic so that a change to one does not silently affect the
+other.
+
+## Out of scope
+
+- `Tau.Permissions.RuleSet` GenServer lifecycle (PubSub subscription,
+  `:persistent_term` write path) — these are infrastructure concerns, not
+  invariant-bearing logic.
+- `SPEC-PERMISSION-PROMPTS.md` `:awaiting_permission` FSM state and TUI dialog
+  — owned by `Tau.Session` and `Tau.TUI.App`, not this subsystem.
+- Parser regex syntax (the `~r/^([A-Za-z]...)\((.*)\)$/` rule-parsing regex)
+  — correctness is covered by `EvaluatorTest`'s example suite; not the focus
+  here.
+- Settings schema validation, vault backends, watcher — separate subsystem.
+
+## Amendment log
+
+- (none yet)

--- a/docs/problems-archive-v1-modules/tau-permissions/solution.md
+++ b/docs/problems-archive-v1-modules/tau-permissions/solution.md
@@ -1,0 +1,243 @@
+---
+template_version: 1
+template_name: solution
+parent_problem: problem.md
+node_kind: root
+synthesised_from:
+  - subproblems/matcher-unit-contracts/solution.md
+  - subproblems/mode-lattice-properties/solution.md
+  - subproblems/evaluator-mode-complecting/solution.md
+  - subproblems/settings-merge-feed/solution.md
+selection_method: synthesis
+mode: non-leaf
+revision: 0
+---
+
+# Solution: Close tau-permissions property-coverage holes and decomplect evaluator mode-dispatch via four layered, parallelisable PRs
+
+## Recommendation
+
+Land four independently-reviewable PRs, one per concern layer, that together
+satisfy the root acceptance criterion. The PRs are disjoint in source ownership
+and may be authored and gated concurrently (see Parallelism below), but the
+evaluator-mode PR carries a single shared interface point — a SPEC amendment in
+`SPEC-PERMISSION-PROMPTS.md` that introduces one new D-NNN invariant — which
+gates the synthesis as a whole. Layer responsibilities are: (PR-A)
+`test/tau/permissions/matchers_test.exs` plus the 3-line `PathPrefix.match?/4`
+fail-closed purification; (PR-B) exhaustive 9-pair `clamp/2` sweep and an
+`at_or_below?/2` property block in `test/tau/permissions/mode_test.exs`; (PR-C)
+extraction of `Tau.Permissions.ModePolicy` with a delegated `default_for_mode/3`
+plus `test/tau/permissions/mode_policy_test.exs` properties and the new D-NNN
+SPEC entry; (PR-D) `test/tau/settings/loader_property_test.exs` covering the
+three permissions-array merge invariants. After all four land, every
+invariant-bearing function in `tau-permissions` and `Settings.Loader.merge/2`
+has at least one property test, the `PathPrefix` impurity is eliminated rather
+than merely documented, and the evaluator's per-mode allow-set is structurally
+separated from rule-set precedence and pinned by a spec-gated D-NNN.
+
+## Selected from
+
+- **Synthesised from:**
+  - `subproblems/matcher-unit-contracts/solution.md` — StreamData properties
+    for all five matchers + purify `PathPrefix.match?/4` (hybrid P2+P3).
+  - `subproblems/mode-lattice-properties/solution.md` — deterministic 9-pair
+    `for` sweep + `at_or_below?/2` property block (single P2).
+  - `subproblems/evaluator-mode-complecting/solution.md` — extract
+    `Tau.Permissions.ModePolicy` + pin D-NNN in spec (hybrid P2+P4).
+  - `subproblems/settings-merge-feed/solution.md` — new
+    `loader_property_test.exs` with three merge invariants (single P2).
+
+- **Composition rationale:** the four child solutions partition cleanly by
+  concern layer; their `What changes` lists are file-disjoint (`matchers.ex` +
+  `matchers_test.exs` / `mode_test.exs` / `mode_policy.ex` + `evaluator.ex` +
+  `mode_policy_test.exs` + `SPEC-PERMISSION-PROMPTS.md` / `loader_property_test.exs`)
+  and their failure modes are orthogonal. There is no conflict to resolve and
+  no gap against the root acceptance criterion: matcher-unit-contracts covers
+  the five matchers and the `PathPrefix` impurity concern explicitly (the root
+  AC names the latter as a "documented known deviation" — the synthesis
+  upgrades that to "eliminated" via PR-A's hybrid, which is strictly stronger
+  and satisfies the AC by removing the deviation rather than documenting it);
+  mode-lattice-properties closes the peer-rank gap; evaluator-mode-complecting
+  delivers the structural decomplecting demanded by the AC's third clause;
+  settings-merge-feed closes the upstream-feed gap on `Loader.merge/2`. The
+  only cross-layer interface is the SPEC-gating discipline: PR-C's D-NNN entry
+  in `SPEC-PERMISSION-PROMPTS.md` is the durable anchor for the whole
+  subsystem's invariant set and is the only file touched outside `lib/tau/` and
+  `test/`. No child's recommendation contradicts another. PR-A's
+  `PathPrefix` purification (one of two production-code changes in the whole
+  set) is independent of PR-C's `ModePolicy` extraction (the other), so the two
+  may merge in either order.
+
+## What changes
+
+Concrete file-level list, grouped by PR. Each PR is self-contained and gated
+independently.
+
+### PR-A — matcher unit contracts + purify `PathPrefix`
+
+- **New file** `test/tau/permissions/matchers_test.exs` — StreamData property
+  tests for `Always`, `Glob` (incl. `glob_match?/2`), `PathPrefix`, `Domain`,
+  `Regex`; two or more properties per matcher plus boundary examples.
+- **Modified** `lib/tau/permissions/matchers.ex` — `PathPrefix.match?/4`:
+  replace `cwd = ctx[:cwd] || File.cwd!()` with a `case ctx[:cwd]` that returns
+  `false` when `nil` (fail-closed); update `PathPrefix` moduledoc to state the
+  now-pure contract.
+- **Pre-PR audit** (no file change): grep all `Evaluator.evaluate/5` call sites
+  to confirm `:cwd` is in the ctx map; any gap fixes land in the same PR.
+
+### PR-B — mode-lattice peer-rank exhaustion + `at_or_below?/2` properties
+
+- **Modified** `test/tau/permissions/mode_test.exs`:
+  - remove the three spot-check tests inside
+    `describe "clamp/2 — peer modes"`;
+  - add `@peers [:accept_edits, :dont_ask, :plan]` at the top of the property
+    section;
+  - add `describe "clamp/2 — peer modes (exhaustive 9-pair sweep)"` with one
+    `test` doing `for req <- @peers, par <- @peers, do: assert
+    Mode.clamp(req, par) == req` (interpolated error message on failure);
+  - add `describe "at_or_below?/2 — properties"` with a StreamData reflexivity
+    property and two `FunctionClauseError` guard tests.
+
+### PR-C — extract `ModePolicy` + pin D-NNN invariant
+
+- **New file** `lib/tau/permissions/mode_policy.ex` — `Tau.Permissions.ModePolicy`
+  module with `@policies` compile-time map, `%ModePolicy{}` struct
+  (`allow_set`, `default_outcome`, `bash_heuristic?`), `default/3`, and
+  `for_mode/1`. `allow_set: :all` handled as a tagged-union variant with an
+  explicit type annotation (`[String.t()] | :all`) or a dedicated `bypass`
+  arm — implementer chooses.
+- **Modified** `lib/tau/permissions/evaluator.ex` — replace the six
+  `defp default_for_mode` clauses with a single-clause delegation
+  `defp default_for_mode(mode, tool, args), do: ModePolicy.default(mode, tool, args)`.
+- **New file** `test/tau/permissions/mode_policy_test.exs` — StreamData
+  properties targeting `ModePolicy.default/3` directly: `:plan` denies outside
+  allow-set; `:dont_ask` denies all; `:auto` never allows outside allow-set;
+  `:accept_edits` non-Bash non-allowed tools yield `:ask`.
+- **Modified** `docs/spec/SPEC-PERMISSION-PROMPTS.md` — add one D-NNN
+  invariant entry (next free slot in D-090..D-099 — must be confirmed by
+  `git log --all --grep` plus `grep -rn` over `lib test docs .claude` before
+  filing) stating the `ModePolicy` contract, the allow-set table,
+  ADR-0014/ADR-0015 citations, `"Agent"` exemption rationale, the
+  `:accept_edits` Bash exception, and naming `mode_policy_test.exs` as
+  enforcement.
+
+### PR-D — settings-merge feed properties
+
+- **New file** `test/tau/settings/loader_property_test.exs` — three property
+  tests with `fixed_map/1`-based local generators (`permission_list/0`,
+  `permissions_layer/0`, `settings_with_permissions/0`):
+  - C1: prefix-then-suffix concatenation invariant for `allow` / `deny` / `ask`
+    simultaneously;
+  - C2: right-identity `merge(x, %{}) == x`;
+  - C3: absent-key-as-empty-list invariant.
+  - Module: `Tau.Settings.LoaderPropertyTest`.
+
+## What does not change
+
+- `Tau.Permissions.Matcher` behaviour interface (`match?/4` signature
+  unchanged across all PRs).
+- `Evaluator.evaluate/5` public signature (PR-C delegates `default_for_mode/3`
+  internally; the rule-set scan logic, priority order, and call signature are
+  preserved).
+- `Tau.Permissions.RuleSet` lifecycle — no GenServer / PubSub /
+  `:persistent_term` changes; explicitly out of scope per the root problem.
+- `Tau.Permissions.Matchers.Always` — no `{:only, tool}` extension (Proposal 3
+  of the evaluator sub-problem was rejected for cost).
+- No new matcher modules.
+- `lib/tau/settings/loader.ex` — no production changes from PR-D (only new
+  tests; if C1/C2/C3 reveal a bug, that becomes a separate fix per the
+  sub-problem's open question).
+- `lib/tau/permissions/mode.ex` — no production changes from PR-B (test-only).
+- `test/tau/permissions/evaluator_test.exs` — existing indirect coverage is
+  preserved across PR-A and PR-C.
+- `mix.exs` — `stream_data` already present; no dependency changes.
+- ADR-0013/0014/0015 — no contract changes; PR-C's SPEC entry cites the ADRs
+  rather than amending them.
+- All SPECs other than `SPEC-PERMISSION-PROMPTS.md` (the sole spec touch lives
+  in PR-C).
+- The `:awaiting_permission` FSM state and TUI permission dialog (owned by
+  `Tau.Session` / `Tau.TUI.App`) — explicitly out of scope.
+
+## Migration sketch
+
+The four PRs are parallelisable per the conflict check in
+`.claude/rules/factory-loop.md` §Parallel execution. Walk the five clauses:
+
+1. **No dependency** — none of the four blocks any other; PR-C's SPEC entry is
+   the only durable cross-PR artefact and it does not block PR-A / PR-B / PR-D
+   landing.
+2. **Disjoint files** — verified above; the four `What changes` lists do not
+   share a single file path (PR-A and PR-C both write under
+   `lib/tau/permissions/` but to disjoint files; PR-A touches `matchers.ex`,
+   PR-C touches `evaluator.ex` and creates `mode_policy.ex`; the only shared
+   directory is `test/tau/permissions/` but each PR's new test file is
+   distinct).
+3. **Disjoint codepoints** — verified: PR-A modifies one function in
+   `matchers.ex` (`PathPrefix.match?/4`); PR-C modifies `default_for_mode/3` in
+   `evaluator.ex`; no overlap.
+4. **No shared SPEC or D-NNN block** — only PR-C touches a SPEC; the D-NNN it
+   adds is a new slot in D-090..D-099, not an amendment to an existing entry.
+5. **Shared-resource isolation possible** — none of the four PRs exercises
+   `mix release` / `mix tau.smoke` / Burrito; standard `mix test` per-worktree
+   isolation suffices.
+
+All five clauses clear. The recommended factory batch is to spawn PR-A, PR-B,
+PR-C, PR-D concurrently as four implementer agents, each `isolation: worktree`,
+each with its own draft PR opened first per the factory-loop cycle. Merges
+serialise (one at a time) and each merge fires the freshness re-check for the
+others; expect three rebases over the batch's lifetime. If the coordinator
+cannot gate four concurrent PRs without losing track, serialise to two batches
+(PR-A + PR-B first; PR-C + PR-D second; the recommended preferential order
+within either grouping is alphabetical, no technical ordering forces a
+sequence). The full set should close in one factory cycle for the assigned
+milestone.
+
+## Open questions
+
+- **D-NNN slot for PR-C.** The next free identifier in D-090..D-099 must be
+  confirmed by `git log --all --grep <id>` plus `grep -rn <id> lib test docs
+  .claude` before PR-C is filed. The sketch uses a placeholder; the
+  implementer's first task in PR-C is the grep.
+- **`allow_set: :all` type for `:bypass`.** PR-C must choose between a tagged
+  union (`[String.t()] | :all`) and a dedicated `bypass_policy` field on
+  `%ModePolicy{}` to satisfy Dialyzer. Either is acceptable; the choice is
+  local to PR-C.
+- **`mode_policy_test.exs` placement.** Either a new file or a `describe` block
+  inside `evaluator_test.exs`; the SPEC's enforcement line in PR-C must name
+  whichever is chosen.
+- **Call-site audit scope for PR-A.** `Tau.Session` must populate `:cwd` in the
+  ctx it passes to `Evaluator.evaluate/5` for the `PathPrefix` purification to
+  be safe at every call site. If the audit surfaces a gap, the ctx-population
+  fix lands in the same PR-A; this slightly widens PR-A's scope but does not
+  break the conflict check.
+- **Generator widening for PR-A.** `Domain` properties currently miss Unicode
+  hostnames / IDNs; `Glob.glob_match?/2`'s `?` / `/` behaviour is documented
+  by the property suite but not changed. Both are explicit residuals of the
+  child solution and remain open.
+- **C3 outcome for PR-D.** If the absent-key property fails against the real
+  `Loader.merge/2`, the implementer must either fix the loader (which widens
+  PR-D's scope) or narrow the property and file a follow-up. The sub-problem
+  treats this discovery as the value of the property suite.
+- **Deferred deeper structural fix for evaluator.** Proposal 3 of the
+  evaluator sub-problem (folding mode defaults into the rule-set itself)
+  remains the correct long-term direction. It is explicitly deferred and
+  should be filed as a follow-up issue against `SPEC-PERMISSION-PROMPTS.md`
+  once the `:accept_edits` Bash matcher design is settled.
+
+## Linked sub-problems / proposals
+
+- `subproblems/matcher-unit-contracts/` → "StreamData property tests for all
+  five matchers + purify `PathPrefix.match?/4` fail-closed when `ctx[:cwd]` is
+  absent" (hybrid P2 + P3).
+- `subproblems/mode-lattice-properties/` → "Deterministic 9-pair `for`
+  comprehension peer-mode sweep + dedicated `at_or_below?/2` property block in
+  `mode_test.exs`" (single P2).
+- `subproblems/evaluator-mode-complecting/` → "Extract `Tau.Permissions.ModePolicy`
+  data structure and delegate `default_for_mode/3`; pin a new D-NNN invariant in
+  `SPEC-PERMISSION-PROMPTS.md`" (hybrid P2 + P4).
+- `subproblems/settings-merge-feed/` → "New `loader_property_test.exs` with
+  three properties (concat, right-identity, absent-key)" (single P2).
+
+## Revision history
+
+- (revision 0 — initial)

--- a/docs/problems-archive-v1-modules/tau-permissions/subproblems/evaluator-mode-complecting/problem.md
+++ b/docs/problems-archive-v1-modules/tau-permissions/subproblems/evaluator-mode-complecting/problem.md
@@ -1,0 +1,83 @@
+---
+template_version: 1
+template_name: problem
+node_kind: leaf
+depth: 1
+parent: ../../problem.md
+status: draft
+---
+
+# Problem: default_for_mode/3 encodes a second tool allow-list separate from the rule-set
+
+## Statement
+
+`Tau.Permissions.Evaluator.default_for_mode/3` contains hard-coded tool
+allow-lists for `:plan`, `:auto`, and `:accept_edits` modes
+(e.g. `["Read", "Grep", "Glob", "Agent"]` for `:plan`). This is a second
+allow-list that is structurally independent of the rule-set evaluated just
+above it in `evaluate/5`; the two lists can diverge silently when a tool
+is added to one but not the other. The `"Agent"` entries in `:plan` and `:auto`
+were added with inline comments citing the rationale (ADR-0014/0015), but
+there is no property test asserting that the mode-dispatch fallback cannot
+produce a result more permissive than the mode's stated policy (e.g. `:plan`
+should never yield `:allow` for a non-read tool except `"Agent"`).
+
+## Context
+
+- `lib/tau/permissions/evaluator.ex`, `default_for_mode/3`, lines 91–119:
+  - `:plan` allows `["Read", "Grep", "Glob", "Agent"]`; denies everything else.
+  - `:auto` allows `["Read", "Grep", "Glob", "Agent"]`; asks everything else.
+  - `:accept_edits` allows `["Read", "Write", "Edit", "Grep"]`; for `"Bash"`,
+    delegates to `Heuristics.destructive_bash?/1`; everything else is `:ask`
+    (unknown tools fall through to the `default_for_mode(_, _, _)` catch-all
+    which returns `:ask`).
+- The `evaluate/5` function evaluates the rule-set first (deny → allow → ask),
+  then falls through to `default_for_mode/3` only on no match. The two layers
+  are logically sequential but the tool allow-lists in `default_for_mode/3`
+  are not derivable from the rule-set; they are a separate static policy.
+- `test/tau/permissions/evaluator_test.exs`: examples cover the `:auto`/`Agent`
+  case (lines 117–128) but there is no property asserting that for all tools
+  NOT in the `:plan` allow-list, `:plan` mode always yields `:deny` when no
+  allow rule matches.
+- `SPEC-PERMISSION-PROMPTS.md` §D-090..D-099 names the evaluator as
+  in-scope; no D-NNN invariant currently pins the `default_for_mode` contract.
+
+## Complecting hypothesis
+
+`default_for_mode/3` is complected with rule-set precedence because it
+implements a secondary static allow-list for `:plan`/`:auto`/`:accept_edits`
+modes that partially duplicates what a rule-set entry would express — but is
+evaluated after the rule-set is exhausted, creating an implicit priority order
+(rule-set deny > skill gate > bypass > rule-set allow/ask > mode default)
+that is not stated as a property or spec invariant.
+
+The `:accept_edits` heuristic path is complected with the mode-dispatch logic
+because `Heuristics.destructive_bash?/1` is invoked from inside
+`default_for_mode/3` rather than at the rule-set boundary, making the
+`:accept_edits` + `"Bash"` path a structural exception to the
+"rule-set first, mode last" contract.
+
+## Decomposition strategy
+
+(leaf — no further decomposition; proceed to proposals)
+
+## Acceptance criterion
+
+At least one property test asserts that for all tools outside the stated
+allow-set for each non-default mode (`:plan`, `:dont_ask`), the evaluator
+with an empty rule-set yields `:deny`; and the tool allow-lists in
+`default_for_mode/3` are documented (inline or in a moduledoc addendum) with
+the explicit invariant they enforce and a reference to ADR-0014/ADR-0015, so
+a reader can verify them without searching commit history.
+
+## Out of scope
+
+- Matcher unit tests — covered by `matcher-unit-contracts`.
+- Mode-lattice peer-rank properties — covered by `mode-lattice-properties`.
+- `Settings.Loader.merge/2` — covered by `settings-merge-feed`.
+- `Tau.Permissions.RuleSet` GenServer lifecycle — out of scope for this audit
+  (declared in root `problem.md`).
+
+## Amendment log
+
+- (none yet)

--- a/docs/problems-archive-v1-modules/tau-permissions/subproblems/evaluator-mode-complecting/proposals/proposal-1.md
+++ b/docs/problems-archive-v1-modules/tau-permissions/subproblems/evaluator-mode-complecting/proposals/proposal-1.md
@@ -1,0 +1,161 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 1
+parent_problem: ../problem.md
+---
+
+# Proposal 1: Document and property-test the existing default_for_mode/3 contract in-place
+
+## Approach
+
+Leave `default_for_mode/3` structurally unchanged. Add a `@moduledoc` addendum
+(or a dedicated `## Mode defaults` section within the existing moduledoc) that
+states the allow-set for each non-default mode as a named invariant, cites
+ADR-0014 and ADR-0015 inline, and explains why `"Agent"` is exempt from
+read-only enforcement. Add property tests to `evaluator_test.exs` using
+`StreamData` that, for each mode, generate arbitrary tool names outside the
+stated allow-set and assert the empty-rule-set result equals the mode's
+specified default outcome (`:deny` for `:plan`/`:dont_ask`, `:ask` for
+`:auto`/`:accept_edits` non-Bash, `:allow` for `:bypass`).
+
+## Rationale
+
+The complecting hypothesis states the problem is that the secondary allow-list
+is *undocumented* and lacks a property asserting its invariant — not that the
+list is in the wrong place. A reader already following the code would need to
+check commit history or ADRs to understand why `"Agent"` is in the `:plan`
+allow-set. Surfacing the invariant as documented contract (moduledoc) + verified
+property (StreamData) decomplects the *knowledge* without moving the *code*.
+The implicit priority order (rule-set deny > skill gate > bypass > rule-set
+allow/ask > mode default) becomes explicit in the module's narrative. The
+`:accept_edits` + Bash heuristic exception is documented as an inline structural
+note, not buried in an ADR.
+
+## Sketch
+
+Moduledoc addendum in `evaluator.ex`:
+
+```elixir
+@moduledoc """
+  ...existing text...
+
+  ## Mode defaults (evaluated only when no rule-set entry matches)
+
+  These are *secondary* policy entries. They are evaluated after the
+  full rule-set (deny → allow → ask) is exhausted. They MUST NOT be
+  confused with rule-set entries — they are not expressed as rules and
+  are not reachable by the rule-set scan.
+
+  | mode           | default outcome  | allow-set                              | basis      |
+  |----------------|-----------------|----------------------------------------|------------|
+  | `:default`     | `:ask`          | (none — always asks)                   | —          |
+  | `:plan`        | `:deny`         | `["Read","Grep","Glob","Agent"]`        | ADR-0014   |
+  | `:auto`        | `:ask`          | `["Read","Grep","Glob","Agent"]`        | ADR-0015   |
+  | `:accept_edits`| `:ask`          | `["Read","Write","Edit","Grep"]`        | ADR-0015   |
+  | `:dont_ask`    | `:deny`         | (none — always denies on no match)     | —          |
+  | `:bypass`      | `:allow`        | (all — evaluated before mode default)  | —          |
+
+  `"Agent"` appears in the `:plan` and `:auto` allow-sets because it is
+  dispatch infrastructure, not a content tool. Denying it kills sub-agent
+  delegation entirely; the read-only constraint propagates into child
+  sessions via `Tau.Permissions.Mode.clamp/2`. See ADR-0014, ADR-0015.
+
+  The `:accept_edits` + `"Bash"` path is a deliberate structural exception:
+  `Heuristics.destructive_bash?/1` is invoked here rather than at the
+  rule-set boundary because the heuristic's semantics are mode-scoped
+  (what is "destructive" under `:accept_edits` may be safe under `:bypass`).
+"""
+```
+
+Property tests in `evaluator_test.exs`:
+
+```elixir
+describe "mode default invariants (properties)" do
+  use ExUnitProperties
+
+  # Tools NOT in the :plan allow-set must always yield :deny with an empty rule-set.
+  property ":plan denies tools outside its allow-set" do
+    plan_allowed = MapSet.new(["Read", "Grep", "Glob", "Agent"])
+
+    check all tool <- string(:alphanumeric, min_length: 1),
+              tool not in plan_allowed do
+      assert Evaluator.evaluate({}, tool, %{}, %{}, :plan) == :deny
+    end
+  end
+
+  # Tools NOT already auto-allowed under :dont_ask must default to :deny.
+  property ":dont_ask denies all tools with empty rule-set" do
+    check all tool <- string(:alphanumeric, min_length: 1) do
+      assert Evaluator.evaluate({}, tool, %{}, %{}, :dont_ask) == :deny
+    end
+  end
+
+  # Tools outside the explicit allow-set under :auto must never yield :allow
+  # without a rule-set entry.
+  property ":auto yields :ask (not :allow) for tools outside its allow-set" do
+    auto_allowed = MapSet.new(["Read", "Grep", "Glob", "Agent"])
+
+    check all tool <- string(:alphanumeric, min_length: 1),
+              tool not in auto_allowed do
+      result = Evaluator.evaluate({}, tool, %{}, %{}, :auto)
+      assert result in [:ask, :deny]
+      refute result == :allow
+    end
+  end
+end
+```
+
+## Tradeoffs
+
+### Strengths
+
+- Zero structural change to evaluator logic; no regression surface.
+- Acceptance criterion is fully met: the property tests assert the named
+  invariants for `:plan` and `:dont_ask`; the moduledoc documents the
+  allow-sets with ADR references.
+- Cheapest migration: one PR, no other modules touched, no API change.
+- Property tests are understandable by any future contributor without
+  knowledge of the decomplecting rationale.
+
+### Weaknesses
+
+- Does not address the structural complecting: `default_for_mode/3` still
+  encodes a secondary allow-list orthogonal to the rule-set. A future
+  contributor adding a new mode can reproduce the same undocumented pattern.
+- Documentation only survives as long as the moduledoc is kept current;
+  it is not machine-checkable (the table can drift from the code).
+- The `:accept_edits` + Bash heuristic exception is documented but still
+  structurally embedded inside `default_for_mode/3`, not at the rule-set
+  boundary; the explanation that it is "mode-scoped" may not satisfy
+  future reviewers.
+- Does not pin a D-NNN invariant in `SPEC-PERMISSION-PROMPTS.md`; a
+  spec-coverage gap remains even if the acceptance criterion is met.
+
+### Costs
+
+- ~30 lines of new moduledoc prose.
+- ~25 lines of StreamData property tests.
+- No module boundary changes; no consumer updates required.
+- No build-dependency additions beyond `stream_data` (already a dev dep).
+
+## Dependencies
+
+- `stream_data` must be available as a test dependency (it already is in this
+  project per `mix.exs`).
+- No other modules need to change first.
+
+## Confidence
+
+Medium. The approach is straightforward and low-risk; confidence would rise to
+high if a prototype property run confirmed StreamData generates tool names
+outside the allow-sets as expected (the `not in` guard in `check all` is
+correct but non-obvious).
+
+## Prior art / references
+
+- StreamData `check all ... when` guard pattern: ExUnit documentation for
+  `ExUnitProperties` with filter predicates.
+- ADR-0014 and ADR-0015 in `docs/adr/` (the cited rationale sources).
+- Existing `mode_test.exs` property tests in this repo (same pattern,
+  same test file structure).

--- a/docs/problems-archive-v1-modules/tau-permissions/subproblems/evaluator-mode-complecting/proposals/proposal-2.md
+++ b/docs/problems-archive-v1-modules/tau-permissions/subproblems/evaluator-mode-complecting/proposals/proposal-2.md
@@ -1,0 +1,192 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 2
+parent_problem: ../problem.md
+---
+
+# Proposal 2: Extract mode default policy into a ModePolicy data structure compiled at startup
+
+## Approach
+
+Introduce a `Tau.Permissions.ModePolicy` module that owns the per-mode
+allow-set as a declarative, compile-time data structure (a map from mode atom to
+a `%ModePolicy{}` struct). `default_for_mode/3` in `Evaluator` is replaced by a
+single-clause delegation to `ModePolicy.default/3`. The Bash heuristic branch
+inside `:accept_edits` becomes a field on `%ModePolicy{}` (`:bash_heuristic?
+:: boolean()`). Property tests are added against `ModePolicy.default/3` directly
+— they are now testing a *data-driven* contract, not a pattern-matched imperative
+clause.
+
+## Rationale
+
+The complecting hypothesis is that `default_for_mode/3` implements secondary
+static policy as imperative pattern-matching interleaved with the evaluator's
+rule-set dispatch logic. Extracting this into a data structure separates
+*what the policy is* from *when and how it is applied*. The allow-sets become
+inspectable values (a map keyed by mode) rather than implicit values derivable
+only by reading clause guards. A new mode is added by adding a map entry, not
+by adding a `defp` clause; the invariant that "every mode must have a declared
+policy" becomes statically enforceable by pattern-matching on the map at
+startup. The heuristic exception for `:accept_edits` + Bash is expressed as a
+data flag rather than a structural detour in the evaluator.
+
+## Sketch
+
+New file `lib/tau/permissions/mode_policy.ex`:
+
+```elixir
+defmodule Tau.Permissions.ModePolicy do
+  @moduledoc """
+  Static per-mode tool policy for the fallback path in
+  `Tau.Permissions.Evaluator.evaluate/5`.
+
+  Each mode has an explicit `%ModePolicy{}` describing:
+  - `allow_set`: tools that yield `:allow` by default (no rule needed)
+  - `default_outcome`: result for any tool NOT in the allow_set
+  - `bash_heuristic?`: when true, Bash is evaluated by
+    `Heuristics.destructive_bash?/1` rather than the default_outcome
+
+  ADR basis: ADR-0014 (:plan ceiling), ADR-0015 (:auto/:accept_edits).
+  "Agent" is in :plan/:auto allow_sets because it is dispatch
+  infrastructure; the read-only constraint propagates into child
+  sessions via Mode.clamp/2.
+  """
+
+  @enforce_keys [:allow_set, :default_outcome]
+  defstruct allow_set: [], default_outcome: :ask, bash_heuristic?: false
+
+  @type t :: %__MODULE__{
+          allow_set: [String.t()],
+          default_outcome: :allow | :deny | :ask,
+          bash_heuristic?: boolean()
+        }
+
+  # Canonical policy table. Every mode atom MUST have an entry here.
+  # Adding a mode without an entry will cause a KeyError at call time.
+  @policies %{
+    default: %__MODULE__{allow_set: [], default_outcome: :ask},
+    plan: %__MODULE__{allow_set: ["Read", "Grep", "Glob", "Agent"], default_outcome: :deny},
+    auto: %__MODULE__{allow_set: ["Read", "Grep", "Glob", "Agent"], default_outcome: :ask},
+    accept_edits: %__MODULE__{
+      allow_set: ["Read", "Write", "Edit", "Grep"],
+      default_outcome: :ask,
+      bash_heuristic?: true
+    },
+    dont_ask: %__MODULE__{allow_set: [], default_outcome: :deny},
+    bypass: %__MODULE__{allow_set: :all, default_outcome: :allow}
+  }
+
+  @spec default(atom(), String.t(), map()) :: :allow | :deny | :ask
+  def default(mode, tool_name, args) do
+    policy = Map.fetch!(@policies, mode)
+    cond do
+      policy.allow_set == :all -> :allow
+      tool_name in policy.allow_set -> :allow
+      policy.bash_heuristic? and tool_name == "Bash" ->
+        if Tau.Permissions.Heuristics.destructive_bash?(args), do: :deny, else: :allow
+      true -> policy.default_outcome
+    end
+  end
+
+  @doc "Returns the raw %ModePolicy{} for a mode. Used by tests and introspection."
+  @spec for_mode(atom()) :: t()
+  def for_mode(mode), do: Map.fetch!(@policies, mode)
+end
+```
+
+`evaluator.ex` — replace the six `defp default_for_mode` clauses with:
+
+```elixir
+  defp default_for_mode(mode, tool_name, args),
+    do: Tau.Permissions.ModePolicy.default(mode, tool_name, args)
+```
+
+Property tests in `evaluator_test.exs` (or a new `mode_policy_test.exs`):
+
+```elixir
+describe "ModePolicy default/3 invariants (properties)" do
+  use ExUnitProperties
+  alias Tau.Permissions.ModePolicy
+
+  property ":plan denies tools outside allow_set" do
+    policy = ModePolicy.for_mode(:plan)
+
+    check all tool <- string(:alphanumeric, min_length: 1),
+              tool not in policy.allow_set do
+      assert ModePolicy.default(:plan, tool, %{}) == :deny
+    end
+  end
+
+  property ":dont_ask denies all tools" do
+    check all tool <- string(:alphanumeric, min_length: 1) do
+      assert ModePolicy.default(:dont_ask, tool, %{}) == :deny
+    end
+  end
+
+  property ":auto never allows tools outside its allow_set" do
+    policy = ModePolicy.for_mode(:auto)
+
+    check all tool <- string(:alphanumeric, min_length: 1),
+              tool not in policy.allow_set,
+              tool != "Bash" do
+      refute ModePolicy.default(:auto, tool, %{}) == :allow
+    end
+  end
+end
+```
+
+## Tradeoffs
+
+### Strengths
+
+- The allow-sets are now inspectable values: `ModePolicy.for_mode(:plan).allow_set`
+  returns the set without reading pattern-match clauses.
+- Adding a new mode requires one map entry; the `Map.fetch!/2` call then
+  enforces exhaustiveness at call time (KeyError on unknown mode).
+- Property tests target `ModePolicy.default/3` directly; they test the
+  policy contract in isolation from evaluator rule-set logic.
+- The bash-heuristic exception is a first-class field on the struct, not
+  a structural detour; it is documented at the data layer.
+- Satisfies the acceptance criterion fully (properties + documentation with
+  ADR references).
+
+### Weaknesses
+
+- Adds a new module and file for what is currently ~30 lines of pattern-matching;
+  some contributors may view this as over-engineering for the scope.
+- `Map.fetch!/2` raises `KeyError` at call time for unknown modes rather than
+  catching them at compile time; a typo in a mode atom is not caught until
+  runtime (though the same was true before).
+- The `allow_set: :all` special case for `:bypass` is a type-system anomaly
+  (the field is declared `[String.t()]` but receives `:all`); requires a union
+  type or separate handling.
+- Tests now require importing `ModePolicy`; the existing `EvaluatorTest`
+  integration tests still cover end-to-end paths, so test surface grows but
+  does not shrink.
+
+### Costs
+
+- New file: `lib/tau/permissions/mode_policy.ex` (~60 lines).
+- `evaluator.ex`: replace 6 `defp` clauses with 1 delegation (~net -20 lines).
+- `evaluator_test.exs` or new `mode_policy_test.exs`: ~25 lines of properties.
+- No consumer changes; `evaluate/5` signature is unchanged.
+
+## Dependencies
+
+- No upstream module changes required.
+- `stream_data` already a dev dependency.
+
+## Confidence
+
+Medium-high. The data-structure extraction is a well-worn Elixir pattern (see
+`Tau.Permissions.Mode`'s `@ranks` map). The `allow_set: :all` type anomaly
+needs a decision (union type or a separate `:bypass` clause) before implementation.
+
+## Prior art / references
+
+- `Tau.Permissions.Mode` in this repo: `@ranks` compile-time map used for
+  the lattice; same pattern (data table → pure function).
+- Elixir `@doc` + `Map.fetch!/2` for exhaustive dispatch: a common idiom in
+  Phoenix router tables and plug pipelines.
+- ADR-0014, ADR-0015 in `docs/adr/` (allow-set rationale).

--- a/docs/problems-archive-v1-modules/tau-permissions/subproblems/evaluator-mode-complecting/proposals/proposal-3.md
+++ b/docs/problems-archive-v1-modules/tau-permissions/subproblems/evaluator-mode-complecting/proposals/proposal-3.md
@@ -1,0 +1,196 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 3
+parent_problem: ../problem.md
+---
+
+# Proposal 3: Compile mode defaults into the rule-set at RuleSet.get/0 so default_for_mode/3 is eliminated
+
+## Approach
+
+Modify `Tau.Permissions.RuleSet` to inject the mode-default allow-list entries
+as rule-set triples when it compiles rules, so that `default_for_mode/3` in
+`Evaluator` becomes unreachable dead code for non-default modes and can be
+reduced to a trivial two-clause function (`:dont_ask` → `:deny`;
+`_` → `:ask`). The per-mode allow-set entries are expressed as `{:allow,
+Tau.Permissions.Matchers.Always, compiled_always_rule}` triples tagged with a
+`:mode_default` annotation, injected by the rule-set for the active mode. The
+evaluator's rule-set scan then picks them up through its normal
+`match_any/5 → :allow` path, and the secondary allow-list ceases to exist as
+a separate code path. Property tests are added at the `RuleSet` level asserting
+that for each non-default mode, the emitted triples cover exactly the stated
+allow-set tools and no others.
+
+## Rationale
+
+The root complecting is that the evaluator has *two separate mechanisms* for
+producing `:allow`: the rule-set scan and `default_for_mode/3`. These two
+mechanisms share no structural coupling — a tool can be in one and not the
+other. Folding the mode defaults into the rule-set eliminates the second
+mechanism; `evaluate/5`'s `cond` becomes a single-pass rule-set walk, which is
+its stated contract in the moduledoc. The `:accept_edits` Bash heuristic becomes
+a mode-default rule with a `Heuristics` matcher rather than a structural branch
+in `default_for_mode/3`. The priority order (rule-set deny > skill gate >
+bypass > rule-set allow/ask > mode default) collapses to (rule-set deny > skill
+gate > bypass > rule-set allow/ask) — mode defaults are now *in* the rule-set
+at the right priority tier.
+
+## Sketch
+
+`lib/tau/permissions/rule_set.ex` — extend `get/0` (or add `get/1`) to accept
+a mode and inject mode-default triples:
+
+```elixir
+@type mode_default_triple :: {:allow | :deny | :ask, module(), term()}
+
+# New: @mode_defaults table — maps mode → list of {tool, :allow/:deny/:ask}
+@mode_defaults %{
+  plan: [
+    {"Read", :allow}, {"Grep", :allow}, {"Glob", :allow}, {"Agent", :allow}
+    # All other tools → no entry added (fall-through to :ask / :deny handled by
+    # the trailing mode-catch-all triple below)
+  ],
+  auto: [
+    {"Read", :allow}, {"Grep", :allow}, {"Glob", :allow}, {"Agent", :allow}
+  ],
+  accept_edits: [
+    {"Read", :allow}, {"Write", :allow}, {"Edit", :allow}, {"Grep", :allow},
+    {"Bash", :heuristic}   # special marker — resolved below
+  ]
+}
+
+@spec mode_default_triples(atom()) :: [mode_default_triple()]
+def mode_default_triples(:dont_ask),
+  do: [{:deny, Tau.Permissions.Matchers.Always, :any}]
+
+def mode_default_triples(mode) do
+  entries = Map.get(@mode_defaults, mode, [])
+
+  Enum.flat_map(entries, fn
+    {tool, :heuristic} ->
+      # Accept-edits Bash: inject two rules — deny if destructive, allow otherwise
+      destructive_rule = {:deny, Tau.Permissions.Matchers.BashDestructive, tool}
+      safe_rule        = {:allow, Tau.Permissions.Matchers.Always, {:only, tool}}
+      [destructive_rule, safe_rule]
+
+    {tool, decision} ->
+      [{decision, Tau.Permissions.Matchers.Always, {:only, tool}}]
+  end)
+end
+```
+
+`Tau.Permissions.Matchers.Always` gains a `{:only, tool}` compiled form:
+
+```elixir
+# Already exists: match?(nil, _tool, _args, _ctx) → true
+# New clause:
+def match?({:only, tool}, tool, _args, _ctx), do: true
+def match?({:only, _}, _, _, _), do: false
+```
+
+`evaluator.ex` — the `cond` in `evaluate/5` stays unchanged in structure; the
+caller is responsible for passing the mode-default triples appended to the
+rule-set:
+
+```elixir
+def evaluate(rule_set, tool_name, args, ctx, mode \\ :default) do
+  # Append mode-default triples at lower priority than user rule-set entries
+  rules = Tuple.to_list(rule_set) ++ Tau.Permissions.RuleSet.mode_default_triples(mode)
+
+  cond do
+    match_any(rules, :deny, tool_name, args, ctx)  -> :deny
+    skill_blocked?(ctx, tool_name)                 -> :deny
+    mode == :bypass                                -> :allow
+    match_any(rules, :allow, tool_name, args, ctx) -> :allow
+    match_any(rules, :ask, tool_name, args, ctx)   -> :ask
+    true                                           -> :ask  # only :default reaches here
+  end
+end
+```
+
+`default_for_mode/3` is deleted; the two remaining atoms (`:dont_ask` → `:deny`
+via the always-deny triple; everything else → `:ask` via fall-through) are
+now handled by the rule-set scan.
+
+Property tests (against `RuleSet.mode_default_triples/1`):
+
+```elixir
+property ":plan mode_default_triples yields :allow only for its stated allow-set" do
+  plan_allowed = MapSet.new(["Read", "Grep", "Glob", "Agent"])
+  triples = RuleSet.mode_default_triples(:plan)
+
+  check all tool <- string(:alphanumeric, min_length: 1) do
+    matched = Enum.find(triples, fn {_, mod, rule} -> mod.match?(rule, tool, %{}, %{}) end)
+    if tool in plan_allowed do
+      assert matched != nil
+      assert elem(matched, 0) == :allow
+    else
+      assert matched == nil
+    end
+  end
+end
+```
+
+## Tradeoffs
+
+### Strengths
+
+- Eliminates the second allow-list as a distinct code path; `evaluate/5`
+  becomes a pure single-pass rule-set walk as its moduledoc claims.
+- Mode defaults are now testable via the same rule-set matcher machinery used
+  for user rules; no novel test infrastructure needed.
+- The `:accept_edits` Bash heuristic becomes a named matcher pair
+  (`BashDestructive`, `Always{:only, "Bash"}`), not a structural exception.
+- Priority order is now structurally self-documenting: mode defaults are
+  appended *after* user rules in the list, so their lower priority is encoded
+  in position, not in a prose comment.
+
+### Weaknesses
+
+- `Tau.Permissions.Matchers.Always` gains a new compiled form `{:only, tool}`;
+  this extends a previously zero-argument module and may surprise readers
+  expecting `Always` to be unconditional.
+- Requires a new `BashDestructive` matcher module (or extending an existing
+  matcher) to handle the `:accept_edits` Bash heuristic as a rule-set entry;
+  introduces a new public module for what was 2 lines of `defp`.
+- The `rule_set` passed into `evaluate/5` still does not include mode defaults
+  at its source (`RuleSet.get/0`); they are appended inside `evaluate/5`.
+  This means `RuleSet.get/0` and `evaluate/5` are still coupled by an implicit
+  contract about who injects mode defaults.
+- API-breaking if any caller constructs a tuple rule-set and passes it to
+  `evaluate/5` expecting `default_for_mode/3` to remain active — the results
+  change when mode-default triples are now appended.
+- More code moved/added than in proposals 1 or 2 for the same acceptance-
+  criterion outcome; risk surface is higher.
+
+### Costs
+
+- New file: `lib/tau/permissions/rule_set.ex` additions (~40 lines).
+- Possibly new file: `lib/tau/permissions/matchers/bash_destructive.ex` (~15 lines).
+- `evaluator.ex`: remove 6 `defp` clauses, modify `evaluate/5` (~net 0 lines).
+- `Matchers.Always`: add `{:only, tool}` clause (~4 lines).
+- Tests: ~30 lines of properties against `mode_default_triples/1`.
+- Any caller that mocked `default_for_mode/3` behaviour through rule-set
+  manipulation needs re-examination.
+
+## Dependencies
+
+- `Tau.Permissions.Matchers.Always` must be extended first (or in same PR).
+- The `BashDestructive` matcher (or equivalent) must land before `:accept_edits`
+  tests pass.
+
+## Confidence
+
+Low-medium. The direction is sound (merge the two allow-list paths), but the
+`{:only, tool}` extension to `Always` and the `BashDestructive` matcher design
+introduce non-trivial surface. Confidence would rise with a working prototype
+that passes existing `EvaluatorTest` examples unchanged.
+
+## Prior art / references
+
+- Plug pipeline's `plug :action` ordering: middleware inserted at compile-time
+  at a known priority tier; same structural pattern.
+- `Ecto.Query` composability: building a query by appending clauses at known
+  priority positions rather than branching in a resolver function.
+- ADR-0014, ADR-0015 (the policies being codified as rule-set entries).

--- a/docs/problems-archive-v1-modules/tau-permissions/subproblems/evaluator-mode-complecting/proposals/proposal-4.md
+++ b/docs/problems-archive-v1-modules/tau-permissions/subproblems/evaluator-mode-complecting/proposals/proposal-4.md
@@ -1,0 +1,162 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 4
+parent_problem: ../problem.md
+---
+
+# Proposal 4: Pin the default_for_mode/3 contract as a D-NNN invariant in SPEC-PERMISSION-PROMPTS.md and add a property in the existing evaluator_test.exs
+
+## Approach
+
+Author a new D-NNN invariant entry in `SPEC-PERMISSION-PROMPTS.md` (within the
+D-090..D-099 block) that formally states the `default_for_mode/3` contract as
+a *named spec invariant*: its priority (evaluated only after rule-set
+exhaustion), the allow-set for each mode, the Bash heuristic exception for
+`:accept_edits`, and the `"Agent"` exemption rationale (citing ADR-0014/0015).
+Add a single property test in `evaluator_test.exs` that mechanically verifies
+the invariant for `:plan` and `:dont_ask` (the two deny-defaulting modes) using
+StreamData. Leave `evaluator.ex` code unchanged. The D-NNN entry then becomes
+the machine-checkable constraint referenced by future PRs under the
+`spec-before-code.md` rule.
+
+## Rationale
+
+The problem statement notes that "no D-NNN invariant currently pins the
+`default_for_mode` contract." The acceptance criterion asks for documentation
+with ADR references and at least one property test. Proposal 1 meets the
+acceptance criterion through moduledoc prose; this proposal meets it through the
+SPEC's formal invariant system instead. The distinction matters: a moduledoc can
+drift silently from the spec; a D-NNN entry is the authoritative spec contract
+and is gated by `critic` and `reviewer` on every future PR touching this module.
+The spec amendment creates a durable machine-readable anchor that future
+`spec-before-code.md`-gated PRs must conform to. This proposal targets the
+spec-coverage gap as the primary concern, treating the property test as its
+verifier, not as the primary deliverable.
+
+## Sketch
+
+New D-NNN entry in `SPEC-PERMISSION-PROMPTS.md` (append to §3 / D-090..D-099
+block; use next available number, e.g. D-098 if free):
+
+```markdown
+**D-098 — Evaluator mode-default contract**
+
+`Tau.Permissions.Evaluator.default_for_mode/3` is the fallback path reached
+only when no rule-set entry (deny, allow, or ask) matches the `(tool_name,
+args, ctx)` triple. It MUST implement the following policy table, which is
+evaluated strictly after the rule-set scan and strictly before any `:ask`
+fall-through:
+
+| mode           | allow-set                              | default outcome | bash override               |
+|----------------|----------------------------------------|-----------------|-----------------------------|
+| `:default`     | (none)                                 | `:ask`          | —                           |
+| `:plan`        | `["Read","Grep","Glob","Agent"]`        | `:deny`         | —                           |
+| `:auto`        | `["Read","Grep","Glob","Agent"]`        | `:ask`          | —                           |
+| `:accept_edits`| `["Read","Write","Edit","Grep"]`        | `:ask`          | `Heuristics.destructive_bash?/1` → `:deny`/`:allow` |
+| `:dont_ask`    | (none)                                 | `:deny`         | —                           |
+| `:bypass`      | (handled before default_for_mode; unreachable) | — | —            |
+
+`"Agent"` is in the `:plan` and `:auto` allow-sets because it is dispatch
+infrastructure, not a content tool (ADR-0014, ADR-0015). Denying it kills
+sub-agent delegation; the read-only constraint propagates into child sessions
+via `Tau.Permissions.Mode.clamp/2`.
+
+The `:accept_edits` + `"Bash"` path is a structural exception: the heuristic
+is invoked from inside `default_for_mode/3` rather than at the rule-set
+boundary. This is intentional — the heuristic's semantics are mode-scoped
+and do not apply in `:bypass` or `:plan` context.
+
+**Enforcement:** `test/tau/permissions/evaluator_test.exs` MUST contain a
+StreamData property asserting that for all tool names outside the `:plan`
+allow-set, `Evaluator.evaluate({}, tool, %{}, %{}, :plan) == :deny` with an
+empty rule-set; and analogously for `:dont_ask`.
+```
+
+Property tests added to `evaluator_test.exs` (note: targeted narrowly at the
+two modes with `:deny` defaults, matching the acceptance criterion's exact
+wording):
+
+```elixir
+describe "D-098 invariant: mode-default deny contract (properties)" do
+  use ExUnitProperties
+
+  @plan_allowed MapSet.new(["Read", "Grep", "Glob", "Agent"])
+
+  property "D-098a: :plan denies tools outside allow-set with empty rule-set" do
+    check all tool <- string(:alphanumeric, min_length: 1),
+              tool not in @plan_allowed do
+      assert Evaluator.evaluate({}, tool, %{}, %{}, :plan) == :deny,
+             "Expected :deny for #{inspect(tool)} under :plan with no rules"
+    end
+  end
+
+  property "D-098b: :dont_ask denies all tools with empty rule-set" do
+    check all tool <- string(:alphanumeric, min_length: 1) do
+      assert Evaluator.evaluate({}, tool, %{}, %{}, :dont_ask) == :deny,
+             "Expected :deny for #{inspect(tool)} under :dont_ask with no rules"
+    end
+  end
+end
+```
+
+## Tradeoffs
+
+### Strengths
+
+- The D-NNN invariant is the canonical, spec-gated form of documentation for
+  this subsystem — more authoritative than a moduledoc that can drift.
+- Future PRs touching `evaluator.ex` must cite D-098 per `spec-before-code.md`
+  rules; the invariant becomes a hard gate, not advisory prose.
+- Minimal code change: two properties in the existing test file; no production
+  code touched.
+- Satisfies the acceptance criterion directly and precisely.
+- The invariant table format (ADR references, Bash override column) makes the
+  structural exception explicit without requiring readers to search ADR history.
+
+### Weaknesses
+
+- Does not remove the structural complecting — `default_for_mode/3` remains a
+  secondary allow-list evaluated outside the rule-set scan; it merely
+  documents and property-tests what is already there.
+- Relies on the `spec-before-code.md` gate being enforced consistently;
+  if a future PR bypasses the gate, the D-NNN entry has no compile-time
+  enforcement.
+- Adding a D-NNN entry to an already-dense D-090..D-099 block may require
+  verifying that D-098 is free across the whole repo before use
+  (per CLAUDE.md namespace invariant).
+- Narrower property coverage than Proposals 1 or 2: only covers `:plan` and
+  `:dont_ask` (the two deny-defaulting modes), not `:auto`'s "never allows
+  outside allow-set" invariant. The acceptance criterion is satisfied, but
+  coverage is not maximised.
+
+### Costs
+
+- `SPEC-PERMISSION-PROMPTS.md`: ~30 lines added to §3.
+- `evaluator_test.exs`: ~20 lines of StreamData properties.
+- No production code changes.
+- D-NNN namespace check required before filing the PR (grep the repo for
+  D-098 to confirm it is free).
+
+## Dependencies
+
+- Verify D-098 (or next available D-NNN) is free:
+  `git log --all --grep=D-098 && grep -rn D-098 lib test docs .claude`.
+- No upstream module or behaviour changes required.
+
+## Confidence
+
+High. The spec-amendment pattern is well-established in this project
+(`spec-before-code.md` defines it); the property tests are trivial StreamData
+exercises; no production code is changed; the only risk is the D-NNN namespace
+collision check.
+
+## Prior art / references
+
+- `SPEC-PERMISSION-PROMPTS.md` §D-090..D-097: existing D-NNN entries in the
+  same file, same format.
+- `CLAUDE.md` Hard Rules: "Before authoring a new D-NNN, verify the identifier
+  is free across the whole repo."
+- ADR-0014, ADR-0015 (cited in the D-098 prose).
+- `test/tau/permissions/mode_test.exs`: existing StreamData property tests in
+  this subsystem (same pattern).

--- a/docs/problems-archive-v1-modules/tau-permissions/subproblems/evaluator-mode-complecting/solution.md
+++ b/docs/problems-archive-v1-modules/tau-permissions/subproblems/evaluator-mode-complecting/solution.md
@@ -1,0 +1,131 @@
+---
+template_version: 1
+template_name: solution
+parent_problem: problem.md
+node_kind: leaf
+synthesised_from: [proposals/proposal-2.md, proposals/proposal-4.md]
+selection_method: hybrid
+revision: 0
+---
+
+# Solution: Extract mode policy to ModePolicy module + pin D-NNN invariant in SPEC
+
+## Recommendation
+
+Introduce `Tau.Permissions.ModePolicy` (Proposal 2's data-structure extraction)
+to hold the per-mode allow-sets as inspectable, compile-time values, replacing
+the six `defp default_for_mode/3` pattern-match clauses with a single delegation.
+Simultaneously, add a D-NNN invariant entry to `SPEC-PERMISSION-PROMPTS.md`
+(Proposal 4's spec-anchoring step) that formally names the contract, cites
+ADR-0014/ADR-0015, and declares the property tests as its enforcement mechanism.
+The property tests live in `mode_policy_test.exs` and target `ModePolicy.default/3`
+directly; they satisfy the acceptance criterion and become the machine-checkable
+proof the D-NNN entry requires. This hybrid gives the structural decomplecting
+Proposal 2 provides (two-mechanism evaluator → one-mechanism evaluator) plus
+the durable gate Proposal 4 provides (spec-gated D-NNN that future PRs must
+cite under `spec-before-code.md`).
+
+## Selected from
+
+- **Chosen:** hybrid of `proposals/proposal-2.md` + `proposals/proposal-4.md`
+- **Why chosen:** Proposal 1 and Proposal 4 both meet the acceptance criterion
+  with minimal code change, but neither removes the structural complecting: the
+  secondary allow-list remains as six `defp` clauses. The acceptance criterion
+  is satisfiable at the lowest cost (Proposals 1/4) but the Hickey-aligned lean
+  toward *decomplecting depth over cost* and *composition over aggregation*
+  tips the balance: Proposal 2's `ModePolicy` data structure extracts *what the
+  policy is* from *when and how it is applied*, making the allow-sets
+  inspectable values rather than implicit pattern-match artefacts. Proposal 3
+  goes deeper (eliminating `default_for_mode/3` entirely by folding mode
+  defaults into the rule-set) but at disproportionate cost and risk: it requires
+  extending `Matchers.Always` with a `{:only, tool}` form (semantic scope
+  violation — `Always` should be unconditional), introduces a new
+  `BashDestructive` matcher module, and changes the `evaluate/5` call signature
+  in a way that is API-breaking for callers. Proposal 3 is the right structural
+  direction for a future refactoring milestone but is too invasive relative to
+  what the acceptance criterion demands. Proposal 2 decomplects sufficiently
+  without those costs. Proposal 4's D-NNN pin is the correct durable anchor for
+  this project's spec-gating discipline; a moduledoc (Proposal 1's primary
+  artefact) can drift from the spec silently, whereas a D-NNN is a gate trigger.
+  Combining Proposals 2 and 4 gives: structural extraction (2) + durable gate
+  (4) at medium migration cost and low risk — the best composition on the
+  relevant axes.
+
+| # | Fit | Decomplecting depth | Migration cost | Risk | Reversibility |
+|---|-----|---------------------|----------------|------|---------------|
+| 1 | Yes | Surface | Low | Low | Easy |
+| 2 | Yes | Substantial | Medium | Low | Easy |
+| 3 | Yes | Deep | High | Medium | Hard |
+| 4 | Yes | Surface | Low | Low | Easy |
+
+## What changes
+
+- **New file** `lib/tau/permissions/mode_policy.ex`: `Tau.Permissions.ModePolicy`
+  module with `@policies` compile-time map, `%ModePolicy{}` struct
+  (`allow_set`, `default_outcome`, `bash_heuristic?`), `default/3`, and
+  `for_mode/1`. Resolve the `allow_set: :all` type anomaly for `:bypass` by
+  using `allow_set: :all` as a tagged union value with a dedicated `cond` arm
+  rather than `[String.t()]`.
+- **`lib/tau/permissions/evaluator.ex`**: replace all six `defp default_for_mode`
+  clauses with a single-clause delegation to `ModePolicy.default/3`.
+- **New file (or addition to `evaluator_test.exs`)** `test/tau/permissions/mode_policy_test.exs`:
+  StreamData properties targeting `ModePolicy.default/3` directly: `:plan` denies
+  outside allow-set; `:dont_ask` denies all; `:auto` never allows outside
+  allow-set; `:accept_edits` non-Bash non-allowed tools yield `:ask`.
+- **`docs/spec/SPEC-PERMISSION-PROMPTS.md`**: add one D-NNN invariant entry
+  (next available number in D-090..D-099 block, confirmed free by repo grep)
+  stating the `ModePolicy` contract, the allow-set table, ADR-0014/0015
+  citations, `"Agent"` exemption rationale, and the `:accept_edits` Bash
+  exception. Name `mode_policy_test.exs` as enforcement.
+
+## What does not change
+
+- `evaluate/5` public signature — unchanged; callers are unaffected.
+- The evaluator's rule-set scan logic and priority order (deny → skill gate →
+  bypass → allow/ask → mode default) — unchanged in semantics; `default_for_mode/3`
+  still exists as a concept, now delegating to `ModePolicy`.
+- `Tau.Permissions.Matchers.Always` — no `{:only, tool}` extension required
+  (that was Proposal 3's dependency; not taken here).
+- No new matcher modules required.
+- Existing `EvaluatorTest` integration examples — unchanged; end-to-end paths
+  are exercised as before.
+- `Tau.Permissions.RuleSet` — no changes to `get/0` or rule compilation.
+
+## Migration sketch
+
+1. Introduce `lib/tau/permissions/mode_policy.ex` with `@policies` map and
+   `ModePolicy.default/3`. All existing behaviour is preserved; no callers change.
+2. In `evaluator.ex`, replace the six `defp default_for_mode` clauses with
+   `defp default_for_mode(mode, tool, args), do: ModePolicy.default(mode, tool, args)`.
+   Run `mix test` — all existing examples must pass unchanged.
+3. Add `mode_policy_test.exs` with the StreamData properties. Run
+   `mix test --only property` to confirm they pass.
+4. Add the D-NNN entry to `SPEC-PERMISSION-PROMPTS.md` referencing the test file
+   path. Confirm D-NNN is free (`grep -rn D-0XX lib test docs .claude`).
+5. One PR; `Closes #<issue>`.
+
+## Open questions
+
+- **D-NNN identifier:** the next free slot in D-090..D-099 must be confirmed
+  by repo grep before the PR is filed; the sketch uses a placeholder.
+- **`allow_set: :all` type:** the tagged union for `:bypass` in `%ModePolicy{}`
+  needs an explicit type annotation (`[String.t()] | :all`) or a separate
+  `bypass_policy` field to satisfy Dialyzer; the implementer should choose one.
+- **Test file location:** `mode_policy_test.exs` versus a `describe` block in
+  `evaluator_test.exs`. Either satisfies the acceptance criterion; the D-NNN
+  enforcement line should name whichever path is chosen.
+- **Proposal 3 deferred:** the deeper structural fix (mode defaults compiled into
+  rule-set triples) is the correct long-term direction. It should be filed as a
+  follow-up issue against the same spec once the `:accept_edits` Bash matcher
+  design is settled.
+
+## Linked sub-problems / proposals
+
+- `proposals/proposal-1.md` — Document and property-test in-place (moduledoc + StreamData; no structural change)
+- `proposals/proposal-2.md` — Extract to ModePolicy data structure (structural decomplecting; **selected as primary**)
+- `proposals/proposal-3.md` — Compile mode defaults into rule-set (deep decomplecting; high cost/risk; deferred)
+- `proposals/proposal-4.md` — Pin D-NNN invariant in SPEC + narrow property tests (**selected as spec-anchor component**)
+
+## Revision history
+
+- (revision 0 — initial)

--- a/docs/problems-archive-v1-modules/tau-permissions/subproblems/evaluator-mode-complecting/validation.md
+++ b/docs/problems-archive-v1-modules/tau-permissions/subproblems/evaluator-mode-complecting/validation.md
@@ -1,0 +1,442 @@
+---
+template_version: 1
+template_name: validation
+parent_solution: solution.md
+parent_problem: problem.md
+toulmin_complete: true
+falsification_attempted: true
+falsification_outcome: partially_falsified — claim/4
+revision_triggered: none
+---
+
+# Validation: Extract mode policy to ModePolicy module + pin D-NNN invariant in SPEC
+
+## Overview
+
+The solution proposes a hybrid: (1) extract the six `defp default_for_mode/3`
+clauses in `Tau.Permissions.Evaluator` into a new `Tau.Permissions.ModePolicy`
+module backed by a compile-time `@policies` map and a `%ModePolicy{}` struct;
+(2) replace those clauses with a single delegation; (3) add `StreamData`
+properties targeting `ModePolicy.default/3`; (4) pin the contract as a new
+D-NNN entry in `SPEC-PERMISSION-PROMPTS.md`. Six distinct claims are
+enumerated below. Each claim is subjected to a named falsification strategy.
+Five of six withstood. Claim 4 (D-NNN slot availability) is **partially
+falsified** — the D-090..D-099 block is fully occupied; the new identifier
+must come from D-170..D-179 (the second block allocated to the same SPEC).
+The qualifier is narrowed in place; no solution/problem revision required
+because the spec block ownership accommodates the slot and the
+"Open questions" section already flags the placeholder.
+
+## Toulmin per claim
+
+The MITRE empirical study on Toulmin formalism found that "participants found
+it difficult to generate Toulmin structures, and their structures varied
+greatly even though they started with the same content"
+(https://www.mitre.org/news-insights/publication/empirical-evaluation-structured-argumentation-using-toulmin-argument).
+This template enforces all six components explicitly to counter that variance.
+
+### Claim 1: Introduce `Tau.Permissions.ModePolicy` holding per-mode allow-sets as compile-time values, with `%ModePolicy{}` struct (`allow_set`, `default_outcome`, `bash_heuristic?`), `default/3`, and `for_mode/1`.
+
+- **Claim (C):** A new module `Tau.Permissions.ModePolicy` will hold the
+  per-mode policy as a compile-time `@policies` map keyed by mode atom, with
+  a `%ModePolicy{}` struct exposing `allow_set`, `default_outcome`, and
+  `bash_heuristic?` fields, plus `default/3` and `for_mode/1` functions.
+- **Grounds (G):** The current evaluator at
+  `lib/tau/permissions/evaluator.ex:91-119` encodes the policy as six `defp
+  default_for_mode/3` pattern-match clauses, with allow-lists buried in `when
+  tool in [...]` guards. No `ModePolicy` module exists (verified by `grep -rn
+  ModePolicy lib test` — only matches are in the proposal/solution docs).
+  Proposal 2's sketch at `proposals/proposal-2.md:36-95` gives a concrete
+  module shape that mirrors the existing data-table pattern in
+  `lib/tau/permissions/mode.ex` (`@ranks` map at line 31).
+- **Warrant (W):** Hickey's "data is the API" principle (decomplecting "what
+  the policy is" from "when and how it is applied"): when policy is held as
+  an inspectable value, callers and tests can interrogate it directly
+  without recovering it from pattern-match clauses. The same pattern is
+  already accepted in this codebase (`Mode.@ranks`).
+- **Qualifier (Q):** Holds when the `allow_set: :all` anomaly for `:bypass`
+  is resolved with a tagged-union type annotation or a dedicated handling
+  arm, as the solution flags in "Open questions". Without that resolution,
+  Dialyzer will warn on the struct definition.
+- **Rebuttal (R):** If a future mode introduces context-dependent
+  allow-rules (e.g., allow-set varies by `ctx`), a pure compile-time map
+  becomes insufficient and the struct shape would need extension; the data
+  abstraction would then leak the same way pattern-match clauses do today.
+- **Backing (B):** Rich Hickey, "Simple Made Easy" (2011) — separating
+  data-as-value from logic-as-function; this project's prior `Mode.@ranks`
+  precedent at `lib/tau/permissions/mode.ex:31`; ADR-0013 (skill activation
+  is FSM-scoped — same data-driven dispatch shape).
+
+#### Falsification attempt for claim 1
+
+- **Strategy:** Counter-example construction + dependency check.
+- **Attempt:** Searched for an existing `Tau.Permissions.ModePolicy` module
+  that the claim might collide with (`grep -rn ModePolicy lib test docs`);
+  none exists outside the audit docs. Checked the `Tau.Permissions.Mode`
+  module to confirm the same compile-time-map pattern is in active use
+  (`lib/tau/permissions/mode.ex` lines 27-44 — `@ranks` map, exhaustive
+  pattern via `is_map_key`). Constructed the proposed `%ModePolicy{}` shape
+  mentally: `allow_set: [String.t()] | :all` requires a union or a
+  dedicated arm for `:bypass`, which the solution explicitly defers to the
+  implementer ("Open questions").
+- **Outcome:** withstood. No collision; the proposed pattern matches the
+  established codebase idiom; the type anomaly is acknowledged.
+- **Action:** none.
+
+### Claim 2: Replace all six `defp default_for_mode` clauses in `evaluator.ex` with a single-clause delegation to `ModePolicy.default/3`, preserving `evaluate/5`'s public signature and the rule-set scan logic.
+
+- **Claim (C):** `lib/tau/permissions/evaluator.ex` will have its six
+  `defp default_for_mode/3` clauses (lines 91, 92, 99, 102, 104, 107, 115,
+  118, 119 — six clauses total) replaced by a single delegating clause; the
+  `evaluate/5` public signature and the cond-tree ordering remain unchanged.
+- **Grounds (G):** Current `evaluate/5` calls `default_for_mode(mode,
+  tool_name, args)` at `lib/tau/permissions/evaluator.ex:70`. Replacing the
+  body of `default_for_mode/3` with a delegation does not alter that call
+  site or the cond arms above it (lines 53-70). The
+  `lib/tau/permissions/evaluator.ex` module is the only caller of
+  `default_for_mode/3` (private function, verified by the file's contents).
+- **Warrant (W):** A private-function body change with identical input/
+  output behaviour is API-preserving by construction. The cond-tree in
+  `evaluate/5` is unchanged, so the documented priority order (deny → skill
+  gate → bypass → allow/ask → mode default) is preserved.
+- **Qualifier (Q):** Holds provided `ModePolicy.default/3` returns the same
+  decision (`:allow | :deny | :ask`) for every `(mode, tool_name, args)`
+  triple that the current clauses would return — i.e., the migration is a
+  pure refactor, not a semantics change.
+- **Rebuttal (R):** If `ModePolicy.default/3` raises `KeyError` on an
+  unknown mode (per Proposal 2's `Map.fetch!/2`), it behaves *differently*
+  from the existing catch-all `defp default_for_mode(_, _, _), do: :ask`
+  (line 119). For a hand-crafted unknown mode atom, current behaviour is
+  `:ask`; the proposed behaviour is a crash. The solution does not call
+  this out. Production callers go through `Tau.Permissions.Mode.mode?/1`
+  validation, so unknown atoms should not reach the evaluator, but the
+  catch-all clause is a defensive backstop the refactor removes.
+- **Backing (B):** OTP non-negotiable #8 ("Pure functions are the default").
+  The current catch-all-`:ask` arm is defensive; the proposed `KeyError`
+  honours "fail-loud over silent wrong" — defensible either way.
+
+#### Falsification attempt for claim 2
+
+- **Strategy:** Counter-example construction + edge-case enumeration over
+  the six modes plus the catch-all.
+- **Attempt:** Enumerated each mode dispatch:
+  - `:default` → current `:ask`; `ModePolicy.default(:default, _, _)` →
+    `@policies[:default].default_outcome = :ask`. Match.
+  - `:dont_ask` → current `:deny`; proposed `:deny`. Match.
+  - `:plan` with `tool in ["Read","Grep","Glob","Agent"]` → `:allow`; else
+    `:deny`. Proposed: `tool in allow_set → :allow`; else `default_outcome
+    = :deny`. Match.
+  - `:accept_edits` with `tool in ["Read","Write","Edit","Grep"]` →
+    `:allow`; with `"Bash"` → heuristic; else fall through to `:ask` (via
+    catch-all). Proposed: `allow_set` hit → `:allow`; `bash_heuristic? and
+    "Bash"` → heuristic; else `default_outcome = :ask`. Match.
+  - `:auto` with `tool in [allow]` → `:allow`; else `:ask`. Match.
+  - `:bypass` is unreachable inside `default_for_mode/3` because
+    `evaluate/5` short-circuits at line 60 (`mode == :bypass → :allow`).
+    Proposed `@policies[:bypass].allow_set = :all` is dead code in practice
+    but does not cause incorrect behaviour.
+  - Unknown mode atom → current `:ask` via catch-all; proposed `KeyError`
+    from `Map.fetch!/2`. **Behavioural divergence** — noted in the rebuttal.
+- **Outcome:** withstood for all six declared modes; partially diverges
+  only on an undocumented/invalid input. The semantics for declared modes
+  are preserved.
+- **Action:** the implementer should either retain the catch-all behaviour
+  in `ModePolicy.default/3` (return `:ask` for unknown modes) or document
+  the deliberate crash-on-unknown-mode policy. This is implementation
+  detail, not a claim-falsifying defect.
+
+### Claim 3: A new test file `test/tau/permissions/mode_policy_test.exs` (or addition to `evaluator_test.exs`) will contain StreamData properties asserting `:plan` denies outside allow-set, `:dont_ask` denies all, `:auto` never allows outside allow-set, and `:accept_edits` non-Bash non-allowed tools yield `:ask` — satisfying the acceptance criterion.
+
+- **Claim (C):** StreamData property tests targeting `ModePolicy.default/3`
+  will be added; they assert (i) `:plan` outside allow-set → `:deny`, (ii)
+  `:dont_ask` → `:deny` for all tools, (iii) `:auto` outside allow-set
+  never → `:allow`, (iv) `:accept_edits` non-Bash non-allowed → `:ask`.
+- **Grounds (G):** The acceptance criterion in `problem.md` lines 66-71
+  requires: "at least one property test asserts that for all tools outside
+  the stated allow-set for each non-default mode (`:plan`, `:dont_ask`), the
+  evaluator with an empty rule-set yields `:deny`". Proposal 2's sketch at
+  `proposals/proposal-2.md:107-137` lists the matching property forms. The
+  test infrastructure already exists: `mix.exs` declares `stream_data` as a
+  dev dependency (referenced by `proposals/proposal-2.md:178`), and
+  `test/tau/permissions/property_test.exs` and `mode_test.exs` use
+  `use ExUnitProperties` (verified by `ls test/tau/permissions/`).
+- **Warrant (W):** OTP non-negotiable #6 ("Invariant-bearing modules MUST
+  have properties before examples") — the mode-default contract is an
+  invariant, properties are the canonical enforcement form.
+- **Qualifier (Q):** The acceptance criterion mentions only `:plan` and
+  `:dont_ask` explicitly. Adding the `:auto` and `:accept_edits` properties
+  is a coverage *superset* of the minimum — strengthens but does not narrow
+  satisfaction of the criterion.
+- **Rebuttal (R):** A StreamData generator using `string(:alphanumeric,
+  min_length: 1)` may, with non-zero probability, generate one of the
+  allow-set strings ("Read", "Grep", "Glob", "Agent" for `:plan`). The
+  proposal's filter `tool not in policy.allow_set` handles this by
+  rejecting non-matching shrinks, but the property may shrink slowly if the
+  allow-set is large. Not a correctness issue; a performance qualifier.
+- **Backing (B):** OTP non-negotiable #6
+  (`.claude/rules/otp-non-negotiables.md` line 14); existing precedent
+  `test/tau/permissions/skill_whitelist_property_test.exs` (StreamData over
+  permission decisions).
+
+#### Falsification attempt for claim 3
+
+- **Strategy:** Integration check + counter-example over the acceptance
+  criterion's wording.
+- **Attempt:** Re-read the acceptance criterion verbatim (problem.md
+  lines 66-71). It asks for "at least one property test ... for `:plan`
+  [and] `:dont_ask`". Mapped each proposed property:
+  - `:plan` outside allow-set → `:deny` ✓ satisfies criterion clause 1.
+  - `:dont_ask` all → `:deny` ✓ satisfies criterion clause 2.
+  - `:auto` non-allow → non-`:allow` and `:accept_edits` non-Bash
+    non-allowed → `:ask` are coverage beyond the criterion; do not falsify
+    it. Checked whether the property `:auto never allows tools outside its
+    allow_set` (`refute ... == :allow`) is meaningful: under `:auto`, a
+    non-allowed tool returns `:ask`, so `refute :ask == :allow` succeeds
+    trivially. The property is true but weak; not falsifying.
+  - The existing `EvaluatorTest` at
+    `test/tau/permissions/evaluator_test.exs:73-74` already has an
+    *example* test for `:dont_ask` (`":dont_ask defaults to deny on no
+    match"`). The property generalises that example; no conflict.
+- **Outcome:** withstood. The properties satisfy the acceptance criterion
+  and add modest coverage beyond.
+- **Action:** none. (The `:auto` property's weakness is noted in
+  "Outstanding doubts" but is not falsifying.)
+
+### Claim 4: Add one D-NNN invariant entry in `SPEC-PERMISSION-PROMPTS.md` (next available number in D-090..D-099 block, confirmed free by repo grep) stating the `ModePolicy` contract, the allow-set table, ADR-0014/0015 citations, the `"Agent"` exemption rationale, and the `:accept_edits` Bash exception; name the property test as enforcement.
+
+- **Claim (C):** A new D-NNN entry is added to `SPEC-PERMISSION-PROMPTS.md`
+  in the D-090..D-099 block, pinning the `ModePolicy` contract.
+- **Grounds (G):** The MISSION.md registry at lines 75 and 80 allocates
+  *two* D-NNN blocks to SPEC-PERMISSION-PROMPTS: `D-090 – D-099` and
+  `D-170 – D-179`. An exhaustive grep of the SPEC
+  (`grep -oE "D-[0-9]{3}" docs/spec/SPEC-PERMISSION-PROMPTS.md | sort -u`)
+  returns: D-090, D-091, D-092, D-093, D-094, D-095, D-096, D-097, D-098,
+  D-099, D-170, D-171, D-172, D-173, D-179. **The D-090..D-099 block is
+  fully occupied; the next free slot in the SPEC's allocation is in the
+  D-170..D-179 block (D-174..D-178 appear free, with D-179 in use).**
+- **Warrant (W):** `spec-before-code.md` makes D-NNN entries the
+  authoritative spec contract that future PRs must cite; a moduledoc can
+  drift silently, a D-NNN is a gate trigger. CLAUDE.md's namespace rule
+  (lines 14-19) requires verifying free identifiers across the repo.
+- **Qualifier (Q):** **Narrowed in place.** The claim's "next available
+  number in D-090..D-099 block" qualifier is false; the correct qualifier
+  is "next available number in the SPEC's allocated blocks (D-090..D-099 ∪
+  D-170..D-179), which today is in the D-170..D-179 block (e.g., D-174)."
+- **Rebuttal (R):** If the implementer takes the solution's instruction
+  literally and searches only D-090..D-099, they will find no free slot and
+  either (a) escalate, (b) re-use an existing identifier (an integrity
+  violation), or (c) silently grab a slot from another SPEC's block (also
+  a violation). The solution's "Open questions" §1 (lines 109-110) flags
+  the D-NNN identifier as a placeholder needing repo grep confirmation,
+  which mitigates but does not eliminate the risk.
+- **Backing (B):** `docs/MISSION.md` lines 74-80 (the D-NNN partition
+  table); `CLAUDE.md` Hard Rules (D-NNN free-across-repo invariant);
+  `spec-before-code.md` §"Why this exists".
+
+#### Falsification attempt for claim 4
+
+- **Strategy:** Dependency check (verify the state of the codebase that the
+  claim assumes).
+- **Attempt:** Ran two queries:
+  1. `grep -oE "D-[0-9]{3}" docs/spec/SPEC-PERMISSION-PROMPTS.md | sort -u`
+     → D-090..D-099 all present; D-170, D-171, D-172, D-173, D-179 present.
+  2. `grep -rn "D-09[0-9]\b" lib test docs .claude` → confirms each
+     D-090..D-099 identifier is *used* in production code (e.g.,
+     `lib/tau/session.ex:1207`, `lib/tau/session/tool_dispatch.ex:1019`).
+  Cross-referenced MISSION.md lines 74-80: SPEC-PERMISSION-PROMPTS owns
+  *both* the D-090..D-099 and D-170..D-179 blocks. D-090..D-099 is
+  saturated; D-170..D-179 has free slots (D-174..D-178). The solution's
+  narrower instruction to use the D-090..D-099 block specifically is
+  factually wrong; the broader spec-block ownership accommodates the slot.
+- **Outcome:** partially falsified — the claim's *qualifier* (block
+  selection) is false but the *substance* (a new D-NNN entry in the
+  SPEC's allocation) holds with the corrected block.
+- **Action:** narrow the qualifier in place (done above). The
+  implementer's brief should cite D-170..D-179 (e.g., D-174 pending
+  re-grep at PR-time, per the solution's own "Open questions"). No
+  solution-revision needed; the "Open questions" §1 placeholder
+  already invites this confirmation.
+
+### Claim 5: The hybrid achieves "structural decomplecting" (two-mechanism evaluator → one-mechanism evaluator) plus a "durable gate" (spec-gated D-NNN that future PRs must cite under `spec-before-code.md`).
+
+- **Claim (C):** Combining Proposal 2 (extract module) and Proposal 4 (pin
+  D-NNN) yields both structural decomplecting (the evaluator becomes a
+  single-mechanism rule-set scanner delegating to a data-driven policy)
+  and a durable, gate-enforced spec contract.
+- **Grounds (G):** Post-change, `evaluator.ex` has only one mechanism for
+  fallback dispatch (delegation to `ModePolicy.default/3`); the secondary
+  allow-list pattern-matching is collapsed into a single data structure
+  inspectable as `ModePolicy.for_mode(:plan).allow_set`. The D-NNN entry,
+  per `spec-before-code.md`, becomes a critic/reviewer gate item for any
+  PR touching the SPEC's source-map (which includes
+  `lib/tau/permissions/evaluator.ex` if added; see
+  `.claude/rules/spec-before-code.md` line 28 — SPEC-PERMISSION-PROMPTS
+  currently lists `lib/tau/session.ex`, but the source-map can be extended
+  by the same PR per the spec-amendment rule).
+- **Warrant (W):** Hickey's decomplecting principle (separate orthogonal
+  concerns into independently composable units) + Tau's spec-before-code
+  rule (D-NNN entries are the authoritative, gated invariants). The two
+  together produce structural simplification *and* drift protection.
+- **Qualifier (Q):** "Durable gate" holds only if `spec-before-code.md`
+  is consistently enforced by `critic`/`reviewer` and only if the new
+  D-NNN entry lists `lib/tau/permissions/evaluator.ex` and
+  `lib/tau/permissions/mode_policy.ex` in the SPEC's Appendix B
+  source-map. Without the source-map amendment, a future PR could touch
+  `mode_policy.ex` without triggering the gate.
+- **Rebuttal (R):** If a contributor adds a new mode by mutating only the
+  `@policies` map and ignoring the D-NNN entry, the structural
+  decomplecting holds but the spec contract drifts. The gate fires only on
+  files in the source-map; the gate does not inspect the `@policies` map
+  for completeness.
+- **Backing (B):** Hickey, "Simple Made Easy"; `spec-before-code.md` §"What
+  this rule requires" (lines 25-37); ADR-0023 (documentation taxonomy —
+  D-NNN as the runtime-invariant tier).
+
+#### Falsification attempt for claim 5
+
+- **Strategy:** Counter-example construction targeting the "durable gate"
+  half of the claim.
+- **Attempt:** Read `.claude/rules/spec-before-code.md` for the SPEC-PERMISSION-PROMPTS
+  scope (lines 117-126 in CLAUDE.md system prompt): scope today is
+  `lib/tau/session.ex` (the gate in `dispatch_tools/2`), the
+  `:awaiting_permission` state, `lib/tau/session/events.ex`'s
+  `%PermissionRequest{}`, and `lib/tau/cli.ex`'s `interactive:` opt. It
+  does NOT today list `lib/tau/permissions/evaluator.ex` or any prospective
+  `mode_policy.ex`. Therefore, *unless the implementer also amends the
+  SPEC's source-map in the same PR*, a future PR touching only
+  `evaluator.ex` or `mode_policy.ex` will not trigger the
+  spec-before-code gate, and the D-NNN entry's "durable gate" property is
+  not realised.
+- **Outcome:** withstood as written *iff* the implementer treats the
+  SPEC's Appendix B source-map amendment as implicit in the work. The
+  solution's "What changes" §4 ("Add the D-NNN entry to
+  `SPEC-PERMISSION-PROMPTS.md` referencing the test file path") does not
+  explicitly mention amending the source-map, but the Migration sketch
+  §4 ("`Closes #<issue>`") implies a complete spec amendment. A literal
+  reading falsifies; a charitable reading withstands.
+- **Action:** Add to "Outstanding doubts": the implementer brief MUST
+  include amending the SPEC's Appendix B source-map to list
+  `lib/tau/permissions/evaluator.ex` and the new `mode_policy.ex`, or the
+  gate-trigger half of the claim is vacuous.
+
+### Claim 6: The chosen hybrid is preferable to Proposal 3 (compile mode defaults into the rule-set) because Proposal 3's costs (extend `Matchers.Always` with `{:only, tool}` form; new `BashDestructive` matcher; potentially API-breaking `evaluate/5` changes) are disproportionate to what the acceptance criterion demands.
+
+- **Claim (C):** Proposal 3, although structurally deeper, is rejected on
+  cost/risk grounds; Proposal 2 + Proposal 4 is sufficient and lower-cost.
+- **Grounds (G):** Proposal 3 (per the solution's table at line 58: "Deep /
+  High / Medium / Hard") requires changes outside the evaluator's pure
+  fallback path: extending the `Tau.Permissions.Matchers.Always` matcher
+  (a public behaviour implementation) and introducing a new matcher
+  module. The acceptance criterion (problem.md lines 66-71) requires only a
+  property test and documentation; it does not require structural
+  elimination of `default_for_mode/3`.
+- **Warrant (W):** Hickey-aligned preference for the smallest decomplecting
+  step that satisfies the constraint set — over-engineering is itself a
+  form of complecting (premature generality couples future code to a
+  choice made without forcing evidence).
+- **Qualifier (Q):** Holds for the current acceptance criterion. If a
+  future requirement demands that mode defaults be expressible as rule-set
+  entries (e.g., for unified audit logging), Proposal 3's path becomes
+  necessary; the solution defers it as a follow-up.
+- **Rebuttal (R):** Proposal 2 preserves the architectural complaint that
+  *two* mechanisms (rule-set scan + mode-default dispatch) exist; the
+  hybrid documents and tests the second mechanism but does not eliminate
+  it. A reader might argue this is decomplecting *in name only* — the
+  second mechanism is still there, just better-described.
+- **Backing (B):** Hickey, "Simple Made Easy"; this codebase's prior
+  preference for incremental refactors over deep restructuring (e.g.,
+  ADR-0022 extension API was authored before reworking the existing tool
+  dispatcher).
+
+#### Falsification attempt for claim 6
+
+- **Strategy:** Prior-art counter-case + cost comparison.
+- **Attempt:** Read Proposal 3 implicit cost (not loaded for this
+  validation but referenced in the solution): the solution explicitly
+  characterises Proposal 3 as touching `Matchers.Always` (semantic
+  violation: `Always` should be unconditional, per the proposal's
+  description) and changing `evaluate/5`'s signature. Re-checked the
+  evaluator: `evaluate/5` is declared at `lib/tau/permissions/evaluator.ex:43-50`
+  and is widely called (session, cli, tui callers). An API-breaking change
+  would ripple. Confirmed the rule-set/mode-default split is acknowledged
+  in the moduledoc (lines 5-8: "walks them in deny → ask → allow order;
+  first match wins" — followed by the mode list). The hybrid does not
+  eliminate the two-mechanism shape, but it makes the second mechanism a
+  data-driven module rather than imperative dispatch, which is the
+  Hickey-aligned middle path.
+- **Outcome:** withstood. Proposal 3's cost is concretely higher
+  (API-breaking, matcher-semantics violation) and its decomplecting
+  benefit is incremental, not categorical. The hybrid is the cost-minimal
+  satisfaction of the criterion + decomplecting depth.
+- **Action:** none.
+
+## Cross-claim consistency
+
+Claims 1, 2, 3 form a coherent extraction-and-property unit (data structure
++ delegation + tests). Claims 4 and 5 add the spec-anchor layer. Claim 6
+justifies the rejection of the deeper alternative. No internal tensions
+between claims.
+
+One observed tension between Claim 4 and Claim 5: Claim 4 asserts the
+D-NNN slot is in D-090..D-099 (false — partially falsified above), while
+Claim 5 assumes the D-NNN entry is properly authored against the SPEC's
+source-map (which today does not list `evaluator.ex`). Both gaps are
+implementation-detail issues, not solution-falsifying. They are recorded in
+"Revision required" (qualifier narrowing only) and "Outstanding doubts".
+
+## Falsification summary
+
+| # | Claim (short) | Strategy | Outcome | Action |
+|---|---|---|---|---|
+| 1 | New `ModePolicy` module with compile-time map | Counter-example + dependency check | withstood | none |
+| 2 | Replace 6 `defp` clauses with delegation; preserve `evaluate/5` API | Counter-example + edge-case enumeration | withstood | implementer documents unknown-mode behaviour |
+| 3 | StreamData properties for `:plan`, `:dont_ask`, `:auto`, `:accept_edits` | Integration check + criterion mapping | withstood | none |
+| 4 | New D-NNN entry in D-090..D-099 block | Dependency check (grep SPEC) | partially falsified | narrow qualifier: use D-170..D-179 block (e.g., D-174) |
+| 5 | Hybrid yields structural decomplecting + durable gate | Counter-example on gate triggerability | withstood (charitable reading) | brief MUST include SPEC Appendix B source-map amendment |
+| 6 | Hybrid is preferable to Proposal 3 on cost/risk | Prior-art + cost comparison | withstood | none |
+
+## Revision required
+
+No `solution.md` revision and no `problem.md` revision is required.
+
+- **Target file:** solution.md (qualifier narrowing only; not a re-run)
+- **Revision kind:** surgical update — the implementer brief at PR time
+  should cite the corrected D-NNN block (D-170..D-179, with D-174..D-178
+  candidates). The solution's "Open questions" §1 (lines 109-110) already
+  invites this re-grep at PR-time, so the implementer brief inherits the
+  correction without solution re-authoring.
+- **Rationale:** the substance of Claim 4 (a new D-NNN entry pinning the
+  contract) holds; only the block specification is wrong. The solution's
+  own placeholder discipline ("placeholder; confirm by repo grep")
+  accommodates the fix at implementer-brief time, so no propose/select
+  re-run is justified.
+
+## Outstanding doubts
+
+- **Claim 2 — unknown-mode behaviour divergence.** Current evaluator's
+  catch-all `defp default_for_mode(_, _, _), do: :ask` returns `:ask` for
+  any unrecognised mode atom; Proposal 2's `Map.fetch!/2` raises
+  `KeyError`. The implementer should choose explicitly: defensive `:ask`
+  (mirrors current behaviour, weaker exhaustiveness signal) or fail-loud
+  `KeyError` (stronger exhaustiveness signal, removes a defensive
+  backstop). Recommended: fail-loud, with `Tau.Permissions.Mode.mode?/1`
+  validation at the boundary. Not falsifying.
+- **Claim 3 — `:auto` property weakness.** The property `:auto never
+  allows outside allow_set` reduces to `refute :ask == :allow` for the
+  non-allow-set branch, which is trivially true. A stronger property
+  would assert `default(:auto, tool, %{}) == :ask` for non-Bash
+  non-allowed tools. The proposal's wording matches the criterion; the
+  implementer may strengthen at no risk.
+- **Claim 5 — SPEC source-map amendment.** The new D-NNN entry's
+  "durable gate" property requires that `SPEC-PERMISSION-PROMPTS.md`'s
+  Appendix B source-map be amended in the same PR to list
+  `lib/tau/permissions/evaluator.ex` and `lib/tau/permissions/mode_policy.ex`,
+  or future PRs touching only those files will not trigger
+  spec-before-code review. The solution does not call this out
+  explicitly; the implementer brief should.
+- **Claim 6 — second-mechanism persistence.** The hybrid documents and
+  property-tests the mode-default mechanism but does not eliminate it
+  (Proposal 3 would). Future audits should consider whether the
+  documentation/data-structure layer is sufficient or whether
+  Proposal 3's path becomes worthwhile after the `:accept_edits` Bash
+  matcher design settles. Not a defect of the current solution.

--- a/docs/problems-archive-v1-modules/tau-permissions/subproblems/matcher-unit-contracts/problem.md
+++ b/docs/problems-archive-v1-modules/tau-permissions/subproblems/matcher-unit-contracts/problem.md
@@ -1,0 +1,73 @@
+---
+template_version: 1
+template_name: problem
+node_kind: leaf
+depth: 1
+parent: ../../problem.md
+status: draft
+---
+
+# Problem: matcher modules have no direct unit or property tests
+
+## Statement
+
+The five concrete matcher modules in `lib/tau/permissions/matchers.ex`
+(`Always`, `Glob`, `PathPrefix`, `Domain`, `Regex`) have zero direct unit or
+property tests; they are exercised only indirectly through `EvaluatorTest`.
+This means boundary conditions — empty args, wildcard tool name `"*"`,
+`PathPrefix` when `ctx[:cwd]` is absent, `Glob.glob_match?/2` edge cases,
+`Domain` subdomain matching — are not contractually pinned, and a silent
+regression in any matcher changes permission decisions without a failing test.
+
+## Context
+
+- `lib/tau/permissions/matchers.ex` — all five matchers, one file.
+- `Tau.Permissions.Matcher` behaviour: `match?/4` — the only public callback.
+- `PathPrefix.match?/4` line 82: `cwd = ctx[:cwd] || File.cwd!()` — impure
+  fallback when `ctx[:cwd]` is absent; this is the only place in the subsystem
+  where a nominally-pure function makes an OS call.
+- `Glob.glob_match?/2` is a public function (used by the module's `match?/4`
+  and potentially by other callers) but has no direct tests.
+- `test/tau/permissions/evaluator_test.exs` exercises matchers indirectly via
+  `Parser.compile/1 + Evaluator.evaluate/5`; no file under
+  `test/tau/permissions/` directly imports a `Matchers.*` module.
+- `Domain` matcher relies on `URI.parse/1`; subdomain matching (`host == domain
+  or String.ends_with?(host, "." <> domain)`) has no property covering arbitrary
+  hostnames.
+
+## Complecting hypothesis
+
+`PathPrefix.match?/4` is complected with process environment because it
+calls `File.cwd!/0` when `ctx[:cwd]` is absent, making its contract
+non-deterministic under different OS working directories — a pure function
+should not read ambient state.
+
+`Glob.glob_match?/2` is complected with its caller's responsibility because the
+function is public but untested at the unit level, so callers cannot reason
+about its contract (e.g. does `*` match the empty string? does `?` match `/`?)
+without reading its implementation.
+
+## Decomposition strategy
+
+(leaf — no further decomposition; proceed to proposals)
+
+## Acceptance criterion
+
+Each matcher module has at least two direct property or unit tests pinning its
+`match?/4` contract for valid and boundary inputs; `Glob.glob_match?/2` has at
+least one property; the `PathPrefix` `File.cwd!` fallback is either replaced
+with a ctx-driven default (pure) or its non-determinism is documented in a
+`@note` in the moduledoc.
+
+## Out of scope
+
+- `Tau.Permissions.Parser` — the string-to-matcher compilation logic is tested
+  indirectly and is not a matcher-unit concern.
+- `Evaluator.evaluate/5` — covered by the `evaluator-mode-complecting`
+  sub-problem.
+- Mode lattice properties — covered by `mode-lattice-properties`.
+- `Settings.Loader.merge/2` — covered by `settings-merge-feed`.
+
+## Amendment log
+
+- (none yet)

--- a/docs/problems-archive-v1-modules/tau-permissions/subproblems/matcher-unit-contracts/proposals/proposal-1.md
+++ b/docs/problems-archive-v1-modules/tau-permissions/subproblems/matcher-unit-contracts/proposals/proposal-1.md
@@ -1,0 +1,257 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 1
+parent_problem: ../problem.md
+---
+
+# Proposal 1: Direct example-based unit tests, no refactor
+
+## Approach
+
+Add a new test file `test/tau/permissions/matchers_test.exs` with
+`ExUnit.Case` example tests that directly import each of the five
+`Tau.Permissions.Matchers.*` modules and call `match?/4` (and
+`Glob.glob_match?/2`) with handpicked boundary inputs. The production
+code in `lib/tau/permissions/matchers.ex` is not touched. The
+`PathPrefix` `File.cwd!` fallback is documented with a `@note` in
+the moduledoc rather than removed.
+
+## Rationale
+
+The acceptance criterion requires at least two direct tests per
+matcher module and at least one property for `Glob.glob_match?/2`.
+This proposal satisfies the first two requirements via example tests
+for all five matchers and defers the property requirement to a
+`glob_match?` example covering `*`-empty-string and `?`-slash edge
+cases. The `File.cwd!` concern is resolved by documentation rather
+than code change: the moduledoc gains a `@note` identifying the
+deviation. Because no production code changes, the risk surface is
+zero and the PR diff is test-only.
+
+## Sketch
+
+New file `test/tau/permissions/matchers_test.exs`:
+
+```elixir
+defmodule Tau.Permissions.MatchersTest do
+  use ExUnit.Case, async: true
+
+  alias Tau.Permissions.Matchers.{Always, Glob, PathPrefix, Domain, Regex}
+
+  describe "Always" do
+    test "wildcard * matches any tool" do
+      assert Always.match?("*", "Bash", %{}, %{})
+      assert Always.match?("*", "Read", %{}, %{})
+    end
+
+    test "bare rule matches exact tool name only" do
+      assert Always.match?("Read", "Read", %{}, %{})
+      refute Always.match?("Read", "Bash", %{}, %{})
+    end
+
+    test "non-binary rule returns false" do
+      refute Always.match?(nil, "Read", %{}, %{})
+    end
+  end
+
+  describe "Glob.glob_match?/2" do
+    test "* matches empty string" do
+      assert Glob.glob_match?("npm *", "npm ")
+    end
+
+    test "* does not require trailing content" do
+      assert Glob.glob_match?("npm*", "npm")
+    end
+
+    test "? matches a single character but not /" do
+      assert Glob.glob_match?("foo?bar", "fooxbar")
+      assert Glob.glob_match?("foo?bar", "foo/bar")  # documents current behaviour
+    end
+
+    test "literal pattern matches itself exactly" do
+      assert Glob.glob_match?("npm test", "npm test")
+      refute Glob.glob_match?("npm test", "npm tests")
+    end
+  end
+
+  describe "Glob.match?/4" do
+    test "tool wildcard * matches any tool name" do
+      assert Glob.match?({"*", "npm *"}, "Bash", %{"command" => "npm test"}, %{})
+      assert Glob.match?({"*", "npm *"}, "Write", %{"path" => "npm test"}, %{})
+    end
+
+    test "specific tool only matches that tool" do
+      assert Glob.match?({"Bash", "npm *"}, "Bash", %{"command" => "npm build"}, %{})
+      refute Glob.match?({"Bash", "npm *"}, "Read", %{"command" => "npm build"}, %{})
+    end
+
+    test "no matching arg key returns false (empty arg_str)" do
+      refute Glob.match?({"Bash", "npm *"}, "Bash", %{}, %{})
+    end
+  end
+
+  describe "PathPrefix" do
+    test "path under prefix matches" do
+      assert PathPrefix.match?(
+               {"Read", "/tmp"},
+               "Read",
+               %{"path" => "/tmp/foo.txt"},
+               %{cwd: "/"}
+             )
+    end
+
+    test "path outside prefix does not match" do
+      refute PathPrefix.match?(
+               {"Read", "/tmp"},
+               "Read",
+               %{"path" => "/etc/passwd"},
+               %{cwd: "/"}
+             )
+    end
+
+    test "relative path is expanded against ctx[:cwd]" do
+      assert PathPrefix.match?(
+               {"Read", "lib"},
+               "Read",
+               %{"path" => "lib/foo.ex"},
+               %{cwd: "/app"}
+             )
+    end
+
+    # File.cwd! fallback: when ctx[:cwd] is absent the OS cwd is used.
+    # This is documented in the moduledoc @note; this test pins the
+    # behaviour rather than asserting purity.
+    test "absent ctx[:cwd] falls back to File.cwd!" do
+      result = PathPrefix.match?({"Read", "."}, "Read", %{"path" => "."}, %{})
+      assert is_boolean(result)
+    end
+  end
+
+  describe "Domain" do
+    test "exact host matches" do
+      assert Domain.match?(
+               {"WebFetch", "github.com"},
+               "WebFetch",
+               %{"url" => "https://github.com/x"},
+               %{}
+             )
+    end
+
+    test "subdomain matches" do
+      assert Domain.match?(
+               {"WebFetch", "github.com"},
+               "WebFetch",
+               %{"url" => "https://api.github.com/x"},
+               %{}
+             )
+    end
+
+    test "unrelated domain does not match" do
+      refute Domain.match?(
+               {"WebFetch", "github.com"},
+               "WebFetch",
+               %{"url" => "https://evil.com/"},
+               %{}
+             )
+    end
+
+    test "non-URL string does not match" do
+      refute Domain.match?({"WebFetch", "github.com"}, "WebFetch", %{"url" => "not-a-url"}, %{})
+    end
+
+    test "empty url does not match" do
+      refute Domain.match?({"WebFetch", "github.com"}, "WebFetch", %{}, %{})
+    end
+  end
+
+  describe "Regex" do
+    test "matching regex allows" do
+      re = ~r/^sudo/
+      assert Regex.match?({"Bash", re}, "Bash", %{"command" => "sudo rm"}, %{})
+    end
+
+    test "non-matching regex denies" do
+      re = ~r/^sudo/
+      refute Regex.match?({"Bash", re}, "Bash", %{"command" => "ls"}, %{})
+    end
+
+    test "tool mismatch returns false" do
+      re = ~r/.*/
+      refute Regex.match?({"Bash", re}, "Read", %{"command" => "anything"}, %{})
+    end
+  end
+end
+```
+
+`PathPrefix` moduledoc addition in `matchers.ex`:
+
+```elixir
+defmodule Tau.Permissions.Matchers.PathPrefix do
+  @moduledoc """
+  Matches when the tool argument's path is under the given prefix.
+
+  @note When `ctx[:cwd]` is absent, this matcher calls `File.cwd!/0`
+  to resolve relative paths. This makes `match?/4` non-deterministic
+  under different OS working directories — a known deviation from the
+  pure-function contract shared by all other matchers. Callers that
+  need deterministic results MUST supply `ctx[:cwd]`.
+  """
+  ...
+end
+```
+
+## Tradeoffs
+
+### Strengths
+
+- Zero production-code risk: diff is test-only plus a two-line moduledoc.
+- Immediately satisfies the acceptance criterion for all five matchers.
+- Pins the `?`-matches-`/` and `*`-matches-empty-string edge cases of
+  `Glob.glob_match?/2` as documented behaviour.
+- The `PathPrefix` fallback behaviour is now contractually documented
+  (the test asserting `is_boolean/1` and the `@note` together form the
+  documentation contract).
+- Lowest-effort path from red acceptance criterion to green.
+
+### Weaknesses
+
+- No property coverage: the tests cover specific chosen inputs, so
+  unanticipated boundary conditions (e.g. Unicode in hostnames, paths
+  with `..` components, regex special characters in glob patterns)
+  remain uncovered.
+- The `PathPrefix` `File.cwd!` fallback remains impure; the test pins
+  that the call doesn't crash but cannot assert determinism.
+- `Glob.glob_match?/2` boundary coverage is limited to the three
+  hand-picked cases; a StreamData property would cover far more of the
+  input space.
+- Documenting a known deviation rather than fixing it is technical debt
+  acknowledged but not retired.
+
+### Costs
+
+- One new test file (~80 lines).
+- No migration cost; no API changes.
+- The `@note` addition is a one-line moduledoc change.
+
+## Dependencies
+
+- None. All matchers are already importable; no library additions needed.
+
+## Confidence
+
+Medium. The approach is straightforward and the sketch is complete, but
+the absence of property tests means the acceptance criterion is met only
+at its minimum bar ("at least two direct tests per matcher… at least one
+property for `Glob.glob_match?/2`"). The `Glob` coverage here uses
+example tests, not a StreamData property — the acceptance criterion says
+"at least one property"; review whether example tests qualify or whether
+a property is strictly required. Confidence would be high if "property"
+is interpreted loosely.
+
+## Prior art / references
+
+- `test/tau/permissions/evaluator_test.exs` — existing example-test
+  pattern in this subsystem; the new file follows the same structure.
+- Elixir `ExUnit.Case` docs — `async: true` is safe here since all
+  matchers are pure modules with no shared state.

--- a/docs/problems-archive-v1-modules/tau-permissions/subproblems/matcher-unit-contracts/proposals/proposal-2.md
+++ b/docs/problems-archive-v1-modules/tau-permissions/subproblems/matcher-unit-contracts/proposals/proposal-2.md
@@ -1,0 +1,198 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 2
+parent_problem: ../problem.md
+---
+
+# Proposal 2: StreamData property tests for all five matchers
+
+## Approach
+
+Add `test/tau/permissions/matchers_test.exs` using `StreamData` /
+`ExUnitProperties` with property-based tests for each matcher. Every
+matcher gets at least two properties: one asserting the deterministic
+invariant of a valid input class (e.g. "for any binary tool name equal
+to the rule's tool, `Always.match?/4` returns `true`") and one
+asserting a boundary (e.g. "for any `{tool, domain}` where the URL host
+is a proper suffix, `Domain.match?/4` returns `true`"). `Glob.glob_match?/2`
+gets its own property. No production code is changed. The `PathPrefix`
+fallback is documented via `@note` in the moduledoc (same as Proposal 1).
+
+## Rationale
+
+The acceptance criterion explicitly requires "at least one property" for
+`Glob.glob_match?/2` and properties are the natural fit for the
+invariant-bearing matchers named in OTP non-negotiable #6. Property
+tests explore far more of the input space than handpicked examples,
+catching boundary conditions (Unicode hostnames, paths with `..`, glob
+patterns containing regex metacharacters, empty strings in every
+position) that example tests miss. This proposal satisfies the
+acceptance criterion at its stated intent, not just its minimum count.
+
+## Sketch
+
+New file `test/tau/permissions/matchers_test.exs`:
+
+```elixir
+defmodule Tau.Permissions.MatchersTest do
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  alias Tau.Permissions.Matchers.{Always, Glob, PathPrefix, Domain, Regex, as: M}
+
+  # ── Always ──────────────────────────────────────────────────────────
+
+  property "Always: wildcard * matches any tool name" do
+    check all tool <- StreamData.string(:printable, min_length: 1) do
+      assert Always.match?("*", tool, %{}, %{})
+    end
+  end
+
+  property "Always: binary rule matches iff tool_name equals rule" do
+    check all rule <- StreamData.string(:alphanumeric, min_length: 1),
+              tool <- StreamData.string(:alphanumeric, min_length: 1) do
+      assert Always.match?(rule, tool, %{}, %{}) == (rule == tool)
+    end
+  end
+
+  # ── Glob.glob_match?/2 ───────────────────────────────────────────────
+
+  property "Glob.glob_match?/2: literal pattern matches only itself" do
+    check all s <- StreamData.string(:alphanumeric, min_length: 1) do
+      assert Glob.glob_match?(s, s)
+      # any single extra char appended makes it not match the literal
+      refute Glob.glob_match?(s, s <> "X")
+    end
+  end
+
+  property "Glob.glob_match?/2: * alone matches any string" do
+    check all s <- StreamData.string(:printable) do
+      assert Glob.glob_match?("*", s)
+    end
+  end
+
+  property "Glob.glob_match?/2: prefix* matches any string starting with prefix" do
+    check all prefix <- StreamData.string(:alphanumeric, min_length: 1),
+              suffix <- StreamData.string(:printable) do
+      assert Glob.glob_match?(prefix <> "*", prefix <> suffix)
+    end
+  end
+
+  # ── PathPrefix ───────────────────────────────────────────────────────
+
+  property "PathPrefix: path under prefix matches; path outside does not" do
+    check all dir <- StreamData.string(:alphanumeric, min_length: 1),
+              filename <- StreamData.string(:alphanumeric, min_length: 1) do
+      inside  = "/tmp/" <> dir <> "/" <> filename
+      outside = "/etc/" <> filename
+      prefix  = "/tmp/" <> dir
+
+      assert PathPrefix.match?({"Read", prefix}, "Read", %{"path" => inside},  %{cwd: "/"})
+      refute PathPrefix.match?({"Read", prefix}, "Read", %{"path" => outside}, %{cwd: "/"})
+    end
+  end
+
+  property "PathPrefix: tool mismatch always returns false" do
+    check all tool <- StreamData.member_of(["Bash", "Write", "Edit"]),
+              path <- StreamData.string(:alphanumeric) do
+      refute PathPrefix.match?({"Read", "/tmp"}, tool, %{"path" => path}, %{cwd: "/"})
+    end
+  end
+
+  # ── Domain ───────────────────────────────────────────────────────────
+
+  property "Domain: exact host always matches" do
+    check all domain <- StreamData.string(:alphanumeric, min_length: 1) do
+      url = "https://" <> domain <> "/path"
+      assert Domain.match?({"WebFetch", domain}, "WebFetch", %{"url" => url}, %{})
+    end
+  end
+
+  property "Domain: subdomain always matches parent domain" do
+    check all sub    <- StreamData.string(:alphanumeric, min_length: 1),
+              domain <- StreamData.string(:alphanumeric, min_length: 1) do
+      url = "https://" <> sub <> "." <> domain <> "/path"
+      assert Domain.match?({"WebFetch", domain}, "WebFetch", %{"url" => url}, %{})
+    end
+  end
+
+  # ── Regex ─────────────────────────────────────────────────────────────
+
+  property "Regex: tool wildcard * dispatches to regex match on arg" do
+    check all s <- StreamData.string(:alphanumeric, min_length: 1) do
+      re = Elixir.Regex.compile!("^" <> s)
+      assert M.Regex.match?({"*", re}, "Bash",  %{"command" => s <> " extra"}, %{})
+      refute M.Regex.match?({"*", re}, "Bash",  %{"command" => "x" <> s},     %{})
+    end
+  end
+end
+```
+
+`mix.exs` already lists `stream_data` as a dependency per existing
+property tests in the codebase (e.g. `test/tau/permissions/mode_test.exs`);
+no new dependency.
+
+`PathPrefix` moduledoc `@note` — identical to Proposal 1.
+
+## Tradeoffs
+
+### Strengths
+
+- Directly satisfies the "at least one property" language in the
+  acceptance criterion, including for `Glob.glob_match?/2`.
+- OTP non-negotiable #6 ("properties before examples for
+  invariant-bearing modules") is honoured at the spirit level: the
+  matcher module contracts are now property-verified.
+- Input space explored is orders of magnitude larger than any example
+  suite; edge conditions like `dir` containing dots, subdomains of length
+  1, globs with no wildcard, etc. are caught probabilistically.
+- Still no production-code change; diff is test-only plus `@note`.
+
+### Weaknesses
+
+- Properties are harder to write than examples and easier to write
+  wrongly: a property that generates only "safe" inputs (e.g.
+  `:alphanumeric` strings for domain tests) misses Unicode hostnames,
+  IDNs, and empty strings. The sketch uses `:alphanumeric` generators in
+  several places precisely to avoid generator failure rather than to
+  capture the full contract — those are weaker than they appear.
+- `Glob.glob_match?/2` semantics for `?` matching `/` are not tested
+  by the property (because generating `?` as a glob metachar and `/`
+  as a path separator requires a custom generator). This corner is
+  documented but not exercised as a property.
+- The `PathPrefix` `File.cwd!` fallback is still impure; the property
+  suite only runs with `ctx[:cwd]` supplied.
+- `stream_data` dependency is already present, but the import of
+  `ExUnitProperties` adds a `use` macro not yet used in the matchers
+  test namespace — minor, but may require a `config/test.exs` addition
+  if `async: true` + StreamData conflicts with any global setup.
+
+### Costs
+
+- One new test file (~80 lines of property tests).
+- No API changes, no production-code risk.
+- Slightly higher cognitive overhead for future contributors unfamiliar
+  with StreamData generators.
+
+## Dependencies
+
+- `stream_data` must be in `mix.exs` test deps. Existing
+  `test/tau/permissions/mode_test.exs` already uses `StreamData`, so
+  this is already satisfied.
+
+## Confidence
+
+Medium-high. The approach is well-established in the codebase
+(mode_test.exs pattern). Confidence would be high if the generator
+choices were widened to cover Unicode and empty-string edge cases beyond
+`:alphanumeric` / `:printable`.
+
+## Prior art / references
+
+- `test/tau/permissions/mode_test.exs` — existing StreamData property
+  pattern in the same subsystem; the new file mirrors its structure.
+- CLAUDE.md OTP non-negotiable #6: "Properties before examples for
+  invariant-bearing modules."
+- Elixir `stream_data` hex docs — `StreamData.string/2`,
+  `StreamData.member_of/1`.

--- a/docs/problems-archive-v1-modules/tau-permissions/subproblems/matcher-unit-contracts/proposals/proposal-3.md
+++ b/docs/problems-archive-v1-modules/tau-permissions/subproblems/matcher-unit-contracts/proposals/proposal-3.md
@@ -1,0 +1,158 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 3
+parent_problem: ../problem.md
+---
+
+# Proposal 3: Purify PathPrefix (replace File.cwd! with ctx-driven default) + property tests
+
+## Approach
+
+Change `PathPrefix.match?/4` in `lib/tau/permissions/matchers.ex` to
+require `ctx[:cwd]` and return `false` (fail-closed) when it is absent,
+eliminating the `File.cwd!/0` side-effect. Add
+`test/tau/permissions/matchers_test.exs` with StreamData property tests
+for all five matchers (same scope as Proposal 2), plus an explicit
+property asserting the new behaviour: "absent `ctx[:cwd]` → `false`
+for any input." The moduledoc `@note` is replaced with a doc that states
+the now-pure contract.
+
+## Rationale
+
+The problem statement identifies `PathPrefix.match?/4` as complected
+with process environment: calling `File.cwd!/0` makes a nominally-pure
+function non-deterministic. Replacing the fallback with fail-closed
+`false` decomplects the function from OS state, restores referential
+transparency, and makes the contract testable as a pure property.
+Combined with a direct property suite, this satisfies the acceptance
+criterion at its strictest reading ("replaced with a ctx-driven default")
+rather than its documentation-only escape hatch.
+
+## Sketch
+
+Change in `lib/tau/permissions/matchers.ex`, `PathPrefix.match?/4`:
+
+```elixir
+# BEFORE
+def match?({tool, prefix}, tool_name, args, ctx) do
+  if tool == "*" or tool == tool_name do
+    path = args["path"] || ""
+    cwd = ctx[:cwd] || File.cwd!()          # <── impure fallback
+    full = Path.expand(path, cwd)
+    String.starts_with?(full, Path.expand(prefix, cwd))
+  else
+    false
+  end
+end
+
+# AFTER
+def match?({tool, prefix}, tool_name, args, ctx) do
+  if tool == "*" or tool == tool_name do
+    case ctx[:cwd] do
+      nil ->
+        false                                # <── fail-closed; no OS call
+      cwd ->
+        path = args["path"] || ""
+        full = Path.expand(path, cwd)
+        String.starts_with?(full, Path.expand(prefix, cwd))
+    end
+  else
+    false
+  end
+end
+```
+
+Updated moduledoc:
+
+```elixir
+defmodule Tau.Permissions.Matchers.PathPrefix do
+  @moduledoc """
+  Matches when the tool argument's path is under the given prefix.
+
+  `ctx[:cwd]` MUST be supplied; when absent, `match?/4` returns `false`
+  (fail-closed). This makes the function pure and its contract testable
+  without OS state.
+  """
+```
+
+New property in `test/tau/permissions/matchers_test.exs`:
+
+```elixir
+property "PathPrefix: absent ctx[:cwd] always returns false" do
+  check all tool   <- StreamData.member_of(["Read", "Write", "*"]),
+            prefix <- StreamData.string(:alphanumeric),
+            path   <- StreamData.string(:alphanumeric) do
+    refute PathPrefix.match?({tool, prefix}, tool, %{"path" => path}, %{})
+  end
+end
+```
+
+All other tests identical to Proposal 2.
+
+## Tradeoffs
+
+### Strengths
+
+- Eliminates the only impure function in the matcher subsystem;
+  `match?/4` on all five matchers is now a total pure function.
+- The contract becomes testable as a StreamData property without needing
+  OS fixtures or `:meck` stubbing.
+- Fail-closed on `ctx[:cwd]` absence is the safer permission default:
+  a missing context does not silently expand to the process's OS cwd,
+  which could be a different directory than the user's project root.
+- Satisfies the acceptance criterion at its most restrictive reading
+  ("replaced with a ctx-driven default").
+- Aligns with OTP non-negotiable #8 ("pure functions are the default").
+
+### Weaknesses
+
+- **Behaviour-correcting change**: any caller that relies on the
+  `File.cwd!` fallback (i.e. passes no `ctx[:cwd]`) will now get
+  `false` instead of a path-based match. This is a silent semantic
+  change for those callers — they will stop matching `PathPrefix` rules
+  where they previously matched.
+- Must audit all callers of `PathPrefix.match?/4` (direct and indirect
+  via `Evaluator.evaluate/5`) to confirm `ctx[:cwd]` is always supplied.
+  From the current codebase, `Evaluator` receives `ctx` from the session;
+  if any session call site omits `:cwd`, rules silently stop matching.
+- If `File.cwd!` is currently what makes the TUI's PathPrefix rules work
+  in practice (e.g. no call site passes `:cwd` today), this change
+  silently breaks that use case.
+- Larger PR diff: both a production change and a test change.
+
+### Costs
+
+- 3-line production diff in `matchers.ex`.
+- Requires a grep for all `Evaluator.evaluate` call sites to confirm
+  `ctx[:cwd]` propagation; at minimum `lib/tau/session.ex` and
+  `lib/tau/tui/app.ex` need inspection.
+- If any call site is missing `:cwd`, a follow-up fix is needed before
+  this change ships — or the PR must include that fix.
+
+## Dependencies
+
+- Audit: confirm every `Evaluator.evaluate/5` call site passes `:cwd`
+  in the ctx map. The primary sites are `Tau.Session` and any test that
+  calls `Evaluator.evaluate` with `PathPrefix`-containing rule sets.
+- If a call site is discovered that does not pass `:cwd`, that caller
+  must be patched in the same PR or the risk mitigated by a default
+  argument change.
+
+## Confidence
+
+Medium. The code change is small and the intent is sound, but the
+behaviour-correcting impact depends on a call-site audit that has not
+been done. Confidence would be high after confirming `:cwd` is always
+present in the ctx passed to `Evaluator.evaluate/5` at the call sites
+in `lib/tau/session.ex`.
+
+## Prior art / references
+
+- `PathPrefix.match?/4` line 82 in `lib/tau/permissions/matchers.ex`
+  — the specific offending line identified in the problem statement.
+- Hickey "Simple Made Easy" (2011) — "complecting" as weaving two
+  concerns that should be separated; removing the OS-state dependency
+  is the canonical decomplecting move.
+- OTP non-negotiable #8: "pure functions are the default; processes are
+  the exception."

--- a/docs/problems-archive-v1-modules/tau-permissions/subproblems/matcher-unit-contracts/proposals/proposal-4.md
+++ b/docs/problems-archive-v1-modules/tau-permissions/subproblems/matcher-unit-contracts/proposals/proposal-4.md
@@ -1,0 +1,232 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 4
+parent_problem: ../problem.md
+---
+
+# Proposal 4: Extract Glob.glob_match?/2 into Tau.Permissions.GlobMatcher with a standalone contract module
+
+## Approach
+
+Extract `Glob.glob_match?/2` and its private `compile/1` helper from
+`Tau.Permissions.Matchers.Glob` into a dedicated module
+`Tau.Permissions.GlobMatcher`. `Matchers.Glob` delegates to it.
+`GlobMatcher` has its own dedicated test module
+`test/tau/permissions/glob_matcher_test.exs` with StreamData properties
+covering the full contract of `glob_match?/2`. The remaining four
+matchers get direct unit tests in `test/tau/permissions/matchers_test.exs`
+(example-based, two per matcher). `PathPrefix` is documented with
+`@note`. The new module is the single canonical export of the glob
+algorithm; other future callers (e.g. path-prefix glob extensions) use
+`GlobMatcher.glob_match?/2` directly.
+
+## Rationale
+
+The problem identifies two complecting concerns: `Glob.glob_match?/2` is
+a public function embedded in a `Matcher` implementation module, making
+its contract discoverable only by reading that implementation. Extracting
+it to `Tau.Permissions.GlobMatcher` makes the contract first-class and
+separately testable, decomplecting the "glob algorithm" from the "glob
+matcher behaviour implementation." The separation also enables
+`PathPrefix` to eventually use `GlobMatcher.glob_match?/2` for prefix
+patterns (a future seam), and prevents the common mistake of callers
+importing `Matchers.Glob` just for the algorithm.
+
+## Sketch
+
+New file `lib/tau/permissions/glob_matcher.ex`:
+
+```elixir
+defmodule Tau.Permissions.GlobMatcher do
+  @moduledoc """
+  Trivial `*`/`?` glob algorithm, decoupled from the `Matcher` behaviour.
+
+  ## Contract
+
+  - `*` matches zero or more of any character (including empty string).
+  - `?` matches exactly one character (any character, including `/`).
+  - All other characters match themselves literally.
+  - No character classes, no `**`, no brace expansion.
+
+  This module is the canonical home for glob semantics in the
+  `tau-permissions` subsystem. Import it directly rather than calling
+  `Tau.Permissions.Matchers.Glob.glob_match?/2`.
+  """
+
+  @doc """
+  Returns `true` iff `str` matches `pattern` under the `*`/`?` glob rules.
+  """
+  @spec glob_match?(String.t(), String.t()) :: boolean()
+  def glob_match?(pattern, str) do
+    re = compile(pattern)
+    Regex.match?(re, str)
+  end
+
+  @spec compile(String.t()) :: Regex.t()
+  defp compile(pattern) do
+    body =
+      pattern
+      |> String.codepoints()
+      |> Enum.map_join("", fn
+        "*" -> ".*"
+        "?" -> "."
+        c when c in ~w(. ^ $ + ( ) [ ] { } | \\) -> "\\" <> c
+        c -> c
+      end)
+
+    Regex.compile!("^" <> body <> "$")
+  end
+end
+```
+
+Modified `lib/tau/permissions/matchers.ex`, `Glob` module:
+
+```elixir
+defmodule Tau.Permissions.Matchers.Glob do
+  @moduledoc """
+  Glob matcher. Patterns look like `Bash(npm run *)`, `Read(./*.exs)`.
+  Glob semantics are defined in `Tau.Permissions.GlobMatcher`.
+  """
+  @behaviour Tau.Permissions.Matcher
+  alias Tau.Permissions.GlobMatcher
+
+  @impl true
+  def match?({tool, glob}, tool_name, args, _ctx) do
+    if tool == "*" or tool == tool_name do
+      arg_str = arg_for(tool_name, args)
+      GlobMatcher.glob_match?(glob, arg_str)
+    else
+      false
+    end
+  end
+
+  # glob_match?/2 removed from this module; callers use GlobMatcher directly.
+  # arg_for/2 kept private here.
+  ...
+end
+```
+
+New test file `test/tau/permissions/glob_matcher_test.exs`:
+
+```elixir
+defmodule Tau.Permissions.GlobMatcherTest do
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  alias Tau.Permissions.GlobMatcher
+
+  property "* alone matches any string" do
+    check all s <- StreamData.string(:printable) do
+      assert GlobMatcher.glob_match?("*", s)
+    end
+  end
+
+  property "literal pattern matches only itself" do
+    check all s <- StreamData.string(:alphanumeric, min_length: 1) do
+      assert GlobMatcher.glob_match?(s, s)
+      refute GlobMatcher.glob_match?(s, s <> "X")
+    end
+  end
+
+  property "prefix* matches any string that begins with prefix" do
+    check all prefix <- StreamData.string(:alphanumeric, min_length: 1),
+              suffix <- StreamData.string(:printable) do
+      assert GlobMatcher.glob_match?(prefix <> "*", prefix <> suffix)
+    end
+  end
+
+  property "? matches exactly one character" do
+    check all c <- StreamData.string(:printable, length: 1),
+              prefix <- StreamData.string(:alphanumeric) do
+      assert GlobMatcher.glob_match?(prefix <> "?" <> "*", prefix <> c)
+    end
+  end
+
+  # Documents the ? behaviour for / (currently matches; not treated as separator)
+  test "? matches / (not a path separator in this implementation)" do
+    assert GlobMatcher.glob_match?("foo?bar", "foo/bar")
+  end
+
+  test "* matches empty string" do
+    assert GlobMatcher.glob_match?("npm *", "npm ")
+    assert GlobMatcher.glob_match?("npm*", "npm")
+  end
+end
+```
+
+Old callers: `Tau.Permissions.Matchers.Glob` now delegates; any external
+caller that referenced `Matchers.Glob.glob_match?/2` must be updated to
+`GlobMatcher.glob_match?/2`. From a codebase search, no file outside
+`matchers.ex` calls `Glob.glob_match?/2` directly today (only `Evaluator`
+tests call it indirectly via the full stack).
+
+## Tradeoffs
+
+### Strengths
+
+- `Glob.glob_match?/2` is now a standalone module with a clearly
+  documented contract; callers can import `GlobMatcher` without taking
+  a dependency on the `Matcher` behaviour implementation.
+- The contract is now the authoritative source of truth for glob
+  semantics in the subsystem; future matchers (e.g. a path-prefix-glob
+  matcher) reuse it without copying.
+- The property suite lives in its own test file, scoped to the algorithm;
+  easier to extend as the glob language grows.
+- Sets the structural precedent for further algorithm extraction (e.g.
+  domain-matching logic into `Tau.Permissions.DomainMatcher`).
+- Acceptance criterion met: `glob_match?/2` has multiple StreamData
+  properties, and the `Glob.match?/4` delegation is trivially verifiable.
+
+### Weaknesses
+
+- **API-breaking for external callers of `Matchers.Glob.glob_match?/2`**:
+  the public function moves. While no external callers exist today, any
+  tooling or test that references the old path breaks silently at compile
+  time (missing function) rather than at runtime.
+- Larger diff than proposals 1–3: new module, new test file, modified
+  `matchers.ex`. Higher review surface.
+- The extraction is architectural rather than strictly required by the
+  acceptance criterion: a property test on `Matchers.Glob.glob_match?/2`
+  in-place would satisfy the criterion without the module split.
+- Introduces a new module namespace (`Tau.Permissions.GlobMatcher`)
+  that may be considered over-engineering for a ~10-line function.
+- Requires updating the spec catalog (`spec-before-code.md`) if
+  `GlobMatcher` is considered a new coordinating component — unlikely
+  (it is stateless), but worth noting.
+
+### Costs
+
+- One new production file (`glob_matcher.ex`, ~30 lines).
+- One new test file (`glob_matcher_test.exs`, ~40 lines).
+- Modified `matchers.ex` (~3 lines changed in `Glob`).
+- Any external caller of `Matchers.Glob.glob_match?/2` needs updating —
+  zero today, but future PRs that add callers need to know the canonical
+  location has changed.
+
+## Dependencies
+
+- No library changes; `stream_data` already present.
+- Should update `spec-before-code.md` to reference `glob_matcher.ex`
+  in the `SPEC-PERMISSION-PROMPTS` source-map appendix if the spec
+  explicitly lists matchers files — confirm before opening the PR.
+
+## Confidence
+
+Medium. The extraction is clean and the sketch is complete, but the
+benefit over a simpler in-place property test (Proposal 2) is marginal
+given the current codebase size and the zero external callers of
+`glob_match?/2` today. Confidence in the structural choice would be
+higher if a second caller of `GlobMatcher.glob_match?/2` existed or was
+planned (e.g. a path-prefix-glob extension).
+
+## Prior art / references
+
+- Clojure's `clojure.string` extract pattern: algorithm moved out of
+  the context where it was first needed into a named, independently
+  testable namespace.
+- `Tau.Permissions.GlobMatcher` naming mirrors `Tau.Permissions.Matcher`
+  behaviour naming convention; `*Matcher` is already the module suffix
+  for concrete implementations.
+- `lib/tau/permissions/matchers.ex` — current home of `Glob.glob_match?/2`,
+  the function being extracted.

--- a/docs/problems-archive-v1-modules/tau-permissions/subproblems/matcher-unit-contracts/solution.md
+++ b/docs/problems-archive-v1-modules/tau-permissions/subproblems/matcher-unit-contracts/solution.md
@@ -1,0 +1,81 @@
+---
+template_version: 1
+template_name: solution
+parent_problem: problem.md
+node_kind: leaf
+synthesised_from:
+  - proposals/proposal-2.md
+  - proposals/proposal-3.md
+selection_method: hybrid
+revision: 0
+---
+
+# Solution: StreamData property tests + purify PathPrefix (hybrid P2 + P3)
+
+## Recommendation
+
+Add `test/tau/permissions/matchers_test.exs` with StreamData property tests for all five matchers and `Glob.glob_match?/2` (from Proposal 2), and simultaneously replace `PathPrefix.match?/4`'s `File.cwd!/0` fallback with fail-closed `false` when `ctx[:cwd]` is absent (from Proposal 3). The property suite is the primary deliverable; the `PathPrefix` purification is a 3-line production change that makes the suite's assertions about purity true rather than aspirational. Both changes ship in the same PR. The `@note` documentation path (Proposals 1 and 3's fallback) is abandoned: a known deviation should be fixed, not documented.
+
+## Selected from
+
+- **Chosen:** hybrid of `proposals/proposal-2.md` + `proposals/proposal-3.md`
+- **Why chosen:** Proposal 2 satisfies the acceptance criterion's "at least one property" requirement with properties that explore orders of magnitude more input space than Proposal 1's examples, and honours OTP non-negotiable #6 at the spirit level. Proposal 3 takes the decomplecting step that Proposal 2 defers: it removes the `File.cwd!` side-effect rather than merely documenting it. The two are strictly complementary — Proposal 2 provides the test suite; Proposal 3 provides the production fix that the property suite can then assert. Neither alone is as strong: Proposal 2 without the fix means the "absent `ctx[:cwd]`" property cannot make a deterministic claim; Proposal 3 without the full property suite meets only the minimum bar. Proposal 1 is subsumed by this hybrid (example tests are weaker than properties; documentation-only for the fallback is weaker than elimination). Proposal 4's extraction of `GlobMatcher` is over-engineered for zero current external callers and adds a production file to satisfy what a property test in-place already satisfies.
+
+## Scoring table
+
+| # | Fit | Decomplecting depth | Migration cost | Risk | Reversibility |
+|---|---|---|---|---|---|
+| 1 | Partially | Surface | Low | Low | Easy |
+| 2 | Yes | Substantial | Low | Low | Easy |
+| 3 | Yes | Deep | Low–Medium | Medium | Easy |
+| 4 | Partially | Substantial | Medium | Low | Easy |
+
+Notes:
+- P1: "Partially" because the acceptance criterion says "at least one property" for `Glob.glob_match?/2`; P1 uses examples only. "Surface" decomplecting because the `File.cwd!` impurity remains.
+- P2: "Yes" fit; "Substantial" because properties cover the input space, but impurity stays.
+- P3: "Yes" fit; "Deep" because it eliminates the only impure function in the subsystem, but "Medium" risk due to the call-site audit requirement.
+- P4: "Partially" because the extraction is not required by the acceptance criterion; the split adds structural change that is premature given zero external callers.
+
+The hybrid of P2 + P3 scores "Yes / Deep / Low–Medium / Low–Medium / Easy" — the best overall profile.
+
+## What changes
+
+- **New file** `test/tau/permissions/matchers_test.exs`: StreamData property tests for `Always`, `Glob` (including `glob_match?/2`), `PathPrefix`, `Domain`, `Regex` — two or more properties per matcher plus boundary examples where properties are insufficient (e.g. `?`/`/` semantics documentation test).
+- **`lib/tau/permissions/matchers.ex`**, `PathPrefix.match?/4`: replace `cwd = ctx[:cwd] || File.cwd!()` with a `case ctx[:cwd]` that returns `false` when `nil` (fail-closed).
+- **`lib/tau/permissions/matchers.ex`**, `PathPrefix` moduledoc: update to state the now-pure contract ("when `ctx[:cwd]` is absent, returns `false`; no OS call").
+- **Pre-PR audit** (not a file change, but a required step): grep all `Evaluator.evaluate/5` call sites (`lib/tau/session.ex`, `lib/tau/tui/app.ex`, any tests using `PathPrefix`-containing rule sets) to confirm `:cwd` is present in the ctx map. If any call site is missing `:cwd`, that fix lands in the same PR.
+
+## What does not change
+
+- `Tau.Permissions.Matcher` behaviour interface (`match?/4` signature unchanged).
+- `lib/tau/permissions/matchers.ex` — all five matchers except the 3-line `PathPrefix` change.
+- `test/tau/permissions/evaluator_test.exs` — existing indirect coverage is not removed.
+- `Tau.Permissions.Matchers.Glob.glob_match?/2` remains a public function on its current module (no extraction, no rename); the property tests call it directly.
+- `mix.exs` dependencies — `stream_data` is already present.
+- No SPEC amendments required: the acceptance criterion is under `SPEC-PERMISSION-PROMPTS` but the change is test-only plus a 3-line production fix with no new public API surface.
+
+## Migration sketch
+
+1. Run the call-site audit for `Evaluator.evaluate/5` to confirm `:cwd` propagation. Fix any gap in the same PR before changing production code.
+2. Apply the `PathPrefix.match?/4` 3-line change and update the moduledoc.
+3. Add `test/tau/permissions/matchers_test.exs` with the full property suite.
+4. Run `mix test test/tau/permissions/matchers_test.exs` — all green (the audit from step 1 ensures no regressions from the `PathPrefix` change).
+5. Run `mix test` — full suite green.
+6. The gate picks up the new tests as gating-test paths; mutation check (gate 5.3) verifies at least one property fails against the pre-fix production code.
+
+## Open questions
+
+- **Call-site audit scope**: does `Tau.Session` always populate `:cwd` in the ctx it passes to `Evaluator.evaluate/5`? This is the only gate-risk for the P3 component. If the answer is no, the PR must include the ctx-population fix, and the scope slightly widens.
+- **Generator widening**: Proposal 2 noted that `:alphanumeric` generators miss Unicode hostnames, IDNs, and paths with `..` components. The hybrid inherits this weakness. Widening to `:utf8` or custom generators for `Domain` properties is left as a follow-up; the minimum bar of the acceptance criterion is met without it.
+- **`Glob.glob_match?/2` `?`/`/` behaviour**: current implementation treats `?` as matching any single character including `/`. The property suite documents this but does not change it. If the intended contract is `?` does not match `/`, that is a separate issue.
+
+## Linked sub-problems / proposals
+
+- `proposals/proposal-1.md` — Example-based tests + `@note` doc for `PathPrefix`. Subsumed; weaker on both property coverage and the impurity fix.
+- `proposals/proposal-2.md` — StreamData property tests, no production change. Selected as the test-suite component of this hybrid.
+- `proposals/proposal-3.md` — Purify `PathPrefix` + property tests. Selected as the production-fix component of this hybrid.
+- `proposals/proposal-4.md` — Extract `GlobMatcher` module + properties. Rejected as premature architecture with no current second caller.
+
+## Revision history
+
+- (revision 0 — initial)

--- a/docs/problems-archive-v1-modules/tau-permissions/subproblems/matcher-unit-contracts/validation.md
+++ b/docs/problems-archive-v1-modules/tau-permissions/subproblems/matcher-unit-contracts/validation.md
@@ -1,0 +1,457 @@
+---
+template_version: 1
+template_name: validation
+parent_solution: solution.md
+parent_problem: problem.md
+toulmin_complete: true
+falsification_attempted: true
+falsification_outcome: partially_falsified — claim/6
+revision_triggered: none
+---
+
+# Validation: StreamData property tests + purify PathPrefix (hybrid P2 + P3)
+
+## Overview
+
+The solution makes two coupled changes: (a) add a property suite
+`test/tau/permissions/matchers_test.exs` covering all five matchers and
+`Glob.glob_match?/2`, and (b) replace `PathPrefix.match?/4`'s
+`File.cwd!/0` fallback with fail-closed `false` when `ctx[:cwd]` is
+absent. Eight distinct propositions were extracted across the
+Recommendation and What-changes / What-does-not-change sections.
+Falsification strategies were chosen per claim from the catalog
+(dependency check, integration check, edge-case enumeration,
+counter-example construction, type-level check, prior-art
+counter-case). Seven claims withstood; **claim 6** (no SPEC amendment
+required) was **partially falsified** — narrowing its Qualifier (see
+§Falsification summary). No solution or problem revision is required;
+the Qualifier narrowing is recorded in place.
+
+## Toulmin per claim
+
+The MITRE empirical study on Toulmin formalism found that "participants
+found it difficult to generate Toulmin structures, and their structures
+varied greatly even though they started with the same content"
+(https://www.mitre.org/news-insights/publication/empirical-evaluation-structured-argumentation-using-toulmin-argument).
+The six fields below are filled explicitly per claim to counter that
+variance.
+
+### Claim 1: Property tests in a new `test/tau/permissions/matchers_test.exs` satisfy the acceptance criterion's "at least two direct property or unit tests per matcher" and "at least one property for `Glob.glob_match?/2`".
+
+- **Claim (C):** Adding `test/tau/permissions/matchers_test.exs` with
+  StreamData properties for `Always`, `Glob` (including
+  `glob_match?/2`), `PathPrefix`, `Domain`, and `Regex` — two or more
+  per matcher — satisfies the acceptance criterion in `problem.md`.
+- **Grounds (G):**
+  `docs/problems/.../matcher-unit-contracts/problem.md` lines 55-60
+  state the criterion verbatim ("at least two direct property or unit
+  tests pinning its `match?/4` contract"); `solution.md` line 43
+  enumerates the new tests; `mix.exs` line 129 confirms
+  `{:stream_data, "~> 1.1", only: [:test, :dev]}` is already a test
+  dependency so no dep PR is needed.
+- **Warrant (W):** A property test is strictly stronger than a unit
+  test for the same input domain because it samples that domain
+  randomly rather than at fixed points (StreamData generators emit
+  ~100 inputs per property by default); therefore "at least one
+  property" subsumes "at least one unit test". This is OTP
+  non-negotiable #6 ("Properties before examples for invariant-bearing
+  modules"; `.claude/rules/otp-non-negotiables.md`) applied in the
+  direction the rule names.
+- **Qualifier (Q):** Holds provided each per-matcher property has a
+  non-degenerate generator (e.g. `string(:alphanumeric)` is acceptable
+  for path/domain inputs at this layer; `constant("")` is degenerate
+  and would not satisfy the spirit of the criterion). The solution's
+  open question on Unicode/IDN/`..` widening is acknowledged but the
+  acceptance criterion's threshold is met without it.
+- **Rebuttal (R):** Would not hold if "direct test" is read narrowly
+  to require examples *in addition to* properties; the acceptance
+  criterion says "property or unit tests", so properties alone count.
+- **Backing (B):** `.claude/rules/otp-non-negotiables.md` §6
+  ("Invariant-bearing modules MUST have properties before examples
+  … `StreamData`"); StreamData defaults documented at
+  https://hexdocs.pm/stream_data/StreamData.html (default 100 runs
+  per property).
+
+#### Falsification attempt for claim 1
+
+- **Strategy:** dependency check.
+- **Attempt:** Verified `stream_data ~> 1.1` is already in `mix.exs`
+  deps (line 129) so the property suite compiles; verified
+  `test/tau/permissions/` contains no file directly importing
+  `Tau.Permissions.Matchers.*` today (`grep -rn
+  "Tau.Permissions.Matchers\." test/` returned no matches) so the new
+  file genuinely fills the gap rather than duplicating coverage.
+- **Outcome:** withstood. No dependency or duplication blocker.
+- **Action:** none.
+
+### Claim 2: Replacing `PathPrefix.match?/4`'s `cwd = ctx[:cwd] || File.cwd!()` with a fail-closed `false` when `ctx[:cwd]` is `nil` is a 3-line production change.
+
+- **Claim (C):** The production change to `PathPrefix.match?/4` fits
+  within ~3 lines and is localised to one function in
+  `lib/tau/permissions/matchers.ex`.
+- **Grounds (G):** `lib/tau/permissions/matchers.ex:79-88` is the
+  current body of `PathPrefix.match?/4`; the impure line is exactly
+  line 82 (`cwd = ctx[:cwd] || File.cwd!()`). Replacing that single
+  line with `case ctx[:cwd] do nil -> false; cwd -> …` reshapes lines
+  82-84 only; the `tool == "*" or tool == tool_name` guard at line 80
+  and the `String.starts_with?` test at line 84 stay verbatim.
+- **Warrant (W):** A local pattern-match restructure that does not
+  cross function or module boundaries is a closed-scope edit by
+  construction; the diff size is bounded by the lines it touches.
+- **Qualifier (Q):** "3-line" is the order of magnitude, not a hard
+  cap; the precise diff size depends on formatting (the `case` may
+  cost one extra line). Holds in all formatter outcomes within a small
+  constant.
+- **Rebuttal (R):** Would not hold if the change forced a cascading
+  callback signature change — e.g. if `match?/4` became `match?/5`.
+  It does not: the behaviour `Tau.Permissions.Matcher` (line 1 of
+  `lib/tau/permissions/matcher.ex`) defines `match?/4` and the change
+  preserves arity and return type (`boolean()`).
+- **Backing (B):** OTP non-negotiable #2 (extensibility seams MUST be
+  behaviours; pattern match on atoms and structs;
+  `.claude/rules/otp-non-negotiables.md`) — preserving the behaviour
+  signature is the rule licensing the bounded-edit claim.
+
+#### Falsification attempt for claim 2
+
+- **Strategy:** counter-example construction.
+- **Attempt:** Drafted the post-change shape:
+  ```
+  def match?({tool, prefix}, tool_name, args, ctx) do
+    if tool == "*" or tool == tool_name do
+      case ctx[:cwd] do
+        nil -> false
+        cwd ->
+          path = args["path"] || ""
+          full = Path.expand(path, cwd)
+          String.starts_with?(full, Path.expand(prefix, cwd))
+      end
+    else
+      false
+    end
+  end
+  ```
+  Diff vs. current: net +3 lines (the `case` head, the `nil -> false`
+  arm, and the closing `end`); body line preserved. No counter-example
+  to "3-line order of magnitude" found.
+- **Outcome:** withstood.
+- **Action:** none.
+
+### Claim 3: After the change, `PathPrefix.match?/4` is pure (no OS call) and fails closed.
+
+- **Claim (C):** Post-change, `PathPrefix.match?/4` performs no OS
+  call and returns `false` when `ctx[:cwd]` is absent — a
+  fail-closed, deterministic contract.
+- **Grounds (G):** Pre-change, `lib/tau/permissions/matchers.ex:82`
+  invokes `File.cwd!/0` — the *only* OS call in
+  `lib/tau/permissions/matchers.ex` (grepped the file: no other
+  `File.*`, `System.*`, `:os.*`, or `Process.*` calls). Post-change,
+  the `case` branch on `nil` returns `false` directly without any
+  side-effecting call.
+- **Warrant (W):** A function whose only side-effecting line is
+  removed and whose remaining body is pure data transformation
+  (`Path.expand/2`, `String.starts_with?/2`) is pure. This matches
+  Hickey's "decomplecting" — removing the ambient-state dependency
+  separates the matcher's policy decision from process state.
+- **Qualifier (Q):** Pure modulo `Path.expand/2`'s implementation;
+  `Path.expand/2` itself is documented as a pure path manipulation
+  (https://hexdocs.pm/elixir/Path.html#expand/2) and makes no OS call
+  when given an explicit second `cwd` argument.
+- **Rebuttal (R):** Would not hold if a future change reintroduces an
+  OS-state read (e.g. a `Path.absname/1` call without the explicit
+  cwd argument). The property suite assertion that `match?/4` returns
+  `false` on `ctx[:cwd] == nil` guards against silent regressions.
+- **Backing (B):** OTP non-negotiable #8 ("Pure functions are the
+  default; processes are the exception";
+  `.claude/rules/otp-non-negotiables.md`); `Path.expand/2` docs at
+  https://hexdocs.pm/elixir/Path.html#expand/2.
+
+#### Falsification attempt for claim 3
+
+- **Strategy:** edge-case enumeration over side-effect surfaces.
+- **Attempt:** Enumerated possible OS interactions of the post-change
+  body: (i) `Path.expand(path, cwd)` with `cwd :: String.t()` — pure
+  by docs; (ii) `String.starts_with?/2` — pure; (iii) `case ctx[:cwd]`
+  — pure map access. No remaining OS-state read.
+- **Outcome:** withstood.
+- **Action:** none.
+
+### Claim 4: All current call sites of `Evaluator.evaluate/5` already populate `:cwd` in the ctx, so the fail-closed `nil` branch is reachable only by test or future bug, not by today's production path.
+
+- **Claim (C):** The pre-PR audit will find every production call
+  site of `Evaluator.evaluate/5` already passes `:cwd` in its ctx;
+  the new fail-closed branch does not regress today's behaviour.
+- **Grounds (G):** `grep -rn "Evaluator.evaluate"
+  /home/brentw/src/tau/lib/` returns exactly one production call
+  site: `lib/tau/session/tool_dispatch.ex:88`. Its `eval_ctx` is
+  built on line 81 as `%{cwd: data.cwd, active_skill:
+  data.active_skill}` — `:cwd` is always present (the
+  `Tau.Session.Data` struct enforces `:cwd` as a required key:
+  `lib/tau/session.ex:100` `@enforce_keys [:id, :cwd, :created_at]`).
+- **Warrant (W):** A struct field declared in `@enforce_keys` cannot
+  be `nil` at struct-construction time; therefore `data.cwd` is
+  guaranteed non-nil for any `Tau.Session.Data` that exists, and the
+  map literal `%{cwd: data.cwd, …}` always includes a non-nil
+  `:cwd` key.
+- **Qualifier (Q):** Holds for the current codebase as of this
+  validation's audit (single production call site, struct enforces
+  the key). A future call site that omits `:cwd` would silently
+  trigger the fail-closed branch; the property suite catches that
+  category by asserting the behaviour.
+- **Rebuttal (R):** `@enforce_keys` does not prevent later
+  assignment to `nil` via `%{data | cwd: nil}`. Grepping `lib/`
+  found no such assignment; the rebuttal is hypothetical.
+- **Backing (B):** Elixir `@enforce_keys` docs at
+  https://hexdocs.pm/elixir/Module.html#module-enforce_keys; struct
+  definition at `lib/tau/session.ex:100-101`.
+
+#### Falsification attempt for claim 4
+
+- **Strategy:** integration check (boundary enumeration).
+- **Attempt:** Enumerated every `Evaluator.evaluate` call in `lib/`
+  (one hit, `tool_dispatch.ex:88`); traced the `eval_ctx` construction
+  to line 81; verified `:cwd` key is unconditionally present; verified
+  `@enforce_keys` guarantees `data.cwd != nil` at struct creation.
+- **Outcome:** withstood.
+- **Action:** none. The solution's "Open question — call-site audit
+  scope" is resolved in favour of no widening.
+
+### Claim 5: The hybrid of P2 + P3 is strictly stronger than either alone and subsumes P1; P4 is over-engineered.
+
+- **Claim (C):** The hybrid is the best fit across the four
+  proposals because P1 is example-only (weaker than properties), P2
+  alone leaves the impurity, P3 alone meets only the minimum bar,
+  and P4 introduces a module extraction with zero current external
+  callers.
+- **Grounds (G):** `solution.md` scoring table (lines 25-39) records
+  P1 as "Partially / Surface", P2 as "Yes / Substantial", P3 as
+  "Yes / Deep", P4 as "Partially / Substantial". The hybrid covers
+  P2's column (property suite) AND P3's column (purification) — by
+  inspection, no column is worse than either parent. `grep -rn
+  "glob_match?\|Matchers.Glob" /home/brentw/src/tau/lib` confirms
+  exactly one caller of `Glob.glob_match?/2`
+  (`lib/tau/permissions/matchers.ex` itself) and one caller of the
+  `Glob` module (`lib/tau/permissions/parser.ex:67`), making P4's
+  extraction premature.
+- **Warrant (W):** When two proposals modify orthogonal axes (P2
+  modifies tests only; P3 modifies production only) and neither
+  regresses the other's axis, their union dominates each alone. The
+  YAGNI rule (Hickey: "Decomplect; don't add structure to satisfy
+  imagined needs") rejects P4's extraction.
+- **Qualifier (Q):** "Strictly stronger" holds against the
+  acceptance criterion as written; a stricter criterion that
+  demanded example coverage in addition to properties (P1 + P2)
+  would change the calculus, but the criterion does not so demand.
+- **Rebuttal (R):** Would not hold if P2's properties exercised the
+  pre-fix `File.cwd!/0` path in a way that broke when P3 lands — but
+  the properties as specified pass `ctx[:cwd]` explicitly, so they
+  exercise the post-fix path.
+- **Backing (B):** Hickey, "Simple Made Easy" (2011) — decomplecting
+  via removal of state, not via additional structure
+  (https://www.youtube.com/watch?v=SxdOUGdseq4); YAGNI in
+  XP/Beck (https://martinfowler.com/bliki/Yagni.html).
+
+#### Falsification attempt for claim 5
+
+- **Strategy:** prior-art counter-case.
+- **Attempt:** Searched for known cases where a "test-only + tiny
+  production fix" hybrid produced worse outcomes than either alone.
+  The risk pattern in the literature is "hidden coupling" — the test
+  encodes the impurity and locks it in. The hybrid does the opposite:
+  it removes the impurity in the same PR as the test, so the test
+  encodes the *post-fix* contract. No counter-case applies.
+- **Outcome:** withstood.
+- **Action:** none.
+
+### Claim 6: No SPEC amendment is required because the change is "test-only plus a 3-line production fix with no new public API surface".
+
+- **Claim (C):** `solution.md` line 55 asserts that no SPEC
+  amendment is required for this PR.
+- **Grounds (G):** `solution.md` line 55; `lib/tau/permissions/`
+  contains no `SPEC-MATCHERS.md` reference in
+  `.claude/rules/spec-before-code.md`'s catalog;
+  `.claude/rules/spec-before-code.md` lists
+  `SPEC-PERMISSION-PROMPTS.md` as the relevant spec but its
+  mandatory scope is limited to `lib/tau/session.ex` (the permission
+  gate), `lib/tau/session/events.ex` (the `%PermissionRequest{}`
+  struct), and `lib/tau/cli.ex` (the `interactive:` opt). The PR
+  touches neither.
+- **Warrant (W):** `spec-before-code.md` says a PR is in scope of a
+  SPEC if it "touches any file the SPEC's source-map (Appendix B)
+  names, OR it changes a boundary contract (§4), OR it introduces
+  new state at any boundary the spec lists." The PR touches none of
+  `SPEC-PERMISSION-PROMPTS`'s listed files.
+- **Qualifier (Q):** Holds provided the contract change in
+  `PathPrefix.match?/4` (the behaviour change from "fallback to
+  `File.cwd!`" to "fail closed") is NOT considered a boundary
+  contract under SPEC-PERMISSION-PROMPTS §4. The validator is
+  partially uncertain on this point (see falsification).
+- **Rebuttal (R):** If the behaviour change shifts an `:allow` verdict
+  to `:deny` (or vice versa) for any historical input, that is
+  observably a permission-decision change. The pre-fix branch was
+  reached only when `ctx[:cwd] == nil`; this validator confirmed
+  (claim 4) that production never passes `nil`, so production
+  permission verdicts are unchanged. Tests that previously relied on
+  the implicit `File.cwd!/0` fallback would change; the new property
+  suite makes the post-fix contract explicit.
+- **Backing (B):** `.claude/rules/spec-before-code.md` §"What this
+  rule requires"; `docs/spec/SPEC-PERMISSION-PROMPTS.md` §"Source
+  map".
+
+#### Falsification attempt for claim 6
+
+- **Strategy:** edge-case enumeration over `spec-before-code.md`'s
+  three trigger conditions.
+- **Attempt:** Iterated the three triggers: (i) source-map files
+  touched — `lib/tau/permissions/matchers.ex` is NOT in
+  SPEC-PERMISSION-PROMPTS's source map; (ii) boundary contract
+  change — the matcher's `match?/4` callback IS part of a behaviour
+  contract (`Tau.Permissions.Matcher`), and altering the implicit
+  semantics for `nil` `:cwd` IS a contract change at the matcher
+  boundary (even if no callable signature changes); (iii) new state
+  at a boundary — no new state. Trigger (ii) raises a non-trivial
+  question: does
+  `Tau.Permissions.Matcher` have a SPEC? It does not appear in the
+  catalog at all, so no SPEC owns it. The "no SPEC amendment"
+  conclusion holds for the existing catalog, but a more precise
+  framing is needed.
+- **Outcome:** **partially falsified**. The original claim is too
+  strong as written ("no new public API surface" elides the fact
+  that the implicit-vs-explicit semantics of `nil` `:cwd` IS a
+  contract refinement at the `Tau.Permissions.Matcher` behaviour
+  level — there just happens to be no SPEC that codifies it today).
+- **Action:** narrow the Qualifier in place. Narrowed claim: "No
+  amendment to any existing `docs/spec/SPEC-*.md` is required
+  because no SPEC currently owns `Tau.Permissions.Matcher`. The
+  PR's moduledoc update to `PathPrefix` documents the contract
+  refinement; that documentation suffices in the absence of a
+  matcher SPEC." Solution revision is NOT needed — the narrowed
+  conclusion is the same operational decision (no SPEC PR), and
+  the moduledoc update is already in `solution.md`'s What-changes
+  list (line 45).
+
+### Claim 7: The existing `test/tau/permissions/evaluator_test.exs` indirect coverage is preserved.
+
+- **Claim (C):** Adding the new matchers test file does not remove
+  the existing indirect coverage in `evaluator_test.exs`.
+- **Grounds (G):** `solution.md` line 52 ("`test/tau/permissions/
+  evaluator_test.exs` — existing indirect coverage is not removed");
+  `What does not change` list explicitly preserves it. New file
+  addition does not modify existing files.
+- **Warrant (W):** Creating a new test file is an additive operation
+  in Mix's test runner; it cannot delete or skip an existing file
+  unless `mix.exs`'s `test_paths`/`test_pattern` is changed (the
+  solution does not change `mix.exs`).
+- **Qualifier (Q):** Universal for `mix test`'s default file
+  discovery semantics.
+- **Rebuttal (R):** Would not hold if the new file shadowed
+  `evaluator_test.exs`'s module name; ExUnit would warn on duplicate
+  module names. The proposed file name (`MatchersTest`) does not
+  collide with `EvaluatorTest`.
+- **Backing (B):** Mix test discovery docs
+  (https://hexdocs.pm/mix/Mix.Tasks.Test.html); ExUnit module
+  naming conventions.
+
+#### Falsification attempt for claim 7
+
+- **Strategy:** counter-example construction (module-name collision).
+- **Attempt:** Verified `EvaluatorTest` module names current
+  `Tau.Permissions.EvaluatorTest`; the new file is
+  `Tau.Permissions.MatchersTest`. No collision.
+- **Outcome:** withstood.
+- **Action:** none.
+
+### Claim 8: `Tau.Permissions.Matchers.Glob.glob_match?/2` remains a public function on its current module (no extraction, no rename); the property tests call it directly.
+
+- **Claim (C):** The property suite invokes `glob_match?/2` directly
+  on `Tau.Permissions.Matchers.Glob`; no module extraction or rename
+  is proposed.
+- **Grounds (G):** `solution.md` line 53; `lib/tau/permissions/
+  matchers.ex:42` declares `@spec glob_match?(String.t(), String.t())
+  :: boolean()` and line 43 defines it as `def`. The function is
+  already public — no API change is needed to test it directly.
+- **Warrant (W):** A `def`-declared function in Elixir is callable
+  by any external module by definition
+  (https://hexdocs.pm/elixir/Kernel.html#def/2); therefore a test
+  in another module can call it without any production change.
+- **Qualifier (Q):** Universal — `def` is public.
+- **Rebuttal (R):** None. The function would have to be `defp` to
+  block this approach; it is `def`.
+- **Backing (B):** Elixir Kernel docs
+  (https://hexdocs.pm/elixir/Kernel.html#def/2).
+
+#### Falsification attempt for claim 8
+
+- **Strategy:** type-level check (visibility).
+- **Attempt:** Inspected `lib/tau/permissions/matchers.ex:43`; the
+  declaration is `def glob_match?` not `defp glob_match?`. Direct
+  external call is permitted.
+- **Outcome:** withstood.
+- **Action:** none.
+
+## Cross-claim consistency
+
+Claims are mutually consistent:
+
+- Claims 1 (property suite satisfies criterion), 2 (3-line fix), 3
+  (post-fix purity), and 8 (`glob_match?/2` is callable directly)
+  jointly describe the deliverable: tests + small production fix +
+  no API change.
+- Claim 4 (call sites already pass `:cwd`) and claim 3 (post-fix
+  purity) together guarantee no production behaviour change today.
+- Claim 5 (hybrid dominance) ratifies the selection rationale and is
+  internally consistent with the proposal scoring table.
+- Claim 6 (narrowed: no SPEC amendment because no SPEC currently
+  owns `Tau.Permissions.Matcher`) is consistent with claim 2's
+  bounded edit — both depend on the matcher behaviour being a tacit
+  contract rather than a codified SPEC §4 surface.
+- Claim 7 (existing coverage preserved) is consistent with the
+  additive nature of all other claims.
+
+No tension requires resolution.
+
+## Falsification summary
+
+| # | Claim (short) | Strategy | Outcome | Action |
+|---|---|---|---|---|
+| 1 | Property suite meets the acceptance criterion | dependency check | withstood | none |
+| 2 | `PathPrefix` fix is a 3-line change | counter-example construction | withstood | none |
+| 3 | Post-fix `PathPrefix.match?/4` is pure and fail-closed | edge-case enumeration | withstood | none |
+| 4 | All current `Evaluator.evaluate/5` callers pass `:cwd` | integration check | withstood | none |
+| 5 | Hybrid P2+P3 dominates P1, P2, P3, P4 individually | prior-art counter-case | withstood | none |
+| 6 | No SPEC amendment required | edge-case enumeration | partially falsified | narrow Qualifier in place |
+| 7 | Existing `evaluator_test.exs` coverage preserved | counter-example construction | withstood | none |
+| 8 | `glob_match?/2` is testable as-is (public function) | type-level check | withstood | none |
+
+## Revision required
+
+No solution or problem revision is required. The single partial
+falsification (claim 6) is handled by a Qualifier narrowing recorded
+in place; the operational decision (no SPEC PR; ship the moduledoc
+update) is unchanged.
+
+- **Target file:** none
+- **Revision kind:** in-place Qualifier narrowing on claim 6
+- **Rationale:** The narrowed claim ("no SPEC amendment because no
+  SPEC currently owns `Tau.Permissions.Matcher`; the PR's moduledoc
+  update documents the contract refinement") produces the same
+  observable PR scope as the original. Triggering a full solution
+  revision over a precision-of-framing issue would be
+  pre-emptive-over-narrowing in reverse — it would block on a
+  semantic-only correction.
+
+## Outstanding doubts
+
+- Whether `Tau.Permissions.Matcher` *should* have a SPEC of its own
+  is outside this node's scope but is a candidate for a future spec
+  catalog entry. Recording here so the parent node's validator can
+  surface it.
+- The solution's open question on Unicode/IDN generator widening
+  remains a real follow-up but does not block the acceptance
+  criterion. The parent validator inherits this doubt.
+- A future change that introduces a second production call site of
+  `Evaluator.evaluate/5` MUST populate `:cwd` or it will silently
+  fail closed under the post-fix `PathPrefix`. The property suite
+  documents this contract; consider whether a behaviour-level
+  assertion (e.g. `@callback match?/4` with a `@spec` comment
+  requiring `:cwd`) is warranted (also outside this node's scope).

--- a/docs/problems-archive-v1-modules/tau-permissions/subproblems/mode-lattice-properties/problem.md
+++ b/docs/problems-archive-v1-modules/tau-permissions/subproblems/mode-lattice-properties/problem.md
@@ -1,0 +1,75 @@
+---
+template_version: 1
+template_name: problem
+node_kind: leaf
+depth: 1
+parent: ../../problem.md
+status: draft
+---
+
+# Problem: Mode lattice peer-rank contract is only spot-checked, not property-swept
+
+## Statement
+
+`Tau.Permissions.Mode` has example tests and two properties in
+`test/tau/permissions/mode_test.exs`, but the peer-rank invariant — that
+`:accept_edits`, `:dont_ask`, and `:plan` all share rank 3 and therefore
+`clamp/2` treats any peer as "already restricted enough" against any other
+peer — is verified by three discrete example tests rather than a property that
+exhausts all peer × peer combinations. Additionally, `at_or_below?/2` is not
+covered by a property; it is exercised only through `clamp/2`'s implementation
+path, so a regression in `at_or_below?/2`'s guard clause (which only accepts
+known modes) would not be caught independently.
+
+## Context
+
+- `lib/tau/permissions/mode.ex`:
+  - `@ranks` map: `bypass: 0, auto: 1, default: 2, accept_edits: 3,
+    dont_ask: 3, plan: 3`.
+  - `at_or_below?/2` — guarded with `when is_map_key(@ranks, child) and
+    is_map_key(@ranks, parent)`; raises `FunctionClauseError` on unknown atoms.
+  - `clamp/2` calls `at_or_below?/2` only after `mode?(requested)` is true;
+    the guard in `at_or_below?/2` is therefore dead code for `clamp/2`'s
+    callers, but external callers (e.g. tests, future code) could pass unknown
+    atoms and receive a `FunctionClauseError`.
+- `test/tau/permissions/mode_test.exs`: two properties present — `"clamp/2
+  result never more permissive than parent"` and `"clamp/2 returns requested
+  when requested is a mode at-or-below parent"`. These are strong. The
+  peer-rank section has three spot-checks (`plan under accept_edits`,
+  `accept_edits under plan`, `dont_ask under plan`) but does not sweep all
+  nine peer × peer combinations.
+- ADR-0015: ceiling clamp for sub-agent spawn relies on these rank invariants.
+
+## Complecting hypothesis
+
+The peer-rank contract of `clamp/2` is complected with the representation
+choice (`@ranks` map assigning the same integer to three atoms) because the
+correctness of the "peer modes are interchangeable" behaviour depends on an
+unstated invariant — that all three share the same rank — which is not
+separately tested as a property. A future edit adding a rank-4 mode or
+changing a peer's rank would not surface a failing test.
+
+## Decomposition strategy
+
+(leaf — no further decomposition; proceed to proposals)
+
+## Acceptance criterion
+
+A property test exhausts all combinations of the three peer modes under
+`clamp/2` (9 pairs: requested × parent in `{:accept_edits, :dont_ask, :plan}²`)
+asserting that the result equals `requested` in all cases; and a separate
+property asserts `at_or_below?/2`'s reflexivity (`∀ m: at_or_below?(m, m)`)
+and that it raises or returns `false` on unknown atoms (clarifying the guard
+semantics for external callers).
+
+## Out of scope
+
+- The existing two `clamp/2` properties in `mode_test.exs` — these are
+  correct; the gap is additive, not corrective.
+- Matcher unit tests — covered by `matcher-unit-contracts`.
+- Evaluator mode dispatch — covered by `evaluator-mode-complecting`.
+- `Settings.Loader.merge/2` — covered by `settings-merge-feed`.
+
+## Amendment log
+
+- (none yet)

--- a/docs/problems-archive-v1-modules/tau-permissions/subproblems/mode-lattice-properties/proposals/proposal-1.md
+++ b/docs/problems-archive-v1-modules/tau-permissions/subproblems/mode-lattice-properties/proposals/proposal-1.md
@@ -1,0 +1,123 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 1
+parent_problem: ../problem.md
+---
+
+# Proposal 1: Additive property block directly in mode_test.exs
+
+## Approach
+
+Add two new `property` blocks to the existing `test/tau/permissions/mode_test.exs`
+file — one for the peer-rank exhaustion and one for `at_or_below?/2`'s reflexivity
+and guard behaviour — without touching any other file or introducing new helpers.
+The peer-rank property generates `{requested, parent}` from
+`StreamData.member_of([:accept_edits, :dont_ask, :plan])` and asserts
+`clamp(requested, parent) == requested`. The `at_or_below?/2` property generates
+from `StreamData.member_of(@modes)` and asserts reflexivity (`at_or_below?(m, m)`)
+plus a separate example block for the guard-raises path.
+
+## Rationale
+
+The acceptance criterion is purely additive — the existing two properties are
+correct and need no change. The gap is a missing 9-pair sweep of the peer tier
+and a missing independent test of `at_or_below?/2`. Adding two `property` blocks
+to the existing file is the smallest possible change: no new module, no new
+support infrastructure, no behaviour change. The peer-rank invariant
+("all three peers share rank 3, so clamp leaves requested standing") is directly
+expressible as a StreamData property over a three-element `member_of` generator.
+
+## Sketch
+
+```elixir
+# Addition to test/tau/permissions/mode_test.exs — inside the @moduletag :property section
+
+@peers [:accept_edits, :dont_ask, :plan]
+
+property "clamp/2 preserves requested for all peer × peer combinations" do
+  check all(
+    requested <- StreamData.member_of(@peers),
+    parent    <- StreamData.member_of(@peers)
+  ) do
+    assert Mode.clamp(requested, parent) == requested
+  end
+end
+
+property "at_or_below?/2 is reflexive for all known modes" do
+  check all(m <- StreamData.member_of(@modes)) do
+    assert Mode.at_or_below?(m, m)
+  end
+end
+
+# Example test (not a property) clarifying guard semantics for external callers:
+describe "at_or_below?/2 — guard semantics on unknown atoms" do
+  test "raises FunctionClauseError for unknown child" do
+    assert_raise FunctionClauseError, fn -> Mode.at_or_below?(:nope, :default) end
+  end
+
+  test "raises FunctionClauseError for unknown parent" do
+    assert_raise FunctionClauseError, fn -> Mode.at_or_below?(:plan, :nope) end
+  end
+end
+```
+
+No new files. No new modules. The `@peers` module attribute is defined at the
+top of the property section. The guard-semantics block uses example tests (not
+a property) because the space of "unknown atoms" is infinite and the interesting
+claim is just that the guard fires, not a distribution over unknowns.
+
+## Tradeoffs
+
+### Strengths
+
+- Minimal diff: two `property` blocks and one `describe` block in one file.
+- Immediately satisfies the acceptance criterion in full: 9 pairs swept (the
+  `check all` generator over a 3-element set is exhaustive under StreamData's
+  default run count, but more importantly is *structurally* exhaustive — the
+  cartesian product is the generator), reflexivity covered, guard semantics
+  documented.
+- No risk of touching production code, new modules, or supervision trees.
+- `@peers` attribute makes the intent explicit at the top of the property
+  section; a future rank-4 mode addition requires updating `@peers` explicitly,
+  making the invariant visible.
+
+### Weaknesses
+
+- `@peers` is a test-local constant, not tied to `Mode.@ranks`; if a new rank-3
+  mode is added to production code, the test will not automatically include it.
+  The author must remember to update `@peers`.
+- StreamData's `check all` over a 3-element set does not guarantee all 9 pairs
+  are generated in any single run; it exhausts them probabilistically. A
+  deterministic exhaustion would require `for req <- @peers, par <- @peers` in
+  an example test. This proposal accepts the probabilistic coverage.
+- The `FunctionClauseError` example tests hard-code two specific unknown atoms;
+  a property over `StreamData.atom(:alphanumeric)` filtered against `@modes`
+  would be stronger but is not required by the acceptance criterion.
+
+### Costs
+
+- One file changed: `test/tau/permissions/mode_test.exs`.
+- ~25 lines added.
+- No new dependency; `StreamData` is already in use.
+- Zero production-code risk.
+
+## Dependencies
+
+- None. The production module `Tau.Permissions.Mode` is unchanged.
+- `ExUnitProperties` already `use`d in the existing test module.
+
+## Confidence
+
+medium. The sketch is concrete and maps directly to the acceptance criterion.
+Confidence is not `high` because the probabilistic vs deterministic question
+(StreamData exhaustion over a 3-element set) has not been prototyped; a
+5-minute `mix test` run would raise it to `high`.
+
+## Prior art / references
+
+- Existing `property "clamp/2 returns requested when requested is a mode at-or-below parent"` in `mode_test.exs` — direct structural predecessor.
+- StreamData `member_of/1` docs: a generator over a finite list naturally
+  produces the cartesian product given sufficient runs.
+- ADR-0015 (ceiling clamp for sub-agent spawn) — the peer-rank invariant is the
+  operational foundation of the ADR.

--- a/docs/problems-archive-v1-modules/tau-permissions/subproblems/mode-lattice-properties/proposals/proposal-2.md
+++ b/docs/problems-archive-v1-modules/tau-permissions/subproblems/mode-lattice-properties/proposals/proposal-2.md
@@ -1,0 +1,121 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 2
+parent_problem: ../problem.md
+---
+
+# Proposal 2: Deterministic exhaustion via explicit cartesian-product example test
+
+## Approach
+
+Replace the three spot-check example tests in `describe "clamp/2 — peer modes"`
+with a single example test that iterates all 9 peer × peer combinations using
+a comprehension, and add a separate dedicated `describe "at_or_below?/2 —
+properties"` block with a property for reflexivity and an explicit guard
+documentation test. Unlike Proposal 1, this approach uses `for req <- @peers,
+par <- @peers` (deterministic exhaustion) rather than a StreamData property,
+and removes the three now-redundant spot-checks that it replaces. Production
+code is not touched.
+
+## Rationale
+
+The acceptance criterion says "a property test exhausts all combinations." A
+`for` comprehension over a 3-element list is provably exhaustive — it generates
+exactly 9 assertions in every test run, without probabilistic sampling. The
+existing three spot-checks are a strict subset of the 9 pairs; replacing them
+with the comprehensive loop removes the gap and the redundancy simultaneously.
+This directly decomplects "we checked some peers" from "we checked all peers":
+the exhaustion is structural, not statistical. The description also tightens
+the claim from "tests pass for some peers" to "tests pass for all peers."
+
+## Sketch
+
+```elixir
+# In test/tau/permissions/mode_test.exs
+
+@peers [:accept_edits, :dont_ask, :plan]
+
+# REPLACE the existing three-test "clamp/2 — peer modes" describe block with:
+describe "clamp/2 — peer modes (exhaustive 9-pair sweep)" do
+  # The peer-rank invariant: all three share rank 3, so clamp leaves
+  # requested standing in every peer × peer combination.
+  # ADR-0015 ceiling clamp relies on this.
+  test "all 9 peer × peer combinations: requested is returned unchanged" do
+    for req <- @peers, par <- @peers do
+      assert Mode.clamp(req, par) == req,
+             "expected clamp(#{inspect(req)}, #{inspect(par)}) == #{inspect(req)}"
+    end
+  end
+end
+
+# ADD a new dedicated describe block (does not replace any existing block):
+describe "at_or_below?/2 — properties" do
+  @moduletag :property
+
+  property "at_or_below?/2 is reflexive for all known modes" do
+    check all(m <- StreamData.member_of(@modes)) do
+      assert Mode.at_or_below?(m, m)
+    end
+  end
+
+  test "guard raises FunctionClauseError on unknown child" do
+    assert_raise FunctionClauseError, fn -> Mode.at_or_below?(:nope, :plan) end
+  end
+
+  test "guard raises FunctionClauseError on unknown parent" do
+    assert_raise FunctionClauseError, fn -> Mode.at_or_below?(:plan, :nope) end
+  end
+end
+```
+
+File-level change summary:
+- `test/tau/permissions/mode_test.exs`: remove 3 tests, add 1 test + 1 property + 2 tests.
+- Net: +1 test, +1 property, -3 tests → test count decreases by 1 but coverage increases.
+
+## Tradeoffs
+
+### Strengths
+
+- Deterministically exhaustive: every run exercises all 9 combinations; no
+  statistical sampling risk.
+- Self-documenting error message with `inspect` interpolation pinpoints exactly
+  which `(req, par)` pair failed.
+- Removes the three spot-checks that gave false comfort, clarifying that the
+  test is now complete rather than representative.
+- Aligns acceptance criterion language ("exhausts all combinations") with
+  implementation language (a loop that literally iterates the cartesian product).
+
+### Weaknesses
+
+- Deletes existing tests, which may be seen as behaviour-correcting rather than
+  purely additive. This requires reviewer attention to confirm the new loop is
+  strictly a superset of the removed spot-checks.
+- A `for` comprehension test is sometimes seen as "testing the test" rather than
+  naming each case; if a case fails, the error message is harder to read in
+  tree-view test reporters that don't show per-iteration context.
+- The reflexivity property still uses StreamData; a reviewer expecting purely
+  deterministic tests may question why StreamData is used for a 6-element space.
+
+### Costs
+
+- One file changed: `test/tau/permissions/mode_test.exs`.
+- ~20 lines added, 10 lines removed (the three individual spot-check tests).
+- Minor review cost: a reviewer must confirm the 3 removed tests are subsumed.
+
+## Dependencies
+
+- None. Production module unchanged.
+- `ExUnitProperties` already `use`d.
+
+## Confidence
+
+high. The cartesian product over a 3-element list is a standard Elixir idiom;
+the `for` comprehension approach is demonstrated in the existing `describe "clamp/2
+— equal modes"` block (`for m <- @modes`). No new dependency or tooling needed.
+
+## Prior art / references
+
+- Existing `test "every mode clamped against itself returns itself"` uses `for m <- @modes` — direct structural predecessor for the exhaustion pattern.
+- Elixir `for` comprehension with multiple `<-` generators produces the cartesian product by definition.
+- ADR-0015: peer-rank invariant underpins the ceiling clamp contract.

--- a/docs/problems-archive-v1-modules/tau-permissions/subproblems/mode-lattice-properties/proposals/proposal-3.md
+++ b/docs/problems-archive-v1-modules/tau-permissions/subproblems/mode-lattice-properties/proposals/proposal-3.md
@@ -1,0 +1,148 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 3
+parent_problem: ../problem.md
+---
+
+# Proposal 3: Expose peer-rank set from Mode module and derive tests from it
+
+## Approach
+
+Add a public `Mode.peer_modes/0` function (or a `@peer_modes` module attribute
+exposed via a zero-arity function) to `lib/tau/permissions/mode.ex` that returns
+the set of modes sharing the highest rank. Tests in `mode_test.exs` then derive
+the peer set from the production module itself: the peer-rank property generates
+from `StreamData.member_of(Mode.peer_modes())`, and the `at_or_below?/2` property
+generates from `StreamData.member_of(Mode.modes())` (a new companion function
+returning all known modes). This decomplects the test's knowledge of which modes
+are peers from the test itself: the test no longer hard-codes `[:accept_edits,
+:dont_ask, :plan]` but instead queries the module.
+
+## Rationale
+
+The existing acceptance criterion is a test-coverage gap, but its deeper
+root is that the peer-rank invariant is unstated in the production code: the
+fact that three atoms share rank 3 is embedded in `@ranks` and documented
+in a moduledoc comment, but there is no machine-readable boundary a caller
+or test can query. Exposing `peer_modes/0` moves the definition of "which modes
+are peers" into the module that owns the lattice. Tests automatically track
+lattice changes: if a new rank-3 mode is added to `@ranks`, `peer_modes/0`
+returns it and the property includes it without a manual test update. This
+is the data-shape axis: the fix is in the interface, not just in the tests.
+
+## Sketch
+
+```elixir
+# Addition to lib/tau/permissions/mode.ex
+
+@doc """
+Returns the set of modes sharing the maximum (most-restrictive) rank.
+These modes are unordered relative to each other; `clamp/2` treats any
+peer as at-or-below any other peer.
+
+Used by property tests and by callers that need to enumerate the peer
+tier without hard-coding atoms.
+"""
+@spec peer_modes() :: [mode()]
+def peer_modes do
+  max_rank = @ranks |> Map.values() |> Enum.max()
+  @ranks |> Enum.filter(fn {_m, r} -> r == max_rank end) |> Enum.map(&elem(&1, 0))
+end
+
+@doc """
+Returns all recognised mode atoms. Equivalent to `Map.keys(@ranks)`.
+"""
+@spec modes() :: [mode()]
+def modes, do: Map.keys(@ranks)
+```
+
+```elixir
+# Additions to test/tau/permissions/mode_test.exs
+
+@moduletag :property
+
+property "clamp/2 preserves requested for all peer × peer combinations" do
+  peers = Mode.peer_modes()
+  check all(
+    requested <- StreamData.member_of(peers),
+    parent    <- StreamData.member_of(peers)
+  ) do
+    assert Mode.clamp(requested, parent) == requested
+  end
+end
+
+property "at_or_below?/2 is reflexive for all known modes" do
+  check all(m <- StreamData.member_of(Mode.modes())) do
+    assert Mode.at_or_below?(m, m)
+  end
+end
+
+describe "at_or_below?/2 — guard on unknown atoms" do
+  test "raises for unknown child" do
+    assert_raise FunctionClauseError, fn -> Mode.at_or_below?(:unknown, :plan) end
+  end
+
+  test "raises for unknown parent" do
+    assert_raise FunctionClauseError, fn -> Mode.at_or_below?(:plan, :unknown) end
+  end
+end
+```
+
+File changes:
+- `lib/tau/permissions/mode.ex`: add `peer_modes/0` and `modes/0` (pure, no side effects).
+- `test/tau/permissions/mode_test.exs`: add two properties and one describe block.
+  The existing `@modes` test-local attribute can be replaced by `Mode.modes()`.
+
+## Tradeoffs
+
+### Strengths
+
+- Self-maintaining: adding a new rank-3 mode to `@ranks` automatically includes
+  it in the peer-sweep property without touching the test.
+- Decomplects the "which modes are peers" knowledge from the test into the
+  module, which is where it belongs under the lattice's stated ownership contract.
+- `modes/0` unifies the test-local `@modes` attribute with the production
+  module — one source of truth.
+- Tests use the module's own definition of its lattice, making them robust to
+  lattice extension (the stated regression scenario in the problem).
+
+### Weaknesses
+
+- Touches production code (`mode.ex`) to fix a test-coverage gap. This may
+  be seen as scope creep — the gap is a test gap, and a production API change
+  to serve tests is a code-smell in some disciplines.
+- `peer_modes/0` returns a list (order undefined by Elixir's `Map.keys`); tests
+  that depend on it must not assume order, which is fine for StreamData but
+  could surprise future example-test authors.
+- Two new public functions add API surface to a module that otherwise has a
+  compact public interface (`mode?`, `clamp`, `at_or_below?`, `rank`).
+- The acceptance criterion names no requirement for a production API change;
+  this proposal goes beyond the stated criterion.
+
+### Costs
+
+- Two files changed: `lib/tau/permissions/mode.ex` (+10 lines), `test/tau/permissions/mode_test.exs` (+~20 lines, optional removal of `@modes`).
+- New public functions require `@spec` and `@doc` (included in sketch).
+- Dialyzer will typecheck the new specs; no added risk.
+
+## Dependencies
+
+- None beyond the existing `Tau.Permissions.Mode` module.
+- `StreamData` already in use.
+
+## Confidence
+
+medium. The production-code change is straightforward, but "touch production
+to fix a test gap" is a non-obvious trade. Confidence would rise to `high`
+with a reviewer sign-off that `peer_modes/0` and `modes/0` are desirable API
+additions independent of the test motivation.
+
+## Prior art / references
+
+- Haskell `QuickCheck` idiom: derive generators from the data type's own
+  constructors/reflection rather than hard-coding them in tests.
+- Elixir `Ecto.Type` pattern: expose `cast/1` + `type/0` so tests can
+  enumerate the type's values without hard-coding.
+- ADR-0015: the peer tier is semantically distinct; exposing it as
+  `peer_modes/0` makes ADR-0015's "peer" concept machine-readable.

--- a/docs/problems-archive-v1-modules/tau-permissions/subproblems/mode-lattice-properties/proposals/proposal-4.md
+++ b/docs/problems-archive-v1-modules/tau-permissions/subproblems/mode-lattice-properties/proposals/proposal-4.md
@@ -1,0 +1,171 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 4
+parent_problem: ../problem.md
+---
+
+# Proposal 4: Split at_or_below?/2 into guarded and total variants, then test both
+
+## Approach
+
+Refactor `at_or_below?/2` in `lib/tau/permissions/mode.ex` into two functions:
+`at_or_below?/2` (kept as the guarded function, unchanged contract, raises on
+unknown atoms) and a new `at_or_below_safe?/2` (total function, returns
+`{:ok, boolean()} | {:error, :unknown_mode}`). Tests cover both:
+`at_or_below?/2` gets a reflexivity property over known modes and explicit
+raise-assertions for unknown atoms; `at_or_below_safe?/2` gets a property
+that it never returns `:error` for known modes and always returns `:error`
+for unknown atoms. `clamp/2` continues to call `at_or_below?/2` (no callers
+change). The peer-sweep property for `clamp/2` is added as in Proposal 1.
+
+## Rationale
+
+The problem statement identifies two distinct issues: (a) peer-rank not
+property-swept, and (b) `at_or_below?/2`'s guard clause is "dead code for
+`clamp/2`'s callers, but external callers could pass unknown atoms and receive
+a FunctionClauseError." The acceptance criterion asks for a property that
+"raises or returns false on unknown atoms — clarifying the guard semantics."
+The phrase "clarifying" implies the current semantics are ambiguous. Proposal 4
+resolves the ambiguity by making the two behaviours explicit: the guarded
+function raises (contract: caller must ensure valid modes), the safe function
+returns a tagged tuple (contract: caller handles unknown atoms). This is a
+behaviour-correcting refactor on `at_or_below?/2`'s external API — not on
+`clamp/2`, which calls the guarded variant after `mode?/1` validation.
+
+## Sketch
+
+```elixir
+# lib/tau/permissions/mode.ex — add alongside existing at_or_below?/2
+
+@doc """
+Total variant of `at_or_below?/2`. Returns `{:ok, boolean()}` for known
+modes, `{:error, :unknown_mode}` when either argument is not a recognised
+mode atom. Never raises.
+
+Prefer this when callers cannot guarantee their inputs are valid modes
+(e.g. values from user config, network payloads). Use `at_or_below?/2`
+directly only when calling code has already validated both arguments
+(as `clamp/2` does via `mode?/1`).
+"""
+@spec at_or_below_safe?(term(), term()) :: {:ok, boolean()} | {:error, :unknown_mode}
+def at_or_below_safe?(child, parent) do
+  if mode?(child) and mode?(parent) do
+    {:ok, at_or_below?(child, parent)}
+  else
+    {:error, :unknown_mode}
+  end
+end
+```
+
+```elixir
+# test/tau/permissions/mode_test.exs — additions
+
+@peers [:accept_edits, :dont_ask, :plan]
+
+# Peer-rank sweep (same as Proposal 1, included for completeness):
+property "clamp/2 preserves requested for all peer × peer combinations" do
+  check all(
+    requested <- StreamData.member_of(@peers),
+    parent    <- StreamData.member_of(@peers)
+  ) do
+    assert Mode.clamp(requested, parent) == requested
+  end
+end
+
+# Guarded at_or_below?/2 properties:
+property "at_or_below?/2 is reflexive for all known modes" do
+  check all(m <- StreamData.member_of(@modes)) do
+    assert Mode.at_or_below?(m, m)
+  end
+end
+
+describe "at_or_below?/2 — guard raises for unknown atoms" do
+  test "unknown child raises" do
+    assert_raise FunctionClauseError, fn -> Mode.at_or_below?(:nope, :plan) end
+  end
+  test "unknown parent raises" do
+    assert_raise FunctionClauseError, fn -> Mode.at_or_below?(:plan, :nope) end
+  end
+end
+
+# Safe total variant properties:
+property "at_or_below_safe?/2 returns {:ok, _} for all known-mode pairs" do
+  check all(
+    child  <- StreamData.member_of(@modes),
+    parent <- StreamData.member_of(@modes)
+  ) do
+    assert {:ok, _} = Mode.at_or_below_safe?(child, parent)
+  end
+end
+
+property "at_or_below_safe?/2 returns {:error, :unknown_mode} for any unknown atom" do
+  check all(
+    child  <- StreamData.one_of([StreamData.constant(:nope), StreamData.member_of(@modes)]),
+    parent <- StreamData.one_of([StreamData.constant(:nope), StreamData.member_of(@modes)]),
+    child == :nope or parent == :nope
+  ) do
+    assert Mode.at_or_below_safe?(child, parent) == {:error, :unknown_mode}
+  end
+end
+```
+
+File changes:
+- `lib/tau/permissions/mode.ex`: add `at_or_below_safe?/2` (+12 lines).
+- `test/tau/permissions/mode_test.exs`: add 4 properties + 1 describe block (+~40 lines).
+
+## Tradeoffs
+
+### Strengths
+
+- Directly resolves the stated ambiguity in the guard semantics: the two
+  behaviours (raise vs return-false) are now separate functions with distinct
+  type signatures.
+- Test coverage is broader: the safe variant is fully property-swept over both
+  valid and invalid inputs; the guarded variant's raises are documented and
+  tested.
+- Future callers that need fault-tolerant mode comparison have a clear API path
+  (`at_or_below_safe?/2`) without needing to wrap `at_or_below?/2` in `try/rescue`.
+- Adheres to the OTP non-negotiable "do not swallow errors, use tagged tuples."
+
+### Weaknesses
+
+- Adds production API surface beyond what the acceptance criterion requires; the
+  criterion says "clarify guard semantics," not "add a total variant."
+- `at_or_below_safe?/2` is unlikely to have callers in the current codebase;
+  it may be dead code added speculatively.
+- The proposal is the largest diff of the four: it touches both production and
+  test files, adds two new properties for the safe variant, and the filter-based
+  StreamData generator for the "any unknown" property is non-trivial to write
+  correctly (the `check all` filter approach shown above may need tuning for
+  shrinkability).
+- Overloads the single-problem scope slightly: the acceptance criterion is about
+  test coverage, not API design.
+
+### Costs
+
+- Two files changed: `lib/tau/permissions/mode.ex` (+~12 lines),
+  `test/tau/permissions/mode_test.exs` (+~40 lines).
+- New `@spec` and `@doc` required on the safe variant.
+- Dialyzer coverage extended to the new function.
+- Review cost is higher than Proposals 1 or 2 due to the production code change.
+
+## Dependencies
+
+- None. Production module change is purely additive; no callers change.
+- `StreamData` already in use.
+
+## Confidence
+
+low. The proposal is sound, but the production API addition goes beyond the
+acceptance criterion, and the StreamData filter-based generator for
+"at least one unknown atom" requires careful construction to avoid `assume/1`
+exhaustion. Confidence would rise to `medium` with a working prototype of the
+safe-variant property, and to `high` with a reviewer endorsement that
+`at_or_below_safe?/2` is wanted.
+
+## Prior art / references
+
+- Elixir convention: `foo!/1` raises, `foo/1` returns `{:ok, _} | {:error, _}` — this proposal inverts the naming (keeping `?` suffix), but follows the tagged-tuple pattern.
+- `StreamData.filter/2` vs `StreamData.unshrinkable/1` tradeoff documented in StreamData docs — relevant to the "any unknown" property's generator design.
+- ADR-0015: the guard clause in `at_or_below?/2` is documented as "dead code for `clamp/2`'s callers" — this proposal gives it a documented external caller contract instead.

--- a/docs/problems-archive-v1-modules/tau-permissions/subproblems/mode-lattice-properties/solution.md
+++ b/docs/problems-archive-v1-modules/tau-permissions/subproblems/mode-lattice-properties/solution.md
@@ -1,0 +1,97 @@
+---
+template_version: 1
+template_name: solution
+parent_problem: ../../problem.md
+node_kind: leaf
+synthesised_from: [proposals/proposal-2.md]
+selection_method: single
+revision: 0
+---
+
+# Solution: Deterministic 9-pair sweep via `for` comprehension + dedicated `at_or_below?/2` property block
+
+## Recommendation
+
+Replace the three spot-check tests in `describe "clamp/2 — peer modes"` with
+a single example test that iterates all 9 peer × peer combinations via a `for`
+comprehension, and add a dedicated `describe "at_or_below?/2 — properties"`
+block containing a StreamData reflexivity property over all known modes and two
+explicit `FunctionClauseError` guard tests. Both changes land in
+`test/tau/permissions/mode_test.exs` only; no production code is touched.
+
+## Selected from
+
+- **Chosen:** `proposals/proposal-2.md`
+- **Why chosen:** The acceptance criterion requires a test that "exhausts all
+  combinations" of the nine peer × peer pairs. Proposal 2 satisfies this
+  literally and provably: `for req <- @peers, par <- @peers` generates exactly
+  9 assertions per run by definition of cartesian-product comprehension. Proposal
+  1 also satisfies the criterion but relies on StreamData's probabilistic
+  sampling over a 3-element set — statistically sound but structurally weaker
+  than a deterministic loop, and confidence is explicitly rated medium for that
+  reason. Proposals 3 and 4 both touch production code beyond what the criterion
+  requires (new public API functions on `Mode`), introducing review cost and API
+  surface that is out of scope. Proposal 2 dominates on fit and determinism with
+  the same low risk and easy reversibility as Proposal 1, and the same-file
+  migration cost is the lowest of any proposal that touches production.
+
+## What changes
+
+- `test/tau/permissions/mode_test.exs`:
+  - **Remove** the three individual spot-check tests inside `describe "clamp/2 —
+    peer modes"` (`plan under accept_edits`, `accept_edits under plan`,
+    `dont_ask under plan`).
+  - **Add** module attribute `@peers [:accept_edits, :dont_ask, :plan]` at the
+    top of the property section.
+  - **Add** `describe "clamp/2 — peer modes (exhaustive 9-pair sweep)"` containing
+    one `test` with `for req <- @peers, par <- @peers` asserting
+    `Mode.clamp(req, par) == req` with an interpolated error message.
+  - **Add** `describe "at_or_below?/2 — properties"` containing:
+    - `property "at_or_below?/2 is reflexive for all known modes"` using
+      `StreamData.member_of(@modes)`.
+    - `test "guard raises FunctionClauseError on unknown child"`.
+    - `test "guard raises FunctionClauseError on unknown parent"`.
+
+## What does not change
+
+- `lib/tau/permissions/mode.ex` — no production code change.
+- The two existing `clamp/2` properties (`"clamp/2 result never more permissive
+  than parent"` and `"clamp/2 returns requested when requested is a mode
+  at-or-below parent"`) — these are correct and are not touched.
+- All other test modules and support files.
+- ADR-0015 — no contract change; this PR only adds test coverage for an
+  already-specified invariant.
+
+## Migration sketch
+
+One PR: open `test/tau/permissions/mode_test.exs`, delete the three
+spot-check tests from the peer-modes describe block, add `@peers`, add the
+comprehension test, add the `at_or_below?/2` describe block. Run
+`mix test test/tau/permissions/mode_test.exs` to confirm net count and that
+all new assertions pass. No compile step, no supervisor changes, no migration
+ordering concern.
+
+## Open questions
+
+- Whether the existing `@modes` test-local attribute should be replaced by
+  `Mode.modes()` (as Proposal 3 suggests) is a separate decision; this solution
+  does not depend on it either way.
+- The comprehension test fires all 9 assertions inside a single `test` block;
+  if a pair fails, the error message must carry enough context to identify the
+  failing pair. The sketch in Proposal 2 includes `inspect` interpolation — this
+  must be confirmed in the actual edit.
+- StreamData's reflexivity property over `@modes` (6 elements) samples
+  probabilistically; it covers the full space in practice but is not provably
+  exhaustive per run. This is acceptable because reflexivity is a weaker claim
+  than peer-rank exhaustion and the set is small.
+
+## Linked sub-problems / proposals
+
+- `proposals/proposal-1.md` — Additive property block directly in mode_test.exs; probabilistic StreamData sweep over peers; test-local `@peers` hardcoded. Not chosen: probabilistic rather than deterministic exhaustion; confidence medium.
+- `proposals/proposal-2.md` — Deterministic exhaustion via `for` comprehension; replaces three spot-checks; adds `at_or_below?/2` property block. **Chosen.**
+- `proposals/proposal-3.md` — Adds `peer_modes/0` and `modes/0` to production mode.ex; tests derive peer set from module. Not chosen: touches production code beyond the acceptance criterion; API surface addition out of scope.
+- `proposals/proposal-4.md` — Splits `at_or_below?/2` into guarded + safe total variant; adds four new properties. Not chosen: production API addition out of scope; low proposer confidence; filter-based StreamData generator risk.
+
+## Revision history
+
+- (revision 0 — initial)

--- a/docs/problems-archive-v1-modules/tau-permissions/subproblems/mode-lattice-properties/validation.md
+++ b/docs/problems-archive-v1-modules/tau-permissions/subproblems/mode-lattice-properties/validation.md
@@ -1,0 +1,439 @@
+---
+template_version: 1
+template_name: validation
+parent_solution: solution.md
+parent_problem: problem.md
+toulmin_complete: true
+falsification_attempted: true
+falsification_outcome: partially_falsified — claim/5
+revision_triggered: none
+---
+
+# Validation: Deterministic 9-pair sweep + dedicated `at_or_below?/2` property block
+
+## Overview
+
+The solution makes seven distinct checkable propositions: (1) the three peer
+spot-checks in the existing `describe "clamp/2 — peer modes"` block will be
+removed; (2) a module attribute `@peers` will be added; (3) a single new test
+will deterministically exhaust the 9-pair peer × peer cartesian product via a
+`for` comprehension; (4) a new `describe "at_or_below?/2 — properties"` block
+will contain a StreamData reflexivity property; (5) that block will contain two
+explicit `FunctionClauseError` guard tests pinning `at_or_below?/2`'s unknown-
+atom semantics; (6) `lib/tau/permissions/mode.ex` is not touched; (7) the two
+existing `clamp/2` properties are preserved. Each claim is examined with a
+named falsification strategy: counter-example construction, dependency check,
+edge-case enumeration, and an integration check against the acceptance
+criterion. Six claims withstand; claim 5 is partially falsified — the guard
+tests pin `at_or_below?/2`'s `FunctionClauseError` semantics, but the
+acceptance criterion's "raises or returns `false` on unknown atoms" disjunction
+is decided in favour of "raises", which is a narrowing of the criterion rather
+than a falsification of it. The narrowing is faithful to the current
+implementation (`mode.ex:94` guard) and is recorded in the Qualifier without
+triggering a revision.
+
+## Toulmin per claim
+
+The MITRE empirical study on Toulmin formalism found that "participants
+found it difficult to generate Toulmin structures, and their structures
+varied greatly even though they started with the same content"
+(https://www.mitre.org/news-insights/publication/empirical-evaluation-structured-argumentation-using-toulmin-argument).
+This template enforces all six components explicitly with prompts to
+counter that variance.
+
+### Claim 1: The three individual spot-check tests in `describe "clamp/2 — peer modes"` will be removed
+
+- **Claim (C):** The solution will "Remove the three individual spot-check
+  tests inside `describe \"clamp/2 — peer modes\"` (`plan under accept_edits`,
+  `accept_edits under plan`, `dont_ask under plan`)."
+- **Grounds (G):** The named tests exist verbatim at
+  `test/tau/permissions/mode_test.exs:129-139` inside the describe block
+  declared at `mode_test.exs:123`. Solution §"What changes" first bullet
+  states "Remove" against the same three identifiers. Proposal 2's sketch
+  (`proposals/proposal-2.md:39-50`) shows the replacement that supersedes
+  them.
+- **Warrant (W):** A solution that explicitly enumerates the removed tests
+  by name and located them in the same file Grounds cites is internally
+  consistent with the intent to delete those exact assertions. An edit
+  matching the solution's verbatim instructions necessarily satisfies the
+  claim.
+- **Qualifier (Q):** Holds for the next implementation edit on this file
+  as long as the test names and describe-block heading remain at their
+  cited lines. If a different PR renames or restructures those tests
+  before this solution is implemented, the editor must re-locate by name
+  rather than by line.
+- **Rebuttal (R):** The claim would not hold if an implementer chose to
+  "additively" keep the three spot-checks alongside the new comprehension
+  loop on grounds of "more coverage is better". The solution's chosen
+  rationale (decomplecting "some peers" from "all peers" and removing
+  redundancy — `proposals/proposal-2.md:25-30`) explicitly rejects that
+  framing.
+- **Backing (B):** `proposals/proposal-2.md` ("Strengths" §:
+  "Removes the three spot-checks that gave false comfort, clarifying that
+  the test is now complete rather than representative") plus the Hickey
+  principle that redundancy in a test suite hides intent.
+
+#### Falsification attempt for claim 1
+
+- **Strategy:** counter-example construction.
+- **Attempt:** Searched for any constraint that would force keeping the
+  three spot-checks: (a) ADR-0015 — no requirement to retain example
+  tests; (b) `mode_test.exs` — no shared fixtures keyed on the three test
+  names; (c) project test-naming policy — none requires per-pair tests;
+  (d) the comprehension test is a strict superset of the three spot-checks
+  (all three pairs `(plan, accept_edits)`, `(accept_edits, plan)`,
+  `(dont_ask, plan)` are in the 9-pair cartesian product). No counter-
+  example was constructed.
+- **Outcome:** withstood.
+- **Action:** None.
+
+### Claim 2: A module attribute `@peers [:accept_edits, :dont_ask, :plan]` will be added
+
+- **Claim (C):** The solution will "Add module attribute `@peers
+  [:accept_edits, :dont_ask, :plan]` at the top of the property section."
+- **Grounds (G):** Solution §"What changes" second bullet (`solution.md:44`).
+  Proposal 2's sketch (`proposals/proposal-2.md:37`) shows the attribute
+  declaration. The existing `@modes` attribute at `mode_test.exs:24`
+  establishes the file's convention for module-attribute test fixtures.
+- **Warrant (W):** Module attributes in Elixir test files are evaluated
+  at compile time and are referenced by `@peers` inside `test` and
+  `property` blocks. The existing `@modes` precedent (`mode_test.exs:24`,
+  used at `mode_test.exs:69` inside a `for` comprehension) demonstrates
+  the pattern works for cartesian-product tests in this file.
+- **Qualifier (Q):** Holds when the attribute is declared at module
+  scope before any `describe` block that references it. The solution's
+  phrase "at the top of the property section" is slightly imprecise —
+  `@peers` must be declared at module scope (not inside `describe`), but
+  may appear adjacent to the `@moduletag :property` line at
+  `mode_test.exs:169`.
+- **Rebuttal (R):** The claim would not hold if `@peers` were declared
+  inside a `describe` block (an Elixir compile error), or if a stray
+  `defp peers, do: ...` were used instead. The solution names "module
+  attribute" specifically.
+- **Backing (B):** Elixir docs on module attributes
+  (https://hexdocs.pm/elixir/Module.html#module-module-attributes) and
+  the established `@modes` pattern at `mode_test.exs:24`.
+
+#### Falsification attempt for claim 2
+
+- **Strategy:** dependency check.
+- **Attempt:** Verified `ExUnit.Case` and `ExUnitProperties` are already
+  `use`d at `mode_test.exs:19-20`, so no new dependency is required.
+  Verified the existing `@modes` attribute is referenced from inside both
+  `test` blocks (`mode_test.exs:28, 69`) and `property` blocks
+  (`mode_test.exs:198, 199`) without a `use` change, demonstrating the
+  exact pattern `@peers` will follow. No dependency gap.
+- **Outcome:** withstood.
+- **Action:** None.
+
+### Claim 3: A new test will deterministically exhaust the 9-pair peer × peer cartesian product via `for` comprehension
+
+- **Claim (C):** The solution will "Add `describe \"clamp/2 — peer modes
+  (exhaustive 9-pair sweep)\"` containing one `test` with `for req <-
+  @peers, par <- @peers` asserting `Mode.clamp(req, par) == req` with an
+  interpolated error message."
+- **Grounds (G):** Solution §"What changes" fourth bullet
+  (`solution.md:46-48`). Proposal 2 sketch
+  (`proposals/proposal-2.md:40-50`) shows the exact comprehension shape.
+  The acceptance criterion in `problem.md:58-62` requires "all
+  combinations of the three peer modes under `clamp/2` (9 pairs:
+  requested × parent in `{:accept_edits, :dont_ask, :plan}²`)" with
+  result equal to `requested`.
+- **Warrant (W):** An Elixir `for req <- L1, par <- L2` comprehension with
+  two generators iterates the cartesian product `L1 × L2` exhaustively;
+  this is the documented semantics of multi-generator comprehensions. For
+  `L1 = L2 = @peers` (3 elements), the comprehension produces exactly
+  9 iterations per run. Determinism follows from `@peers` being a fixed
+  list; exhaustion follows from cartesian-product semantics.
+- **Qualifier (Q):** Holds when (a) `@peers` is the exact 3-element list
+  `[:accept_edits, :dont_ask, :plan]` (claim 2); (b) the `Mode.clamp(req,
+  par) == req` invariant is true for all 9 pairs in the production
+  implementation. Property (b) follows from `mode.ex:31-38` where all
+  three peers share rank 3, and `mode.ex:80-81` returns `requested` when
+  `at_or_below?(requested, parent)` (which is true on rank equality at
+  `mode.ex:94-96`).
+- **Rebuttal (R):** Would not hold if (i) `@ranks` is changed so that
+  the three peers no longer share rank 3 — but that is exactly the
+  regression the test is designed to catch, so the test correctly fails
+  in that case (which is the intended behaviour, not a falsification of
+  this claim); (ii) the implementer writes `for req <- @peers, par <-
+  @peers, do: ...` without `assert`, which compiles but tests nothing —
+  prevented by the solution's verbatim "asserting `Mode.clamp(req, par)
+  == req`" language.
+- **Backing (B):** Elixir docs on comprehensions
+  (https://hexdocs.pm/elixir/Kernel.SpecialForms.html#for/1 — "When
+  multiple generators are given, the values are processed in nested
+  loops"); the structural predecessor in this file at `mode_test.exs:69`
+  uses the same multi-generator pattern; ADR-0015 ceiling-clamp contract.
+
+#### Falsification attempt for claim 3
+
+- **Strategy:** integration check + counter-example construction over
+  all 9 pairs.
+- **Attempt:** Enumerated all 9 pairs and verified `Mode.clamp/2`'s
+  behaviour against `mode.ex:70-86`. For every `(req, par)` ∈ `{:accept_edits,
+  :dont_ask, :plan}²`: `mode?(req)` is true (`mode.ex:44`), `parent` is
+  already a known mode so `normalise_parent` returns it (`mode.ex:105`).
+  If `req == par`, the second `cond` clause (`mode.ex:77`) returns
+  `parent` which equals `req`. If `req != par`, both have rank 3, so
+  `at_or_below?(req, par)` returns `true` (`mode.ex:95`), and the third
+  `cond` clause returns `requested`. In every case the result equals
+  `requested`. No counter-example exists in the current implementation.
+- **Outcome:** withstood.
+- **Action:** None. The 9-pair sweep is a deterministic, sound check of
+  the peer-rank invariant the solution targets.
+
+### Claim 4: A reflexivity property over all known modes will be added
+
+- **Claim (C):** The solution will add `property "at_or_below?/2 is
+  reflexive for all known modes"` using `StreamData.member_of(@modes)`.
+- **Grounds (G):** Solution §"What changes" fifth bullet first sub-bullet
+  (`solution.md:50-51`). Proposal 2 sketch
+  (`proposals/proposal-2.md:56-60`) shows
+  `check all(m <- StreamData.member_of(@modes)) do assert
+  Mode.at_or_below?(m, m) end`. The acceptance criterion
+  (`problem.md:62-63`) requires "a separate property asserts
+  `at_or_below?/2`'s reflexivity (`∀ m: at_or_below?(m, m)`)".
+- **Warrant (W):** Reflexivity of `at_or_below?/2` is provable from
+  `mode.ex:94-96`: `Map.fetch!(@ranks, m) >= Map.fetch!(@ranks, m)` is
+  trivially true for any `m` that is a key of `@ranks`.
+  `StreamData.member_of(@modes)` samples uniformly from the 6-element
+  set, so reflexivity is checked over the entire mode-atom space across
+  enough runs.
+- **Qualifier (Q):** Holds for all `m ∈ @modes`. The property covers the
+  6-element space probabilistically, but because the implementation is
+  deterministic and the space is small, every run with the default
+  StreamData `max_runs: 100` will exercise every element with
+  overwhelming probability (P(some element missed) ≤ 6·(5/6)^100 ≈
+  3.4×10^-7). Open question #3 in `solution.md:84-86` acknowledges this
+  is acceptable because reflexivity is a weaker claim than the peer-rank
+  exhaustion that claim 3 covers deterministically.
+- **Rebuttal (R):** Would not hold if `@modes` were declared *before*
+  the property in a way that excluded a mode (e.g., if a future edit
+  removed `:plan` from `@modes` but kept it in `@ranks`). The solution
+  does not modify `@modes`, so the rebuttal is mitigated.
+- **Backing (B):** StreamData docs
+  (https://hexdocs.pm/stream_data/StreamData.html#member_of/1); reflexive
+  relations as defined in lattice theory; `at_or_below?/2`'s
+  implementation at `mode.ex:94-96`.
+
+#### Falsification attempt for claim 4
+
+- **Strategy:** edge-case enumeration over all 6 known modes.
+- **Attempt:** For each `m ∈ @modes`, `Map.fetch!(@ranks, m) >=
+  Map.fetch!(@ranks, m)` evaluates to `0 >= 0` (`:bypass`), `1 >= 1`
+  (`:auto`), `2 >= 2` (`:default`), `3 >= 3` (each of `:accept_edits`,
+  `:dont_ask`, `:plan`). All six are true. The guard
+  `is_map_key(@ranks, child) and is_map_key(@ranks, parent)` admits
+  each pair `(m, m)` since `m ∈ @modes` implies `m` is a `@ranks` key
+  (the two structures share keys by inspection of `mode.ex:31-38` and
+  `mode_test.exs:24`). No edge case falsifies the claim.
+- **Outcome:** withstood.
+- **Action:** None.
+
+### Claim 5: Two explicit `FunctionClauseError` guard tests will pin `at_or_below?/2`'s unknown-atom semantics
+
+- **Claim (C):** The solution will add `test "guard raises
+  FunctionClauseError on unknown child"` and `test "guard raises
+  FunctionClauseError on unknown parent"`.
+- **Grounds (G):** Solution §"What changes" fifth bullet sub-bullets two
+  and three (`solution.md:52-53`). Proposal 2 sketch
+  (`proposals/proposal-2.md:62-68`) shows
+  `assert_raise FunctionClauseError, fn -> Mode.at_or_below?(:nope,
+  :plan) end` and the parent-symmetric variant. The implementation at
+  `mode.ex:94` has `when is_map_key(@ranks, child) and is_map_key(@ranks,
+  parent)`, which causes a `FunctionClauseError` for any non-key atom.
+- **Warrant (W):** Elixir's `when` clause produces a
+  `FunctionClauseError` when no head matches — this is the documented
+  failure mode of unmatched guards. Pinning this behaviour in a test
+  documents the public contract for external callers (whom the solution
+  identifies as the population at risk — `problem.md:21-22`).
+- **Qualifier (Q):** *Narrowed by validation.* The acceptance criterion
+  (`problem.md:64-65`) reads "raises **or** returns `false` on unknown
+  atoms (clarifying the guard semantics for external callers)" — an
+  inclusive disjunction. The solution's two guard tests pin **only** the
+  "raises" disjunct. This is a faithful pin of the current
+  implementation (`mode.ex:94`), not a wider contract. If a future
+  change replaced the guard with a `case` returning `false` on unknown
+  atoms, both pin-tests would fail and force re-evaluation. This is the
+  intended outcome (the criterion says "clarifying the guard semantics"
+  — pinning *one* semantics is the clarification), so the narrowing is
+  not a defect, but the validator records the narrowing here.
+- **Rebuttal (R):** The narrowing would be a defect if the problem
+  statement required the test suite to remain agnostic to which side of
+  the disjunction holds — but the criterion's parenthetical
+  ("clarifying the guard semantics") indicates the intent is to pin
+  *one* specific behaviour. The narrowing is therefore faithful.
+- **Backing (B):** Elixir docs on function guards
+  (https://hexdocs.pm/elixir/patterns-and-guards.html — "If no clause
+  matches, a `FunctionClauseError` is raised"); the guard at
+  `mode.ex:94`; the problem statement's framing of unknown atoms as a
+  contract clarification (`problem.md:32-34`).
+
+#### Falsification attempt for claim 5
+
+- **Strategy:** edge-case enumeration over the disjunction in the
+  acceptance criterion.
+- **Attempt:** Enumerated the two disjuncts: (i) "raises" — pinned by
+  the two guard tests, faithful to `mode.ex:94`; (ii) "returns `false`"
+  — not pinned. Asked: does the criterion's parenthetical "clarifying
+  the guard semantics for external callers" require both disjuncts to
+  be pinned, or only the one that matches the implementation? The
+  parenthetical's intent is a *clarification* of the existing semantics,
+  not a contract that admits both. The solution's two guard tests
+  therefore satisfy the criterion's intent while narrowing the literal
+  disjunction. Outcome: the literal disjunction is partially falsified
+  (the "returns `false`" disjunct is not pinned), but the criterion's
+  intent (pin one semantics) is satisfied. Narrowing is faithful.
+- **Outcome:** partially_falsified.
+- **Action:** Narrow Qualifier in place (see Q above). No `revision_triggered`.
+
+### Claim 6: `lib/tau/permissions/mode.ex` is not touched
+
+- **Claim (C):** "`lib/tau/permissions/mode.ex` — no production code
+  change."
+- **Grounds (G):** Solution §"What does not change" first bullet
+  (`solution.md:57`). Proposal 2's "File-level change summary"
+  (`proposals/proposal-2.md:72-74`) lists only the test file as changed.
+  The selection rationale (`solution.md:24-36`) explicitly cites
+  "Proposals 3 and 4 both touch production code beyond what the
+  criterion requires (new public API functions on `Mode`), introducing
+  review cost and API surface that is out of scope" as the reason for
+  choosing proposal 2 over them.
+- **Warrant (W):** The acceptance criterion (`problem.md:58-65`) is
+  satisfied entirely by additions and reorganisation in the test file;
+  no production change is required. Restricting the diff to the test
+  file minimises blast radius and aligns with the project's "tests
+  first; production unchanged" approach for additive coverage.
+- **Qualifier (Q):** Holds for this PR's diff. A future PR may add
+  `peer_modes/0` or `modes/0` to `Mode` (open question #1 —
+  `solution.md:78-80`), but that is explicitly out of scope here.
+- **Rebuttal (R):** Would not hold if a reviewer or implementer adds
+  `peer_modes/0` to `Mode` while implementing this solution. The
+  solution's "Open questions" §1 (`solution.md:78-80`) explicitly
+  defers that decision.
+- **Backing (B):** Selection rationale in `solution.md:24-36` rejecting
+  proposals 3 and 4; project OTP non-negotiable #8 ("pure functions are
+  the default; processes are the exception") — applies analogously here
+  as "tests are the default for additive coverage; production change is
+  the exception".
+
+#### Falsification attempt for claim 6
+
+- **Strategy:** dependency check.
+- **Attempt:** Checked whether any new test in the solution requires a
+  production-side change. (a) The 9-pair `for` test uses only `clamp/2`
+  (already public). (b) The reflexivity property uses only
+  `at_or_below?/2` (already public). (c) The two guard tests use only
+  `at_or_below?/2`. (d) `@peers` is a test-local list of literal atoms;
+  it does not require a `Mode` function. No production change is
+  necessitated by the solution.
+- **Outcome:** withstood.
+- **Action:** None.
+
+### Claim 7: The two existing `clamp/2` properties are preserved
+
+- **Claim (C):** "The two existing `clamp/2` properties (`\"clamp/2
+  result never more permissive than parent\"` and `\"clamp/2 returns
+  requested when requested is a mode at-or-below parent\"`) — these are
+  correct and are not touched."
+- **Grounds (G):** Solution §"What does not change" second bullet
+  (`solution.md:58-60`). The two named properties exist at
+  `mode_test.exs:180-194` and `mode_test.exs:196-209`. The problem
+  statement explicitly puts them out of scope (`problem.md:67-69`).
+- **Warrant (W):** A solution that adds new describe blocks and
+  modifies one specific describe block by name (claim 1) does not
+  affect properties in other regions of the file. The two existing
+  properties are inside their own `property` blocks under no described-
+  by-name block — they are at module scope after the `@moduletag
+  :property` declaration (`mode_test.exs:169`).
+- **Qualifier (Q):** Holds as long as the implementer does not
+  re-organise the file beyond the solution's literal instructions.
+- **Rebuttal (R):** Would not hold if an implementer chose to
+  consolidate all properties into a new shared describe block, moving
+  the two existing properties in the process. The solution does not
+  authorise that move.
+- **Backing (B):** Problem statement's "Out of scope" §
+  (`problem.md:67-69`); the literal text of the solution's "What does
+  not change" §.
+
+#### Falsification attempt for claim 7
+
+- **Strategy:** counter-example construction.
+- **Attempt:** Considered whether adding `describe "at_or_below?/2 —
+  properties"` could collide with the two existing properties. The
+  existing properties are at module scope (no `describe`); the new
+  describe block adds a named scope that does not contain or displace
+  them. No naming collision exists (`clamp/2` vs `at_or_below?/2`
+  describes). No counter-example constructed.
+- **Outcome:** withstood.
+- **Action:** None.
+
+## Cross-claim consistency
+
+Claims 1-7 form a consistent set:
+
+- Claim 1 (remove three spot-checks) and claim 3 (add 9-pair sweep) are
+  complementary — the sweep is a strict superset of the spot-checks, so
+  removing the spot-checks does not reduce coverage.
+- Claim 2 (`@peers` attribute) supports claim 3 (the comprehension
+  iterates `@peers`) — order of edits matters but is implicit in any
+  reasonable implementation.
+- Claim 6 (no production change) constrains the scope and is consistent
+  with claims 1-5, which all describe test-file edits.
+- Claim 7 (preserve existing properties) does not conflict with claim 4
+  (add a new property in a new describe block) — they live in different
+  regions of the same file.
+
+No internal tension. The narrowed Qualifier on claim 5 is a local
+narrowing of the criterion's disjunction and does not affect any other
+claim.
+
+## Falsification summary
+
+| # | Claim (short) | Strategy | Outcome | Action |
+|---|---|---|---|---|
+| 1 | Remove three peer spot-checks | counter-example construction | withstood | none |
+| 2 | Add `@peers` module attribute | dependency check | withstood | none |
+| 3 | Add 9-pair `for` comprehension sweep | integration + counter-example | withstood | none |
+| 4 | Add reflexivity property over `@modes` | edge-case enumeration | withstood | none |
+| 5 | Add two `FunctionClauseError` guard tests | edge-case enumeration | partially_falsified | narrow Qualifier in place (criterion's "raises or returns false" disjunction pinned only to "raises", faithful to current `mode.ex:94` guard) |
+| 6 | No `lib/tau/permissions/mode.ex` change | dependency check | withstood | none |
+| 7 | Two existing `clamp/2` properties preserved | counter-example construction | withstood | none |
+
+## Revision required
+
+No revision required. Claim 5 is partially falsified by literal reading
+of the acceptance criterion's disjunction, but the narrowing is
+faithful to the implementation and to the criterion's stated intent
+("clarifying the guard semantics for external callers" — pinning one
+specific semantics IS the clarification). The narrowed Qualifier in
+claim 5 records the narrowing for parent-level inheritance.
+
+- **Target file:** none
+- **Revision kind:** n/a
+- **Rationale:** All withstood except claim 5, which is partially
+  falsified at the Qualifier level only. Per the validator protocol §5,
+  partial falsifications are handled by narrowing the qualifier in
+  place, not by triggering revision.
+
+## Outstanding doubts
+
+- The comprehension test fires all 9 assertions inside a single `test`
+  block. If pair `n` fails, ExUnit will report the first failure and
+  stop iterating; pairs `n+1`..`9` go un-evaluated within that run. The
+  `inspect`-interpolated error message identifies the failing pair, but
+  a regression that breaks multiple pairs requires multiple runs to
+  surface them all. Acceptable: the solution's stated goal (catch a
+  regression in the peer-rank invariant) is satisfied by surfacing the
+  first failure.
+- Open question #1 (`solution.md:78-80`) defers the `peer_modes/0` /
+  `modes/0` decision. If a future PR adds those functions, the test
+  file should be migrated to reference them rather than the test-local
+  `@peers` and `@modes` attributes. This validation does not require
+  that migration but notes it for the parent validator.
+- Reflexivity over a 6-element space sampled probabilistically
+  (claim 4, default `max_runs: 100`) has P(missed element) ≈ 3.4×10^-7.
+  Acceptable in practice; a future hardening pass could replace with a
+  deterministic `for m <- @modes` loop. Not a falsification of the
+  current solution.

--- a/docs/problems-archive-v1-modules/tau-permissions/subproblems/settings-merge-feed/problem.md
+++ b/docs/problems-archive-v1-modules/tau-permissions/subproblems/settings-merge-feed/problem.md
@@ -1,0 +1,74 @@
+---
+template_version: 1
+template_name: problem
+node_kind: leaf
+depth: 1
+parent: ../../problem.md
+status: draft
+---
+
+# Problem: Settings.Loader.merge/2 has no property tests for permissions-array invariants
+
+## Statement
+
+`Tau.Settings.Loader.merge/2` is the upstream feed for `Tau.Permissions.RuleSet`:
+it deep-merges layered settings maps and concatenates `allow`, `deny`, and `ask`
+arrays from each layer. The concatenation order determines which rules the
+evaluator sees first, and because `Evaluator.evaluate/5` uses first-match-wins
+semantics for deny and allow, merge order is a correctness-bearing contract.
+`test/tau/settings/loader_test.exs` has only example tests (no properties), so
+the invariants — array concatenation preserves order within each layer, repeated
+merge is idempotent for map keys, and a permissions block absent from one layer
+is treated as an empty list not nil — are not mechanically enforced.
+
+## Context
+
+- `lib/tau/settings/loader.ex`: `merge/2` (exact implementation not read;
+  test evidence shows it deep-merges nested maps and concatenates list-valued
+  keys like `hooks`, `extensions`, and permissions arrays).
+- `test/tau/settings/loader_test.exs` line 27–31: example test showing deny
+  rules from two layers concatenate correctly. No `StreamData` import; no
+  `property` blocks.
+- `lib/tau/permissions/rule_set.ex` line 45–48: `compile_from_settings/1`
+  calls `Tau.Settings.Cache.get()` then `Tau.Permissions.Parser.compile/1`.
+  The permissions block is fetched from the merged settings; if merge silently
+  drops or reorders entries, `Parser.compile/1` and `Evaluator.evaluate/5`
+  receive a corrupted rule-set with no observable signal at the permissions
+  layer.
+- `CLAUDE.md` OTP NN #6: "Invariant-bearing modules MUST have properties before
+  examples." `Settings.Loader.merge/2` is named in the audit brief as one of the
+  two missing property targets.
+
+## Complecting hypothesis
+
+`Settings.Loader.merge/2`'s permissions-array concatenation is complected with
+`Evaluator`'s first-match-wins semantics because the evaluator's correctness
+depends on the merge contract (layer B's deny entries appear after layer A's),
+yet this contract is only expressed as two discrete example tests — not as a
+property that survives arbitrary inputs, making the coupling invisible at the
+test boundary.
+
+## Decomposition strategy
+
+(leaf — no further decomposition; proceed to proposals)
+
+## Acceptance criterion
+
+`test/tau/settings/loader_test.exs` (or a new `property_test.exs` sibling)
+contains at least two StreamData properties: one asserting that
+`merge(a, b)[:permissions][:deny]` is a prefix-then-suffix concatenation of
+`a[:permissions][:deny]` and `b[:permissions][:deny]` for arbitrary
+list-valued permission arrays; and one asserting that merging any settings map
+with an empty map is an identity (`merge(x, %{}) == x` for all map shapes that
+include a permissions block).
+
+## Out of scope
+
+- Matcher unit tests — covered by `matcher-unit-contracts`.
+- Mode-lattice properties — covered by `mode-lattice-properties`.
+- Evaluator mode-dispatch complecting — covered by `evaluator-mode-complecting`.
+- Settings schema validation, vault, watcher — separate subsystem.
+
+## Amendment log
+
+- (none yet)

--- a/docs/problems-archive-v1-modules/tau-permissions/subproblems/settings-merge-feed/proposals/proposal-1.md
+++ b/docs/problems-archive-v1-modules/tau-permissions/subproblems/settings-merge-feed/proposals/proposal-1.md
@@ -1,0 +1,141 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 1
+parent_problem: ../problem.md
+---
+
+# Proposal 1: Add StreamData properties in-place to loader_test.exs
+
+## Approach
+
+Extend the existing `test/tau/settings/loader_test.exs` file with two new
+`property` blocks inside the existing `describe "merge/2"` group. No new
+files, no new modules. Add `use ExUnitProperties` and `import StreamData` at
+the top of the module, then write the two properties the acceptance criterion
+names: (1) the prefix-then-suffix concatenation invariant for all three
+permissions arrays (`allow`, `deny`, `ask`), and (2) the identity invariant
+for merging any settings map with an empty map.
+
+## Rationale
+
+The problem is a test-coverage gap, not a structural deficiency in the
+production code. The simplest path to closing the gap is to add the
+properties alongside the existing examples, keeping all tests for `merge/2`
+co-located. This directly satisfies the acceptance criterion with the
+minimum diff surface: two `property` blocks added to one file. It also
+makes the pairing between example tests and property tests visible at a
+glance — a reader sees both probes of the same function in one place.
+The existing example on line 27–31 (deny concatenation) acts as a sanity
+anchor for the new property.
+
+## Sketch
+
+```elixir
+# test/tau/settings/loader_test.exs  — additions only
+
+defmodule Tau.Settings.LoaderTest do
+  use ExUnit.Case, async: true
+  use ExUnitProperties          # ← add
+
+  alias Tau.Settings.Loader
+
+  # --- existing describe block unchanged ---
+
+  describe "merge/2 properties" do
+    property "permissions arrays (allow/deny/ask) are prefix-then-suffix concatenation" do
+      check all(
+              a_list <- list_of(string(:alphanumeric, min_length: 1)),
+              b_list <- list_of(string(:alphanumeric, min_length: 1)),
+              key    <- member_of([:allow, :deny, :ask])
+            ) do
+        a = %{permissions: %{key => a_list}}
+        b = %{permissions: %{key => b_list}}
+        merged = Loader.merge(a, b)
+        assert merged[:permissions][key] == a_list ++ b_list
+      end
+    end
+
+    property "merging any settings map with empty map is identity" do
+      check all(
+              # Generate a map that may or may not contain a permissions block
+              base <- map_of(
+                        atom(:alphanumeric),
+                        one_of([
+                          string(:alphanumeric),
+                          integer(),
+                          list_of(string(:alphanumeric))
+                        ])
+                      )
+            ) do
+        assert Loader.merge(base, %{}) == base
+      end
+    end
+  end
+end
+```
+
+Both properties depend only on `StreamData`, which is already a test
+dependency in `mix.exs`. No generator helpers are needed; inline generators
+are sufficient.
+
+## Tradeoffs
+
+### Strengths
+
+- Smallest possible diff: one file, two `property` blocks, one added `use`.
+- Co-location — all `merge/2` coverage (examples + properties) lives in one
+  test module, easy to find and reason about together.
+- Zero new modules; zero new files; the change is atomic and reviewable in
+  one scroll.
+- Directly satisfies both acceptance-criterion properties with minimal risk
+  of reviewer scope-creep concern.
+
+### Weaknesses
+
+- The property generator for the `merge(x, %{})` identity test uses
+  `map_of(atom(:alphanumeric), ...)` which generates atom keys, not the
+  mixed atom/string key shapes that real settings maps may use. A subtle
+  generator mismatch could leave the identity property satisfied trivially
+  for generated inputs but failing for real-world inputs with string keys.
+- Inline generators make the test harder to reuse if other test modules in
+  this problem set (e.g. `matcher_test.exs`) need similar settings shapes.
+  Each module would re-invent generators from scratch.
+- The `concat` property tests only the three named keys (`allow`/`deny`/`ask`)
+  individually. It does not cover the multi-key case where all three are
+  present simultaneously in both layers — a gap an adversary could exploit
+  to introduce a cross-key ordering bug.
+- No assertion that `merge/2`'s concat semantics for `:hooks` and
+  `:extensions` (sibling list-keys) are preserved; the acceptance criterion
+  doesn't require this, but in-file placement invites scope inflation later.
+
+### Costs
+
+- ~25 lines of new test code.
+- No migration cost; no callsite changes; no new dependencies.
+- CI impact: property tests run `check all` with 100 (default) iterations
+  each; negligible wall-time addition (< 1 s in typical StreamData runs).
+
+## Dependencies
+
+- `{:stream_data, "~> 1.1", only: [:test, :dev]}` already present in
+  `mix.exs` — no dependency change.
+- No production code changes required.
+
+## Confidence
+
+medium — The approach is structurally straightforward and prior art
+(existing property tests in `mode_test.exs`) demonstrates StreamData is used
+in this project. Confidence is not `high` because the identity property's
+generator shape needs verification that `Loader.merge/2` handles atom-keyed
+generated maps correctly (the function takes `map()`, which includes both
+atom and string keys, but real settings are always atom-keyed from
+`Jason.decode(..., keys: :atoms)` — the generator matches reality).
+
+## Prior art / references
+
+- `test/tau/permissions/mode_test.exs` — existing StreamData property usage
+  in this project; the `check all` + `member_of` pattern mirrors what is
+  proposed here.
+- `ExUnitProperties` docs: https://hexdocs.pm/stream_data/ExUnitProperties.html
+- OTP NN #6: "Invariant-bearing modules MUST have properties before examples."

--- a/docs/problems-archive-v1-modules/tau-permissions/subproblems/settings-merge-feed/proposals/proposal-2.md
+++ b/docs/problems-archive-v1-modules/tau-permissions/subproblems/settings-merge-feed/proposals/proposal-2.md
@@ -1,0 +1,166 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 2
+parent_problem: ../problem.md
+---
+
+# Proposal 2: Separate property test file loader_property_test.exs
+
+## Approach
+
+Create a new file `test/tau/settings/loader_property_test.exs` containing
+only `ExUnitProperties`-tagged tests for `Loader.merge/2`. Leave the existing
+`loader_test.exs` untouched. The new file owns three properties: the
+prefix-then-suffix concatenation invariant, the identity invariant, and a
+third property asserting that absent permissions keys in one layer are treated
+as empty lists (not nil) — the third invariant named in the problem statement
+that the acceptance criterion encodes implicitly.
+
+## Rationale
+
+Separating property tests from example tests follows the established pattern
+in `test/tau/permissions/` where modules with rich property coverage tend to
+have dedicated property files. The separation makes the OTP NN #6 check
+mechanical: `grep -r "use ExUnitProperties" test/tau/settings/` yields
+`loader_property_test.exs` and unambiguously confirms coverage. It also
+protects the example test file from accretion: `loader_test.exs` remains
+a readable, compact exemplar of expected behaviors; the property file
+contains the full combinatorial coverage. A reviewer can look at either file
+with a clear mental model of what it does.
+
+## Sketch
+
+```
+test/tau/settings/
+  loader_test.exs           # unchanged
+  loader_property_test.exs  # new
+```
+
+```elixir
+# test/tau/settings/loader_property_test.exs  — full new file
+
+defmodule Tau.Settings.LoaderPropertyTest do
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  alias Tau.Settings.Loader
+
+  @perm_keys [:allow, :deny, :ask]
+
+  # ── generators ──────────────────────────────────────────────────────────
+
+  defp permission_list, do: list_of(string(:alphanumeric, min_length: 1))
+
+  defp permissions_layer do
+    fixed_map(%{
+      allow: permission_list(),
+      deny:  permission_list(),
+      ask:   permission_list()
+    })
+  end
+
+  defp settings_with_permissions do
+    fixed_map(%{permissions: permissions_layer()})
+  end
+
+  # ── properties ──────────────────────────────────────────────────────────
+
+  property "merge/2: permissions arrays are prefix-then-suffix concat for each key" do
+    check all(
+              a <- settings_with_permissions(),
+              b <- settings_with_permissions()
+            ) do
+      merged = Loader.merge(a, b)
+
+      for key <- @perm_keys do
+        assert merged[:permissions][key] ==
+                 a[:permissions][key] ++ b[:permissions][key],
+               "key #{key}: expected a-prefix then b-suffix"
+      end
+    end
+  end
+
+  property "merge/2: merge(x, %{}) == x for any settings map with permissions" do
+    check all(x <- settings_with_permissions()) do
+      assert Loader.merge(x, %{}) == x
+    end
+  end
+
+  property "merge/2: absent permissions key in layer b treated as empty list, not nil" do
+    check all(
+              a_list <- permission_list(),
+              key    <- member_of(@perm_keys)
+            ) do
+      a = %{permissions: %{key => a_list}}
+      # layer b omits this key entirely
+      b = %{permissions: %{}}
+      merged = Loader.merge(a, b)
+      # must equal a's list, not nil
+      assert merged[:permissions][key] == a_list
+      refute is_nil(merged[:permissions][key])
+    end
+  end
+end
+```
+
+The `fixed_map/1` generator produces maps with all keys always present,
+removing key-presence variation from the concat property and isolating the
+nil-vs-empty-list invariant to its own property.
+
+## Tradeoffs
+
+### Strengths
+
+- OTP NN #6 compliance is unambiguous: the module name `LoaderPropertyTest`
+  and the file suffix `_property_test.exs` signal pure property coverage.
+- Three properties vs two: the nil-vs-empty-list invariant (the third invariant
+  from the problem statement) is explicitly covered, not left to inference.
+- `loader_test.exs` is not touched, so no risk of breaking existing passing
+  tests during the PR.
+- `fixed_map/1`-based generators are more readable than inline `map_of`
+  generators and more representative of real settings shapes.
+- File is naturally mixable with `mix test --only property` if a `:property`
+  tag is added.
+
+### Weaknesses
+
+- A new file means two places to look for `merge/2` coverage; a new
+  contributor might not know to check `loader_property_test.exs`.
+- The `settings_with_permissions/0` generator produces maps with all three
+  permission keys always present; it doesn't cover sparse maps where only
+  some keys exist. This is partially compensated by the nil-vs-empty-list
+  property but doesn't cover the three-key-subset combinations.
+- Introduces a naming convention (`_property_test.exs`) that may or may not
+  be followed elsewhere in the project — a convention inconsistency if other
+  modules don't follow it.
+- `fixed_map/1` is a `StreamData` function that some contributors may be
+  less familiar with than the more common `map_of/2`.
+
+### Costs
+
+- One new file (~60 lines).
+- No production code changes; no dependency changes.
+- CI: adds ~3 `check all` runs at 100 iterations each; estimated < 2 s.
+
+## Dependencies
+
+- `{:stream_data, "~> 1.1"}` already present.
+- No production code changes required.
+- Existing `loader_test.exs` left untouched.
+
+## Confidence
+
+high — `fixed_map/1`, `list_of/1`, `member_of/1` are standard StreamData
+primitives well-established in this codebase. The three properties map
+directly to the problem statement's three named invariants. The generator
+shapes match real settings maps (atom-keyed, nested permissions map).
+
+## Prior art / references
+
+- `test/tau/permissions/mode_test.exs` — existing property test file in the
+  permissions subsystem; pattern precedent for a dedicated property file.
+- `StreamData.fixed_map/1` docs:
+  https://hexdocs.pm/stream_data/StreamData.html#fixed_map/1
+- Problem statement §Context: "No `StreamData` import; no `property` blocks"
+  — the nil-vs-empty-list invariant is named but untested.

--- a/docs/problems-archive-v1-modules/tau-permissions/subproblems/settings-merge-feed/proposals/proposal-3.md
+++ b/docs/problems-archive-v1-modules/tau-permissions/subproblems/settings-merge-feed/proposals/proposal-3.md
@@ -1,0 +1,200 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 3
+parent_problem: ../problem.md
+---
+
+# Proposal 3: Shared SettingsGen generator module + property test file
+
+## Approach
+
+Introduce `test/support/settings_gen.ex` — a reusable StreamData generator
+library for the settings subsystem — and a new
+`test/tau/settings/loader_property_test.exs` that imports it. The generator
+module provides `SettingsGen.settings_map/0`, `SettingsGen.permissions_layer/0`,
+and `SettingsGen.permission_list/0`, exposing them for reuse by any other
+test module in the `tau-permissions` problem set (matchers, evaluator) that
+needs realistic settings shapes. The two acceptance-criterion properties
+(concat and identity) plus the nil-vs-empty-list invariant are expressed
+in the property test file using the shared generators.
+
+## Rationale
+
+The four sub-problems in `tau-permissions` all need settings-shaped inputs.
+Without a shared generator, each property test file re-invents generators
+independently — a secondary complecting where generator logic is scattered
+across test modules, duplicated, and allowed to drift. Extracting generators
+into `test/support/settings_gen.ex` makes the test data contract first-class:
+the generator module is the single source of truth for "what does a valid
+settings map look like in tests." This is the data-shape axis of decomplecting:
+instead of coupling test assertions to inline generator logic, the generators
+become a typed, composable interface. Future property test files for matchers
+and the evaluator import the same generators, reducing drift across the whole
+`tau-permissions` property-test sweep.
+
+## Sketch
+
+```
+test/support/
+  settings_gen.ex       # new — shared generator module
+test/tau/settings/
+  loader_test.exs       # unchanged
+  loader_property_test.exs  # new — imports SettingsGen
+```
+
+```elixir
+# test/support/settings_gen.ex
+
+defmodule SettingsGen do
+  @moduledoc """
+  StreamData generators for settings maps and permissions blocks.
+  Reused across Tau.Settings and Tau.Permissions property tests.
+  """
+  import StreamData
+
+  @perm_keys [:allow, :deny, :ask]
+
+  @doc "A list of permission rule strings (non-empty alphanumeric atoms)."
+  def permission_list do
+    list_of(string(:alphanumeric, min_length: 1))
+  end
+
+  @doc "A permissions sub-map with :allow, :deny, :ask list keys (all present)."
+  def permissions_layer do
+    fixed_map(%{
+      allow: permission_list(),
+      deny:  permission_list(),
+      ask:   permission_list()
+    })
+  end
+
+  @doc "A sparse permissions layer — keys may be absent (tests nil-vs-empty)."
+  def sparse_permissions_layer do
+    map_of(member_of(@perm_keys), permission_list())
+  end
+
+  @doc "A settings map that always includes a permissions block."
+  def settings_map do
+    fixed_map(%{permissions: permissions_layer()})
+  end
+
+  @doc "A settings map where the permissions block may be sparse."
+  def sparse_settings_map do
+    fixed_map(%{permissions: sparse_permissions_layer()})
+  end
+end
+```
+
+```elixir
+# test/tau/settings/loader_property_test.exs
+
+defmodule Tau.Settings.LoaderPropertyTest do
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  alias Tau.Settings.Loader
+
+  property "merge/2: permissions arrays are prefix-then-suffix concat" do
+    check all(
+              a <- SettingsGen.settings_map(),
+              b <- SettingsGen.settings_map()
+            ) do
+      merged = Loader.merge(a, b)
+
+      for key <- [:allow, :deny, :ask] do
+        assert merged[:permissions][key] ==
+                 a[:permissions][key] ++ b[:permissions][key]
+      end
+    end
+  end
+
+  property "merge/2: identity under merge with empty map" do
+    check all(x <- SettingsGen.settings_map()) do
+      assert Loader.merge(x, %{}) == x
+    end
+  end
+
+  property "merge/2: absent permissions key treated as empty list, not nil" do
+    check all(
+              a <- SettingsGen.settings_map(),
+              b <- SettingsGen.sparse_settings_map(),
+              key <- member_of([:allow, :deny, :ask])
+            ) do
+      merged = Loader.merge(a, b)
+      # even if b doesn't have the key, a's list must survive
+      assert is_list(merged[:permissions][key])
+    end
+  end
+end
+```
+
+`test/support/` is on the `elixirc_paths` for `:test` in `mix.exs`
+(standard in ExUnit projects), so `SettingsGen` is available to all test
+modules without explicit import.
+
+## Tradeoffs
+
+### Strengths
+
+- Generator logic is written once and reused across the full `tau-permissions`
+  property sweep (matchers, evaluator) — eliminates generator drift across
+  test files.
+- `sparse_permissions_layer/0` covers the nil-vs-empty-list invariant with a
+  generator that actually generates sparse maps, not just hand-crafted inputs.
+- The generator API (`SettingsGen.settings_map/0`) documents the authoritative
+  shape of a settings map as understood by tests — a living spec.
+- Satisfies all three named invariants from the problem statement, not just
+  the two mandated by the acceptance criterion.
+
+### Weaknesses
+
+- Introduces a new `test/support/` module, which has its own maintenance
+  surface. If `Loader.merge/2`'s understanding of valid settings shapes evolves,
+  `SettingsGen` must be updated in sync — a hidden coupling between production
+  code and the generator module.
+- The generator module is useful only if the other sub-problems (`matcher-unit-
+  contracts`, `evaluator-mode-complecting`) actually import it. If those
+  sub-problems are solved independently, the generator module becomes orphaned
+  support infrastructure with a single user.
+- `test/support/settings_gen.ex` is not a test file — it contains no assertions.
+  Contributors may not know to look there for generator definitions; discoverability
+  depends on documentation or convention.
+- Slightly more scope than strictly required by the acceptance criterion
+  (introduces a module when inline generators would suffice for two properties).
+
+### Costs
+
+- Two new files (~50 + ~45 lines); no production file changes.
+- `test/support/settings_gen.ex` must be listed in `elixirc_paths` for `:test`
+  — this is typically already true in ExUnit projects but should be verified
+  in `mix.exs`.
+- CI impact: same as Proposal 2 (~3 property runs), plus marginal compile
+  overhead for the support module.
+
+## Dependencies
+
+- `{:stream_data, "~> 1.1"}` already present.
+- `test/support/` must be on `elixirc_paths` for `:test` in `mix.exs` (verify,
+  do not assume).
+- The value of this proposal increases if `matcher-unit-contracts` and/or
+  `evaluator-mode-complecting` sub-problems are worked next and import
+  `SettingsGen` — standalone, it is over-engineered for the problem at hand.
+
+## Confidence
+
+medium — The structural approach is sound and mirrors patterns in Elixir
+projects (e.g. ExMachina for Ecto, `DataCase` support modules). Confidence
+is not `high` because the incremental value over Proposal 2 depends on
+whether other sub-problems will reuse `SettingsGen` — a decision not yet
+made. If they won't, this proposal's main differentiator (reuse) collapses
+to overhead.
+
+## Prior art / references
+
+- ExMachina pattern: shared test factory module under `test/support/` for
+  reusable data generation — https://github.com/thoughtbot/ex_machina
+- `test/support/tui_pty_helper.ex` in this project — precedent for shared
+  test support modules that are imported across multiple test files.
+- `StreamData.fixed_map/1` + `StreamData.map_of/2` combined approach:
+  https://hexdocs.pm/stream_data/StreamData.html

--- a/docs/problems-archive-v1-modules/tau-permissions/subproblems/settings-merge-feed/proposals/proposal-4.md
+++ b/docs/problems-archive-v1-modules/tau-permissions/subproblems/settings-merge-feed/proposals/proposal-4.md
@@ -1,0 +1,231 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 4
+parent_problem: ../problem.md
+---
+
+# Proposal 4: Explicit MergeContract module encoding invariants as callable guards
+
+## Approach
+
+Extract the three merge invariants into a new production module
+`Tau.Settings.MergeContract` that exposes one function per invariant
+(`assert_concat_order/3`, `assert_identity/1`, `assert_absent_as_empty/3`).
+Each function takes merged-settings inputs and returns `:ok | {:error, reason}`.
+Add a single property test file `test/tau/settings/loader_property_test.exs`
+that drives `Loader.merge/2` and then calls `MergeContract` assertion functions
+to check correctness — decoupling the "what did merge return" from "does the
+return satisfy the contract." The `MergeContract` module ships in `lib/` (not
+`test/`) so it is usable in runtime diagnostics or integration smoke tests.
+
+## Rationale
+
+The problem identifies an invisible coupling: `Evaluator`'s first-match-wins
+semantics depend on `Loader.merge/2`'s concat order, but this contract lives
+only in comments and example tests. Making the contract a first-class module
+(`MergeContract`) means the coupling becomes discoverable by anyone reading
+`lib/tau/settings/`. A runtime consumer (e.g. a debug endpoint, a CI smoke)
+can call `MergeContract.assert_concat_order/3` directly against a live merged
+settings map without setting up a full property-test harness. The property
+tests then verify that `Loader.merge/2` satisfies `MergeContract` for arbitrary
+inputs — rather than encoding the invariant logic inside the test itself, which
+is where the current example tests fail (the invariant is expressed in the
+assertion, not named and composed). This is an interface-change axis: the
+contract becomes an explicit boundary, not an implicit assumption.
+
+## Sketch
+
+```
+lib/tau/settings/
+  loader.ex                 # unchanged
+  merge_contract.ex         # new — contract module in lib/
+test/tau/settings/
+  loader_test.exs           # unchanged
+  loader_property_test.exs  # new — uses MergeContract
+```
+
+```elixir
+# lib/tau/settings/merge_contract.ex
+
+defmodule Tau.Settings.MergeContract do
+  @moduledoc """
+  Named invariants for `Tau.Settings.Loader.merge/2`.
+
+  Each function returns `:ok` or `{:error, {key, expected, actual}}`.
+  Usable in property tests, runtime diagnostics, and smoke tests.
+
+  Invariants:
+    C1 — permissions arrays are prefix-then-suffix concatenations.
+    C2 — merge(x, %{}) == x  (right-identity).
+    C3 — absent permissions key in a layer is treated as [], not nil.
+  """
+
+  @perm_keys [:allow, :deny, :ask]
+
+  @doc """
+  C1: assert that each permissions key in `merged` equals
+  `a_perms[key] ++ b_perms[key]` for all three permission keys.
+  """
+  @spec assert_concat_order(map(), map(), map()) ::
+          :ok | {:error, {atom(), list(), list()}}
+  def assert_concat_order(a, b, merged) do
+    Enum.reduce_while(@perm_keys, :ok, fn key, :ok ->
+      expected = (get_in(a, [:permissions, key]) || []) ++
+                 (get_in(b, [:permissions, key]) || [])
+      actual   = get_in(merged, [:permissions, key]) || []
+
+      if actual == expected do
+        {:cont, :ok}
+      else
+        {:halt, {:error, {key, expected, actual}}}
+      end
+    end)
+  end
+
+  @doc """
+  C2: assert merge(x, %{}) == x.
+  """
+  @spec assert_identity(map()) :: :ok | {:error, {map(), map()}}
+  def assert_identity(x) do
+    merged = Tau.Settings.Loader.merge(x, %{})
+    if merged == x, do: :ok, else: {:error, {x, merged}}
+  end
+
+  @doc """
+  C3: assert absent key in b is treated as [], not nil.
+  Returns :ok when merged[:permissions][key] is a list.
+  """
+  @spec assert_absent_as_empty(map(), map(), atom()) ::
+          :ok | {:error, {:nil_result, atom()}}
+  def assert_absent_as_empty(a, b, key) do
+    merged = Tau.Settings.Loader.merge(a, b)
+
+    case get_in(merged, [:permissions, key]) do
+      nil  -> {:error, {:nil_result, key}}
+      list when is_list(list) -> :ok
+    end
+  end
+end
+```
+
+```elixir
+# test/tau/settings/loader_property_test.exs
+
+defmodule Tau.Settings.LoaderPropertyTest do
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  alias Tau.Settings.{Loader, MergeContract}
+
+  defp perm_list, do: list_of(string(:alphanumeric, min_length: 1))
+
+  defp perms_map do
+    fixed_map(%{allow: perm_list(), deny: perm_list(), ask: perm_list()})
+  end
+
+  defp settings_with_perms do
+    fixed_map(%{permissions: perms_map()})
+  end
+
+  property "C1: concat order invariant holds for arbitrary permissions layers" do
+    check all(a <- settings_with_perms(), b <- settings_with_perms()) do
+      merged = Loader.merge(a, b)
+      assert MergeContract.assert_concat_order(a, b, merged) == :ok
+    end
+  end
+
+  property "C2: right-identity invariant holds for arbitrary settings maps" do
+    check all(x <- settings_with_perms()) do
+      assert MergeContract.assert_identity(x) == :ok
+    end
+  end
+
+  property "C3: absent permissions key treated as empty list, not nil" do
+    check all(
+              a    <- settings_with_perms(),
+              key  <- member_of([:allow, :deny, :ask])
+            ) do
+      b = %{permissions: Map.delete(%{allow: [], deny: [], ask: []}, key)}
+      assert MergeContract.assert_absent_as_empty(a, b, key) == :ok
+    end
+  end
+end
+```
+
+The `MergeContract` module ships under `lib/` so it is compiled into the
+release and reachable from `iex -S mix`, runtime diagnostics, and integration
+tests without requiring `ExUnit` to be running.
+
+## Tradeoffs
+
+### Strengths
+
+- The merge contract becomes a named, versioned, first-class module — the
+  coupling between `Evaluator`'s first-match semantics and `Loader.merge/2`'s
+  concat order is now visible in `lib/`, not only in test assertions.
+- `MergeContract` functions return tagged tuples, making them usable in runtime
+  diagnostics (e.g. `mix tau.settings.check`), not just in property tests.
+- Invariant identifiers (C1, C2, C3) create stable references in PRs,
+  error messages, and documentation — easier to cite in ADRs and spec amendments.
+- The property tests are shorter and more readable because the assertion logic
+  lives in `MergeContract`, not inline in `check all` blocks.
+
+### Weaknesses
+
+- Adding a production module (`MergeContract`) to close a test-coverage gap
+  is overkill for this problem's stated scope. The problem is a missing
+  property test; the fix is a property test. A new `lib/` module is a
+  structural change whose cost exceeds the problem's severity.
+- `MergeContract.assert_identity/1` calls `Loader.merge/2` internally, which
+  means the contract module is tightly coupled to the module it validates —
+  an inside-out dependency that inverts the usual test-subject relationship.
+  This makes `MergeContract` unsuitable as an independent oracle.
+- The `:error` return tuple shapes differ across the three invariant functions,
+  making programmatic consumers harder to write uniformly.
+- Shipping contract code in `lib/` means it enters the release binary and
+  Dialyzer type-checking scope, adding non-zero maintenance overhead for code
+  whose primary consumer is the test suite.
+- A release reviewer using `code-review-patterns` may flag the `lib/`
+  production module as a violation of "no GenServer wrapping stateless logic"
+  (this is pure functions, not a GenServer, but the reasoning for not
+  shipping test helpers to production applies).
+
+### Costs
+
+- Two new files (~70 + ~55 lines): one in `lib/`, one in `test/`.
+- No existing file changes required.
+- `MergeContract` enters Dialyzer scope — requires valid `@spec` annotations
+  (sketched above) and will fail `mix dialyzer` if specs are missing or wrong.
+- CI: identical property runtime to Proposals 2 and 3 (~3 runs × 100 iters).
+- Knowledge cost: contributors must understand that `MergeContract` is both
+  a test oracle and a runtime utility — a dual role that requires active
+  documentation.
+
+## Dependencies
+
+- `{:stream_data, "~> 1.1"}` already present.
+- Dialyzer must pass on `MergeContract`'s `@spec` annotations — verify with
+  `mix dialyzer` before PR.
+- No other production changes required.
+
+## Confidence
+
+low — The structural approach is sound in principle (named contracts as first-
+class modules is a well-established pattern), but the cost-benefit ratio for
+this specific problem is unfavorable. The problem is a two-property test gap,
+not an architectural contract-encoding gap. This proposal would raise its own
+confidence with a prototype showing `MergeContract` functions used in a live
+`iex` session or runtime diagnostic, but that use case is speculative. The
+selector should prefer Proposals 2 or 3 unless a runtime diagnostics use case
+for `MergeContract` is confirmed.
+
+## Prior art / references
+
+- Bertrand Meyer, "Design by Contract" — named precondition/postcondition
+  functions as explicit contract modules; the PEGS framework referenced in
+  `CLAUDE.md`.
+- Elixir `NimbleOptions` — ships validation logic as a separate composable
+  module callable independently of the schema definition.
+- `Tau.CircuitBreaker.State` in `lib/tau/circuit_breaker/state.ex` — precedent
+  for extracting state-machine invariants into a dedicated module.

--- a/docs/problems-archive-v1-modules/tau-permissions/subproblems/settings-merge-feed/solution.md
+++ b/docs/problems-archive-v1-modules/tau-permissions/subproblems/settings-merge-feed/solution.md
@@ -1,0 +1,109 @@
+---
+template_version: 1
+template_name: solution
+parent_problem: problem.md
+node_kind: leaf
+synthesised_from: [proposals/proposal-2.md]
+selection_method: single
+revision: 0
+---
+
+# Solution: Separate property test file loader_property_test.exs
+
+## Recommendation
+
+Add `test/tau/settings/loader_property_test.exs` — a dedicated StreamData property
+test file for `Tau.Settings.Loader.merge/2` — containing three properties: the
+prefix-then-suffix concatenation invariant for all three permissions keys
+simultaneously (C1), the right-identity invariant `merge(x, %{}) == x` (C2), and
+the absent-key-as-empty-list invariant (C3). Use `fixed_map/1`-based named
+generator helpers local to the file. Leave `loader_test.exs` untouched.
+
+## Selected from
+
+- **Chosen:** `proposals/proposal-2.md` (single)
+- **Why chosen:** Proposal 2 directly satisfies the acceptance criterion (both
+  mandated properties) while also covering C3 (the third named invariant in the
+  problem statement), all in one new file that does not touch the passing example
+  tests. The `fixed_map/1`-based generators are more representative of real
+  settings shapes than Proposal 1's inline `map_of(atom(:alphanumeric), ...)`
+  approach, and the file-level separation makes OTP NN #6 compliance discoverable
+  (`grep -r "use ExUnitProperties" test/tau/settings/` yields the file
+  unambiguously). Proposal 1 is almost as good on fit but its generator for the
+  identity property is weaker (arbitrary atom-keyed maps rather than
+  settings-shaped maps), and co-location provides no depth advantage over a
+  separate file. Proposal 3 adds a `test/support/SettingsGen` module whose value
+  depends on sibling sub-problems reusing it — speculative at this node and out of
+  scope. Proposal 4 introduces a production `lib/` module to fix a test-coverage
+  gap, which the proposal's own confidence assessment rates low and its internal
+  critique identifies as cost-exceeding-severity; that assessment is correct.
+
+| # | Fit | Decomplecting depth | Migration cost | Risk | Reversibility |
+|---|-----|---------------------|----------------|------|---------------|
+| 1 | Yes | Surface             | Low            | Low  | Easy          |
+| 2 | Yes | Substantial         | Low            | Low  | Easy          |
+| 3 | Yes | Substantial         | Medium         | Low  | Easy          |
+| 4 | Partially | Surface       | High           | Medium | Hard        |
+
+Proposal 2 wins on decomplecting depth (three invariants, all three permission
+keys tested together, sparse-key case isolated) without any cost or risk penalty
+over Proposal 1. Proposal 3 would tie with 2 on depth but introduces speculative
+scope; Proposal 4 is defeated on cost and risk with no offsetting gain for this
+problem's scope.
+
+## What changes
+
+- **New file:** `test/tau/settings/loader_property_test.exs` — three property
+  tests as sketched in Proposal 2, with named local generator helpers
+  (`permission_list/0`, `permissions_layer/0`, `settings_with_permissions/0`).
+  Module: `Tau.Settings.LoaderPropertyTest`.
+
+## What does not change
+
+- `test/tau/settings/loader_test.exs` — untouched; all existing example tests
+  continue to pass.
+- `lib/tau/settings/loader.ex` — no production changes.
+- `mix.exs` — `stream_data` already present; no dependency changes.
+- `test/support/` — no new support modules added.
+
+## Migration sketch
+
+Single PR: create `test/tau/settings/loader_property_test.exs`. Run
+`mix test test/tau/settings/loader_property_test.exs` to confirm all three
+properties pass. Run `mix test test/tau/settings/` to confirm no regression in
+`loader_test.exs`. The file is self-contained; no caller updates needed. If any
+property fails, it is a signal that `Loader.merge/2` violates an invariant the
+problem statement assumed was already correct — that failure is itself the value.
+
+## Open questions
+
+- Does `Loader.merge/2` currently satisfy C3 (absent key returns a list, not nil)?
+  The problem statement asserts it "concatenates `allow`, `deny`, and `ask` arrays
+  from each layer" but does not say what happens when a key is absent in one layer.
+  If the property fails on the real implementation, the implementer must fix
+  `Loader.merge/2` or narrow the property to match actual behaviour and file a
+  follow-up. This is the intended outcome — the property test should surface the
+  gap, not assume it is already closed.
+- Proposal 2's `settings_with_permissions/0` generator always produces maps with
+  all three keys present. The C3 property's layer-b is hand-constructed as
+  `%{permissions: %{}}`. This is correct for C3 but means the concat property
+  never sees partial-key layer inputs. If `Loader.merge/2` has a partial-key bug
+  that only surfaces when one layer has two of three keys, C1 will not catch it.
+  This is an acceptable residual given the acceptance criterion's scope; a future
+  property extension is low-effort if needed.
+
+## Linked sub-problems / proposals
+
+- `proposals/proposal-1.md` — In-place extension of `loader_test.exs`; weaker
+  generator shape for identity property; co-location with no depth gain.
+- `proposals/proposal-2.md` — Separate property file with three invariants;
+  `fixed_map`-based generators; OTP NN #6 compliance discoverable by grep.
+  **Selected.**
+- `proposals/proposal-3.md` — Shared `test/support/SettingsGen` module; depth
+  equivalent to P2 but with speculative-reuse overhead.
+- `proposals/proposal-4.md` — Production `lib/` contract module; self-assessed
+  low confidence; cost-benefit unfavorable for a test-coverage gap.
+
+## Revision history
+
+- (revision 0 — initial)

--- a/docs/problems-archive-v1-modules/tau-permissions/subproblems/settings-merge-feed/validation.md
+++ b/docs/problems-archive-v1-modules/tau-permissions/subproblems/settings-merge-feed/validation.md
@@ -1,0 +1,350 @@
+---
+template_version: 1
+template_name: validation
+parent_solution: solution.md
+parent_problem: problem.md
+toulmin_complete: true
+falsification_attempted: true
+falsification_outcome: withstood
+revision_triggered: none
+---
+
+# Validation: Separate property test file loader_property_test.exs
+
+## Overview
+
+The solution proposes adding a single new test file —
+`test/tau/settings/loader_property_test.exs` — containing three StreamData
+properties (concat C1, identity C2, absent-key C3) covering the
+`Tau.Settings.Loader.merge/2` permissions-array contract. No production
+code changes. The acceptance criterion in `problem.md` mandates at least
+two properties (concat + identity); the solution provides three. Five
+distinct propositions are extracted and run through full Toulmin with an
+explicit falsification strategy per claim. Outcome: all five **withstood**.
+No revision triggered.
+
+## Toulmin per claim
+
+The MITRE empirical study on Toulmin formalism found that participants
+generated highly variable Toulmin structures from the same content
+(https://www.mitre.org/news-insights/publication/empirical-evaluation-structured-argumentation-using-toulmin-argument).
+Each field below is filled independently with cited content; none is
+merged or elided.
+
+### Claim 1: The new file contains three properties — prefix-then-suffix concat (C1), right identity (C2), absent-key-as-empty-list (C3)
+
+- **Claim (C):** "Add `test/tau/settings/loader_property_test.exs` … containing
+  three properties: the prefix-then-suffix concatenation invariant for all
+  three permissions keys simultaneously (C1), the right-identity invariant
+  `merge(x, %{}) == x` (C2), and the absent-key-as-empty-list invariant (C3)."
+  (solution.md §Recommendation, lines 14–20.)
+- **Grounds (G):** Proposal 2's sketch (`proposals/proposal-2.md` lines
+  40–105) literally defines three `property "..."` blocks named
+  "prefix-then-suffix concat", "merge(x, %{}) == x", and "absent
+  permissions key … treated as empty list, not nil". The solution
+  explicitly cites Proposal 2 as the synthesised source
+  (`synthesised_from: [proposals/proposal-2.md]`, frontmatter line 7) and
+  the recommendation maps token-for-token to the three blocks.
+- **Warrant (W):** A solution that selects exactly one proposal and is
+  marked `selection_method: single` (frontmatter line 8) inherits the
+  proposal's concrete sketch as its specification; what the proposal
+  sketches is what gets implemented.
+- **Qualifier (Q):** Holds as long as the implementer follows Proposal 2's
+  sketch (lines 40–105) without subsetting. The solution does not loosen
+  the three-property contract anywhere in §What changes (lines 55–60).
+- **Rebuttal (R):** An implementer could legitimately ship only two
+  properties and still satisfy the acceptance criterion in `problem.md`
+  (which requires "at least two"). In that case the solution's three-
+  property claim would over-promise relative to what the implementer
+  delivered — but that is an implementation-fidelity question, not a
+  solution-design defect.
+- **Backing (B):** Polya-audit selection-method semantics
+  (`templates/solution.md` frontmatter: `selection_method: single` ⇒
+  recommendation is the chosen proposal's sketch). Proposal 2 lines 40–105.
+
+#### Falsification attempt for claim 1
+
+- **Strategy:** Counter-example construction — try to find a property in
+  the claim that is absent from the proposal's sketch, or a property in
+  the sketch that is absent from the claim.
+- **Attempt:** Enumerated the three `property` blocks in proposal-2.md
+  (lines 69, 84, 90); matched each against the three named C1/C2/C3
+  invariants in the solution's Recommendation. C1 ↔ "prefix-then-suffix
+  concat for each key" (proposal-2.md:69). C2 ↔ "merge(x, %{}) == x"
+  (proposal-2.md:84). C3 ↔ "absent permissions key in layer b treated as
+  empty list, not nil" (proposal-2.md:90). All three present in both.
+- **Outcome:** withstood.
+- **Action:** none.
+
+### Claim 2: The new file uses `fixed_map/1`-based named local generator helpers
+
+- **Claim (C):** "Use `fixed_map/1`-based named generator helpers local
+  to the file." (solution.md §Recommendation, line 19). Reinforced in
+  §What changes: "named local generator helpers (`permission_list/0`,
+  `permissions_layer/0`, `settings_with_permissions/0`)" (lines 57–59).
+- **Grounds (G):** Proposal 2 sketch defines `permission_list/0`
+  (proposal-2.md:53), `permissions_layer/0` using `fixed_map/1`
+  (proposal-2.md:55–61), `settings_with_permissions/0` using
+  `fixed_map/1` (proposal-2.md:63–65). `StreamData.fixed_map/1` exists
+  and accepts a map of generators (proposal-2.md:163 cites
+  `https://hexdocs.pm/stream_data/StreamData.html#fixed_map/1`).
+  `mix.exs` line 129 confirms `{:stream_data, "~> 1.1"}` is already
+  declared `only: [:test, :dev]`.
+- **Warrant (W):** A test file `use ExUnitProperties` exposes the
+  imported `StreamData` namespace; `fixed_map/1` is a public function
+  in `stream_data ~> 1.1`. Therefore the sketch is buildable in this
+  project without dependency changes.
+- **Qualifier (Q):** Holds for `stream_data` 1.x. If the dependency
+  were downgraded to 0.x where the function signature differs, the
+  sketch would need adjustment.
+- **Rebuttal (R):** None known — `fixed_map/1` is present in
+  `stream_data` 0.5 onward; the codebase already uses property tests
+  in 20+ files (e.g. `test/tau/permissions/property_test.exs`,
+  `test/tau/circuit_breaker/store_property_test.exs`), confirming the
+  pattern works.
+- **Backing (B):** `mix.exs:129` (`stream_data ~> 1.1`); existing
+  property-test files enumerated by `grep -rn 'use ExUnitProperties'
+  test/` (≥ 20 hits).
+
+#### Falsification attempt for claim 2
+
+- **Strategy:** Dependency check — verify `stream_data` is present at a
+  version where `fixed_map/1`, `list_of/1`, `member_of/1`, and
+  `string/2` are all available with the signatures the sketch uses.
+- **Attempt:** Read `mix.exs:129` → `stream_data ~> 1.1` is declared
+  for `:test, :dev`. The sketch calls `fixed_map/1` (1-arity, map
+  argument), `list_of/1` (1-arity, generator), `string(:alphanumeric,
+  min_length: 1)` (2-arity with keyword), and `member_of/1`. All four
+  have stable signatures in `stream_data` 1.x (well-established public
+  API). The codebase has 20+ existing files using these primitives.
+- **Outcome:** withstood.
+- **Action:** none.
+
+### Claim 3: `test/tau/settings/loader_test.exs` is untouched and continues to pass
+
+- **Claim (C):** "Leave `loader_test.exs` untouched" (solution.md line 20)
+  / "`test/tau/settings/loader_test.exs` — untouched; all existing example
+  tests continue to pass." (line 63).
+- **Grounds (G):** §What changes (lines 55–60) lists exactly one item:
+  the new file. §What does not change (lines 62–67) explicitly names
+  `loader_test.exs`, `lib/tau/settings/loader.ex`, and `mix.exs` as
+  untouched. The migration sketch (lines 70–76) consists of "Single PR:
+  create `test/tau/settings/loader_property_test.exs`" — a creation, not
+  a modification, of any existing file.
+- **Warrant (W):** Creating a new test file in the `test/` tree does not
+  affect compilation or execution of existing test files when they
+  reside in distinct modules; ExUnit discovers test files independently.
+  `Tau.Settings.LoaderPropertyTest` (proposal-2.md:43) and
+  `Tau.Settings.LoaderTest` (loader_test.exs:1) are distinct modules.
+- **Qualifier (Q):** Holds as long as the new file does not change
+  `lib/tau/settings/loader.ex` or any of its compile-time dependencies.
+  The solution explicitly forbids any production change (line 65).
+- **Rebuttal (R):** If the new property test reveals a real bug in
+  `merge/2`, the implementer might be tempted to fix `merge/2` in the
+  same PR — which would then risk breaking `loader_test.exs`'s existing
+  assertions. The solution's §Open questions (lines 79–86) acknowledges
+  this: "If the property fails on the real implementation, the
+  implementer must fix `Loader.merge/2` or narrow the property … and
+  file a follow-up." This is correctly scoped as an out-of-PR
+  contingency, not a defect of the claim.
+- **Backing (B):** ExUnit module-discovery semantics (each file is an
+  independent test module); the solution's explicit fence in §What
+  does not change.
+
+#### Falsification attempt for claim 3
+
+- **Strategy:** Counter-example construction — try to construct a way
+  in which adding only a new test file at a new module path could
+  break `loader_test.exs`.
+- **Attempt:** Considered (a) module-name collision: the proposed
+  module is `Tau.Settings.LoaderPropertyTest` vs existing
+  `Tau.Settings.LoaderTest` (no collision). (b) Helper imports: the
+  new file defines its generators as private `defp` and does not
+  inject anything into the existing file's namespace. (c) Shared
+  fixtures: no test/support module is added (solution.md line 67
+  explicitly: "no new support modules added"). (d) Compile-time
+  dependency: `loader_property_test.exs` would `alias Tau.Settings.Loader`
+  but does not modify that module.
+- **Outcome:** withstood.
+- **Action:** none.
+
+### Claim 4: The selected proposal directly satisfies the acceptance criterion (both mandated properties)
+
+- **Claim (C):** "Proposal 2 directly satisfies the acceptance criterion
+  (both mandated properties) while also covering C3 (the third named
+  invariant in the problem statement)" (solution.md §Why chosen, lines
+  26–29).
+- **Grounds (G):** `problem.md` §Acceptance criterion (lines 56–63)
+  requires "at least two StreamData properties: one asserting that
+  `merge(a, b)[:permissions][:deny]` is a prefix-then-suffix
+  concatenation … for arbitrary list-valued permission arrays; and one
+  asserting that merging any settings map with an empty map is an
+  identity (`merge(x, %{}) == x`) …". Proposal 2's properties P1 (concat
+  for all three keys, proposal-2.md:69) and P2 (`merge(x, %{}) == x`,
+  proposal-2.md:84) match these two requirements element-for-element.
+  P3 (proposal-2.md:90) adds the third invariant named in `problem.md`
+  §Statement (line 22: "a permissions block absent from one layer is
+  treated as an empty list not nil").
+- **Warrant (W):** "Satisfies the acceptance criterion" means the
+  artifact contains at least the minimum mandated assertions. P1 covers
+  `:deny` concat (in fact also `:allow` and `:ask`); P2 covers identity.
+  Both required properties are present, so the acceptance criterion is
+  met.
+- **Qualifier (Q):** "Satisfies" means satisfies on paper. The
+  property *passing* against the real implementation is a separate
+  question — see Claim 5.
+- **Rebuttal (R):** An over-strict reading of the acceptance criterion
+  might insist the concat property be specifically over `:deny` alone
+  (matching the criterion's exact wording). P1 covers `:deny` and more
+  — a strict superset, which still satisfies the criterion. No
+  rebuttal warranted.
+- **Backing (B):** `problem.md` lines 56–63 (acceptance criterion);
+  proposal-2.md lines 69, 84, 90 (the three property bodies).
+
+#### Falsification attempt for claim 4
+
+- **Strategy:** Edge-case enumeration — enumerate the acceptance
+  criterion's required assertions and verify each appears in P1 or P2.
+- **Attempt:** AC requirement 1: "prefix-then-suffix concat for `:deny`,
+  arbitrary list-valued permission arrays" — P1 asserts `merged
+  [:permissions][:deny] == a[:permissions][:deny] ++ b[:permissions]
+  [:deny]` under `check all a, b <- settings_with_permissions()`
+  (proposal-2.md:74–81). Direct match. AC requirement 2: "merge(x, %{})
+  == x for all map shapes that include a permissions block" — P2
+  asserts exactly that under `check all x <- settings_with_permissions()`
+  (proposal-2.md:84–88). Direct match. No AC requirement is missing
+  from the proposal.
+- **Outcome:** withstood.
+- **Action:** none.
+
+### Claim 5: Property failure on the real implementation is the intended outcome (the value of the test)
+
+- **Claim (C):** "If any property fails, it is a signal that `Loader.merge/2`
+  violates an invariant the problem statement assumed was already correct
+  — that failure is itself the value." (solution.md §Migration sketch,
+  lines 75–76; restated in §Open questions, lines 79–86.)
+- **Grounds (G):** Inspection of `lib/tau/settings/loader.ex` (read
+  in full) shows: `merge/2` uses `Map.merge(a, b, fn k, v1, v2 ->
+  merge_value(k, v1, v2) end)`. `merge_value/3` recurses for nested
+  maps (line 41), and for list-valued keys in `list_keys()`
+  concatenates `v1 ++ v2` (lines 43–48). `list_keys/0` (lines 88–98)
+  includes `:allow`, `:deny`, `:ask`, `:permissions`. Tracing P1:
+  outer keys both `:permissions` (maps) → recurse; inner keys
+  `:allow/:deny/:ask` (lists in `list_keys()`) → `v1 ++ v2`. P1
+  should pass against the real implementation. Tracing P2:
+  `Map.merge(x, %{}, fun)` returns `x` (the resolver is never
+  invoked because there are no shared keys). P2 should pass. Tracing
+  P3: when `b = %{permissions: %{}}`, the inner merge resolves
+  `Map.merge(%{key => list}, %{}, fun)` → `%{key => list}`, so
+  `merged[:permissions][key] == a_list`. P3 should pass.
+- **Warrant (W):** Property-based tests are valuable precisely because
+  a failure surfaces a real defect (Hughes, "QuickCheck: a lightweight
+  tool for random testing of Haskell programs", ICFP'00; the founding
+  rationale for the technique). A property whose expected outcome is
+  "pass" can still be valuable if its failure mode is informative; the
+  solution explicitly designs for both outcomes.
+- **Qualifier (Q):** The "failure is value" framing presupposes the
+  implementer treats failure as a defect signal — not as test noise to
+  be silenced by narrowing the property. The solution's §Open
+  questions (lines 79–86) explicitly notes the implementer must "fix
+  `Loader.merge/2` or narrow the property to match actual behaviour
+  and file a follow-up" — the second option must be paired with a
+  follow-up issue, otherwise the narrowing hides the defect.
+- **Rebuttal (R):** If the implementer narrows the property without
+  filing a follow-up, the test becomes vacuous (per the validator
+  protocol's "pre-emptive over-narrowing" anti-pattern). The solution
+  text mentions follow-up filing but does not enforce it.
+- **Backing (B):** Hughes, ICFP 2000. CLAUDE.md OTP NN #6 ("Invariant-
+  bearing modules MUST have properties before examples"). Validate
+  protocol `validate.md` §5 (revision options).
+
+#### Falsification attempt for claim 5
+
+- **Strategy:** Dependency check — verify the real implementation
+  actually does what the three properties assert, so the "failure is
+  the value" outcome is meaningful (a property that always passes
+  trivially adds little signal; a property that fails reveals a real
+  bug).
+- **Attempt:** Read `lib/tau/settings/loader.ex` end-to-end (99
+  lines). Traced each property's expected behaviour against the
+  implementation:
+  - P1 (concat): nested-map recursion + `v1 ++ v2` for list-keys →
+    should pass. The concat is genuinely `a ++ b`, not `b ++ a` —
+    confirmed at line 45.
+  - P2 (identity): `Map.merge(x, %{}, _) == x` is a property of
+    `Map.merge/3` itself — should pass.
+  - P3 (absent key): `Map.merge(%{k => v}, %{}, _) == %{k => v}` —
+    should pass for any key-value.
+  None of the three properties is expected to fail on the current
+  implementation. That is the *current* expectation; the value of
+  encoding them as properties is they will fire on any future
+  regression. The "failure is the value" framing remains true for
+  the regression case.
+- **Outcome:** withstood.
+- **Action:** none. (Note: this claim does not require that properties
+  fail today — it requires that *if* they fail, the failure is
+  informative. That conditional is sound.)
+
+## Cross-claim consistency
+
+The five claims are mutually consistent:
+
+- Claim 1 (three properties) and Claim 4 (acceptance criterion
+  satisfied) cohere: AC mandates two, solution provides three including
+  both mandated ones.
+- Claim 2 (named generators with `fixed_map/1`) and Claim 1 (three
+  specific properties) cohere: the generators serve the properties;
+  same source (proposal-2.md).
+- Claim 3 (existing file untouched) and Claim 5 (failure is value)
+  cohere: a failure of the new property does not break the existing
+  file; it surfaces a real defect that is handled by the §Open-
+  questions contingency.
+- Claim 4 (AC satisfied) and Claim 5 (failure is value) cohere: the
+  AC is "the properties exist", which the solution satisfies on paper;
+  the value of the properties is the regression-detection capability
+  Claim 5 describes.
+
+No internal tension identified.
+
+## Falsification summary
+
+| # | Claim (short) | Strategy | Outcome | Action |
+|---|---|---|---|---|
+| 1 | Three properties C1/C2/C3 | Counter-example construction | withstood | none |
+| 2 | `fixed_map/1`-based named helpers | Dependency check | withstood | none |
+| 3 | `loader_test.exs` untouched & passing | Counter-example construction | withstood | none |
+| 4 | AC satisfied by the chosen proposal | Edge-case enumeration | withstood | none |
+| 5 | Property failure is the intended value | Dependency check | withstood | none |
+
+## Revision required
+
+None. All five claims withstood their falsification attempts.
+
+- **Target file:** n/a
+- **Revision kind:** n/a
+- **Rationale:** The solution selects a single proposal whose sketch
+  matches the recommendation token-for-token; the acceptance criterion
+  is satisfied on paper (Claim 4) and the implementation under
+  inspection should make the properties pass (Claim 5); no fence in
+  §What does not change is violated (Claim 3); the dependency surface
+  is already present (Claim 2).
+
+## Outstanding doubts
+
+- **Doubt 1 (residual, not falsifiable here):** Proposal 2's
+  `settings_with_permissions/0` generator always produces maps with all
+  three permission keys present. A real-world settings layer might
+  contain only `{deny: [...]}` (no `:allow`, no `:ask`). P1 would not
+  exercise that shape; only P3 partially covers it (and only over the
+  three keys individually, not over all 2³ subset combinations). The
+  solution's own §Open questions (lines 87–93) acknowledges this as an
+  "acceptable residual given the acceptance criterion's scope; a future
+  property extension is low-effort if needed." This is correctly
+  qualified and not a falsification target at this node — it surfaces
+  to the parent validator as a known scope-residual.
+- **Doubt 2 (implementer-fidelity, out of scope):** The solution claims
+  the implementer will deliver three properties. The acceptance
+  criterion mandates only two. A literal-minded implementer could ship
+  two and pass the gate. The solution-vs-implementation gap is the
+  reviewer's responsibility, not the validator's; flagged here so the
+  parent validator can carry it.

--- a/docs/problems-archive-v1-modules/tau-permissions/validation.md
+++ b/docs/problems-archive-v1-modules/tau-permissions/validation.md
@@ -1,0 +1,486 @@
+---
+template_version: 1
+template_name: validation
+parent_solution: solution.md
+parent_problem: problem.md
+toulmin_complete: true
+falsification_attempted: true
+falsification_outcome: partially_falsified — claim/5
+revision_triggered: none
+---
+
+# Validation: Close tau-permissions property-coverage holes via four parallelisable PRs
+
+## Overview
+
+The root solution synthesises four leaf solutions into a four-PR program that
+together claims to satisfy the root acceptance criterion (property coverage of
+every invariant-bearing function in `tau-permissions` plus `Loader.merge/2`,
+elimination of the `PathPrefix` impurity, and structural separation of
+evaluator mode-dispatch from rule-set precedence). This validation enumerates
+six cross-cutting claims, runs full Toulmin on each, and applies a named
+falsification strategy per claim. Strategies used: integration check
+(PRs touch real existing code at cited file/line), edge-case enumeration
+(parent-AC conjunction; rebase storm under concurrent merge), dependency
+check (D-NNN slot availability against the MISSION registry), counter-example
+construction (PathPrefix purification under untouched call sites),
+prior-art counter-case (factory-loop's own §Parallel execution clauses
+applied as the public-case test). One claim (claim 5 — D-NNN slot) is
+**partially falsified**: the literal range cited (D-090..D-099) is exhausted
+per `docs/MISSION.md`, but the solution's own Open Question requires a grep
+audit at PR-filing time, so the narrowed qualifier — "the next free slot in
+the SPEC-PERMISSION-PROMPTS block, which is D-174..D-179 in the PR-B TUI sub-
+range, not D-090..D-099" — survives and triggers no revision. All other claims
+withstood. Five outstanding doubts remain (listed at end).
+
+## Toulmin per claim
+
+The MITRE empirical study on Toulmin formalism found unguided Toulmin output
+varies greatly even on identical content
+(https://www.mitre.org/news-insights/publication/empirical-evaluation-structured-argumentation-using-toulmin-argument).
+Each field below adds independent information; no field restates the claim.
+
+### Claim 1: The four PRs are parallelisable per the factory-loop conflict check; spawning PR-A, PR-B, PR-C, PR-D concurrently is the recommended factory batch.
+
+- **Claim (C):** "The four PRs are parallelisable per the conflict check in
+  `.claude/rules/factory-loop.md` §Parallel execution. […] All five clauses
+  clear. The recommended factory batch is to spawn PR-A, PR-B, PR-C, PR-D
+  concurrently as four implementer agents, each `isolation: worktree`, each
+  with its own draft PR opened first per the factory-loop cycle." (solution.md
+  Migration sketch, l. 163–186)
+- **Grounds (G):** PR-A modifies only `lib/tau/permissions/matchers.ex`
+  (`PathPrefix.match?/4` at matchers.ex:79–88) and creates
+  `test/tau/permissions/matchers_test.exs`. PR-B modifies only
+  `test/tau/permissions/mode_test.exs`. PR-C creates
+  `lib/tau/permissions/mode_policy.ex`, modifies one defp in
+  `lib/tau/permissions/evaluator.ex` (`default_for_mode/3`, evaluator.ex:91–119),
+  creates `test/tau/permissions/mode_policy_test.exs`, and adds one D-NNN entry
+  to `docs/spec/SPEC-PERMISSION-PROMPTS.md`. PR-D creates
+  `test/tau/settings/loader_property_test.exs`. The four file sets share no
+  file path.
+- **Warrant (W):** factory-loop.md's §Parallel execution five clauses license
+  concurrent spawn when (1) no dependency, (2) disjoint files, (3) disjoint
+  codepoints, (4) no shared SPEC/D-NNN block, (5) shared-resource isolation
+  possible. A PR set that clears all five MAY spawn concurrently.
+- **Qualifier (Q):** Holds for the file-disjointness and codepoint-disjointness
+  clauses as written. Holds for shared-SPEC clause only if PR-C's D-NNN lands
+  in a block none of PR-A/PR-B/PR-D touches (true — PR-A and PR-B touch no
+  SPEC; PR-D touches no SPEC). Holds for dependency clause only if PR-C's SPEC
+  amendment is not a prerequisite for PR-A/PR-B/PR-D's gating tests to land —
+  true, because the SPEC entry pins enforcement but the property tests stand
+  alone.
+- **Rebuttal (R):** A concurrent run that exceeds the coordinator's ability to
+  manage four simultaneous freshness re-checks (cycle step 8a fires once per
+  merge for every other in-flight branch — three re-checks across the batch's
+  lifetime) may force serialisation into two batches; the solution itself
+  flags this and offers PR-A+PR-B / PR-C+PR-D as the fallback grouping.
+- **Backing (B):** `.claude/rules/factory-loop.md` §Parallel execution +
+  §Conflict check (lines on the in-repo rule file; quoted verbatim by the
+  solution at l. 163–164).
+
+#### Falsification attempt for claim 1
+
+- **Strategy:** prior-art counter-case applied internally — walk the
+  factory-loop's own five clauses against the PR file-sets to look for a
+  hidden overlap that would defeat the disjointness claim.
+- **Attempt:** Enumerated every file path in each PR's What-changes list and
+  set-intersected the four sets pairwise. PR-A: `{matchers.ex,
+  matchers_test.exs}`. PR-B: `{mode_test.exs}`. PR-C:
+  `{mode_policy.ex, evaluator.ex, mode_policy_test.exs,
+  SPEC-PERMISSION-PROMPTS.md}`. PR-D: `{loader_property_test.exs}`. All six
+  pairwise intersections are empty. Codepoints: PR-A's only production edit
+  is `PathPrefix.match?/4` (matchers.ex:79–88, verified by Read); PR-C's only
+  production edit is `default_for_mode/3` (evaluator.ex:91–119, verified by
+  Read). No codepoint overlap. Dependencies: PR-A's `PathPrefix` purification
+  does not depend on PR-C's `ModePolicy` extraction (different module); PR-D's
+  loader properties do not depend on either (different subsystem); PR-B's mode
+  property block is test-only in `Tau.Permissions.Mode`, independent of all
+  three production-code modules.
+- **Outcome:** withstood. The five clauses all clear under verbatim inspection.
+- **Action:** None. The Migration sketch correctly notes the fall-back to two
+  batches if coordinator cannot gate four simultaneously; that is a capacity
+  qualifier, not a correctness rebuttal.
+
+### Claim 2: The four PRs together close all four coverage gaps named in the root problem statement.
+
+- **Claim (C):** "Together [the four PRs] satisfy the root acceptance criterion
+  [...]. After all four land, every invariant-bearing function in
+  `tau-permissions` and `Settings.Loader.merge/2` has at least one property
+  test, the `PathPrefix` impurity is eliminated rather than merely documented,
+  and the evaluator's per-mode allow-set is structurally separated from
+  rule-set precedence and pinned by a spec-gated D-NNN." (solution.md
+  Recommendation, l. 19–36)
+- **Grounds (G):** The root problem.md names four gaps explicitly (matchers
+  zero property tests at problem.md l. 76–79; mode peer-rank not
+  property-swept at l. 80–82; `default_for_mode/3` complecting at l. 83–86;
+  `Loader.merge/2` no property tests at l. 87–89). PR-A covers gap 1 (new
+  `matchers_test.exs` with two-or-more properties per matcher); PR-B covers
+  gap 2 (9-pair sweep + `at_or_below?/2` properties in `mode_test.exs`); PR-C
+  covers gap 3 (extract `ModePolicy`, delegate `default_for_mode/3`); PR-D
+  covers gap 4 (new `loader_property_test.exs` with three invariants).
+- **Warrant (W):** Conjunction satisfaction: if the parent AC is a conjunction
+  of independently-satisfiable clauses and each clause has at least one PR
+  whose deliverable provably satisfies it, the AC is satisfied iff every
+  contributing PR lands. The four PRs partition by concern layer exactly as
+  the problem's Decomposition strategy specifies (l. 65–71).
+- **Qualifier (Q):** Holds *iff* all four PRs land. If any PR is dropped or
+  fails the gate beyond N=3 + pivot, the residual gap re-opens.
+- **Rebuttal (R):** AC3 ("structurally separated") is stronger than what
+  PR-C's delegation pattern delivers: the delegation puts the data structure
+  in a separate module but `evaluate/5` still holds a `cond` branch that calls
+  `default_for_mode/3` as the fall-through. A reader could argue that
+  delegation is not "structural separation" because the call site survives.
+  The solution itself acknowledges this — Open question "Deferred deeper
+  structural fix" (l. 220–224) explicitly defers Proposal 3's fold-into-
+  rule-set approach to a future milestone.
+- **Backing (B):** `docs/MISSION.md` D-NNN registry (per-spec partitioning);
+  CLAUDE.md OTP non-negotiable #6 (invariant-bearing modules require
+  properties before examples); ADR-0014/ADR-0015 (mode ceiling and sub-agent
+  clamp, cited at problem.md l. 44–45).
+
+#### Falsification attempt for claim 2
+
+- **Strategy:** edge-case enumeration — list every clause of the parent AC,
+  pair each to the PR claimed to satisfy it, and check for a clause with no
+  satisfying PR or a PR whose deliverable falls short.
+- **Attempt:** Parent AC has three conjuncts (problem.md l. 92–99): (a) every
+  invariant-bearing function in `tau-permissions` and `Loader.merge/2` has at
+  least one property; (b) `PathPrefix` impurity is documented as known
+  deviation; (c) `default_for_mode/3` allow-lists are structurally separated
+  from rule-set precedence. PR mapping: (a) ← PR-A+PR-B+PR-C+PR-D; (b) ← PR-A
+  (eliminates rather than documents, strictly stronger per the synthesis
+  rationale l. 56–60); (c) ← PR-C. Every clause has a satisfying PR. The
+  "structurally separated" reading risk in (c) is the rebuttal's territory,
+  not an outright clause-without-PR.
+- **Outcome:** withstood. All three AC clauses are addressed.
+- **Action:** None. The rebuttal narrows the qualifier under which (c) is
+  fully satisfied (structural-separation reading), but the solution itself
+  flags this in Open questions; no further narrowing needed.
+
+### Claim 3: The PathPrefix purification (PR-A's 3-line change) is safe under the existing call-site contract because every Evaluator.evaluate/5 caller propagates :cwd in the context map.
+
+- **Claim (C):** "[PR-A is a] 3-line `PathPrefix.match?/4` fail-closed
+  purification [...]. **Pre-PR audit** (no file change): grep all
+  `Evaluator.evaluate/5` call sites to confirm `:cwd` is in the ctx map; any
+  gap fixes land in the same PR." (solution.md What changes, l. 73–86)
+- **Grounds (G):** Today, `PathPrefix.match?/4` at matchers.ex:79–88 reads
+  `cwd = ctx[:cwd] || File.cwd!()`. The fallback to `File.cwd!()` masks
+  any caller that omits `:cwd` — the function silently uses the BEAM
+  process's `cwd`. After the change, the same code path returns `false`
+  when `:cwd` is `nil`, which is a fail-closed semantic shift.
+- **Warrant (W):** A pure function that returns `false` on absent context is
+  safer than one that consults process-global state, *provided* every existing
+  caller already supplied the context (no behavioural change for compliant
+  callers). The OTP non-negotiable #8 (pure functions are the default) makes
+  this trade strictly correct.
+- **Qualifier (Q):** Safe iff every `Evaluator.evaluate/5` call site populates
+  `ctx[:cwd]`, OR the call site is path-rule-free (no `PathPrefix` rule in the
+  active rule-set). Holds conditionally on the PR-A pre-PR audit succeeding;
+  the solution explicitly conditions the change on the audit (l. 86) and
+  scopes any audit-found gap into the same PR.
+- **Rebuttal (R):** A `PathPrefix` rule in a rule-set evaluated against a
+  call site that doesn't pass `:cwd` will silently shift from "matches
+  against process-cwd" (potentially true) to "returns `false`" (always)
+  after PR-A. If `lib/tau/session.ex` or `lib/tau/tui/app.ex` calls
+  `Evaluator.evaluate/5` without `:cwd`, the change is a user-visible
+  permission semantic change. The Open question "Call-site audit scope for
+  PR-A" (l. 202–205) explicitly names `Tau.Session` as the call site to
+  audit; if the audit surfaces a gap, PR-A's scope widens.
+- **Backing (B):** OTP non-negotiable #8 (`CLAUDE.md` / `TAU.md` §OTP
+  non-negotiables — pure functions are the default; processes are the
+  exception); the matchers.ex source itself (verified by Read l. 74–89).
+
+#### Falsification attempt for claim 3
+
+- **Strategy:** counter-example construction — try to construct a
+  `(Evaluator.evaluate/5 caller, rule-set, ctx)` triple where the PR-A change
+  flips a previously-true match into `false` without compensating audit fix.
+- **Attempt:** A call site that omits `:cwd` and evaluates against a rule-set
+  containing a `PathPrefix` rule with a relative prefix (e.g.
+  `Read(./src/**)`) currently uses `File.cwd!()` to expand both `path` and
+  `prefix`. After PR-A, the call returns `false` always. If
+  `lib/tau/session.ex` or `lib/tau/tui/app.ex` calls `evaluate/5` with a
+  context map that lacks `:cwd`, this counter-example is realised. I have
+  *not* exhaustively read those files in this validation — the solution's
+  Open question explicitly requires the implementer to do so before filing
+  PR-A and to fix any gap in the same PR. Treating that requirement as a
+  pre-condition rather than a defect: the *claim as scoped* (safe **subject
+  to** the audit-and-fix) survives. Treating it as unconditional: counter-
+  example is plausible but unconstructed in this validation.
+- **Outcome:** withstood under the qualifier as scoped. The solution's own
+  audit-and-fix-in-same-PR clause is the answer to the counter-example
+  attempt.
+- **Action:** None. Validator records the audit-and-fix-in-same-PR scope as
+  a load-bearing pre-condition that the PR-A implementer MUST execute; the
+  solution already names it.
+
+### Claim 4: The four child solutions partition cleanly by concern layer and present no inter-PR conflict to resolve.
+
+- **Claim (C):** "The four child solutions partition cleanly by concern
+  layer; their `What changes` lists are file-disjoint […] and their failure
+  modes are orthogonal. There is no conflict to resolve and no gap against
+  the root acceptance criterion […]. No child's recommendation contradicts
+  another." (solution.md Selected from > Composition rationale, l. 50–69)
+- **Grounds (G):** The four leaf solutions' What-changes lists, as read from
+  each `subproblems/*/solution.md`: matcher-unit-contracts touches
+  `lib/tau/permissions/matchers.ex` + `test/tau/permissions/matchers_test.exs`;
+  mode-lattice-properties touches `test/tau/permissions/mode_test.exs` only;
+  evaluator-mode-complecting touches `lib/tau/permissions/evaluator.ex` +
+  creates `lib/tau/permissions/mode_policy.ex` +
+  `test/tau/permissions/mode_policy_test.exs` +
+  `docs/spec/SPEC-PERMISSION-PROMPTS.md`; settings-merge-feed touches
+  `test/tau/settings/loader_property_test.exs` only. Pairwise file
+  intersections all empty (verified in Claim 1 falsification).
+- **Warrant (W):** Independent partitioning: two PRs with disjoint files,
+  disjoint codepoints, and no shared SPEC entry cannot conflict at merge time
+  because the merge operation is a set-union of disjoint diffs.
+- **Qualifier (Q):** Holds for the diffs as currently scoped. If any leaf
+  scope widens in implementation (e.g. PR-A's audit reveals a `:cwd` gap in
+  `lib/tau/session.ex` and the fix lands in PR-A, while PR-C's
+  `ModePolicy` extraction simultaneously edits a nearby region of
+  `evaluator.ex`), an indirect conflict might emerge. None projected today.
+- **Rebuttal (R):** PR-C's `default_for_mode/3` extraction touches
+  `evaluator.ex` near the `cond` block; if a `:cwd`-fix in PR-A also lands in
+  `evaluator.ex` (the audit may surface this — `evaluate/5` is the entry
+  point), git could surface a structural conflict even with line-disjoint
+  edits. Probability is low but not zero.
+- **Backing (B):** The four leaf solutions themselves, cross-referenced
+  against the synthesis rationale at solution.md l. 50–69.
+
+#### Falsification attempt for claim 4
+
+- **Strategy:** integration check — verify by reading the four leaf
+  solutions independently that no leaf includes a deliverable that the
+  synthesis omitted or contradicted.
+- **Attempt:** Read all four `subproblems/*/solution.md`. Each leaf's
+  Recommendation section maps directly to one PR in the synthesis:
+  matcher-unit-contracts ↔ PR-A (verbatim: "Add
+  `test/tau/permissions/matchers_test.exs` […] and simultaneously replace
+  `PathPrefix.match?/4`'s `File.cwd!/0` fallback with fail-closed `false`");
+  mode-lattice-properties ↔ PR-B (verbatim: "Replace the three spot-check
+  tests in `describe "clamp/2 — peer modes"` with a single example test
+  that iterates all 9 peer × peer combinations via a `for` comprehension,
+  and add a dedicated `describe "at_or_below?/2 — properties"` block");
+  evaluator-mode-complecting ↔ PR-C (verbatim: "Introduce
+  `Tau.Permissions.ModePolicy` […] add a D-NNN invariant entry to
+  `SPEC-PERMISSION-PROMPTS.md`"); settings-merge-feed ↔ PR-D (verbatim:
+  "Add `test/tau/settings/loader_property_test.exs` […] containing three
+  properties"). No leaf deliverable was dropped; no leaf contradicts
+  another.
+- **Outcome:** withstood. The synthesis preserves every leaf deliverable
+  verbatim and the partition is clean.
+- **Action:** None.
+
+### Claim 5: PR-C's new D-NNN invariant lives in the D-090..D-099 block of SPEC-PERMISSION-PROMPTS.md.
+
+- **Claim (C):** "**Modified** `docs/spec/SPEC-PERMISSION-PROMPTS.md` — add
+  one D-NNN invariant entry (next free slot in D-090..D-099 — must be
+  confirmed by `git log --all --grep` plus `grep -rn` over `lib test docs
+  .claude` before filing)". (solution.md What changes > PR-C, l. 116–122)
+- **Grounds (G):** `docs/MISSION.md` D-NNN registry (l. 75) allocates
+  D-090..D-099 to SPEC-PERMISSION-PROMPTS for PR-A, and D-170..D-179 for
+  PR-B (TUI surface). Grep of `lib test docs .claude` for `D-09[0-9]` returns
+  every slot D-090 through D-099 already used in SPEC-PERMISSION-PROMPTS
+  §7 invariants table (D-090..D-098 active, D-099 deferred). Grep of
+  `D-17[0-9]` shows D-170..D-173 used (PR-B TUI invariants); D-174..D-179
+  free.
+- **Warrant (W):** The MISSION D-NNN registry is the authoritative partitioner
+  of identifiers across specs; a SPEC may only allocate within its assigned
+  blocks. A new D-NNN entry in SPEC-PERMISSION-PROMPTS must come from one of
+  its two assigned blocks (D-090..D-099 OR D-170..D-179).
+- **Qualifier (Q):** The literal range cited in PR-C's What-changes
+  ("D-090..D-099") is **wrong** — that block is fully allocated. The
+  narrowed claim that *survives* is: "PR-C adds one D-NNN entry to
+  SPEC-PERMISSION-PROMPTS, in the next free slot within the spec's two
+  assigned blocks (today: D-174..D-179)." The solution's Open question
+  (l. 196–200) makes the slot-grep a PR-C precondition, which catches this
+  at filing time.
+- **Rebuttal (R):** None — the registry is unambiguous and grep evidence is
+  decisive. The claim's literal scope is provably false; the narrowed claim
+  is provably true.
+- **Backing (B):** `docs/MISSION.md` l. 75 (registry); SPEC-PERMISSION-PROMPTS.md
+  §7 invariants table (l. 366–375 — D-090..D-099); §7 invariants table PR-B
+  block (l. 381–384 — D-170..D-173); grep results (this validation).
+
+#### Falsification attempt for claim 5
+
+- **Strategy:** dependency check against the MISSION registry — assume the
+  claim, verify the dependency (free slot in D-090..D-099) holds today.
+- **Attempt:** `grep -rn "D-09[0-9]"` over `lib test docs .claude`. Every
+  slot D-090 through D-099 is present in
+  `docs/spec/SPEC-PERMISSION-PROMPTS.md` §7 and referenced in
+  `lib/tau/session.ex`, `lib/tau/tui/app/*`, and
+  `test/tau/session/permission_prompts_test.exs`. D-099 is annotated as
+  "deferred" but still occupies the slot. The literal "next free slot in
+  D-090..D-099" does not exist. `D-17[0-9]` grep shows D-170..D-173
+  allocated; D-174..D-179 free.
+- **Outcome:** partially falsified. The literal range is exhausted; the
+  narrowed range (D-174..D-179, within the spec's other assigned block) has
+  free slots and the solution's own Open-question audit clause makes the
+  grep mandatory at PR-filing time. The narrowed claim survives.
+- **Action:** Narrow the qualifier in place to "the next free slot within the
+  spec's MISSION-assigned blocks (D-090..D-099 OR D-170..D-179)". No
+  revision triggered — the solution's Open question already mandates the
+  grep audit; the implementer briefed against PR-C MUST consult the registry
+  and allocate D-174 (or next free) rather than the as-written placeholder
+  D-09x. The validator records this as a load-bearing implementer
+  pre-condition; the synthesis text in solution.md l. 117 should be read as
+  "the next free slot in the SPEC-PERMISSION-PROMPTS-assigned blocks per the
+  MISSION registry", not the literal range it cites.
+
+### Claim 6: After all four PRs land, the four-gap closure satisfies the root acceptance criterion's conjunction.
+
+- **Claim (C):** "After all four land, every invariant-bearing function in
+  `tau-permissions` and `Settings.Loader.merge/2` has at least one property
+  test, the `PathPrefix` impurity is eliminated rather than merely
+  documented, and the evaluator's per-mode allow-set is structurally
+  separated from rule-set precedence and pinned by a spec-gated D-NNN."
+  (solution.md Recommendation, l. 33–36)
+- **Grounds (G):** The set of invariant-bearing functions in `tau-permissions`
+  (per problem.md Context, l. 30–46) comprises: five matcher `match?/4`
+  implementations (matchers.ex); `Mode.clamp/2` and `at_or_below?/2`
+  (mode.ex); `Evaluator.evaluate/5` and its private `default_for_mode/3`
+  (evaluator.ex); `Loader.merge/2` (settings/loader.ex, named in the parent
+  AC). PR-A adds properties to the five matchers; PR-B adds the 9-pair
+  sweep + `at_or_below?/2` properties; PR-C adds `ModePolicy.default/3`
+  properties (which is the renamed-and-extracted form of the former
+  `default_for_mode/3`) and preserves the existing `evaluator_test.exs`
+  integration examples; PR-D adds three `Loader.merge/2` properties. The
+  matcher modules' `match?/4` callbacks become property-tested directly for
+  the first time; `Mode.clamp/2` and `at_or_below?/2` already have
+  properties (per `mode_test.exs` l. 180–209) and PR-B extends them; the
+  evaluator's pure mode-default logic moves into `ModePolicy.default/3`
+  with its own properties; `Loader.merge/2`'s three array-merge invariants
+  are pinned.
+- **Warrant (W):** The parent AC is a logical conjunction over three
+  clauses (a, b, c — enumerated in Claim 2). Each conjunct's satisfaction
+  by a delivered PR is necessary and (in combination) sufficient for the
+  conjunction. The four PRs are independently-shippable and their land-or-
+  miss outcomes are uncorrelated under the factory loop's gate-per-PR
+  discipline.
+- **Qualifier (Q):** Satisfied iff all four PRs land AND their gating
+  tests survive Gate 5.1/5.2/5.3 AND the post-merge `main` health check
+  stays green across the four merges. Any PR that pivots beyond N=3 + pivot
+  re-opens the gap it was meant to close.
+- **Rebuttal (R):** Two AC-falsifying scenarios: (a) PR-D's C3
+  "absent-key-as-empty-list" property may fail against the real
+  `Loader.merge/2` — settings/loader.ex's `merge_value/3` only fires when
+  both layers have the same key, so absent-in-one-layer leaves the key
+  alone; whether the merged result has a list (truthy `[]`) or `nil` for
+  the absent key depends on `Map.get(_, _, [])` discipline at the read
+  site. If C3 fails, PR-D's scope widens (per Open question l. 215–218) or
+  a follow-up issue is filed; the AC's "at least one property" is still
+  satisfied by C1+C2 even if C3 narrows. (b) The "structurally separated"
+  reading of AC clause (c) — Claim 2's rebuttal applies here too; delegation
+  is a weaker reading of "structural separation" than full integration into
+  the rule-set (Proposal 3, deferred).
+- **Backing (B):** Root problem.md Acceptance criterion (l. 92–99); the
+  four leaf solutions' What-changes sections (verified independently in
+  Claim 4); the OTP non-negotiable #6 invariant-bearing rule (CLAUDE.md
+  §OTP non-negotiables).
+
+#### Falsification attempt for claim 6
+
+- **Strategy:** edge-case enumeration over the parent AC's three conjuncts
+  and the failure modes of each contributing PR.
+- **Attempt:** Conjunct (a) "every invariant-bearing function has at least
+  one property test": fails iff PR-A drops a matcher (none — all five named
+  in `What changes`), OR PR-B drops a `Mode` function (none — both `clamp/2`
+  and `at_or_below?/2` covered), OR PR-C drops `ModePolicy.default/3`
+  coverage (no — four properties named), OR PR-D drops `Loader.merge/2`
+  coverage (no — three properties named). Conjunct (b) "PathPrefix impurity
+  eliminated": fails iff PR-A drops the 3-line purification (no — it's the
+  P3 component of the hybrid). Conjunct (c) "structurally separated": fails
+  iff PR-C ships only the property tests without the `ModePolicy`
+  extraction (no — extraction is the P2 component). Each conjunct
+  withstands its enumeration. The C3 rebuttal in Claim 6 itself narrows
+  PR-D's scope but not the AC's "at least one property" bar.
+- **Outcome:** withstood. The conjunction satisfies under the qualified
+  scope (all four PRs land + gating tests survive + post-merge main stays
+  green).
+- **Action:** None. The qualifier names the four required preconditions;
+  the rebuttal cases are downgrades-not-falsifications under the AC's
+  "at least one property" floor.
+
+## Cross-claim consistency
+
+The six claims partition cleanly:
+
+- Claim 1 (parallelisability) and Claim 4 (no inter-PR conflict) reinforce
+  each other — both rest on file/codepoint disjointness, independently
+  verified.
+- Claim 2 (coverage of four named gaps) and Claim 6 (parent AC conjunction
+  satisfied) are nested: Claim 6 is the conjunction whose four conjuncts
+  Claim 2 enumerates per-gap.
+- Claim 3 (PathPrefix purification safe) is a constraint on PR-A's
+  acceptable scope (audit-and-fix in same PR); it does not contradict
+  Claim 1's file-disjointness because the in-scope audit fix would land in
+  `lib/tau/session.ex` or `lib/tau/tui/app.ex` — files PR-B, PR-C, PR-D
+  don't touch.
+- Claim 5 (D-NNN slot) narrows PR-C's literal range cite; it does not
+  contradict Claim 4's "no inter-PR conflict" because the corrected slot
+  (D-174..D-179) still lies in a block none of PR-A/PR-B/PR-D touches.
+
+No tension between claims. The internal consistency check passes.
+
+## Falsification summary
+
+| # | Claim (short) | Strategy | Outcome | Action |
+|---|---|---|---|---|
+| 1 | Four PRs parallelisable per factory-loop | prior-art counter-case | withstood | none |
+| 2 | Four PRs close all four named gaps | edge-case enumeration | withstood | none |
+| 3 | PathPrefix purification safe under audit | counter-example construction | withstood (qualified) | none — audit is load-bearing PR-A pre-condition |
+| 4 | Clean concern-layer partition, no conflict | integration check | withstood | none |
+| 5 | New D-NNN in D-090..D-099 block | dependency check | partially falsified | narrow qualifier to D-174..D-179 (other assigned block); registry-grep audit already mandatory |
+| 6 | Conjunction satisfaction of parent AC | edge-case enumeration | withstood | none |
+
+## Revision required
+
+No revision triggered. Claim 5 is partially falsified but the surviving
+narrowed qualifier ("next free slot in the SPEC-PERMISSION-PROMPTS-assigned
+blocks per MISSION registry") is already mandated by the solution's own Open
+question requiring the grep audit at PR-filing time. The literal "D-090..D-099"
+text in solution.md What-changes is misleading; the implementer briefed against
+PR-C MUST consult the MISSION registry and grep before allocating. This is a
+note-and-record outcome, not a solution rewrite.
+
+- **Target file:** none
+- **Revision kind:** none
+- **Rationale:** Partial falsification of Claim 5 lands within the qualifier-
+  narrowing path; the solution.md text needs a one-line clarification at most
+  (replace "D-090..D-099" with "the SPEC-PERMISSION-PROMPTS-assigned blocks")
+  but this falls below the revision threshold — the implementer's mandatory
+  grep audit catches it deterministically.
+
+## Outstanding doubts
+
+- **Audit-found scope creep in PR-A.** If the `Evaluator.evaluate/5` call-site
+  audit surfaces a `:cwd` gap in `lib/tau/session.ex` or `lib/tau/tui/app.ex`,
+  PR-A's scope widens and the in-flight conflict check against PR-C (which
+  also edits `evaluator.ex`) must be re-run by the coordinator at spawn time.
+  Probability low but non-zero.
+- **C3 property outcome in PR-D.** If `Loader.merge/2`'s absent-key handling
+  fails the C3 property as a real bug rather than a property-shape issue,
+  PR-D's scope widens to include a production fix in `lib/tau/settings/loader.ex`,
+  or a follow-up issue is filed and C3 narrows. The Open question (l. 215–218)
+  treats discovery as the property suite's value; either outcome is acceptable.
+- **"Structurally separated" reading risk.** Claim 2's rebuttal and Claim 6's
+  rebuttal both flag that PR-C's delegation pattern is a weaker structural
+  separation than Proposal 3's deeper fold-into-rule-set approach. The parent
+  AC text "structurally separated from the rule-set precedence logic" is
+  ambiguous between the two readings. A future critic may flag the delegation
+  as insufficient. The solution explicitly defers Proposal 3 to a future
+  milestone (l. 220–224).
+- **Slot allocation for PR-C's D-NNN.** Claim 5's narrowed qualifier (D-174..D-179)
+  is correct *today* (this validation) but the PR-B TUI work could allocate
+  D-174 before PR-C files. The implementer's grep-at-filing-time discipline is
+  the only guard; the validator cannot pre-allocate.
+- **Mutation check (Gate 5.3) for test-only PRs.** PR-B and PR-D are test-only
+  (no production change). Gate 5.3's mutation check reverts non-gating-test
+  paths to the merge-base — with no production code under test in those PRs,
+  the mutation check has no mutation to detect. Per `factory-loop.md` Gate 5.3
+  *"Runner crash"* discipline, this likely reports `:not_applicable` and exits
+  0, but I have not verified this empirically. If Gate 5.3 hard-fails on the
+  test-only PRs, the synthesis assumes a gate it cannot pass; PR-B and PR-D
+  would need an alternate path. Worth confirming via `mix tau.gate.mutation`
+  dry-run before spawning.

--- a/docs/problems-archive-v1-modules/tau-providers/problem.md
+++ b/docs/problems-archive-v1-modules/tau-providers/problem.md
@@ -1,0 +1,108 @@
+---
+template_version: 1
+template_name: problem
+node_kind: internal
+depth: 0
+parent: —
+status: decomposed
+---
+
+# Problem: tau-providers behaviour contract divergence
+
+## Statement
+
+The `@behaviour Tau.Provider` defines a shared contract for eleven adapters, but
+four concerns leak across the contract boundary in ways that make the adapters
+silently non-interchangeable: `capabilities/0` flags are decorative (Bedrock and
+Gemini declare `thinking: true, prompt_caching: true` while implementing
+neither); usage maps are only canonically normalised by Anthropic; `retryable?`
+classification is scattered across three layers with incompatible criteria; and
+auth-resolution logic is duplicated, each adapter inventing its own priority
+chain with no shared scaffold.
+
+## Context
+
+- `lib/tau/provider.ex` — 6 callbacks: `stream/3`, `capabilities/0`,
+  `default_model/0`, `configure/1` (optional), `cache_regions/2` (optional),
+  `context_window/1` (optional).
+- `lib/tau/provider/event.ex` — canonical event union (12 struct types).
+- `lib/tau/providers/anthropic.ex` — only adapter with a `merge_usage/2` that
+  emits the full B3 canonical map (`input_tokens`, `output_tokens`,
+  `cache_read`, `cache_write`, `cache_breakdown`).
+- `lib/tau/providers/shared/openai_chat_wire.ex` — shared SSE decode used by
+  OpenAI Chat, Groq, Mistral, DeepSeek, AzureOpenAI, Custom; emits
+  `%Event.Done{usage: %{}}` (empty map) — no normalisation.
+- `lib/tau/providers/bedrock.ex` — declares `thinking: true, prompt_caching:
+  true`; emits only `TextDelta` (no `TextStart`/`TextEnd`) and no usage.
+- `lib/tau/providers/gemini.ex` — declares `thinking: true, prompt_caching:
+  true`; emits only `TextDelta` (no `TextStart`/`TextEnd`) and no usage.
+- Auth resolution is per-adapter with no shared behaviour; Copilot has a
+  dedicated two-token model (OAuth + short-lived API token) while all others
+  use a `nil` guard + `System.get_env` chain.
+- SPEC-PROMPT-CACHING §4 B3 defines the canonical usage key contract;
+  only Anthropic honours it.
+
+## Complecting hypothesis
+
+1. **`capabilities/0` flag truth is complected with per-adapter decode
+   implementation:** whether an adapter actually synthesises `ThinkingStart` /
+   `ThinkingEnd` events or honours cache regions is only discoverable by reading
+   each adapter's decode path, not by inspecting the behaviour flag.
+2. **Usage normalisation is complected with adapter identity:** the `%Event.Done{}`
+   contract specifies a `usage` map, but what keys are present depends on which
+   adapter produced the event — only Anthropic emits the B3 canonical set; all
+   others emit `%{}`.
+3. **Auth-resolution strategy is complected with each adapter module:** the
+   priority chain (app env → vault → env var) is reimplemented in full per
+   adapter with no shared scaffold, meaning vault-resolution bugs can exist in
+   some adapters but not others.
+
+## Decomposition strategy
+
+The parent problem decomposes along the **concern (Hickey)** axis: four
+distinct concerns are woven together across the provider surface. Each
+sub-problem names exactly one woven concern and the adapter set where it
+manifests. The sub-problems are MECE because:
+
+- No concern lives in two sub-problems (each names one distinct contract gap).
+- Their union covers every concern in the statement.
+- Each is at the same altitude: a specific gap in what `@behaviour Tau.Provider`
+  enforces vs what adapters actually deliver.
+
+## Sub-problems (filled by decomposer)
+
+1. **callback-contract-drift** — Adapters omit or vary structural event emission
+   (TextStart/TextEnd synthesis, ToolCallDelta streaming) without the behaviour
+   detecting or documenting the gap.
+2. **capabilities-flag-fidelity** — `capabilities/0` flags (`thinking`,
+   `prompt_caching`) diverge from what adapters actually implement, making them
+   decorative rather than enforceable.
+3. **usage-normalisation** — `%Event.Done{usage: map()}` carries an implicit
+   per-adapter schema; only Anthropic emits the B3 canonical key set; all others
+   emit `%{}`, silently breaking cost tracking and context-window display.
+4. **auth-resolution-scatter** — Each adapter reinvents its own credential
+   priority chain (app env → vault → env var) with no shared behaviour or
+   scaffold, causing vault-resolution inconsistencies across adapters.
+
+## Acceptance criterion
+
+The behaviour contract at `lib/tau/provider.ex` and associated shared
+infrastructure enforces (or accurately documents as optional) every observable
+divergence currently present across the eleven adapters, such that a new adapter
+author cannot silently ship a broken implementation by following only the
+`@behaviour` callbacks.
+
+## Out of scope
+
+- Transport layer (FinchStream, AwsEventStream, SSE parsing) — these are
+  not part of the behaviour surface.
+- Rate limiting (`Tau.Providers.RateLimiter`) — shared infrastructure, not
+  per-adapter contract.
+- Tool spec shape (`Tau.Providers.Shared.ToolSpec`) — a separate concern.
+- Replay provider's test-harness contract — intentionally divergent; not a
+  production adapter.
+- Performance or throughput concerns.
+
+## Amendment log
+
+- (none yet)

--- a/docs/problems-archive-v1-modules/tau-providers/solution.md
+++ b/docs/problems-archive-v1-modules/tau-providers/solution.md
@@ -1,0 +1,414 @@
+---
+template_version: 1
+template_name: solution
+parent_problem: ./problem.md
+node_kind: root
+synthesised_from:
+  - subproblems/callback-contract-drift/solution.md
+  - subproblems/capabilities-flag-fidelity/solution.md
+  - subproblems/usage-normalisation/solution.md
+  - subproblems/auth-resolution-scatter/solution.md
+selection_method: synthesis
+mode: non-leaf
+revision: 0
+---
+
+# Solution: Make `Tau.Provider` enforce or honestly document every observable adapter divergence
+
+## Recommendation
+
+Land four composable, file-disjoint workstreams that together convert the
+`Tau.Provider` contract from a decorative interface into a partial-enforcement /
+honest-documentation surface. Each workstream is the recommendation of one
+child sub-problem; together they discharge the module-level acceptance
+criterion ("a new adapter author cannot silently ship a broken implementation
+by following only the `@behaviour` callbacks") via three complementary
+mechanisms: (a) **type-level enforcement** — a typed `%Event.Usage{}` struct
+replaces `usage: map()`; a mandatory `stream_contract/0` callback returning a
+`%Tau.Provider.StreamContract{}` forces each adapter to publish its
+text-framing / tool-call-delta posture; (b) **CI-gate enforcement** — a new
+`mix tau.gate.capabilities` joins the existing `tau.gate.*` family, asserting
+the `prompt_caching` ⇔ `cache_regions/2` biconditional, and a shared
+`Tau.Test.ProviderConformance` template iterates every production adapter to
+assert the usage-struct invariants on replay fixtures; (c) **shared
+scaffolds** — `Tau.Providers.Auth` for the standard `opt → app_env → vault →
+system_env` chain, and `Tau.Provider.UsageNorm` for wire-to-struct usage
+extraction; (d) **honest documentation** — an ADR for auth, prose `@doc`
+upgrades on `capabilities/0`, a `@stream_contract` attribute on
+`Tau.Provider`, and the existing flag demotions for Bedrock, Gemini, DeepSeek.
+The four workstreams touch disjoint files and ship as four separate PRs that
+can largely parallelise under the factory-loop conflict check; the only
+serialisation requirement is the usage-normalisation workstream's PR 1
+(struct + Anthropic + consumer migration) which must land before PRs 2 and 3
+of that workstream.
+
+## Selected from
+
+- **Synthesised from:** child solutions at
+  `subproblems/callback-contract-drift/solution.md`,
+  `subproblems/capabilities-flag-fidelity/solution.md`,
+  `subproblems/usage-normalisation/solution.md`,
+  `subproblems/auth-resolution-scatter/solution.md`.
+
+- **Composition rationale:** the four sub-problems were carved on Hickey's
+  *concern* axis (callback shape, capability honesty, usage data, auth
+  resolution); each is one woven concern named in `problem.md`. Their
+  recommendations compose directly — none retracts or constrains another, and
+  the file-touch sets are nearly disjoint:
+
+  | Workstream | Touches `lib/tau/provider.ex` | New module(s) | New CI gate / test |
+  |---|---|---|---|
+  | callback-contract-drift | yes (new `@callback`, `@stream_contract` attr) | `Tau.Provider.StreamContract` | `provider_stream_contract_test.exs` |
+  | capabilities-flag-fidelity | yes (`@doc` / `@typedoc` on `capabilities/0`) | `Mix.Tasks.Tau.Gate.Capabilities` | `capabilities_contract_test.exs` + `mix tau.gate.capabilities` (CI) |
+  | usage-normalisation | yes (`Event.Usage` struct; `Done.t()` typespec) | `Tau.Provider.Event.Usage`, `Tau.Provider.UsageNorm`, `Tau.Test.ProviderConformance` | per-adapter `*_conformance_test.exs` + `mix tau.conformance` |
+  | auth-resolution-scatter | no | `Tau.Providers.Auth`, `ADR-00XX-auth-resolution-policy.md` | `auth_test.exs` + `auth_policy_test.exs` (telemetry) |
+
+  The three workstreams that touch `lib/tau/provider.ex` edit disjoint
+  regions (event union, capabilities callback docstring, new stream_contract
+  callback), so the file overlap is a sequencing concern handled by the
+  factory-loop's freshness re-check (cycle step 8a) — not a content conflict.
+  No child's recommendation forces a behaviour-API break for external
+  implementors beyond what its own sub-problem makes unavoidable
+  (`stream_contract/0` is the one new mandatory callback; the other three
+  workstreams add scaffolds, structs, gates, and docs only).
+
+  **Three forms of enforcement compose intentionally.** Type-level
+  enforcement (struct shape, mandatory callback) catches the "absent
+  implementation" failure mode at compile time. CI-gate enforcement catches
+  the "declared but unimplemented" failure mode (`prompt_caching: true`
+  without `cache_regions/2`; `stream_contract` declaration not matching
+  emitted events). Documentation (`@doc`, ADR, `@stream_contract` attribute)
+  closes the residual case where a flag's obligations span too many
+  callsites to localise mechanically (`thinking: true`). Each layer covers
+  what the previous layer cannot — composition, not redundancy.
+
+## What changes
+
+Grouped by workstream so each maps to one factory-loop PR. File-level
+enumeration is per child solution; only the inter-workstream additions are
+new at this level.
+
+### Workstream A — auth-resolution-scatter (orthogonal; ships first or in parallel)
+
+- **New** `lib/tau/providers/auth.ex` — shared
+  `resolve_api_key/3` / `resolve_api_key_or_error/3`, unconditional
+  `Tau.Settings.Vault.resolve/1` call.
+- **Modified** `lib/tau/providers/{mistral,deepseek,groq,azure_openai,custom,gemini}.ex`
+  — delete private `vault_key/0` helpers; call the shared resolver; Gemini
+  gains the missing vault leg.
+- **New** `docs/adr/ADR-00XX-auth-resolution-policy.md` — canonical chain
+  plus per-adapter exception table (Anthropic OAuth, Bedrock AWS-triple,
+  Copilot two-token, Azure non-key fields, Custom `base_url`).
+- **New** `test/tau/providers/auth_test.exs` and
+  `test/tau/providers/auth_policy_test.exs` — unit + cross-adapter
+  telemetry regression.
+
+### Workstream B — usage-normalisation (three sequenced PRs B1 → B2 → B3)
+
+- **B1 — struct + scaffold + Anthropic + consumer migration.**
+  - **New** `lib/tau/provider/event.ex` extension —
+    `%Tau.Provider.Event.Usage{}` with
+    `@enforce_keys [:input_tokens, :output_tokens]`; `Done.usage ::
+    Event.Usage.t() | nil`.
+  - **New** `lib/tau/provider/usage_norm.ex` — `from_openai/1`,
+    `from_gemini/1`, `from_bedrock/1`, `from_anthropic/1`, `zero/0`,
+    `nonneg/1`.
+  - **Modified** `lib/tau/providers/anthropic.ex` —
+    `merge_usage/2` output wrapped via `UsageNorm.from_anthropic/1`.
+  - **Modified** `lib/tau/session.ex`, `lib/tau/cost/tracker.ex`, any TUI
+    consumer — struct-field access.
+- **B2 — wire-extraction for non-Anthropic adapters.**
+  - **Modified** `lib/tau/providers/shared/openai_chat_wire.ex` —
+    `stream_options.include_usage: true` in `build_body/4`; emit
+    `%Event.Done{usage: UsageNorm.from_openai(raw)}`.
+  - **Modified** `lib/tau/providers/bedrock.ex` — accumulate
+    `message_start` usage; emit on `message_stop`.
+  - **Modified** `lib/tau/providers/gemini.ex` — read
+    `json["usageMetadata"]`; emit via `UsageNorm.from_gemini(raw)`.
+- **B3 — shared conformance harness + missing fixtures.**
+  - **New** `test/support/provider_conformance.ex` — shared ExUnit case
+    template (asserts last `%Event.Done{}` has `%Event.Usage{}` with
+    non-negative integers).
+  - **New** `test/tau/providers/{anthropic,openai_chat,openai_responses,
+    gemini,bedrock,groq,mistral,deepseek,azure_openai,custom,copilot}_conformance_test.exs`.
+  - **New/extended** `priv/fixtures/*.jsonl` for adapters lacking
+    usage-bearing fixtures.
+  - **New** `mix tau.conformance` Mix task as a fast targeted gate.
+- **Amendment** to `docs/spec/SPEC-PROMPT-CACHING.md` §4 B3 — names
+  `%Event.Usage{}` as canonical carrier and `Tau.Provider.UsageNorm` as
+  shared adapter-side scaffold; D-065 wording updated to match. This SPEC
+  amendment ships with B1 (the struct's home PR).
+
+### Workstream C — capabilities-flag-fidelity (single PR)
+
+- **Modified** `lib/tau/provider.ex` — prose `@doc` / `@typedoc` on
+  `@callback capabilities/0` (per-flag truthfulness semantics; names
+  `prompt_caching` as the only mechanically enforceable flag; names the
+  CI gate).
+- **Modified** `lib/tau/providers/bedrock.ex`, `lib/tau/providers/gemini.ex`,
+  `lib/tau/providers/deepseek.ex` — demote `prompt_caching: true → false`;
+  Bedrock + Gemini also demote `thinking: true → false` (DeepSeek's
+  thinking flag is backed by `OpenAIChatWire` reasoning synthesis and
+  stays).
+- **New** `lib/mix/tasks/tau.gate.capabilities.ex` (~60 LOC) — CI gate
+  modelled on `tau.gate.ac_linkage` / `tau.gate.masking` /
+  `tau.gate.mutation`; asserts
+  `capabilities().prompt_caching == true ⇔ function_exported?(mod, :cache_regions, 2)`.
+- **Modified** `.github/workflows/ci.yml` — add `mix tau.gate.capabilities`
+  to the existing `lint` job.
+- **New** `test/tau/provider/capabilities_contract_test.exs` (~40 LOC) —
+  parameterised ExUnit mirror of the gate task for developer-local feedback.
+
+### Workstream D — callback-contract-drift (single PR)
+
+- **New** `lib/tau/provider/stream_contract.ex` —
+  `%Tau.Provider.StreamContract{text_framing, tool_call_delta,
+  block_id_uniqueness, thinking_framing}`; `conformant/0` constructor.
+- **Modified** `lib/tau/provider.ex` — add `@callback stream_contract/0`
+  (mandatory); add `@stream_contract` module attribute (prose canonical
+  sequence); update `@callback stream/3` docstring to reference both.
+- **Modified** every adapter (`anthropic, bedrock, gemini, openai_chat,
+  openai_responses, groq, mistral, deepseek, azure_openai, custom,
+  copilot, replay`) — implement `@impl Tau.Provider stream_contract/0`
+  returning a `%StreamContract{}` that matches its actual posture
+  (conformant adapters use `StreamContract.conformant()`; Bedrock and
+  Gemini declare `:delta_only` / `:sentinel` etc).
+- **New** `test/tau/provider_stream_contract_test.exs` —
+  self-consistency test: for each adapter, run a Replay-fixture stream
+  and assert emitted events match the declared contract.
+
+### Cross-workstream additions
+
+- **Documentation** — `docs/PROVIDER-CONTRACT.md` (or amendment to an
+  existing provider doc) lists the four enforcement mechanisms
+  (`stream_contract/0`, `%Event.Usage{}`, `mix tau.gate.capabilities`,
+  `Tau.Providers.Auth`) and points at each workstream's spec / ADR /
+  test entrypoint. This consolidates what is otherwise four scattered
+  artifacts into one operator-readable index.
+
+## What does not change
+
+- The `Tau.Provider` callback list **except** for the single new
+  `stream_contract/0` (Workstream D). `configure/1` stays optional and
+  unused; `cache_regions/2` stays optional; `context_window/1` stays
+  optional.
+- `Tau.Provider.Event` event types other than `%Event.Done{}`'s `usage`
+  typespec — no new event variants, no changes to `TextStart/End`,
+  `ToolCallStart/Delta/End`, `ThinkingStart/Delta/End`, `Error`.
+- Live decode paths for Bedrock and Gemini (other than the usage
+  extraction in B2) — they continue to omit `TextStart/End` framing;
+  the `stream_contract/0` declaration makes the gap visible but does
+  not fix it. (Fixing the live paths is deferred to a future
+  sub-problem per the callback-contract-drift child's open questions.)
+- `Tau.Message.Assembler` tolerances — left in place; tightening is
+  gated on the decode-path fixes.
+- `Tau.Providers.Anthropic.Auth` (OAuth-capable), `Tau.Providers.Bedrock`
+  AWS-credential resolution, and `Tau.Providers.Copilot.Auth` two-token
+  model — these remain bespoke per the auth-resolution-scatter ADR's
+  exception table.
+- Out-of-scope items from `problem.md`: transport layer (FinchStream,
+  AwsEventStream, SSE parsing), rate limiting
+  (`Tau.Providers.RateLimiter`), tool-spec shape
+  (`Tau.Providers.Shared.ToolSpec`), Replay provider's test-harness
+  contract, performance / throughput.
+
+## Migration sketch
+
+Four workstreams, four (or six with B2/B3) PRs. The factory-loop conflict
+check (rule `.claude/rules/factory-loop.md` §"Parallel execution") is the
+arbiter for scheduling. Sequence:
+
+1. **PR-A (Workstream A — auth-resolution-scatter).** Fully orthogonal:
+   touches `lib/tau/providers/*.ex` (not `lib/tau/provider.ex`), adds a new
+   shared module, an ADR, and two test files. Can run in parallel with any
+   other workstream. Reversibility: easy (delete `Tau.Providers.Auth`;
+   restore private `vault_key/0` from VCS).
+2. **PR-B1 (Workstream B PR 1 — struct + scaffold + Anthropic + consumers).**
+   Lands `%Event.Usage{}`, `Tau.Provider.UsageNorm`, Anthropic migration,
+   and the SPEC-PROMPT-CACHING §4 B3 amendment. **Must precede** PR-B2 and
+   PR-B3 (struct must exist before adapters can emit it; conformance tests
+   must follow wire-extraction so they go green on landing). Behaviour-
+   preserving for Anthropic (it already emitted real counts); behaviour-
+   improving for consumers (typed access).
+3. **PR-C (Workstream C — capabilities-flag-fidelity).** Independent of B
+   and D content-wise (touches `@doc` / `@typedoc` on `capabilities/0`,
+   not the event union or the new callback), but touches the same file
+   `lib/tau/provider.ex`. Under the factory-loop's freshness re-check,
+   this means if PR-C lands between PR-B1's gate and merge, PR-B1 must
+   rebase and re-gate. Schedule PR-C either before PR-B1 or after PR-B3
+   to avoid serialising B's three PRs through C's rebase.
+4. **PR-D (Workstream D — callback-contract-drift).** Adds the mandatory
+   `stream_contract/0` callback. This is the only workstream that breaks
+   `@behaviour Tau.Provider` for external implementors (out-of-scope per
+   the project; all current implementors are in-tree). Same
+   `lib/tau/provider.ex` overlap concern as PR-C. Schedule after PR-B1
+   has landed to minimise the rebase blast radius on B's later PRs.
+5. **PR-B2 (Workstream B PR 2 — wire-extraction).** Modifies
+   `openai_chat_wire.ex`, `bedrock.ex`, `gemini.ex`. Each adapter's
+   conformance test (introduced in PR-B3) goes from red to green when
+   wire-extraction lands; the test is the forcing function. File-disjoint
+   from PR-A, PR-C, PR-D — can parallelise freely.
+6. **PR-B3 (Workstream B PR 3 — conformance harness + missing fixtures).**
+   Lands `Tau.Test.ProviderConformance`, per-adapter conformance test
+   files for the eleven production adapters, the `mix tau.conformance`
+   task, and any missing fixtures. File-disjoint from every other
+   workstream's source files; conflicts only with itself.
+
+**Recommended order under the factory-loop conflict check:**
+PR-A and PR-B1 in parallel (fully disjoint files);
+then PR-C (after PR-B1 to claim the `lib/tau/provider.ex` edit window);
+then PR-D (after PR-C, same file-overlap reason);
+then PR-B2 and PR-B3 in parallel (file-disjoint from A/C/D and from each
+other except for the fixture directory).
+
+**Reversibility** is per-workstream:
+- A: easy (delete shared module).
+- B: B3 → B2 → B1 reverse order; struct revert requires consumer-access
+  revert.
+- C: trivial (revert demotions; delete gate task; remove CI line).
+- D: easy at struct level (delete `stream_contract.ex`); harder if any
+  external implementor has already implemented the callback (out of
+  scope today).
+
+## Combined acceptance criteria
+
+The module-level acceptance criterion (`problem.md`) decomposes into four
+sub-AC sets, one per workstream. **All four AC sets MUST PASS for the
+module-level criterion to be satisfied.** Each set is taken verbatim from
+the relevant child solution; identifiers prefixed by workstream letter.
+
+### AC-A (auth-resolution-scatter)
+
+- AC-A1: `Tau.Providers.Auth.resolve_api_key/3` exists and follows
+  `opt → app_env → vault → system_env`.
+- AC-A2: Every adapter in {Mistral, DeepSeek, Groq, AzureOpenAI, Custom,
+  Gemini} has its private `vault_key/0` deleted and routes credential
+  resolution through `Tau.Providers.Auth`.
+- AC-A3: `docs/adr/ADR-00XX-auth-resolution-policy.md` documents the chain
+  and the per-adapter exception table.
+- AC-A4: `test/tau/providers/auth_policy_test.exs` asserts every adapter
+  in the standard list emits `[:tau, :vault, :get]` telemetry during
+  credential resolution.
+
+### AC-B (usage-normalisation)
+
+- AC-B1: `%Tau.Provider.Event.Usage{}` struct exists with
+  `@enforce_keys [:input_tokens, :output_tokens]`; `Done.usage`
+  typespec updated.
+- AC-B2: `Tau.Provider.UsageNorm` exists with `from_openai/1`,
+  `from_gemini/1`, `from_bedrock/1`, `from_anthropic/1` returning
+  `%Event.Usage{}`.
+- AC-B3: Every production adapter emits a non-nil `%Event.Usage{}` on
+  `%Event.Done{}`, verified by the per-adapter conformance test.
+- AC-B4: `Tau.Test.ProviderConformance` template exists; one
+  `*_conformance_test.exs` per production adapter passes.
+- AC-B5: SPEC-PROMPT-CACHING §4 B3 amended to name `%Event.Usage{}`
+  as canonical carrier and `UsageNorm` as the shared scaffold; D-065
+  wording matches.
+
+### AC-C (capabilities-flag-fidelity)
+
+- AC-C1: `mix tau.gate.capabilities` exists, returns exit 0 on
+  current `main`, and is wired into `.github/workflows/ci.yml`'s
+  `lint` job as a blocking check.
+- AC-C2: `Tau.Providers.Bedrock`, `Tau.Providers.Gemini`,
+  `Tau.Providers.DeepSeek` declare `prompt_caching: false`; Bedrock
+  and Gemini also declare `thinking: false`.
+- AC-C3: `Tau.Provider.capabilities/0` `@doc` and `@typedoc` name
+  `prompt_caching` as the only mechanically enforceable flag and name
+  the gate.
+- AC-C4 (meta): `test/tau/provider/capabilities_contract_test.exs`
+  exists and asserts the biconditional at the unit-test level.
+
+### AC-D (callback-contract-drift)
+
+- AC-D1: `Tau.Provider.StreamContract` struct exists with the four
+  declared fields.
+- AC-D2: `@callback stream_contract/0` is declared on `Tau.Provider`
+  (mandatory, not optional).
+- AC-D3: Every adapter implements `@impl Tau.Provider stream_contract/0`
+  returning a `%StreamContract{}` matching its actual posture.
+- AC-D4: `test/tau/provider_stream_contract_test.exs` exists and the
+  self-consistency assertion (declared posture matches Replay-fixture
+  output) passes for every adapter.
+- AC-D5: `Tau.Provider.@stream_contract` module attribute exists
+  carrying the canonical sequence prose.
+
+### Module-level AC (synthesis)
+
+- AC-M1: A new adapter author following the `@behaviour Tau.Provider`
+  callbacks (including the new mandatory `stream_contract/0`) cannot
+  pass `mix compile --warnings-as-errors`, `mix test`, AND
+  `mix tau.gate.capabilities` without (a) declaring a usage struct
+  that conforms to `Event.Usage` shape, (b) declaring a stream
+  contract that matches their emitted events, (c) declaring
+  `prompt_caching: true` only if they implement `cache_regions/2`, and
+  (d) routing standard API-key resolution through `Tau.Providers.Auth`
+  (or having an ADR exception row). This is the operational form of
+  the module-level criterion in `problem.md`; an integration test
+  scaffolding a stub adapter and asserting each gate fires verifies it.
+
+## Open questions
+
+- **Live decode-path remediation for Bedrock and Gemini.** The
+  callback-contract-drift solution declares non-conformance via
+  `stream_contract/0` but explicitly defers fixing the decode paths
+  (no `TextStart/End` synthesis, no ToolCallDelta streaming). The
+  declaration layer makes the gap visible; eliminating it is a
+  separate sub-problem. Should a follow-up issue be filed before this
+  module-level solution ships, or after the gate-passing baseline is
+  in place?
+- **Replay adapter posture under `stream_contract/0`.** The Replay
+  adapter is intentionally divergent (test-harness contract is out of
+  scope per `problem.md`); should it declare a special `:replay`
+  variant or re-emit the original adapter's contract? Decision needed
+  before PR-D can compile.
+- **`thinking` flag enforcement.** No equivalent biconditional pattern
+  exists for `thinking: true` because obligations span `build_body/3`
+  and the decode path. Whether a future enforcement layer (e.g.
+  `thinking_config/1` callback) should target it is a follow-up
+  sub-problem; the current solution leaves it advisory-by-doc and
+  demotes the two lying adapters.
+- **`Event.Usage.from_replay/1` deserialiser.** The Replay decoder
+  materialises raw maps from JSONL; reconstructing `%Event.Usage{}` on
+  fixture replay needs a small adapter. Scope into PR-B2 or PR-B3.
+- **`configure/1` dead-callback cleanup.** The auth-resolution-scatter
+  solution explicitly defers this (would force breaking changes on every
+  external implementor). Whether to file a follow-up issue now or wait
+  for a concrete need is undecided.
+- **Future adapters added via extensions** (per SPEC-EXTENSIONS Stage B).
+  The `mix tau.gate.capabilities` task iterates `Tau.Providers.*`; whether
+  it should also iterate loaded extension modules is a Stage B question.
+- **SPEC home for `stream_contract/0`.** Is the new callback a
+  SPEC-PROMPT-CACHING amendment, a new `SPEC-PROVIDER-CONTRACT`, or an
+  ADR? The callback-contract-drift child does not specify; the
+  cross-workstream `docs/PROVIDER-CONTRACT.md` index proposed above is a
+  candidate home but is not a SPEC under `.claude/rules/spec-before-code.md`.
+- **PR-D scope vs `spec-before-code.md`.** Adding a mandatory `@callback`
+  to a multi-implementor behaviour may trigger the spec-before-code rule
+  (the `Tau.Provider` behaviour itself is coordination-heavy by virtue of
+  having eleven implementations). Confirm before PR-D that no existing
+  SPEC owns this surface; if not, a small spec or ADR may need to land
+  with PR-D.
+
+## Linked sub-problems / proposals
+
+- `subproblems/auth-resolution-scatter/` → "Extract `Tau.Providers.Auth`
+  shared resolver, migrate standard adapters, add ADR + telemetry
+  regression test; leave `configure/1` alone."
+- `subproblems/callback-contract-drift/` → "Add mandatory
+  `stream_contract/0` callback backed by `%Tau.Provider.StreamContract{}`
+  struct + `@stream_contract` prose attribute; declare non-conformance
+  for Bedrock/Gemini rather than fixing decode paths in this scope."
+- `subproblems/capabilities-flag-fidelity/` → "Honest flag demotions for
+  Bedrock/Gemini/DeepSeek + `mix tau.gate.capabilities` CI gate enforcing
+  the `prompt_caching ⇔ cache_regions/2` biconditional + prose `@doc`
+  contract; leave `thinking` advisory-by-doc."
+- `subproblems/usage-normalisation/` → "Typed `%Event.Usage{}` struct
+  replacing `usage: map()` + shared `Tau.Provider.UsageNorm` wire-extraction
+  scaffold + per-adapter conformance test template; staged across three
+  PRs (struct → wire-extraction → conformance harness)."
+
+## Revision history
+
+- (revision 0 — initial)

--- a/docs/problems-archive-v1-modules/tau-providers/subproblems/auth-resolution-scatter/problem.md
+++ b/docs/problems-archive-v1-modules/tau-providers/subproblems/auth-resolution-scatter/problem.md
@@ -1,0 +1,90 @@
+---
+template_version: 1
+template_name: problem
+node_kind: leaf
+depth: 1
+parent: ../../problem.md
+status: draft
+---
+
+# Problem: auth-resolution-scatter
+
+## Statement
+
+Every production adapter implements its own credential priority chain (app env →
+vault → env var) as private helper functions, with no shared behaviour, module,
+or scaffold. The vault leg specifically is guarded by a `Code.ensure_loaded?/1`
+conditional in each adapter that implements it, but three adapters
+(Anthropic, Bedrock, Gemini) skip the vault leg entirely, creating silent
+inconsistency: operators who configure credentials via `Tau.Settings.Vault`
+find those credentials honoured by some adapters and silently ignored by others.
+
+## Context
+
+- `lib/tau/providers/anthropic.ex` — delegates to `Tau.Providers.Anthropic.Auth`
+  (a dedicated module); vault integration is via `Tau.Settings.Vault.resolve/1`
+  inside `Auth`, which IS loaded unconditionally (no `Code.ensure_loaded?` guard
+  present in `auth.ex`).
+- `lib/tau/providers/bedrock.ex:180-200` — `credentials/0` reads AWS env vars
+  (`AWS_ACCESS_KEY_ID`) or optional `:aws_credentials` library; no
+  `Tau.Settings.Vault` integration at all. Vault is silently absent.
+- `lib/tau/providers/gemini.ex:171-179` — `api_key/0` checks only
+  `Application.get_env` and `System.get_env`; no vault leg.
+- `lib/tau/providers/mistral.ex:88-98` — `api_key/0` has the pattern:
+  `app_env || vault_key() || System.get_env`; `vault_key/0` uses
+  `Code.ensure_loaded?` guard. Vault present but guarded.
+- `lib/tau/providers/deepseek.ex:95-106` — same vault-guarded pattern as Mistral.
+- `lib/tau/providers/groq.ex:88-104` — same vault-guarded pattern.
+- `lib/tau/providers/azure_openai.ex:127-155` — `resolve_config/0` uses
+  vault-guarded pattern for `api_key`; endpoint/deployment/api_version have no
+  vault leg.
+- `lib/tau/providers/custom.ex:130-154` — `resolve_config/0` uses vault-guarded
+  pattern for `api_key`; `base_url` has no vault leg.
+- `lib/tau/providers/copilot/auth.ex` — distinct two-token model (OAuth
+  long-lived + short-lived API token via `TokenStore`); no standard vault chain
+  applicable.
+- The `@optional_callbacks [configure: 1, ...]` in `lib/tau/provider.ex:131`
+  suggests `configure/1` was intended as the auth-resolution hook, but none
+  of the adapters above use it for credentials; they each embed the chain
+  privately.
+
+## Complecting hypothesis
+
+1. **Credential priority ordering is complected with each adapter module:**
+   whether vault is consulted, and in which position, varies per adapter
+   with no shared enforcement. A bug in the vault leg (e.g. the
+   `Code.ensure_loaded?` guard returning false at unexpected times) will
+   manifest differently — or not at all — depending on which adapter is active.
+2. **The `configure/1` optional callback is complected with undocumented
+   disuse:** it exists in the behaviour as the intended auth-configuration
+   seam but is never used by any production adapter, making it dead interface
+   surface that misleads new adapter authors about where credential logic
+   belongs.
+
+## Decomposition strategy
+
+(leaf — no further decomposition; proceed to proposals)
+
+## Acceptance criterion
+
+Every production adapter consults `Tau.Settings.Vault` for its primary secret
+credential (API key, OAuth token, or equivalent) in a consistent, observable
+priority position — either via a shared `Tau.Providers.Auth` utility or via
+documented per-adapter policy — such that an operator who configures vault
+credentials can predict, without reading each adapter's source, whether those
+credentials will be honoured.
+
+## Out of scope
+
+- Copilot's two-token model internals (OAuth exchange, `TokenStore`) — the
+  auth topology is legitimately distinct; the acceptance criterion requires
+  only that vault integration follows the same priority position as other
+  adapters for the OAuth token lookup.
+- AWS Bedrock SigV4 signing logic — transport security, not credential
+  resolution.
+- Event sequencing and usage normalisation — covered by sibling sub-problems.
+- Capabilities flags — covered by `capabilities-flag-fidelity`.
+
+## Amendment log
+
+- (none yet)

--- a/docs/problems-archive-v1-modules/tau-providers/subproblems/auth-resolution-scatter/proposals/proposal-1.md
+++ b/docs/problems-archive-v1-modules/tau-providers/subproblems/auth-resolution-scatter/proposals/proposal-1.md
@@ -1,0 +1,167 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 1
+parent_problem: ../problem.md
+---
+
+# Proposal 1: Tau.Providers.Auth shared utility module
+
+## Approach
+
+Extract a single `Tau.Providers.Auth` module that provides a
+`resolve_api_key/3` function covering the three-step priority chain
+(app env → vault → system env) and a `resolve_or_error/3` wrapper
+that converts nil to `{:error, :missing_api_key}`. Every adapter that
+currently embeds a private `api_key/0` / `vault_key/0` function pair
+replaces those functions with a call to `Tau.Providers.Auth.resolve_api_key/3`.
+The `Code.ensure_loaded?` guards in Mistral, DeepSeek, Groq, AzureOpenAI,
+and Custom are deleted; `Tau.Settings.Vault` is always called unconditionally
+through the shared module. Gemini and Bedrock gain vault legs for their
+primary secret fields (GOOGLE_API_KEY and AWS credentials respectively).
+The existing `Tau.Providers.Anthropic.Auth` module is kept as-is (it handles
+OAuth complexity that exceeds the shared module's scope); the shared module
+handles only the simpler API-key chain for the remaining adapters.
+
+## Rationale
+
+The complecting hypothesis states that the credential priority chain is
+woven into each adapter module. This proposal decomplects by pulling the
+shared chain logic into one place — adapters become callers, not
+re-implementers. The `Code.ensure_loaded?` guard is the observable symptom of
+the complecting: it exists in each adapter because there is no single owner of
+the vault call. Centralising vault access in `Tau.Providers.Auth` removes the
+guard entirely — there is one place to test whether the vault is called, one
+place to fix a vault bug, and one place to add telemetry for auth resolution
+events. The acceptance criterion (predictable vault honoring across adapters)
+is met because every standard API-key adapter goes through the same path.
+
+## Sketch
+
+```elixir
+defmodule Tau.Providers.Auth do
+  @moduledoc """
+  Shared credential-resolution chain for provider adapters.
+
+  Standard three-step priority: explicit opt → vault → system env.
+  Call `resolve_api_key/3` from a provider's `stream/3` entry point.
+  """
+
+  @doc """
+  Resolve an API key using the standard provider priority chain.
+
+  ## Parameters
+  - `app_env_key` — the atom key under `Application.get_env(:tau, adapter_module)`
+  - `vault_name`  — the vault credential name (e.g. `"MISTRAL_API_KEY"`)
+  - `env_var`     — the fallback `System.get_env` name (e.g. `"MISTRAL_API_KEY"`)
+
+  Returns the first non-nil, non-empty string found, or `nil`.
+  """
+  @spec resolve_api_key(module(), String.t(), String.t()) :: String.t() | nil
+  def resolve_api_key(adapter_module, vault_name, env_var) do
+    Application.get_env(:tau, adapter_module, [])[:api_key] ||
+      Tau.Settings.Vault.resolve({:vault, vault_name}) ||
+      System.get_env(env_var)
+  end
+
+  @doc "resolve_api_key/3 wrapped as a tagged tuple; returns {:error, :missing_api_key} on nil."
+  @spec resolve_api_key_or_error(module(), String.t(), String.t()) ::
+          {:ok, String.t()} | {:error, :missing_api_key}
+  def resolve_api_key_or_error(adapter_module, vault_name, env_var) do
+    case resolve_api_key(adapter_module, vault_name, env_var) do
+      nil -> {:error, :missing_api_key}
+      "" -> {:error, :missing_api_key}
+      key -> {:ok, key}
+    end
+  end
+end
+```
+
+**Adapter call-site change (Mistral example):**
+```elixir
+# Before
+defp api_key do
+  Application.get_env(:tau, __MODULE__, [])[:api_key] ||
+    vault_key() ||
+    System.get_env("MISTRAL_API_KEY")
+end
+
+defp vault_key do
+  if Code.ensure_loaded?(Tau.Settings.Vault) do
+    Tau.Settings.Vault.resolve({:vault, "MISTRAL_API_KEY"})
+  end
+end
+
+# After (both private functions removed)
+defp api_key do
+  Tau.Providers.Auth.resolve_api_key(__MODULE__, "MISTRAL_API_KEY", "MISTRAL_API_KEY")
+end
+```
+
+**Gemini addition (vault leg added):**
+```elixir
+# Before
+defp api_key do
+  Application.get_env(:tau, __MODULE__, [])[:api_key] ||
+    System.get_env("GOOGLE_API_KEY") || System.get_env("GEMINI_API_KEY")
+end
+
+# After (vault leg inserted; GOOGLE_API_KEY is the primary env var name)
+defp api_key do
+  Tau.Providers.Auth.resolve_api_key(__MODULE__, "GOOGLE_API_KEY", "GOOGLE_API_KEY") ||
+    System.get_env("GEMINI_API_KEY")
+end
+```
+
+**File changes:**
+- `lib/tau/providers/auth.ex` — new file (~50 lines)
+- `lib/tau/providers/mistral.ex` — delete `vault_key/0`, simplify `api_key/0`
+- `lib/tau/providers/deepseek.ex` — same
+- `lib/tau/providers/groq.ex` — same
+- `lib/tau/providers/azure_openai.ex` — `api_key` leg of `resolve_config/0`
+- `lib/tau/providers/custom.ex` — `api_key` leg of `resolve_config/0`
+- `lib/tau/providers/gemini.ex` — add vault leg to `api_key/0`
+- `lib/tau/providers/bedrock.ex` — add vault option for `AWS_ACCESS_KEY_ID` (or document as out-of-scope per problem.md)
+- `test/tau/providers/auth_test.exs` — new unit + property tests
+
+## Tradeoffs
+
+### Strengths
+
+- Deletes the `Code.ensure_loaded?` guard at all five call sites in one pass; no new instances can appear at new adapters if they follow the pattern.
+- Single place to test vault honoring — one property test covers all adapters indirectly.
+- Incremental: adapters migrate independently; no big-bang rewrite required.
+- No behaviour change to `Tau.Provider` callbacks; zero API breakage to callers.
+- `Tau.Providers.Anthropic.Auth` complexity (OAuth, error descriptions) is left untouched.
+
+### Weaknesses
+
+- Does not address Bedrock's structurally different credential shape (AWS key triple vs single API key); Bedrock gets only a partial fix (the env guard remains around the `:aws_credentials` library leg, which is legitimately optional).
+- The `resolve_api_key/3` signature forces caller-provided `vault_name` and `env_var` strings, meaning a typo in any adapter is still a silent per-adapter defect — it just moves the defect from logic to data.
+- Does not remove the dead `configure/1` callback; that's a separate concern per the problem statement but leaves a confusing interface standing.
+- Gemini's dual env-var fallback (`GOOGLE_API_KEY` vs `GEMINI_API_KEY`) requires a small adapter-specific wrapper that slightly undermines the uniformity story.
+
+### Costs
+
+- 1 new file; 6 adapter files modified; 1 new test file.
+- Zero breaking changes to public API.
+- Migration reviewable in one PR.
+- No new dependencies.
+
+## Dependencies
+
+- `Tau.Settings.Vault` already exists and is already called unconditionally from `Tau.Providers.Anthropic.Auth`; no precondition work needed.
+- The `Code.ensure_loaded?` guards exist because vault was once optional; removing them is safe only if `Tau.Settings.Vault` compiles unconditionally in all mix envs. Verification: `grep -r "Code.ensure_loaded?(Tau.Settings.Vault)" lib/` returns the five adapter sites; none appear in `mix.exs` conditional compilation blocks.
+
+## Confidence
+
+medium — The approach is straightforward and the Anthropic.Auth precedent is
+an existence proof that unconditional vault calls work. Confidence would rise
+to high after verifying that `mix compile --no-deps-check` in a fresh env with
+no optional deps still loads `Tau.Settings.Vault`.
+
+## Prior art / references
+
+- `lib/tau/providers/anthropic/auth.ex` — unconditional vault call without `Code.ensure_loaded?` guard; this is the pattern being generalised.
+- Elixir `Application.get_env` + `||` chain idiom is standard across the Tau codebase.
+- Hickey "Simple Made Easy" — extraction axis: move shared logic to a separate entity rather than duplicating it.

--- a/docs/problems-archive-v1-modules/tau-providers/subproblems/auth-resolution-scatter/proposals/proposal-2.md
+++ b/docs/problems-archive-v1-modules/tau-providers/subproblems/auth-resolution-scatter/proposals/proposal-2.md
@@ -1,0 +1,167 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 2
+parent_problem: ../problem.md
+---
+
+# Proposal 2: Promote configure/1 to a mandatory auth-resolution callback
+
+## Approach
+
+Promote the existing `configure/1` optional callback in `Tau.Provider` to the
+mandatory auth-resolution seam: remove it from `@optional_callbacks`, document
+its contract explicitly (returns `{:ok, resolved_config_map}` or
+`{:error, reason}`), and add a behaviour-level compile-time enforcement
+warning for adapters that do not implement it. Each adapter moves its private
+credential-resolution logic into its own `configure/1` implementation. The
+`Tau.Provider` behaviour adds a `resolve_config/1` default implementation
+(via `defmacro __using__` or a default-impl module) that provides the
+`app_env → vault → system_env` chain as a callable helper for simple adapters
+to delegate to. The dead interface becomes the enforced seam; the scattered
+private functions migrate under a contract that new adapter authors will see
+and follow.
+
+## Rationale
+
+The second complecting hypothesis in the problem statement names the
+`configure/1` optional callback as dead interface that misleads new adapter
+authors. This proposal addresses both hypotheses simultaneously by making
+`configure/1` alive and mandatory rather than extracting a new module. Instead
+of adding a utility module (Proposal 1), this reshapes what the behaviour
+already advertises. Decomplecting: credential resolution is no longer an
+implicit implementation detail of `stream/3` embedded in private functions;
+it becomes an explicit, named, testable behaviour step. The acceptance
+criterion is met because `configure/1` is the single documented seam —
+operators and authors can predict where vault honoring happens without reading
+each adapter's `stream/3`.
+
+## Sketch
+
+**Behaviour change:**
+```elixir
+# lib/tau/provider.ex — before
+@optional_callbacks [configure: 1, chat: 3, cache_regions: 2, context_window: 1]
+
+# After: configure/1 is no longer optional
+@callback configure(opts :: map()) :: {:ok, map()} | {:error, term()}
+@optional_callbacks [chat: 3, cache_regions: 2, context_window: 1]
+```
+
+**Default-chain helper (via __using__ macro):**
+```elixir
+defmacro __using__(_opts) do
+  quote do
+    @doc """
+    Default configure/1: applies the standard app_env → vault → system_env
+    chain for :api_key. Override for custom credential shapes.
+    """
+    def configure(opts) do
+      env = Application.get_env(:tau, __MODULE__, [])
+      api_key =
+        Map.get(opts, :api_key) ||
+          env[:api_key] ||
+          Tau.Settings.Vault.resolve({:vault, __MODULE__.vault_key_name()}) ||
+          System.get_env(__MODULE__.env_var_name())
+
+      case api_key do
+        nil -> {:error, :missing_api_key}
+        "" -> {:error, :missing_api_key}
+        key -> {:ok, Map.put(opts, :api_key, key)}
+      end
+    end
+
+    defoverridable configure: 1
+  end
+end
+```
+
+**Adapter declaration (Mistral example):**
+```elixir
+defmodule Tau.Providers.Mistral do
+  use Tau.Provider
+
+  # Declare the vault/env-var names consumed by the default configure/1
+  @vault_key_name "MISTRAL_API_KEY"
+  @env_var_name   "MISTRAL_API_KEY"
+  def vault_key_name, do: @vault_key_name
+  def env_var_name, do: @env_var_name
+
+  # Private api_key/0 removed; stream/3 calls configure/1 instead
+  @impl true
+  def stream(messages, opts, ctx) do
+    with {:ok, config} <- configure(opts) do
+      ...build_request(config.api_key)...
+    end
+  end
+end
+```
+
+**Anthropic override (keeps full OAuth logic):**
+```elixir
+defmodule Tau.Providers.Anthropic do
+  use Tau.Provider
+
+  @impl true
+  def configure(opts) do
+    # Delegates to the existing Tau.Providers.Anthropic.Auth.resolve/1
+    case Tau.Providers.Anthropic.Auth.resolve(opts) do
+      {:ok, auth} -> {:ok, Map.put(opts, :auth, auth)}
+      {:error, _} = err -> err
+    end
+  end
+end
+```
+
+**Compile-time enforcement option** (adapter omitting `configure/1` gets a
+dialyzer warning from the mandatory callback; no runtime penalty):
+```elixir
+# Any adapter NOT implementing configure/1 will emit:
+# warning: module Tau.Providers.Foo does not implement required callback configure/1
+```
+
+**File changes:**
+- `lib/tau/provider.ex` — remove configure/1 from @optional_callbacks; add `__using__` macro with default impl and defoverridable
+- `lib/tau/providers/mistral.ex`, `deepseek.ex`, `groq.ex`, `azure_openai.ex`, `custom.ex`, `gemini.ex`, `bedrock.ex` — add `vault_key_name/0` and `env_var_name/0`; replace private chain functions; call `configure/1` from `stream/3`
+- `lib/tau/providers/anthropic.ex` — add `@impl true` on `configure/1`, delegate to `Anthropic.Auth`
+- `test/tau/providers/*_test.exs` — add `configure/1` tests per adapter
+
+## Tradeoffs
+
+### Strengths
+
+- Directly resolves the second complecting hypothesis (dead interface) — `configure/1` goes from misleading ghost to the canonical auth seam.
+- Compile-time enforcement: dialyzer flags any new adapter that forgets to implement it, making the contract self-documenting.
+- Default implementation via `__using__` means simple adapters get vault honoring for free without any logic in their module body.
+- `stream/3` becomes cleaner: it calls `configure/1` and pattern-matches the result; no private helper chain inline.
+
+### Weaknesses
+
+- Making `configure/1` mandatory is an API-breaking change to the `Tau.Provider` behaviour. Any external code (plugins, test doubles, the Replay adapter) that implements the behaviour but not `configure/1` will now get a dialyzer warning or compile failure.
+- The `defoverridable` + `vault_key_name/0` / `env_var_name/0` module attribute pattern is an awkward inversion: the default implementation calls module-level functions that the adapter must define, which is more implicit than Proposal 1's explicit parameter passing.
+- Bedrock's credential shape (AWS key triple, not a single API key) does not fit the `{:ok, %{api_key: ...}}` default; Bedrock must fully override `configure/1` with a bespoke implementation — no sharing gained there.
+- The `__using__` macro adds a hidden dependency between `Tau.Provider` and `Tau.Settings.Vault` at compile time; modules that `use Tau.Provider` will now pull in `Tau.Settings.Vault` even if they don't need it (e.g. the Replay adapter).
+- `stream/3` calling `configure/1` changes the call-graph timing: today, configuration errors surface inside private functions called from `stream/3`; after the change, they surface from `configure/1` before `stream/3` body runs, which may change error tuple shapes visible to callers.
+
+### Costs
+
+- Moderate: all eleven adapter modules require changes (not just the five with vault guards).
+- The Replay adapter must either implement a no-op `configure/1` or be special-cased in the `__using__` macro.
+- Any existing call sites that pass `configure/1`-shaped opts may need updating.
+- Dialyzer baseline must be rebuilt after the callback change.
+
+## Dependencies
+
+- No library upgrades needed.
+- The Replay adapter's test-harness contract must be audited before making configure/1 mandatory — if Replay intentionally omits it, a `defoverridable` default must handle the no-op case gracefully.
+- `mix dialyzer` must be re-run to establish clean PLT after the callback promotion.
+
+## Confidence
+
+medium — The `defoverridable` + `__using__` pattern is idiomatic Elixir and used elsewhere in the OTP/Phoenix ecosystem. Confidence constrained to medium because the API breakage surface (external adapter authors, test doubles) is wider than Proposal 1's; a spike to audit all `@behaviour Tau.Provider` implementations in test/ would raise it.
+
+## Prior art / references
+
+- Elixir `__using__` macro with `defoverridable` for default behaviour implementations: used in Phoenix (`Phoenix.Controller`, `Phoenix.LiveView`).
+- `Tau.Provider.@optional_callbacks` existing pattern — inverse of this proposal.
+- Hickey "Simple Made Easy" — interface axis: "complecting" the auth seam with `stream/3`'s body is the problem; making configure/1 a hard contract separates the concerns at the interface level.

--- a/docs/problems-archive-v1-modules/tau-providers/subproblems/auth-resolution-scatter/proposals/proposal-3.md
+++ b/docs/problems-archive-v1-modules/tau-providers/subproblems/auth-resolution-scatter/proposals/proposal-3.md
@@ -1,0 +1,196 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 3
+parent_problem: ../problem.md
+---
+
+# Proposal 3: Auth.Spec data-shape contract + compile-time assertion
+
+## Approach
+
+Define a `Tau.Providers.Auth.Spec` struct that each adapter declares as a
+module attribute, encoding the adapter's credential layout as data (which vault
+names map to which resolved fields, and which env vars are the fallbacks). A
+`Tau.Providers.Auth.Resolver.resolve/2` function takes an `Auth.Spec` and an
+opts map and applies the standard chain. Adapters that fit the standard shape
+declare `@auth_spec` and call `Resolver.resolve(@auth_spec, opts)` from
+`stream/3`; they contain no credential logic. A compile-time `@on_definition`
+hook (or a Mix task `mix tau.check_auth_specs`) asserts that every module
+claiming `@behaviour Tau.Provider` either declares `@auth_spec` or implements
+a documented override marker `@auth_custom true` — making the gap between
+"has a spec" and "silently missing vault" observable without running code.
+
+## Rationale
+
+This proposal addresses the complecting hypothesis at the **data level** rather
+than the control-flow level. Today the credential chain is encoded as procedure
+(a sequence of function calls). This proposal encodes it as data (a struct that
+says "my vault name is X, my env fallback is Y, my app-env key is :api_key").
+The `Auth.Spec` struct makes the priority chain a first-class value: it can be
+inspected, tested independently of any adapter, and emitted as telemetry metadata.
+The compile-time assertion closes the silent-inconsistency hole: an adapter that
+forgets vault coverage fails the assertion rather than silently ignoring vault at
+runtime. The acceptance criterion (predictable, observable vault honoring) is
+met because the spec is the single declaration that an operator or tooling can
+inspect to determine coverage.
+
+## Sketch
+
+```elixir
+defmodule Tau.Providers.Auth.Spec do
+  @moduledoc """
+  Declarative credential layout for a provider adapter.
+
+  Encodes the app_env → vault → system_env priority chain as data.
+  Adapters with non-standard shapes (Anthropic OAuth, Bedrock SigV4)
+  set custom?: true and manage resolution themselves.
+  """
+
+  @enforce_keys [:vault_name, :env_var]
+  defstruct [
+    :vault_name,       # String — vault credential name, e.g. "MISTRAL_API_KEY"
+    :env_var,          # String — System.get_env fallback
+    :app_env_key,      # atom — Application.get_env key (default: :api_key)
+    custom?: false     # true = adapter manages resolution; spec is documentation only
+  ]
+
+  @type t :: %__MODULE__{
+    vault_name:   String.t() | nil,
+    env_var:      String.t() | nil,
+    app_env_key:  atom(),
+    custom?:      boolean()
+  }
+end
+```
+
+```elixir
+defmodule Tau.Providers.Auth.Resolver do
+  @moduledoc "Applies a Tau.Providers.Auth.Spec to an opts map."
+
+  alias Tau.Providers.Auth.Spec
+
+  @spec resolve(Spec.t(), module(), map()) ::
+          {:ok, String.t()} | {:error, :missing_api_key}
+  def resolve(%Spec{custom?: true}, _adapter, _opts) do
+    {:error, :custom_auth_required}
+  end
+
+  def resolve(%Spec{} = spec, adapter, opts) do
+    key =
+      Map.get(opts, spec.app_env_key || :api_key) ||
+        Application.get_env(:tau, adapter, [])[spec.app_env_key || :api_key] ||
+        Tau.Settings.Vault.resolve({:vault, spec.vault_name}) ||
+        System.get_env(spec.env_var)
+
+    case key do
+      nil -> {:error, :missing_api_key}
+      ""  -> {:error, :missing_api_key}
+      k   -> {:ok, k}
+    end
+  end
+end
+```
+
+**Adapter declaration (Mistral):**
+```elixir
+defmodule Tau.Providers.Mistral do
+  @behaviour Tau.Provider
+
+  @auth_spec %Tau.Providers.Auth.Spec{
+    vault_name: "MISTRAL_API_KEY",
+    env_var: "MISTRAL_API_KEY"
+  }
+
+  @impl true
+  def stream(messages, opts, ctx) do
+    with {:ok, api_key} <- Tau.Providers.Auth.Resolver.resolve(@auth_spec, __MODULE__, opts) do
+      ...
+    end
+  end
+  # private api_key/0 and vault_key/0 deleted
+end
+```
+
+**Anthropic (custom shape):**
+```elixir
+@auth_spec %Tau.Providers.Auth.Spec{vault_name: nil, env_var: nil, custom?: true}
+# Anthropic.Auth.resolve/1 still handles OAuth chain; @auth_spec is declarative metadata
+```
+
+**Compile-time assertion (Mix task):**
+```elixir
+defmodule Mix.Tasks.Tau.CheckAuthSpecs do
+  @moduledoc "Assert every Tau.Provider adapter declares @auth_spec."
+  use Mix.Task
+
+  @impl true
+  def run(_args) do
+    providers = Tau.Provider.known_adapters()  # or discovered via :application.get_key
+
+    missing =
+      Enum.filter(providers, fn mod ->
+        not Map.has_key?(mod.__info__(:attributes), :auth_spec)
+      end)
+
+    if missing != [] do
+      Mix.shell().error("Missing @auth_spec on: #{inspect(missing)}")
+      exit({:shutdown, 1})
+    end
+  end
+end
+```
+
+**File changes:**
+- `lib/tau/providers/auth/spec.ex` — new (~25 lines)
+- `lib/tau/providers/auth/resolver.ex` — new (~40 lines)
+- `lib/tau/providers/mistral.ex`, `deepseek.ex`, `groq.ex`, `azure_openai.ex`, `custom.ex`, `gemini.ex` — declare `@auth_spec`, remove private helpers
+- `lib/tau/providers/anthropic.ex` — declare `@auth_spec` with `custom?: true`
+- `lib/tau/providers/bedrock.ex` — declare `@auth_spec` with `custom?: true`
+- `lib/mix/tasks/tau.check_auth_specs.ex` — new (~30 lines)
+- `test/tau/providers/auth/resolver_test.exs` — unit + property tests
+
+## Tradeoffs
+
+### Strengths
+
+- Data-first: the `Auth.Spec` struct is inspectable at runtime (telemetry, `tau doctor`, debug output) — operators can query which adapters have vault coverage without reading source.
+- Compile-time assertion closes the "silently added adapter without vault" gap at the CI level, not just the code-review level.
+- `custom?: true` provides an explicit escape hatch with an annotation trail — it is impossible to silently omit vault without marking `custom?: true`, which is itself visible and searchable.
+- Orthogonal to Proposal 1 and 2: can co-exist with either; `Auth.Spec` is a description, not a replacement for `configure/1` or a utility function.
+
+### Weaknesses
+
+- Higher complexity than Proposal 1: three new artifacts (Spec struct, Resolver, Mix task) vs one utility module.
+- The Mix task `mix tau.check_auth_specs` must be added to CI manually; it is not a compile-time error, only a CI gate — a developer who doesn't run it locally can still merge a missing-spec adapter.
+- `@on_definition` compile-time hooks are possible in Elixir but fragile; the Mix task is more robust but requires discipline to wire into CI.
+- `Tau.Provider.known_adapters/0` does not currently exist; the Mix task needs a registry or module discovery mechanism, which is itself new infrastructure.
+- Struct-as-metadata adds a new dependency direction: `Tau.Providers.Auth.Spec` becomes a type that adapter modules depend on; any future changes to the struct require touching all adapters.
+- Azure's `resolve_config/0` resolves three fields (api_key, endpoint, deployment) but Auth.Spec models only one primary credential field; multi-field adapters would need a spec extension.
+
+### Costs
+
+- 3 new files; 7 adapter files modified; CI wiring change.
+- No breaking changes to `Tau.Provider` callback surface.
+- `Tau.Provider.known_adapters/0` must be implemented or the Mix task must use `:application.get_key` discovery (fragile).
+
+## Dependencies
+
+- A mechanism to enumerate all `@behaviour Tau.Provider` implementations is needed for the Mix task; either a centrally-registered list in `Tau.Provider` or compile-time discovery.
+- No library upgrades needed.
+
+## Confidence
+
+low-medium — The struct + resolver shape is clean and the Auth.Spec concept has
+strong prior art in Ecto's schemaless changesets and Absinthe's type definitions.
+Confidence is constrained by the unresolved adapter-discovery mechanism and the
+Azure multi-field gap. A prototype of the Mix task and a proof that
+`known_adapters/0` can be implemented without `:application.get_key` fragility
+would raise confidence to medium.
+
+## Prior art / references
+
+- Ecto changeset schemas — credential layout as a declared data shape, not procedural validation.
+- Absinthe `object/2` type declarations — making what was implicit (field presence) explicit and inspectable.
+- `mix xref` as a precedent for compile-time cross-module assertions in Mix tasks.
+- Hickey "Simple Made Easy" — data-shape axis: moving from "how" (procedure) to "what" (data declaration).

--- a/docs/problems-archive-v1-modules/tau-providers/subproblems/auth-resolution-scatter/proposals/proposal-4.md
+++ b/docs/problems-archive-v1-modules/tau-providers/subproblems/auth-resolution-scatter/proposals/proposal-4.md
@@ -1,0 +1,184 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 4
+parent_problem: ../problem.md
+---
+
+# Proposal 4: Document-only per-adapter policy + telemetry enforcement (no code extraction)
+
+## Approach
+
+Do not extract shared auth logic. Instead, audit every adapter's auth
+resolution against a documented policy, fix the three adapters with silent
+vault omissions (Gemini, Bedrock primary secret, Azure non-key fields) by
+adding vault legs inline, remove the `Code.ensure_loaded?` guards, and enforce
+correctness going forward via a telemetry-based test that asserts every
+adapter's `stream/3` emits a `[:tau, :vault, :get]` event (or a documented
+`:skipped` tag) before returning its first event. A new `SPEC-PROVIDERS-AUTH`
+section in `docs/spec/SPEC-USER-TURN.md` (or a dedicated `docs/adr/ADR-00XX`)
+documents the expected vault position for each adapter. The policy is enforced
+by a property-based test that stubs `Tau.Settings.Vault` and asserts that each
+adapter honours it. Copilot's custom OAuth shape is documented as the lone
+policy exception.
+
+## Rationale
+
+The complecting hypothesis claims credential resolution is woven into each
+adapter. This proposal challenges the premise that extraction is necessary:
+the woven concern is not inherently bad if each adapter's woven logic is
+correct, minimal, and verified by tests. The acceptance criterion is met not
+by sharing code but by sharing a documented, tested invariant ("vault is at
+position 2 in every adapter's chain"). The `Code.ensure_loaded?` guards are
+bugs, not design — they should be deleted rather than wrapped. This is a
+behaviour-correcting (not extraction) approach: fix the wrong implementations
+in place, document the policy, test it per adapter. Decomplecting: instead
+of pulling out shared code, this proposal makes the policy an explicit artifact
+(ADR + test) that new adapter authors can read and follow, removing the
+complect between "the adapter" and "the undocumented chain convention."
+
+## Sketch
+
+**Inline fix (Gemini, adding vault leg):**
+```elixir
+# lib/tau/providers/gemini.ex — after
+defp api_key do
+  Application.get_env(:tau, __MODULE__, [])[:api_key] ||
+    Tau.Settings.Vault.resolve({:vault, "GOOGLE_API_KEY"}) ||
+    System.get_env("GOOGLE_API_KEY") ||
+    System.get_env("GEMINI_API_KEY")
+end
+```
+
+**Inline fix (Mistral/DeepSeek/Groq — remove Code.ensure_loaded? guard):**
+```elixir
+# lib/tau/providers/mistral.ex — after
+defp api_key do
+  Application.get_env(:tau, __MODULE__, [])[:api_key] ||
+    Tau.Settings.Vault.resolve({:vault, "MISTRAL_API_KEY"}) ||
+    System.get_env("MISTRAL_API_KEY")
+end
+# vault_key/0 private function deleted entirely
+```
+
+**Policy document (ADR or SPEC section):**
+```
+## Auth resolution policy (ADR-00XX or SPEC-USER-TURN §N)
+
+Every production adapter MUST resolve its primary API secret via the
+following priority chain:
+
+  1. Explicit per-call opt (`:api_key` or equivalent)
+  2. `Application.get_env(:tau, adapter_module)[:api_key]`  (app env)
+  3. `Tau.Settings.Vault.resolve({:vault, "<ADAPTER_ENV_VAR_NAME>"})`
+  4. `System.get_env("<ADAPTER_ENV_VAR_NAME>")`             (fallback)
+
+Deviations from this chain MUST be documented in this table:
+
+| Adapter        | Primary secret     | Vault name            | Exception                          |
+|----------------|--------------------|-----------------------|------------------------------------|
+| Anthropic      | OAuth or api_key   | ANTHROPIC_API_KEY     | OAuth leg after vault              |
+| Bedrock        | AWS key triple     | AWS_ACCESS_KEY_ID     | :aws_credentials library leg added |
+| Gemini         | api_key            | GOOGLE_API_KEY        | none                               |
+| Mistral        | api_key            | MISTRAL_API_KEY       | none                               |
+| Groq           | api_key            | GROQ_API_KEY          | none                               |
+| DeepSeek       | api_key            | DEEPSEEK_API_KEY      | none                               |
+| AzureOpenAI    | api_key            | AZURE_OPENAI_API_KEY  | endpoint/deployment: no vault leg  |
+| Custom         | api_key            | (user-defined)        | base_url: no vault leg             |
+| Copilot        | OAuth              | (not applicable)      | two-token model; see SPEC-COPILOT  |
+```
+
+**Property test asserting vault coverage:**
+```elixir
+defmodule Tau.Providers.AuthPolicyTest do
+  use ExUnit.Case, async: false
+
+  @adapters [
+    Tau.Providers.Anthropic,
+    Tau.Providers.Gemini,
+    Tau.Providers.Mistral,
+    Tau.Providers.Groq,
+    Tau.Providers.DeepSeek,
+    Tau.Providers.AzureOpenAI,
+    Tau.Providers.Custom
+  ]
+
+  setup do
+    # Instrument vault get calls
+    :ok = :telemetry.attach_many(
+      "test-vault-#{System.unique_integer()}",
+      [[:tau, :vault, :get]],
+      fn event, measurements, metadata, acc_pid ->
+        send(acc_pid, {:vault_call, metadata.name_hash})
+      end,
+      self()
+    )
+    :ok
+  end
+
+  for adapter <- @adapters do
+    test "#{inspect(adapter)} calls Tau.Settings.Vault before falling back to System.get_env" do
+      # Ensure app env and vault miss, but env var present
+      Application.delete_env(:tau, unquote(adapter))
+
+      # stream/3 will fail (no real API), but vault telemetry fires before network
+      _ = unquote(adapter).stream([], %{}, %{})
+
+      assert_received {:vault_call, _},
+        "#{inspect(unquote(adapter))} did not emit [:tau, :vault, :get] during stream/3"
+    end
+  end
+end
+```
+
+**File changes:**
+- `lib/tau/providers/gemini.ex` — add vault leg (~2 lines)
+- `lib/tau/providers/mistral.ex`, `deepseek.ex`, `groq.ex` — remove `vault_key/0`, inline vault call (~-5 lines each)
+- `lib/tau/providers/azure_openai.ex` — remove `vault_key/0`, inline vault call
+- `lib/tau/providers/custom.ex` — remove `vault_key/0`, inline vault call
+- `docs/adr/ADR-00XX-auth-resolution-policy.md` — new ADR
+- `test/tau/providers/auth_policy_test.exs` — new cross-adapter property test
+
+## Tradeoffs
+
+### Strengths
+
+- Smallest code surface change: no new modules, no behaviour changes, no API breakage.
+- The telemetry-based test creates a regression gate that is adapter-agnostic — a future adapter that omits the vault leg will fail the test without any code change to the test.
+- The policy document (ADR) is the canonical reference that satisfies the acceptance criterion's "predictable without reading source" requirement at low code cost.
+- Preserves each adapter's structural autonomy: Bedrock, Copilot, and AzureOpenAI can keep their specialist shapes without being forced into a one-size-fits-all utility module interface.
+
+### Weaknesses
+
+- Does not remove the duplication of the chain logic itself: each adapter still has a private `api_key/0` or inline chain expression. A future adapter author can still get the order wrong.
+- The telemetry-based test is indirect: it asserts that vault telemetry fires, not that the vault result is used correctly. An adapter could call `Tau.Settings.Vault.get/1` and discard the result — the test would pass.
+- The policy table in the ADR is a documentation artefact that drifts from code over time unless the test is the canonical enforcement (it is not — the test checks telemetry, not table conformance).
+- `Code.ensure_loaded?` guards are removed but replaced with nothing — if `Tau.Settings.Vault` is ever conditionally compiled (e.g. a stripped release), the adapters will compile-error rather than degrade gracefully. (This is arguably the correct behaviour, but it changes the failure mode.)
+- Azure's `endpoint` and `deployment` fields remain without vault legs per the policy table; this is a documented partial fix, but it is a partial fix.
+
+### Costs
+
+- Minimal: 6 adapter files with small edits; 1 new test file; 1 new ADR.
+- No migration cost for callers.
+- CI vault-telemetry test adds a small overhead per adapter tested (each does a network-failing `stream/3` call; mocking required for speed).
+
+## Dependencies
+
+- `Tau.Settings.Vault` must be available in the test environment for the telemetry test (it already is via `ExUnit` application start in `mix test`).
+- The telemetry attachment pattern in `test/support/` should be extracted to a shared test helper if it doesn't already exist.
+
+## Confidence
+
+medium — Inline fixes are low-risk and Anthropic's `Auth` module is a working
+precedent that unconditional vault calls are safe. Confidence in the telemetry
+test mechanism is constrained to medium: it is indirect (telemetry event ≠ used
+result); a stronger assertion would mock `Tau.Settings.Vault.resolve/1` and
+assert the return value is threaded into the request, which requires more test
+setup. That stronger form would raise confidence to high.
+
+## Prior art / references
+
+- Elixir telemetry-driven testing: `Phoenix.Logger` test suite instruments telemetry events to assert log behaviour without coupling to implementation.
+- ADR as policy enforcement artifact: AWS Well-Architected Framework credentials chapter — documents expected chain without mandating a shared library.
+- Hickey "Simple Made Easy" — the "simple" alternative to extraction is sometimes documentation + tests, when the concern is small and the pieces fit together without a new composition layer.
+- `lib/tau/providers/anthropic/auth.ex` — unconditional `Tau.Settings.Vault.resolve/1` call with no guard, as the reference implementation to replicate.

--- a/docs/problems-archive-v1-modules/tau-providers/subproblems/auth-resolution-scatter/solution.md
+++ b/docs/problems-archive-v1-modules/tau-providers/subproblems/auth-resolution-scatter/solution.md
@@ -1,0 +1,193 @@
+---
+template_version: 1
+template_name: solution
+parent_problem: ./problem.md
+node_kind: leaf
+synthesised_from: [proposals/proposal-1.md, proposals/proposal-4.md]
+selection_method: hybrid
+revision: 0
+---
+
+# Solution: Tau.Providers.Auth shared resolver + documented policy + telemetry regression test
+
+## Recommendation
+
+Extract a single `Tau.Providers.Auth` module that owns the canonical
+`opt → app_env → vault → system_env` chain as in Proposal 1, migrate every
+standard API-key adapter (Mistral, DeepSeek, Groq, AzureOpenAI, Custom, Gemini)
+to call it (deleting all `Code.ensure_loaded?(Tau.Settings.Vault)` guards),
+and add the missing vault leg to Gemini. From Proposal 4, also land a
+short `docs/adr/ADR-00XX-auth-resolution-policy.md` documenting the chain
+plus the per-adapter exception table (Bedrock AWS-triple, Anthropic OAuth,
+Copilot two-token, Azure non-key fields, Custom `base_url`), and add a
+cross-adapter `auth_policy_test.exs` that uses `[:tau, :vault, :get]`
+telemetry to assert every listed adapter consults vault during credential
+resolution. Bedrock and Copilot are explicitly out of the shared chain; the
+ADR table is their compliance record. The `configure/1` callback is
+**left alone** in this PR (it remains optional/unused) — promoting it is
+Proposal 2's larger refactor and is not required by the acceptance criterion.
+
+## Selected from
+
+- **Chosen:** hybrid of `proposals/proposal-1.md` (extraction) and
+  `proposals/proposal-4.md` (policy doc + telemetry test).
+- **Why chosen:** Proposal 1 has the deepest decomplecting on the control
+  flow axis — it actually removes the duplicated chain logic and the
+  `Code.ensure_loaded?` guards, giving "one place to test, one place to
+  fix" for the standard API-key case. Proposal 4 alone scores lower on
+  decomplecting depth ("the woven concern is fine if each is correct" —
+  acceptable but leaves the future-adapter footgun open). However,
+  Proposal 4's two non-extraction artifacts — the policy ADR and the
+  telemetry regression test — fill real gaps Proposal 1 leaves: the ADR
+  is the operator-readable artifact the acceptance criterion explicitly
+  asks for ("predict without reading each adapter's source"), and the
+  telemetry test mechanically catches future adapters that bypass
+  `Tau.Providers.Auth`. Proposal 2 (promote `configure/1` to mandatory)
+  is rejected because it breaks the `Tau.Provider` behaviour for every
+  external implementor and forces Bedrock/Replay into an awkward
+  override-only shape — high cost, hard reversibility, and the
+  `__using__`-with-module-attributes inversion is more implicit than
+  Proposal 1's explicit parameter passing. Proposal 3 (Auth.Spec struct
+  + Mix task) is rejected for medium-high cost on three new artifacts,
+  Azure's multi-field gap unaddressed by a single-field Spec, and
+  reliance on a `known_adapters/0` registry that does not exist.
+
+### Scoring table
+
+| # | Fit       | Decomplecting depth | Migration cost | Risk   | Reversibility |
+|---|-----------|---------------------|----------------|--------|---------------|
+| 1 | Yes       | Substantial         | Low            | Low    | Easy          |
+| 2 | Yes       | Deep                | High           | Medium | Hard          |
+| 3 | Yes       | Deep                | Medium-High    | Medium | Medium        |
+| 4 | Partially | Surface             | Low            | Low    | Easy          |
+
+Hybrid 1+4: Yes / Substantial / Low / Low / Easy — strictly dominates
+either alone on the relevant axes.
+
+## What changes
+
+- **New file** `lib/tau/providers/auth.ex` — the
+  `Tau.Providers.Auth.resolve_api_key/3` and
+  `resolve_api_key_or_error/3` functions from Proposal 1's sketch.
+  Unconditional `Tau.Settings.Vault.resolve/1` call (no
+  `Code.ensure_loaded?` guard).
+- **Modified** `lib/tau/providers/mistral.ex`,
+  `lib/tau/providers/deepseek.ex`, `lib/tau/providers/groq.ex` — delete
+  private `vault_key/0`; simplify `api_key/0` to call
+  `Tau.Providers.Auth.resolve_api_key(__MODULE__, "<NAME>", "<NAME>")`.
+- **Modified** `lib/tau/providers/azure_openai.ex` — replace the
+  `:api_key` leg of `resolve_config/0` with a call to
+  `Tau.Providers.Auth`. `endpoint`, `deployment`, `api_version` keep
+  their current resolution (no vault leg) and are recorded as exceptions
+  in the ADR table.
+- **Modified** `lib/tau/providers/custom.ex` — same pattern as Azure for
+  the `:api_key` leg; `base_url` keeps its current resolution and is
+  recorded as an exception.
+- **Modified** `lib/tau/providers/gemini.ex` — add the missing vault leg
+  via `Tau.Providers.Auth.resolve_api_key(__MODULE__, "GOOGLE_API_KEY",
+  "GOOGLE_API_KEY")`, then keep the existing `GEMINI_API_KEY` fallback
+  via a small adapter-specific `||` after the shared call.
+- **New file** `docs/adr/ADR-00XX-auth-resolution-policy.md` — states
+  the four-step chain (`opt → app_env → vault → system_env`) and the
+  per-adapter exception table (Anthropic, Bedrock, Copilot, Azure
+  non-key fields, Custom `base_url`).
+- **New file** `test/tau/providers/auth_test.exs` — unit + property
+  tests for `Tau.Providers.Auth` itself (chain order, empty-string
+  rejection, missing-key error tuple).
+- **New file** `test/tau/providers/auth_policy_test.exs` — Proposal 4's
+  cross-adapter telemetry test: for each adapter in the standard list,
+  assert that `[:tau, :vault, :get]` fires during credential resolution.
+
+## What does not change
+
+- The `Tau.Provider` behaviour and its `@optional_callbacks` list,
+  including `configure/1`. The dead-interface second complecting
+  hypothesis is acknowledged but **not** fixed in this PR; that is a
+  separate decision (Proposal 2's scope) and would force breaking
+  changes on every external `@behaviour Tau.Provider` implementor.
+- `lib/tau/providers/anthropic.ex` and
+  `lib/tau/providers/anthropic/auth.ex` — Anthropic continues to use
+  its dedicated OAuth-capable `Auth` module. It is the ADR's first
+  exception row.
+- `lib/tau/providers/bedrock.ex` — the AWS key triple plus optional
+  `:aws_credentials` library leg stays in place. Bedrock is the ADR's
+  second exception row; vault integration for Bedrock is left as a
+  separate scope per the problem's out-of-scope note.
+- `lib/tau/providers/copilot/auth.ex` — the two-token OAuth model is
+  unchanged; Copilot is documented as the third exception.
+- The `Tau.Settings.Vault` module itself, the Replay adapter, and any
+  test doubles of `Tau.Provider`.
+- The `Tau.Provider.Event` shape and all stream-event semantics.
+
+## Migration sketch
+
+Single PR, reviewable in one pass. Sequence:
+
+1. Add `lib/tau/providers/auth.ex` with the two public functions and the
+   unit test file `test/tau/providers/auth_test.exs`. Run
+   `mix test test/tau/providers/auth_test.exs` to confirm the shared
+   module works in isolation.
+2. Migrate the five guarded adapters one at a time
+   (`mistral → deepseek → groq → azure_openai → custom`); each migration
+   is a self-contained commit deleting the private `vault_key/0` and
+   replacing the call site. Run the per-adapter test suite after each.
+3. Add the missing vault leg to `gemini.ex` as a separate commit.
+4. Add the ADR (`docs/adr/ADR-00XX-auth-resolution-policy.md`) including
+   the per-adapter exception table.
+5. Add `test/tau/providers/auth_policy_test.exs` as the cross-adapter
+   telemetry regression gate; ensure it covers all eight standard
+   adapters (Mistral, DeepSeek, Groq, Azure, Custom, Gemini, plus
+   Anthropic via its own `Auth` module — Anthropic is included because
+   its `Auth.resolve/1` does call `Tau.Settings.Vault`). Bedrock and
+   Copilot are explicitly skipped per the ADR exception table.
+6. Run `mix compile --warnings-as-errors`, `mix test`,
+   `mix credo --strict`, `mix dialyzer`. No baseline rebuild expected
+   because the behaviour is unchanged.
+
+Reversal cost is low: the shared module can be deleted and the private
+helpers restored from VCS if the extraction is later judged wrong; the
+ADR and telemetry test would survive the reversal as a documentation
+and regression-gate layer.
+
+## Open questions
+
+- Does `Tau.Settings.Vault` compile unconditionally in every mix env
+  used by Tau today? Proposal 1's confidence rests on this. A
+  `mix compile --no-deps-check` in a fresh env without optional deps
+  must succeed for the `Code.ensure_loaded?` guard removal to be safe.
+  The validator should falsify by checking `mix.exs` for any
+  conditional-compile block guarding `Tau.Settings.Vault`.
+- Should the `Tau.Providers.Auth.resolve_api_key/3` signature accept a
+  single struct (Proposal 3's `Auth.Spec`) instead of three positional
+  arguments? This solution keeps the positional shape for simplicity,
+  but if a future fourth or fifth parameter is needed (e.g. opt-key
+  override, multiple env-var fallbacks for Gemini), refactoring to a
+  struct would be the natural next move.
+- Is the telemetry-based test (Proposal 4's weakness) sufficient to
+  catch future regressions, given it asserts only that vault is
+  *called*, not that its return value is *used*? Strengthening to a
+  stub-based assertion (mock `Vault.resolve/1` and assert the returned
+  value flows into the outbound request body) is a desirable upgrade
+  but out of scope for this PR; the telemetry assertion is the floor.
+- Does the `configure/1` dead callback warrant its own follow-up issue
+  now, or wait until a concrete need arises? The acceptance criterion
+  does not require resolving it; this solution defers.
+
+## Linked sub-problems / proposals
+
+- `proposals/proposal-1.md` — Tau.Providers.Auth shared utility module
+  (extraction; chosen for its deep decomplecting on the standard chain).
+- `proposals/proposal-2.md` — Promote configure/1 to mandatory callback
+  (rejected: high migration cost, API breakage, awkward `__using__`
+  inversion).
+- `proposals/proposal-3.md` — Auth.Spec data-shape contract + Mix-task
+  assertion (rejected: medium-high cost on three new artifacts,
+  unresolved adapter-discovery mechanism, Azure multi-field gap).
+- `proposals/proposal-4.md` — Document-only policy + telemetry test
+  (chosen for the ADR artifact and the telemetry regression test;
+  Proposal 4's "no extraction" stance is rejected, but its non-code
+  artifacts are kept).
+
+## Revision history
+
+- (revision 0 — initial)

--- a/docs/problems-archive-v1-modules/tau-providers/subproblems/auth-resolution-scatter/validation.md
+++ b/docs/problems-archive-v1-modules/tau-providers/subproblems/auth-resolution-scatter/validation.md
@@ -1,0 +1,515 @@
+---
+template_version: 1
+template_name: validation
+parent_solution: ./solution.md
+parent_problem: ./problem.md
+toulmin_complete: true
+falsification_attempted: true
+falsification_outcome: partially_falsified — claim/3
+revision_triggered: none
+---
+
+# Validation: Tau.Providers.Auth shared resolver + documented policy + telemetry regression test
+
+## Overview
+
+The solution makes eight checkable propositions: (1) a new
+`Tau.Providers.Auth` module owns the canonical
+`opt → app_env → vault → system_env` chain; (2) it removes
+`Code.ensure_loaded?(Tau.Settings.Vault)` guards in five adapters
+(Mistral, DeepSeek, Groq, AzureOpenAI, Custom); (3) Gemini gains a
+vault leg via the shared module; (4) an ADR documents the chain and
+per-adapter exceptions; (5) a cross-adapter telemetry test asserts
+each standard adapter consults vault; (6) the `Tau.Provider` behaviour
+(including `configure/1`) is left unchanged; (7) Anthropic continues
+using its dedicated `Auth` module without modification; (8) Bedrock
+and Copilot are explicitly out of the shared chain and recorded as
+exceptions. Falsification proceeded through dependency check
+(`Tau.Settings.Vault` first-party status), counter-example construction
+(can the shared signature accommodate every cited adapter?), edge-case
+enumeration (Gemini's dual env-var fallback, Anthropic's OAuth path,
+Copilot's two-token model), and integration check (`[:tau, :vault,
+:get]` telemetry event exists). Outcome: seven claims withstood; claim 3
+(Gemini vault leg) is partially falsified — Gemini's existing
+`GOOGLE_API_KEY || GEMINI_API_KEY` fallback chain requires the
+solution's qualifier to be narrowed but does not require revision.
+
+## Toulmin per claim
+
+### Claim 1: A new `Tau.Providers.Auth` module owns the canonical four-step chain `opt → app_env → vault → system_env`, with unconditional `Tau.Settings.Vault.resolve/1` calls and no `Code.ensure_loaded?` guard.
+
+- **Claim (C):** "Extract a single `Tau.Providers.Auth` module that
+  owns the canonical `opt → app_env → vault → system_env` chain …
+  Unconditional `Tau.Settings.Vault.resolve/1` call (no
+  `Code.ensure_loaded?` guard)." (solution.md L14–17, L70–73)
+- **Grounds (G):** `lib/tau/settings/vault.ex:1` defines
+  `Tau.Settings.Vault` as a first-party module in `lib/`, not a
+  dep. The existing Anthropic auth path
+  (`lib/tau/providers/anthropic/auth.ex:79–81`) already calls
+  `Tau.Settings.Vault.resolve/1` and
+  `Tau.Settings.Vault.resolve({:vault, "ANTHROPIC_API_KEY"})`
+  unconditionally with no `Code.ensure_loaded?` guard, in production
+  code that ships today. `mix.exs:47–136` lists no optional
+  declaration around the `Tau.Settings.Vault` module (the module is
+  in the project's own `lib/`, not a Hex dep).
+- **Warrant (W):** A first-party module compiled in the same Mix
+  project is always loaded when the calling module is loaded; the
+  BEAM loader does not require a runtime existence check for code in
+  the project's own application. `Code.ensure_loaded?/1` is a guard
+  only meaningful for optional deps or hot-swap scenarios. Removing
+  the guard therefore cannot change behaviour for any production
+  build.
+- **Qualifier (Q):** Holds for every Mix env that includes
+  `elixirc_paths: ["lib", ...]` (all of `:dev`, `:test`, `:prod`
+  per `mix.exs:44–45`). Does not extend to a hypothetical extraction
+  of `Tau.Settings.Vault` into a separate optional dep — out of
+  scope for this PR.
+- **Rebuttal (R):** If a future refactor moved `Tau.Settings.Vault`
+  into a separate optional package, the unconditional call would
+  fail at compile or runtime. The solution does not foresee this;
+  if it ever happens, the guard would need to be reintroduced.
+- **Backing (B):** ADR-0016 (`docs/adr/0016-credential-custody-is-the-os-not-tau.md`)
+  ratifies `Tau.Settings.Vault` as the canonical credential
+  resolution path. Elixir/OTP standard module-loading semantics
+  (in-project modules are always available when their application
+  is loaded).
+
+#### Falsification attempt for claim 1
+
+- **Strategy:** dependency check.
+- **Attempt:** `grep -rn "Tau.Settings.Vault" lib/` confirms
+  `lib/tau/settings/vault.ex` is the module's home (first-party).
+  Inspected `mix.exs` for any conditional or compile-time
+  exclusion of `lib/tau/settings/vault.ex`; none found.
+  `lib/tau/providers/anthropic/auth.ex:79–81` already calls
+  `Tau.Settings.Vault.resolve/1` unguarded in production code that
+  ships today, demonstrating the call pattern is empirically safe.
+- **Outcome:** withstood.
+- **Action:** none.
+
+### Claim 2: The five adapters Mistral, DeepSeek, Groq, AzureOpenAI, and Custom currently use a `Code.ensure_loaded?(Tau.Settings.Vault)` guard around their vault-key lookup; the solution removes all five.
+
+- **Claim (C):** "Modified `lib/tau/providers/mistral.ex`,
+  `lib/tau/providers/deepseek.ex`, `lib/tau/providers/groq.ex` —
+  delete private `vault_key/0`; simplify `api_key/0` to call
+  `Tau.Providers.Auth.resolve_api_key(...)`" + analogous changes
+  for `azure_openai.ex` and `custom.ex` (solution.md L75–86).
+- **Grounds (G):** Direct file inspection confirms the guard in
+  each:
+  - `lib/tau/providers/mistral.ex:94–98` —
+    `if Code.ensure_loaded?(Tau.Settings.Vault) do …`
+  - `lib/tau/providers/deepseek.ex:101–105` — identical pattern.
+  - `lib/tau/providers/groq.ex:94–98` — identical pattern.
+  - `lib/tau/providers/azure_openai.ex:152–156` — identical pattern
+    keyed to `"AZURE_OPENAI_API_KEY"`.
+  - `lib/tau/providers/custom.ex:156–159` — identical pattern keyed
+    to `"CUSTOM_API_KEY"`.
+- **Warrant (W):** All five sites exhibit the exact pattern claim 1
+  shows to be safely simplifiable (unconditional
+  `Tau.Settings.Vault.resolve/1`). Mechanical substitution by a
+  shared call site removes the duplication without changing
+  observable behaviour, satisfying the
+  "one place to test, one place to fix" decomplecting goal.
+- **Qualifier (Q):** Holds for the five adapters whose primary
+  credential is a single string API key resolved by `{:vault,
+  "<UPPERCASE_NAME>"}`. Does not extend to Azure's non-key fields
+  (`endpoint`, `deployment`, `api_version`) or Custom's `base_url`
+  — explicitly out of scope (solution.md L80–83).
+- **Rebuttal (R):** If any of the five had a side-effecting `vault_key/0`
+  body beyond the simple guard+resolve, replacement would change
+  behaviour. Inspection shows all five bodies are exactly the
+  two-line `if Code.ensure_loaded?(...) do Tau.Settings.Vault.resolve(...) end`
+  — no side effects.
+- **Backing (B):** OTP non-negotiable #2 (extensibility seams MUST
+  be behaviours; pattern match on atoms and structs — duplicated
+  guard logic across five concrete modules is the antipattern this
+  invariant exists to forbid).
+
+#### Falsification attempt for claim 2
+
+- **Strategy:** edge-case enumeration over each of the five adapter
+  files.
+- **Attempt:** Read each `vault_key/0` definition. All five are
+  byte-equivalent modulo the env-var name. No side effects, no
+  branching besides the guard, no logging. The shared
+  `Tau.Providers.Auth.resolve_api_key/3` signature
+  `(module, app_env_key_or_module_lookup, vault_name, env_name)` (as
+  sketched in proposal-1) cleanly accommodates the only varying
+  parameter (the env-var name string). Azure's `vault_key/0` is in a
+  larger `resolve_config/0` that also returns endpoint/deployment;
+  the solution explicitly carves out only the `:api_key` leg
+  (L80–83), so this multi-field shape is non-falsifying.
+- **Outcome:** withstood.
+- **Action:** none.
+
+### Claim 3: Gemini, currently lacking any vault leg, will gain one via `Tau.Providers.Auth` plus a small adapter-specific `||` fallback that preserves the existing `GEMINI_API_KEY` alias.
+
+- **Claim (C):** "Modified `lib/tau/providers/gemini.ex` — add the
+  missing vault leg via
+  `Tau.Providers.Auth.resolve_api_key(__MODULE__, "GOOGLE_API_KEY",
+  "GOOGLE_API_KEY")`, then keep the existing `GEMINI_API_KEY`
+  fallback via a small adapter-specific `||` after the shared call."
+  (solution.md L86–89)
+- **Grounds (G):** `lib/tau/providers/gemini.ex:172–175`:
+  ```
+  defp api_key do
+    Application.get_env(:tau, __MODULE__, [])[:api_key] ||
+      System.get_env("GOOGLE_API_KEY") || System.get_env("GEMINI_API_KEY")
+  end
+  ```
+  No vault leg; two env vars. The acceptance criterion (problem.md
+  L69–75) requires every production adapter consult vault for its
+  primary secret credential.
+- **Warrant (W):** A vault leg inserted between `app_env` and
+  `system_env` matches the canonical chain in claim 1 and brings
+  Gemini into compliance with the acceptance criterion. The
+  `GEMINI_API_KEY` second env var is preserved as a post-shared
+  fallback — appending one `||` after the shared call retains the
+  alias semantics without re-architecting the shared signature.
+- **Qualifier (Q):** Holds only if `Tau.Providers.Auth.resolve_api_key/3`
+  is implemented with a clean composition point: the resolver must
+  return `nil` (not raise) on miss, allowing the caller to chain
+  `|| System.get_env("GEMINI_API_KEY")`. Holds only for a single
+  vault name `"GOOGLE_API_KEY"`; the solution does not claim the
+  vault is also consulted under `"GEMINI_API_KEY"`. **Narrowed
+  during validation:** see falsification attempt below.
+- **Rebuttal (R):** An operator who has stored credentials in the
+  vault under the name `"GEMINI_API_KEY"` (matching the historic
+  second env-var alias) will still find them silently ignored —
+  the post-shared `||` only consults `System.get_env`, not
+  `Tau.Settings.Vault.resolve({:vault, "GEMINI_API_KEY"})`. This
+  is a residual silent-inconsistency footgun the acceptance
+  criterion was written to eliminate, narrowed to one env-var
+  alias on one adapter.
+- **Backing (B):** Acceptance criterion in problem.md L69–75 —
+  "an operator who configures vault credentials can predict,
+  without reading each adapter's source, whether those credentials
+  will be honoured." A vault-aware-for-one-alias-only Gemini
+  partially defeats predictability for the second alias.
+
+#### Falsification attempt for claim 3
+
+- **Strategy:** edge-case enumeration over the existing Gemini
+  env-var aliases.
+- **Attempt:** Gemini currently resolves
+  `GOOGLE_API_KEY || GEMINI_API_KEY`. The solution wires vault for
+  `"GOOGLE_API_KEY"` only. An operator who follows the historic
+  practice of storing under `GEMINI_API_KEY` and migrates to the
+  vault will lose access — vault will not be consulted under that
+  alias.
+- **Outcome:** partially falsified. The solution achieves
+  vault-consultation for Gemini under the primary `GOOGLE_API_KEY`
+  alias but not under the `GEMINI_API_KEY` alias.
+- **Action:** narrow claim 3's Qualifier in place (recorded above)
+  and add an outstanding doubt for the ADR exception table to
+  explicitly document this single-name vault coverage. No revision
+  to solution.md required because the acceptance criterion is
+  satisfied for the primary name and the residual is recordable
+  in the ADR (the artifact the solution already commits to land).
+
+### Claim 4: A new `docs/adr/ADR-00XX-auth-resolution-policy.md` documents the chain plus a per-adapter exception table.
+
+- **Claim (C):** "New file `docs/adr/ADR-00XX-auth-resolution-policy.md`
+  — states the four-step chain (`opt → app_env → vault →
+  system_env`) and the per-adapter exception table (Anthropic,
+  Bedrock, Copilot, Azure non-key fields, Custom `base_url`)."
+  (solution.md L90–93)
+- **Grounds (G):** The acceptance criterion (problem.md L69–75)
+  explicitly requires either "a shared `Tau.Providers.Auth` utility
+  or via documented per-adapter policy" — both are listed as
+  satisfying alternatives, and the solution provides both. The
+  `docs/adr/` directory currently contains 23 ADRs (0000-template
+  through 0023, no auth-resolution entry); the next free
+  identifier is well-defined.
+- **Warrant (W):** Spec-before-code rule (`.claude/rules/spec-before-code.md`)
+  obligates a documented record when a coordination-heavy decision
+  is made; the per-adapter exception table is precisely the
+  artifact that satisfies the "predict without reading each
+  adapter's source" clause of the acceptance criterion.
+- **Qualifier (Q):** Holds when the ADR is actually written into
+  the PR (not deferred to a follow-up). The current `docs/adr/`
+  catalog runs 0000–0023; the new ADR would be 0024 (the
+  `ADR-00XX` placeholder in the solution must be resolved at PR
+  time).
+- **Rebuttal (R):** An ADR is a static document; it does not
+  mechanically enforce its claims. If a future adapter author
+  ignores both the ADR and the shared module, the inconsistency
+  reappears. This is the gap claim 5 is designed to close.
+- **Backing (B):** `.claude/rules/spec-before-code.md` §"What this
+  rule requires" — coordination-heavy components carry a
+  documented decision.
+
+#### Falsification attempt for claim 4
+
+- **Strategy:** dependency check.
+- **Attempt:** Listed `docs/adr/`; no auth-resolution ADR exists.
+  The numbering scheme is monotonic; the next ID is 0024. The
+  solution's `00XX` placeholder is conventional but must be
+  resolved before merge.
+- **Outcome:** withstood.
+- **Action:** none, modulo the placeholder resolution at PR time.
+
+### Claim 5: A cross-adapter telemetry test uses `[:tau, :vault, :get]` to assert every listed adapter consults vault during credential resolution.
+
+- **Claim (C):** "New file `test/tau/providers/auth_policy_test.exs`
+  — Proposal 4's cross-adapter telemetry test: for each adapter in
+  the standard list, assert that `[:tau, :vault, :get]` fires
+  during credential resolution." (solution.md L97–99)
+- **Grounds (G):** `lib/tau/settings/vault.ex:55–60, 195–205`
+  documents and emits `[:tau, :vault, :get]` with metadata
+  `%{backend: atom, result: :ok | :not_found | :error, name_hash:
+  <truncated sha256>}`. The credential value is never in the
+  metadata. An existing test
+  (`test/tau/settings/vault_test.exs:137–157`) already asserts the
+  event fires correctly, demonstrating the event is observable in
+  the test environment.
+- **Warrant (W):** A telemetry handler attached in test setup that
+  captures every emission of `[:tau, :vault, :get]` provides a
+  ground-truth audit of which adapters consulted vault during a
+  given test run. Per-adapter assertion that the event fires once
+  per `api_key/0` invocation is a mechanical regression gate that
+  catches any new adapter (or refactor) that bypasses
+  `Tau.Providers.Auth`.
+- **Qualifier (Q):** Holds as a fire-only assertion, not a
+  return-value assertion (solution.md L166–171 acknowledges this
+  explicitly as the test's weakness). The test cannot tell whether
+  a vault hit was *used* downstream — only that it was *attempted*.
+- **Rebuttal (R):** An adapter could fire the event in a swallowed
+  branch (e.g. `_ = Tau.Settings.Vault.resolve(...)` then discard
+  the result) and the test would still pass. Solution.md L166–171
+  acknowledges this and defers stricter assertion to a follow-up.
+- **Backing (B):** OTP non-negotiable #5 (telemetry events MUST
+  cover everything user-visible or perf-sensitive). The shared
+  Vault telemetry surface is the canonical observation point.
+
+#### Falsification attempt for claim 5
+
+- **Strategy:** integration check (does the boundary exist?).
+- **Attempt:** Confirmed `[:tau, :vault, :get]` is emitted from
+  `lib/tau/settings/vault.ex:197` via `:telemetry.execute/3`.
+  Confirmed `test/tau/settings/vault_test.exs:137–157` already
+  exercises the event in test context, so the test surface is
+  proven to work. A cross-adapter test merely fans the existing
+  pattern over each adapter's `api_key/0` invocation.
+- **Outcome:** withstood (modulo the qualifier already noted).
+- **Action:** none.
+
+### Claim 6: The `Tau.Provider` behaviour and its `@optional_callbacks` list (including `configure/1`) are left unchanged in this PR.
+
+- **Claim (C):** "The `Tau.Provider` behaviour and its
+  `@optional_callbacks` list, including `configure/1`. The
+  dead-interface second complecting hypothesis is acknowledged
+  but **not** fixed in this PR." (solution.md L102–107)
+- **Grounds (G):** `lib/tau/provider.ex:74` declares
+  `@callback configure(map()) :: {:ok, map()} | {:error, term()}`
+  and `lib/tau/provider.ex:131` includes `configure: 1` in
+  `@optional_callbacks`. The solution's "What changes" list does
+  not touch `lib/tau/provider.ex`.
+- **Warrant (W):** Behavioural surface is a load-bearing public
+  contract for every external implementor (out-of-tree adapter
+  modules with `@behaviour Tau.Provider`). Promoting `configure/1`
+  to mandatory would break every such implementor on next compile.
+  Deferring the decision keeps scope tight and preserves
+  reversibility.
+- **Qualifier (Q):** Holds for this PR. The deferral does not
+  resolve the "dead interface surface" hypothesis in problem.md
+  §"Complecting hypothesis" item 2 — only the first hypothesis
+  (credential priority complecting) is addressed.
+- **Rebuttal (R):** Leaving the dead callback misleads new adapter
+  authors about where credential logic belongs. The ADR (claim 4)
+  partially mitigates this by stating policy in prose; a
+  follow-up issue would be appropriate.
+- **Backing (B):** OTP non-negotiable #2 (extensibility seams MUST
+  be behaviours) — but the corollary is that the behaviour's
+  shape MUST NOT be changed gratuitously, because every external
+  implementor depends on it.
+
+#### Falsification attempt for claim 6
+
+- **Strategy:** counter-example construction.
+- **Attempt:** Inspected `lib/tau/provider.ex:74, 131` to confirm
+  `configure/1` is already present and optional. Scanned the
+  solution's "What changes" section for any mention of
+  `provider.ex` — none. Therefore the behaviour is provably
+  unchanged.
+- **Outcome:** withstood.
+- **Action:** none. (An outstanding doubt is recorded that the
+  second complecting hypothesis remains unresolved.)
+
+### Claim 7: Anthropic continues to use its dedicated `Auth` module without modification.
+
+- **Claim (C):** "`lib/tau/providers/anthropic.ex` and
+  `lib/tau/providers/anthropic/auth.ex` — Anthropic continues to
+  use its dedicated OAuth-capable `Auth` module." (solution.md
+  L108–111)
+- **Grounds (G):** `lib/tau/providers/anthropic/auth.ex:67–82`
+  implements `resolve/1` with a four-step chain
+  (`opt → vault(opt) → app_env → vault({:vault, "ANTHROPIC_API_KEY"})`)
+  followed by OAuth file fallback. The vault calls are
+  unconditional. The OAuth path (D-017) is a first-class
+  alternative to API-key auth, with five distinct error variants
+  for actionable user messaging (`:no_auth`, `:oauth_expired`,
+  `:oauth_missing_scope`, `:oauth_malformed`).
+- **Warrant (W):** Anthropic's auth shape is materially distinct
+  from the standard API-key adapters — it has two valid auth
+  modes (key, OAuth) and a credential-file dependency
+  (`~/.claude/.credentials.json`) that the shared resolver
+  cannot generically represent. Forcing it into the shared
+  signature would either lose the OAuth path or balloon the
+  shared signature with mode-discrimination logic that benefits
+  only one caller. The ADR exception table is the right artifact
+  for the divergence.
+- **Qualifier (Q):** Holds while Anthropic continues to support
+  both API-key and OAuth modes. If the OAuth mode were dropped,
+  Anthropic could fold into the shared resolver — out of scope.
+- **Rebuttal (R):** Anthropic's auth module duplicates the
+  `app_env → vault` chain logic that the shared module owns. A
+  future refactor could parameterise the shared module to host
+  Anthropic's first half while keeping the OAuth branch local.
+  Out of scope for this PR.
+- **Backing (B):** ADR-0016 establishes vault as canonical
+  credential custody; the Anthropic OAuth path is the documented
+  exception (`docs/spec/SPEC-USER-TURN.md` D-017).
+
+#### Falsification attempt for claim 7
+
+- **Strategy:** counter-example construction.
+- **Attempt:** Read `anthropic/auth.ex` end-to-end. The OAuth path
+  (`resolve_oauth/1`, lines 84–97) reads `~/.claude/.credentials.json`,
+  validates `expires_at` and `scopes`, and returns a five-field
+  OAuth map. No generic `Tau.Providers.Auth.resolve_api_key/3`
+  signature (string-returning) could accommodate this without
+  losing fidelity. The dedicated module is correct.
+- **Outcome:** withstood.
+- **Action:** none.
+
+### Claim 8: Bedrock and Copilot are explicitly out of the shared chain and recorded as exceptions in the ADR table.
+
+- **Claim (C):** "`lib/tau/providers/bedrock.ex` — the AWS key
+  triple plus optional `:aws_credentials` library leg stays in
+  place. Bedrock is the ADR's second exception row …
+  `lib/tau/providers/copilot/auth.ex` — the two-token OAuth model
+  is unchanged; Copilot is documented as the third exception."
+  (solution.md L111–118)
+- **Grounds (G):** `lib/tau/providers/bedrock.ex:178–200`
+  resolves three independent AWS values (access-key, secret-key,
+  session-token) and falls back to the `:aws_credentials` Erlang
+  library. There is no single primary credential a shared
+  resolver could meaningfully target.
+  `lib/tau/providers/copilot/auth.ex:1–40` documents the
+  two-token model (long-lived OAuth + short-lived API token via
+  `TokenStore`) and uses a credential-file path
+  (`~/.config/github-copilot/hosts.json`) that has no shared-chain
+  analogue.
+- **Warrant (W):** Both adapters have credential topologies the
+  shared chain provably cannot represent (three-field AWS triple;
+  long-lived/short-lived token exchange). The acceptance criterion
+  explicitly contemplates this: "via a shared `Tau.Providers.Auth`
+  utility OR via documented per-adapter policy" — both Bedrock
+  and Copilot belong to the second clause, recorded in the ADR.
+- **Qualifier (Q):** Holds while Bedrock's auth remains the AWS
+  triple and Copilot remains two-token. The problem.md
+  out-of-scope note (L78–84) explicitly excludes both topologies
+  from generalisation.
+- **Rebuttal (R):** Bedrock currently has no vault integration at
+  all. An operator who stores `AWS_ACCESS_KEY_ID` in vault will
+  find it silently ignored. The acceptance criterion's
+  predictability clause is partially defeated for Bedrock —
+  resolved by the ADR exception row, which documents the
+  predictability boundary rather than enforces it.
+- **Backing (B):** Acceptance criterion's
+  "shared OR documented" clause (problem.md L69–75) and
+  out-of-scope note (problem.md L78–84). ADR-0016 establishes
+  vault as the canonical credential channel; the ADR-00XX (new)
+  documents which adapters live outside that channel and why.
+
+#### Falsification attempt for claim 8
+
+- **Strategy:** counter-example construction over the AWS triple.
+- **Attempt:** Tried to fit `{access_key_id, secret_access_key,
+  session_token}` into the proposed
+  `Tau.Providers.Auth.resolve_api_key/3` signature (which returns
+  a single string). It cannot — the AWS triple is three
+  correlated values, not one secret. A separate
+  `resolve_aws_credentials/2` or struct-returning shape would be
+  required. The solution correctly carves this out as an
+  exception.
+- **Outcome:** withstood.
+- **Action:** none.
+
+## Cross-claim consistency
+
+Claims 1–3 together describe a "shared resolver covers most adapters,
+documented exceptions cover the rest" architecture. Claims 4 and 5
+provide the two enforcement layers (operator-readable ADR; mechanical
+telemetry test). Claims 6, 7, 8 enumerate the deliberate
+non-modifications (`Tau.Provider` behaviour, Anthropic dedicated
+module, Bedrock/Copilot exceptions).
+
+A potential tension: Claim 2 says "delete `Code.ensure_loaded?` guards"
+because Claim 1 establishes the call is provably safe. But Claim 7
+preserves Anthropic's unguarded calls without modification — i.e. the
+Anthropic module already operates under Claim 1's warrant in
+production today, which is itself the strongest evidence Claim 1 holds.
+No genuine tension; the consistency check strengthens Claim 1.
+
+A second potential tension: Claim 3's partial falsification (Gemini
+vault-aware only for `GOOGLE_API_KEY`, not `GEMINI_API_KEY`) appears
+to weaken Claim 5's "every listed adapter consults vault" assertion.
+Resolution: Claim 5's test only verifies the event *fires*; it does
+not assert vault is consulted under every historic env-var alias.
+The narrowed Qualifier on Claim 3 is internally consistent with
+Claim 5's narrower scope.
+
+## Falsification summary
+
+| # | Claim (short) | Strategy | Outcome | Action |
+|---|---|---|---|---|
+| 1 | Shared `Tau.Providers.Auth` with unconditional vault call | dependency check | withstood | none |
+| 2 | Remove `Code.ensure_loaded?` guards in five adapters | edge-case enumeration | withstood | none |
+| 3 | Gemini gains a vault leg via shared module | edge-case enumeration | partially falsified | narrow Qualifier (recorded in claim 3 Q+R) |
+| 4 | ADR documents chain + exception table | dependency check | withstood | resolve `00XX` placeholder at PR time |
+| 5 | Cross-adapter telemetry test asserts vault consultation | integration check | withstood | none (qualifier acknowledged in solution) |
+| 6 | `Tau.Provider` behaviour unchanged | counter-example construction | withstood | none |
+| 7 | Anthropic dedicated `Auth` module unchanged | counter-example construction | withstood | none |
+| 8 | Bedrock and Copilot are documented exceptions | counter-example construction | withstood | none |
+
+## Revision required
+
+None. Claim 3 is partially falsified but the falsification narrows the
+Qualifier in place rather than requiring a different solution. The
+narrowing is documented in claim 3's Q and R fields and surfaces
+naturally in the ADR's per-adapter exception table (the artifact
+Claim 4 already commits to deliver) — specifically as an explicit row
+stating "Gemini: vault consulted under `GOOGLE_API_KEY` only;
+`GEMINI_API_KEY` is an env-only alias." The acceptance criterion
+("can predict, without reading each adapter's source") is satisfied
+once the ADR records this boundary.
+
+- **Target file:** n/a (no revision triggered)
+- **Revision kind:** n/a
+- **Rationale:** Partial falsification handled in-place via Qualifier
+  narrowing and surfaced through the ADR artifact the solution
+  already commits to deliver.
+
+## Outstanding doubts
+
+- Claim 3's narrowed Qualifier presumes the ADR row for Gemini
+  explicitly enumerates the single vault-name boundary. If the PR
+  author omits the explicit row, the predictability gap reappears.
+  The reviewer should check the ADR table on PR submission.
+- Claim 5's telemetry assertion is fire-only, not use-only
+  (solution.md L166–171 acknowledges this). A future adapter could
+  consult vault and discard the result, leaving the gate green
+  while the credential is silently lost. Strengthening to a
+  stub-based "vault value flows into outbound request body"
+  assertion is a desirable follow-up but out of scope for this PR.
+- The second complecting hypothesis from problem.md (dead
+  `configure/1` callback misleads new adapter authors) is
+  deliberately left unresolved by this PR. A follow-up issue may
+  be warranted but is not required by the acceptance criterion.
+- Bedrock's complete absence of vault integration (rebuttal under
+  Claim 8) is documented but not closed. An operator who expects
+  AWS keys in vault will be silently denied. The ADR records the
+  boundary; the operator-facing improvement is out of scope per
+  the problem statement.

--- a/docs/problems-archive-v1-modules/tau-providers/subproblems/callback-contract-drift/problem.md
+++ b/docs/problems-archive-v1-modules/tau-providers/subproblems/callback-contract-drift/problem.md
@@ -1,0 +1,78 @@
+---
+template_version: 1
+template_name: problem
+node_kind: leaf
+depth: 1
+parent: ../../problem.md
+status: draft
+---
+
+# Problem: callback-contract-drift
+
+## Statement
+
+The `stream/3` callback's implicit structural contract — which event types an
+adapter MUST emit, in which order, and for which content-block kinds — is
+unspecified in the behaviour. Adapters diverge: Bedrock and Gemini emit raw
+`TextDelta` without framing `TextStart`/`TextEnd`; Gemini emits `ToolCallStart`
++ `ToolCallEnd` in a single chunk with no `ToolCallDelta` intermediates; Bedrock
+ignores `content_block_start` events for tool-use blocks entirely. Consumers
+(`Tau.Message.Assembler`, the session FSM render loop) must silently tolerate
+or paper over missing framing events rather than relying on a declared contract.
+
+## Context
+
+- `lib/tau/provider/event.ex:20-46` — `TextStart`, `TextDelta`, `TextEnd` are
+  sibling event types in the union; the behaviour module-doc does not specify
+  which adapters MUST emit them.
+- `lib/tau/providers/anthropic.ex:182-246` — `dispatch/3` emits
+  `TextStart` on `content_block_start`, `TextDelta` on `content_block_delta`,
+  `TextEnd` on `content_block_stop`.
+- `lib/tau/providers/shared/openai_chat_wire.ex:108-166` — synthesises
+  `TextStart` on first non-empty `content` delta, `TextEnd` on `finish_reason`.
+  Synthesis is present but silently omitted for stream paths that never reach
+  a non-empty delta.
+- `lib/tau/providers/bedrock.ex:118-119` — `decode_anthropic_event/2` emits only
+  `TextDelta{block_id: "text", text: t}` with no start/end framing. The block_id
+  is a hardcoded sentinel `"text"`, not a per-block identity.
+- `lib/tau/providers/gemini.ex:95-109` — emits `TextDelta{block_id: "text"}`
+  with no start/end framing; emits `ToolCallStart` + `ToolCallEnd` in a single
+  step, never `ToolCallDelta`.
+- The `@callback stream/3` doc-string in `lib/tau/provider.ex:67` says "elements
+  are `Tau.Provider.Event` structs" but specifies nothing about ordering,
+  pairing, or mandatory event types.
+
+## Complecting hypothesis
+
+1. **The stream contract (event sequencing) is complected with each adapter's
+   wire protocol knowledge:** whether a text block must be bracketed by Start/End
+   events is decided independently per adapter rather than declared at the
+   behaviour layer.
+2. **Consumer resilience is complected with provider conformance:** `Tau.Message.
+   Assembler` and the render loop carry adapter-specific workarounds (e.g.
+   tolerating un-started blocks) instead of receiving guaranteed framing.
+
+## Decomposition strategy
+
+(leaf — no further decomposition; proceed to proposals)
+
+## Acceptance criterion
+
+The `@behaviour Tau.Provider` (or an accompanying spec module / typespec)
+declares the mandatory event-emission rules for `stream/3` — specifically: which
+event types bracket text and tool-call blocks, what `block_id` uniqueness
+guarantees hold, and what the mandatory event sequence looks like for a
+minimal-turn response — such that any adapter not conforming to these rules is
+detectable without reading the adapter's decode path.
+
+## Out of scope
+
+- Usage-map normalisation within `%Event.Done{}` — covered by
+  `usage-normalisation`.
+- `capabilities/0` flag accuracy — covered by `capabilities-flag-fidelity`.
+- Auth-resolution logic — covered by `auth-resolution-scatter`.
+- Transport or SSE parsing internals.
+
+## Amendment log
+
+- (none yet)

--- a/docs/problems-archive-v1-modules/tau-providers/subproblems/callback-contract-drift/proposals/proposal-1.md
+++ b/docs/problems-archive-v1-modules/tau-providers/subproblems/callback-contract-drift/proposals/proposal-1.md
@@ -1,0 +1,168 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 1
+parent_problem: ../problem.md
+---
+
+# Proposal 1: `@stream_contract` module attribute + compile-time typedoc spec
+
+## Approach
+
+Add a machine-readable `@stream_contract` module attribute to `Tau.Provider`
+that declares the mandatory event-emission sequence for `stream/3` in a
+structured Elixir term. The attribute is not executed at runtime; it is
+documentation that any adapter can `use Tau.Provider` to inherit, and that a
+Mix task (`mix tau.check_stream_contract`) reads at compile time to assert each
+adapter's moduledoc or typespec references the required sequence. The
+`@callback stream/3` docstring is updated to reference the contract attribute
+by name, and the event module's `@moduledoc` cross-links it. No runtime
+overhead; conformance is a documentation/review gate, not an execution gate.
+
+## Rationale
+
+The complecting hypothesis is that event-sequencing rules are decided per adapter
+rather than declared at the behaviour layer. This proposal decomplects by placing
+the canonical sequence definition at exactly one location — the behaviour module
+— while leaving adapter implementations unchanged. Consumers gain a single
+authoritative spec to read; a new adapter author following the behaviour has
+immediate guidance. The compile-time check makes deviations detectable without
+reading decode paths. This is the lowest-disruption approach: it adds no runtime
+path, no struct changes, no new supervision entry, and cannot break an already-
+running stream.
+
+## Sketch
+
+```elixir
+# lib/tau/provider.ex — new module-level attribute
+
+@stream_contract %{
+  text_block: %{
+    required_sequence: [:TextStart, {:one_or_more, :TextDelta}, :TextEnd],
+    block_id: :must_be_unique_per_stream,
+    note: "Adapters that emit TextDelta without framing MUST be updated or wrapped."
+  },
+  tool_call_block: %{
+    required_sequence: [:ToolCallStart, {:zero_or_more, :ToolCallDelta}, :ToolCallEnd],
+    block_id: :equals_tool_call_id,
+    note: "ToolCallDelta MAY be absent for providers that batch args."
+  },
+  thinking_block: %{
+    required_sequence: [:ThinkingStart, {:one_or_more, :ThinkingDelta}, :ThinkingEnd],
+    block_id: :must_be_unique_per_stream,
+    note: "Only emitted when capabilities().thinking == true."
+  },
+  stream_envelope: %{
+    required_sequence: [:Start, {:zero_or_more, :block}, :Done],
+    note: "Error may appear at any position; terminates the stream."
+  }
+}
+
+@doc """
+...existing doc...
+
+## Stream contract
+
+All adapters MUST conform to `@stream_contract` (see `Tau.Provider.stream_contract/0`).
+The minimum well-formed text turn is:
+
+    %Start{} → %TextStart{block_id: "b0"} → %TextDelta{block_id: "b0", text: …}+
+             → %TextEnd{block_id: "b0"} → %Done{}
+
+block_id values MUST be unique within a stream. Emitting TextDelta without a
+preceding TextStart on the same block_id violates the contract.
+"""
+@callback stream(messages(), stream_opts(), ctx()) ::
+            {:ok, Enumerable.t()} | {:error, term()}
+
+# Accessor so tooling can read the contract at runtime/test time
+@spec stream_contract() :: map()
+def stream_contract, do: @stream_contract
+```
+
+```elixir
+# mix/tasks/tau.check_stream_contract.ex (new file, ~60 lines)
+defmodule Mix.Tasks.Tau.CheckStreamContract do
+  @shortdoc "Verifies each provider adapter module-doc references the stream contract."
+  use Mix.Task
+
+  @adapters [
+    Tau.Providers.Anthropic,
+    Tau.Providers.Bedrock,
+    Tau.Providers.Gemini,
+    Tau.Providers.OpenAI.Chat,
+    Tau.Providers.OpenAI.Responses,
+    Tau.Providers.Groq,
+    Tau.Providers.Mistral,
+    Tau.Providers.DeepSeek,
+    Tau.Providers.AzureOpenAI,
+    Tau.Providers.Custom,
+    Tau.Providers.Copilot
+  ]
+
+  def run(_) do
+    contract = Tau.Provider.stream_contract()
+    Enum.each(@adapters, fn mod ->
+      doc = mod.__info__(:attributes)[:moduledoc] || ""
+      missing = missing_contract_refs(doc, contract)
+      unless missing == [] do
+        Mix.raise("#{mod} stream/3 doc missing contract refs: #{inspect(missing)}")
+      end
+    end)
+    Mix.shell().info("All adapters reference stream contract. OK.")
+  end
+
+  defp missing_contract_refs(_doc, _contract), do: []
+  # real impl: scan doc string for block kind keywords; flag absences
+end
+```
+
+## Tradeoffs
+
+### Strengths
+
+- Zero runtime cost: no new process, no ETS, no wrapper around the enumerable.
+- Acceptance criterion is met: the behaviour module declares the mandatory
+  event-emission rules; deviations are detectable by reading `@stream_contract`
+  rather than every adapter's decode path.
+- Idempotent: can be merged without any adapter change; adapter fixes are
+  separate PRs.
+- The Mix task doubles as CI lint — a new adapter that omits the doc fails the
+  build.
+
+### Weaknesses
+
+- The check is doc-coverage, not behavioural correctness: an adapter can comply
+  with the doc check while still emitting non-conforming events at runtime.
+- `@stream_contract` is a bare map, not a machine-executable validator; it
+  cannot generate test fixtures or guard a stream automatically.
+- Mix task enforcement relies on moduledoc text patterns — fragile if doc
+  conventions drift.
+- Does not fix the Bedrock/Gemini non-conformance; it only makes the gap
+  detectable.
+
+### Costs
+
+- ~1 PR: attribute addition to `provider.ex`, updated `@callback` doc, new Mix
+  task (~60 LOC), CI job step.
+- Adapter authors must add a one-paragraph compliance note to their moduledoc
+  (11 adapters × ~5 min = ~1 hour editorial).
+- No migration: consumers unchanged.
+
+## Dependencies
+
+- None. Can land independently of any adapter fix.
+
+## Confidence
+
+medium — the approach is well-understood; the weakness is that it does not
+mechanically enforce correct runtime behaviour. Confidence would rise to high
+with a runtime validator (see Proposal 2).
+
+## Prior art / references
+
+- Elixir `@moduledoc` and module attributes as machine-readable spec metadata:
+  standard idiom in Phoenix (`@doc false`, `@behaviour` guards).
+- `mix xref` (Elixir stdlib) as a compile-time cross-reference checker —
+  analogous pattern for detecting missing references.
+- Tau SPEC-USER-TURN §4 uses a declarative contract table with similar shape.

--- a/docs/problems-archive-v1-modules/tau-providers/subproblems/callback-contract-drift/proposals/proposal-2.md
+++ b/docs/problems-archive-v1-modules/tau-providers/subproblems/callback-contract-drift/proposals/proposal-2.md
@@ -1,0 +1,180 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 2
+parent_problem: ../problem.md
+---
+
+# Proposal 2: `Tau.Provider.EventNormaliser` stream wrapper — behaviour-preserving runtime enforcement
+
+## Approach
+
+Introduce `Tau.Provider.EventNormaliser`, a stateful stream transformer that
+sits between any raw adapter enumerable and its consumer. The normaliser holds a
+per-block-id state machine (`:idle → :open → :idle`) and automatically
+synthesises the missing `TextStart` / `TextEnd` framing events when a
+`TextDelta` arrives without a preceding `TextStart` or is followed by a
+`TextDelta` for a different block (or by `Done`). Similarly, it synthesises a
+`ToolCallDelta` wrapping the full args when `ToolCallEnd` arrives without a
+preceding `ToolCallDelta`. `Tau.Provider`'s default `stream/3` wrapper in the
+`__using__` macro (or the session FSM's call site in `Tau.Provider.chat/4`)
+pipes every adapter's enumerable through `EventNormaliser.wrap/1` before
+returning it to the caller. Non-conforming adapters are silently corrected at
+the boundary; consumers receive a guaranteed-framed stream.
+
+## Rationale
+
+The second complecting hypothesis is that consumer resilience is complected with
+provider conformance — `Tau.Message.Assembler` must tolerate un-started blocks
+because adapters don't guarantee framing. This proposal decomplects by pushing
+the tolerance one layer earlier (the boundary between adapter and consumer) and
+making it explicit and testable. Rather than every consumer carrying ad-hoc
+workarounds, a single normaliser carries all the repair logic. Adapters remain
+unchanged for now; the normaliser is the specification made executable — if an
+adapter emits a `TextDelta` with block_id "text", the normaliser fills in the
+`TextStart` automatically. Conforming adapters (Anthropic) pass through
+unchanged because the state machine's happy path emits nothing extra.
+
+## Sketch
+
+```elixir
+# lib/tau/provider/event_normaliser.ex (new file)
+defmodule Tau.Provider.EventNormaliser do
+  @moduledoc """
+  Stream transformer that guarantees every event stream from a provider adapter
+  conforms to the Tau.Provider stream contract (TextStart before TextDelta,
+  TextEnd after the last TextDelta, ToolCallDelta present before ToolCallEnd).
+
+  Wrap an adapter enumerable:
+
+      {:ok, raw} = adapter.stream(msgs, opts, ctx)
+      {:ok, EventNormaliser.wrap(raw)}
+  """
+
+  alias Tau.Provider.Event
+
+  @type block_state :: %{
+    optional(String.t()) => :text | :tool | :thinking
+  }
+
+  @spec wrap(Enumerable.t()) :: Enumerable.t()
+  def wrap(raw_stream) do
+    Stream.transform(raw_stream, %{}, &normalise_event/2)
+  end
+
+  # --- text block: synthesise TextStart if missing ---
+  defp normalise_event(%Event.TextDelta{block_id: bid} = e, state) do
+    case Map.get(state, bid) do
+      :text ->
+        {[e], state}
+      nil ->
+        synthetic_start = %Event.TextStart{block_id: bid}
+        {[synthetic_start, e], Map.put(state, bid, :text)}
+    end
+  end
+
+  defp normalise_event(%Event.TextEnd{block_id: bid} = e, state) do
+    {[e], Map.delete(state, bid)}
+  end
+
+  defp normalise_event(%Event.TextStart{block_id: bid} = e, state) do
+    {[e], Map.put(state, bid, :text)}
+  end
+
+  # --- tool call: synthesise ToolCallDelta wrapping full args if missing ---
+  defp normalise_event(%Event.ToolCallEnd{tool_call_id: id, params: p} = e, state) do
+    case Map.get(state, {:delta_seen, id}) do
+      true ->
+        {[e], Map.delete(state, {:delta_seen, id})}
+      _ ->
+        synthetic_delta = %Event.ToolCallDelta{
+          tool_call_id: id,
+          json_fragment: Jason.encode!(p)
+        }
+        {[synthetic_delta, e], state}
+    end
+  end
+
+  defp normalise_event(%Event.ToolCallDelta{tool_call_id: id} = e, state) do
+    {[e], Map.put(state, {:delta_seen, id}, true)}
+  end
+
+  # --- Done: close any open text blocks ---
+  defp normalise_event(%Event.Done{} = e, state) do
+    synthetic_ends =
+      state
+      |> Enum.filter(fn {k, _} -> is_binary(k) end)
+      |> Enum.map(fn {bid, :text} -> %Event.TextEnd{block_id: bid} end)
+    {synthetic_ends ++ [e], %{}}
+  end
+
+  defp normalise_event(e, state), do: {[e], state}
+end
+```
+
+```elixir
+# lib/tau/provider.ex — wrap point in chat/4 (or stream/3 dispatch)
+defp normalise_stream({:ok, raw}),
+  do: {:ok, Tau.Provider.EventNormaliser.wrap(raw)}
+defp normalise_stream(err), do: err
+```
+
+## Tradeoffs
+
+### Strengths
+
+- Consumers (`Tau.Message.Assembler`, render loop) can drop all ad-hoc
+  tolerances for un-started blocks — the contract is now guaranteed.
+- Acceptance criterion is satisfied: the behaviour (via `EventNormaliser.wrap`)
+  declares and enforces the sequence; a conforming adapter is detectable by
+  verifying the normaliser emits no synthetic events.
+- Behaviour-preserving: existing adapter code does not change; Anthropic's
+  well-formed output passes through with zero synthetic emissions.
+- Testable in isolation: `EventNormaliser` is a pure `Stream.transform` — no
+  process, no GenServer; property tests can fuzz adapter output and assert
+  normalised framing.
+
+### Weaknesses
+
+- Hides non-conforming adapters rather than surfacing them: Bedrock and Gemini
+  continue emitting bare `TextDelta`; the gap is papered over, not fixed.
+  Technical debt accumulates silently.
+- Synthetic `TextStart` events have a synthesised block_id identical to the
+  original `TextDelta.block_id` — for Bedrock this is the sentinel `"text"`,
+  which is not unique per block. Block identity semantics are still wrong; the
+  normaliser cannot invent a real block_id.
+- `ToolCallEnd` synthesis of `ToolCallDelta` encodes full args as
+  `Jason.encode!/1` — if `params` is already a decoded map the round-trip is
+  fine, but the semantics of `ToolCallDelta.json_fragment` (a streaming
+  fragment) are slightly abused for the atomic case.
+- Adds one `Stream.transform` traversal on every stream — negligible but
+  non-zero overhead.
+
+### Costs
+
+- ~1 PR: new `EventNormaliser` module (~100 LOC), wrap-point in `provider.ex`,
+  property tests for the state machine (25–40 test cases).
+- `Tau.Message.Assembler` can simplify once normaliser is in place — optional
+  follow-on PR.
+- Jason compile-time dependency already present; no new deps.
+
+## Dependencies
+
+- `Jason` must be available at the wrap site (it is — already in `mix.exs`).
+- No adapter changes required; this is intentionally a shim.
+
+## Confidence
+
+high — `Stream.transform` with a per-key state map is a standard Elixir idiom;
+the state machine is straightforward. Prototype would take ~2 hours. Prior art
+in the project: `openai_chat_wire.ex` already synthesises TextStart/End,
+confirming the pattern is sound.
+
+## Prior art / references
+
+- `lib/tau/providers/shared/openai_chat_wire.ex:108-166` — existing synthesis
+  pattern for TextStart/TextEnd; the normaliser generalises this approach to
+  all adapters.
+- Elixir `Stream.transform/3` docs — the standard accumulator-transform idiom.
+- "Tolerant Reader" pattern (Fowler) — consumers tolerate variant inputs; here
+  applied at the adapter boundary rather than the consumer.

--- a/docs/problems-archive-v1-modules/tau-providers/subproblems/callback-contract-drift/proposals/proposal-3.md
+++ b/docs/problems-archive-v1-modules/tau-providers/subproblems/callback-contract-drift/proposals/proposal-3.md
@@ -1,0 +1,196 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 3
+parent_problem: ../problem.md
+---
+
+# Proposal 3: API-breaking `stream_contract/0` callback + Dialyzer-enforced type spec
+
+## Approach
+
+Add a mandatory `@callback stream_contract() :: Tau.Provider.StreamContract.t()`
+to the `Tau.Provider` behaviour. Define `Tau.Provider.StreamContract` as a
+struct with fields that declare, per event-block kind, whether Start/End
+framing is guaranteed and whether Delta streaming is used. All eleven adapters
+must implement `stream_contract/0`; the compiler emits a behaviour warning for
+any that don't. A `mix tau.verify_stream_contracts` task instantiates each
+adapter's contract, validates it against a whitelist of legal combinations, and
+reports conformance gaps. A test in `test/tau/provider_stream_contract_test.exs`
+calls `stream_contract/0` on all adapters, exercises a minimal live stream (or
+Replay fixture), and asserts that the emitted events match the adapter's own
+declared contract — making the contract self-falsifying if the adapter lies.
+
+## Rationale
+
+The first complecting hypothesis is that stream-contract decisions are made
+per-adapter rather than at the behaviour layer. This proposal addresses the root
+cause rather than wrapping it: it promotes the contract to the behaviour's
+mandatory interface, forces each adapter to make an explicit declaration, and
+then holds adapters to their declarations via a property test. An adapter that
+emits bare `TextDelta` (Bedrock, Gemini) must declare
+`text_framing: :delta_only` — making the non-conformance visible in code rather
+than only in runtime observation. Consumers can then pattern-match on the
+adapter's declared contract rather than maintaining silent tolerances.
+
+## Sketch
+
+```elixir
+# lib/tau/provider/stream_contract.ex (new file)
+defmodule Tau.Provider.StreamContract do
+  @moduledoc """
+  Declared event-emission contract for a Tau.Provider adapter.
+
+  Each adapter returns one of these from stream_contract/0.
+  The struct encodes what the adapter guarantees; test helpers and
+  consumers pattern-match on it rather than reading adapter source.
+  """
+  @enforce_keys [:text_framing, :tool_call_delta, :block_id_uniqueness]
+  defstruct [
+    :text_framing,          # :start_delta_end | :delta_only
+    :tool_call_delta,       # :streaming | :atomic (End only, no Delta intermediates)
+    :block_id_uniqueness,   # :per_stream | :sentinel (hardcoded string, not unique)
+    thinking_framing: :not_supported  # :start_delta_end | :delta_only | :not_supported
+  ]
+
+  @type text_framing :: :start_delta_end | :delta_only
+  @type tool_call_delta :: :streaming | :atomic
+  @type block_id_uniqueness :: :per_stream | :sentinel
+  @type thinking_framing :: :start_delta_end | :delta_only | :not_supported
+
+  @type t :: %__MODULE__{
+    text_framing: text_framing(),
+    tool_call_delta: tool_call_delta(),
+    block_id_uniqueness: block_id_uniqueness(),
+    thinking_framing: thinking_framing()
+  }
+
+  @doc "The only fully-conforming contract shape."
+  def conformant do
+    %__MODULE__{
+      text_framing: :start_delta_end,
+      tool_call_delta: :streaming,
+      block_id_uniqueness: :per_stream
+    }
+  end
+end
+```
+
+```elixir
+# lib/tau/provider.ex — new mandatory callback
+@callback stream_contract() :: Tau.Provider.StreamContract.t()
+```
+
+```elixir
+# lib/tau/providers/bedrock.ex — example non-conforming declaration
+@impl Tau.Provider
+def stream_contract do
+  %Tau.Provider.StreamContract{
+    text_framing: :delta_only,
+    tool_call_delta: :streaming,
+    block_id_uniqueness: :sentinel
+  }
+end
+```
+
+```elixir
+# lib/tau/providers/anthropic.ex — example conforming declaration
+@impl Tau.Provider
+def stream_contract do
+  Tau.Provider.StreamContract.conformant()
+end
+```
+
+```elixir
+# test/tau/provider_stream_contract_test.exs (new file, excerpt)
+defmodule Tau.ProviderStreamContractTest do
+  use ExUnit.Case, async: true
+
+  @adapters Tau.Provider.known_adapters()  # returns the 11-module list
+
+  describe "stream_contract/0 self-consistency" do
+    for adapter <- @adapters do
+      test "#{adapter} declared contract matches observed events (Replay fixture)" do
+        contract = unquote(adapter).stream_contract()
+        {:ok, stream} = unquote(adapter).stream(
+          TestFixtures.minimal_messages(),
+          %{},
+          TestFixtures.ctx_for(unquote(adapter))
+        )
+        events = Enum.to_list(stream)
+        assert_contract_matches(contract, events)
+      end
+    end
+  end
+
+  defp assert_contract_matches(%{text_framing: :start_delta_end}, events) do
+    # assert TextDelta events are always preceded by TextStart on same block_id
+    ...
+  end
+  defp assert_contract_matches(%{text_framing: :delta_only}, events) do
+    # assert no TextStart/TextEnd present — pure delta stream
+    ...
+  end
+end
+```
+
+## Tradeoffs
+
+### Strengths
+
+- Acceptance criterion fully satisfied: the behaviour declares the mandatory
+  emission rules AND makes them machine-checkable against the adapter's own
+  declaration.
+- Promotes non-conformance from implicit (read the decode path) to explicit
+  (read `stream_contract/0`) — new adapter authors see the contract immediately
+  via `@impl` requirements.
+- Dialyzer will flag any adapter whose `stream_contract/0` return type doesn't
+  match `StreamContract.t()`.
+- The self-consistency test creates a regression gate: if Bedrock is later fixed
+  to emit framing, its `stream_contract/0` must be updated or the test fails.
+
+### Weaknesses
+
+- API-breaking: adds a mandatory callback, so all eleven adapters need a
+  `stream_contract/0` implementation before the PR can compile. This is the
+  highest migration cost of the four proposals.
+- A dishonest declaration (`stream_contract/0` returns `:start_delta_end` while
+  the adapter still emits bare deltas) passes the contract type check but fails
+  the self-consistency test only if the test runs with a real or realistic
+  fixture.
+- The Replay adapter is intentionally divergent (non-production); its
+  `stream_contract/0` needs a special case or a `:replay` sentinel value.
+- `Tau.Provider.known_adapters/0` doesn't exist yet — must be added or the test
+  must hardcode the list.
+
+### Costs
+
+- ~1–2 PRs: new `StreamContract` struct, new callback, 11 adapter
+  implementations, new test module, optional `known_adapters/0` helper.
+- Each adapter's `stream_contract/0` is ~5 LOC; total adapter burden is ~55 LOC
+  across 11 files.
+- Test fixture setup for non-Anthropic adapters (Bedrock, Gemini) requires
+  Replay-style fixtures — depends on what test infra exists for those adapters.
+
+## Dependencies
+
+- `Tau.Providers.Replay` must handle `stream_contract/0` gracefully (return a
+  special value or implement a `:test_only` framing variant).
+- Test fixture infrastructure for Bedrock and Gemini streams (may be partially
+  present already via `test/support/`).
+
+## Confidence
+
+medium — the struct and callback are straightforward; the self-consistency test
+is well-defined in concept but may encounter fixture gaps for non-Anthropic
+adapters that make it hard to land as a single atomic PR.
+
+## Prior art / references
+
+- `Tau.Provider.capabilities/0` — same pattern: a struct returned from a
+  mandatory callback that declares static adapter properties.
+- SPEC-PROMPT-CACHING `cache_regions/2` — behaviour callback that declares
+  adapter caching strategy; similar "declare your posture" idiom.
+- Erlang `:gen_statem` callback-mode declaration (`callback_mode/0`) — a
+  mandatory callback whose return value tells the OTP framework what contract
+  the implementation uses.

--- a/docs/problems-archive-v1-modules/tau-providers/subproblems/callback-contract-drift/proposals/proposal-4.md
+++ b/docs/problems-archive-v1-modules/tau-providers/subproblems/callback-contract-drift/proposals/proposal-4.md
@@ -1,0 +1,197 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 4
+parent_problem: ../problem.md
+---
+
+# Proposal 4: Fix non-conforming adapters at source — behaviour-correcting rewrites of Bedrock and Gemini decode paths
+
+## Approach
+
+Rewrite `Tau.Providers.Bedrock.decode_anthropic_event/2` and
+`Tau.Providers.Gemini`'s event-emission path to emit conformant
+`TextStart` / `TextEnd` framing and genuine per-block unique `block_id`
+values, eliminating the hardcoded `"text"` sentinel. For Gemini, also
+introduce a `ToolCallDelta` emission between `ToolCallStart` and `ToolCallEnd`
+containing the partial argument JSON (or a single full-arg delta immediately
+before `ToolCallEnd` for the atomic case). Simultaneously add a `@spec` to
+`@callback stream/3`'s docstring declaring the now-uniform mandatory sequence.
+The behaviour remains unchanged in callback count; the contract is declared in
+the docstring and in a `Tau.Provider.ContractTest` that exercises all adapters
+via Replay fixtures and asserts the framing invariants hold.
+
+## Rationale
+
+The root cause of consumer resilience being complected with provider conformance
+is that two specific adapters (Bedrock and Gemini) emit structurally incorrect
+event sequences. The prior three proposals document, wrap, or codify the gap
+without eliminating it. This proposal eliminates the source of divergence:
+Bedrock and Gemini emit what the contract requires. Once both adapters conform,
+the `@callback` docstring can describe a single mandatory sequence without
+caveats. The normaliser (Proposal 2) becomes unnecessary; the contract struct
+(Proposal 3) collapses to a single valid shape. Consumers can drop all ad-hoc
+tolerances unconditionally, not just behind a wrapper.
+
+## Sketch
+
+```elixir
+# lib/tau/providers/bedrock.ex — decode_anthropic_event/2, revised
+
+# Before (non-conforming):
+#   emits only: %TextDelta{block_id: "text", text: t}
+
+# After (conforming):
+defp decode_anthropic_event(
+       %{"type" => "content_block_start", "index" => idx, "content_block" => %{"type" => "text"}},
+       _acc
+     ) do
+  block_id = "bedrock-text-#{idx}"
+  {:emit, %Event.TextStart{block_id: block_id}, %{block_id: block_id}}
+end
+
+defp decode_anthropic_event(
+       %{"type" => "content_block_delta", "delta" => %{"type" => "text_delta", "text" => t}},
+       %{block_id: bid}
+     ) do
+  {:emit, %Event.TextDelta{block_id: bid, text: t}, %{block_id: bid}}
+end
+
+defp decode_anthropic_event(
+       %{"type" => "content_block_stop"},
+       %{block_id: bid}
+     ) do
+  {:emit, %Event.TextEnd{block_id: bid}, %{}}
+end
+
+# tool-use block start (was: silently ignored)
+defp decode_anthropic_event(
+       %{"type" => "content_block_start", "index" => idx,
+         "content_block" => %{"type" => "tool_use", "id" => tool_id, "name" => name}},
+       _acc
+     ) do
+  block_id = tool_id || "bedrock-tool-#{idx}"
+  {:emit, %Event.ToolCallStart{tool_call_id: block_id, name: name}, %{tool_id: block_id}}
+end
+```
+
+```elixir
+# lib/tau/providers/gemini.ex — emit_events/1, revised (excerpt)
+
+# Before: emits TextDelta{block_id: "text"} with no framing
+# After:  emits TextStart, TextDelta+, TextEnd per candidate.content part
+
+defp emit_text_part(text, stream_state) do
+  idx = stream_state.text_index
+  bid = "gemini-text-#{idx}"
+  [
+    %Event.TextStart{block_id: bid},
+    %Event.TextDelta{block_id: bid, text: text},
+    %Event.TextEnd{block_id: bid}
+  ]
+end
+
+# Before: emits ToolCallStart + ToolCallEnd in a single chunk, no ToolCallDelta
+# After:  emits ToolCallStart, synthetic ToolCallDelta with full args JSON, ToolCallEnd
+
+defp emit_tool_call(fc, stream_state) do
+  id = fc["id"] || "gemini-tool-#{stream_state.tool_index}"
+  args_json = Jason.encode!(fc["args"] || %{})
+  [
+    %Event.ToolCallStart{tool_call_id: id, name: fc["name"]},
+    %Event.ToolCallDelta{tool_call_id: id, json_fragment: args_json},
+    %Event.ToolCallEnd{tool_call_id: id, params: fc["args"] || %{}}
+  ]
+end
+```
+
+```elixir
+# lib/tau/provider.ex — updated @callback docstring (no new callbacks)
+@doc """
+...
+
+## Mandatory event sequence (all adapters)
+
+A minimal well-formed text turn MUST emit:
+
+    %Start{}
+    %TextStart{block_id: b}       — b is unique within this stream
+    %TextDelta{block_id: b, ...}+ — one or more deltas
+    %TextEnd{block_id: b}
+    %Done{}
+
+A tool-call block MUST emit:
+
+    %ToolCallStart{tool_call_id: id, name: n}
+    %ToolCallDelta{tool_call_id: id, json_fragment: f}+  — MAY be a single full-args fragment
+    %ToolCallEnd{tool_call_id: id, params: p}
+
+block_id values MUST be unique within a stream. The sentinel "text" is not conformant.
+"""
+@callback stream(messages(), stream_opts(), ctx()) ::
+            {:ok, Enumerable.t()} | {:error, term()}
+```
+
+## Tradeoffs
+
+### Strengths
+
+- Eliminates rather than papers over the source of divergence.
+- Consumers can drop all ad-hoc tolerances unconditionally — no wrapper
+  required, no conditional logic per adapter.
+- The `@callback` docstring describes a single mandatory sequence with no
+  adapter-specific caveats, fully satisfying the acceptance criterion.
+- Bedrock and Gemini users gain correct `block_id` values (useful for
+  block-level attribution and replay fidelity).
+
+### Weaknesses
+
+- Highest risk: changes live decode paths for Bedrock and Gemini. A bug in the
+  rewrite breaks streaming for those providers.
+- Bedrock uses `InvokeModelWithResponseStream` with Anthropic-format events;
+  the decode path is tightly coupled to that wire format. Regression testing
+  requires either live AWS credentials or a byte-accurate Bedrock Replay
+  fixture.
+- Gemini's `functionCall` response does not include a streaming intermediate —
+  the `ToolCallDelta` emitted here is always a single-chunk atomic delta, not
+  true streaming. This is semantically correct but may surprise consumers that
+  optimise for incremental argument display.
+- Does not address OpenAI shared wire path synthesis gaps
+  (`openai_chat_wire.ex:108-166`), which has a conditional TextStart synthesis
+  that silently omits the event on empty deltas.
+- Requires comprehensive Replay fixtures for Bedrock and Gemini to land safely.
+
+### Costs
+
+- ~2 PRs: Bedrock decode rewrite (~40 LOC diff) + Gemini emit rewrite (~30 LOC
+  diff), each with matching Replay fixtures and property tests.
+- Existing tests for Bedrock and Gemini may break if they assert on the old
+  non-conforming event sequences — those tests must be updated.
+- If `Tau.Message.Assembler` has hardcoded tolerances for the `"text"` sentinel
+  block_id, those must be removed in a follow-on PR.
+
+## Dependencies
+
+- Byte-accurate Replay fixtures for Bedrock `content_block_start` /
+  `content_block_stop` events (check `test/support/fixtures/`).
+- Byte-accurate Replay fixture for Gemini `functionCall` response with `args`.
+- `Tau.Message.Assembler` tolerances should be removed in the same PR or a
+  tightly-coupled follow-on to avoid a window where the assembler is too
+  strict before the fix lands.
+
+## Confidence
+
+medium — the code changes are straightforward given the wire format docs;
+the risk is fixture completeness. Confidence would rise to high with confirmed
+byte-accurate Bedrock and Gemini Replay fixtures available in the test suite.
+
+## Prior art / references
+
+- `lib/tau/providers/shared/openai_chat_wire.ex:108-166` — existing synthesis
+  of TextStart/TextEnd in a shared wire decoder; confirms the pattern is viable
+  in Tau's architecture.
+- Anthropic `content_block_start` / `content_block_stop` SSE format docs —
+  the Bedrock rewrite mirrors the Anthropic decode path already in
+  `lib/tau/providers/anthropic.ex:182-246`.
+- `lib/tau/providers/anthropic.ex:182-246` — reference conformant implementation
+  to clone structure from.

--- a/docs/problems-archive-v1-modules/tau-providers/subproblems/callback-contract-drift/solution.md
+++ b/docs/problems-archive-v1-modules/tau-providers/subproblems/callback-contract-drift/solution.md
@@ -1,0 +1,160 @@
+---
+template_version: 1
+template_name: solution
+parent_problem: problem.md
+node_kind: leaf
+synthesised_from:
+  - proposals/proposal-1.md
+  - proposals/proposal-3.md
+selection_method: hybrid
+revision: 0
+---
+
+# Solution: `stream_contract/0` mandatory callback + `@stream_contract` attribute spec
+
+## Recommendation
+
+Add a mandatory `@callback stream_contract() :: Tau.Provider.StreamContract.t()` to
+`Tau.Provider`, backed by a new `Tau.Provider.StreamContract` struct (Proposal 3), and
+simultaneously add a `@stream_contract` module attribute to `Tau.Provider` carrying the
+human-readable canonical sequence (Proposal 1). The struct makes non-conformance
+machine-detectable at compile time and self-falsifying via a property test; the attribute
+gives new adapter authors an immediate narrative specification at the behaviour module.
+Non-conforming adapters (Bedrock, Gemini) declare their actual posture
+(`:delta_only`, `:sentinel`) rather than claiming conformance — making the gap visible in
+code. The normaliser shim (Proposal 2) and the live decode-path rewrites (Proposal 4)
+are explicitly deferred: the declaration layer is the work this problem asks for;
+elimination of non-conformance is a separate, riskier task that should follow once the
+contract is codified and the test baseline is green.
+
+## Selected from
+
+- **Chosen:** hybrid of `proposals/proposal-3.md` (primary) + `proposals/proposal-1.md`
+  (secondary).
+- **Why chosen:** See scoring table below.
+
+### Scoring table
+
+| # | Fit | Decomplecting depth | Migration cost | Risk | Reversibility |
+|---|-----|---------------------|----------------|------|---------------|
+| 1 | Partially | Surface | Low | Low | Easy |
+| 2 | Partially | Substantial | Medium | Low | Easy |
+| 3 | Yes | Deep | Medium | Low | Easy |
+| 4 | Yes | Deep | High | High | Hard |
+
+**Proposal 1** satisfies the acceptance criterion only partially: `@stream_contract` as a
+bare map attribute and a doc-coverage Mix task make the gap *readable* but not
+machine-checkable at the type or callback level. An adapter that omits the moduledoc
+paragraph still compiles and passes Dialyzer. Decomplecting is surface-level — the
+complecting (contract decision per-adapter) remains; only documentation moves.
+
+**Proposal 2** satisfies the criterion partially. `EventNormaliser.wrap` enforces the
+sequence at runtime but does not *declare* it at the behaviour layer — the `@callback`
+docstring is unchanged, and adapters are not required to declare their posture.
+Non-conformance is hidden rather than surfaced. The normaliser is a valuable follow-on
+once the declaration exists, but alone it does not answer "which event types are
+mandatory" at the behaviour module.
+
+**Proposal 3** satisfies the criterion fully. The mandatory `stream_contract/0` callback
+forces each adapter to publish its posture as a typed struct; Dialyzer flags missing
+implementations; a self-consistency test holds adapters to their declaration. This is
+the deepest decomplecting available without changing live decode paths: contract
+decisions move from implicit per-adapter to the single shared struct type. Migration
+cost is medium (11 adapters × ~5 LOC) but low risk — the callback is pure/stateless;
+no stream path changes.
+
+**Proposal 4** also satisfies the criterion fully and eliminates root-cause non-conformance,
+but carries high risk (live decode-path rewrites for Bedrock and Gemini, fixture
+dependencies, possible Assembler coupling) and is hard to reverse if a fixture gap
+causes a regression. It is the right *follow-on* once the declaration layer is in place
+and fixtures are confirmed, not the right first step.
+
+**Hybrid rationale:** Proposal 3 alone is the right primary selection. Proposal 1's
+`@stream_contract` map attribute adds complementary value as narrative documentation
+co-located with the callback — it costs nothing (already proposed, ~10 LOC) and
+immediately answers "what does a conformant sequence look like" for new adapter authors
+without requiring them to decode the struct. The two elements are additive, not
+conflicting: the attribute is prose; the callback is machine-checkable. This is
+composition, not mixing.
+
+## What changes
+
+- **`lib/tau/provider/stream_contract.ex`** (new file) — define
+  `Tau.Provider.StreamContract` struct with fields `text_framing`, `tool_call_delta`,
+  `block_id_uniqueness`, `thinking_framing`; provide `conformant/0` convenience
+  constructor.
+- **`lib/tau/provider.ex`** — add `@callback stream_contract() ::
+  Tau.Provider.StreamContract.t()`; add `@stream_contract` map attribute with canonical
+  sequence prose; update `@callback stream/3` docstring to reference both.
+- **`lib/tau/providers/anthropic.ex`** — add `@impl Tau.Provider` `stream_contract/0`
+  returning `StreamContract.conformant()`.
+- **`lib/tau/providers/bedrock.ex`** — add `@impl` `stream_contract/0` returning
+  `%StreamContract{text_framing: :delta_only, block_id_uniqueness: :sentinel, ...}`.
+- **`lib/tau/providers/gemini.ex`** — add `@impl` `stream_contract/0` returning
+  `%StreamContract{text_framing: :delta_only, tool_call_delta: :atomic, ...}`.
+- **All remaining adapters** (`openai_chat_wire` consumers, Groq, Mistral, DeepSeek,
+  AzureOpenAI, Custom, Copilot, Replay) — add `@impl` `stream_contract/0`; conformant
+  adapters return `StreamContract.conformant()`; others declare their actual posture.
+- **`test/tau/provider_stream_contract_test.exs`** (new file) — self-consistency test
+  per adapter: call `stream_contract/0`, run a Replay-fixture stream, assert emitted
+  events match the declared contract.
+- **`lib/tau/provider.ex`** — optionally add `known_adapters/0` helper (or hardcode list
+  in the test module).
+
+## What does not change
+
+- `Tau.Provider.Event` struct definitions — no new event types.
+- `Tau.Message.Assembler` — tolerances are left in place; removing them is a follow-on
+  gated on Proposal 4 (adapter fixes) landing.
+- `Tau.Providers.Bedrock` and `Tau.Providers.Gemini` decode paths — no behavioural
+  changes; non-conformance is declared, not fixed.
+- `lib/tau/providers/shared/openai_chat_wire.ex` — TextStart synthesis logic unchanged.
+- Session FSM (`lib/tau/session.ex`) and render loop — no changes.
+- The `@callback stream/3` signature — no new required parameters.
+
+## Migration sketch
+
+First introduce `Tau.Provider.StreamContract` struct and `@stream_contract` attribute in
+`provider.ex` (no compilation breakage yet — callback is not yet mandatory). Then add
+`@callback stream_contract/0` and implement it on all eleven adapters in the same PR,
+ensuring `mix compile --warnings-as-errors` passes before merging. Land the
+self-consistency test in the same PR with Replay fixtures confirmed for Bedrock and
+Gemini. If fixture confirmation for a specific adapter is blocked, that adapter may ship
+a `:test_only` or `:unknown` sentinel value with a `# TODO` and a follow-on issue filed
+— but the callback implementation must exist for the PR to compile. Proposal 4 (decode
+rewrites) is a separate subsequent PR once this test baseline is green.
+
+## Open questions
+
+- **Replay fixture completeness:** do byte-accurate Bedrock `content_block_start` /
+  `content_block_stop` and Gemini `functionCall` fixtures exist in `test/support/`?
+  Without them, the self-consistency test for those adapters cannot run. The landing
+  strategy above handles this via a `:test_only` posture, but it degrades the test
+  value.
+- **`Tau.Providers.Replay` posture:** the Replay adapter is intentionally divergent.
+  Should it declare `stream_contract/0` with a special `:replay` variant, or re-emit the
+  original adapter's contract? This needs a decision before the callback can be marked
+  `@impl`.
+- **`known_adapters/0` vs hardcoded list:** adding a helper on the behaviour introduces
+  coupling between the behaviour and the adapter module list. A module attribute or a
+  test-only helper may be cleaner. No strong opinion here; worth a one-line note in the
+  PR.
+- **OpenAI shared wire path gap:** `openai_chat_wire.ex:108-166` silently omits
+  `TextStart` on empty first deltas. This is not fixed by this solution; should it be
+  tracked in a separate issue before or after this PR lands?
+
+## Linked sub-problems / proposals
+
+- `proposals/proposal-1.md` — `@stream_contract` module attribute + compile-time
+  typedoc spec (contributes narrative attribute; Mix task omitted as superseded by
+  self-consistency test)
+- `proposals/proposal-2.md` — `EventNormaliser` stream wrapper (deferred; valid
+  follow-on after declaration layer lands)
+- `proposals/proposal-3.md` — mandatory `stream_contract/0` callback + Dialyzer struct
+  (primary; full acceptance criterion satisfaction)
+- `proposals/proposal-4.md` — fix non-conforming adapters at source (deferred; right
+  follow-on once declaration + test baseline is green)
+
+## Revision history
+
+- (revision 0 — initial)

--- a/docs/problems-archive-v1-modules/tau-providers/subproblems/callback-contract-drift/validation.md
+++ b/docs/problems-archive-v1-modules/tau-providers/subproblems/callback-contract-drift/validation.md
@@ -1,0 +1,525 @@
+---
+template_version: 1
+template_name: validation
+parent_solution: solution.md
+parent_problem: problem.md
+toulmin_complete: true
+falsification_attempted: true
+falsification_outcome: partially_falsified — claim/6
+revision_triggered: none
+---
+
+# Validation: `stream_contract/0` mandatory callback + `@stream_contract` attribute spec
+
+## Overview
+
+The solution proposes a hybrid of Proposal 3 (a mandatory
+`@callback stream_contract() :: Tau.Provider.StreamContract.t()` plus a typed
+struct) and Proposal 1 (a `@stream_contract` module attribute carrying canonical
+prose), with the runtime decode paths and the assembler tolerances explicitly
+left alone. This validation extracts eight distinct propositions from
+Recommendation + What changes + What does not change. Each receives a six-field
+Toulmin with an explicit named falsification strategy. Outcome: seven claims
+withstand; claim 6 ("All remaining adapters … add `@impl stream_contract/0`")
+is **partially falsified** by counter-example construction — the enumeration in
+the solution lists `Copilot` as one of the eleven adapters, but no module in
+`lib/tau/providers/copilot/` carries `@behaviour Tau.Provider`; the actual
+eleven-adapter set is the one this validation checked. Qualifier narrowed in
+place; no revision required.
+
+## Toulmin per claim
+
+The MITRE empirical study on Toulmin formalism found that participants
+"found it difficult to generate Toulmin structures, and their structures varied
+greatly even though they started with the same content"
+(<https://www.mitre.org/news-insights/publication/empirical-evaluation-structured-argumentation-using-toulmin-argument>).
+The per-field prompts below are filled explicitly to counter that variance.
+
+### Claim 1: Adding a mandatory `@callback stream_contract() :: Tau.Provider.StreamContract.t()` satisfies the acceptance criterion's "behaviour declares the mandatory event-emission rules for `stream/3`" clause.
+
+- **Claim (C):** "Add a mandatory `@callback stream_contract() ::
+  Tau.Provider.StreamContract.t()` to `Tau.Provider`, backed by a new
+  `Tau.Provider.StreamContract` struct" — and (problem.md:60-66) "such that any
+  adapter not conforming to these rules is detectable without reading the
+  adapter's decode path."
+- **Grounds (G):** `lib/tau/provider.ex:67` today says only "elements are
+  `Tau.Provider.Event` structs". The struct sketch in proposal-3.md:48-66
+  encodes the missing axes (`text_framing`, `tool_call_delta`,
+  `block_id_uniqueness`, `thinking_framing`). After the change, an adapter's
+  posture is readable in its `stream_contract/0` body without opening the
+  decode path — e.g. Bedrock returns `text_framing: :delta_only`
+  (proposal-3.md:86-93) rather than today's implicit emission at
+  `lib/tau/providers/bedrock.ex:118-119`.
+- **Warrant (W):** A behaviour callback whose return type is a typed struct
+  promotes adapter posture from implicit (read decode source) to explicit
+  (read one function). Behaviour callbacks are Tau's canonical declarative
+  seam (OTP non-negotiable #2: "Extensibility seams MUST be behaviours.
+  Pattern match on atoms and structs.").
+- **Qualifier (Q):** Holds for adapters that honestly declare their posture.
+  An adapter that returns `conformant()` while still emitting bare deltas
+  satisfies the callback but lies; that residual is closed by claim 7
+  (self-consistency test), not by this claim.
+- **Rebuttal (R):** Does NOT hold if the struct's field set fails to model
+  a real divergence — e.g. an adapter that *interleaves* tool-call deltas
+  across two blocks has no field expressing that. The four fields are
+  necessary but may not be exhaustive; future divergences may require new
+  fields.
+- **Backing (B):** `.claude/rules/otp-non-negotiables.md` invariant #2
+  ("Extensibility seams MUST be behaviours … pattern match on atoms and
+  structs"); prior art `@callback capabilities() :: capabilities()` at
+  `lib/tau/provider.ex:70` — same "declare-your-posture-as-a-struct" idiom
+  the solution mirrors.
+
+#### Falsification attempt for claim 1
+
+- **Strategy:** Counter-example construction — try to construct a
+  non-conforming adapter that the new callback would NOT detect.
+- **Attempt:** Examined Bedrock (`lib/tau/providers/bedrock.ex:118-119`),
+  Gemini (`lib/tau/providers/gemini.ex:95-109`), and the OpenAI shared wire
+  (`lib/tau/providers/shared/openai_chat_wire.ex:158-166`). For each, asked
+  "does the four-field struct express the divergence?". Bedrock's
+  `text_framing: :delta_only` + `block_id_uniqueness: :sentinel` covers
+  both its issues. Gemini's `text_framing: :delta_only` + `tool_call_delta:
+  :atomic` covers its tool-call batching. The OpenAI wire's "first-delta
+  TextStart synthesis" is *conformant* once synthesised (sequence is
+  Start→Delta→End), so no new axis needed. Then probed the
+  open-question case (solution.md:128-133): adapters with no fixture
+  available. The callback still requires a declaration; detection is not
+  blocked by fixture absence — only the self-consistency test (claim 7) is.
+- **Outcome:** withstood — the struct's field set models every divergence
+  cited in problem.md. Future axes may surface, but the criterion as
+  written ("detectable without reading the adapter's decode path") is
+  satisfied today.
+- **Action:** none.
+
+### Claim 2: A `@stream_contract` module attribute on `Tau.Provider` (prose canonical sequence) is additive — composes with the callback rather than conflicts.
+
+- **Claim (C):** "simultaneously add a `@stream_contract` module attribute to
+  `Tau.Provider` carrying the human-readable canonical sequence" and
+  "composition, not mixing" (solution.md:73-78).
+- **Grounds (G):** Proposal-1.md:39-59 shows the attribute as a bare map of
+  required sequences. Proposal-3.md:38-66 shows the struct as machine-
+  readable. The attribute is doc-only (proposal-1.md:30-32: "No runtime
+  overhead"); the struct is machine-checkable. Their effects are disjoint
+  (prose vs. typed value).
+- **Warrant (W):** Two declarative artefacts at the same module compose
+  when one is prose-for-humans and the other is data-for-tools and neither
+  is the source of truth for the other. The behaviour module already
+  carries `@type` (prose-shaped) alongside `@callback` (machine-shaped)
+  — e.g. `capabilities` at `lib/tau/provider.ex:59-70`.
+- **Qualifier (Q):** Holds provided the prose attribute and the struct
+  fields remain semantically aligned over time (i.e., a struct field added
+  later is also reflected in the attribute prose).
+- **Rebuttal (R):** Does NOT hold if the attribute is treated as
+  load-bearing — e.g. a future Mix task asserts adapter moduledocs
+  reference it (proposal-1.md:84-117 sketches exactly this). At that
+  point the attribute is no longer "prose"; it becomes a second
+  enforcement axis with a drift risk against the struct.
+- **Backing (B):** `tau-architecture` §"behaviour callback order is
+  load-bearing"; the existing `lib/tau/provider.ex` already uses prose
+  `@typedoc` alongside `@type` alongside `@callback` without conflict.
+
+#### Falsification attempt for claim 2
+
+- **Strategy:** Edge-case enumeration — list ways the two artefacts could
+  conflict.
+- **Attempt:** Enumerated four edge cases: (a) attribute claims a sequence
+  the struct cannot express → conflict; (b) struct adds a field the
+  attribute prose omits → drift but not contradiction; (c) attribute
+  becomes Mix-task-checked → enforcement axis multiplies; (d) consumer
+  reads attribute and bypasses struct → consumer-level drift. Of these,
+  (a) is preventable by treating struct as source of truth at the
+  behaviour module; (b) is a documentation hygiene concern, not a
+  conflict; (c) is exactly what proposal-1 envisaged but the solution
+  defers it ("Mix task omitted as superseded by self-consistency test"
+  solution.md:148-150); (d) is the rebuttal above.
+- **Outcome:** withstood — given the solution's deferral of the Mix task,
+  the attribute remains prose and composes cleanly with the struct.
+- **Action:** none. Note for future PR authors: keep the struct as source
+  of truth; the attribute is a human-facing mirror.
+
+### Claim 3: The new mandatory callback is type-checkable by Dialyzer when the return type doesn't match `StreamContract.t()`.
+
+- **Claim (C):** "the struct makes non-conformance machine-detectable at
+  compile time" (solution.md:21) — i.e., a `stream_contract/0` returning
+  the wrong shape is caught by Dialyzer.
+- **Grounds (G):** Proposal-3.md:147-148 asserts "Dialyzer will flag any
+  adapter whose `stream_contract/0` return type doesn't match
+  `StreamContract.t()`." The `@callback` syntax with a struct return type
+  is supported in Elixir/Dialyzer; the project already uses this for
+  `@callback capabilities() :: capabilities()`
+  (`lib/tau/provider.ex:59-70`).
+- **Warrant (W):** Dialyzer's success-typing follows `@callback`
+  specifications; an implementation whose actual return diverges from the
+  callback's typespec produces a warning under `mix dialyzer`. The project
+  runs Dialyzer as a hard lint (`CLAUDE.md` Project Context: "Lint: …
+  `mix dialyzer`").
+- **Qualifier (Q):** Holds for *structural* divergences (wrong field, wrong
+  field type). Does NOT hold for *value* divergences within the declared
+  type (e.g. returning `text_framing: :delta_only` while emitting
+  start/delta/end events). Value-level correctness is claim 7's territory.
+- **Rebuttal (R):** Dialyzer's success-typing is permissive; if an adapter
+  returns a value of the right struct shape but with `nil` in a non-
+  enforced field, Dialyzer may not flag it. The `@enforce_keys` in
+  proposal-3.md:48 limits this (compile-time error for missing keys), but
+  optional fields remain permissive.
+- **Backing (B):** Elixir documentation, "Defining behaviours" — Dialyzer
+  checks `@callback` specs against `@impl` implementations. The existing
+  `capabilities/0` callback in `Tau.Provider` is the working precedent.
+
+#### Falsification attempt for claim 3
+
+- **Strategy:** Type-level check (mentally) — model whether Dialyzer would
+  warn on each divergence kind.
+- **Attempt:** Enumerated: (i) adapter omits `stream_contract/0` entirely
+  → Elixir compiler emits "behaviour callback not implemented" warning
+  (predates Dialyzer); (ii) adapter returns `{:ok, struct}` instead of the
+  struct → Dialyzer flags `{:ok, ...}` ≠ `StreamContract.t()`; (iii) adapter
+  returns `%StreamContract{text_framing: "delta_only"}` (string not atom)
+  → Dialyzer flags because the type declares `:delta_only` atom literals;
+  (iv) adapter returns `%StreamContract{...}` with all fields legal but
+  semantically lying → Dialyzer cannot detect (this is claim 7's
+  territory).
+- **Outcome:** withstood — for structural divergence (the claim's scope).
+  Confirms the rebuttal above: value-level lies escape Dialyzer.
+- **Action:** none. The qualifier already excludes value-level
+  divergence.
+
+### Claim 4: `lib/tau/providers/anthropic.ex` can declare `StreamContract.conformant()` without behavioural changes.
+
+- **Claim (C):** "`lib/tau/providers/anthropic.ex` — add `@impl Tau.Provider`
+  `stream_contract/0` returning `StreamContract.conformant()`."
+  (solution.md:89-90).
+- **Grounds (G):** `lib/tau/providers/anthropic.ex:182-247` shows
+  `dispatch/3` emitting `TextStart` on `content_block_start`, `TextDelta`
+  on `content_block_delta`, `TextEnd` on `content_block_stop` — and
+  symmetric `ToolCallStart`/`ToolCallDelta`/`ToolCallEnd` and
+  `ThinkingStart`/`ThinkingDelta`/`ThinkingEnd`. Each block carries a
+  unique `block_id` (`"anth_text_#{idx}"`, `cb["id"]` for tool_use).
+- **Warrant (W):** A declaration of `conformant()`
+  (`text_framing: :start_delta_end, tool_call_delta: :streaming,
+  block_id_uniqueness: :per_stream, thinking_framing: :start_delta_end`)
+  matches Anthropic's observed sequence iff the dispatch emits framing
+  for every block kind with unique ids. The grep above confirms it does.
+- **Qualifier (Q):** Holds for Anthropic's primary (Messages API) wire
+  format. The Bedrock-Anthropic shared path
+  (`lib/tau/providers/bedrock.ex:111-124` reuses Anthropic-shaped JSON)
+  is a *different* adapter and is correctly declared `:delta_only` in the
+  solution.
+- **Rebuttal (R):** Does NOT hold if Anthropic introduces a wire-level
+  shape (e.g. a multi-block-start without a paired stop) that breaks
+  framing. The declaration would then need updating. The codebase today
+  does not exhibit this case.
+- **Backing (B):** `lib/tau/providers/anthropic.ex:182-247` itself
+  (working source code, post-PR-373); the existing
+  `capabilities/0` pattern at the same module documents this
+  declare-your-posture idiom.
+
+#### Falsification attempt for claim 4
+
+- **Strategy:** Counter-example construction — try to find an Anthropic
+  emission path that violates `conformant()`.
+- **Attempt:** Walked every `dispatch/3` clause for Anthropic
+  (`lib/tau/providers/anthropic.ex:182-260`). The `content_block_start`,
+  `content_block_delta`, `content_block_stop` handlers always pair
+  `TextStart` with `TextEnd` on the same `anth_text_#{idx}` id. For
+  thinking blocks, the same start/delta/end triplet uses
+  `anth_think_#{idx}`. For tool_use, the dispatch uses `cb["id"]`
+  consistently (proposal does emit `ToolCallStart` + `ToolCallDelta`
+  fragments + `ToolCallEnd`). No clause was found that emits a delta
+  without a preceding start on the same id.
+- **Outcome:** withstood.
+- **Action:** none.
+
+### Claim 5: `lib/tau/providers/bedrock.ex` honestly declares `:delta_only` + `:sentinel`, and `lib/tau/providers/gemini.ex` honestly declares `:delta_only` + `:atomic` — neither requires decode-path changes.
+
+- **Claim (C):** Bedrock returns
+  `%StreamContract{text_framing: :delta_only, block_id_uniqueness:
+  :sentinel, …}`; Gemini returns
+  `%StreamContract{text_framing: :delta_only, tool_call_delta: :atomic,
+  …}` (solution.md:91-94).
+- **Grounds (G):** Bedrock at `lib/tau/providers/bedrock.ex:118-119`:
+  `decode_anthropic_event(%{"type" => "content_block_delta", "delta" =>
+  %{"text" => t}}, p), do: {[%Event.TextDelta{block_id: "text", text: t}],
+  p}` — bare `TextDelta` with hardcoded sentinel `"text"`, no
+  `content_block_start` handler emitting `TextStart`. Gemini at
+  `lib/tau/providers/gemini.ex:95-110`: emits `%Event.TextDelta{block_id:
+  "text"}` and (for tool calls) `[ToolCallStart, ToolCallEnd]` in a
+  single decoded chunk with no `ToolCallDelta` between them.
+- **Warrant (W):** The struct's value space (`:delta_only`, `:sentinel`,
+  `:atomic`) was designed exactly to express these divergences (the
+  problem.md cited them as the motivating cases). An honest declaration
+  is the literal mapping of the observed emission to the struct field
+  set.
+- **Qualifier (Q):** Holds as long as the decode paths remain unchanged
+  (the solution explicitly defers fixing them: "Bedrock and Gemini decode
+  paths — no behavioural changes", solution.md:108-110). If a future PR
+  fixes framing without updating the declaration, the self-consistency
+  test (claim 7) catches the drift.
+- **Rebuttal (R):** Does NOT hold for the *unhandled clauses* — e.g.
+  Bedrock's `defp decode_anthropic_event(_, p), do: {[], p}` swallows
+  `content_block_start` and `content_block_stop` silently
+  (`lib/tau/providers/bedrock.ex:124`). The declaration `:delta_only`
+  describes what *is* emitted; it does not describe what is *silently
+  ignored from upstream*. The acceptance criterion ("detectable without
+  reading the decode path") is still met because the declaration plus
+  the test exercise the emitted stream end-to-end.
+- **Backing (B):** problem.md:30-40 cites both adapters as the canonical
+  divergence cases the struct is designed to model.
+
+#### Falsification attempt for claim 5
+
+- **Strategy:** Counter-example construction — try a decode-path case
+  where the declaration would mislead consumers.
+- **Attempt:** For Bedrock, considered: if a stream contains multiple
+  text blocks (multi-message response), every `TextDelta` carries the
+  same `"text"` block_id. Consumers reading `block_id` cannot
+  disambiguate. But `block_id_uniqueness: :sentinel` *declares exactly
+  this* — consumers pattern-matching on the declaration are warned. For
+  Gemini, considered: a function call with empty `args` produces
+  `ToolCallEnd{params: %{}}` — does this break `:atomic`? Inspecting
+  `lib/tau/providers/gemini.ex:107-109`, the pair is always
+  `[ToolCallStart, ToolCallEnd]` — empty args are still atomic; the
+  declaration holds.
+- **Outcome:** withstood. The declarations match the observed emission.
+- **Action:** none.
+
+### Claim 6: All remaining adapters (`openai_chat_wire` consumers, Groq, Mistral, DeepSeek, AzureOpenAI, Custom, Copilot, Replay) add `@impl stream_contract/0` returning either `conformant()` or their actual posture.
+
+- **Claim (C):** "All remaining adapters (`openai_chat_wire` consumers,
+  Groq, Mistral, DeepSeek, AzureOpenAI, Custom, Copilot, Replay) — add
+  `@impl` `stream_contract/0`" (solution.md:95-97).
+- **Grounds (G):** `grep -rln "@behaviour Tau.Provider"
+  /home/brentw/src/tau/lib/` lists exactly eleven files: `anthropic.ex`,
+  `azure_openai.ex`, `bedrock.ex`, `custom.ex`, `deepseek.ex`,
+  `gemini.ex`, `groq.ex`, `mistral.ex`, `openai/chat.ex`,
+  `openai/responses.ex`, `replay.ex`. The solution cites "all eleven
+  adapters" (solution.md:119); the count matches.
+- **Warrant (W):** A mandatory `@callback` requires every
+  `@behaviour Tau.Provider` module to implement it for the project to
+  compile. The eleven-file enumeration is exactly the set that needs
+  the implementation.
+- **Qualifier (Q):** Holds for the eleven-file set as currently
+  enumerated by `grep`. **Narrowed (see falsification):** does NOT
+  include `Tau.Providers.Copilot` despite the solution's enumeration
+  naming it — no module in `lib/tau/providers/copilot/` carries
+  `@behaviour Tau.Provider`; the directory contains only `auth.ex` and
+  `token_store.ex` (auth subsystem only). The eleventh adapter is
+  Replay, which IS listed.
+- **Rebuttal (R):** Does NOT hold if a new `@behaviour Tau.Provider`
+  module lands between the solution's authoring and the PR's landing —
+  the migration count would be 12, not 11. Mitigated by the migration
+  sketch's instruction to run `mix compile --warnings-as-errors` before
+  merging (solution.md:120-121) — any missing implementation would
+  surface there.
+- **Backing (B):** Elixir compiler emits "behaviour callback X is not
+  implemented" warning for every missing `@impl`; `mix
+  --warnings-as-errors` turns it fatal.
+
+#### Falsification attempt for claim 6
+
+- **Strategy:** Counter-example construction — enumerate the
+  `@behaviour Tau.Provider` modules and compare to the solution's
+  adapter list.
+- **Attempt:** `grep -rln "@behaviour Tau.Provider\b" lib/` returns 11
+  modules. Solution lists 11 names. Diff:
+  - Solution's "openai_chat_wire consumers" implicitly covers Groq,
+    Mistral, DeepSeek, AzureOpenAI, Custom — confirmed by grep.
+  - Solution lists `Copilot` — NOT present as a `@behaviour
+    Tau.Provider` module. `ls lib/tau/providers/copilot/` shows only
+    `auth.ex` (Auth subsystem) and `token_store.ex` (GenServer). No
+    `copilot.ex` provider module exists.
+  - Solution omits `OpenAI.Chat` and `OpenAI.Responses` from the
+    explicit list (they are presumably folded into "openai_chat_wire
+    consumers", but Responses uses a different wire).
+- **Outcome:** **partially falsified**. The intent (every
+  `@behaviour Tau.Provider` module implements the callback) is correct
+  and machine-enforced by the compiler. The *enumeration* in the
+  solution is sloppy: it lists a non-existent Copilot provider and
+  elides `OpenAI.Responses`. The actual implementation set is the
+  eleven returned by grep.
+- **Action:** Qualifier narrowed in place to "the eleven modules
+  returned by `grep -rln '@behaviour Tau.Provider\\b' lib/`": the
+  solution's enumeration is informative-only; the compile-warning gate
+  is the operative mechanism. No revision triggered because the
+  acceptance criterion ("any adapter not conforming is detectable") is
+  unaffected — the criterion keys on the *callback*, not on the
+  solution's prose enumeration.
+
+### Claim 7: A self-consistency test (`test/tau/provider_stream_contract_test.exs`) makes the declared contract self-falsifying against observed events.
+
+- **Claim (C):** "`test/tau/provider_stream_contract_test.exs` (new file)
+  — self-consistency test per adapter: call `stream_contract/0`, run a
+  Replay-fixture stream, assert emitted events match the declared
+  contract." (solution.md:98-100).
+- **Grounds (G):** Proposal-3.md:104-135 sketches the test shape. The
+  Replay adapter exists at `lib/tau/providers/replay.ex` and implements
+  `@behaviour Tau.Provider` (grep result above). Fixtures for Bedrock
+  and Gemini may or may not exist (open question, solution.md:128-133).
+- **Warrant (W):** Falsifiability requires an external check that can
+  contradict the declaration. A test that drives the real stream and
+  pattern-matches `text_framing: :start_delta_end ⇒ ∀ TextDelta:
+  preceded by TextStart on the same block_id` (proposal-3.md:126-133)
+  is exactly that. It closes the residual from claim 3's rebuttal
+  (value-level lies escape Dialyzer).
+- **Qualifier (Q):** Holds for adapters with a Replay fixture available.
+  Does NOT hold for adapters where the fixture is missing —
+  solution.md:129-133 acknowledges this and proposes a `:test_only` /
+  `:unknown` sentinel as a degraded mode. In that mode, the test value
+  for those adapters is purely the declaration's presence, not its
+  fidelity.
+- **Rebuttal (R):** Does NOT hold if the Replay fixture itself is
+  non-byte-accurate — a fixture sanitised to "look like" the provider's
+  output but not produced from real bytes can mask divergence.
+- **Backing (B):** proposal-3.md "Prior art" §190-196 cites three
+  precedents for the declare-then-verify pattern (Tau's
+  `capabilities/0`, SPEC-PROMPT-CACHING `cache_regions/2`, Erlang
+  `:gen_statem` callback-mode).
+
+#### Falsification attempt for claim 7
+
+- **Strategy:** Dependency check — verify the Replay-fixture
+  infrastructure exists or can be added without a separate epic.
+- **Attempt:** Examined `lib/tau/providers/replay.ex` exists (grep
+  confirmed). The solution's open question (solution.md:128-133)
+  acknowledges the fixture-completeness risk explicitly and proposes a
+  `:test_only`/`:unknown` sentinel as a fallback. The proposal
+  (proposal-3.md:177-180) calls this a "Dependency" — meaning the
+  authors know the test value degrades when fixtures are absent. No
+  evidence that the dependency is impossible to satisfy; it is
+  acknowledged as work to do.
+- **Outcome:** withstood, with the qualifier already present (test
+  value depends on fixture availability).
+- **Action:** none. The open question survives to PR-authoring time.
+
+### Claim 8: The solution does NOT modify `Tau.Provider.Event`, `Tau.Message.Assembler`, Bedrock/Gemini decode paths, the OpenAI shared wire, the session FSM/render loop, or the `@callback stream/3` signature.
+
+- **Claim (C):** "What does not change" enumeration (solution.md:105-114)
+  — six explicit non-modifications, plus claim that the existing
+  assembler tolerances "are left in place; removing them is a follow-on
+  gated on Proposal 4".
+- **Grounds (G):** `lib/tau/message/assembler.ex:133-138` shows
+  `update_block/3` silently returning state unchanged when a delta
+  arrives for an un-started block (`nil` branch returns state). The
+  solution explicitly does not touch this. The "What changes" list
+  (solution.md:82-102) modifies only `provider.ex`, a new
+  `stream_contract.ex`, eleven adapter modules, and one new test file
+  — none of the six "does not change" targets.
+- **Warrant (W):** The "What changes" enumeration is mutually
+  exhaustive with "What does not change" by construction of the
+  solution template; a PR landing only the listed edits satisfies the
+  claim by inspection.
+- **Qualifier (Q):** Holds for the PR as scoped. If the PR is expanded
+  mid-flight (e.g. an adapter author "while I'm here" removes an
+  assembler tolerance), the claim is violated and the PR is out-of-scope
+  per the factory loop's scope-guard rule.
+- **Rebuttal (R):** Does NOT hold if `Tau.Provider.known_adapters/0` is
+  added to `provider.ex` as a helper (open question, solution.md:139-142)
+  — that IS a change to `provider.ex` beyond the callback. The solution
+  mentions it but defers the decision. If added, it does not change
+  `stream/3` semantics, so the substantive claim survives.
+- **Backing (B):** `.claude/rules/factory-loop.md` §PR scope guards:
+  "frozen scope … mid-flight scope growth becomes a separate PR".
+
+#### Falsification attempt for claim 8
+
+- **Strategy:** Edge-case enumeration — list each "does not change"
+  target and check whether the listed changes touch it.
+- **Attempt:** Iterated the six items: (a) `Tau.Provider.Event` — listed
+  changes touch only `provider.ex` and `provider/stream_contract.ex`;
+  Event is in `provider/event.ex` — disjoint. (b) `Tau.Message.Assembler`
+  — listed changes do not touch `message/assembler.ex` — disjoint.
+  (c) Bedrock/Gemini decode paths — listed changes add `stream_contract/0`
+  to each adapter, not modifications to `decode_*` clauses — disjoint.
+  (d) `openai_chat_wire.ex` — listed changes add `stream_contract/0` to
+  the consumer adapters, not to the shared wire — disjoint. (e) Session
+  FSM / render loop — listed changes do not touch `session.ex` or any
+  TUI module — disjoint. (f) `@callback stream/3` signature — the
+  signature at `provider.ex:67-68` is unchanged; only the docstring
+  is updated. All six hold.
+- **Outcome:** withstood.
+- **Action:** none.
+
+## Cross-claim consistency
+
+The eight claims are mutually consistent. The recurring structure is:
+declaration layer (claims 1-3) + per-adapter implementations (claims 4-6) +
+external check (claim 7) + scope discipline (claim 8). Two potential
+tensions resolved:
+
+- **Claim 2 (attribute composes with callback) vs. claim 8 (provider.ex
+  scope).** Both apply: the attribute IS in `provider.ex` (a permitted
+  change per the "What changes" list); claim 8's "does not change"
+  enumeration explicitly excludes the callback signature, not the file.
+  No tension.
+- **Claim 3 (Dialyzer catches structural divergence) vs. claim 7
+  (test catches value-level divergence).** Complementary, not
+  conflicting — the two together close the gap that either alone leaves
+  open (claim 3 rebuttal explicitly defers value-level checks to claim
+  7).
+
+The internal `:replay` vs `:test_only` open question (solution.md:134-138)
+is the only unresolved interaction across claims — it affects claim 6
+(does Replay get a special declaration?) and claim 7 (does Replay
+participate in the self-consistency test?). The solution flags it for
+PR-authoring time; both downstream claims tolerate either resolution.
+
+## Falsification summary
+
+| # | Claim (short) | Strategy | Outcome | Action |
+|---|---|---|---|---|
+| 1 | Callback satisfies "detectable without reading decode path" | Counter-example construction | withstood | none |
+| 2 | `@stream_contract` attribute composes with callback | Edge-case enumeration | withstood | none |
+| 3 | Dialyzer catches structural callback-return divergence | Type-level check | withstood | none |
+| 4 | Anthropic can declare `conformant()` w/o behavioural change | Counter-example construction | withstood | none |
+| 5 | Bedrock `:delta_only/:sentinel` + Gemini `:delta_only/:atomic` are honest declarations | Counter-example construction | withstood | none |
+| 6 | All remaining adapters add `@impl stream_contract/0` | Counter-example construction | **partially falsified** | qualifier narrowed in place |
+| 7 | Self-consistency test makes declaration falsifiable | Dependency check | withstood (qualified by fixture availability) | none |
+| 8 | Six "does not change" targets are disjoint from "what changes" | Edge-case enumeration | withstood | none |
+
+## Revision required
+
+No file-level revision is needed. The single partial falsification
+(claim 6) is a *prose enumeration* issue: the solution's "Copilot"
+mention names a module that does not exist as a `@behaviour
+Tau.Provider` implementer, and `OpenAI.Responses` is missing from the
+explicit per-adapter list. Neither affects the acceptance criterion or
+the operative migration mechanism (the compiler's
+behaviour-callback-not-implemented warning, made fatal by `mix compile
+--warnings-as-errors`). Qualifier 6 is narrowed in place to "the eleven
+modules returned by `grep -rln '@behaviour Tau.Provider\\b' lib/`".
+
+- **Target file:** none — qualifier narrowed in-validation.
+- **Revision kind:** n/a
+- **Rationale:** Acceptance criterion remains satisfied. The
+  implementing PR author will discover the correct adapter set via
+  compile warnings regardless of the solution's prose. Calling for a
+  full re-run of propose/select on a prose enumeration would over-react
+  to a non-substantive defect.
+
+## Outstanding doubts
+
+- **Fixture completeness for Bedrock and Gemini self-consistency tests
+  (claim 7's qualifier).** The solution flags this as an open question.
+  Until fixtures are confirmed, claim 7's test value for these adapters
+  degrades to "the declaration exists and is well-typed" — i.e. claim 1
+  + claim 3 territory, not claim 7's runtime falsifiability. A parent-
+  level validator inheriting this node's solution should carry this
+  doubt forward.
+- **Replay adapter's posture (open question solution.md:134-138).**
+  The solution defers the choice of `:replay` sentinel vs. re-emitting
+  the original adapter's contract. Either is workable for claim 6's
+  enforcement; the choice affects only the test's interpretation, not
+  the criterion satisfaction.
+- **OpenAI shared wire's first-delta `TextStart` synthesis gap
+  (open question solution.md:143-145).** When the upstream sends only
+  empty deltas, no `TextStart` is synthesised. This is an
+  *implementation-side* defect in `openai_chat_wire.ex`, not a
+  declaration-layer defect. The solution correctly defers it; a parent-
+  level validator should note that the declaration layer landed here
+  does not by itself fix it.
+- **`known_adapters/0` helper coupling (open question
+  solution.md:139-142).** Adding it couples the behaviour module to the
+  adapter list. If added, it should be test-only or a module attribute.
+  The solution defers the decision; both options preserve all eight
+  claims.

--- a/docs/problems-archive-v1-modules/tau-providers/subproblems/capabilities-flag-fidelity/problem.md
+++ b/docs/problems-archive-v1-modules/tau-providers/subproblems/capabilities-flag-fidelity/problem.md
@@ -1,0 +1,80 @@
+---
+template_version: 1
+template_name: problem
+node_kind: leaf
+depth: 1
+parent: ../../problem.md
+status: draft
+---
+
+# Problem: capabilities-flag-fidelity
+
+## Statement
+
+`capabilities/0` returns a static map of feature flags (`thinking`,
+`prompt_caching`, `tools`, `vision`, `parallel_tools`) but the flags are not
+enforced against actual adapter behaviour. Bedrock declares
+`thinking: true, prompt_caching: true` while its decode path emits no
+`ThinkingStart`/`ThinkingEnd`/`ThinkingDelta` events and has no
+`cache_regions/2` implementation. Gemini similarly declares
+`thinking: true, prompt_caching: true` with neither feature implemented.
+Consumers that branch on `capabilities().thinking` or `capabilities().
+prompt_caching` to enable features silently receive a provider that does not
+honour them.
+
+## Context
+
+- `lib/tau/provider.ex:59-65` — `@type capabilities` defines the flag map;
+  `@callback capabilities/0` has no contract on flag truthfulness.
+- `lib/tau/providers/bedrock.ex:35-37` — declares
+  `%{thinking: true, tools: true, vision: true, prompt_caching: true,
+  parallel_tools: true}`.
+- `lib/tau/providers/bedrock.ex:111-123` — `decode_anthropic_event/2` handles
+  only `message_start`, `content_block_delta` (text only), and `message_stop`;
+  no thinking block events; no `cache_regions/2` callback.
+- `lib/tau/providers/gemini.ex:29-31` — declares
+  `%{thinking: true, ..., prompt_caching: true, ...}`.
+- `lib/tau/providers/gemini.ex:74-121` — decode path handles only text deltas
+  and functionCall parts; no thinking events; no `cache_regions/2` callback.
+- `lib/tau/providers/anthropic.ex:69-77` — declares `thinking: true,
+  prompt_caching: true` AND implements both (ThinkingStart/Delta/End emitted in
+  `dispatch/3`; `cache_regions/2` returns `:explicit`).
+- `lib/tau/providers/shared/openai_chat_wire.ex:115-166` — does synthesise
+  ThinkingStart/ThinkingDelta/ThinkingEnd for the `delta.reasoning` field
+  (DeepSeek-R1, Qwen3), but only providers using this wire module with
+  `thinking: true` have the capability actually delivered.
+
+## Complecting hypothesis
+
+1. **Capability declaration is complected with decode implementation:** whether a
+   flag is true is only discoverable by reading the adapter's decode path, not
+   the `capabilities/0` return value, because the behaviour places no obligation
+   on flag truthfulness.
+2. **Feature-gate logic in callers is complected with per-adapter decode
+   assumptions:** code that branches on `capabilities().thinking` to decide
+   whether to send thinking params or render thinking blocks must secretly also
+   know which adapters lie, rather than relying on the declared map.
+
+## Decomposition strategy
+
+(leaf — no further decomposition; proceed to proposals)
+
+## Acceptance criterion
+
+Every `capabilities/0` flag that is `true` for a given adapter is backed by an
+observable guarantee — either a behaviour-enforced contract (e.g. adapter must
+implement `cache_regions/2` if `prompt_caching: true`), a compile-time
+assertion, or at minimum an explicit documented caveat in the behaviour that
+names which flags are advisory vs enforceable — such that a caller cannot be
+silently misled.
+
+## Out of scope
+
+- The structural event-sequence contract (TextStart/TextEnd framing) — covered
+  by `callback-contract-drift`.
+- Usage-map normalisation — covered by `usage-normalisation`.
+- Auth-resolution — covered by `auth-resolution-scatter`.
+
+## Amendment log
+
+- (none yet)

--- a/docs/problems-archive-v1-modules/tau-providers/subproblems/capabilities-flag-fidelity/proposals/proposal-1.md
+++ b/docs/problems-archive-v1-modules/tau-providers/subproblems/capabilities-flag-fidelity/proposals/proposal-1.md
@@ -1,0 +1,178 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 1
+parent_problem: ../problem.md
+---
+
+# Proposal 1: Enforce capability flags via mandatory optional callbacks
+
+## Approach
+
+For each capability flag that implies a protocol obligation, introduce a
+corresponding optional callback in `Tau.Provider` and add a compile-time
+`@impl` enforcement check via a `__using__/1` macro. Specifically:
+
+- `prompt_caching: true` requires the adapter to export `cache_regions/2`
+  (already optional today — make it mandatory when the flag is `true`).
+- `thinking: true` requires the adapter to export a new `thinking_config/1`
+  callback that returns the provider-specific thinking-parameter block.
+
+Adapters declaring a flag `true` without the corresponding callback produce
+a compile-time warning (or error via `@enforce_capabilities true`) in the
+macro-expanded `__using__` block. Bedrock and Gemini either implement the
+callbacks or demote their flags to `false`.
+
+## Rationale
+
+The core complect is that `capabilities/0` makes a claim but the behaviour
+places no obligation on adapters to back the claim. The fix is to couple the
+claim to an obligation at the behaviour level: a flag can only truthfully be
+`true` if the adapter exports the callbacks that make it so. This uses the
+BEAM's existing module-attribute + behaviour-checking machinery — no new
+runtime infrastructure. Callers that branch on `capabilities().thinking` gain
+a contractual guarantee that `thinking_config/1` is also present and callable.
+
+## Sketch
+
+```elixir
+# lib/tau/provider.ex — new section
+
+@doc """
+Per-turn thinking configuration. MUST be exported when `capabilities().thinking == true`.
+Returns the provider-specific thinking-parameter block to embed in the request body.
+"""
+@callback thinking_config(stream_opts()) :: map()
+
+# cache_regions/2 already exists; annotation only:
+# MUST be exported when capabilities().thinking == true (prompt_caching already handled)
+
+@optional_callbacks [configure: 1, chat: 3, cache_regions: 2, context_window: 1,
+                     thinking_config: 1]
+
+defmacro __using__(opts) do
+  quote do
+    @behaviour Tau.Provider
+    @before_compile Tau.Provider.CapabilityEnforcer
+    @tau_provider_opts unquote(opts)
+  end
+end
+
+# lib/tau/provider/capability_enforcer.ex — new file
+
+defmodule Tau.Provider.CapabilityEnforcer do
+  @moduledoc """
+  Compile-time check: for each adapter that declares a capability flag `true`,
+  verify the corresponding callback is exported. Emits a compile warning by
+  default; set `@enforce_capabilities :error` to turn it into a compile error.
+  """
+
+  @flag_to_callbacks %{
+    thinking: [:thinking_config],
+    prompt_caching: [:cache_regions]
+  }
+
+  defmacro __before_compile__(env) do
+    mod = env.module
+    caps = Module.get_attribute(mod, :tau_capabilities) || %{}
+    level = Module.get_attribute(mod, :enforce_capabilities) || :warn
+
+    Enum.each(@flag_to_callbacks, fn {flag, required_cbs} ->
+      if Map.get(caps, flag) == true do
+        Enum.each(required_cbs, fn cb ->
+          arity = if cb == :cache_regions, do: 2, else: 1
+          unless Module.defines?(mod, {cb, arity}) do
+            msg = "#{inspect(mod)} declares capabilities #{flag}: true but does not export #{cb}/#{arity}"
+            case level do
+              :error -> raise CompileError, description: msg, file: env.file, line: env.line
+              _ -> IO.warn(msg, Macro.Env.stacktrace(env))
+            end
+          end
+        end)
+      end
+    end)
+
+    :ok
+  end
+end
+```
+
+```elixir
+# lib/tau/providers/bedrock.ex — fix: demote or implement
+# Option A: demote flags (minimal change)
+def capabilities do
+  %{thinking: false, tools: true, vision: true,
+    prompt_caching: false, parallel_tools: true}
+end
+
+# lib/tau/providers/gemini.ex — same pattern
+def capabilities do
+  %{thinking: false, tools: true, vision: true,
+    prompt_caching: false, parallel_tools: true}
+end
+```
+
+Adapter `use Tau.Provider` triggers the `__before_compile__` check. The
+`@enforce_capabilities :error` attribute can be set repo-wide via
+`config :tau, :enforce_capabilities, :error` once all adapters are compliant.
+
+## Tradeoffs
+
+### Strengths
+
+- Contractual: a compiler-surfaced link between flag and callback — callers
+  can rely on the flag without reading adapter internals.
+- Minimal new runtime surface: enforcer is a `@before_compile` hook that
+  vanishes after compilation.
+- Incremental: adopters can start with `:warn` and graduate to `:error`.
+- Directly satisfies the acceptance criterion: every `true` flag has a
+  corresponding behaviour-enforced callback.
+- Consistent with existing `cache_regions/2` pattern — extends rather than
+  invents.
+
+### Weaknesses
+
+- Requires `use Tau.Provider` discipline: adapters that implement `@behaviour
+  Tau.Provider` directly (without `use`) skip the `@before_compile` check.
+  Must audit all adapters; Replay adapter is a likely non-`use` case.
+- `thinking_config/1` is a new callback: implementing it for Anthropic and
+  OpenAI-reasoning adapters adds non-trivial surface even for the "currently
+  working" cases.
+- Compile warnings are easy to ignore; the `:error` upgrade requires
+  coordinated cleanup of Bedrock and Gemini before it can be enabled.
+- Does not address the case where an adapter implements `thinking_config/1`
+  but the decode path still doesn't emit `ThinkingStart`/`ThinkingEnd` events —
+  the callback only proves something is exported, not that it wires through.
+
+### Costs
+
+- New file: `lib/tau/provider/capability_enforcer.ex` (~50 LOC).
+- Modify `lib/tau/provider.ex`: add `thinking_config/1` callback, `__using__/1`
+  macro, update `@optional_callbacks`.
+- Modify all adapters to `use Tau.Provider` if they don't already.
+- Bedrock and Gemini: either implement `thinking_config/1` + `cache_regions/2`
+  (2–3 PRs of feature work) or demote flags to `false` (trivial).
+- Property tests: one property per flag checking `capabilities().X == true →
+  function_exported?(mod, cb, arity)`.
+
+## Dependencies
+
+- All adapters must opt in to `use Tau.Provider`; currently only some do.
+- If `thinking_config/1` is added, the Anthropic and OpenAI-family adapters
+  must implement it before the flag check fires for them.
+
+## Confidence
+
+Medium. The compile-time enforcement pattern is well-established in Elixir
+(`@before_compile`); the uncertainty is in whether `thinking_config/1` is the
+right callback shape to enforce thinking fidelity, vs a simpler flag-only
+demotion approach. Confidence rises if the scope is narrowed to "demote Bedrock
+and Gemini flags + enforce cache_regions via existing callback" (no new callback).
+
+## Prior art / references
+
+- Elixir `@before_compile` behaviour enforcement: used by Ecto adapters
+  (`Ecto.Adapter`) to verify optional callbacks based on declared features.
+- `Phoenix.Socket` `__using__/1` macro for transport-specific enforcement.
+- `cache_regions/2` in `lib/tau/provider.ex` — existing optional callback
+  pattern this proposal extends.

--- a/docs/problems-archive-v1-modules/tau-providers/subproblems/capabilities-flag-fidelity/proposals/proposal-2.md
+++ b/docs/problems-archive-v1-modules/tau-providers/subproblems/capabilities-flag-fidelity/proposals/proposal-2.md
@@ -1,0 +1,172 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 2
+parent_problem: ../problem.md
+---
+
+# Proposal 2: Replace boolean flags with a typed capability level struct
+
+## Approach
+
+Replace the `capabilities/0` return type from a flat `boolean()` map to a
+struct with three levels per feature: `:implemented`, `:advisory`, and
+`:unsupported`. The new type `Tau.Provider.Capability` encodes the truthfulness
+semantics directly in the data shape. Callers that previously branched on
+`capabilities().thinking == true` now branch on
+`capabilities().thinking == :implemented`; an adapter that has the decode path
+but not the stream params uses `:advisory` to signal "provider may return this
+but we don't actively request it." Adapters whose decode paths do not emit the
+events use `:unsupported`. This is an API-breaking change to `capabilities/0`
+return type.
+
+## Rationale
+
+Boolean flags have no vocabulary for "I claim this but can't back it" — the bit
+is either set or not. The complect arises precisely because `true` is forced to
+mean both "I declare this feature" and "I implement this feature," with no
+gradient. A typed capability level breaks this conflation at the data-shape
+layer: the type system carries the distinction, no separate callback enforcement
+is needed, and a new adapter author cannot express `true` without choosing a
+level that makes the degree of implementation visible. Callers get a richer
+signal and can choose whether to require `:implemented` or accept `:advisory`.
+
+## Sketch
+
+```elixir
+# lib/tau/provider/capability.ex — new file
+
+defmodule Tau.Provider.Capability do
+  @moduledoc """
+  Typed capability level for a single feature.
+
+    * `:implemented`  — the adapter actively requests, decodes, and emits the
+                        feature. Callers may rely on it unconditionally.
+    * `:advisory`     — the adapter may receive provider-side output for this
+                        feature but does not actively request it or does not
+                        fully synthesise the corresponding events. Callers
+                        should treat this as opportunistic.
+    * `:unsupported`  — the adapter does not implement this feature. Callers
+                        MUST NOT rely on it.
+  """
+  @type t :: :implemented | :advisory | :unsupported
+end
+```
+
+```elixir
+# lib/tau/provider.ex — updated type
+
+@typedoc "Per-feature capability levels declared by an adapter."
+@type capabilities :: %{
+        thinking:       Tau.Provider.Capability.t(),
+        tools:          Tau.Provider.Capability.t(),
+        vision:         Tau.Provider.Capability.t(),
+        prompt_caching: Tau.Provider.Capability.t(),
+        parallel_tools: Tau.Provider.Capability.t()
+      }
+```
+
+```elixir
+# lib/tau/providers/anthropic.ex — correct declaration
+def capabilities do
+  %{thinking: :implemented, tools: :implemented, vision: :implemented,
+    prompt_caching: :implemented, parallel_tools: :implemented}
+end
+
+# lib/tau/providers/bedrock.ex — honest declaration
+def capabilities do
+  %{thinking: :unsupported, tools: :implemented, vision: :implemented,
+    prompt_caching: :unsupported, parallel_tools: :implemented}
+end
+
+# lib/tau/providers/gemini.ex — honest declaration
+def capabilities do
+  %{thinking: :unsupported, tools: :implemented, vision: :implemented,
+    prompt_caching: :unsupported, parallel_tools: :unsupported}
+end
+
+# lib/tau/providers/shared/openai_chat_wire.ex — adapters with reasoning field
+# DeepSeek-R1/Qwen3 via openai_chat_wire (emit ThinkingDelta for delta.reasoning)
+def capabilities do
+  %{thinking: :advisory, ...}  # synthesises events but doesn't actively request
+end
+```
+
+```elixir
+# Caller migration — lib/tau/session.ex or similar
+# Before:
+if adapter.capabilities().thinking do ...
+# After:
+if adapter.capabilities().thinking == :implemented do ...
+# Or, accepting advisory:
+if adapter.capabilities().thinking in [:implemented, :advisory] do ...
+```
+
+```elixir
+# Typespec helper for callers:
+@spec capability_at_least?(Tau.Provider.Capability.t(), :implemented | :advisory) :: boolean()
+def capability_at_least?(:implemented, _), do: true
+def capability_at_least?(:advisory, :advisory), do: true
+def capability_at_least?(_, _), do: false
+```
+
+## Tradeoffs
+
+### Strengths
+
+- The data shape now precisely models the fidelity spectrum; `:advisory`
+  captures the OpenAI-wire "we synthesise but don't request" case which a
+  boolean cannot express.
+- Forces every adapter author to consciously choose a level — no way to
+  accidentally assert `:implemented` for a feature that isn't wired.
+- No new callbacks or macros: enforcement is structural rather than procedural.
+- Satisfies the acceptance criterion: `:implemented` is a documented,
+  observable guarantee; `:advisory` and `:unsupported` are explicit caveats
+  in the type.
+- Dialyzer catches callers comparing capabilities to `true`/`false`
+  (incompatible type), surfacing migrations automatically.
+
+### Weaknesses
+
+- API-breaking: every caller of `capabilities/0` that pattern-matches on
+  `true`/`false` must be updated. This includes session.ex, TUI render paths,
+  and any external consumer.
+- `:advisory` is a new concept that callers must understand — it adds cognitive
+  load compared to a boolean.
+- Does not mechanically enforce that `:implemented` is true: an adapter can
+  still lie by declaring `:implemented` without the decode path. The type
+  alone does not create a compile-time check.
+- Dialyzer will flag mismatched callers as warnings, not errors, unless
+  `--warnings-as-errors` is active for dialyzer in CI (it is not by default).
+- Migration of eleven adapters is a coordinated, non-trivial change.
+
+### Costs
+
+- New file: `lib/tau/provider/capability.ex` (~25 LOC).
+- Modify `lib/tau/provider.ex`: update `@type capabilities`.
+- Modify all eleven adapters: replace boolean values with typed atoms.
+- Modify all callers of `capabilities/0`: search-and-replace pattern + manual
+  review for each branch. Estimate ~15–20 call sites based on the feature gating
+  pattern.
+- Update property tests and any fixture that asserts `capabilities()` structure.
+
+## Dependencies
+
+- No library or behaviour changes beyond `lib/tau/provider.ex`.
+- Caller migration can be staged: ship the type change first with a Dialyzer
+  run, fix callers in a second PR.
+
+## Confidence
+
+Medium-high. Elixir tagged atoms are idiomatic for typed enumerations; the
+pattern is well-established. Uncertainty is in migration cost (unknown number
+of call sites without a code scan) and in whether `:advisory` is a useful
+level or overcomplicates the API for callers that just want a binary gate.
+
+## Prior art / references
+
+- Elixir typed option enumerations: `Phoenix.Socket.Transport` uses
+  `:websocket | :longpoll` rather than booleans for transport type.
+- `Ecto.Adapter.Migration` capability atoms: `:up | :down | :unknown`.
+- Hickey "Simple Made Easy": distinguishing declaration from implementation
+  as a decomplecting move at the data-shape layer.

--- a/docs/problems-archive-v1-modules/tau-providers/subproblems/capabilities-flag-fidelity/proposals/proposal-3.md
+++ b/docs/problems-archive-v1-modules/tau-providers/subproblems/capabilities-flag-fidelity/proposals/proposal-3.md
@@ -1,0 +1,209 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 3
+parent_problem: ../problem.md
+---
+
+# Proposal 3: Documented advisory caveat in behaviour — no enforcement, maximum honesty
+
+## Approach
+
+Do not change the `capabilities/0` return type or add new callbacks. Instead,
+(1) add a module-level `@doc` contract to `@callback capabilities/0` that
+explicitly defines the truthfulness semantics of each flag — distinguishing
+"enforced by a mandatory callback" from "advisory (provider may support it but
+Tau does not actively request or synthesise it)" — and (2) demote Bedrock and
+Gemini's `thinking` and `prompt_caching` flags to `false` to match their actual
+decode paths. The behaviour @doc becomes the single source of truth for what
+each flag means; the codebase is correct-by-inspection rather than
+correct-by-enforcement.
+
+## Rationale
+
+The acceptance criterion allows a third path: "at minimum an explicit documented
+caveat in the behaviour that names which flags are advisory vs enforceable." The
+core harm today is not a missing type: it is that adapters declare `true` for
+features they do not implement, and no documentation warns callers. Demoting the
+lying flags to `false` eliminates the silent misleading. The doc contract
+formalises what "true" guarantees so future adapters cannot misread it.
+This is the smallest change that fully satisfies the criterion without
+introducing compile-time machinery or API breakage.
+
+## Sketch
+
+```elixir
+# lib/tau/provider.ex — updated callback doc
+
+@typedoc """
+Static capability flags declared by an adapter.
+
+## Flag semantics
+
+  * `thinking`        — `true` IFF the adapter (a) sends the provider-specific
+                        thinking-parameter block in `build_body/3` and (b) emits
+                        `%Event.ThinkingStart{}`, `%Event.ThinkingDelta{}`, and
+                        `%Event.ThinkingEnd{}` events in its decode path.
+                        Advisory: if the adapter merely passes through reasoning
+                        content that the provider returns unprompted, set `false`
+                        and document the pass-through in the module @doc.
+
+  * `prompt_caching`  — `true` IFF the adapter exports `cache_regions/2`.
+                        Because `cache_regions/2` is a behaviour callback, this
+                        flag is verifiable: `function_exported?(mod, :cache_regions, 2)`.
+
+  * `tools`           — `true` IFF the adapter serialises tool specs in `build_body/3`
+                        and dispatches `%Event.ToolCallStart{}`/`%Event.ToolCallDelta{}`/
+                        `%Event.ToolCallEnd{}` events in its decode path.
+
+  * `vision`          — `true` IFF the adapter serialises image content blocks
+                        in `build_body/3`.
+
+  * `parallel_tools`  — `true` IFF the adapter's provider supports issuing
+                        multiple concurrent tool calls in a single turn, and the
+                        adapter serialises `tool_choice: :auto` to request it.
+
+All flags are `true` only when Tau actively exercises the feature on the adapter,
+not merely because the underlying provider API supports it.
+"""
+@type capabilities :: %{
+        thinking: boolean(),
+        tools: boolean(),
+        vision: boolean(),
+        prompt_caching: boolean(),
+        parallel_tools: boolean()
+      }
+
+@doc """
+Returns the static capability flags for this adapter.
+
+See `t:capabilities/0` for the truthfulness contract of each flag.
+
+Callers MAY verify `prompt_caching` mechanically:
+
+    caps = adapter.capabilities()
+    if caps.prompt_caching do
+      true = function_exported?(adapter, :cache_regions, 2)
+    end
+
+All other flags are verified only by reading the adapter's decode path.
+"""
+@callback capabilities() :: capabilities()
+```
+
+```elixir
+# lib/tau/providers/bedrock.ex — demote to honest values
+def capabilities do
+  %{
+    thinking: false,        # decode path handles only text/tool; no ThinkingStart/Delta/End
+    tools: true,
+    vision: true,
+    prompt_caching: false,  # no cache_regions/2 exported
+    parallel_tools: true
+  }
+end
+
+# lib/tau/providers/gemini.ex — demote to honest values
+def capabilities do
+  %{
+    thinking: false,        # decode path handles only text deltas and functionCall parts
+    tools: true,
+    vision: true,
+    prompt_caching: false,  # no cache_regions/2 exported
+    parallel_tools: false
+  }
+end
+```
+
+```elixir
+# lib/tau/providers/shared/openai_chat_wire.ex — document the advisory case
+# Adapters using this wire with thinking: true (DeepSeek-R1, Qwen3 via delta.reasoning)
+# correctly declare thinking: true because the wire DOES emit ThinkingStart/Delta/End
+# (lines 115–166 confirmed in problem.md context). No change needed.
+```
+
+```elixir
+# Property test — test/tau/provider/capabilities_contract_test.exs (new)
+defmodule Tau.Provider.CapabilitiesContractTest do
+  @all_adapters [
+    Tau.Providers.Anthropic, Tau.Providers.Bedrock, Tau.Providers.Gemini,
+    Tau.Providers.OpenAI.Chat, Tau.Providers.OpenAI.Responses
+    # ... all adapters
+  ]
+
+  for adapter <- @all_adapters do
+    test "#{adapter}: prompt_caching: true iff cache_regions/2 exported" do
+      caps = unquote(adapter).capabilities()
+      if caps.prompt_caching do
+        assert function_exported?(unquote(adapter), :cache_regions, 2),
+               "#{unquote(adapter)} declares prompt_caching: true but does not export cache_regions/2"
+      else
+        refute function_exported?(unquote(adapter), :cache_regions, 2),
+               "#{unquote(adapter)} exports cache_regions/2 but declares prompt_caching: false"
+      end
+    end
+  end
+end
+```
+
+The `prompt_caching` flag becomes mechanically verifiable via the existing
+`cache_regions/2` optional callback. The `thinking` flag remains advisory
+(defined in the doc contract) because there is no single "thinking callback"
+to check against.
+
+## Tradeoffs
+
+### Strengths
+
+- Zero API breakage: `capabilities/0` return type is unchanged; all callers
+  continue to compile and run identically.
+- Satisfies the acceptance criterion via the "documented caveat" path: flags
+  are honest (demoted), and the doc contract explicitly names which flags are
+  enforceable (prompt_caching via cache_regions/2) vs advisory (thinking).
+- Smallest diff: two adapter capability maps + one @doc update + one test file.
+- Immediately corrects the silent misleading without requiring a multi-PR
+  migration.
+- `prompt_caching` becomes mechanically verifiable via a property test.
+
+### Weaknesses
+
+- `thinking` flag remains advisory: there is still no compile-time or runtime
+  check that an adapter declaring `thinking: true` actually emits
+  `ThinkingStart/Delta/End` events. The documentation is honest, but a future
+  adapter author can still lie.
+- Doc contracts are not machine-readable: the guarantees only hold as long as
+  humans read and honour the `@doc`. Dialyzer cannot enforce prose.
+- Does not scale as new flags are added: each new flag needs a human to update
+  the doc and demote any lying adapters.
+- Property test for `prompt_caching` cannot be generalised to `thinking` without
+  a new callback (the check is callback-specific, not structural).
+- No enforcement prevents a future PR from silently re-elevating Bedrock or
+  Gemini `thinking` to `true` without implementing the decode path.
+
+### Costs
+
+- New test file: `test/tau/provider/capabilities_contract_test.exs` (~40 LOC).
+- Modify `lib/tau/provider.ex`: update `@doc` and `@typedoc` (~30 lines added).
+- Modify `lib/tau/providers/bedrock.ex` and `lib/tau/providers/gemini.ex`:
+  demote 4 flag values total (4 one-line changes).
+- No migration of callers, adapters, or types.
+
+## Dependencies
+
+- None. This is a standalone documentation + correction change.
+
+## Confidence
+
+High. The change is purely additive documentation plus honest flag demotion.
+The `prompt_caching` ↔ `cache_regions/2` relationship is already implicit in
+the codebase and only needs to be made explicit. The property test pattern
+is standard ExUnit parameterisation.
+
+## Prior art / references
+
+- Elixir `@optional_callbacks` documentation pattern: Phoenix uses prose
+  contracts in `@doc` to define what "optional" means for each callback.
+- `lib/tau/provider.ex:89-109` — the existing `cache_regions/2` @doc already
+  uses this prose-contract pattern; this proposal extends it to `capabilities/0`.
+- Bertrand Meyer PEGS framework: documented contracts are valid obligations
+  even when not machine-enforced, provided they are clear and complete.

--- a/docs/problems-archive-v1-modules/tau-providers/subproblems/capabilities-flag-fidelity/proposals/proposal-4.md
+++ b/docs/problems-archive-v1-modules/tau-providers/subproblems/capabilities-flag-fidelity/proposals/proposal-4.md
@@ -1,0 +1,215 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 4
+parent_problem: ../problem.md
+---
+
+# Proposal 4: Runtime capability probe — adapters self-verify via a mandatory `probe/0` callback
+
+## Approach
+
+Add a mandatory `probe/0` callback to `Tau.Provider` that returns
+`{:ok, verified_capabilities}` or `{:error, [failed_flags]}`. Each adapter
+implements `probe/0` to exercise its own decode path against a minimal canned
+input (no real network call — a fixture struct that simulates a provider
+response chunk). `probe/0` is called at application startup (and optionally
+on demand) by a new `Tau.Provider.Registry` GenServer; it replaces the static
+`capabilities/0` return value with a runtime-verified map. Adapters that fail
+their probe have the failing flags demoted to `false` at runtime, with a
+startup log warning. `capabilities/0` is retained for the static declared
+intent but the Registry's verified map is what callers use.
+
+## Rationale
+
+Static maps and doc contracts both rely on human discipline. A runtime probe
+breaks the complect at the only layer where it cannot be bypassed: execution.
+If Bedrock's decode path does not emit `ThinkingStart`, `probe/0` running
+a fixture chunk through `decode_anthropic_event/2` will not observe the event,
+and the `thinking` flag is demoted at runtime — without any human needing to
+read the adapter. This scales to new flags and new adapters without requiring
+a doc update: the probe is the contract. Callers query the Registry instead of
+calling `adapter.capabilities()` directly, so the verified map is always current.
+
+## Sketch
+
+```elixir
+# lib/tau/provider.ex — new mandatory callback
+
+@doc """
+Exercises the adapter's own decode path against a provider-specific canned
+fixture and returns the verified capability flags.
+
+The probe MUST NOT make any network call. It runs against in-process fixture
+data (a minimal simulated provider response chunk). It returns:
+
+  * `{:ok, capabilities()}` — all declared capabilities verified.
+  * `{:error, failed :: [atom()]}` — one or more declared capabilities could
+    not be verified. The registry demotes the failing flags to `false` at
+    startup.
+
+Probe failures are logged at `:warning` level. The adapter continues to
+operate; unverified flags are conservatively set to `false`.
+"""
+@callback probe() :: {:ok, capabilities()} | {:error, [atom()]}
+```
+
+```elixir
+# lib/tau/provider/registry.ex — new supervised GenServer
+
+defmodule Tau.Provider.Registry do
+  @moduledoc """
+  Supervised GenServer that probes all configured adapters at startup and
+  maintains a runtime-verified capability map per adapter.
+
+  Callers use `Tau.Provider.Registry.capabilities/1` instead of
+  `adapter.capabilities/0` for the verified map.
+  """
+  use GenServer
+  require Logger
+
+  def start_link(opts \\ []) do
+    GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+  end
+
+  @spec capabilities(module()) :: Tau.Provider.capabilities()
+  def capabilities(adapter) do
+    GenServer.call(__MODULE__, {:capabilities, adapter})
+  end
+
+  @impl true
+  def init(_opts) do
+    adapters = Application.get_env(:tau, :providers, [])
+    verified = Map.new(adapters, fn mod -> {mod, probe_adapter(mod)} end)
+    {:ok, verified}
+  end
+
+  @impl true
+  def handle_call({:capabilities, adapter}, _from, verified) do
+    caps = Map.get(verified, adapter, adapter.capabilities())
+    {:reply, caps, verified}
+  end
+
+  defp probe_adapter(mod) do
+    declared = mod.capabilities()
+    case mod.probe() do
+      {:ok, verified} ->
+        verified
+      {:error, failed} ->
+        Logger.warning("#{inspect(mod)} probe failed for flags: #{inspect(failed)}; demoting to false")
+        Enum.reduce(failed, declared, fn flag, acc -> Map.put(acc, flag, false) end)
+    end
+  end
+end
+```
+
+```elixir
+# lib/tau/providers/bedrock.ex — example probe implementation
+
+def probe do
+  # Simulate a ThinkingStart chunk through decode_anthropic_event/2
+  thinking_fixture = %{
+    "type" => "content_block_start",
+    "content_block" => %{"type" => "thinking", "thinking" => ""}
+  }
+  case decode_anthropic_event(thinking_fixture, %{}) do
+    {events, _} when is_list(events) ->
+      has_thinking = Enum.any?(events, &match?(%Tau.Provider.Event.ThinkingStart{}, &1))
+      if has_thinking do
+        {:ok, capabilities()}
+      else
+        {:error, [:thinking]}
+      end
+    _ ->
+      {:error, [:thinking]}
+  end
+  # prompt_caching probe: check function_exported? (already verifiable statically)
+  # Can be added as a second clause
+end
+```
+
+```elixir
+# Caller migration — minimal:
+# Before:
+adapter.capabilities().thinking
+# After:
+Tau.Provider.Registry.capabilities(adapter).thinking
+```
+
+Existing `capabilities/0` on each adapter is retained for documentation
+purposes (declares intent) but is no longer the authoritative source for
+feature gating.
+
+## Tradeoffs
+
+### Strengths
+
+- The only proposal that mechanically catches a lying `decode_anthropic_event`
+  path at runtime, without requiring humans to read code.
+- Self-healing: if an adapter's decode is fixed in a later PR, the probe
+  automatically elevates the flag on next startup — no separate flag PR needed.
+- Scales to new flags without doc updates: add a new fixture to `probe/0`.
+- Directly satisfies "observable guarantee" in the acceptance criterion — the
+  guarantee is verified, not just declared.
+- Probe results can be exposed via telemetry for observability.
+
+### Weaknesses
+
+- `probe/0` is mandatory: adding it to eleven adapters is a significant
+  migration. The probe must be adapter-specific (fixture format differs per
+  provider), making it non-trivial to write correctly.
+- Fixture fidelity problem: a probe that passes a minimal fixture through
+  the decode path only proves the path exists for that fixture shape — a
+  decode path that happens to emit `ThinkingStart` for the fixture but not
+  for real provider chunks would pass the probe and still mislead callers.
+- Adds startup latency: all adapters probe on startup (in-process, so fast,
+  but still non-zero).
+- New process `Tau.Provider.Registry` in the supervision tree adds complexity;
+  caller migration from `adapter.capabilities()` to `Registry.capabilities(adapter)`
+  is a widespread change.
+- Probe infrastructure can drift from real usage: if `decode_anthropic_event`
+  changes its fixture handling but probes aren't updated, probes pass falsely.
+- API-breaking: callers should use `Registry.capabilities/1` not
+  `adapter.capabilities/0` — this is a significant coordination change.
+
+### Costs
+
+- New files: `lib/tau/provider/registry.ex` (~80 LOC),
+  `test/tau/provider/registry_test.exs`.
+- Modify `lib/tau/provider.ex`: add `probe/0` callback to `@callback` list.
+- Modify all eleven adapters: implement `probe/0` with adapter-specific fixtures.
+- Modify `lib/tau/application.ex`: add `Tau.Provider.Registry` to supervision tree.
+- Modify all callers of `capabilities/0`: route through Registry or use a
+  compatibility shim.
+- Fixture maintenance: each adapter's `probe/0` must be updated when the
+  provider's response format changes.
+
+## Dependencies
+
+- All adapters must implement `probe/0` before `Tau.Provider.Registry` can be
+  started with a complete verified map.
+- `Tau.Provider.Registry` must be started before any caller invokes
+  `Registry.capabilities/1`; supervision order must be updated.
+- Can be staged: ship `probe/0` as `@optional_callbacks` initially; Registry
+  falls back to `adapter.capabilities()` for adapters that don't yet have a probe.
+
+## Confidence
+
+Low. The fixture-fidelity problem is significant: a probe that only checks
+the static module structure (e.g. `function_exported?`) is equivalent to
+Proposal 1 with more machinery. A probe that exercises real decode paths
+requires non-trivial fixture engineering per adapter and ongoing maintenance.
+Confidence rises substantially if the scope is narrowed to a "structural probe
+only" (function_exported? checks) — but then Proposal 1 achieves the same
+result more simply.
+
+## Prior art / references
+
+- Erlang `:application` and `:health_check` pattern: modules self-report health
+  via a callback at startup.
+- PostgreSQL `pg_hba_file_rules` self-test: the auth config is verified at
+  reload, not just at write time.
+- Elixir `Nimble.Options` schema validation: validating a map's values against
+  declared constraints at use-time rather than definition-time.
+- Tau `Tau.CircuitBreaker` (SPEC-CIRCUIT-BREAKER): uses ETS-owner lifecycle
+  probe as a pattern for startup-time state verification.

--- a/docs/problems-archive-v1-modules/tau-providers/subproblems/capabilities-flag-fidelity/solution.md
+++ b/docs/problems-archive-v1-modules/tau-providers/subproblems/capabilities-flag-fidelity/solution.md
@@ -1,0 +1,217 @@
+---
+template_version: 1
+template_name: solution
+parent_problem: ../problem.md
+node_kind: leaf
+synthesised_from: [proposals/proposal-3.md, proposals/proposal-1.md]
+selection_method: hybrid
+revision: 1
+---
+
+# Solution: honest flags, mechanically enforced for the only verifiable flag
+
+## Recommendation
+
+Adopt Proposal 3's "honest flags + documented contract" as the spine of the
+fix, and graft on Proposal 1's structural-enforcement idea — but implemented as
+a **project-level CI gate task** (`mix tau.gate.capabilities`) rather than a
+`@before_compile` hook. The new gate, modelled on the existing
+`tau.gate.ac_linkage` / `tau.gate.masking` / `tau.gate.mutation` family, scans
+every `Tau.Providers.*` module and fails CI when `capabilities().prompt_caching
+== true` is not paired with an exported `cache_regions/2`, and vice versa. The
+behaviour module gains a single, prose-level `@doc` contract that names which
+flags are mechanically enforceable (`prompt_caching` only) and which are
+advisory-by-documentation (`thinking`, `tools`, `vision`, `parallel_tools`).
+Every adapter whose declared `prompt_caching: true` is unbacked is demoted in
+the same PR: today that means **Bedrock, Gemini, and DeepSeek**. No new
+`@callback`, no `@optional_callbacks` churn, no `@before_compile`, no
+`__using__` macro, no API-breaking type change.
+
+## Selected from
+
+- **Chosen:** hybrid of `proposals/proposal-3.md` (documented caveat + flag
+  demotion) + `proposals/proposal-1.md` (the enforcement idea, but reshaped
+  into a CI-gate task instead of a `@before_compile` hook).
+- **Why chosen:** Proposal 3 wins on every comparison axis (zero API breakage,
+  zero new callbacks, smallest diff, scores Yes on fit) but admits one
+  weakness — "no enforcement prevents a future PR from silently re-elevating
+  Bedrock or Gemini `thinking` to `true` without implementing the decode
+  path". For the `prompt_caching` flag specifically, that weakness can be
+  closed cheaply by adding the same kind of CI gate the repo already has for
+  every other enforcement need. We borrow the *motivation* of Proposal 1
+  (mechanical, not human-discipline-only) while rejecting its *mechanism*
+  (`@before_compile` via `__using__`) because every existing adapter binds via
+  `@behaviour Tau.Provider` directly (verified: `grep -n '@behaviour
+  Tau.Provider\|use Tau.Provider' lib/tau/providers/*.ex` returns nine
+  `@behaviour` matches and zero `use` matches), so the hook never fires
+  unless every adapter is also migrated to `use Tau.Provider` — that
+  migration is exactly what the prior selector's solution overlooked.
+  Proposal 2's typed-level enum is rejected on cost (eleven-adapter migration
+  plus ~15–20 caller sites for a problem whose only mechanically verifiable
+  flag is `prompt_caching`). Proposal 4's runtime probe is rejected on the
+  fixture-fidelity weakness its own author flagged (Confidence: Low).
+
+### Comparison table
+
+| # | Fit | Decomplecting depth | Migration cost | Risk | Reversibility |
+|---|---|---|---|---|---|
+| 1 | Yes — but mechanism (`@before_compile`) silently no-ops against `@behaviour`-binding adapters | Substantial in principle, Surface in practice | Medium (audit + migrate all adapters to `use`) | Medium (silent no-op already happened) | Easy |
+| 2 | Yes | Deep | High (11 adapters + 15–20 caller sites) | Medium | Hard (API break) |
+| 3 | Yes (via the "documented caveat" branch of the AC) | Substantial | Low (3 adapter edits + 1 doc + 1 test) | Low | Easy |
+| 4 | Partially — fixture fidelity gap | Substantial | High (11 adapters + supervisor + caller migration) | Medium-High | Hard |
+| **Hybrid (3 + CI gate)** | **Yes** | **Substantial** | **Low (3 adapter edits + 1 doc + 1 test + 1 mix task)** | **Low** | **Easy** |
+
+## What changes
+
+Concrete, file-level enumeration:
+
+1. **`lib/tau/provider.ex`** — extend the `@typedoc` and `@doc` on
+   `@callback capabilities/0` with the prose contract from Proposal 3 §Sketch
+   (flag-by-flag truthfulness semantics). Explicitly name `prompt_caching` as
+   the only mechanically enforceable flag and state that the enforcement runs
+   as the CI gate `mix tau.gate.capabilities`. **No new `@callback`, no
+   change to `@optional_callbacks`, no `__using__` macro, no
+   `@before_compile`.** (The existing `@callback cache_regions/2` declared at
+   `lib/tau/provider.ex:110` is already correctly paired with its
+   `@optional_callbacks` entry at line 131 and remains untouched.)
+
+2. **`lib/tau/providers/bedrock.ex:35-37`** — demote `thinking: true → false`
+   and `prompt_caching: true → false` (no `cache_regions/2` exists in this
+   module; decode path emits no thinking events).
+
+3. **`lib/tau/providers/gemini.ex:29-31`** — demote `thinking: true → false`
+   and `prompt_caching: true → false` (same justification; verified by
+   `grep cache_regions lib/tau/providers/gemini.ex` returning empty).
+
+4. **`lib/tau/providers/deepseek.ex:46-54`** — demote `prompt_caching: true →
+   false` (no `cache_regions/2` exists in this module; verified by
+   `grep -n 'def cache_regions' lib/tau/providers/deepseek.ex` returning
+   empty). The `thinking: true` flag on DeepSeek IS backed — the decode path
+   goes through `Tau.Providers.Shared.OpenAIChatWire` which synthesises
+   `ThinkingStart/Delta/End` events for `delta.reasoning` (per problem.md
+   Context, `openai_chat_wire.ex:115-166`) — so `thinking: true` stays.
+
+5. **`lib/mix/tasks/tau.gate.capabilities.ex`** (new file, ~60 LOC) — a
+   `Mix.Task` modelled directly on `lib/mix/tasks/tau.gate.ac_linkage.ex` /
+   `lib/mix/tasks/tau.gate.masking.ex` / `lib/mix/tasks/tau.gate.mutation.ex`
+   (precedent files already exist in `lib/mix/tasks/`). It loads every
+   module under the `Tau.Providers.` namespace that implements
+   `Tau.Provider`, reads each module's `capabilities/0`, and asserts the
+   biconditional
+
+   ```
+   capabilities().prompt_caching == true  ⇔  function_exported?(mod, :cache_regions, 2)
+   ```
+
+   Exit 0 on full agreement; exit 1 with a per-adapter diagnostic line on any
+   violation. The task is pure: no side effects, no network, no GenServer.
+   Shared helpers (if any emerge) live under `lib/mix/gate/`, following the
+   existing layout.
+
+6. **`.github/workflows/ci.yml`** — add an invocation of `mix
+   tau.gate.capabilities` to the existing `lint` job, alongside the existing
+   `mix tau.gate.ac_linkage` and `mix tau.gate.masking` lines (precedent at
+   ci.yml:101 and ci.yml:115). Blocking, same as `ac_linkage`.
+
+7. **`test/tau/provider/capabilities_contract_test.exs`** (new file, ~40 LOC) —
+   parameterised ExUnit case asserting the same biconditional at the unit-test
+   level for every adapter. Belt-and-braces with the gate task: the test runs
+   under `mix test` (developer-local fast feedback) and the gate task runs in
+   CI (PR-blocking, mirrors the gate-task pattern used elsewhere in the repo).
+
+## What does not change
+
+- The `capabilities/0` return shape (still `%{atom() => boolean()}`).
+- The set of `@callback` declarations in `Tau.Provider` (no addition; no
+  removal). `@optional_callbacks` is unchanged — `cache_regions/2` and
+  `context_window/1` remain optional, both still paired with `@callback`
+  declarations as the behaviour requires.
+- The binding style of any adapter (`@behaviour Tau.Provider` stays — no
+  forced migration to `use Tau.Provider`).
+- The `Tau.Providers.Anthropic` capability map (already honest: declares
+  `prompt_caching: true` and implements `cache_regions/2` at
+  `lib/tau/providers/anthropic.ex:92`).
+- The `Tau.Providers.OpenAI.Chat`, `Tau.Providers.OpenAI.Responses`,
+  `Tau.Providers.AzureOpenAI`, `Tau.Providers.Groq`,
+  `Tau.Providers.Mistral`, `Tau.Providers.Custom`, and `Tau.Providers.Replay`
+  capability maps — already declare `prompt_caching: false` and have no
+  `cache_regions/2`. The biconditional already holds for them.
+- The `thinking` flag's enforcement model. It remains advisory-by-doc; no
+  callback is added for it. Decomplecting a flag whose decode-path
+  obligations are not localisable to a single callback is left for a future
+  PR (open question below).
+- All non-provider call sites and all callers of `adapter.capabilities()`.
+
+## Migration sketch
+
+Single PR, in this order:
+
+1. Land the `@doc` / `@typedoc` prose contract on
+   `Tau.Provider.capabilities/0` (no behaviour change).
+2. Demote `Tau.Providers.Bedrock`, `Tau.Providers.Gemini`, and
+   `Tau.Providers.DeepSeek` capability maps to their honest values. Compile
+   stays green (boolean values unchanged in shape).
+3. Add `test/tau/provider/capabilities_contract_test.exs`; it passes the
+   moment step 2 is in place.
+4. Add `lib/mix/tasks/tau.gate.capabilities.ex`; run it locally
+   (`mix tau.gate.capabilities`) to confirm exit 0.
+5. Wire the gate into `.github/workflows/ci.yml`'s `lint` job.
+
+Rollback is trivial: revert any single step; later steps degrade to no-ops.
+The CI gate (step 5) is the only step with cross-PR enforcement — it can be
+reverted by deleting one line in ci.yml.
+
+## Open questions
+
+- **`thinking` flag enforcement.** The biconditional pattern works for
+  `prompt_caching` because there is exactly one callback (`cache_regions/2`)
+  whose presence is necessary AND sufficient evidence that the adapter
+  participates. No equivalent single callback exists for `thinking` — the
+  obligations are spread across `build_body/3` (sending the param block) and
+  the decode path (emitting `ThinkingStart/Delta/End`). Proposal 1's
+  `thinking_config/1` is one possible synthesis target, but until the
+  decode-path side is also enforced, the callback only proves something is
+  exported. The current solution leaves `thinking` advisory-by-doc and demotes
+  the two lying adapters (Bedrock, Gemini); whether a future enforcement
+  layer should target it is for a follow-up sub-problem.
+- **Should the test live alongside the gate or replace it?** This solution
+  ships both belt-and-braces. If maintenance friction surfaces, the unit test
+  is the obvious dropout candidate (the CI gate is the contract; the unit
+  test only mirrors it).
+- **Future adapters added via extensions** (per SPEC-EXTENSIONS) — the gate
+  task currently iterates `Tau.Providers.*`; whether it should also iterate
+  loaded extension modules is a Stage B question once extensions can register
+  providers.
+
+## Linked sub-problems / proposals
+
+- `proposals/proposal-1.md` — Enforce capability flags via mandatory optional
+  callbacks. Mechanism rejected (`@before_compile` silently no-ops against
+  `@behaviour`-binding adapters; every current adapter binds via `@behaviour`,
+  none via `use`); enforcement *motivation* preserved as the CI gate task.
+- `proposals/proposal-2.md` — Replace boolean flags with a typed capability
+  level struct. Rejected on migration cost and API breakage for a problem
+  whose mechanically verifiable surface is one flag.
+- `proposals/proposal-3.md` — Documented advisory caveat in behaviour. Chosen
+  as the spine of the solution.
+- `proposals/proposal-4.md` — Runtime capability probe. Rejected on the
+  fixture-fidelity weakness its own author flagged (Confidence: Low).
+
+## Revision history
+
+- (revision 0 — initial selection) Proposed Proposal 3 + a `@before_compile`
+  enforcer for `prompt_caching`. Falsified on three points: (a) the
+  enforcer never fires because every adapter binds via `@behaviour`, not
+  `use` (verified: `grep -n '@behaviour Tau.Provider\|use Tau.Provider'
+  lib/tau/providers/*.ex` returns nine `@behaviour` matches, zero `use`);
+  (b) the proposal would add `@optional_callbacks thinking_config: 1` without
+  a matching `@callback thinking_config(...)` declaration, emitting a compile
+  warning ("undefined callback function ..."); (c) the violation enumeration
+  omitted `Tau.Providers.DeepSeek`, which declares `prompt_caching: true` at
+  `lib/tau/providers/deepseek.ex:51` without exporting `cache_regions/2`.
+- (revision 1 — current) Replaced `@before_compile` enforcer with a CI-gate
+  task (`mix tau.gate.capabilities`) modelled on the existing
+  `tau.gate.ac_linkage` / `tau.gate.masking` / `tau.gate.mutation` family;
+  this enforcement mechanism is binding-style-agnostic. Added DeepSeek to
+  the demotion list. Removed all `@callback` / `@optional_callbacks` churn
+  — no behaviour-level changes beyond `@doc` / `@typedoc` prose.

--- a/docs/problems-archive-v1-modules/tau-providers/subproblems/capabilities-flag-fidelity/validation.md
+++ b/docs/problems-archive-v1-modules/tau-providers/subproblems/capabilities-flag-fidelity/validation.md
@@ -1,0 +1,567 @@
+---
+template_version: 1
+template_name: validation
+parent_solution: ./solution.md
+parent_problem: ./problem.md
+toulmin_complete: true
+falsification_attempted: true
+falsification_outcome: partially_falsified — claim/4
+revision_triggered: none
+---
+
+# Validation: honest flags, mechanically enforced for the only verifiable flag
+
+## Overview
+
+The solution proposes seven concrete changes: (1) extend `Tau.Provider`
+prose contract on `capabilities/0`, (2) demote Bedrock flags, (3) demote
+Gemini flags, (4) demote DeepSeek `prompt_caching` only (keeping
+`thinking: true`), (5) add a new Mix task `mix tau.gate.capabilities`, (6)
+wire it into `.github/workflows/ci.yml` lint job, (7) add an ExUnit
+parameterised contract test. This validation enumerates nine distinct
+claims, runs Toulmin per claim, and applies one falsification strategy per
+claim (mix of counter-example construction, dependency check, edge-case
+enumeration, prior-art counter-case). Outcome: eight withstood, one
+partially falsified (Claim 4 — the `thinking: true` retention on DeepSeek
+is correct given the current decode path, but the same biconditional logic
+the solution applies to `prompt_caching` would also flag DeepSeek's
+`thinking` as un-enforced; the partial falsification narrows the claim's
+qualifier and does NOT require revision of solution.md). No claim was
+fully falsified; no revision triggered.
+
+## Toulmin per claim
+
+### Claim 1: The behaviour module `Tau.Provider` will gain a prose contract on `@callback capabilities/0` naming `prompt_caching` as the only mechanically enforceable flag (Solution §What changes #1).
+
+- **Claim (C):** "extend the `@typedoc` and `@doc` on `@callback
+  capabilities/0` with the prose contract from Proposal 3 §Sketch (flag-by-
+  flag truthfulness semantics). Explicitly name `prompt_caching` as the
+  only mechanically enforceable flag and state that the enforcement runs
+  as the CI gate `mix tau.gate.capabilities`. No new `@callback`, no
+  change to `@optional_callbacks`, no `__using__` macro, no
+  `@before_compile`."
+- **Grounds (G):** `lib/tau/provider.ex:58-70` shows the current
+  `@typedoc "Static capability flags declared by an adapter."` followed by
+  `@type capabilities :: %{thinking: boolean(), tools: boolean(), vision:
+  boolean(), prompt_caching: boolean(), parallel_tools: boolean()}` and
+  `@callback capabilities() :: capabilities()`. Both attachment points
+  exist; adding `@doc` text to a `@callback` is the documented Elixir
+  mechanism (the file already does this on `@callback cache_regions/2`
+  and `@callback context_window/1`, lines 88-129). `@optional_callbacks`
+  at line 131 lists `[configure: 1, chat: 3, cache_regions: 2,
+  context_window: 1]` — unchanged by Claim 1.
+- **Warrant (W):** Elixir lets `@doc` attach prose to a subsequent
+  `@callback` declaration. Documentation is the canonical mechanism for
+  advisory-by-doc contracts when no mechanical enforcement is available
+  (Hickey's "complect" warning #2: prose-only contracts ARE legitimate
+  if their advisory status is explicit and not silently load-bearing).
+- **Qualifier (Q):** Holds unconditionally for the prose change itself.
+  The *effectiveness* of advisory-by-doc as a contract is bounded by the
+  CI gate (Claims 5/6) for `prompt_caching`; for the other four flags it
+  is bounded only by reviewer attention.
+- **Rebuttal (R):** A future contributor could ignore the docs. That is
+  not a falsification of Claim 1 — it is the standing weakness of advisory
+  documentation that the gate task partly mitigates (Claim 5).
+- **Backing (B):** `tau-architecture` OTP non-negotiable #2 — "extensibility
+  seams are behaviours; pattern match on atoms and structs." Adding prose
+  to an existing `@callback` does not change the seam; no ADR or SPEC
+  prohibits it. Precedent: `lib/tau/provider.ex:88-111` already attaches
+  detailed prose to `@callback cache_regions/2`.
+
+#### Falsification attempt for claim 1
+
+- **Strategy:** Counter-example construction — attempt to construct a code
+  state where adding `@doc`/`@typedoc` text to `@callback capabilities/0`
+  fails compile or violates a behaviour/SPEC invariant.
+- **Attempt:** Read the existing `Tau.Provider` module to confirm
+  attachment-point shape; search for any SPEC owning `lib/tau/provider.ex`
+  prose; check `spec-before-code.md`'s SPEC catalog for ownership of
+  `provider.ex`. Catalog entries that touch `lib/tau/provider.ex`:
+  SPEC-USER-TURN, SPEC-PROMPT-CACHING. Neither owns the `capabilities/0`
+  callback prose; SPEC-PROMPT-CACHING owns `cache_regions/2`.
+- **Outcome:** withstood. No counter-example produced. Caveat captured
+  under Outstanding doubts: the PR landing this change will still need to
+  cite the in-scope SPECs per `spec-before-code.md`, but that is an
+  implementation-PR obligation, not a falsification of Claim 1.
+- **Action:** none.
+
+### Claim 2: Bedrock's capability map will be demoted from `thinking: true, prompt_caching: true` to `thinking: false, prompt_caching: false` (Solution §What changes #2).
+
+- **Claim (C):** "`lib/tau/providers/bedrock.ex:35-37` — demote `thinking:
+  true → false` and `prompt_caching: true → false` (no `cache_regions/2`
+  exists in this module; decode path emits no thinking events)."
+- **Grounds (G):** `lib/tau/providers/bedrock.ex:35-37` reads `def
+  capabilities do %{thinking: true, tools: true, vision: true,
+  prompt_caching: true, parallel_tools: true} end` (verified). `grep -rn
+  'def cache_regions' lib/tau/providers/` returns only
+  `anthropic.ex:92` — no `cache_regions/2` exists in `bedrock.ex`. The
+  problem statement at `problem.md:31-34` documents that Bedrock's
+  `decode_anthropic_event/2` emits no thinking events.
+- **Warrant (W):** A `capabilities/0` flag declared `true` is a public
+  promise about adapter behaviour. When the adapter cannot honour the
+  promise (no `cache_regions/2` for `prompt_caching`; no
+  ThinkingStart/Delta/End emission for `thinking`), the honest value is
+  `false`. (Acceptance criterion in `problem.md:64-69`.)
+- **Qualifier (Q):** Holds for the current code state of `bedrock.ex` on
+  this commit. A future PR that *implements* Bedrock thinking or
+  cache_regions would re-elevate the flag; that is allowed and the gate
+  task (Claim 5) would let it through.
+- **Rebuttal (R):** If Bedrock's underlying API silently supported caching
+  via a request-shape Tau does not yet emit (e.g. a Bedrock-side prompt
+  cache that activates without explicit markers), the flag could be
+  advisory-true and still observably accurate. This is precisely what
+  Proposal 1's distinction between "Family B/C automatic caching" and
+  "Family A explicit caching" addresses — and the solution's `cache_regions/2`
+  return values cover (`:explicit | :automatic | :none`). Since Bedrock
+  does not implement `cache_regions/2` at all, neither `:automatic` nor
+  `:explicit` is declared, so demotion to `prompt_caching: false` is
+  consistent with the existing SPEC-PROMPT-CACHING contract.
+- **Backing (B):** SPEC-PROMPT-CACHING B1 (cited in
+  `lib/tau/provider.ex:89-108`) — "Dispatch is via `function_exported?/3`
+  at the call site; an adapter that does not implement it is treated as
+  `:none` (caching disabled for that adapter)." Demoting
+  `prompt_caching: false` brings the flag into alignment with the
+  callback-presence contract.
+
+#### Falsification attempt for claim 2
+
+- **Strategy:** Edge-case enumeration. List the conditions under which
+  Bedrock could legitimately keep `prompt_caching: true` or `thinking:
+  true` despite the absence of `cache_regions/2` and thinking events.
+- **Attempt:** (a) Bedrock could route through a different decode path
+  that emits thinking — checked `bedrock.ex` for any branch on model
+  family that delegates to OpenAIChatWire or Anthropic decode; the
+  decode-event handler is `decode_anthropic_event/2`, called only on
+  the streaming SSE chunks; no synthesis of `ThinkingStart/Delta/End`
+  appears. (b) Bedrock could rely on AWS-side opaque caching — possible
+  in principle, but the `cache_regions/2` callback is the *declared*
+  evidence that the adapter participates in Tau-side caching policy; no
+  implementation = no participation.
+- **Outcome:** withstood. Edge cases do not falsify; they reinforce the
+  current honest-flags reading.
+- **Action:** none.
+
+### Claim 3: Gemini's capability map will be demoted from `thinking: true, prompt_caching: true` to `thinking: false, prompt_caching: false` (Solution §What changes #3).
+
+- **Claim (C):** "`lib/tau/providers/gemini.ex:29-31` — demote `thinking:
+  true → false` and `prompt_caching: true → false` (same justification;
+  verified by `grep cache_regions lib/tau/providers/gemini.ex` returning
+  empty)."
+- **Grounds (G):** `lib/tau/providers/gemini.ex:29-31` reads `def
+  capabilities do %{thinking: true, tools: true, vision: true,
+  prompt_caching: true, parallel_tools: true} end` (verified by reading
+  the file). `grep -rn 'def cache_regions' lib/tau/providers/` shows no
+  match in `gemini.ex`. Problem statement `problem.md:35-38` documents
+  the absent thinking events and absent `cache_regions/2`.
+- **Warrant (W):** Same as Claim 2 — a flag declared `true` is a public
+  promise; absent the substrate to honour it, the honest value is `false`.
+- **Qualifier (Q):** Holds for the current code state of `gemini.ex`.
+  Gemini's native API does support cached content (`cachedContent`
+  resource lifecycle), per SPEC-PROMPT-CACHING Family D — but the spec
+  explicitly marks Family D as "deferred". Until that work lands, the
+  honest declaration is `false`.
+- **Rebuttal (R):** If a future PR lands SPEC-PROMPT-CACHING Family D for
+  Gemini, this flag re-elevates. That is the intended flow, not a
+  rebuttal of Claim 3 itself.
+- **Backing (B):** SPEC-PROMPT-CACHING (cited in `spec-before-code.md`):
+  "Family D — cachedContent resource lifecycle, deferred." The deferral
+  is documented; demotion is consistent with the deferral.
+
+#### Falsification attempt for claim 3
+
+- **Strategy:** Dependency check — does Gemini secretly satisfy the
+  contract via a different mechanism Tau already sees?
+- **Attempt:** `grep -rn 'cachedContent\|cache_regions' lib/tau/providers/
+  gemini.ex` → no results. Read `gemini.ex` decode path
+  (`problem.md:39-40` cites `decode/2` handling text and functionCall
+  only). Nothing in the current code base bridges Gemini's native cache to
+  Tau's `prompt_caching` flag.
+- **Outcome:** withstood.
+- **Action:** none.
+
+### Claim 4: DeepSeek's capability map will be demoted ONLY on `prompt_caching` (true → false); `thinking: true` is preserved because the OpenAIChatWire decode path synthesises `ThinkingStart/Delta/End` for the `delta.reasoning` field (Solution §What changes #4).
+
+- **Claim (C):** "`lib/tau/providers/deepseek.ex:46-54` — demote
+  `prompt_caching: true → false` (no `cache_regions/2` exists in this
+  module). The `thinking: true` flag on DeepSeek IS backed — the decode
+  path goes through `Tau.Providers.Shared.OpenAIChatWire` which
+  synthesises `ThinkingStart/Delta/End` events for `delta.reasoning`."
+- **Grounds (G):** `lib/tau/providers/deepseek.ex:46-54` reads (verified):
+  ```elixir
+  def capabilities do
+    %{thinking: true, tools: true, vision: false, prompt_caching: true,
+      parallel_tools: true}
+  end
+  ```
+  `grep -n 'def cache_regions' lib/tau/providers/deepseek.ex` → empty.
+  `lib/tau/providers/shared/openai_chat_wire.ex:115-133` synthesises
+  `%Event.ThinkingStart{}` and `%Event.ThinkingDelta{}` from
+  `Map.get(delta, "reasoning")`. `deepseek.ex:83` confirms DeepSeek
+  decodes via `&OpenAIChatWire.decode/2`.
+- **Warrant (W):** A flag is honestly `true` iff there exists an
+  observable path that delivers the feature. For `thinking`, that
+  observable path is "ThinkingStart/Delta/End events appear in the stream
+  emitted by the adapter's `stream/3`." That path exists for DeepSeek via
+  OpenAIChatWire. For `prompt_caching`, the observable path is
+  "`cache_regions/2` returns `:explicit | :automatic`." That path does not
+  exist for DeepSeek.
+- **Qualifier (Q):** The `thinking: true` retention holds *only when the
+  underlying DeepSeek model emits `delta.reasoning`* (e.g. DeepSeek-R1).
+  A future DeepSeek model that drops the reasoning field would silently
+  invalidate the flag. The solution does NOT add a mechanism to detect
+  this; the flag is per-adapter, not per-model. **This is a narrower
+  qualifier than the solution states.**
+- **Rebuttal (R):** If DeepSeek API silently caches via the
+  `prompt_cache_key` Mistral-style mechanism (SPEC-PROMPT-CACHING
+  Family E), then `prompt_caching: false` could be too pessimistic.
+  However, the existing code does not emit `prompt_cache_key` for
+  DeepSeek (verified — `grep -n 'prompt_cache_key'
+  lib/tau/providers/deepseek.ex lib/tau/providers/shared/openai_chat_wire.ex`
+  returns no results), so the honest declaration today is `false`.
+- **Backing (B):** SPEC-PROMPT-CACHING (cited in `spec-before-code.md`)
+  + the observable-path warrant in problem.md AC.
+
+#### Falsification attempt for claim 4
+
+- **Strategy:** Counter-example construction — apply the solution's own
+  biconditional logic to `thinking` and see if DeepSeek violates it.
+- **Attempt:** The solution's gate biconditional is `capabilities().
+  prompt_caching == true ⇔ function_exported?(mod, :cache_regions, 2)`.
+  There is *no equivalent callback* for `thinking`; obligations are
+  spread across `build_body/3` (sending the thinking param block) and
+  the decode path (emitting `ThinkingStart/Delta/End`). The solution
+  acknowledges this in §Open questions ("no equivalent single callback
+  exists for `thinking`"). Therefore `thinking: true` on DeepSeek is
+  *advisory-by-doc* under the solution, the same way it is for OpenAI
+  Responses (`thinking: true, prompt_caching: false`) and `Custom`
+  (`thinking: true, prompt_caching: false`) — which the solution leaves
+  untouched. The claim is internally consistent with the solution's own
+  framing.
+- **Outcome:** partially falsified. The narrowing: the solution's
+  qualifier should be tightened to "DeepSeek's `thinking: true` is
+  preserved as advisory-by-doc, on the same terms as OpenAI Responses
+  and Custom — observably correct *today* for DeepSeek-R1, but the
+  solution provides no mechanical enforcement for it." This is the
+  same outstanding doubt the solution itself records under §Open
+  questions ("thinking flag enforcement"). The partial falsification
+  records that DeepSeek inherits this gap, not just Bedrock/Gemini.
+- **Action:** narrow qualifier in place. No revision of solution.md
+  triggered — the solution already states the limit in §Open questions
+  and §What does not change ("The thinking flag's enforcement model. It
+  remains advisory-by-doc; no callback is added for it.").
+
+### Claim 5: A new Mix task `mix tau.gate.capabilities` will enforce the biconditional `capabilities().prompt_caching == true ⇔ function_exported?(mod, :cache_regions, 2)` across all `Tau.Providers.*` modules, modelled on existing `tau.gate.ac_linkage` / `tau.gate.masking` / `tau.gate.mutation` (Solution §What changes #5).
+
+- **Claim (C):** "`lib/mix/tasks/tau.gate.capabilities.ex` (new file,
+  ~60 LOC) — a `Mix.Task` modelled directly on
+  `lib/mix/tasks/tau.gate.ac_linkage.ex` /
+  `lib/mix/tasks/tau.gate.masking.ex` / `lib/mix/tasks/tau.gate.mutation.ex`.
+  It loads every module under the `Tau.Providers.` namespace that
+  implements `Tau.Provider`, reads each module's `capabilities/0`, and
+  asserts the biconditional `capabilities().prompt_caching == true ⇔
+  function_exported?(mod, :cache_regions, 2)`. Exit 0 on full agreement;
+  exit 1 with a per-adapter diagnostic line on any violation."
+- **Grounds (G):** Three precedent files exist (verified via `ls
+  lib/mix/tasks/`): `tau.gate.ac_linkage.ex`, `tau.gate.masking.ex`,
+  `tau.gate.mutation.ex`. Shared helpers under `lib/mix/gate/`:
+  `ac_linkage.ex`, `common.ex`, `masking.ex`, `mutation.ex`. The pattern
+  is established: pure Mix.Task → pure helper module → exit code 0/1.
+  `function_exported?/3` is used pervasively in the codebase (16 hits),
+  including `lib/tau/settings/schema.ex:302-304` checking
+  `function_exported?(mod, :stream, 3)` etc. on provider modules.
+- **Warrant (W):** Mix.Task is the documented Elixir mechanism for
+  CI-time enforcement gates. `function_exported?/3` returns true iff the
+  module is loaded AND exports the function — the gate task can call
+  `Code.ensure_loaded?/1` first (precedent at
+  `lib/tau/extensions/loader.ex:483`, `lib/tau/cli.ex:753`,
+  `lib/tau/tui/app/events.ex:325`). The biconditional is a sound
+  contract: if `prompt_caching: true` claims caching participation,
+  `cache_regions/2` is the existing callback that *declares* that
+  participation (SPEC-PROMPT-CACHING B1).
+- **Qualifier (Q):** Holds for modules under `Tau.Providers.*` whose
+  beam files are reachable at gate time. Excludes extension-loaded
+  provider modules (Solution §Open questions). Excludes any module that
+  fails to compile (gate runs *after* the compile step in the lint job).
+- **Rebuttal (R):** If a module enumeration based on namespace prefix
+  misses a provider module (e.g. one nested deeper than
+  `Tau.Providers.OpenAI.*`), the gate would silently skip it.
+  Mitigation: the implementation can use a behaviour-introspection
+  approach (`:attributes` lookup for `Tau.Provider`) instead of a
+  namespace prefix walk. The solution does not specify which, but both
+  approaches are sound.
+- **Backing (B):** `factory-loop.md` §"The three mechanical gates" — the
+  established pattern for repo-wide invariant enforcement is a CI gate
+  task. `:code.all_loaded/0` + `function_exported?/3` is the documented
+  introspection pattern (Erlang stdlib).
+
+#### Falsification attempt for claim 5
+
+- **Strategy:** Dependency check — does the proposed mechanism rely on
+  any precondition that doesn't hold today?
+- **Attempt:** (a) Check that `function_exported?/3` returns reliably for
+  *loaded* modules — yes, this is its documented contract. (b) Check
+  that all provider modules are loadable in the lint job context —
+  `mix compile --warnings-as-errors` precedes the gate in the lint job
+  (ci.yml:101 wires `tau.gate.ac_linkage` *after* compile), so all
+  `lib/tau/providers/**` modules are compiled. (c) Check for module
+  enumeration footgun: `Tau.Providers.OpenAI.Chat` and
+  `Tau.Providers.OpenAI.Responses` are nested under
+  `Tau.Providers.OpenAI` — a naive `for {mod, _} <- :code.all_loaded(),
+  String.starts_with?(Atom.to_string(mod), "Elixir.Tau.Providers.")` would
+  catch them. A behaviour-introspection approach (filter on
+  `mod.module_info(:attributes)[:behaviour]`) is equally sound.
+- **Outcome:** withstood. Two implementation choices exist; both are
+  sound. The solution's text does not over-constrain.
+- **Action:** none. Implementer should note the `Code.ensure_loaded?/1`
+  precaution.
+
+### Claim 6: The gate task will be wired into `.github/workflows/ci.yml`'s existing `lint` job, blocking on failure (Solution §What changes #6).
+
+- **Claim (C):** "`.github/workflows/ci.yml` — add an invocation of
+  `mix tau.gate.capabilities` to the existing `lint` job, alongside the
+  existing `mix tau.gate.ac_linkage` and `mix tau.gate.masking` lines
+  (precedent at ci.yml:101 and ci.yml:115). Blocking, same as
+  `ac_linkage`."
+- **Grounds (G):** `grep -n 'tau.gate' .github/workflows/ci.yml` returns
+  three matches: `:101 mix tau.gate.ac_linkage` (blocking), `:115 mix
+  tau.gate.masking ... || true` (detection-only), `:227 mix
+  tau.gate.mutation` (blocking, in mutation-check job). The lint-job
+  precedent for a blocking gate task is `ac_linkage` at line 101.
+- **Warrant (W):** A CI gate is binding iff a non-zero exit fails the
+  job. The `ac_linkage` invocation at line 101 lacks `|| true`, so its
+  exit code propagates — that is the binding pattern.
+- **Qualifier (Q):** Holds for PR-trigger events (the gate runs in the
+  lint job). Holds for push events to main if the lint job runs on push
+  (CI-config detail; not material to claim).
+- **Rebuttal (R):** A gate that runs only on PRs misses direct pushes to
+  main. Mitigation: the lint job in this repo runs on both `push` and
+  `pull_request` (standard pattern); the solution does not promise
+  otherwise.
+- **Backing (B):** `factory-loop.md` §"The three mechanical gates":
+  "Verified by CI via `mix tau.gate.ac_linkage` in the `lint` job
+  (blocking)."
+
+#### Falsification attempt for claim 6
+
+- **Strategy:** Counter-example construction — find a wiring choice that
+  defeats the blocking intent.
+- **Attempt:** `|| true` after the command would suppress the failure
+  (precedent of suppression at line 115 for the detection-only gate).
+  The solution explicitly says "Blocking, same as `ac_linkage`" — so the
+  implementer is instructed to omit `|| true`. No counter-example
+  construction defeats the *claim*; the implementation discipline is
+  what enforces it.
+- **Outcome:** withstood.
+- **Action:** none.
+
+### Claim 7: A new parameterised ExUnit test `test/tau/provider/capabilities_contract_test.exs` will assert the same biconditional at the unit-test level (Solution §What changes #7).
+
+- **Claim (C):** "`test/tau/provider/capabilities_contract_test.exs`
+  (new file, ~40 LOC) — parameterised ExUnit case asserting the same
+  biconditional at the unit-test level for every adapter. Belt-and-
+  braces with the gate task."
+- **Grounds (G):** ExUnit supports parameterised tests via dynamic
+  `test/2` definitions in `for`/`Enum.each` blocks (idiomatic
+  Elixir). The biconditional is the same one the gate enforces.
+- **Warrant (W):** A unit test runs under `mix test` and gives
+  developer-local fast feedback. A CI gate runs in the lint job and
+  blocks merge. Having both is a defence-in-depth pattern (acknowledged
+  by the solution itself as "belt-and-braces", with a flag that the
+  unit test is the obvious dropout if maintenance friction emerges).
+- **Qualifier (Q):** Holds for adapters loadable at test time.
+  Identical scope as the gate task.
+- **Rebuttal (R):** Duplication: two enforcement paths for one
+  invariant. The solution acknowledges this and flags the unit test as
+  the dropout candidate. Acceptable per the "complect" risk being
+  unidirectional (one-way deletion).
+- **Backing (B):** `factory-loop.md` permits both unit-test and gate-
+  task enforcement; the gates are the canonical CI-blocking layer.
+
+#### Falsification attempt for claim 7
+
+- **Strategy:** Counter-example construction — can the test give a
+  false-positive (passing while the gate fails or vice versa)?
+- **Attempt:** Both check `capabilities().prompt_caching ==
+  function_exported?(mod, :cache_regions, 2)` against the same set of
+  loaded modules. The only divergence vector is module-load timing
+  (unit test runs in `mix test`; gate runs after `mix compile`). Both
+  contexts load `lib/tau/providers/**` modules transitively from
+  `Tau.Provider` references. No divergence found.
+- **Outcome:** withstood.
+- **Action:** none.
+
+### Claim 8: The solution's enumeration of "what does not change" is complete and accurate for the providers it lists as already biconditional-compliant (Anthropic, OpenAI.Chat, OpenAI.Responses, Azure, Groq, Mistral, Custom, Replay).
+
+- **Claim (C):** "The `Tau.Providers.OpenAI.Chat`,
+  `Tau.Providers.OpenAI.Responses`, `Tau.Providers.AzureOpenAI`,
+  `Tau.Providers.Groq`, `Tau.Providers.Mistral`, `Tau.Providers.Custom`,
+  and `Tau.Providers.Replay` capability maps — already declare
+  `prompt_caching: false` and have no `cache_regions/2`. The
+  biconditional already holds for them."
+- **Grounds (G):** Verified via `grep -n -A 9 'def capabilities'` against
+  each file:
+  - openai/chat.ex:32 — `prompt_caching: false` ✓
+  - openai/responses.ex:29 — `prompt_caching: false` ✓
+  - azure_openai.ex:70 — `prompt_caching: false` ✓
+  - groq.ex:44 — `prompt_caching: false` ✓
+  - mistral.ex:44 — `prompt_caching: false` ✓
+  - custom.ex:70 — `prompt_caching: false` ✓
+  - replay.ex:71 — `prompt_caching: false` ✓
+  - anthropic.ex:69-77 — `prompt_caching: true` paired with
+    `cache_regions/2` at line 92 ✓
+  `grep -rn 'def cache_regions' lib/tau/providers/` returns ONLY
+  `anthropic.ex:92`. Biconditional holds for the eight listed providers.
+- **Warrant (W):** The biconditional is `prompt_caching == true ⇔
+  cache_regions/2 exported`. `false ⇔ not exported` holds vacuously for
+  the seven providers declaring `false`. `true ⇔ exported` holds for
+  Anthropic.
+- **Qualifier (Q):** Holds at the current commit. A future PR that
+  declares `prompt_caching: true` without `cache_regions/2` would fail
+  the gate — which is the intended behaviour.
+- **Rebuttal (R):** `Tau.Providers.OpenAI.Responses` declares
+  `thinking: true` without a callback to back it; same for
+  `Tau.Providers.Custom`. The solution leaves both untouched and
+  acknowledges this in §Open questions and Claim 4's analysis. The
+  biconditional Claim 8 covers is *prompt_caching*, not *thinking* — so
+  this is not a falsification of Claim 8, but it is an inherited
+  outstanding doubt (recorded below).
+- **Backing (B):** Direct file inspection (cited).
+
+#### Falsification attempt for claim 8
+
+- **Strategy:** Edge-case enumeration — for each of the eight providers,
+  check whether some other code path silently makes the flag claim
+  honest (e.g. a wire helper that injects cache markers).
+- **Attempt:** `grep -rn 'cache_regions\|prompt_cache_key\|cachedContent'
+  lib/tau/providers/` returns: only `anthropic.ex:92` (`cache_regions`)
+  and the SPEC reference text in `provider.ex` docstrings. No hidden
+  cache-marker injection in OpenAIChatWire or any other shared module.
+- **Outcome:** withstood.
+- **Action:** none.
+
+### Claim 9: The single-PR migration sketch (steps 1→5) is sound; rollback is trivial (revert any step, later steps degrade to no-ops).
+
+- **Claim (C):** "Single PR, in this order: 1. Land the @doc/@typedoc
+  prose contract. 2. Demote Bedrock, Gemini, DeepSeek capability maps.
+  3. Add unit test (passes immediately after step 2). 4. Add Mix task
+  (passes locally after step 2). 5. Wire into CI. Rollback is trivial:
+  revert any single step; later steps degrade to no-ops."
+- **Grounds (G):** Each step is file-isolated and commit-isolated; step
+  1 changes only docstrings; step 2 changes only `capabilities/0`
+  return values; step 3 adds a new test file; step 4 adds a new Mix task
+  file under `lib/mix/tasks/`; step 5 adds one line to ci.yml.
+- **Warrant (W):** Independent file changes admit independent reverts.
+  The biconditional check is consistent with the post-step-2 code state,
+  so adding the test (step 3) or gate (step 4) against the post-step-2
+  state passes without test/gate authoring touching production code.
+- **Qualifier (Q):** Rollback is trivial *as long as no downstream
+  consumer started branching on the new flag values between steps*.
+  Within a single PR, this risk is bounded; across PRs after merge, the
+  flag is observably honest, which is the point of the change.
+- **Rebuttal (R):** Step 2 (demotion) is technically a behaviour change
+  visible to any caller that previously branched on `capabilities().
+  prompt_caching` for Bedrock/Gemini/DeepSeek. If such a caller existed
+  and depended on the lie, the demotion would disable a feature for it.
+  Checked: `grep -rn 'capabilities().prompt_caching\|capabilities\.
+  prompt_caching\|\.prompt_caching' lib/ test/` — needed to verify no
+  caller branches on the lie. (See falsification attempt for details.)
+- **Backing (B):** `factory-loop.md` §"PR scope guards": a coherent,
+  single-PR scope with rollback is the preferred shape.
+
+#### Falsification attempt for claim 9
+
+- **Strategy:** Dependency check — does any consumer currently rely on
+  the (lying) `prompt_caching: true` for Bedrock/Gemini/DeepSeek?
+- **Attempt:** `grep -rn 'prompt_caching' lib/ test/` would surface
+  consumers. Within validator's allowed Bash scope: `grep -rn
+  'prompt_caching' /home/brentw/src/tau/lib/ /home/brentw/src/tau/test/`
+  was not executed during validation; rely on the structural argument:
+  the only way a consumer "gets" caching today is by the adapter
+  emitting cache markers in `build_body/3` (Family A) or relying on
+  automatic prefix caching (Family B/C). Neither path is implemented in
+  Bedrock/Gemini/DeepSeek, so any consumer branching on
+  `capabilities().prompt_caching == true` for these adapters was
+  already getting nothing. Demoting the flag to `false` reveals the
+  truth; it does not regress observable behaviour.
+- **Outcome:** withstood (structural argument). Recorded under
+  Outstanding doubts: a concrete grep for `prompt_caching` consumers in
+  the implementer PR would close the residual doubt mechanically.
+- **Action:** none for solution.md; implementer PR should run the grep
+  and surface any consumer that would change observable behaviour.
+
+## Cross-claim consistency
+
+Claims 2, 3, and 4 collectively assert demotions across three adapters.
+They are consistent with each other and with Claim 5 (the gate). Claim 5
+requires that AFTER demotion, every `prompt_caching: true` declaration
+is paired with an exported `cache_regions/2`. Post-demotion:
+- Anthropic: `true` ↔ exported ✓
+- Bedrock, Gemini, DeepSeek: `false` ↔ not exported ✓
+- All others: `false` ↔ not exported ✓
+Biconditional holds. Gate passes. Consistency confirmed.
+
+Claim 1 (prose contract) and Claim 8 (already-compliant providers) are
+mutually reinforcing: the prose contract documents the biconditional
+that Claim 8 demonstrates already holds for eight of nine providers
+(with Anthropic being the single `true` case).
+
+The Claim 4 partial falsification (DeepSeek's `thinking: true` is
+advisory-by-doc, same as OpenAI Responses and Custom) is consistent
+with the solution's own §Open questions and §What does not change. No
+internal tension.
+
+## Falsification summary
+
+| # | Claim (short) | Strategy | Outcome | Action |
+|---|---|---|---|---|
+| 1 | Prose contract on capabilities/0 | counter-example construction | withstood | none |
+| 2 | Demote Bedrock thinking+prompt_caching | edge-case enumeration | withstood | none |
+| 3 | Demote Gemini thinking+prompt_caching | dependency check | withstood | none |
+| 4 | Demote DeepSeek prompt_caching, keep thinking | counter-example construction | partially falsified | narrow qualifier in place |
+| 5 | New `mix tau.gate.capabilities` task | dependency check | withstood | none |
+| 6 | Wire gate into ci.yml lint job (blocking) | counter-example construction | withstood | none |
+| 7 | Parameterised ExUnit contract test | counter-example construction | withstood | none |
+| 8 | Eight already-compliant providers unchanged | edge-case enumeration | withstood | none |
+| 9 | Single-PR migration sketch | dependency check | withstood (structural) | implementer-PR grep advised |
+
+## Revision required
+
+None. No claim was fully falsified. The single partial falsification
+(Claim 4) narrows the qualifier in place: DeepSeek's `thinking: true`
+retention is advisory-by-doc on the same terms as OpenAI Responses and
+Custom, and the solution already records this limit explicitly in §Open
+questions and §What does not change. No edit to solution.md needed.
+
+## Outstanding doubts
+
+These do not falsify the solution but are flagged for the parent-level
+validator and the implementer PR:
+
+- **Module-load timing in the gate task.** `function_exported?/3` requires
+  the module to be loaded. Implementer should call `Code.ensure_loaded?/1`
+  first (precedent at `lib/tau/extensions/loader.ex:483`); the solution
+  does not specify this but the implementer should not omit it.
+- **Module enumeration choice.** Namespace prefix walk vs.
+  `module_info(:attributes)[:behaviour]` introspection — both sound,
+  unspecified in the solution. Implementer's choice.
+- **`thinking` flag enforcement gap on three adapters** (OpenAI Responses,
+  Custom, DeepSeek-R1-shaped models). Inherited from §Open questions;
+  out of scope of this sub-problem per the acceptance criterion ("at
+  minimum an explicit documented caveat... names which flags are
+  advisory vs enforceable"). The solution satisfies the AC via the
+  documented-caveat branch.
+- **SPEC ownership for `lib/tau/provider.ex` callback prose.** The PR
+  landing Claim 1 should cite SPEC-USER-TURN and SPEC-PROMPT-CACHING in
+  scope per `spec-before-code.md`, since both list `provider.ex` in
+  their source maps. This is an implementer-PR obligation, not a
+  validation finding.
+- **Consumer grep for `prompt_caching` callers.** Not run during this
+  validation; implementer PR should run `grep -rn 'prompt_caching' lib/
+  test/` to confirm no consumer's observable behaviour regresses.
+- **Extension-loaded providers.** Per §Open questions, the gate
+  currently iterates compiled `Tau.Providers.*` modules; extension-
+  registered providers are out of scope (Stage B).
+- **DeepSeek model-family fragility.** `thinking: true` is honest *only
+  when* the configured DeepSeek model emits `delta.reasoning`. A future
+  DeepSeek non-reasoning model would silently invalidate the flag, with
+  no mechanical signal. Solution-acknowledged limit (advisory-by-doc).

--- a/docs/problems-archive-v1-modules/tau-providers/subproblems/usage-normalisation/problem.md
+++ b/docs/problems-archive-v1-modules/tau-providers/subproblems/usage-normalisation/problem.md
@@ -1,0 +1,81 @@
+---
+template_version: 1
+template_name: problem
+node_kind: leaf
+depth: 1
+parent: ../../problem.md
+status: draft
+---
+
+# Problem: usage-normalisation
+
+## Statement
+
+`%Tau.Provider.Event.Done{usage: map()}` carries an implicit per-adapter
+schema. SPEC-PROMPT-CACHING §4 B3 defines the canonical key set
+(`input_tokens`, `output_tokens`, `cache_read`, `cache_write`,
+`cache_breakdown`), but only Anthropic's `merge_usage/2` emits it. All adapters
+using `OpenAIChatWire.decode/2` emit `%Event.Done{stop_reason: ..., usage: %{}}`
+— an empty map — regardless of whether the upstream API returned token counts.
+Bedrock and Gemini also emit empty usage. Consumers relying on usage maps for
+cost tracking, context-window percentage display, or cache-efficiency reporting
+silently receive zero or absent values for all non-Anthropic providers.
+
+## Context
+
+- `lib/tau/provider/event.ex:90-95` — `Done.t()` specifies `usage: map()` with
+  no further constraint on which keys are present.
+- `lib/tau/providers/anthropic.ex:284-315` — `merge_usage/2` normalises
+  `message_start` + `message_delta` usage blocks into the B3 canonical map.
+  It is an adapter-private function, not a shared utility or callback.
+- `lib/tau/providers/shared/openai_chat_wire.ex:66` — `%Event.Done{stop_reason:
+  :stop}` (no `usage:` key; defaults to `%{}`). The OpenAI Chat Completions
+  SSE stream does include token usage in the final `[DONE]` delta when
+  `stream_options: {include_usage: true}` is set, but `build_body/4` never
+  sets it — so the data is never requested.
+- `lib/tau/providers/bedrock.ex:121-123` — `message_stop` handler emits
+  `%Event.Done{stop_reason: :stop}` with no usage.
+- `lib/tau/providers/gemini.ex:112-118` — finish-reason handler emits
+  `%Event.Done{stop_reason: :stop}` with no usage. The Gemini response does
+  include `usageMetadata` at the top level, but `decode_chunk/2` never reads it.
+- SPEC-PROMPT-CACHING §4 B3 and D-065 define the canonical usage contract; the
+  SPEC names it as "each adapter's own `merge_usage`-side responsibility" but
+  provides no scaffold or shared utility to enforce it.
+
+## Complecting hypothesis
+
+1. **Usage key presence is complected with adapter identity:** whether
+   `Done.usage` carries meaningful token counts depends on which adapter
+   produced the event, not on the declared event type contract.
+2. **Raw wire-protocol usage fields are complected with normalisation
+   responsibility:** each adapter is individually responsible for mapping its
+   wire-format usage fields to canonical Tau keys, but the behaviour provides
+   no shared utility, no typespec constraint on the `usage` map, and no test
+   fixture to validate conformance.
+
+## Decomposition strategy
+
+(leaf — no further decomposition; proceed to proposals)
+
+## Acceptance criterion
+
+Every production adapter that receives token-usage data from its upstream API
+emits a `%Event.Done{usage: map()}` where `usage` contains at minimum the
+canonical keys `input_tokens` and `output_tokens` with non-negative integer
+values, and where any absent upstream field yields `0` rather than a missing key
+— verified by a shared conformance test or typespec that all adapters satisfy.
+
+## Out of scope
+
+- Event sequencing (TextStart/TextEnd framing) — covered by
+  `callback-contract-drift`.
+- Capabilities flag accuracy — covered by `capabilities-flag-fidelity`.
+- Auth-resolution — covered by `auth-resolution-scatter`.
+- The `cache_read` / `cache_write` / `cache_breakdown` sub-keys for
+  adapters that do not support prompt caching — these are legitimately `0`
+  or absent for non-caching adapters; the acceptance criterion only requires
+  the base `input_tokens`/`output_tokens` pair.
+
+## Amendment log
+
+- (none yet)

--- a/docs/problems-archive-v1-modules/tau-providers/subproblems/usage-normalisation/proposals/proposal-1.md
+++ b/docs/problems-archive-v1-modules/tau-providers/subproblems/usage-normalisation/proposals/proposal-1.md
@@ -1,0 +1,234 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 1
+parent_problem: ../problem.md
+---
+
+# Proposal 1: `normalise_usage/1` behaviour callback with shared zero-default scaffold
+
+## Approach
+
+Add a new optional callback `normalise_usage/1` to `Tau.Provider` that each
+adapter implements. Provide a shared default implementation in
+`Tau.Provider.UsageNorm` that each adapter calls (or delegates to directly).
+The callback receives the raw wire-format usage map returned by the upstream API
+and returns the canonical B3 map. `stream/3` wrappers in each adapter call this
+before emitting `%Event.Done{}`, replacing the empty `%{}` default. A shared
+`UsageNorm.zero/0` returns `%{input_tokens: 0, output_tokens: 0, cache_read: 0,
+cache_write: 0, cache_breakdown: %{}}` so adapters that receive no usage data
+from the upstream have a conforming fallback. The behaviour module enforces
+conformance through an `@optional_callbacks [normalise_usage: 1]` declaration
+and documents that omission is treated as `UsageNorm.zero/0`.
+
+## Rationale
+
+The complecting hypothesis names two entangled concerns: (1) adapter identity
+determining key presence and (2) no shared normalisation scaffold. A behaviour
+callback directly decomplects (1) by placing the normalisation responsibility
+explicitly at the adapter interface boundary, making it a contract obligation
+rather than ad-hoc internal logic. The shared scaffold addresses (2): adapters
+cannot "forget" to normalise if the behaviour points them at `UsageNorm`. The
+canonical pattern in the codebase (e.g. `cache_regions/2`, `configure/1`) is
+optional callbacks with documented defaults, making this approach idiomatic to
+the existing `Tau.Provider` design.
+
+## Sketch
+
+```elixir
+# lib/tau/provider/usage_norm.ex  (new file)
+defmodule Tau.Provider.UsageNorm do
+  @moduledoc """
+  Shared utility for normalising per-adapter wire-format usage maps into the
+  SPEC-PROMPT-CACHING §4 B3 canonical key set.
+  """
+
+  @type canonical :: %{
+    input_tokens: non_neg_integer(),
+    output_tokens: non_neg_integer(),
+    cache_read: non_neg_integer(),
+    cache_write: non_neg_integer(),
+    cache_breakdown: map()
+  }
+
+  @spec zero() :: canonical()
+  def zero,
+    do: %{input_tokens: 0, output_tokens: 0, cache_read: 0, cache_write: 0, cache_breakdown: %{}}
+
+  @spec nonneg(term()) :: non_neg_integer()
+  def nonneg(n) when is_integer(n) and n >= 0, do: n
+  def nonneg(_), do: 0
+
+  @spec from_openai(map() | nil) :: canonical()
+  def from_openai(nil), do: zero()
+  def from_openai(u) do
+    %{
+      input_tokens: nonneg(u["prompt_tokens"]),
+      output_tokens: nonneg(u["completion_tokens"]),
+      cache_read: 0,
+      cache_write: 0,
+      cache_breakdown: %{}
+    }
+  end
+
+  @spec from_gemini(map() | nil) :: canonical()
+  def from_gemini(nil), do: zero()
+  def from_gemini(u) do
+    %{
+      input_tokens: nonneg(u["promptTokenCount"]),
+      output_tokens: nonneg(u["candidatesTokenCount"]),
+      cache_read: nonneg(u["cachedContentTokenCount"]),
+      cache_write: 0,
+      cache_breakdown: %{}
+    }
+  end
+end
+
+# lib/tau/provider.ex  (diff: add optional callback)
+@callback normalise_usage(raw :: map() | nil) :: Tau.Provider.UsageNorm.canonical()
+@optional_callbacks [normalise_usage: 1, configure: 1, cache_regions: 2, context_window: 1]
+
+# lib/tau/providers/shared/openai_chat_wire.ex  (diff: inject into Done emission)
+# Before (line 66):
+#   def decode(%{data: "[DONE]"}, partial), do: {[%Event.Done{stop_reason: :stop}], partial}
+# After: wire the `usage` accumulated in partial (requires build_body to request it via
+#        `stream_options: %{include_usage: true}` so the final SSE chunk carries usage):
+
+def decode(%{data: "[DONE]"}, %{usage: raw_usage, provider: mod} = partial) do
+  usage =
+    if function_exported?(mod, :normalise_usage, 1),
+      do: mod.normalise_usage(raw_usage),
+      else: Tau.Provider.UsageNorm.from_openai(raw_usage)
+  {[%Event.Done{stop_reason: :stop, usage: usage}], partial}
+end
+
+# lib/tau/providers/bedrock.ex  (diff: message_stop handler reads usage from partial)
+defp decode_anthropic_event(%{"type" => "message_stop"}, p) do
+  usage = Tau.Provider.UsageNorm.nonneg_bedrock(Map.get(p, :usage_raw, %{}))
+  {[%Event.Done{stop_reason: :stop, usage: usage}], p}
+end
+
+# lib/tau/providers/gemini.ex  (diff: pass usageMetadata from top-level JSON into Done)
+finish =
+  case get_in(json, ["candidates", Access.at(0), "finishReason"]) do
+    "STOP" ->
+      usage = Tau.Provider.UsageNorm.from_gemini(json["usageMetadata"])
+      [%Event.Done{stop_reason: :stop, usage: usage}]
+    "MAX_TOKENS" ->
+      usage = Tau.Provider.UsageNorm.from_gemini(json["usageMetadata"])
+      [%Event.Done{stop_reason: :length, usage: usage}]
+    _ -> []
+  end
+```
+
+Conformance test (new `test/tau/provider/usage_norm_test.exs`):
+```elixir
+defmodule Tau.Provider.UsageNormTest do
+  use ExUnit.Case, async: true
+
+  @adapters [
+    Tau.Providers.Anthropic,
+    Tau.Providers.OpenAI.Chat,
+    Tau.Providers.OpenAI.Responses,
+    Tau.Providers.Gemini,
+    Tau.Providers.Bedrock,
+    Tau.Providers.Groq,
+    Tau.Providers.Mistral,
+    Tau.Providers.DeepSeek,
+    Tau.Providers.AzureOpenAI,
+    Tau.Providers.Custom,
+    Tau.Providers.Copilot
+  ]
+
+  test "all production adapters emit usage with at least input_tokens and output_tokens" do
+    for adapter <- @adapters do
+      # Drive a fixture stream for each adapter via the Replay mechanism or
+      # by calling normalise_usage/1 directly on a representative wire payload.
+      usage =
+        if function_exported?(adapter, :normalise_usage, 1),
+          do: adapter.normalise_usage(%{}),
+          else: Tau.Provider.UsageNorm.zero()
+
+      assert is_integer(usage.input_tokens) and usage.input_tokens >= 0,
+             "#{adapter}: input_tokens must be non-negative integer"
+      assert is_integer(usage.output_tokens) and usage.output_tokens >= 0,
+             "#{adapter}: output_tokens must be non-negative integer"
+    end
+  end
+end
+```
+
+Files changed:
+- `lib/tau/provider.ex` — +1 optional callback
+- `lib/tau/provider/usage_norm.ex` — new (~60 lines)
+- `lib/tau/providers/shared/openai_chat_wire.ex` — wire usage accumulation + Done emission
+- `lib/tau/providers/bedrock.ex` — message_stop usage read
+- `lib/tau/providers/gemini.ex` — usageMetadata read into Done
+- `lib/tau/providers/anthropic.ex` — add `normalise_usage/1` delegating to existing `merge_usage/2`
+- `test/tau/provider/usage_norm_test.exs` — new conformance test
+
+## Tradeoffs
+
+### Strengths
+
+- Directly addresses complecting hypothesis (1): normalisation is now a named
+  contract obligation at the behaviour boundary, not implicit per-adapter logic.
+- Directly addresses complecting hypothesis (2): `UsageNorm` provides the shared
+  scaffold and zero-default, making compliance the path of least resistance.
+- Idiomatic: `@optional_callbacks` with documented defaults is the existing
+  pattern in `Tau.Provider` (`configure/1`, `cache_regions/2`).
+- No API-breaking change to `%Event.Done{}` struct shape — `usage` remains a
+  map; consumers are unaffected.
+- Anthropic's `merge_usage/2` migrates trivially by delegating to it from
+  `normalise_usage/1`.
+- The conformance test iterates all known adapters, so a new adapter that forgets
+  the callback is caught by the test rather than silently regressing.
+
+### Weaknesses
+
+- `@optional_callbacks` means a new adapter author can still omit the callback
+  and get `%{}` at runtime unless they notice the fallback path in `decode`. The
+  behaviour does not force implementation — it documents intent.
+- The `include_usage: true` addition to OpenAI `build_body/4` adds one field to
+  every OpenAI-family request body; this is intentional but a wire-level change
+  that may surface in tests or replay fixtures.
+- Bedrock's `message_stop` usage requires accumulating usage from `message_start`
+  into partial state, which is a non-trivial addition to the decode loop.
+- Partial accumulation across chunks (for Bedrock's separate `message_start` /
+  `message_delta` usage blocks) mirrors Anthropic's existing pattern but requires
+  porting it to the Bedrock decode path, which is currently simpler.
+
+### Costs
+
+- ~100 lines new code (`UsageNorm`, test).
+- ~30 lines changed across 4 adapters + `provider.ex`.
+- Replay fixtures for OpenAI-family adapters may need a `usage` key added to
+  their final `[DONE]` chunk to make the conformance test cover real wire data.
+- SPEC-PROMPT-CACHING §4 B3 amendment: document `normalise_usage/1` as the new
+  adapter-side hook (small prose addition).
+
+## Dependencies
+
+- `stream_options: %{include_usage: true}` must be added to `build_body/4` in
+  `OpenAIChatWire` before OpenAI-family adapters can populate real usage data;
+  without it, the wire payload carries no usage and `UsageNorm.from_openai/1`
+  will return `zero()` (conforming, but zero-valued).
+- No library additions required.
+
+## Confidence
+
+**Medium.** The approach is structurally clear and idiomatic, but the Bedrock
+partial-accumulation path requires reading the full Bedrock decode loop to
+confirm the partial shape accepts a new `usage_raw` key without conflict.
+Confidence would rise to **high** after verifying the Bedrock partial map
+structure and confirming `include_usage: true` is honoured by all OpenAI-family
+endpoints (Groq, Mistral, DeepSeek, Azure, Custom).
+
+## Prior art / references
+
+- `Tau.Provider` `configure/1` and `cache_regions/2` — existing optional-callback
+  pattern with defaults.
+- `Tau.Providers.Anthropic.merge_usage/2` — private implementation that becomes
+  the prototype for the shared scaffold.
+- SPEC-PROMPT-CACHING §4 B3 — canonical key set this proposal enforces.
+- OpenAI Chat Completions API docs — `stream_options.include_usage` parameter.

--- a/docs/problems-archive-v1-modules/tau-providers/subproblems/usage-normalisation/proposals/proposal-2.md
+++ b/docs/problems-archive-v1-modules/tau-providers/subproblems/usage-normalisation/proposals/proposal-2.md
@@ -1,0 +1,209 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 2
+parent_problem: ../problem.md
+---
+
+# Proposal 2: `%Event.Usage{}` typed struct replaces `usage: map()` in `Done.t()`
+
+## Approach
+
+Replace the `usage: map()` field on `%Event.Done{}` with `usage:
+%Tau.Provider.Event.Usage{}` — a new struct with `@enforce_keys` requiring
+`input_tokens` and `output_tokens`, and defaulting `cache_read`, `cache_write`,
+and `cache_breakdown` to `0` / `%{}`. Every site that currently emits
+`%Event.Done{stop_reason: ...}` (with the implicit `usage: %{}` default) must
+provide an explicit `%Event.Usage{}`. The compiler enforces the required keys.
+No new behaviour callback is added; normalisation is enforced by the type system
+rather than by contract. A module-level `@type` on `Event.Usage` documents the
+canonical key set; Dialyzer will catch consumers accessing keys that don't exist
+on the struct.
+
+## Rationale
+
+The core complecting problem is that `usage: map()` is an unstructured type —
+any key or no key is equally valid to the compiler. Replacing it with a struct
+enforces the B3 canonical key set at the data-shape level rather than at the
+interface level. This directly decomplects (1) adapter identity from key
+presence: all adapters must produce the same struct shape, which cannot vary by
+adapter without a compile or Dialyzer error. For (2), the struct's default
+fields serve as the shared scaffold — adapters that can't populate a field
+simply omit the key and get the declared default, rather than leaving the map
+empty.
+
+## Sketch
+
+```elixir
+# lib/tau/provider/event.ex  (diff: new struct + Done update)
+
+defmodule Tau.Provider.Event.Usage do
+  @moduledoc """
+  Canonical token-usage record for a completed provider stream.
+
+  `input_tokens` and `output_tokens` are required (non-negative integers).
+  Cache-related keys default to 0 / empty map for providers that do not
+  support prompt caching.
+  """
+  @enforce_keys [:input_tokens, :output_tokens]
+  defstruct [
+    :input_tokens,
+    :output_tokens,
+    cache_read: 0,
+    cache_write: 0,
+    cache_breakdown: %{}
+  ]
+
+  @type t :: %__MODULE__{
+    input_tokens: non_neg_integer(),
+    output_tokens: non_neg_integer(),
+    cache_read: non_neg_integer(),
+    cache_write: non_neg_integer(),
+    cache_breakdown: map()
+  }
+end
+
+defmodule Tau.Provider.Event.Done do
+  @moduledoc "Stream finished cleanly."
+  @enforce_keys [:stop_reason]
+  defstruct [:stop_reason, usage: nil]
+  @type t :: %__MODULE__{
+    stop_reason: atom(),
+    usage: Tau.Provider.Event.Usage.t() | nil
+  }
+end
+```
+
+Call-site changes (every `%Event.Done{}` without usage):
+```elixir
+# lib/tau/providers/shared/openai_chat_wire.ex
+# Before:
+%Event.Done{stop_reason: :stop}
+# After (with include_usage SSE data accumulated in partial):
+%Event.Done{
+  stop_reason: :stop,
+  usage: %Event.Usage{input_tokens: partial.usage_in, output_tokens: partial.usage_out}
+}
+
+# lib/tau/providers/bedrock.ex
+%Event.Done{
+  stop_reason: :stop,
+  usage: %Event.Usage{
+    input_tokens: Map.get(p, :usage_in, 0),
+    output_tokens: Map.get(p, :usage_out, 0)
+  }
+}
+
+# lib/tau/providers/gemini.ex
+%Event.Done{
+  stop_reason: :stop,
+  usage: %Event.Usage{
+    input_tokens: get_in(json, ["usageMetadata", "promptTokenCount"]) || 0,
+    output_tokens: get_in(json, ["usageMetadata", "candidatesTokenCount"]) || 0,
+    cache_read: get_in(json, ["usageMetadata", "cachedContentTokenCount"]) || 0
+  }
+}
+
+# lib/tau/providers/anthropic.ex  (existing merge_usage/2 output wrapped)
+%Event.Done{
+  stop_reason: stop_reason,
+  usage: struct!(Event.Usage, Anthropic.merge_usage(start_u, delta_u))
+}
+```
+
+Conformance test (new):
+```elixir
+defmodule Tau.Provider.Event.UsageConformanceTest do
+  use ExUnit.Case, async: true
+
+  test "Event.Usage struct enforces required fields" do
+    assert_raise ArgumentError, fn ->
+      struct!(Tau.Provider.Event.Usage, %{})
+    end
+  end
+
+  test "Event.Usage has correct defaults for cache fields" do
+    u = %Tau.Provider.Event.Usage{input_tokens: 10, output_tokens: 5}
+    assert u.cache_read == 0
+    assert u.cache_write == 0
+    assert u.cache_breakdown == %{}
+  end
+end
+```
+
+Consumer migration: sites reading `event.usage["input_tokens"]` change to
+`event.usage.input_tokens`; most consumers are in `Tau.Session` and
+`Tau.Cost.Tracker`. The `usage: nil` default on `Done` (rather than `%{}`) lets
+existing consumers guard on `is_nil(event.usage)` during migration.
+
+Files changed:
+- `lib/tau/provider/event.ex` — new `Usage` struct; update `Done.t()`
+- `lib/tau/providers/shared/openai_chat_wire.ex` — emit `%Event.Usage{}`
+- `lib/tau/providers/bedrock.ex` — emit `%Event.Usage{}`
+- `lib/tau/providers/gemini.ex` — emit `%Event.Usage{}`
+- `lib/tau/providers/anthropic.ex` — wrap `merge_usage/2` in `%Event.Usage{}`
+- Any consumer reading `event.usage["..."]` → `event.usage.key`
+- `test/tau/provider/event/usage_conformance_test.exs` — new
+
+## Tradeoffs
+
+### Strengths
+
+- Strongest enforcement mechanism available without a runtime check: the
+  compiler enforces `@enforce_keys`; Dialyzer enforces the field types.
+- Decomplects (1) completely: adapter identity cannot influence key presence
+  because the struct shape is fixed at the type level.
+- Decomplects (2) by making the scaffold the struct itself — adapters
+  trivially satisfy the contract by constructing `%Event.Usage{input_tokens: x,
+  output_tokens: y}` and getting defaults for the rest.
+- Zero runtime overhead over the existing map default.
+- Future extensions (e.g. Anthropic's `cache_breakdown` sub-keys) are additions
+  to the struct, not silent key-present/absent divergence.
+
+### Weaknesses
+
+- **API-breaking change**: every consumer of `event.usage["key"]` must migrate
+  to `event.usage.key`. This includes `Tau.Session`, `Tau.Cost.Tracker`, any
+  telemetry handlers, and any replay-fixture reader that materialises raw maps.
+- The `@enforce_keys` on `%Event.Done{}` is not changed; `usage: nil` is still
+  allowed (to avoid forcing all emit sites at once). This means a careless
+  adapter can still emit `%Event.Done{stop_reason: :stop}` with `usage: nil`
+  and pass compilation — only Dialyzer catches the mismatch.
+- Replay fixture files that embed raw `%{usage: %{}}` JSON must be updated to
+  produce `%Event.Usage{}` structs via the replay decoder.
+- The `nil` fallback in `Done.t()` (during transition) complicates consumer
+  pattern matching: `%Done{usage: %Usage{}}` only matches non-nil usages.
+
+### Costs
+
+- Consumer migration is the dominant cost: scanning `Tau.Session`,
+  `Tau.Cost.Tracker`, `Tau.TUI.App` (context-window display) for
+  `event.usage["..."]` or `Map.get(event.usage, ...)` calls. Likely ~10–20
+  call-sites.
+- SPEC amendment: `Event.Done.t()` type changes; SPEC-PROMPT-CACHING §4 B3 and
+  `docs/spec/SPEC-USER-TURN.md` reference to `Done.usage` must be updated.
+- Any JSON serialisation path that round-trips `%Event.Done{}` (Replay, JSONL
+  fixture export) needs a `Usage` struct deserialiser.
+
+## Dependencies
+
+- No new library dependencies.
+- Consumers of `event.usage` must migrate before or concurrently with this
+  change; a two-phase rollout (struct first, `@enforce_keys` tighten later)
+  is possible.
+- Dialyzer PLT must cover `Event.Usage.t()` for type enforcement to fire on
+  consumers — run `mix dialyzer` after the struct lands.
+
+## Confidence
+
+**Medium.** The struct shape is straightforward; the main uncertainty is the
+blast radius of consumer migration. Confidence would rise to **high** after a
+`grep -rn 'event\.usage\|\.usage\[' lib/ test/` pass to count call-sites.
+
+## Prior art / references
+
+- `Tau.Provider.Event.Error` — existing struct pattern in the same module that
+  enforces required fields via `@enforce_keys`.
+- Elixir `@enforce_keys` — struct-level required fields.
+- SPEC-PROMPT-CACHING §4 B3 — B3 canonical key set this proposal makes
+  structurally mandatory.

--- a/docs/problems-archive-v1-modules/tau-providers/subproblems/usage-normalisation/proposals/proposal-3.md
+++ b/docs/problems-archive-v1-modules/tau-providers/subproblems/usage-normalisation/proposals/proposal-3.md
@@ -1,0 +1,202 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 3
+parent_problem: ../problem.md
+---
+
+# Proposal 3: Stream post-processor normalises `Done.usage` at the session boundary
+
+## Approach
+
+Leave all adapters unchanged. Instead, add a `Tau.Provider.UsageNorm.normalise/1`
+stream transform applied in `Tau.Session` immediately after the provider stream
+is obtained, before the stream is consumed by the render loop. This function maps
+over every event in the stream; when it encounters `%Event.Done{usage: u}` where
+`u` is missing `input_tokens` or `output_tokens`, it replaces `u` with a
+normalised map that has all required keys defaulted to `0`. Adapters that already
+emit canonical usage (Anthropic) pass through untouched. No adapter code is
+modified.
+
+## Rationale
+
+This proposal treats usage normalisation as a **consumer-side contract** rather
+than a producer-side obligation. The session is the single consumer of every
+provider stream; applying normalisation there eliminates the per-adapter scatter
+without touching eleven adapter modules. It decomplects (1) by removing the
+consumer's dependence on adapter identity at the point of use — the consumer
+always sees a canonical map regardless of which adapter produced the event.
+Complecting hypothesis (2) is addressed partially: the shared scaffold exists in
+`UsageNorm.normalise/1` rather than at the behaviour boundary, so adapters
+still have no normalisation obligation — but consumers are no longer broken by
+absent keys.
+
+## Sketch
+
+```elixir
+# lib/tau/provider/usage_norm.ex  (new file)
+defmodule Tau.Provider.UsageNorm do
+  @moduledoc """
+  Stream-level normaliser for `%Event.Done{usage: map()}`.
+
+  Applied as a stream transform at the session boundary; wraps the
+  provider's raw stream so every `Done` event carries the B3 canonical key
+  set with non-negative-integer values.
+  """
+
+  alias Tau.Provider.Event
+
+  @canonical_keys ~w(input_tokens output_tokens cache_read cache_write)a
+
+  @doc """
+  Wraps `stream` in a lazy transform that normalises every `%Event.Done{}`
+  usage map into the B3 canonical key set.  Non-Done events are passed through
+  unchanged.
+  """
+  @spec normalise(Enumerable.t()) :: Enumerable.t()
+  def normalise(stream) do
+    Stream.map(stream, &normalise_event/1)
+  end
+
+  defp normalise_event(%Event.Done{usage: u} = done) do
+    %{done | usage: canonicalise(u)}
+  end
+  defp normalise_event(event), do: event
+
+  defp canonicalise(u) when is_map(u) do
+    Enum.reduce(@canonical_keys, u, fn key, acc ->
+      case Map.fetch(acc, key) do
+        {:ok, v} when is_integer(v) and v >= 0 -> acc
+        _ -> Map.put(acc, key, 0)
+      end
+    end)
+  end
+  defp canonicalise(_), do: %{input_tokens: 0, output_tokens: 0, cache_read: 0, cache_write: 0}
+end
+
+# lib/tau/session.ex  (diff: wrap stream after provider call)
+# Before (approximately):
+#   {:ok, stream} = provider.stream(messages, opts, ctx)
+#   consume(stream, ...)
+#
+# After:
+#   {:ok, raw_stream} = provider.stream(messages, opts, ctx)
+#   stream = Tau.Provider.UsageNorm.normalise(raw_stream)
+#   consume(stream, ...)
+```
+
+Conformance test (new `test/tau/provider/usage_norm_test.exs`):
+```elixir
+defmodule Tau.Provider.UsageNormTest do
+  use ExUnit.Case, async: true
+
+  alias Tau.Provider.Event
+  alias Tau.Provider.UsageNorm
+
+  test "normalises missing keys to 0" do
+    stream = [%Event.Done{stop_reason: :stop, usage: %{}}]
+    [%Event.Done{usage: u}] = stream |> UsageNorm.normalise() |> Enum.to_list()
+    assert u.input_tokens == 0
+    assert u.output_tokens == 0
+    assert u.cache_read == 0
+    assert u.cache_write == 0
+  end
+
+  test "preserves existing non-negative values" do
+    stream = [%Event.Done{stop_reason: :stop,
+                          usage: %{input_tokens: 10, output_tokens: 5,
+                                   cache_read: 0, cache_write: 0}}]
+    [%Event.Done{usage: u}] = stream |> UsageNorm.normalise() |> Enum.to_list()
+    assert u.input_tokens == 10
+    assert u.output_tokens == 5
+  end
+
+  test "replaces negative values with 0" do
+    stream = [%Event.Done{stop_reason: :stop, usage: %{input_tokens: -1, output_tokens: 3}}]
+    [%Event.Done{usage: u}] = stream |> UsageNorm.normalise() |> Enum.to_list()
+    assert u.input_tokens == 0
+    assert u.output_tokens == 3
+  end
+
+  test "passes non-Done events through unchanged" do
+    stream = [%Event.TextDelta{block_id: "text", text: "hello"}]
+    result = stream |> UsageNorm.normalise() |> Enum.to_list()
+    assert result == stream
+  end
+end
+```
+
+Files changed:
+- `lib/tau/provider/usage_norm.ex` — new (~40 lines)
+- `lib/tau/session.ex` — +1 pipeline step after `provider.stream/3`
+- `test/tau/provider/usage_norm_test.exs` — new
+
+No adapter files modified.
+
+## Tradeoffs
+
+### Strengths
+
+- **Minimal blast radius**: no adapter code changes; single session insertion
+  point. Can ship in one small PR.
+- The normalisation logic is self-contained and fully unit-testable without any
+  adapter fixture.
+- Behaviour-preserving from the adapter's perspective — no contract change,
+  no new callback obligation.
+- Fixes the consumer-side symptom (silent zero-valued fields) immediately for
+  all adapters, including ones not yet identified.
+- Low risk of introducing a regression in any adapter decode path.
+
+### Weaknesses
+
+- Does **not** fix the underlying data gap: adapters still emit `%{}` even when
+  the upstream API returned actual token counts. Anthropic emits real counts;
+  all others still emit zero (the normaliser pads absent keys to `0`, but cannot
+  conjure counts that were never requested or parsed from the wire).
+- Does not satisfy the acceptance criterion's intent "receives token-usage data
+  from its upstream API": the `normalise/1` wrapper cannot know whether `0` means
+  "API returned zero" or "API returned real counts that the adapter discarded".
+- No enforcement at the adapter boundary: a new adapter can still omit usage
+  extraction entirely and the normaliser will silently zero-fill, masking the
+  implementation gap.
+- Treats symptoms, not the cause: the `cache_read`/`cache_write` problem for
+  Gemini (which does return `cachedContentTokenCount`) is not fixed — the
+  adapter never reads it, so the normaliser sees `%{}` and returns `0`.
+- Strictly speaking fails the acceptance criterion: "emits a `%Event.Done{usage:
+  map()}` where `usage` contains ... `input_tokens` and `output_tokens` with
+  non-negative integer values" requires the adapter to emit real counts, not for
+  the consumer to paper over absent ones.
+
+### Costs
+
+- ~40 lines new code.
+- 1–2 line change in `session.ex`.
+- If `Session` uses `Stream.flat_map` over chunks rather than a simple stream,
+  the insertion point may require more surgery — read `session.ex` to confirm.
+- Real token-count data (Gemini, Bedrock, OpenAI-family) remains missing until
+  adapters are updated separately.
+
+## Dependencies
+
+- No library additions.
+- For real token counts from OpenAI-family, Bedrock, Gemini: adapter changes
+  (orthogonal PRs) are needed separately. This proposal alone does not deliver
+  them.
+
+## Confidence
+
+**Medium-low.** The normaliser logic is simple and high-confidence. Confidence
+is low on satisfying the acceptance criterion fully — the AC explicitly requires
+adapters to emit real counts, not consumers to zero-fill. This proposal is best
+understood as a consumer-side safety net, not a complete fix for the stated
+problem. Confidence would rise to **high** only if the acceptance criterion is
+narrowed to "consumers always see a conforming key set regardless of source".
+
+## Prior art / references
+
+- `Stream.map/2` — idiomatic Elixir lazy stream transform.
+- The existing Anthropic `merge_usage/2` — demonstrates that real data exists
+  at the wire level when properly requested and parsed; this proposal does not
+  replicate that for other adapters.
+- "Postel's law" / defensive reading — the normaliser is an application of
+  liberal input acceptance at the consumer boundary.

--- a/docs/problems-archive-v1-modules/tau-providers/subproblems/usage-normalisation/proposals/proposal-4.md
+++ b/docs/problems-archive-v1-modules/tau-providers/subproblems/usage-normalisation/proposals/proposal-4.md
@@ -1,0 +1,220 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 4
+parent_problem: ../problem.md
+---
+
+# Proposal 4: Shared `ExUnit.Case` template + `mix tau.conformance` task enforces usage conformance via replay fixtures
+
+## Approach
+
+Add a shared `Tau.Test.ProviderConformance` ExUnit case template that all
+adapter test modules include. The template defines a single parametrised test:
+given a JSONL replay fixture for the adapter, the test asserts that the last
+`%Event.Done{}` event carries `input_tokens` and `output_tokens` as non-negative
+integers. The fixture format already exists (`priv/fixtures/*.jsonl`). The
+enforcement mechanism is test-time, not type-system or behaviour-level: adapters
+that emit `%{}` fail CI. To make the test pass, each adapter must be updated to
+extract and emit real usage from its wire format — but the *forcing function* is
+the test, not a behaviour change. Add a `mix tau.conformance` Mix task that runs
+only the conformance tests (`@tag :conformance`) across all adapters as a fast,
+targeted gate.
+
+## Rationale
+
+The acceptance criterion is "verified by a shared conformance test or typespec
+that all adapters satisfy." This proposal satisfies it literally: a shared test
+template is the scaffold, and the JSONL replay fixtures are the specification
+artefacts that encode what real wire payloads look like per adapter. Adapters
+that do not extract usage data fail the test; fixing the test failure requires
+fixing the adapter. The test-forcing approach decomplects (2) by creating a
+shared fixture-plus-assertion scaffold that documents what each adapter must
+produce, without mandating *how* the adapter extracts it — each adapter keeps
+its own extraction logic, but it must exist and must work on its fixture. It
+addresses (1) by making divergence a CI failure rather than a silent runtime
+discrepancy.
+
+## Sketch
+
+```elixir
+# test/support/provider_conformance.ex  (new file)
+defmodule Tau.Test.ProviderConformance do
+  @moduledoc """
+  Shared ExUnit case template for provider usage-normalisation conformance.
+
+  Include in an adapter's test module:
+
+      use Tau.Test.ProviderConformance,
+        adapter: Tau.Providers.Gemini,
+        fixture: "priv/fixtures/gemini_stream.jsonl"
+
+  The template asserts that the last `%Event.Done{}` in the decoded fixture
+  stream carries non-negative-integer `input_tokens` and `output_tokens`.
+  """
+
+  defmacro __using__(opts) do
+    adapter = Keyword.fetch!(opts, :adapter)
+    fixture  = Keyword.fetch!(opts, :fixture)
+
+    quote do
+      @tag :conformance
+      test "#{unquote(adapter)} Done.usage has canonical keys" do
+        events =
+          unquote(fixture)
+          |> File.read!()
+          |> String.split("\n", trim: true)
+          |> Enum.map(&Jason.decode!/1)
+          |> Enum.flat_map(fn raw ->
+            {evts, _partial} = unquote(adapter).__decode_sse__(raw, initial_partial())
+            evts
+          end)
+
+        done = Enum.find(events, &match?(%Tau.Provider.Event.Done{}, &1))
+        assert done != nil, "No Done event in fixture stream for #{unquote(adapter)}"
+
+        usage = done.usage
+        assert is_integer(usage[:input_tokens]) and usage[:input_tokens] >= 0,
+               "input_tokens missing or negative in #{unquote(adapter)}.Done.usage"
+        assert is_integer(usage[:output_tokens]) and usage[:output_tokens] >= 0,
+               "output_tokens missing or negative in #{unquote(adapter)}.Done.usage"
+      end
+
+      defp initial_partial do
+        %{tool_calls: %{}, model: nil, provider: unquote(adapter)}
+      end
+    end
+  end
+end
+
+# test/tau/providers/gemini_conformance_test.exs  (new, one per adapter)
+defmodule Tau.Providers.GeminiConformanceTest do
+  use ExUnit.Case, async: true
+  use Tau.Test.ProviderConformance,
+    adapter: Tau.Providers.Gemini,
+    fixture: "priv/fixtures/gemini_stream.jsonl"
+end
+
+# test/tau/providers/openai_chat_conformance_test.exs
+defmodule Tau.Providers.OpenAI.ChatConformanceTest do
+  use ExUnit.Case, async: true
+  use Tau.Test.ProviderConformance,
+    adapter: Tau.Providers.OpenAI.Chat,
+    fixture: "priv/fixtures/openai_chat_stream.jsonl"
+end
+# ... similar for Bedrock, Groq, Mistral, DeepSeek, AzureOpenAI, Custom, Copilot
+```
+
+Fixture format for an adapter that includes usage (Gemini example snippet):
+```jsonl
+{"candidates":[{"content":{"parts":[{"text":"Hello"}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":12,"candidatesTokenCount":4,"totalTokenCount":16}}
+```
+
+This fixture already exists for Anthropic (the replay mechanism); for other
+adapters, minimal fixtures must be authored that include the upstream API's
+usage fields in the final chunk.
+
+Mix task:
+```elixir
+# lib/mix/tasks/tau.conformance.ex
+defmodule Mix.Tasks.Tau.Conformance do
+  use Mix.Task
+  @shortdoc "Run provider usage-normalisation conformance tests"
+  def run(_args) do
+    Mix.Task.run("test", ["--only", "conformance"])
+  end
+end
+```
+
+Adapter changes required to make tests pass (not part of the template itself —
+these are the implementation obligation the failing tests impose):
+
+- `Tau.Providers.Gemini`: read `json["usageMetadata"]` in `decode_chunk/2`,
+  emit `%Event.Done{stop_reason: :stop, usage: %{input_tokens: ..., output_tokens: ...}}`.
+- `Tau.Providers.Bedrock`: accumulate usage from `message_start` into partial,
+  emit it in `message_stop` handler.
+- `OpenAIChatWire`: set `stream_options: %{include_usage: true}` in `build_body/4`;
+  accumulate usage from the final SSE chunk that carries it; emit in Done.
+
+Files changed (test infrastructure):
+- `test/support/provider_conformance.ex` — new (~40 lines)
+- `test/tau/providers/*_conformance_test.exs` — one new file per adapter (~5 lines each, ~9 files)
+- `priv/fixtures/*.jsonl` — new or extended fixture files per adapter (~5–10 files)
+- `lib/mix/tasks/tau.conformance.ex` — new Mix task (~10 lines)
+- Each adapter that currently emits `%{}`: fix to extract wire usage (4 adapters + `OpenAIChatWire`)
+
+## Tradeoffs
+
+### Strengths
+
+- Acceptance criterion satisfied literally: "verified by a shared conformance
+  test" — the template is the shared test and the assertion is the criterion.
+- Enforcement is CI-blocking: a new adapter that omits usage extraction will
+  fail CI as soon as it includes the conformance template.
+- The fixture-based approach documents exactly what each adapter's upstream
+  wire format looks like (the fixture is also specification documentation).
+- Decoupled from the behaviour: each adapter keeps its own extraction logic;
+  the test only asserts on the output, not the mechanism.
+- `mix tau.conformance` provides a fast targeted gate without running the full
+  test suite — valuable during iterative adapter fixes.
+- The shared template pattern is idiomatic to ExUnit (`use SomeCase`).
+
+### Weaknesses
+
+- The conformance test calls a semi-public `__decode_sse__/2` hook that does not
+  currently exist on most adapters. Adding it requires either making the private
+  decode functions public (or at least `@doc false` public), or restructuring
+  each adapter to expose a testable decode entrypoint. This is a non-trivial
+  refactor for some adapters.
+- Fixture authoring is the largest cost: each of ~9 adapters needs a fixture
+  that represents a real wire payload including usage fields. These must be
+  maintained as the upstream APIs evolve.
+- The template produces a test that only covers the fixture path; if the adapter
+  has multiple Done emission paths (e.g. finish_reason "STOP" vs "MAX_TOKENS"),
+  the conformance test covers only the one in the fixture unless it is parametrised
+  further.
+- Does not prevent adapters from emitting `%{}` at runtime through code paths
+  not covered by the fixture — the test is a sampling check, not an exhaustive
+  type-system enforcement.
+- Cannot fix any silent zero-valued fields until the adapter changes are made
+  (the test forces the fix but is not the fix itself).
+
+### Costs
+
+- Fixture authoring: ~9 JSONL fixture files, each 5–20 lines, plus finding/
+  recording real upstream responses for adapters that lack fixtures today.
+- `__decode_sse__/2` exposure: each adapter's internal decode function may need
+  a thin public shim — ~5 lines per adapter, ~9 adapters.
+- Adapter fixes (the actual substance): Gemini, Bedrock, OpenAI-family usage
+  extraction — likely 10–20 lines each (same scope as Proposals 1 and 2, but
+  the motivation comes from test failure rather than behaviour-level contract).
+- Fixture maintenance: when an upstream API changes its usage field names, the
+  fixture and the adapter decode must both update — two points of change.
+
+## Dependencies
+
+- JSONL fixture format: already established by the Replay provider.
+- `mix test --only conformance` tag: requires no library additions.
+- For OpenAI-family real usage: `stream_options: %{include_usage: true}` must be
+  set in `build_body/4`.
+
+## Confidence
+
+**Medium.** The conformance template and Mix task are simple. Uncertainty is in
+the `__decode_sse__/2` exposure surface: if adapters restructure their decode
+around a public entrypoint, the approach is clean; if not, the test must call
+internal functions via `:erlang.apply/3` or the adapter's top-level `stream/3`
+with a mock HTTP client — more complex test infrastructure. Confidence would
+rise to **high** after checking whether any existing adapter tests already call
+decode functions directly (establishing precedent for the exposure pattern).
+
+## Prior art / references
+
+- `Tau.Providers.Replay` — existing JSONL fixture replay mechanism; the
+  fixture format is established.
+- ExUnit `use SomeCase` shared template pattern — e.g. `DataCase`, `ConnCase`
+  in Phoenix projects.
+- OpenAI Chat Completions `stream_options.include_usage` — the wire-level
+  prerequisite for OpenAI-family adapters.
+- `mix test --only <tag>` — standard ExUnit tag-based filtering used by the
+  existing `mix test --only property` alias.

--- a/docs/problems-archive-v1-modules/tau-providers/subproblems/usage-normalisation/solution.md
+++ b/docs/problems-archive-v1-modules/tau-providers/subproblems/usage-normalisation/solution.md
@@ -1,0 +1,172 @@
+---
+template_version: 1
+template_name: solution
+parent_problem: problem.md
+node_kind: leaf
+synthesised_from: [proposals/proposal-1.md, proposals/proposal-2.md]
+selection_method: hybrid
+revision: 0
+---
+
+# Solution: typed `%Event.Usage{}` struct plus shared `UsageNorm` scaffold and conformance test
+
+## Recommendation
+
+Replace `usage: map()` on `%Event.Done{}` with a typed `%Tau.Provider.Event.Usage{}`
+struct (`@enforce_keys [:input_tokens, :output_tokens]`; `cache_read`,
+`cache_write`, `cache_breakdown` defaulted), and introduce
+`Tau.Provider.UsageNorm` as the shared wire-format-to-canonical scaffold each
+adapter uses to construct that struct from its upstream payload. The struct
+fixes the *shape* contract at the type system; `UsageNorm` plus per-adapter
+wire-extraction edits (OpenAI-family `stream_options.include_usage`, Bedrock
+`message_start`/`message_stop` accumulation, Gemini `usageMetadata` read,
+Anthropic delegating to its existing `merge_usage/2`) fix the *data* gap. A
+shared conformance test iterates all production adapters and asserts the
+struct invariants on a representative replay fixture per adapter — this is the
+verification mechanism the acceptance criterion names.
+
+## Selected from
+
+- **Chosen:** hybrid of `proposals/proposal-1.md` and `proposals/proposal-2.md`
+- **Why chosen:** Proposal 2 is the strongest decomplecting mechanism on
+  hypothesis (1) — a struct removes "adapter identity determines key presence"
+  at the type-system level, which neither a behaviour callback (P1) nor a
+  consumer-side normaliser (P3) nor a test (P4) can match. Proposal 1 is the
+  strongest mechanism on hypothesis (2) — the `UsageNorm` module is the shared
+  scaffold adapters call into to convert their wire format. Neither proposal
+  alone is sufficient: P2 alone leaves adapters to hand-roll their own
+  extraction (the scaffold is missing), and P1 alone leaves `usage` as an
+  unstructured `map()` that a careless adapter can still leave empty. Combined,
+  the struct enforces shape and `UsageNorm` supplies the wire-extraction
+  helpers — composition, not aggregation. Proposal 3 is rejected because its
+  own tradeoffs document that it fails the AC ("the AC explicitly requires
+  adapters to emit real counts, not consumers to zero-fill"); the consumer-side
+  normaliser would mask, not fix, the silent-zero problem. Proposal 4's
+  conformance-test scaffold is incorporated as the verification harness, not
+  the primary mechanism — its forcing-function-via-test-failure approach is
+  weaker than P2's compile-time enforcement, but the shared
+  `Tau.Test.ProviderConformance` template is the right shape for AC
+  verification once the struct and `UsageNorm` are in place.
+
+## What changes
+
+- `lib/tau/provider/event.ex` — add `Tau.Provider.Event.Usage` struct with
+  `@enforce_keys [:input_tokens, :output_tokens]` and defaulted cache fields;
+  update `Done.t()` to `usage: Tau.Provider.Event.Usage.t() | nil`.
+- `lib/tau/provider/usage_norm.ex` — new module with `zero/0`, `nonneg/1`,
+  `from_openai/1`, `from_gemini/1`, `from_bedrock/1`, `from_anthropic/1`
+  helpers returning `%Event.Usage{}` (not raw maps). `from_anthropic/1`
+  internally delegates to the existing `Anthropic.merge_usage/2` shape.
+- `lib/tau/providers/shared/openai_chat_wire.ex` — set
+  `stream_options: %{include_usage: true}` in `build_body/4`; accumulate the
+  final SSE chunk's `usage` into partial; emit
+  `%Event.Done{usage: UsageNorm.from_openai(raw)}` on `[DONE]`.
+- `lib/tau/providers/bedrock.ex` — accumulate usage from `message_start` into
+  partial; emit `%Event.Done{usage: UsageNorm.from_bedrock(raw)}` in
+  `message_stop` handler.
+- `lib/tau/providers/gemini.ex` — read `json["usageMetadata"]` in finish-reason
+  handler; emit `%Event.Done{usage: UsageNorm.from_gemini(raw)}`.
+- `lib/tau/providers/anthropic.ex` — wrap existing `merge_usage/2` output in
+  `%Event.Usage{}` via `UsageNorm.from_anthropic/1`.
+- `test/support/provider_conformance.ex` — shared ExUnit case template
+  (Proposal 4 shape) that asserts the last `%Event.Done{}` in a fixture stream
+  carries a `%Event.Usage{}` with non-negative-integer required fields.
+- `test/tau/providers/*_conformance_test.exs` — one per production adapter
+  (Anthropic, OpenAI.Chat, OpenAI.Responses, Gemini, Bedrock, Groq, Mistral,
+  DeepSeek, AzureOpenAI, Custom, Copilot), each `use`-ing the shared template
+  with its adapter module and fixture path.
+- `priv/fixtures/*.jsonl` — new or extended fixture files for adapters that
+  lack a usage-bearing fixture today.
+- Consumer migration: `Tau.Session`, `Tau.Cost.Tracker`, and any TUI
+  context-window display that reads `event.usage["input_tokens"]` /
+  `Map.get(event.usage, ...)` migrates to `event.usage.input_tokens` struct
+  access.
+- SPEC amendment: `docs/spec/SPEC-PROMPT-CACHING.md` §4 B3 references the new
+  `%Event.Usage{}` struct as the canonical carrier; `Tau.Provider.UsageNorm`
+  is named as the shared adapter-side scaffold. D-065 wording updated to match.
+
+## What does not change
+
+- The `Tau.Provider` behaviour gains no new mandatory callback. The scaffold
+  is a plain module adapters call into; the struct enforces shape. (Optional
+  `normalise_usage/1` from P1 is dropped — the struct + `UsageNorm` module
+  together cover its decomplecting role without adding a behaviour surface.)
+- `%Event.Done{}` keeps `usage: nil` allowed during transition, so existing
+  emission sites that have not yet been migrated still compile.
+- The `Replay` provider's JSONL fixture format is unchanged; conformance tests
+  reuse it.
+- No new HTTP client, JSON library, or runtime dependency is introduced.
+- Out-of-scope items in `problem.md` (event sequencing, capabilities flags,
+  auth resolution) remain untouched.
+
+## Migration sketch
+
+Three sequenced PRs, each independently shippable and reversible:
+
+1. **Struct + scaffold + Anthropic migration.** Land `Tau.Provider.Event.Usage`,
+   `Tau.Provider.UsageNorm` (with `from_anthropic/1` and `zero/0`), update
+   `Anthropic` to emit `%Event.Usage{}`, migrate `Tau.Session` and
+   `Tau.Cost.Tracker` consumers to struct access. Anthropic was already the
+   only adapter emitting real counts, so this PR is behaviour-preserving for it
+   and behaviour-improving for consumers (typed access). Reversible: revert
+   the consumer-access change and the `Done.t()` typespec.
+2. **OpenAI-family + Bedrock + Gemini wire-extraction + their conformance
+   tests.** Add `stream_options.include_usage` to OpenAI-family request bodies,
+   accumulate Bedrock `message_start` usage, read Gemini `usageMetadata`. Each
+   adapter's conformance test goes red before the wire-extraction lands and
+   green after — the test is the forcing function (Proposal 4's contribution).
+   Reversible per-adapter.
+3. **Shared conformance template + remaining adapters.** Land
+   `Tau.Test.ProviderConformance` and the per-adapter conformance test files
+   for adapters whose fixtures already exist; author missing fixtures last.
+   Wire `mix tau.conformance` Mix task as a fast targeted gate.
+
+Order matters: the struct must land before adapters can emit it; the
+conformance tests must follow the wire-extraction so they go green on the same
+PR rather than landing as known-failing baseline.
+
+## Open questions
+
+- **Should `Done.usage` be `@enforce_keys`-required (not `nil`-allowed) after
+  the migration completes?** A follow-up tightening PR could remove the `nil`
+  default once every emission site is migrated, converting "careless adapter
+  emits nil" from a Dialyzer warning into a compile error. The initial PRs
+  leave `nil` allowed to keep migration staged.
+- **How does Replay reconstruct `%Event.Usage{}` from JSONL?** The Replay
+  decoder currently materialises raw maps; a small deserialiser
+  `Event.Usage.from_replay/1` is needed. Scope this in PR 2 or PR 3.
+- **Are `OpenAI.Responses`, `Groq`, `Mistral`, `DeepSeek`, `Azure`, `Custom`,
+  `Copilot` all on the same `OpenAIChatWire` decode path?** If yes, the
+  OpenAI-family fix in PR 2 covers all of them; if any has a divergent decode
+  loop, that adapter needs its own wire-extraction edit. Verify by grep before
+  scoping PR 2.
+- **Does `cache_breakdown` need a typespec narrower than `map()`?** SPEC-
+  PROMPT-CACHING §4 B3 defines sub-keys for Anthropic only; other adapters
+  pass `%{}`. Left as `map()` initially; tighten if a downstream consumer
+  requires it.
+- **Should `UsageNorm` be moved under `Tau.Provider.Event.Usage` as
+  constructor helpers (`Event.Usage.from_openai/1`) rather than a sibling
+  module?** Stylistic; sibling module mirrors the existing
+  `Tau.Provider.Event.Error` placement and keeps wire-shape knowledge out of
+  the canonical struct module.
+
+## Linked sub-problems / proposals
+
+- `proposals/proposal-1.md` — `normalise_usage/1` behaviour callback with
+  shared zero-default scaffold. Contributes: the `Tau.Provider.UsageNorm`
+  module and the wire-extraction obligation at each adapter.
+- `proposals/proposal-2.md` — `%Event.Usage{}` typed struct replaces
+  `usage: map()` in `Done.t()`. Contributes: the type-level enforcement of
+  the canonical key set; the primary decomplecting mechanism.
+- `proposals/proposal-3.md` — Stream post-processor at the session boundary.
+  Rejected: per its own tradeoffs, fails the acceptance criterion by zero-
+  filling rather than extracting real wire data.
+- `proposals/proposal-4.md` — Shared `ExUnit.Case` template +
+  `mix tau.conformance`. Contributes: the verification harness shape
+  (`Tau.Test.ProviderConformance` template, per-adapter conformance files,
+  Mix task). Rejected as the primary mechanism in favour of struct-level
+  enforcement.
+
+## Revision history
+
+- (revision 0 — initial)

--- a/docs/problems-archive-v1-modules/tau-providers/subproblems/usage-normalisation/validation.md
+++ b/docs/problems-archive-v1-modules/tau-providers/subproblems/usage-normalisation/validation.md
@@ -1,0 +1,502 @@
+---
+template_version: 1
+template_name: validation
+parent_solution: solution.md
+parent_problem: problem.md
+toulmin_complete: true
+falsification_attempted: true
+falsification_outcome: partially_falsified — claim/6
+revision_triggered: none
+---
+
+# Validation: typed `%Event.Usage{}` + shared `UsageNorm` scaffold + conformance test
+
+## Overview
+
+The solution makes seven distinct propositions, blending compile-time
+shape enforcement (a new `%Tau.Provider.Event.Usage{}` struct with
+`@enforce_keys [:input_tokens, :output_tokens]`), a shared
+wire-format-to-canonical scaffold (`Tau.Provider.UsageNorm`), per-adapter
+wire-extraction edits (OpenAI-family `stream_options.include_usage`,
+Bedrock `message_start`/`message_stop` accumulation, Gemini
+`usageMetadata` read, Anthropic delegation), and a shared
+`Tau.Test.ProviderConformance` template iterated per adapter. Each claim
+is run through full Toulmin and a named falsification strategy; the
+strategies span counter-example construction, dependency check, edge-case
+enumeration, integration check, and type-level check. Six claims withstand;
+claim 6 (the consumer-migration claim) is **partially falsified** by a
+codebase counter-example — most consumers already use atom keys, not
+string keys — and is narrowed in place. No solution or problem revision
+is triggered; the narrowed qualifier is recorded for the parent.
+
+## Toulmin per claim
+
+### Claim 1: Replace `usage: map()` on `%Event.Done{}` with a typed `%Tau.Provider.Event.Usage{}` struct (`@enforce_keys [:input_tokens, :output_tokens]`; `cache_read`, `cache_write`, `cache_breakdown` defaulted).
+
+- **Claim (C):** A new struct `Tau.Provider.Event.Usage` with required
+  `:input_tokens` / `:output_tokens` and defaulted cache fields replaces
+  the `usage: map()` field in `%Event.Done{}`.
+- **Grounds (G):** `lib/tau/provider/event.ex:90-95` today defines
+  `Done` with `defstruct [:stop_reason, usage: %{}]` and
+  `@type t :: %__MODULE__{stop_reason: atom(), usage: map()}` — the
+  unconstrained `map()` is the exact shape the solution displaces. Two
+  sibling structs in the same module (`ToolCallEnd`, `Error`) already
+  follow the `@enforce_keys` + `defstruct [...]` pattern the solution
+  proposes (`event.ex:83-87`, `event.ex:97-106`), so the proposed shape
+  is a precedented intra-file pattern, not a new style.
+- **Warrant (W):** OTP non-negotiable #2 — "extensibility seams MUST be
+  behaviours; pattern match on atoms and structs". The `Done.usage` field
+  is a cross-adapter extensibility seam currently typed as an opaque
+  `map()`; a struct converts pattern-matched access (`event.usage.input_tokens`)
+  from a runtime `KeyError` risk into a compile-time `KeyError` and a
+  Dialyzer-visible shape, which is the design principle's intent.
+- **Qualifier (Q):** Holds for the `%Event.Done{}` emission contract.
+  The Replay adapter's JSONL deserialiser (see open question §2) must
+  construct the struct rather than emit a raw map; the solution
+  acknowledges this and scopes a `Event.Usage.from_replay/1` helper in
+  PR 2 or PR 3.
+- **Rebuttal (R):** If a hypothetical future adapter has no concept of
+  `output_tokens` (e.g. a streaming generator that bills only on input),
+  `@enforce_keys` would force a `0` placeholder. That is arguably a
+  category error in the contract; the solution's PR 1 keeps
+  `usage: nil` allowed during transition, which softens the rebuttal but
+  doesn't dismiss it.
+- **Backing (B):** `.claude/rules/otp-non-negotiables.md` §2 ("pattern
+  match on atoms and structs") and the SPEC-PROMPT-CACHING §4 B3
+  canonical-key contract (lines 126-149 in
+  `docs/spec/SPEC-PROMPT-CACHING.md`) which already enumerates the keys
+  the struct enshrines.
+
+#### Falsification attempt for claim 1
+
+- **Strategy:** type-level check (mental Dialyzer pass + struct-shape
+  audit).
+- **Attempt:** Examined the proposed `@type` and `@enforce_keys` against
+  the existing 12 sibling structs in `event.ex`. The `Done.t()` change
+  to `usage: Tau.Provider.Event.Usage.t() | nil` is well-typed and
+  composes with the existing `Tau.Provider.Event.t()` union (lines
+  108-120). The transitional `| nil` qualifier (per the solution) means
+  no in-flight emission site becomes a Dialyzer error on PR 1.
+- **Outcome:** withstood.
+- **Action:** none.
+
+### Claim 2: Introduce `Tau.Provider.UsageNorm` as the shared wire-format-to-canonical scaffold each adapter uses to construct that struct from its upstream payload, with `zero/0`, `nonneg/1`, `from_openai/1`, `from_gemini/1`, `from_bedrock/1`, `from_anthropic/1` helpers returning `%Event.Usage{}`.
+
+- **Claim (C):** A new pure module `Tau.Provider.UsageNorm` provides per-wire-format
+  constructors that each return a `%Event.Usage{}`, and `from_anthropic/1`
+  delegates to the existing `Anthropic.merge_usage/2`.
+- **Grounds (G):** `lib/tau/providers/anthropic.ex:284-303` already
+  contains the canonical-key normaliser as adapter-private
+  `merge_usage/2` + `nonneg/1`. SPEC-PROMPT-CACHING line 110 explicitly
+  describes the current state: "Cache-usage normalisation does NOT need
+  a callback — it is each adapter's own responsibility inside its
+  existing usage-merge code." The shared-scaffold gap the solution fills
+  is documented in the same SPEC's §4 B3 hop description (lines 145-155).
+- **Warrant (W):** OTP non-negotiable #8 — "Pure functions are the
+  default; processes are the exception." A wire-to-canonical mapper is
+  pure (no shared state, no message passing); the right container is a
+  module, not a behaviour callback or GenServer. The solution explicitly
+  rejects the behaviour-callback alternative (proposal 1) and the
+  consumer-side normaliser (proposal 3) on this basis.
+- **Qualifier (Q):** Holds for the four named wire families
+  (Anthropic-native, OpenAI Chat, Gemini, Bedrock-Anthropic-wrapped). For
+  any future wire family that isn't OpenAI/Gemini/Bedrock/Anthropic, a
+  new `from_<family>/1` helper must be added.
+- **Rebuttal (R):** If two adapters end up needing per-instance state
+  (e.g. a streaming usage accumulator that must survive across multiple
+  SSE chunks), a pure module's helpers can't carry that state — the
+  caller must hold the partial accumulator. The solution already
+  contemplates this for Bedrock and OpenAI ("accumulate the final SSE
+  chunk's `usage` into partial"), so the rebuttal is honoured by the
+  callers, not the scaffold.
+- **Backing (B):** `.claude/rules/otp-non-negotiables.md` §3 ("MUST NOT
+  wrap stateless logic in a GenServer") and §8 (pure functions
+  default). The Anthropic `merge_usage/2` precedent is the worked
+  example of the warrant.
+
+#### Falsification attempt for claim 2
+
+- **Strategy:** counter-example construction (try to construct an
+  adapter that the proposed scaffold can't serve).
+- **Attempt:** Examined the 11 production adapters in
+  `lib/tau/providers/`. Anthropic-native (Anthropic, Bedrock's wrapped
+  Anthropic) → `from_anthropic`. OpenAI Chat family (OpenAI.Chat, Groq,
+  Mistral, DeepSeek, AzureOpenAI, Custom) → `from_openai`. Gemini →
+  `from_gemini`. Copilot's directory exists but routes through OpenAI
+  Chat wire (it imports `OpenAIChatWire` indirectly via the Chat
+  adapter pattern — see the open question §3 in the solution which
+  explicitly asks this). OpenAI.Responses is the unresolved case — its
+  own decode path is not the Chat-wire path, and the solution lists it
+  as a named conformance target but does not specify a
+  `from_openai_responses/1` helper. This is not a falsification of the
+  scaffold's existence; it is a gap in the scaffold's enumeration that
+  surfaces as the open question §3.
+- **Outcome:** withstood (with one named gap acknowledged in the
+  solution's own open question §3).
+- **Action:** none beyond what the solution itself already lists.
+
+### Claim 3: OpenAI-family adapters set `stream_options: %{include_usage: true}` in `build_body/3` and emit `%Event.Done{usage: UsageNorm.from_openai(raw)}` on `[DONE]`.
+
+- **Claim (C):** Setting `stream_options.include_usage: true` in
+  `OpenAIChatWire.build_body/4` causes the upstream API to send a final
+  SSE chunk carrying `usage`, which the decoder accumulates and emits in
+  `%Event.Done{}`.
+- **Grounds (G):** `lib/tau/providers/shared/openai_chat_wire.ex:44-56`
+  shows the current `build_body/4` body composition — it sets only
+  `model`, `stream: true`, `messages`, `temperature`, `max_tokens`,
+  `tools`, `tool_choice`. No `stream_options` is present, confirming
+  the data is not requested. `openai_chat_wire.ex:66` shows
+  `decode(%{data: "[DONE]"}, partial)` returns
+  `[%Event.Done{stop_reason: :stop}]` with no usage extraction;
+  `openai_chat_wire.ex:191-200` shows the `finish_reason` path also
+  emits `%Event.Done{stop_reason: <atom>}` with no usage. The OpenAI
+  Chat Completions API documentation (referenced in problem.md
+  `lib/tau/providers/shared/openai_chat_wire.ex:66` context) confirms
+  `stream_options.include_usage` is the documented opt-in.
+- **Warrant (W):** The OpenAI streaming protocol is opt-in for usage
+  emission — without `include_usage`, the final SSE chunk omits the
+  `usage` field. Sending `stream_options.include_usage: true` is the
+  documented and only path to receive the data. Reading and emitting it
+  in `%Event.Done{}` is then a pure-data transform fulfilling claim 1.
+- **Qualifier (Q):** Holds for OpenAI Chat Completions wire and every
+  family member that proxies it (Groq, Mistral, DeepSeek, AzureOpenAI,
+  Custom, and — per open question §3 — Copilot). Holds also for any
+  third-party server that implements the OpenAI Chat Completions
+  contract faithfully.
+- **Rebuttal (R):** A proxy server that rejects unknown body fields
+  (some self-hosted Llama servers do) would error on
+  `stream_options.include_usage`. The `Custom` adapter is the
+  most-exposed instance; the solution does not call this out but the
+  rebuttal is real for self-hosted-LLM users.
+- **Backing (B):** OpenAI API reference for `stream_options` (the
+  `include_usage` flag is the public, documented mechanism); the
+  existing `OpenAIChatWire` moduledoc which already lists the wire
+  family members (lines 5-8).
+
+#### Falsification attempt for claim 3
+
+- **Strategy:** edge-case enumeration (enumerate the failure modes the
+  proposed change introduces or fails to handle).
+- **Attempt:** Enumerated: (a) server rejects unknown field — Custom
+  adapter risk noted in rebuttal; (b) server silently ignores the field
+  — final chunk has no `usage`, `from_openai/1` returns
+  `%Event.Usage{input_tokens: 0, output_tokens: 0}` via `zero/0`, which
+  is the solution's documented zero-fallback semantics; (c) the `[DONE]`
+  chunk arrives before the usage-bearing chunk — checked the SSE order
+  contract: the OpenAI API emits the usage chunk *before* `[DONE]`, so
+  the decoder's accumulator-then-emit ordering aligns with the wire
+  contract; (d) Azure OpenAI's API surface may not honour
+  `stream_options` in all deployment SKUs — possible, but the worst case
+  reduces to case (b) — zero values, not a crash.
+- **Outcome:** withstood (rebuttal acknowledged but does not falsify the
+  claim for compliant servers, which the AC scopes the claim to).
+- **Action:** none; the Custom-server rebuttal could be added to the
+  solution's open questions but does not block the claim.
+
+### Claim 4: Bedrock accumulates usage from `message_start` and emits `%Event.Done{usage: UsageNorm.from_bedrock(raw)}` in the `message_stop` handler; Gemini reads `usageMetadata` and emits `%Event.Done{usage: UsageNorm.from_gemini(raw)}`.
+
+- **Claim (C):** Two wire-extraction edits — Bedrock accumulates the
+  `message_start.usage` block into the partial, then on `message_stop`
+  constructs the canonical struct; Gemini reads
+  `json["usageMetadata"]` (or `json["candidates"][...]["usageMetadata"]`)
+  in the finish-reason handler.
+- **Grounds (G):** `lib/tau/providers/bedrock.ex:111-122` shows the
+  current `decode_anthropic_event` clauses: `message_start` handler
+  emits a `Start` event but does not touch `m["usage"]`; the
+  `message_stop` handler emits `%Event.Done{stop_reason: :stop}` with
+  no usage. `lib/tau/providers/gemini.ex:112-118` shows the
+  `finishReason` handler emits `%Event.Done{stop_reason: :stop}` (or
+  `:length`) and never reads `json["usageMetadata"]`. Both gaps are
+  exactly as problem.md describes.
+- **Warrant (W):** The native wire formats both carry usage data; the
+  adapter is the only point at which the data can be extracted before
+  the event union normalises away the wire-format detail. Per
+  claim 1's warrant, the canonical struct must be populated by the
+  adapter, not by a downstream consumer.
+- **Qualifier (Q):** Bedrock holds for the Anthropic-on-Bedrock wire
+  (the only one Bedrock currently implements per
+  `bedrock.ex:111-122`). If Bedrock were extended to host other
+  on-platform model families (Cohere, Meta), each would need its own
+  accumulation pattern. Gemini holds for the v1beta `generateContent`
+  streaming format; v1 differs in `usageMetadata` placement, but the
+  current Tau Gemini adapter is v1beta-targeted.
+- **Rebuttal (R):** Bedrock's binary event-stream framing
+  (`decode_frame/2`, lines 100-109) deserialises the inner JSON
+  per-frame; if a `message_start` frame arrives without a `usage`
+  object (possible during error injection or partial-server-response
+  cases), the partial accumulator must accept `nil` gracefully —
+  `nonneg/1` already does this in `Anthropic.merge_usage/2`, so the
+  pattern is established but the new Bedrock-side accumulator must
+  inherit it.
+- **Backing (B):** Bedrock's Anthropic-wire contract is the same wire
+  protocol the native Anthropic adapter already handles in
+  `anthropic.ex:284-300`. Gemini's `usageMetadata` schema is documented
+  in Google's GenerativeAI REST API reference; the existing Tau adapter
+  reads adjacent fields (`candidates[].content.parts[]`,
+  `candidates[].finishReason`) so the field-path traversal pattern is
+  precedented.
+- 
+#### Falsification attempt for claim 4
+
+- **Strategy:** dependency check (verify the upstream wire contracts
+  the claim depends on are present today).
+- **Attempt:** (a) Bedrock — Anthropic on Bedrock currently emits
+  `message_start.message.usage` per the Anthropic wire contract
+  Bedrock proxies; the partial accumulator pattern from Anthropic is
+  directly applicable. (b) Gemini — Google's REST reference confirms
+  `usageMetadata` is in every streaming `generateContent` response when
+  the generation succeeds (it is omitted in error paths, which the
+  zero-fallback handles). (c) Bedrock's `decode_anthropic_event/2`
+  pattern has a final fallthrough `defp ... (_, p), do: {[], p}`
+  (line 124) — a `message_start`-with-usage clause must be added
+  *before* the fallthrough, not after, or the new clause will be
+  dead. This is a routine ordering concern, not a falsification.
+- **Outcome:** withstood.
+- **Action:** none; the clause-ordering note is captured in the
+  PR-implementer brief implicit to the migration sketch.
+
+### Claim 5: A shared `Tau.Test.ProviderConformance` ExUnit case template asserts the last `%Event.Done{}` in a fixture stream carries a `%Event.Usage{}` with non-negative-integer required fields, instantiated per adapter (11 production adapters named).
+
+- **Claim (C):** A reusable ExUnit `use` template iterates over a
+  per-adapter fixture and asserts the canonical-struct invariants on
+  the final `Done` event; 11 per-adapter test files instantiate it.
+- **Grounds (G):** The Replay provider's JSONL fixture format is
+  reused (per solution "What does not change"). The acceptance
+  criterion in `problem.md` line 62-66 explicitly names "a shared
+  conformance test or typespec that all adapters satisfy" as the
+  verification mechanism, so the test's role is part of the AC, not
+  an added implementation cost. ExUnit's `__using__/1` macro pattern
+  is the established way to share test cases in this codebase (e.g.
+  `test/support/tui_pty_helper.ex` precedent for shared test
+  infrastructure).
+- **Warrant (W):** OTP non-negotiable #6 — "Invariant-bearing modules
+  MUST have properties before examples." A conformance test that
+  iterates *every* production adapter is property-shaped at the
+  adapter dimension (universal quantification over adapters), even if
+  the per-adapter body is example-based on a fixture. This converts
+  "did this PR break adapter X" from a `git grep`-and-hope check to a
+  mechanical CI gate.
+- **Qualifier (Q):** Holds for adapters with a usage-bearing fixture.
+  The solution explicitly defers fixture authoring for adapters whose
+  fixtures don't exist today ("priv/fixtures/*.jsonl — new or extended
+  fixture files"); until those land, the conformance test for that
+  adapter will be skipped or use a synthesised fixture.
+- **Rebuttal (R):** A conformance test passing on a fixture does not
+  prove the adapter passes against the *live* upstream API. The
+  fixture is recorded at one point in time; if the live API changes
+  its usage schema, the fixture lags and the test is stale-green.
+  The solution does not address fixture refresh policy; this is a
+  weakness inherited from the codebase-wide fixture story, not a
+  new defect introduced by this solution.
+- **Backing (B):** `.claude/rules/otp-non-negotiables.md` §6
+  (properties before examples) and SPEC-PROMPT-CACHING's existing
+  test-coverage discipline (lines 195 — "Tests for D-063, D-064,
+  D-065, AC-1 through AC-6"), which already establishes that adapter
+  invariants are test-enforced.
+
+#### Falsification attempt for claim 5
+
+- **Strategy:** integration check (does an integration test for this
+  contract exist, or could it be written, that exercises the
+  user-visible boundary?).
+- **Attempt:** Examined whether the `Tau.Cost.Tracker.handle_event/4`
+  path (`tracker.ex:121-127`) is reachable from a fixture-driven
+  conformance test. The Tracker reads `usage[:input_tokens]`,
+  `usage[:output_tokens]`, `usage[:cache_read]`, `usage[:cache_write]`
+  — all canonical keys. The conformance test as proposed asserts the
+  `%Event.Usage{}` shape; this is necessary but not sufficient for
+  the user-visible Tracker outcome. A second assertion that the
+  Tracker's ETS row is incremented after the fixture replays is
+  trivially addable (SPEC-PROMPT-CACHING AC-2 already uses this
+  Bypass-driven pattern). The conformance test as scoped is therefore
+  a *shape* gate; an *end-to-end* gate is a strict additional layer
+  the solution does not require but the AC's "verified by" clause
+  permits. This does not falsify the claim; it narrows what the
+  conformance test alone proves.
+- **Outcome:** withstood.
+- **Action:** none; the narrower scoping of the conformance test as
+  "shape gate" is captured implicitly in the solution's verification-
+  harness role.
+
+### Claim 6: Consumer migration — `Tau.Session`, `Tau.Cost.Tracker`, and any TUI context-window display that reads `event.usage["input_tokens"]` / `Map.get(event.usage, ...)` migrates to `event.usage.input_tokens` struct access.
+
+- **Claim (C):** Existing consumers that access `usage` via
+  string-keyed lookup (`event.usage["input_tokens"]`) or
+  `Map.get(event.usage, ...)` will switch to struct field access.
+- **Grounds (G):** Grep of the live codebase
+  (`grep -rn "Map.get(.*usage\\|event.usage" lib/`) returns:
+  `lib/tau/providers/anthropic.ex:251` (adapter-internal usage of
+  the partial accumulator, not a consumer);
+  `lib/tau/compactor/summarize_tail.ex:32` —
+  `Map.get(usage, :input_tokens, 0)`; `lib/tau/tui/app/view.ex:124` —
+  `Map.get(model, :usage, %{input_tokens: 0, output_tokens: 0,
+  cache_read: 0, cache_write: 0})`. `lib/tau/cost/tracker.ex:121-127`
+  uses **atom-keyed bracket access** (`usage[:input_tokens]`), not
+  string-keyed. So the *only* call sites are atom-key or `Map.get`
+  with atom keys.
+- **Warrant (W):** Struct field access (`event.usage.input_tokens`)
+  is type-checked at compile time and Dialyzer-visible; bracket
+  access on a struct (`event.usage[:input_tokens]`) is *also* legal
+  in Elixir (the `Access` behaviour is auto-implemented for structs
+  with `defstruct`'s atom keys) so existing call sites continue to
+  compile **without migration** for atom-keyed reads. The solution's
+  statement of the migration target is therefore over-broad.
+- **Qualifier (Q) — NARROWED:** Holds only for consumer sites that
+  use **string-keyed** access (`event.usage["input_tokens"]`); a grep
+  finds **none** in the current codebase. The atom-keyed bracket
+  access in `Tau.Cost.Tracker` and `Tau.Compactor.SummarizeTail`
+  continues to work unchanged against the new struct. The TUI
+  `Map.get(model, :usage, ...)` call site is a model lookup, not an
+  event-usage lookup, and is unaffected. The migration step is
+  therefore largely a no-op against the present codebase; only the
+  Anthropic adapter's `merge_usage/2`-result construction site is
+  changed (to wrap in `%Event.Usage{}`).
+- **Rebuttal (R):** If a downstream extension or test helper outside
+  `lib/` (e.g. `test/`, `priv/`, or an external plugin) reads
+  `event.usage` via string keys, this would break silently. A
+  repo-wide grep including `test/` is the minimum due-diligence
+  step the implementer should perform.
+- **Backing (B):** Elixir's `Access` behaviour documentation
+  (https://hexdocs.pm/elixir/Access.html) confirms that `struct[key]`
+  is rewritten to `Access.get(struct, key, nil)` and that
+  `defstruct`-generated structs implement `Access.fetch/2` for atom
+  keys.
+
+#### Falsification attempt for claim 6
+
+- **Strategy:** counter-example construction (search the codebase for
+  the call sites the claim names).
+- **Attempt:** Ran `grep -rn 'event.usage\\["\\|Map.get(.*usage'`
+  across `lib/`. **No** string-keyed `event.usage["..."]` access
+  exists. The closest match is `Map.get(usage, :input_tokens, 0)`
+  in `summarize_tail.ex:32`, which uses an atom key against the
+  current `usage: %{}` map; against the new `%Event.Usage{}` struct
+  the same call still resolves correctly through the auto-derived
+  `Access` implementation. The `Tau.Cost.Tracker` path is atom-
+  bracket and continues to work. The TUI `view.ex:124` lookup is a
+  model-field default, not an event-usage access, and is unaffected.
+- **Outcome:** **partially falsified** — the migration cost the
+  solution describes is over-stated against the present codebase.
+  The string-keyed-access migration target named in claim 6 does
+  not exist.
+- **Action:** **narrow the qualifier in place** (done above). No
+  solution revision required: the over-stated migration cost is a
+  conservative-over-estimate, not a false claim about a required
+  change. The actual minimum migration step is "wrap
+  `Anthropic.merge_usage/2`'s return in `%Event.Usage{}`" — which
+  is captured under claim 4's adapter edits, not as an independent
+  consumer concern.
+
+### Claim 7: SPEC amendment — `docs/spec/SPEC-PROMPT-CACHING.md` §4 B3 references the new `%Event.Usage{}` struct as the canonical carrier; `Tau.Provider.UsageNorm` is named as the shared adapter-side scaffold; D-065 wording updated to match.
+
+- **Claim (C):** The SPEC's §4 B3 contract and D-065 invariant text
+  are updated in the same PR(s) that land the struct + scaffold, so
+  the SPEC and code stay in lock-step.
+- **Grounds (G):** `docs/spec/SPEC-PROMPT-CACHING.md` lines 110, 126-155,
+  169, 240 establish the current B3 + D-065 contract: "Cache-usage
+  normalisation … is each adapter's own `merge_usage`-side
+  responsibility." The text presupposes raw maps and per-adapter
+  `merge_usage/2`; the solution proposes both a typed carrier
+  (`%Event.Usage{}`) and a shared scaffold (`UsageNorm`) — both
+  novelties the SPEC text does not yet name.
+- **Warrant (W):** `.claude/rules/spec-before-code.md` mandates that
+  PRs adding new state at a SPEC'd boundary land the corresponding §3
+  entry and §4 contract update in the same PR (the rule's "What this
+  rule forbids" first bullet). The `%Event.Usage{}` struct **is** new
+  state at the §4 B3 boundary; therefore the SPEC amendment is not
+  optional.
+- **Qualifier (Q):** Holds unconditionally for this PR series — the
+  rule admits no exception for "internal" struct additions.
+- **Rebuttal (R):** None — the spec-before-code rule is binary and
+  the boundary is unambiguously the same one §4 B3 names.
+- **Backing (B):** `.claude/rules/spec-before-code.md` "What this rule
+  forbids" §1 ("MUST NOT merge a PR that adds new state to a SPEC'd
+  boundary without a corresponding §3 entry and §4 contract update in
+  the same PR"); SPEC-PROMPT-CACHING line 192-195 (B3 / D-065 testing
+  obligation).
+
+#### Falsification attempt for claim 7
+
+- **Strategy:** dependency check (does the inherited rule the warrant
+  cites still hold today?).
+- **Attempt:** Re-read `.claude/rules/spec-before-code.md` —
+  SPEC-PROMPT-CACHING is named in "the current spec catalog" and its
+  source-map (Appendix B) includes the adapter files the solution
+  edits. The rule applies and is enforced by the critic/reviewer gate
+  amendments (rule section "Critic / reviewer gate amendment").
+- **Outcome:** withstood.
+- **Action:** none; the solution already names the SPEC amendment
+  under "What changes" — verify the implementer lands it in PR 1.
+
+## Cross-claim consistency
+
+Claims 1, 2, 3, 4, 5, and 7 form a compositional set: the struct
+(claim 1) is the shape contract, the scaffold (claim 2) is the
+construction helper, the wire edits (claims 3 and 4) populate it,
+the conformance test (claim 5) gates it, and the SPEC amendment
+(claim 7) records the new contract. No internal tension.
+
+Claim 6 (consumer migration) was partially falsified — the migration
+cost is over-stated. This **does not** create tension with the other
+claims; it simplifies them. The Anthropic adapter edit under claim 4
+("wrap existing `merge_usage/2` output in `%Event.Usage{}` via
+`UsageNorm.from_anthropic/1`") covers the only consumer-visible
+construction site that genuinely needs to change. Atom-keyed access
+through the `Access` behaviour is the load-bearing detail that makes
+this cheap.
+
+One residual concern: the solution's open question §1 ("Should
+`Done.usage` be `@enforce_keys`-required (not `nil`-allowed) after
+migration?") creates a temporal coupling between PR 1 (which keeps
+`nil` allowed) and a hypothetical follow-up that tightens to
+required. This is acceptable as scoped — the open question is
+explicit — but the parent's validator should not credit "the
+canonical key set is enforced at the type system" as fully achieved
+until the tightening lands.
+
+## Falsification summary
+
+| # | Claim (short) | Strategy | Outcome | Action |
+|---|---|---|---|---|
+| 1 | `%Event.Usage{}` struct replaces `usage: map()` | type-level check | withstood | none |
+| 2 | `UsageNorm` shared scaffold module | counter-example construction | withstood | none |
+| 3 | OpenAI-family `stream_options.include_usage` + emit | edge-case enumeration | withstood | none |
+| 4 | Bedrock `message_start` accumulate + Gemini `usageMetadata` read | dependency check | withstood | none |
+| 5 | Shared `ProviderConformance` template, 11 instances | integration check | withstood | none |
+| 6 | Migrate consumers from string-key to struct access | counter-example construction | partially_falsified | narrow Q in place — done |
+| 7 | SPEC §4 B3 + D-065 amendment in the same PR | dependency check | withstood | none |
+
+## Revision required
+
+No solution or problem revision is required. Claim 6's qualifier is
+narrowed in place above; the solution's prose over-states the
+migration cost but does not require a different *technical* solution.
+
+- **Target file:** n/a
+- **Revision kind:** n/a
+- **Rationale:** Partial falsifications narrow qualifiers in place
+  (per validate.md §5); no revision required.
+
+## Outstanding doubts
+
+- **OpenAI.Responses wire-extraction.** The solution names it as a
+  conformance target but does not specify `from_openai_responses/1`
+  in `UsageNorm`. Open question §3 captures this; the implementer
+  must close it in PR 2 scoping.
+- **Custom-adapter rebuttal under claim 3.** Self-hosted OpenAI-
+  compatible servers may reject `stream_options.include_usage`. The
+  worst case is zero-fill, not crash, but this should be added to
+  the solution's open questions for downstream-user visibility.
+- **Replay deserialiser shape coverage.** Open question §2 captures
+  this. The conformance test (claim 5) relies on fixtures replayed
+  through `Tau.Providers.Replay`, so the deserialiser must construct
+  `%Event.Usage{}` before the conformance test for any adapter that
+  uses Replay-driven fixtures can go green.
+- **Fixture refresh policy.** Claim 5's rebuttal — the live API may
+  drift from the fixture — is a codebase-wide concern this solution
+  does not address. Not a defect of this solution; a known gap.
+- **`@enforce_keys` tightening (open question §1).** Until the
+  follow-up that removes the `| nil` transitional qualifier lands,
+  the type-level enforcement claim 1 makes is partial: a careless
+  adapter can still emit `%Event.Done{usage: nil}` without a
+  compile error.

--- a/docs/problems-archive-v1-modules/tau-providers/validation.md
+++ b/docs/problems-archive-v1-modules/tau-providers/validation.md
@@ -1,0 +1,905 @@
+---
+template_version: 1
+template_name: validation
+parent_solution: ./solution.md
+parent_problem: ./problem.md
+toulmin_complete: true
+falsification_attempted: true
+falsification_outcome: partially_falsified — claim/7
+revision_triggered: none
+---
+
+# Validation: four-workstream composition makes `Tau.Provider` enforce or honestly document every observable adapter divergence
+
+## Overview
+
+The root solution is a *synthesis* of four child solutions. To avoid
+re-litigating per-child claims (each child has its own `validation.md`
+on file), this validation focuses on the **cross-cutting integration
+claims** the synthesis newly asserts at the parent level: workstream
+composability, the conjunction satisfaction of the module-level
+acceptance criterion AC-M1, the disjoint-files / shared-file-region
+parallelisability of the four PRs, and the "every observable adapter
+divergence currently present is covered" coverage claim. Ten claims
+are enumerated and run through full six-field Toulmin with a named
+falsification strategy each. Falsification strategies span
+counter-example construction, edge-case enumeration, integration
+check, dependency check, and type-level check. Outcome: nine claims
+withstand; claim 7 ("every observable adapter divergence currently
+present across the eleven adapters" is enforced or honestly
+documented) is **partially falsified** by counter-example construction
+— the live-decode-path defects for Bedrock and Gemini (missing
+`TextStart`/`TextEnd` synthesis, atomic `ToolCallDelta` batching) are
+*declared* via `stream_contract/0` but **not fixed** in this scope;
+the parent solution itself acknowledges this under §What does not
+change and §Open questions. The qualifier on claim 7 is narrowed in
+place: "enforced or *declared* (declaration-only for two named
+deferrals)". No revision to `solution.md` or `problem.md` is
+triggered.
+
+This validation also **inherits** the child validators' partial
+falsifications and outstanding doubts; they are listed under §Inherited
+qualifiers from child validations so the parent-level discharge of
+AC-M1 carries them forward into its own Qualifier fields where
+relevant.
+
+## Toulmin per claim
+
+The MITRE empirical study on Toulmin formalism warns that participants
+"found it difficult to generate Toulmin structures, and their
+structures varied greatly even though they started with the same
+content"
+(<https://www.mitre.org/news-insights/publication/empirical-evaluation-structured-argumentation-using-toulmin-argument>).
+Each of the six fields is filled explicitly below to counter that
+variance.
+
+### Claim 1: The four workstreams' recommendations compose directly — none retracts or constrains another.
+
+- **Claim (C):** "their recommendations compose directly — none
+  retracts or constrains another, and the file-touch sets are nearly
+  disjoint" (solution.md §"Composition rationale").
+- **Grounds (G):** The file-touch table in solution.md L59–64
+  enumerates each workstream's targets. Workstream A touches
+  `lib/tau/providers/*.ex` (six adapters' `vault_key/0` helpers) +
+  one new `lib/tau/providers/auth.ex` + one ADR + two tests, and does
+  NOT touch `lib/tau/provider.ex`. Workstream B touches
+  `lib/tau/provider/event.ex` (the `Event` union, distinct file from
+  `provider.ex`), three adapter wire files, plus new modules and
+  tests. Workstream C touches `@doc`/`@typedoc` on
+  `capabilities/0` in `lib/tau/provider.ex` (lines 58–70), three
+  adapters' `capabilities/0` return values, one new Mix task, one
+  ci.yml line. Workstream D touches the new `@callback
+  stream_contract/0` in `lib/tau/provider.ex` (a new region appended
+  after L131's `@optional_callbacks`), all eleven adapters'
+  `stream_contract/0` implementations, one new struct file. **No two
+  workstreams modify the same adapter `capabilities/0` body, the
+  same `vault_key/0` helper, the same wire file, or the same
+  `provider.ex` region.**
+- **Warrant (W):** Two PRs that touch strictly disjoint files (or
+  disjoint stable regions of a shared file) compose by source-control
+  3-way merge without semantic conflict — the merge result is the
+  union of each diff applied to the base. The factory-loop's parallel
+  execution conflict check (`.claude/rules/factory-loop.md` §"The
+  conflict check" clauses 2–3) is the canonical operational
+  formalisation of this principle for the project.
+- **Qualifier (Q):** Holds for the file-touch table as written. The
+  three workstreams that touch `lib/tau/provider.ex` (B, C, D) edit
+  *different* regions of that file but trigger the factory-loop
+  freshness re-check (cycle step 8a) when scheduled concurrently —
+  i.e., a textual rebase is needed but no merge conflict arises.
+- **Rebuttal (R):** Does NOT hold if one workstream's implementer
+  silently extends scope into another's region (e.g., the
+  Workstream-B1 author "while I'm here" also edits the `@callback
+  capabilities/0` docstring). The factory-loop's PR-scope guard
+  forbids this and the critic gate is supposed to flag scope creep,
+  but the validator cannot guarantee implementer discipline.
+- **Backing (B):** `.claude/rules/factory-loop.md` §"Parallel
+  execution" clause 2 ("Disjoint files") and clause 3 ("Disjoint
+  codepoints"); `.claude/rules/factory-loop.md` §"PR scope guards"
+  ("Declared, frozen scope").
+
+#### Falsification attempt for claim 1
+
+- **Strategy:** Edge-case enumeration over the four pairs of
+  workstreams that could conflict (A×B, A×C, A×D, B×C, B×D, C×D —
+  six pairs).
+- **Attempt:** A×B: A edits `vault_key/0`/`api_key/0` helpers; B
+  edits adapter `decode/2` (Bedrock, Gemini) and shared
+  `openai_chat_wire.ex` decode functions. Disjoint functions in
+  potentially the same file (Gemini and Bedrock are touched by both,
+  but at distinct function definitions). Verified by inspecting
+  `lib/tau/providers/bedrock.ex` (api_key resolution is at the top of
+  the module; `decode_anthropic_event/2` is at line 111+) and
+  `lib/tau/providers/gemini.ex` (api_key at line 172; decode at line
+  95+). No function overlap. A×C: A touches no `capabilities/0`
+  return-value lines; C touches no `vault_key/0` lines. Disjoint.
+  A×D: A adds no `stream_contract/0` implementations; D adds one per
+  adapter. Disjoint. B×C: B touches `event.ex`, `openai_chat_wire`,
+  `bedrock.ex`/`gemini.ex` decode paths; C touches `@doc` on
+  `provider.ex` and `capabilities/0` bodies on three adapters.
+  Disjoint regions in shared adapter files. B×D: B touches event
+  union and adapter decode paths; D adds the `stream_contract/0`
+  callback declaration and one per-adapter implementation. The
+  Bedrock and Gemini adapter files are touched by both, but at
+  distinct function definitions. C×D: both touch `lib/tau/provider.ex`
+  but at distinct regions — C edits L58–70 (`capabilities/0` doc) +
+  L131 area; D appends a new `@callback` block after L131. Distinct
+  textual regions. **All six pairs are file-or-region disjoint.**
+- **Outcome:** withstood.
+- **Action:** none.
+
+### Claim 2: Three enforcement mechanisms (type-level, CI-gate, documentation) compose intentionally and each layer covers what the previous cannot.
+
+- **Claim (C):** "Three forms of enforcement compose intentionally.
+  Type-level enforcement … catches the 'absent implementation'
+  failure mode at compile time. CI-gate enforcement catches the
+  'declared but unimplemented' failure mode … Documentation … closes
+  the residual case where a flag's obligations span too many callsites
+  to localise mechanically. Each layer covers what the previous layer
+  cannot — composition, not redundancy." (solution.md §"Composition
+  rationale" L79–84).
+- **Grounds (G):** Type-level: `%Event.Usage{}` with
+  `@enforce_keys [:input_tokens, :output_tokens]` (Workstream B); the
+  mandatory `stream_contract/0` callback (Workstream D) producing a
+  compile warning if any adapter omits it (made fatal by
+  `mix compile --warnings-as-errors`). CI-gate:
+  `mix tau.gate.capabilities` enforcing
+  `prompt_caching == true ⇔ function_exported?(mod, :cache_regions, 2)`
+  (Workstream C); `mix tau.conformance` iterating
+  `Tau.Test.ProviderConformance` per adapter (Workstream B PR-B3).
+  Documentation: `@doc`/`@typedoc` on `capabilities/0`
+  (Workstream C), the `@stream_contract` module attribute prose
+  (Workstream D), `ADR-00XX-auth-resolution-policy.md` (Workstream A),
+  and the cross-workstream `docs/PROVIDER-CONTRACT.md` index. The
+  child `capabilities-flag-fidelity/validation.md` confirms (Claim 4
+  partial-falsification) that `thinking: true` enforcement has no
+  equivalent single-callback target — obligations span `build_body/3`
+  and the decode path — so documentation is the only remaining
+  enforcement layer for `thinking`.
+- **Warrant (W):** Defence-in-depth across orthogonal mechanisms is
+  the canonical pattern when no single mechanism covers the full
+  failure surface. The three mechanisms here are orthogonal because
+  they catch divergent failure modes: type-level catches *absent*
+  declarations at compile time; CI-gate catches *false* declarations
+  at PR time; documentation guides authors *before* either gate fires.
+- **Qualifier (Q):** Holds for the failure modes the parent solution
+  enumerates. Does NOT hold for failure modes outside this set: an
+  adapter that declares an honest `stream_contract/0` but emits
+  *wrong* events (a "value-level lie" inherited from the
+  callback-contract-drift validation's claim 3 rebuttal) is caught
+  only by the self-consistency test (Workstream D's
+  `provider_stream_contract_test.exs`), which itself depends on a
+  Replay fixture (the inherited fixture-completeness doubt from
+  child Claim 7).
+- **Rebuttal (R):** Does NOT hold if the three layers' inputs drift
+  out of sync — e.g., a future workstream extends `Event.Usage` with
+  a new field but the prose `@stream_contract` attribute and the
+  capabilities gate are not updated. The cross-workstream
+  `docs/PROVIDER-CONTRACT.md` index is the soft mitigation; no hard
+  mitigation exists.
+- **Backing (B):** `.claude/rules/factory-loop.md` §"The three
+  mechanical gates" — established pattern for layering gates of
+  different mechanism classes. OTP non-negotiable #2 (struct/atom
+  pattern-matching for extensibility seams).
+
+#### Falsification attempt for claim 2
+
+- **Strategy:** Integration check — for each named "what each layer
+  cannot do" boundary, verify the next layer actually does it.
+- **Attempt:** (a) Type-level cannot catch a declared-but-lying
+  `stream_contract/0` → CI-gate via the self-consistency test
+  (Workstream D) catches it. Verified the test is in scope per
+  solution.md L177–179. (b) Type-level cannot catch a `prompt_caching:
+  true` declared without `cache_regions/2` → `mix
+  tau.gate.capabilities` (Workstream C) catches it. Verified the
+  biconditional and the gate's CI-blocking position. (c) Type-level
+  and CI-gate cannot catch `thinking: true` lies because no single
+  callback owns the obligation → documentation is the only remaining
+  layer; `capabilities/0` docstring and `@stream_contract` prose are
+  the artefacts. This *does* leave a gap (no mechanical catch), which
+  the parent solution acknowledges under §Open questions
+  ("`thinking` flag enforcement"). The composition claim survives:
+  documentation is the named layer for this case, even if its
+  enforcement strength is lower than the other two.
+- **Outcome:** withstood.
+- **Action:** none. Note: the parent's claim is "each layer covers
+  what the previous *cannot*"; this is correct in the sense that
+  documentation is the only layer that *can* address `thinking`, not
+  in the sense that documentation *enforces* `thinking` honesty.
+
+### Claim 3: The four workstreams ship as four (or six with B2/B3) separate PRs that can largely parallelise under the factory-loop conflict check.
+
+- **Claim (C):** "The four workstreams touch disjoint files and ship
+  as four separate PRs that can largely parallelise under the
+  factory-loop conflict check" (solution.md §Recommendation L43–45).
+- **Grounds (G):** The migration sketch (solution.md §"Migration
+  sketch" L217–262) enumerates the PR sequence: PR-A and PR-B1 in
+  parallel (fully disjoint files); PR-C after PR-B1 to claim the
+  `lib/tau/provider.ex` edit window; PR-D after PR-C for the same
+  reason; PR-B2 and PR-B3 in parallel after that. The
+  factory-loop conflict check (rule §"The conflict check" clauses
+  1–5) explicitly defines the parallelisation criterion: no
+  dependency, disjoint files, disjoint codepoints, no shared SPEC/D-NNN
+  block, shared-resource isolation possible.
+- **Warrant (W):** The factory-loop conflict check is the project's
+  authoritative concurrency arbiter; any PR set that clears all five
+  of its clauses can be parallelised by definition. Claim 1's
+  validation shows the four workstreams are file/region-disjoint;
+  Workstream A introduces no SPEC; Workstream B amends
+  SPEC-PROMPT-CACHING (`%Event.Usage{}` is new state at §4 B3);
+  Workstream C may need a brief SPEC entry or ADR (Open question 6
+  in solution.md); Workstream D may need its own SPEC entry (Open
+  question 7). The SPEC-clause (4) is satisfied because no two
+  workstreams amend the same SPEC.
+- **Qualifier (Q):** Holds with the explicit serialisation noted:
+  PR-B1 strictly precedes PR-B2 and PR-B3 (Workstream B's
+  intra-sequencing); PR-C and PR-D should not run concurrently with
+  PR-B1 to minimise rebase blast radius. The parent solution names
+  this serialisation in its migration sketch.
+- **Rebuttal (R):** Does NOT hold if Workstream D's SPEC question
+  (Open question 7) lands as a SPEC amendment that Workstream B also
+  amends in the same window — that would violate clause 4 (shared
+  SPEC). The parent solution flags this open question; if it
+  resolves as "new SPEC-PROVIDER-CONTRACT", B and D no longer share a
+  SPEC. If it resolves as "amendment to SPEC-PROMPT-CACHING", B and
+  D both amend it and must serialise on the SPEC amendment.
+- **Backing (B):** `.claude/rules/factory-loop.md` §"Parallel
+  execution" §"The conflict check"; `.claude/rules/spec-before-code.md`
+  §"Critic / reviewer gate amendment".
+
+#### Falsification attempt for claim 3
+
+- **Strategy:** Counter-example construction — try to find a PR pair
+  that the conflict check would reject despite the solution's
+  parallelisation claim.
+- **Attempt:** Examined the six PR pairs under the five clauses.
+  Dependency (clause 1): only B1→B2 and B1→B3 are dependencies,
+  matching the solution's stated serialisation. Disjoint files
+  (clause 2): per claim 1 validation, all pairs are file-or-region
+  disjoint. Disjoint codepoints (clause 3): no two PRs modify the
+  same function. SPEC blocks (clause 4): A authors no SPEC; B amends
+  SPEC-PROMPT-CACHING B3; C amends none mechanically (could need a
+  small ADR); D's SPEC home is the open question. The
+  worst-case-SPEC-collision is B and D both amending
+  SPEC-PROMPT-CACHING — but D's content is *not* about prompt
+  caching; the solution explicitly recommends a new
+  `SPEC-PROVIDER-CONTRACT` (or ADR) for D. Shared-resource isolation
+  (clause 5): none of the four workstreams invokes `mix tau.smoke` or
+  `mix release tau ...`; the burrito-cache issue cited in
+  `worktree-discipline.md` does not apply.
+- **Outcome:** withstood (with the open-question 7 caveat under
+  Outstanding doubts).
+- **Action:** none. Implementer of PR-D must resolve the SPEC home
+  before scheduling concurrently with PR-B series.
+
+### Claim 4: PR-D (Workstream D — `stream_contract/0`) is the only workstream that breaks `@behaviour Tau.Provider` for external implementors.
+
+- **Claim (C):** "PR-D … is the only workstream that breaks
+  `@behaviour Tau.Provider` for external implementors (out-of-scope
+  per the project; all current implementors are in-tree)."
+  (solution.md §"Migration sketch" L240–242).
+- **Grounds (G):** Inspection of `lib/tau/provider.ex` shows the
+  current callback list: `stream/3` (mandatory), `capabilities/0`
+  (mandatory), `default_model/0` (mandatory), `configure/1`
+  (optional), `chat/3` (optional), `cache_regions/2` (optional),
+  `context_window/1` (optional). The mandatory set is unchanged
+  except for the addition of `stream_contract/0` (Workstream D).
+  Workstream A adds no callback. Workstream B replaces the typespec
+  of `%Event.Done{}.usage` from `map()` to `Event.Usage.t() | nil` —
+  this is a *typespec* tightening on a struct *field*, not a
+  behaviour-callback change; any adapter that emits `%Event.Done{usage:
+  %{...}}` (a raw map) still compiles but fails Dialyzer's
+  success-typing. Workstream C adds `@doc`/`@typedoc` text and a
+  capabilities biconditional gate, but does not change the
+  `capabilities/0` callback signature.
+  `grep -rln '@behaviour Tau.Provider\b' lib/` returns exactly 11
+  modules; no external (out-of-tree) implementor is shipped.
+- **Warrant (W):** Adding a mandatory `@callback` requires every
+  `@behaviour Tau.Provider` module to implement it; the compiler
+  emits "behaviour callback X is not implemented" and
+  `mix compile --warnings-as-errors` makes it fatal. This is the
+  precise mechanism the child callback-contract-drift validation's
+  Claim 6 cites. Adding an optional callback, a `@doc`, a typespec, or
+  a new struct does NOT trigger the warning; therefore those changes
+  do not break external implementors.
+- **Qualifier (Q):** Holds while no external `@behaviour
+  Tau.Provider` implementor ships. If an extension-loaded provider
+  (SPEC-EXTENSIONS Stage B) is materialised before PR-D lands, the
+  extension's compile step fails on the new mandatory callback —
+  exactly the "behaviour break" the claim names.
+- **Rebuttal (R):** Workstream B's `%Event.Usage{}` struct technically
+  is a contract tightening on `%Event.Done{}`; an external implementor
+  that emits a raw `usage: %{}` map would not fail compile (the
+  emission site is the adapter's own code; the typespec is at the
+  emitter side) but would surface as a Dialyzer warning. This is a
+  *soft* break of the contract — not a hard compile break, so Claim 4
+  remains correct that PR-D is the only *hard* break.
+- **Backing (B):** Elixir documentation on behaviour callback warnings;
+  `.claude/rules/factory-loop.md` §"PR scope guards" treats hard
+  compile breaks as triggering the freshness re-check.
+
+#### Falsification attempt for claim 4
+
+- **Strategy:** Counter-example construction — enumerate the four
+  workstreams' changes and check each for a hard behaviour break.
+- **Attempt:** Workstream A: adds `Tau.Providers.Auth` and removes
+  private helpers from six adapters. No `@callback` change. No break.
+  Workstream B: typespec tightening on `Done.usage`; struct addition
+  to `Tau.Provider.Event`. No `@callback` change. No hard break.
+  Workstream C: `@doc`/`@typedoc` text; demotion of three adapters'
+  flag values; new Mix task; ci.yml line. No `@callback` change. No
+  break. Workstream D: adds mandatory `@callback stream_contract/0`.
+  Every `@behaviour Tau.Provider` module must implement it or fail
+  compile. **Confirmed hard break — but only Workstream D triggers
+  it.** Claim 4 holds.
+- **Outcome:** withstood.
+- **Action:** none.
+
+### Claim 5: A new adapter author following `@behaviour Tau.Provider` cannot pass `mix compile --warnings-as-errors`, `mix test`, AND `mix tau.gate.capabilities` without satisfying all four sub-criteria (AC-M1, the module-level synthesis criterion).
+
+- **Claim (C):** AC-M1 verbatim (solution.md §"Module-level AC" L338–349):
+  the new author must (a) declare a usage struct conforming to
+  `Event.Usage`, (b) declare a stream contract matching emitted
+  events, (c) declare `prompt_caching: true` only if implementing
+  `cache_regions/2`, and (d) route standard API-key resolution through
+  `Tau.Providers.Auth`.
+- **Grounds (G):** Sub-criterion (a) is enforced by the mandatory
+  `Done.usage` typespec change (Workstream B) plus the
+  `ProviderConformance` test template (Workstream B PR-B3) iterating
+  every adapter. (b) is enforced by Workstream D's mandatory
+  `stream_contract/0` callback (Dialyzer-checked for structural
+  divergence per child Claim 3) and the self-consistency test for
+  value-level divergence (child Claim 7). (c) is enforced by `mix
+  tau.gate.capabilities` (Workstream C, child Claim 5) which is
+  wired into the lint job as blocking (child Claim 6). (d) is the
+  weakest of the four: the cross-adapter telemetry test (Workstream
+  A, child Claim 5) asserts `[:tau, :vault, :get]` fires during
+  credential resolution but does NOT assert the call goes through
+  `Tau.Providers.Auth` specifically — an adapter could call
+  `Tau.Settings.Vault.resolve/1` directly and the telemetry test
+  would still pass.
+- **Warrant (W):** AC-M1 is satisfied iff every sub-criterion is
+  satisfied (logical conjunction). Each child sub-AC set is
+  individually validated (child validations on file); their union
+  discharges the conjunction iff the union covers the full failure
+  surface AC-M1 names. The four sub-criteria are exhaustive of the
+  "ship a broken implementation" failure modes the parent problem
+  cited (capabilities-flag fidelity, usage normalisation, callback
+  contract drift, auth-resolution scatter).
+- **Qualifier (Q):** Holds for the four named failure modes. **Narrowed
+  for sub-criterion (d):** the telemetry test enforces "vault was
+  consulted" rather than "`Tau.Providers.Auth` was the consulting
+  module"; an adapter that goes directly to vault satisfies the test
+  but not the spirit of routing-through-Auth. The ADR (Workstream A,
+  child Claim 4) is the soft mitigation; the parent solution does
+  not name a stricter test.
+- **Rebuttal (R):** A new adapter author who skips
+  `@behaviour Tau.Provider` entirely (e.g., implements the functions
+  duck-typed) escapes the type-level enforcement; the compile warning
+  is keyed on the `@behaviour` declaration. This is an edge case
+  (every existing adapter does declare `@behaviour`), but it is a
+  loophole the four workstreams do not close.
+- **Backing (B):** Parent problem.md §"Acceptance criterion" L88–93;
+  the four child validations' AC discharge sections.
+
+#### Falsification attempt for claim 5
+
+- **Strategy:** Counter-example construction — imagine a "minimum
+  malicious adapter" and check whether each gate fires.
+- **Attempt:** Author writes `Tau.Providers.Evil`, declares
+  `@behaviour Tau.Provider`, implements `stream/3`, `capabilities/0`
+  with `prompt_caching: true` but no `cache_regions/2`,
+  `default_model/0`, and `stream_contract/0` claiming
+  `text_framing: :start_delta_end` while emitting bare
+  `%Event.TextDelta{}`. Result: (a) Dialyzer flags
+  `%Event.Done{usage: nil}` if not wrapped, but a knowing author
+  could call `UsageNorm.zero()` and pass type-level; conformance
+  test fails if a fixture exists, but author can ship without one
+  initially. (b) `stream_contract/0` declaration of conformant +
+  bare-delta emission: self-consistency test fails (child Claim 7,
+  qualified by fixture availability). (c) `prompt_caching: true` no
+  `cache_regions/2`: `mix tau.gate.capabilities` fails — blocking.
+  (d) `api_key/0` calls `Tau.Settings.Vault.resolve/1` directly
+  (bypassing `Tau.Providers.Auth`): telemetry test passes (fires on
+  vault), so this gate does NOT fire. **Sub-criterion (d) is the
+  weakest** — but the *intent* of AC-M1 ("cannot silently ship a
+  broken implementation") is still met for the gates that fire,
+  and the bypass route is observable in the ADR's exception table on
+  review. No claim falsification, but the Qualifier narrowing under
+  (d) is consistent with the child auth-resolution-scatter
+  validation's outstanding doubt that the telemetry assertion is
+  fire-only not use-only.
+- **Outcome:** withstood (with the narrowed qualifier under (d)).
+- **Action:** none. The narrowed qualifier is recorded; the
+  underlying weakness is inherited from the auth-resolution-scatter
+  child's Outstanding doubts.
+
+### Claim 6: `Tau.Provider`'s existing callback list is preserved except for the single new `stream_contract/0`; optional callbacks remain optional.
+
+- **Claim (C):** "The `Tau.Provider` callback list **except** for the
+  single new `stream_contract/0` (Workstream D). `configure/1` stays
+  optional and unused; `cache_regions/2` stays optional;
+  `context_window/1` stays optional." (solution.md §"What does not
+  change" L191–195).
+- **Grounds (G):** `lib/tau/provider.ex:131` reads `@optional_callbacks
+  [configure: 1, chat: 3, cache_regions: 2, context_window: 1]`. The
+  parent solution's "What changes" enumeration touches only: B's
+  event-union typespec; C's `@doc`/`@typedoc` on `capabilities/0`;
+  D's `@callback stream_contract/0` declaration (appended, not
+  replacing). No workstream modifies the `@optional_callbacks` list
+  or promotes/demotes existing callbacks.
+- **Warrant (W):** Preserving an established public surface
+  (callback list + optionality status) is the canonical Hyrum's-law
+  consideration for an interface with 11 implementors. The child
+  auth-resolution-scatter validation's Claim 6 verified `configure/1`
+  remains optional; the parent inherits.
+- **Qualifier (Q):** Holds for the four workstreams' scope as
+  declared. A future PR could promote `configure/1` to mandatory
+  (the auth-resolution-scatter Outstanding doubt #3), but the
+  parent solution explicitly defers this.
+- **Rebuttal (R):** None — the change set is enumerable and the
+  preservation is by-construction.
+- **Backing (B):** OTP non-negotiable #2 ("extensibility seams MUST
+  be behaviours"; corollary: the seam's shape MUST NOT be changed
+  gratuitously). Child validation
+  `subproblems/auth-resolution-scatter/validation.md` §Claim 6.
+
+#### Falsification attempt for claim 6
+
+- **Strategy:** Counter-example construction — search the parent
+  solution's "What changes" for any modification to
+  `@optional_callbacks` or any existing callback's mandatory/optional
+  status.
+- **Attempt:** Read solution.md L86–187 (the "What changes" block).
+  Search hits for `@optional_callbacks`: zero. Search hits for
+  `configure/1` outside §"What does not change": one (the
+  callback-contract-drift child's open question about `known_adapters/0`
+  helper does not touch `configure/1`). The Workstream D addition is
+  explicitly stated as "mandatory, not optional" but it is a new
+  callback, not a status change on an existing one.
+- **Outcome:** withstood.
+- **Action:** none.
+
+### Claim 7: The behaviour contract and shared infrastructure enforces (or accurately documents as optional) **every observable divergence currently present** across the eleven adapters.
+
+- **Claim (C):** The parent problem's acceptance criterion verbatim:
+  "the behaviour contract at `lib/tau/provider.ex` and associated
+  shared infrastructure enforces (or accurately documents as
+  optional) every observable divergence currently present across
+  the eleven adapters" (problem.md §"Acceptance criterion" L88–93;
+  AC-M1 in solution.md L338–349 is the operational form).
+- **Grounds (G):** The four workstreams collectively address the
+  four divergence axes problem.md enumerates (L46–58): (1)
+  capabilities flag fidelity → Workstream C; (2) usage normalisation
+  → Workstream B; (3) auth-resolution scatter → Workstream A; (4)
+  callback-contract drift → Workstream D. The child validations
+  individually validate that each workstream achieves its sub-AC.
+  However, the parent solution's §"What does not change" L196–201
+  explicitly notes: "Live decode paths for Bedrock and Gemini (other
+  than the usage extraction in B2) — they continue to omit
+  `TextStart/End` framing; the `stream_contract/0` declaration makes
+  the gap visible but does not fix it." The child
+  callback-contract-drift validation's Claim 5 confirms this
+  declaration-only treatment.
+- **Warrant (W):** "Enforces or accurately documents as optional"
+  has two satisfying disjuncts: hard enforcement (compile/CI gate
+  fires on violation) or accurate documentation (the divergence is
+  declared and discoverable without reading the decode path). The
+  `stream_contract/0` callback satisfies the second disjunct for
+  Bedrock and Gemini: their divergence is *declared* (`text_framing:
+  :delta_only`), even though it is not *fixed*.
+- **Qualifier (Q) — NARROWED during validation:** Holds with two
+  named exceptions: (a) Bedrock's and Gemini's live-decode-path
+  divergences (no `TextStart/End`, atomic `ToolCallDelta`) are
+  declared via `stream_contract/0` but **not corrected** in scope.
+  The parent solution names this under §"What does not change" and
+  §"Open questions" (Bedrock/Gemini decode-path remediation is a
+  follow-up sub-problem). (b) The `thinking` flag's enforcement
+  remains advisory-by-doc (parent's §"Open questions" item 3 and
+  child capabilities-flag-fidelity's Claim 4 partial falsification).
+- **Rebuttal (R):** A maximally strict reading of AC-M1 might
+  interpret "enforces or accurately documents as optional" as
+  excluding declaration-only treatment (the divergence must be
+  enforced *or* the divergence must be optional, not "declared but
+  unfixed"). Under that reading, claim 7 is *fully* falsified, not
+  partially: the live-decode-path divergences are neither enforced
+  nor optional; they are declared-as-broken. The parent solution
+  rejects this reading and treats declaration as sufficient
+  documentation; the parent problem's acceptance criterion is
+  ambiguous on the point.
+- **Backing (B):** Parent problem.md L88–93; child
+  `subproblems/callback-contract-drift/validation.md` §Claim 5 and
+  §Open questions; child
+  `subproblems/capabilities-flag-fidelity/validation.md` §Claim 4
+  partial-falsification.
+
+#### Falsification attempt for claim 7
+
+- **Strategy:** Counter-example construction — enumerate every
+  divergence in problem.md L24–43 and check whether each is either
+  enforced or accurately documented post-synthesis.
+- **Attempt:** (1) "`capabilities/0` flags are decorative
+  (Bedrock/Gemini declare `thinking: true, prompt_caching: true`
+  while implementing neither)" → Workstream C demotes the flags and
+  the gate enforces `prompt_caching`. Enforced. (2) "usage maps are
+  only canonically normalised by Anthropic" → Workstream B introduces
+  the struct, scaffold, wire-extraction, and conformance test.
+  Enforced. (3) "`retryable?` classification scattered across three
+  layers with incompatible criteria" → **NOT in any workstream's
+  scope.** The parent problem mentions `retryable?` in §Statement
+  L18–21 but no sub-problem covers it. Workstream A is auth-only;
+  Workstream B is usage-only; Workstream C is capability-flag-only;
+  Workstream D is stream-contract-only. **Claim 7 is silently
+  understating the gap: the `retryable?` divergence problem.md
+  cites is unaddressed.** (4) "auth-resolution logic is duplicated"
+  → Workstream A. Enforced. Plus the structural divergences from
+  callback-contract-drift (Bedrock/Gemini decode paths) → Workstream
+  D declares but does not fix.
+- **Outcome:** **partially falsified.** Two distinct underspecification
+  exceptions: (i) `retryable?` classification is named in problem.md
+  §Statement but no sub-problem and no workstream addresses it; (ii)
+  Bedrock/Gemini live-decode-path divergences are declared but not
+  fixed.
+- **Action:** **narrow the qualifier in place** (done above).
+  Specifically: claim 7's Qualifier is narrowed to "every divergence
+  enumerated as a sub-problem in problem.md L72–85", which is the
+  decomposition the synthesis acts on. The `retryable?` line in
+  problem.md §Statement was decomposed away — it appears in the
+  statement but is not present in the four sub-problems. This is a
+  **problem decomposition gap**, not a solution defect: the
+  decomposition step (proposer-level) elided one of four divergences
+  in problem.md §Statement when carving the four sub-problems.
+  Recording as an outstanding doubt and flagging for the coordinator;
+  no revision of the parent solution.md (it correctly synthesises the
+  four children) but the **parent problem.md may need an amendment
+  log entry** clarifying that `retryable?` is deferred. Not
+  triggering a `revision_triggered: problem` because the acceptance
+  criterion still holds for the divergences that *were* decomposed,
+  and the missing decomposition is recoverable as a future
+  sub-problem.
+
+### Claim 8: The cross-workstream `docs/PROVIDER-CONTRACT.md` index consolidates four scattered artefacts into one operator-readable index.
+
+- **Claim (C):** "Documentation — `docs/PROVIDER-CONTRACT.md` (or
+  amendment to an existing provider doc) lists the four enforcement
+  mechanisms (`stream_contract/0`, `%Event.Usage{}`, `mix
+  tau.gate.capabilities`, `Tau.Providers.Auth`) and points at each
+  workstream's spec / ADR / test entrypoint. This consolidates what is
+  otherwise four scattered artifacts into one operator-readable index."
+  (solution.md §"Cross-workstream additions" L181–187).
+- **Grounds (G):** Each workstream produces its own artefact:
+  Workstream A's `ADR-00XX-auth-resolution-policy.md`, Workstream B's
+  SPEC-PROMPT-CACHING §4 B3 amendment, Workstream C's
+  `capabilities/0` `@doc`/`@typedoc`, Workstream D's
+  `@stream_contract` attribute and (per open question 7) a
+  SPEC-PROVIDER-CONTRACT or ADR. Without consolidation, a new
+  contributor must read all four to understand the provider contract.
+- **Warrant (W):** Reducing N independent reference points to 1
+  index reduces the activation cost of correct adapter authorship
+  from O(N) to O(1) — a soft engineering benefit.
+- **Qualifier (Q):** Holds when the index actually lands. The
+  parent solution treats it as a cross-workstream addition; which PR
+  authors it is unspecified. If no PR authors it, the four
+  artefacts remain scattered.
+- **Rebuttal (R):** The index can drift from the four canonical
+  sources (the standard "documentation that mirrors code" risk).
+  The solution does not address refresh policy.
+- **Backing (B):** The `tau-architecture` skill's general guidance
+  on layering documentation alongside code. No formal SPEC mandates
+  this kind of index.
+
+#### Falsification attempt for claim 8
+
+- **Strategy:** Dependency check — does the parent solution name
+  which PR owns the index?
+- **Attempt:** Searched solution.md for `PROVIDER-CONTRACT`: three
+  mentions, all in §"Cross-workstream additions" and §"Open
+  questions". The PR ownership is unspecified — it is "Cross-
+  workstream", not assigned to any of the six listed PRs (A, B1, B2,
+  B3, C, D). This is a soft defect: a deliverable named with no
+  owner risks not being delivered.
+- **Outcome:** withstood (the claim is about the *value* of the
+  index if it exists, not about its delivery). The delivery risk
+  is flagged under Outstanding doubts.
+- **Action:** none. Flag for the implementer-coordinator: assign the
+  `docs/PROVIDER-CONTRACT.md` authorship to a specific PR (e.g.,
+  the last to merge, so it can reference all four canonical sources).
+
+### Claim 9: The per-workstream reversibility table (A: easy delete; B: B3→B2→B1 reverse; C: trivial revert; D: easy at struct level) is accurate.
+
+- **Claim (C):** "Reversibility is per-workstream: A: easy (delete
+  shared module). B: B3 → B2 → B1 reverse order; struct revert
+  requires consumer-access revert. C: trivial (revert demotions;
+  delete gate task; remove CI line). D: easy at struct level (delete
+  `stream_contract.ex`); harder if any external implementor has
+  already implemented the callback (out of scope today)."
+  (solution.md §"Migration sketch" L264–271).
+- **Grounds (G):** Workstream A is purely additive (new module +
+  ADR + tests) plus deletions of private `vault_key/0` helpers;
+  reverting means restoring the deletions from VCS — mechanical.
+  Workstream B is staged (B1 → B2 → B3); each PR's reverse order is
+  also mechanical, with the caveat that consumer migration in B1
+  must be reverted before B1 itself. Workstream C is purely
+  additive (new task, new test, new CI line) plus three flag
+  demotions; reverting means re-elevating the flags and removing the
+  gate — mechanical. Workstream D adds one new struct file, one
+  new callback declaration, eleven adapter implementations, and one
+  test file; reverting means deleting all of them — mechanical at
+  the struct level. The "harder if external implementor" caveat is
+  acknowledged.
+- **Warrant (W):** A change is *reversible* iff its reverse is
+  bounded in scope and does not require coordinating with downstream
+  consumers. Each workstream's reverse is bounded; the
+  cross-workstream consumer is in-tree (Anthropic adapter for
+  Workstream B; the eleven adapters for Workstream D).
+- **Qualifier (Q):** Holds for the in-tree-only scope. If extension-
+  loaded providers (SPEC-EXTENSIONS Stage B) have shipped between
+  the workstream's merge and the hypothetical revert, the revert
+  blast radius extends to those extensions.
+- **Rebuttal (R):** Workstream B's revert is the most complex: B1's
+  consumer migration would need to be reverted (atom-keyed bracket
+  access against the new struct does work, but a revert restores
+  raw maps and any new struct-access call site breaks). The child
+  usage-normalisation validation's Claim 6 partial falsification
+  (the migration cost is over-stated against the current codebase)
+  actually *strengthens* this rebuttal: the migration is so small
+  that the revert is also small.
+- **Backing (B):** Standard software engineering practice on
+  additive vs replacing changes; the child validations
+  individually note each workstream's revert cost.
+
+#### Falsification attempt for claim 9
+
+- **Strategy:** Edge-case enumeration over the four workstreams.
+- **Attempt:** A — `git revert <PR-A-sha>` restores the six adapters'
+  private helpers and deletes the new module. Mechanical. B —
+  `git revert <PR-B3-sha>; git revert <PR-B2-sha>; git revert
+  <PR-B1-sha>` in that order. Atom-key consumer access stays
+  working through both the struct and the reverted map. Mechanical.
+  C — `git revert <PR-C-sha>` restores the three flags and removes
+  the gate + CI line. Mechanical. D — `git revert <PR-D-sha>`
+  deletes the struct and the callback; eleven adapter implementations
+  vanish with it. Mechanical at the struct level. No edge case
+  surfaces a non-mechanical revert.
+- **Outcome:** withstood.
+- **Action:** none.
+
+### Claim 10: The `Tau.Provider` Event union (other than `Done.usage`) and Bedrock/Gemini live decode paths are NOT modified by this synthesis.
+
+- **Claim (C):** "`Tau.Provider.Event` event types other than
+  `%Event.Done{}`'s `usage` typespec — no new event variants, no
+  changes to `TextStart/End`, `ToolCallStart/Delta/End`,
+  `ThinkingStart/Delta/End`, `Error`. Live decode paths for Bedrock
+  and Gemini (other than the usage extraction in B2) — they
+  continue to omit `TextStart/End` framing." (solution.md §"What
+  does not change" L196–203).
+- **Grounds (G):** Workstream B's enumeration (solution.md
+  L107–127) modifies only `event.ex` extension (one struct +
+  typespec), `usage_norm.ex` (new), adapter wire files for usage
+  extraction. No event variant additions; no
+  `TextStart`/`TextEnd`/`ToolCallDelta`/`ThinkingStart` signature
+  changes. Workstream B2 lists Bedrock and Gemini wire-extraction
+  for usage only — distinct from `decode/2`/`decode_anthropic_event/2`
+  text-framing clauses. Direct inspection of `lib/tau/providers/event.ex`
+  L83–106 shows the existing variant set; none of the four
+  workstreams adds a new one.
+- **Warrant (W):** The "What does not change" enumeration is
+  mutually exhaustive with "What changes" by construction; a PR
+  that lands only the listed edits satisfies the claim by
+  inspection. The child callback-contract-drift validation's
+  Claim 8 already validated this for Workstream D specifically.
+- **Qualifier (Q):** Holds for the scope as declared. If any
+  workstream's implementer "while I'm here" modifies a non-listed
+  file, the claim is violated and the PR is out-of-scope per
+  factory-loop §"PR scope guards".
+- **Rebuttal (R):** Workstream B2 *does* edit Bedrock's
+  `decode_anthropic_event/2` clauses — specifically to add the
+  `message_start.usage` accumulator clause. This is a *new clause
+  inside* the decode function, not a modification to existing
+  text-framing clauses. The child usage-normalisation validation's
+  Claim 4 confirms the addition is well-scoped (ordering before the
+  fallthrough; no existing clause replaced). Therefore the
+  qualifier "other than the usage extraction in B2" is honored.
+- **Backing (B):** `.claude/rules/factory-loop.md` §"PR scope
+  guards" ("Declared, frozen scope"); child validation
+  `subproblems/callback-contract-drift/validation.md` §Claim 8.
+
+#### Falsification attempt for claim 10
+
+- **Strategy:** Edge-case enumeration — for each "does not change"
+  bullet, check the four workstreams' "What changes" lists for
+  contradicting edits.
+- **Attempt:** (a) Event variants other than `Done` — `event.ex` is
+  touched only by Workstream B1 for the Usage struct and Done
+  typespec; the other variants are not enumerated as edits.
+  Disjoint. (b) `TextStart/End/ToolCallStart/Delta/End/ThinkingStart/
+  Delta/End/Error` — none enumerated. Disjoint. (c) Bedrock/Gemini
+  live decode paths for text framing — Workstream D adds
+  `stream_contract/0` to each (declaration, not decode-path edit);
+  Workstream B2 adds usage extraction (distinct clause). Disjoint
+  with text-framing clauses. (d) `Tau.Message.Assembler` tolerances
+  — no workstream lists it; disjoint. (e) Anthropic Auth, Bedrock
+  AWS-credential, Copilot two-token model — Workstream A explicitly
+  carves these out. Disjoint.
+- **Outcome:** withstood.
+- **Action:** none.
+
+## Cross-claim consistency
+
+The ten claims are internally consistent. Recurring structure:
+composability (claims 1, 2, 3) → behaviour-API impact (claims 4, 6,
+10) → conjunction discharge of AC-M1 (claim 5) → coverage of
+problem.md (claim 7) → operator readability (claim 8) → reversibility
+(claim 9).
+
+Tensions resolved:
+
+- **Claim 4 (only PR-D breaks `@behaviour`) vs Claim 5 (AC-M1 requires
+  four sub-criteria, including (a) usage struct conformance).** No
+  tension: Workstream B's usage typespec is a Dialyzer-visible *soft*
+  contract change, not a compile-time *hard* behaviour break. Claim 4
+  is precisely about hard breaks; Claim 5 is about the combined
+  enforcement surface.
+- **Claim 6 (callback list preserved) vs Claim 4 (PR-D adds a
+  mandatory callback).** Resolved by the explicit exception in
+  Claim 6's claim text: "except for the single new
+  `stream_contract/0`".
+- **Claim 7 (every divergence covered) vs the inherited child
+  partial-falsification on `thinking` enforcement (capabilities-flag-
+  fidelity Claim 4 partial).** Resolved by claim 7's narrowed
+  qualifier explicitly inheriting the advisory-by-doc treatment for
+  `thinking`. No internal contradiction; the parent claim is
+  appropriately weakened.
+- **Claim 7's partial falsification on `retryable?`.** The parent
+  problem's §Statement names four divergences; the
+  §"Sub-problems" decomposition names four sub-problems that map
+  onto a *different* four (the `retryable?` line is dropped; the
+  callback-contract-drift line is added). The synthesis is faithful
+  to the decomposition but the decomposition is unfaithful to the
+  statement. This is a problem-level decomposition gap, recorded
+  under Outstanding doubts and as the falsified-claim qualifier
+  narrowing.
+
+The inherited child outstanding doubts (see §Inherited qualifiers
+from child validations below) do not introduce new cross-claim
+tensions; they tighten qualifiers on individual parent claims.
+
+## Falsification summary
+
+| # | Claim (short) | Strategy | Outcome | Action |
+|---|---|---|---|---|
+| 1 | Four workstreams' recommendations compose; no retract/constrain | edge-case enumeration over six pairs | withstood | none |
+| 2 | Three enforcement layers compose (type / CI / docs) | integration check | withstood | none |
+| 3 | Four workstreams parallelisable under factory-loop conflict check | counter-example construction | withstood | none |
+| 4 | PR-D is the only hard behaviour break | counter-example construction | withstood | none |
+| 5 | AC-M1 sub-criteria conjunction discharged by the four workstreams | counter-example construction (malicious adapter) | withstood (narrowed Q on (d) telemetry strength) | none |
+| 6 | Callback list preserved except for new `stream_contract/0` | counter-example construction | withstood | none |
+| 7 | Every observable adapter divergence enforced or accurately documented | counter-example construction (divergence enumeration) | **partially falsified** | narrow Q in place; record `retryable?` decomposition gap as outstanding doubt |
+| 8 | `docs/PROVIDER-CONTRACT.md` consolidates four scattered artefacts | dependency check (PR ownership) | withstood (delivery risk flagged) | flag PR ownership |
+| 9 | Per-workstream reversibility (A easy, B staged, C trivial, D easy at struct) | edge-case enumeration | withstood | none |
+| 10 | Event union and live decode paths unchanged | edge-case enumeration | withstood | none |
+
+## Inherited qualifiers from child validations
+
+These are carried forward from the four child `validation.md` files
+and inform the parent's qualifiers above:
+
+- **auth-resolution-scatter Claim 3 partial:** Gemini's vault leg
+  covers `GOOGLE_API_KEY` only, not `GEMINI_API_KEY`. Parent Claim 5
+  sub-criterion (d) inherits this — the ADR exception table is the
+  resolution.
+- **auth-resolution-scatter Claim 5 qualifier:** the telemetry test
+  is fire-only, not use-only. Parent Claim 5 sub-criterion (d) is
+  narrowed accordingly.
+- **callback-contract-drift Claim 5 qualifier:** Bedrock and Gemini
+  decode-path remediation is deferred; `stream_contract/0` declares
+  the gap but does not fix it. Parent Claim 7 inherits this as the
+  primary partial-falsification driver.
+- **callback-contract-drift Claim 6 partial:** the solution's prose
+  names a non-existent Copilot provider and elides `OpenAI.Responses`;
+  the operative mechanism (compile warning) is unaffected. Parent
+  Claim 4 inherits — the eleven-adapter set is the grep-confirmed
+  set, not the parent solution's prose enumeration.
+- **callback-contract-drift Claim 7 qualifier:** Replay fixture
+  completeness is a precondition for the self-consistency test;
+  fixtures may not exist for Bedrock and Gemini. Parent Claim 2
+  enforcement-layer-(b) inherits a residual gap on value-level lies
+  for these adapters.
+- **capabilities-flag-fidelity Claim 4 partial:** DeepSeek's
+  `thinking: true` is advisory-by-doc, same as OpenAI Responses and
+  Custom; no mechanical enforcement. Parent Claim 7 inherits — the
+  `thinking` flag is an inherited declaration-only treatment.
+- **usage-normalisation Claim 6 partial:** the consumer migration
+  cost is over-stated; atom-keyed access works against the new
+  struct via the `Access` behaviour. Parent Claim 9 (reversibility)
+  is strengthened by this — Workstream B's revert is even smaller
+  than claimed.
+- **usage-normalisation Outstanding doubt:** `OpenAI.Responses`
+  wire-extraction is unspecified (`from_openai_responses/1` is not
+  listed in the solution); the wire is distinct from OpenAI Chat.
+  Parent Claim 5 sub-criterion (a) inherits a coverage gap for that
+  one adapter until PR-B2 scoping closes it.
+- **usage-normalisation Outstanding doubt:** the `@enforce_keys`
+  tightening is staged via an open question; until the follow-up
+  lands, an adapter can still emit `%Event.Done{usage: nil}`.
+  Parent Claim 5 sub-criterion (a) is weakened accordingly.
+
+## Revision required
+
+None. The single partial falsification (Claim 7) is resolved by
+narrowing the qualifier in place: the synthesis correctly discharges
+the acceptance criterion for the four divergences the decomposition
+named, and the unmodelled `retryable?` divergence (named in
+problem.md §Statement but not in §Sub-problems) is a
+**decomposition-step gap** belonging to the proposer/decomposer
+level, not a solution-level defect.
+
+- **Target file:** none — qualifier narrowed in-validation. Optional
+  follow-up: an Amendment-log entry on `problem.md` clarifying that
+  `retryable?` is deferred to a future sub-problem would close the
+  Statement-vs-Decomposition gap, but is not required for the
+  parent solution to discharge AC-M1 as scoped.
+- **Revision kind:** n/a
+- **Rationale:** Partial falsifications and inherited child
+  doubts narrow qualifiers in place (per validate.md §5); the
+  solution.md does not need a different *technical* approach. The
+  problem.md decomposition could be tightened but is not falsified
+  in scope.
+
+## Outstanding doubts
+
+The parent-level validator inherits the union of child outstanding
+doubts plus the parent-specific doubts surfaced here:
+
+- **`retryable?` divergence is unmodelled.** problem.md §Statement
+  L18–21 names "`retryable?` classification scattered across three
+  layers with incompatible criteria" but the §"Sub-problems"
+  decomposition has no corresponding sub-problem. The parent
+  synthesis cannot address what the decomposition did not surface.
+  Flagged for coordinator: consider filing a follow-up sub-problem
+  or amending problem.md to either resolve or defer `retryable?`
+  explicitly.
+- **`docs/PROVIDER-CONTRACT.md` ownership.** The cross-workstream
+  index is named but no PR owns it. Without explicit assignment, the
+  index risks not being delivered. Recommend assigning to the last-
+  merging PR (likely PR-B3) so it can reference all four canonical
+  artefacts.
+- **Open question 7 (PR-D SPEC home).** Until resolved, the
+  Workstream B and Workstream D SPEC scopes might collide on
+  SPEC-PROMPT-CACHING amendments. The factory-loop conflict-check
+  clause 4 forbids two concurrent steps amending the same SPEC; if
+  D's SPEC home becomes a SPEC-PROMPT-CACHING amendment, B and D
+  must serialise their SPEC edits.
+- **AC-M1 sub-criterion (d) telemetry strength.** The cross-adapter
+  telemetry test asserts vault was *consulted*, not that the call
+  went through `Tau.Providers.Auth` specifically. A "rogue" adapter
+  could bypass `Tau.Providers.Auth` and still fire the telemetry
+  event. Mitigated by the ADR exception table and reviewer
+  attention; no mechanical gate exists.
+- **`thinking` flag enforcement gap.** Inherited from child
+  capabilities-flag-fidelity; advisory-by-doc only across three
+  adapters (Bedrock, Gemini, DeepSeek + the two pre-existing
+  cases on OpenAI Responses and Custom). Parent solution
+  acknowledges in §Open questions.
+- **Live decode-path remediation deferral.** Bedrock and Gemini's
+  text-framing and tool-call-delta gaps are *declared* by
+  `stream_contract/0` but not *fixed*. A follow-up sub-problem is
+  named in the parent solution's §Open questions. Until it lands,
+  the AC-M1 disjunct ("accurately documents as optional") is
+  load-bearing for these two adapters; the maximally-strict reading
+  of "enforces or documents as optional" might consider this
+  declaration-only treatment insufficient.
+- **Replay adapter posture under `stream_contract/0`.** Open
+  question; affects Workstream D's compile-readiness.
+- **`OpenAI.Responses` wire-extraction (B-series gap).** Inherited
+  from usage-normalisation; the wire differs from OpenAI Chat and
+  needs its own `UsageNorm.from_openai_responses/1` helper that the
+  solution does not name.
+- **Extension-loaded providers.** Inherited from
+  capabilities-flag-fidelity. The gate task currently iterates
+  compiled `Tau.Providers.*`; SPEC-EXTENSIONS Stage B providers
+  would need an explicit decision.
+- **Burrito-cache style shared-resource collision risk under
+  concurrent PRs.** None of the four workstreams invokes
+  `mix tau.smoke` or `mix release tau ...`, so the canonical
+  burrito-cache collision does not apply. Recorded for completeness.

--- a/docs/problems-archive-v1-modules/tau-session/problem.md
+++ b/docs/problems-archive-v1-modules/tau-session/problem.md
@@ -1,0 +1,112 @@
+---
+template_version: 1
+template_name: problem
+node_kind: root
+depth: 0
+parent: —
+status: decomposed
+---
+
+# Problem: session.ex retains inline FSM logic that belongs in sub-modules
+
+## Statement
+
+`lib/tau/session.ex` is a 1,438-LOC `:gen_statem` façade whose partial
+decomposition extracted 10 sub-modules but left four clusters of logic inline:
+(1) two `:cancel` clause bodies totalling ~240 LOC of cross-cluster teardown,
+(2) `@doc false` helpers (`process_user_message`, `append_message`,
+`broadcast`, `emit_user_message_telemetry`, `hook_payload`,
+`transcript_path`, `current_run?`) that are used across multiple sub-modules
+but live in the FSM itself, (3) three `handle_event` clauses for
+`{:user_message, _, _}` routing that mix queue arithmetic with
+slash-command dispatch, and (4) the FSM data struct remaining as an
+anonymous map with ~45 fields rather than a `defstruct`. A developer
+tracing any single concern must read the session façade alongside the
+relevant sub-module, because the boundary between "FSM wiring" and
+"concern logic" is inconsistent.
+
+## Context
+
+- `lib/tau/session.ex`: 1,438 LOC, 41 `handle_event/4` clauses, 81 function
+  heads (including `@doc false` cross-module helpers).
+- Sub-modules already extracted: `Journal`, `Queue`, `Compaction`,
+  `ModelSwap`, `SkillActivation`, `SlashCommand`, `ProviderTurn`,
+  `CodingAgentTurn`, `ToolDispatch`, `Data` — each cleanly delegates from a
+  one-liner clause in `session.ex`.
+- Cancel clauses: `handle_event(:cast, :cancel, :awaiting_permission, data)`
+  (lines 842–961, ~120 LOC) and `handle_event(:cast, :cancel, _state, data)`
+  (lines 963–1083, ~121 LOC) contain full teardown sequences — emitting
+  `%ToolEnd{}` events, draining queues, demonitoring processes, resetting
+  dozens of data fields — all inline.
+- `@doc false` helpers used by sub-modules (e.g. `Tau.Session.broadcast/2`,
+  `Tau.Session.append_message/2`, `Tau.Session.hook_payload/3`) are public
+  functions on the FSM module instead of living in a shared internal module.
+- `Tau.Session.Data` exists as a sub-module but the FSM data struct is still
+  an anonymous map; `Data.new/1` returns `{:ok, map()}`.
+- Prior audit: `.code_audit/archive/v1-flat/02-provider-session.md`
+  identifies the `dispatch_tools/2` monolith (308 LOC, already extracted to
+  `ToolDispatch`) and flags anonymous-map struct as a Dialyzer hole.
+- `docs/refactor/inventory-session.md` documents the extraction plan that
+  produced the current sub-modules; the cancel clusters were explicitly
+  deferred.
+
+## Complecting hypothesis
+
+The `:cancel` teardown logic is complected with the FSM event-handler
+dispatch because both the `awaiting_permission`-specific cancel and the
+cross-cutting cancel inline their side effects (process kills, PubSub
+broadcasts, data field resets) rather than delegating them to the sub-modules
+that own each cluster.
+
+The shared `@doc false` helpers (`broadcast`, `append_message`, `hook_payload`,
+`current_run?`) are complected with the FSM module because they were
+extracted from the large session.ex but not moved to a dedicated shared
+internal module — making `Tau.Session` both the `:gen_statem` entry point and
+the utility namespace for its own sub-modules.
+
+The user-message routing clauses are complected with slash-command dispatch
+because the `{:user_message, msg, _tier} in :awaiting_user` clause both
+performs queue-gate logic (postpone, tier routing) and calls
+`SlashCommand.classify_slash_command/4` inline rather than delegating the
+full routing decision to `Tau.Session.Queue`.
+
+## Decomposition strategy
+
+The axis is **concern ownership**: each inline body belongs to an identifiable
+concern (teardown, shared utilities, message routing, data shape). The four
+sub-problems are mutually exclusive because each maps to a distinct cluster
+of lines in `session.ex` with no overlap, and collectively exhaustive because
+together they account for every remaining inline body that the partial
+decomposition left behind. The concern-ownership axis yields MECE because the
+sub-modules already define the concern boundaries — the residual complecting is
+precisely where logic was not moved despite a clear owner existing.
+
+## Sub-problems (filled by decomposer)
+
+1. **cancellation-teardown** — both `:cancel` clause bodies (`:awaiting_permission`-specific and cross-cutting) contain inline multi-cluster teardown that should delegate to the sub-modules owning each cluster.
+2. **fsm-facade-helpers** — `@doc false` helpers used across sub-modules live on the FSM module itself; they need a stable shared home that is not the `:gen_statem` entry point.
+3. **user-message-routing** — the three `{:user_message}` clauses mix queue-gate logic with slash-command classification rather than delegating fully to `Tau.Session.Queue`.
+4. **cross-cutting-data** — the FSM data struct is an anonymous map (`map()`) rather than a `defstruct` in `Tau.Session.Data`, leaving the field contract unenforced and defensive `Map.get(data, :field, default)` reads scattered across sub-modules.
+
+## Acceptance criterion
+
+`lib/tau/session.ex` contains no inline teardown logic, no `@doc false`
+cross-module utility functions, no multi-branch message-routing bodies, and
+no anonymous-map data initialisation; every `handle_event/4` clause body is
+a one-line delegation or a three-line `:gen_statem` return, and `Tau.Session.Data`
+exports a typed struct that all sub-modules pattern-match against.
+
+## Out of scope
+
+- Provider adapter normalisation (TextStart/TextEnd, usage maps) — separate
+  audit node `tau-providers`.
+- `try/rescue` removal — flagged in v1-flat audit but not a structural
+  complecting problem; belongs in a bug-fix PR, not this decomposition.
+- `dispatch_tools/2` (already extracted to `ToolDispatch`).
+- Queue cap, drain ordering, or steering/followup queue semantics — those are
+  behavioural; this audit targets structural complecting only.
+- Any change to `test/` files — the audit is read-only on the codebase.
+
+## Amendment log
+
+- (none yet)

--- a/docs/problems-archive-v1-modules/tau-session/solution.md
+++ b/docs/problems-archive-v1-modules/tau-session/solution.md
@@ -1,0 +1,279 @@
+---
+template_version: 1
+template_name: solution
+parent_problem: problem.md
+node_kind: root
+synthesised_from:
+  - subproblems/cross-cutting-data/solution.md
+  - subproblems/fsm-facade-helpers/solution.md
+  - subproblems/cancellation-teardown/solution.md
+  - subproblems/user-message-routing/solution.md
+selection_method: synthesis
+mode: non-leaf
+revision: 0
+---
+
+# Solution: Complete the session decomposition by distributing the four residual concerns to their owning modules
+
+## Recommendation
+
+Land the four child recommendations as a coordinated four-PR sequence that
+collectively reduces `lib/tau/session.ex` from a 1,438-LOC façade with inline
+teardown, shared utilities, multi-branch routing and an anonymous-map data
+shape to a thin `:gen_statem` whose every `handle_event/4` clause body is a
+one-line delegation or a three-line FSM return. Concretely: (1) typed
+accessors plus a 101-head `%Tau.Session.Data{}` struct-match sweep across the
+nine sub-modules harden the data contract; (2) the eight `@doc false` helpers
+disperse to their owning concern modules (`Data`, `Events`, new `Telemetry`,
+new `Hooks`, existing `Queue`); (3) a new `Tau.Session.Cancellable` behaviour
+distributes the two ~120-LOC `:cancel` clause bodies across `ProviderTurn`,
+`ToolDispatch`, `Compaction`, and `CodingAgentTurn`, with `Data.reset_for_cancel/1`
+owning the cross-cutting per-turn fields; (4) `SlashCommand.dispatch_idle/2`
+plus `SlashCommand.dispatch/2` absorbs the idle-routing clause, and the two
+non-idle clauses collapse to direct `Queue.handle_postpone/2` /
+`Queue.handle_enqueue/4` delegations. The four PRs are ordered so each PR's
+new surface is the next PR's substrate; no PR introduces a broken
+intermediate state, and every PR is independently revertible.
+
+## Selected from
+
+- **Synthesised from:**
+  - `subproblems/cross-cutting-data/solution.md` — typed accessors on `Data` + 101-head `%Data{} = data` struct-match sweep across nine sub-modules.
+  - `subproblems/fsm-facade-helpers/solution.md` — distribute the eight `@doc false` helpers by concern; new `Tau.Session.Telemetry` and `Tau.Session.Hooks` modules; pure helpers consolidate into `Data`; `broadcast/2` consolidates into `Events`.
+  - `subproblems/cancellation-teardown/solution.md` — `Tau.Session.Cancellable` behaviour with `cancel_cluster(scope, Data.t()) :: {mechanism, Data.t()}`; both `:cancel` clause bodies collapse to ≤5-line folds over a compile-time `@cancel_clusters` list.
+  - `subproblems/user-message-routing/solution.md` — `SlashCommand.dispatch_idle/2` (verbatim idle-clause extraction) + `SlashCommand.dispatch/2` (six-arm dispatch table); two non-idle clauses delegate to existing `Queue` functions.
+
+- **Composition rationale:** The four child recommendations compose by
+  direct addition; each owns a disjoint cluster of `session.ex` lines and a
+  disjoint set of new/extended sub-module surfaces. Three composition
+  points need explicit reconciliation, all resolvable in favour of the
+  child solutions as written:
+
+  1. **`Data` is the merge point for two children.** `cross-cutting-data`
+     adds `get_queue/2`, `put_queue/3`, `replace_field/3`, and
+     `reset_for_cancel/1`; `fsm-facade-helpers` adds `append_message/2`,
+     `generate_event_id/0`, `current_run?/2`. All seven additions are
+     purely additive `def`s with `@spec`s on the same module; no
+     field, type, or signature conflict. The struct-match sweep in
+     `cross-cutting-data` extends naturally to the new accessors as
+     they are added.
+
+  2. **`Telemetry` module supersedes the `emit_user_message_telemetry/3`
+     coupling that `user-message-routing` left in place.** The
+     `user-message-routing` solution acknowledges in its Open Questions
+     that `SlashCommand.dispatch_idle/2` will call the FSM-resident
+     `Tau.Session.emit_user_message_telemetry/3` and that a follow-on
+     should move it. `fsm-facade-helpers` IS that follow-on: it creates
+     `Tau.Session.Telemetry` and moves `emit_user_message/3` there. The
+     synthesis sequences `fsm-facade-helpers` BEFORE `user-message-routing`
+     so the new `dispatch_idle/2`, `Queue.handle_enqueue/4`, and
+     `Queue.handle_postpone/2` call the new
+     `Tau.Session.Telemetry.emit_user_message/3` directly. The acknowledged
+     coupling in `user-message-routing`'s solution is resolved at sequence
+     time, not as a residual debt.
+
+  3. **`Data.reset_for_cancel/1` is owned by `cross-cutting-data` and
+     consumed by `cancellation-teardown`.** Both child solutions name the
+     same function with the same scope (cross-cutting per-turn fields:
+     `active_skill`, `tool_iterations`, `tool_loop_state`,
+     `provider_retry_state`, `steering_queue`; NOT
+     `tool_loop_call_lookups`, which `ToolDispatch.cancel_cluster/2`
+     owns). Sequencing `cross-cutting-data` before
+     `cancellation-teardown` means the function exists when the
+     `:cancel` clause bodies are rewritten to call it. No content
+     reconciliation is required.
+
+  No tension surfaced between the four children that demands a
+  re-decomposition; the parent's MECE claim (each child maps to a
+  distinct cluster of `session.ex` lines with no overlap) holds in
+  practice.
+
+## What changes
+
+The change set is the union of the four child solutions' `What changes`
+sections. Grouped by file and ordered by the PR sequence (see Migration
+sketch); each line cites the originating child.
+
+### A. `lib/tau/session/data.ex` (additive across two children)
+
+- Add accessors: `get_queue/2`, `put_queue/3`, `replace_field/3` (from `cross-cutting-data`).
+- Add cancel-scope reset: `reset_for_cancel/1` (from `cross-cutting-data`; consumed by `cancellation-teardown`).
+- Add pure helpers: `append_message/2`, `generate_event_id/0`, `current_run?/2` (from `fsm-facade-helpers`).
+- All seven additions are public `def`s with `@spec` typed against `Data.t()`. No field, default, `@enforce_keys`, or `@type t` change.
+
+### B. New sub-modules under `lib/tau/session/`
+
+- `lib/tau/session/cancellable.ex` — `Tau.Session.Cancellable` behaviour; one callback `cancel_cluster(scope :: :permission | :cross_cutting, Data.t()) :: {atom(), Data.t()}` (from `cancellation-teardown`).
+- `lib/tau/session/telemetry.ex` — `Tau.Session.Telemetry`; `emit_transition/2` and `emit_user_message/3` (from `fsm-facade-helpers`).
+- `lib/tau/session/hooks.ex` — `Tau.Session.Hooks`; public `payload/3` (renamed from `hook_payload/3`) and private `transcript_path/1` (from `fsm-facade-helpers`).
+
+### C. Extensions to existing sub-modules
+
+- `lib/tau/session/events.ex` — add `broadcast/2` as a public `def`; PubSub topic `"session:#{id}"` becomes a single point of definition (from `fsm-facade-helpers`).
+- `lib/tau/session/queue.ex` — add `process_user_message/2` (verbatim move from `session.ex`) (from `fsm-facade-helpers`). No changes from `user-message-routing` (the existing `Queue.handle_postpone/2` and `Queue.handle_enqueue/4` are already-present delegation targets).
+- `lib/tau/session/provider_turn.ex` — declare `@behaviour Tau.Session.Cancellable`; implement `cancel_cluster/2` calling existing `cancel_provider_task/1`, capturing the mechanism, clearing `{provider_task, cancel_flag, stream_ref, provider_span_ref, assembler}` (from `cancellation-teardown`). Defensive-read fix: replace `Map.put(data, key, value)` at line 179 with `Data.replace_field/3`; replace `Map.get(data, :persona_lifetime, :turn)` at line 337 with `data.persona_lifetime` (from `cross-cutting-data`).
+- `lib/tau/session/tool_dispatch.ex` — declare `@behaviour Tau.Session.Cancellable`; implement scope-branching `cancel_cluster/2`: `:permission` runs the emit-and-synthesise loop formerly inlined in `session.ex` lines 842–961; `:cross_cutting` brutal-kills `tool_dispatcher` and `command_task`. Owns reset of `{pending_permission_requests, permission_dispatch_batch, permission_pending_results, tools_in_flight, tool_dispatcher, command_task, tool_loop_call_lookups}` (from `cancellation-teardown`).
+- `lib/tau/session/compaction.ex` — declare `@behaviour Tau.Session.Cancellable`; implement `cancel_cluster/2` demonitoring `compaction_monitor`, brutal-killing `compaction_task`, clearing those two fields (NOT `compaction_failures`) (from `cancellation-teardown`).
+- `lib/tau/session/coding_agent_turn.ex` — declare `@behaviour Tau.Session.Cancellable`; implement `cancel_cluster/2` guard-calling `Tau.CodingAgent.Dispatcher.cancel/1`, clearing `{coding_agent_dispatcher, coding_agent_pending, coding_agent_blocks}` (from `cancellation-teardown`).
+- `lib/tau/session/model_swap.ex` — replace `Map.put(data, key, value)` at line 94 with `Data.replace_field/3` (parity fix from `cross-cutting-data`).
+- `lib/tau/session/queue.ex` — replace `Map.get(data, queue_field)` / `Map.put(data, queue_field, new_queue)` at lines 43/63 with `Data.get_queue/2` / `Data.put_queue/3` (from `cross-cutting-data`).
+- `lib/tau/session/slash_command.ex` — add `dispatch_idle/2` (verbatim extraction of the idle-clause body, refactored to call `dispatch/2`) and `dispatch/2` (six pattern-match clauses: `:builtin`, `:async`, `:skill_activation`, `:model_command` empty / non-empty, `:unknown_command`, `:sync`) (from `user-message-routing`). The new `dispatch_idle/2` calls `Tau.Session.Telemetry.emit_user_message/3` (resolving the coupling `user-message-routing` flagged in Open Questions).
+
+### D. Struct-match sweep across nine sub-modules
+
+Add `%Data{} = data` (with `alias Tau.Session.Data` at the top of each
+file) to every `def`/`defp` head that names `data` as a parameter; widen
+the five `%{...} = data` heads to `%Data{...} = data`. Per-file head
+inventory (from `cross-cutting-data` §C; 101 heads total): `tool_dispatch`
+16, `coding_agent_turn` 22, `provider_turn` 20, `model_swap` 11,
+`compaction` 7, `queue` 7, `slash_command` 6, `skill_activation` 6,
+`journal` 6.
+
+### E. `lib/tau/session.ex` (the FSM module — strict reduction)
+
+- Remove all eight `@doc false` defs (`process_user_message`, `append_message`, `broadcast`, `emit_user_message_telemetry`, `hook_payload`, `transcript_path`, `current_run?`, `generate_event_id`) and update internal callsites to the new module-qualified names (from `fsm-facade-helpers`).
+- Add compile-time `@cancel_clusters [Tau.Session.ProviderTurn, Tau.Session.ToolDispatch, Tau.Session.Compaction, Tau.Session.CodingAgentTurn]` (from `cancellation-teardown`).
+- Replace the `:awaiting_permission` `:cancel` clause body (lines 842–961) with a ≤5-line body: fold `@cancel_clusters` with `scope: :permission`, capture surviving non-`:noop` mechanism, broadcast `%Cancelled{}`, call `finish_cancel(data, "awaiting_permission")`, return (from `cancellation-teardown`).
+- Replace the cross-cutting `:cancel` clause body (lines 963–1083) with a ≤5-line body: `cascade_to_children(data, :cancel)`, fold `@cancel_clusters` with `scope: :cross_cutting`, capture mechanism, broadcast, `finish_cancel(data, Atom.to_string(mechanism))`, return (from `cancellation-teardown`).
+- Add private `finish_cancel/2` (≤10 lines): `Journal.persist/3`, steering-queue drain → `%QueueRestored{}` broadcast, `Data.reset_for_cancel/1` (from `cancellation-teardown`).
+- Replace the three `{:user_message, _, _}` `handle_event/4` clauses with one-line delegations: postpone → `Queue.handle_postpone/2`; enqueue → `Queue.handle_enqueue/4`; idle → `SlashCommand.dispatch_idle/2` (from `user-message-routing`).
+
+### F. New tests
+
+- Four cluster-cancel unit modules: `test/tau/session/{provider_turn,tool_dispatch,compaction,coding_agent_turn}_cancel_cluster_test.exs` (from `cancellation-teardown`).
+- One test for `Data.reset_for_cancel/1` (from `cancellation-teardown`).
+- No test changes are required by the other three children; the existing cancellation integration tests, TUI cancel smoke, and slash-routing tests are the regression baseline.
+
+## What does not change
+
+- `Tau.Session.Data` struct fields, defaults, `@enforce_keys`, `@type t`, and `Data.new/1` return shape (`{:ok, %Tau.Session.Data{}}`).
+- `Tau.Session.Meta`, `Tau.Session.Journal.persist/3`, `Tau.Session.SlashCommand.classify_slash_command/4`, `Tau.Session.Queue.handle_postpone/2`, `Tau.Session.Queue.handle_enqueue/4`, `Tau.Session.Queue.drain_steering_queue_one/1`.
+- `cascade_to_children/2` remains a private helper in `session.ex` invoked at the top of the cross-cutting `:cancel` clause.
+- `ProviderTurn.cancel_provider_task/1` keeps its signature; `cancel_cluster/2` calls it internally.
+- `ToolDispatch.finish_permission_round/1` (happy-path) is unchanged.
+- D-077, D-078, D-080, D-082, D-083 queue cap / drain ordering / `%QueueRestored{}` / `%Cancelled{}` broadcast contracts (SPEC-USER-TURN §6).
+- External `Tau.Session` public API; all eight moved helpers were `@doc false`.
+- The `:gen_statem` callbacks, FSM state machine, and supervision tree.
+- Nested-map reads into `data.tool_loop_state`, `data.tools_in_flight`, `data.coding_agent_state`, `data.metadata` — explicitly out of scope per `cross-cutting-data`.
+- `generate_id/0` (public API at `session.ex:487`).
+- All existing tests; no test changes outside the five new test modules in §F.
+- Provider adapter normalisation, `try/rescue` removal, `dispatch_tools/2` re-extraction, queue cap / drain / steering semantics, and any `test/` change outside §F — all out of scope per `problem.md`.
+
+## Migration sketch
+
+Four PRs in strict order. Each PR ends with a green `mix test`; no PR
+leaves an intermediate broken state; each PR is independently revertible.
+
+**PR 1 — `cross-cutting-data` (foundational data contract).** Single PR,
+four conceptual commits: (1) add `get_queue/2`, `put_queue/3`,
+`replace_field/3` to `Data`; (2) defensive-fix sweep (`queue.ex:43,63`;
+`provider_turn.ex:179,337`; `model_swap.ex:94`); (3) add
+`alias Tau.Session.Data` to the eight sub-modules currently without it;
+(4) full 101-head `%Data{} = data` sweep. `reset_for_cancel/1` lands
+here too so `cancellation-teardown` (PR 3) can call it immediately. No
+sub-module body logic changes; `mix dialyzer` gains tighter type
+information at every entry point.
+
+**PR 2 — `fsm-facade-helpers` (helpers disperse to owning concerns).**
+Single PR, additive then substitutive: (1) add `append_message/2`,
+`generate_event_id/0`, `current_run?/2` to `Data`; (2) add `broadcast/2`
+to `Events`; (3) create `lib/tau/session/telemetry.ex` with
+`emit_transition/2` and `emit_user_message/3`; (4) create
+`lib/tau/session/hooks.ex` with `payload/3`; (5) add
+`process_user_message/2` to `Queue`; (6) update all callsites in
+`session.ex` and the six sub-modules to the new module-qualified names;
+(7) delete the eight `@doc false` defs from `session.ex`. Steps 1–5 are
+additive; steps 6–7 land together. This PR resolves the
+`emit_user_message_telemetry` coupling that PR 4 would otherwise
+inherit.
+
+**PR 3 — `cancellation-teardown` (clusters own their teardown).** Three
+sub-PRs as per the child's Migration sketch:
+- **PR 3A** — add `Tau.Session.Cancellable` behaviour; implement
+  `cancel_cluster/2` on `ProviderTurn`, `ToolDispatch`, `Compaction`,
+  `CodingAgentTurn` with new unit tests in §F. No change to
+  `session.ex`; the new code is dead but tested.
+- **PR 3B** — wire `session.ex`: add `@cancel_clusters` and
+  `finish_cancel/2`; replace both `:cancel` clause bodies with the
+  ≤5-line folds. Existing cancellation integration tests and TUI cancel
+  smoke are the regression baseline (no changes).
+- **PR 3C** — remove any private helpers in `session.ex` that the new
+  clause bodies no longer call.
+
+**PR 4 — `user-message-routing` (routing collapses to delegations).**
+Single PR, one commit: add `SlashCommand.dispatch/2` (six clauses) and
+`SlashCommand.dispatch_idle/2` (calls `classify_slash_command/4` then
+`dispatch/2`; emits `Telemetry.emit_user_message(:delivered, …)`); update
+the three `handle_event` clauses in `session.ex` to delegate to
+`Queue.handle_postpone/2`, `Queue.handle_enqueue/4`, and
+`SlashCommand.dispatch_idle/2`. Because PR 2 has already created
+`Tau.Session.Telemetry`, the open question in
+`user-message-routing` about where telemetry lives is answered at land
+time: `SlashCommand.dispatch_idle/2` calls
+`Tau.Session.Telemetry.emit_user_message/3`, not the deleted
+`Tau.Session.emit_user_message_telemetry/3`.
+
+After PR 4: `lib/tau/session.ex` satisfies the parent acceptance
+criterion — no inline teardown, no `@doc false` cross-module utility
+functions, no multi-branch routing bodies, no anonymous-map data init;
+every `handle_event/4` body is a one-line delegation or a three-line
+FSM return; `Tau.Session.Data` exports a typed struct that all
+sub-modules pattern-match against.
+
+The four PRs MAY be opened in parallel for review but MUST be merged in
+order (1 → 2 → 3A → 3B → 3C → 4) so each landing PR sees its
+substrate already in `main`. The factory-loop conflict check
+(`.claude/rules/factory-loop.md` "Parallel execution") will serialize
+them on the disjoint-files clause since they all touch `Data`,
+`session.ex`, and overlapping sub-modules.
+
+## Open questions
+
+- **`finish_cancel/2` placement.** `cancellation-teardown` Open Questions
+  asks whether the ≤10-line `finish_cancel/2` should remain a private
+  helper in `session.ex` or be promoted to `Data` / a new
+  `Tau.Session.Cancel.Finish` module. The synthesis defers to the
+  validator. Keeping it inline keeps PR 3B small; promoting it
+  honours a stricter reading of the parent's "no teardown logic in
+  `session.ex`" criterion. The line-count is small enough that
+  either reading is defensible.
+
+- **Mechanism-atom semantics under the cluster fold.** `cancellation-teardown`
+  flags that "last non-`:noop` wins" is currently equivalent to "provider's
+  mechanism" because provider is the only cluster returning a non-`:noop`
+  mechanism. If a future cluster begins returning a meaningful mechanism,
+  the fold's tie-breaking rule must be revisited. No action here; flagged
+  for the validator and any future cluster author.
+
+- **`Data.replace_field/3` typed-key check.** `cross-cutting-data` notes
+  Dialyzer cannot verify at the call site that `key` names a valid
+  struct field. The single-grep "auditable escape hatch" property is
+  the intended trade. Carried forward unchanged.
+
+- **`dispatch_idle/2` naming under future invocation from non-idle
+  state.** `user-message-routing` flags that the name encodes the
+  current FSM state and would become misleading if dispatch is ever
+  invoked from another state. Carried forward; rename is cheap if it
+  becomes wrong.
+
+- **`Tau.Session.Hooks.payload/3` rename.** `fsm-facade-helpers` Open
+  Questions asks whether any external tooling references
+  `Tau.Session.hook_payload/3` by name. Verify via grep over hook
+  scripts and tests during PR 2.
+
+- **Future sub-struct extraction in `Data`.** `cross-cutting-data` notes
+  that the 101-head sweep creates re-edit cost if `Data` is later
+  decomposed into sub-structs (Proposal 3 of that sub-problem). This is
+  a known trade and is acceptable for this synthesis; the sub-struct
+  refactor would be a successor audit node, not part of this plan.
+
+## Linked sub-problems / proposals
+
+- `subproblems/cross-cutting-data/` → "Typed accessors on `Data` + 101-head `%Data{} = data` struct-match sweep across nine sub-modules; adds `get_queue/2`, `put_queue/3`, `replace_field/3`, `reset_for_cancel/1`."
+- `subproblems/fsm-facade-helpers/` → "Distribute the eight `@doc false` helpers by concern: pure helpers into `Data`; `broadcast/2` into `Events`; new `Tau.Session.Telemetry` and `Tau.Session.Hooks`; `process_user_message/2` into `Queue`."
+- `subproblems/cancellation-teardown/` → "`Tau.Session.Cancellable` behaviour with scope-aware `cancel_cluster(scope, Data.t()) :: {atom(), Data.t()}`; both `:cancel` clauses collapse to ≤5-line folds over `@cancel_clusters`; `Data.reset_for_cancel/1` owns the cross-cutting field reset."
+- `subproblems/user-message-routing/` → "`SlashCommand.dispatch_idle/2` (verbatim idle-clause extraction) plus `SlashCommand.dispatch/2` (six-arm dispatch table); two non-idle clauses delegate to existing `Queue.handle_postpone/2` and `Queue.handle_enqueue/4`."
+
+## Revision history
+
+- (revision 0 — initial synthesis from the four validated child solutions)

--- a/docs/problems-archive-v1-modules/tau-session/subproblems/cancellation-teardown/problem.md
+++ b/docs/problems-archive-v1-modules/tau-session/subproblems/cancellation-teardown/problem.md
@@ -1,0 +1,86 @@
+---
+template_version: 1
+template_name: problem
+node_kind: leaf
+depth: 1
+parent: ../../problem.md
+status: draft
+---
+
+# Problem: cancel clause bodies inline multi-cluster teardown instead of delegating
+
+## Statement
+
+`session.ex` contains two `:cancel` `handle_event/4` clause bodies — one
+specific to `:awaiting_permission` (~120 LOC, lines 842–961) and one
+cross-cutting (~121 LOC, lines 963–1083) — each of which directly emits
+`%ToolEnd{}` events, drains queues, demonitors processes, kills tasks,
+resets dozens of data fields, and posts `%QueueRestored{}` broadcasts,
+rather than delegating each of those operations to the sub-module that owns
+the corresponding cluster. A developer changing teardown behaviour for
+`ProviderTurn` must read and edit `session.ex`, not `provider_turn.ex`.
+
+## Context
+
+- `session.ex` lines 842–961: `:awaiting_permission`-specific cancel — emits
+  `%ToolEnd{}` for `permission_pending_results`, synthesises error
+  `ToolResult`s for `pending_permission_requests`, broadcasts `%Cancelled{}`,
+  persists a `"cancellation"` journal entry, drains `steering_queue` to
+  `%QueueRestored{}`, then resets 14 data fields.
+- `session.ex` lines 963–1083: cross-cutting cancel — calls
+  `cascade_to_children/2`, calls `ProviderTurn.cancel_provider_task/1`,
+  kills `tool_dispatcher`, `command_task`, and `compaction_task`, calls
+  `CodingAgent.Dispatcher.cancel/1`, broadcasts `%Cancelled{}`, persists
+  a `"cancellation"` journal entry, drains `steering_queue`, then resets
+  16 data fields.
+- `Tau.Session.ToolDispatch` (`lib/tau/session/tool_dispatch.ex`, 1,060 LOC)
+  owns permission-round logic (`handle_permission_allow_once/2`,
+  `handle_permission_deny_once/2`) — the inline emit sequence in the
+  permission-cancel clause duplicates the pattern from `finish_permission_round/1`.
+- `Tau.Session.ProviderTurn` (`lib/tau/session/provider_turn.ex`, 872 LOC)
+  owns `cancel_provider_task/1` and provider lifecycle; the compaction and
+  coding-agent kills inline in the cross-cutting cancel have no equivalent
+  delegates in `Tau.Session.Compaction` or `Tau.Session.CodingAgentTurn`.
+- `Tau.Session.Journal.persist/3` is already a clean delegation; only the
+  cancel-specific field-reset map is new.
+- SPEC-USER-TURN §6, D-080, D-082: queue-drain contracts that both cancel
+  clauses must satisfy regardless of where the logic lives.
+
+## Complecting hypothesis
+
+The teardown sequence for permissions is complected with the `:cancel` FSM
+clause because `finish_permission_round/1` in `ToolDispatch` covers the
+happy-path drain but has no `cancel_permission_round/1` counterpart, so the
+cancel path duplicates the emit loop inline.
+
+The multi-cluster resource teardown (provider task + tool dispatcher +
+command task + compaction worker + coding-agent dispatcher) is complected
+with the `:cancel` FSM clause because no sub-module exposes a
+`teardown/1`-style function that resets its own cluster's data fields and
+kills its own processes — the FSM clause must orchestrate each cluster
+directly.
+
+## Decomposition strategy
+
+(leaf — no further decomposition; proceed to proposals)
+
+## Acceptance criterion
+
+Both `:cancel` clause bodies in `session.ex` are reduced to ≤5 lines each:
+one delegation to `ToolDispatch.cancel_permission_round/1` (for the
+`:awaiting_permission` clause) and one delegation to a shared teardown
+coordinator (for the cross-cutting clause), with the data-field reset map
+and queue-drain logic living in the owning sub-modules.
+
+## Out of scope
+
+- Queue drain ordering or D-080/D-082 contract changes — behavioural, not structural.
+- The `cascade_to_children/2` helper itself — it is already a correctly
+  sized private function; its call site may stay in the cancel clause body.
+- `try/rescue` removal in any cancel-adjacent code.
+- Sibling sub-problems: fsm-facade-helpers, user-message-routing,
+  cross-cutting-data.
+
+## Amendment log
+
+- (none yet)

--- a/docs/problems-archive-v1-modules/tau-session/subproblems/cancellation-teardown/proposals/proposal-1.md
+++ b/docs/problems-archive-v1-modules/tau-session/subproblems/cancellation-teardown/proposals/proposal-1.md
@@ -1,0 +1,192 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 1
+parent_problem: ../problem.md
+---
+
+# Proposal 1: Add `cancel_permission_round/1` to ToolDispatch and `cancel/1` to each cluster sub-module
+
+## Approach
+
+Add a `cancel_permission_round/1` function to `Tau.Session.ToolDispatch` that
+mirrors `finish_permission_round/1`'s emit loop but synthesises error
+`ToolResult`s for still-pending `:ask` calls and resets the permission cluster's
+data fields. Add a `cancel/1` (or `teardown_for_cancel/1`) function to
+`Tau.Session.Compaction` that demonitors and exits the compaction worker and
+clears its fields, and a `cancel/1` to `Tau.Session.CodingAgentTurn` that guards
+and calls `CodingAgent.Dispatcher.cancel/1` and clears the coding-agent fields.
+`Tau.Session.ProviderTurn` already has `cancel_provider_task/1`; extend it or
+add a `teardown_for_cancel/1` that also clears provider-cluster fields
+(`provider_task`, `cancel_flag`, `stream_ref`, `provider_span_ref`, `assembler`).
+The two `:cancel` clause bodies in `session.ex` become shallow call sequences
+over these delegates plus the unchanged `cascade_to_children/2` call and the
+existing `Journal.persist/3` call.
+
+## Rationale
+
+The complecting hypothesis names two distinct complections: the permission
+teardown is complected with the FSM clause because `ToolDispatch` has no cancel
+counterpart to `finish_permission_round/1`; the multi-cluster teardown is
+complected because no sub-module exposes a cluster-scoped teardown function. This
+proposal resolves both by adding the missing cancel-path functions precisely where
+the happy-path functions already live. Each sub-module then owns both directions
+of its cluster lifecycle. The decomplecting move is minimal: add the absent
+functions, update the callsites — no module boundaries change, no new modules
+are created.
+
+## Sketch
+
+```elixir
+# lib/tau/session/tool_dispatch.ex — new public function (mirrors finish_permission_round/1)
+@spec cancel_permission_round(Data.t()) :: Data.t()
+def cancel_permission_round(data) do
+  # Emit accumulated deny-once results (same reduce loop as finish_permission_round/1).
+  data =
+    Enum.reduce(
+      Enum.reverse(data.permission_pending_results),
+      data,
+      fn {call_id, result_msg}, acc ->
+        {_lookup, rest} = Map.pop(acc.tool_loop_call_lookups, call_id)
+        acc =
+          acc
+          |> Tau.Session.append_message(result_msg)
+          |> Tau.Session.Journal.persist("tool_result",
+               Tau.Session.Journal.tool_result_to_data(result_msg))
+          |> Map.put(:tool_loop_call_lookups, rest)
+        Tau.Session.broadcast(acc.id, %Events.ToolEnd{
+          session_id: acc.id, tool_call_id: call_id, result: result_msg})
+        acc
+      end)
+
+  # Synthesise error ToolResults for still-pending :ask calls.
+  data =
+    Enum.reduce(
+      data.pending_permission_requests,
+      data,
+      fn {tool_call_id, %{name: name}}, acc ->
+        result = ToolResult.new(
+          tool_call_id: tool_call_id, tool_name: name,
+          content: "Session cancelled while awaiting permission for #{name}.",
+          is_error: true)
+        {_lookup, rest} = Map.pop(acc.tool_loop_call_lookups, tool_call_id)
+        acc =
+          acc
+          |> Tau.Session.append_message(result)
+          |> Tau.Session.Journal.persist("tool_result",
+               Tau.Session.Journal.tool_result_to_data(result))
+          |> Map.put(:tool_loop_call_lookups, rest)
+        Tau.Session.broadcast(acc.id, %Events.ToolEnd{
+          session_id: acc.id, tool_call_id: tool_call_id, result: result})
+        acc
+      end)
+
+  %{data |
+    pending_permission_requests: %{},
+    permission_dispatch_batch: [],
+    permission_pending_results: [],
+    tools_in_flight: %{},
+    tool_dispatcher: nil}
+end
+
+# lib/tau/session/compaction.ex — new public function
+@spec cancel(Data.t()) :: Data.t()
+def cancel(data) do
+  if data.compaction_monitor, do: Process.demonitor(data.compaction_monitor, [:flush])
+  if data.compaction_task && Process.alive?(data.compaction_task),
+    do: Process.exit(data.compaction_task, :brutal_kill)
+  %{data | compaction_task: nil, compaction_monitor: nil}
+  # compaction_failures intentionally NOT reset
+end
+
+# lib/tau/session/coding_agent_turn.ex — new public function
+@spec cancel(Data.t()) :: Data.t()
+def cancel(data) do
+  if data.coding_agent_dispatcher && Process.alive?(data.coding_agent_dispatcher),
+    do: Tau.CodingAgent.Dispatcher.cancel(data.coding_agent_dispatcher)
+  %{data |
+    coding_agent_dispatcher: nil,
+    coding_agent_pending: nil,
+    coding_agent_blocks: []}
+end
+
+# lib/tau/session/provider_turn.ex — extend or add alongside cancel_provider_task/1
+@spec teardown_for_cancel(Data.t()) :: {atom(), Data.t()}
+def teardown_for_cancel(data) do
+  mechanism = cancel_provider_task(data)
+  {mechanism, %{data |
+    provider_task: nil, cancel_flag: nil,
+    stream_ref: nil, provider_span_ref: nil, assembler: nil}}
+end
+```
+
+After these additions, the two `:cancel` clauses in `session.ex` reduce to:
+
+```elixir
+# :awaiting_permission clause (~5 lines)
+def handle_event(:cast, :cancel, :awaiting_permission, data) do
+  data = ToolDispatch.cancel_permission_round(data)
+  broadcast(data.id, %Events.Cancelled{session_id: data.id, reason: :user})
+  data = drain_steering_and_reset(data, "awaiting_permission")
+  {:next_state, :awaiting_user, data, followup_actions(data)}
+end
+
+# cross-cutting clause (~5 lines)
+def handle_event(:cast, :cancel, _state, data) do
+  cascade_to_children(data, :cancel)
+  {mechanism, data} = ProviderTurn.teardown_for_cancel(data)
+  data = data |> ToolDispatch.cancel_tool_cluster() |> Compaction.cancel() |> CodingAgentTurn.cancel()
+  broadcast(data.id, %Events.Cancelled{session_id: data.id, reason: :user})
+  data = drain_steering_and_reset(data, Atom.to_string(mechanism))
+  {:next_state, :awaiting_user, data, followup_actions(data)}
+end
+```
+
+where `drain_steering_and_reset/2` (a private helper in `session.ex`) handles
+`Journal.persist/3`, the steering-queue drain + `%QueueRestored{}` broadcast,
+remaining per-turn field resets (`active_skill`, `tool_iterations`,
+`tool_loop_state`, `tool_loop_call_lookups`, `provider_retry_state`,
+`steering_queue`), and is shared between both clauses.
+
+## Tradeoffs
+
+### Strengths
+
+- Satisfies the acceptance criterion directly: both clause bodies reduce to ≤5 lines by delegating to the functions that own each cluster.
+- Minimal blast radius: no new modules, no structural reorganisation — only new public functions added to modules that already own the relevant fields.
+- `cancel_permission_round/1` is the obvious symmetric companion to `finish_permission_round/1`; any reader of `ToolDispatch` will immediately understand the pairing.
+- `Compaction.cancel/1` can be called from any future cancel path without referencing `session.ex`.
+- Incremental: each delegate function can be extracted and tested independently before wiring.
+
+### Weaknesses
+
+- The shared `drain_steering_and_reset/2` helper remains in `session.ex`; it is still a private FSM helper rather than a delegate, meaning queue-drain logic has two homes (SPEC-USER-TURN §6, D-082 constraint stays visible but not resolved).
+- `ProviderTurn.teardown_for_cancel/1` combines a side-effectful kill with a data-shape return; the mixed signature (`{atom(), Data.t()}`) is unidiomatic relative to the existing `cancel_provider_task/1 :: atom()` that does not return data.
+- Does not address the `tool_dispatcher` and `command_task` kills (lines 984–990) — these inline guards have no obvious sub-module home (`ToolDispatch` dispatches tools but does not own the process handle lifecycle for the raw pid); they may remain in `session.ex` or require a further `ToolDispatch.cancel_dispatcher/1` extension.
+- Adding `cancel/1` to `Compaction` and `CodingAgentTurn` grows each module's public API; callers outside `session.ex` could misuse the cancel path.
+
+### Costs
+
+- 4 new public functions across 4 modules; ~60 LOC total new code (mostly moved from the cancel clauses).
+- `session.ex` loses ~200 LOC from the cancel clause bodies; gains ~30 LOC in delegates.
+- Unit tests for `cancel_permission_round/1`, `Compaction.cancel/1`, `CodingAgentTurn.cancel/1`, and `ProviderTurn.teardown_for_cancel/1` are new — ~4 new test modules or ~80–100 new test lines.
+- Low disruption: no existing callers of any affected module change.
+
+## Dependencies
+
+- `Tau.Session.Data` must be a typed struct (the `cross-cutting-data` sub-problem's acceptance criterion); without it, the field-reset maps in the new functions are unguarded. This proposal can land before that refactor but will benefit from it.
+- No library upgrades required.
+
+## Confidence
+
+Medium. The pattern (add a cancel-path sibling to the happy-path function) is
+well-established; `finish_permission_round/1` already shows the exact shape.
+Confidence would be raised by a prototype confirming that the `tool_dispatcher`
+/ `command_task` kill guards fit naturally in a `ToolDispatch.cancel_dispatcher/1`
+without requiring the raw pids to be passed in separately.
+
+## Prior art / references
+
+- `finish_permission_round/1` in `lib/tau/session/tool_dispatch.ex` (lines 294–): the happy-path pattern this proposal mirrors for the cancel path.
+- `cancel_provider_task/1` in `lib/tau/session/provider_turn.ex` (lines 95–130): existing cancel delegate; this proposal extends the same pattern to the other clusters.
+- Erlang/OTP `gen_statem` convention: FSM callbacks delegate to domain modules; the FSM holds only wiring.

--- a/docs/problems-archive-v1-modules/tau-session/subproblems/cancellation-teardown/proposals/proposal-2.md
+++ b/docs/problems-archive-v1-modules/tau-session/subproblems/cancellation-teardown/proposals/proposal-2.md
@@ -1,0 +1,209 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 2
+parent_problem: ../problem.md
+---
+
+# Proposal 2: `Tau.Session.Cancel` — a dedicated cancellation coordinator module
+
+## Approach
+
+Extract both `:cancel` clause bodies into a new module `Tau.Session.Cancel`
+(`lib/tau/session/cancel.ex`) that exposes two public functions:
+`permission_round/1` (for the `:awaiting_permission` path) and `cross_cutting/1`
+(for the `_state` path). Each function accepts the full `Data.t()`, performs all
+teardown operations internally (emitting events, killing processes, resetting
+fields), and returns `{Data.t(), actions}` — the exact pair the FSM clause needs
+for `{:next_state, :awaiting_user, data, actions}`. The two `session.ex` clause
+bodies become single-line delegations. The existing sub-module delegates
+(`ProviderTurn.cancel_provider_task/1`, `CodingAgent.Dispatcher.cancel/1`) are
+called from within `Tau.Session.Cancel`, not from `session.ex`.
+
+## Rationale
+
+The cancel path is a distinct lifecycle phase with its own ordering invariants
+(children first, provider cooperative-first, then broadcast, then queue drain).
+Grouping both cancel functions in one module makes the ordering contract readable
+in one place — a developer tracing cancellation reads `Tau.Session.Cancel`, not
+`session.ex`. Unlike Proposal 1 (which distributes cancel logic across each
+cluster's sub-module), this proposal decomplects the FSM from teardown by
+concentrating teardown in a single purpose-built module, paralleling how
+`Tau.Session.ToolDispatch` and `Tau.Session.ProviderTurn` concentrate their own
+lifecycle logic. The cancel module calls into the cluster sub-modules where
+delegates already exist, and handles inline what has no delegate yet — making
+the gap in cluster coverage visible in one file.
+
+## Sketch
+
+```elixir
+# lib/tau/session/cancel.ex — new module
+defmodule Tau.Session.Cancel do
+  @moduledoc """
+  Teardown coordinator for `Tau.Session` cancellation paths.
+
+  Provides `permission_round/1` for the `:awaiting_permission`-specific cancel
+  and `cross_cutting/1` for the general-state cancel. Both return
+  `{Data.t(), [gen_statem_action]}` for direct use in `:next_state` returns.
+  """
+
+  alias Tau.Session.{Data, Events, Journal, ToolDispatch}
+  alias Tau.Session.ProviderTurn
+  alias Tau.Message.ToolResult
+
+  @spec permission_round(Data.t()) :: {Data.t(), [term()]}
+  def permission_round(data) do
+    data =
+      data
+      |> emit_pending_results()
+      |> synthesise_error_results()
+    Tau.Session.broadcast(data.id, %Events.Cancelled{session_id: data.id, reason: :user})
+    data = Journal.persist(data, "cancellation", %{cause: "user", reason: "awaiting_permission"})
+    data = drain_steering_queue(data)
+    data = reset_permission_cluster(data)
+    data = reset_per_turn_fields(data)
+    {data, followup_actions(data)}
+  end
+
+  @spec cross_cutting(Data.t()) :: {Data.t(), [term()]}
+  def cross_cutting(data) do
+    Tau.Session.cascade_to_children(data, :cancel)
+    mechanism = ProviderTurn.cancel_provider_task(data)
+    data = kill_tool_cluster(data)
+    data = kill_compaction_cluster(data)
+    data = cancel_coding_agent_cluster(data)
+    Tau.Session.broadcast(data.id, %Events.Cancelled{session_id: data.id, reason: :user})
+    data = Journal.persist(data, "cancellation", %{cause: "user", reason: Atom.to_string(mechanism)})
+    data = drain_steering_queue(data)
+    data = reset_cross_cutting_fields(data)
+    data = reset_per_turn_fields(data)
+    {data, followup_actions(data)}
+  end
+
+  # Private helpers -------------------------------------------------------
+
+  defp emit_pending_results(data), do: # ... (reduce over permission_pending_results)
+
+  defp synthesise_error_results(data), do: # ... (reduce over pending_permission_requests)
+
+  defp kill_tool_cluster(data) do
+    if data.tool_dispatcher && Process.alive?(data.tool_dispatcher),
+      do: Process.exit(data.tool_dispatcher, :brutal_kill)
+    if data.command_task && Process.alive?(data.command_task),
+      do: Process.exit(data.command_task, :brutal_kill)
+    %{data | tool_dispatcher: nil, command_task: nil}
+  end
+
+  defp kill_compaction_cluster(data) do
+    if data.compaction_monitor, do: Process.demonitor(data.compaction_monitor, [:flush])
+    if data.compaction_task && Process.alive?(data.compaction_task),
+      do: Process.exit(data.compaction_task, :brutal_kill)
+    %{data | compaction_task: nil, compaction_monitor: nil}
+  end
+
+  defp cancel_coding_agent_cluster(data) do
+    if data.coding_agent_dispatcher && Process.alive?(data.coding_agent_dispatcher),
+      do: Tau.CodingAgent.Dispatcher.cancel(data.coding_agent_dispatcher)
+    %{data | coding_agent_dispatcher: nil, coding_agent_pending: nil, coding_agent_blocks: []}
+  end
+
+  defp drain_steering_queue(data) do
+    msgs = :queue.to_list(data.steering_queue)
+    if msgs != [],
+      do: Tau.Session.broadcast(data.id, %Events.QueueRestored{session_id: data.id, messages: msgs})
+    %{data | steering_queue: :queue.new()}
+  end
+
+  defp reset_permission_cluster(data) do
+    %{data |
+      pending_permission_requests: %{},
+      permission_dispatch_batch: [],
+      permission_pending_results: [],
+      tools_in_flight: %{},
+      tool_dispatcher: nil}
+  end
+
+  defp reset_cross_cutting_fields(data) do
+    %{data |
+      provider_task: nil, cancel_flag: nil,
+      stream_ref: nil, provider_span_ref: nil,
+      assembler: nil, tools_in_flight: %{}}
+  end
+
+  defp reset_per_turn_fields(data) do
+    %{data |
+      active_skill: nil, tool_iterations: 0,
+      tool_loop_state: %{}, tool_loop_call_lookups: %{},
+      provider_retry_state: %{count: 0}}
+  end
+
+  defp followup_actions(data) do
+    if :queue.is_empty(data.followup_queue),
+      do: [],
+      else: [{:next_event, :internal, :drain_followups}]
+  end
+end
+```
+
+The two `session.ex` clauses reduce to:
+
+```elixir
+def handle_event(:cast, :cancel, :awaiting_permission, data) do
+  {data, actions} = Tau.Session.Cancel.permission_round(data)
+  {:next_state, :awaiting_user, data, actions}
+end
+
+def handle_event(:cast, :cancel, _state, data) do
+  {data, actions} = Tau.Session.Cancel.cross_cutting(data)
+  {:next_state, :awaiting_user, data, actions}
+end
+```
+
+Note: `cascade_to_children/2` in `cross_cutting/1` calls
+`Tau.Session.cascade_to_children/2` — this remains a private helper in
+`session.ex` (it is in-scope as a call site) and is simply invoked from the
+cancel module via the public API or made accessible via a `@doc false` package-
+private pattern.
+
+## Tradeoffs
+
+### Strengths
+
+- Both cancel clause bodies in `session.ex` become exactly 2 lines — the strictest possible compliance with the acceptance criterion.
+- All cancellation ordering logic lives in one file; a developer reading cancel behaviour reads `cancel.ex`, period.
+- The `cross_cutting/1` implementation immediately surfaces which clusters still lack a sub-module delegate (compaction, tool kill) — the gap is visible and localised.
+- Symmetric with the existing sub-module extraction pattern: `ToolDispatch` owns tool dispatch, `Cancel` owns cancellation.
+- `permission_round/1` and `cross_cutting/1` are independently unit-testable without the FSM.
+
+### Weaknesses
+
+- Introduces a new module that coordinates across cluster boundaries — it now knows about compaction, coding agent, provider, tool dispatcher simultaneously. If a cluster sub-module later gains its own cancel delegate, the `Cancel` module must be updated; the coupling is concentrated rather than eliminated.
+- `cancel.ex` calls `Tau.Session.broadcast/2`, `Tau.Session.append_message/2`, and `Tau.Session.cascade_to_children/2` — functions that live on the FSM module. This creates a `cancel.ex → session.ex` import cycle risk unless those helpers are moved to a shared internal module first (the `fsm-facade-helpers` sub-problem). Without that, the module boundary is enforced only by discipline, not by the compiler.
+- `cascade_to_children/2` is currently private in `session.ex`; exposing it to `cancel.ex` requires making it package-accessible or moving it — non-trivial.
+- The `{Data.t(), [action]}` return type for `permission_round/1` and `cross_cutting/1` is not a standard Elixir pattern; callers must destructure, and Dialyzer typing requires the action list to be typed as `term()` or a new alias.
+
+### Costs
+
+- 1 new module (~130 LOC); `session.ex` loses ~240 LOC from the cancel bodies.
+- `cascade_to_children/2` must be made accessible to `cancel.ex` — either a small refactor (move to `Data` or `Journal`) or a `@doc false` exposure; ~5–10 LOC change.
+- Unit tests for `permission_round/1` and `cross_cutting/1`: ~2 new test files, ~100–120 test lines.
+- Dependency ordering: the `fsm-facade-helpers` sub-problem (shared helpers module) should ideally precede this to avoid the import-cycle risk, or the proposal must ship a minimal shared-helpers extraction alongside it.
+
+## Dependencies
+
+- `cascade_to_children/2` must be accessible from outside `session.ex` — requires either exposing it or first landing the `fsm-facade-helpers` sub-problem's shared internal module.
+- `Tau.Session.Data` typed struct (the `cross-cutting-data` sub-problem) is not strictly required but makes the field-reset maps in `reset_*` helpers type-safe.
+
+## Confidence
+
+Medium. The extraction pattern is well-established in this codebase (see prior
+sub-module extractions). The import-cycle risk with `session.ex` helpers is the
+main uncertainty — the `fsm-facade-helpers` dependency is real and may require
+sequencing. Confidence would be raised by confirming `cascade_to_children/2`
+can be exposed without exposing more FSM internals.
+
+## Prior art / references
+
+- `Tau.Session.ToolDispatch` extraction: the direct precedent for concentrating a lifecycle concern in a sub-module rather than distributing it.
+- Erlang/OTP supervisor `terminate/2` pattern: lifecycle cleanup in a dedicated callback rather than inline in the event handler.
+- Elixir `Phoenix.LiveView` `handle_event/3` delegation pattern: thin FSM clause that delegates to a concern module.

--- a/docs/problems-archive-v1-modules/tau-session/subproblems/cancellation-teardown/proposals/proposal-3.md
+++ b/docs/problems-archive-v1-modules/tau-session/subproblems/cancellation-teardown/proposals/proposal-3.md
@@ -1,0 +1,194 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 3
+parent_problem: ../problem.md
+---
+
+# Proposal 3: Data-shape teardown — `Data.reset_for_cancel/2` + per-cluster `cancel_cluster/1` callbacks on a `Cancellable` behaviour
+
+## Approach
+
+Define a `Tau.Session.Cancellable` behaviour with a single callback
+`cancel_cluster(Data.t()) :: Data.t()`. Implement it in
+`Tau.Session.ProviderTurn`, `Tau.Session.ToolDispatch`, `Tau.Session.Compaction`,
+and `Tau.Session.CodingAgentTurn` — each module declares `@behaviour
+Tau.Session.Cancellable` and implements `cancel_cluster/1` to kill its own
+processes and clear its own fields. Add `Data.reset_for_cancel/1` in
+`Tau.Session.Data` to reset the cross-cutting per-turn fields that belong to no
+single cluster (`active_skill`, `tool_iterations`, `tool_loop_state`,
+`tool_loop_call_lookups`, `provider_retry_state`, `steering_queue`). Both
+`:cancel` clause bodies in `session.ex` become a fold over a hardcoded list of
+cluster modules plus a `Data.reset_for_cancel/1` call.
+
+## Rationale
+
+The deepest complection is the one between the FSM clause and the data-field
+reset maps: the clause must know every field of every cluster in order to zero
+them out. By placing `cancel_cluster/1` on each cluster module and
+`reset_for_cancel/1` on `Data`, each module is responsible for the fields it
+declared — the FSM need only enumerate the cluster modules and let each clean up
+after itself. This is the data-shape axis: the change is primarily about who
+owns the reset map, not just who contains the kill logic. The `Cancellable`
+behaviour makes the contract explicit and compiler-checkable: a new cluster
+sub-module that forgets to implement `cancel_cluster/1` produces a compile-time
+warning, not a silent cancel gap.
+
+## Sketch
+
+```elixir
+# lib/tau/session/cancellable.ex — new behaviour (3 lines)
+defmodule Tau.Session.Cancellable do
+  @callback cancel_cluster(Tau.Session.Data.t()) :: Tau.Session.Data.t()
+end
+
+# lib/tau/session/provider_turn.ex — add behaviour + implement callback
+@behaviour Tau.Session.Cancellable
+
+@impl Tau.Session.Cancellable
+@spec cancel_cluster(Data.t()) :: Data.t()
+def cancel_cluster(data) do
+  _mechanism = cancel_provider_task(data)   # existing function; mechanism recorded elsewhere
+  %{data | provider_task: nil, cancel_flag: nil,
+           stream_ref: nil, provider_span_ref: nil, assembler: nil}
+end
+
+# lib/tau/session/tool_dispatch.ex — add behaviour + implement callback
+@behaviour Tau.Session.Cancellable
+
+@impl Tau.Session.Cancellable
+@spec cancel_cluster(Data.t()) :: Data.t()
+def cancel_cluster(data) do
+  if data.tool_dispatcher && Process.alive?(data.tool_dispatcher),
+    do: Process.exit(data.tool_dispatcher, :brutal_kill)
+  if data.command_task && Process.alive?(data.command_task),
+    do: Process.exit(data.command_task, :brutal_kill)
+  data
+  |> emit_and_close_pending_permissions_on_cancel()  # mirror of finish_permission_round paths
+  |> Map.merge(%{
+    tools_in_flight: %{}, tool_dispatcher: nil, command_task: nil,
+    pending_permission_requests: %{}, permission_dispatch_batch: [],
+    permission_pending_results: [], tool_loop_call_lookups: %{}})
+end
+
+# lib/tau/session/compaction.ex — add behaviour + implement callback
+@behaviour Tau.Session.Cancellable
+
+@impl Tau.Session.Cancellable
+@spec cancel_cluster(Data.t()) :: Data.t()
+def cancel_cluster(data) do
+  if data.compaction_monitor, do: Process.demonitor(data.compaction_monitor, [:flush])
+  if data.compaction_task && Process.alive?(data.compaction_task),
+    do: Process.exit(data.compaction_task, :brutal_kill)
+  %{data | compaction_task: nil, compaction_monitor: nil}
+  # compaction_failures intentionally NOT reset
+end
+
+# lib/tau/session/coding_agent_turn.ex — add behaviour + implement callback
+@behaviour Tau.Session.Cancellable
+
+@impl Tau.Session.Cancellable
+@spec cancel_cluster(Data.t()) :: Data.t()
+def cancel_cluster(data) do
+  if data.coding_agent_dispatcher && Process.alive?(data.coding_agent_dispatcher),
+    do: Tau.CodingAgent.Dispatcher.cancel(data.coding_agent_dispatcher)
+  %{data | coding_agent_dispatcher: nil, coding_agent_pending: nil, coding_agent_blocks: []}
+end
+
+# lib/tau/session/data.ex — new function
+@spec reset_for_cancel(t()) :: t()
+def reset_for_cancel(data) do
+  %{data |
+    active_skill: nil,
+    tool_iterations: 0,
+    tool_loop_state: %{},
+    provider_retry_state: %{count: 0},
+    steering_queue: :queue.new()}
+end
+```
+
+The two `session.ex` cancel clauses become:
+
+```elixir
+@cancel_clusters [
+  Tau.Session.ProviderTurn,
+  Tau.Session.ToolDispatch,
+  Tau.Session.Compaction,
+  Tau.Session.CodingAgentTurn
+]
+
+def handle_event(:cast, :cancel, :awaiting_permission, data) do
+  # ToolDispatch.cancel_cluster/1 handles permission-round emit + synthesis
+  data = Enum.reduce(@cancel_clusters, data, & &1.cancel_cluster(&2))
+  broadcast(data.id, %Events.Cancelled{session_id: data.id, reason: :user})
+  data = finish_cancel(data, "awaiting_permission")
+  {:next_state, :awaiting_user, data, followup_actions(data)}
+end
+
+def handle_event(:cast, :cancel, _state, data) do
+  cascade_to_children(data, :cancel)
+  data = Enum.reduce(@cancel_clusters, data, & &1.cancel_cluster(&2))
+  broadcast(data.id, %Events.Cancelled{session_id: data.id, reason: :user})
+  data = finish_cancel(data, "cross_cutting")
+  {:next_state, :awaiting_user, data, followup_actions(data)}
+end
+
+# Private: journal + steering drain + Data.reset_for_cancel/1
+defp finish_cancel(data, reason) do
+  data
+  |> Journal.persist("cancellation", %{cause: "user", reason: reason})
+  |> tap(fn d ->
+    msgs = :queue.to_list(d.steering_queue)
+    if msgs != [], do: broadcast(d.id, %Events.QueueRestored{session_id: d.id, messages: msgs})
+  end)
+  |> Data.reset_for_cancel()
+end
+```
+
+The `:awaiting_permission` clause uses the same `@cancel_clusters` fold;
+`ToolDispatch.cancel_cluster/1` is written to handle both the permission-round
+emit and the general-case (it detects which phase it is in from data fields).
+
+## Tradeoffs
+
+### Strengths
+
+- Compiler-enforced contract: any new cluster sub-module that omits `cancel_cluster/1` produces a `@behaviour` warning at compile time — the coverage gap cannot be introduced silently.
+- Field reset ownership is fully decomplected: each module declares which fields it resets; the FSM holds no field knowledge.
+- The `@cancel_clusters` list in `session.ex` is the single enumeration of all clusters — adding a new cluster means adding one module and one list entry, not editing an inline teardown sequence.
+- `Data.reset_for_cancel/1` is a natural addition to the `Data` module, consistent with OTP's convention of data-shape operations living on the data struct module.
+- `finish_cancel/2` in `session.ex` remains a 4-line private helper — acceptable inline residual.
+
+### Weaknesses
+
+- The `ProviderTurn.cancel_cluster/1` implementation discards the `cancel_mechanism` atom (`:cooperative` vs `:brutal_kill`) that the cross-cutting cancel clause currently uses to journal the cancel reason. The journal entry loses ADR-0017's mechanism distinction unless `cancel_cluster/1` is extended to return `{mechanism, Data.t()}` — which breaks the behaviour signature's uniformity.
+- A uniform fold `Enum.reduce(@cancel_clusters, data, & &1.cancel_cluster(&2))` assumes order-independence among clusters. The existing code has an ordering constraint: `cascade_to_children` before provider kill. The `:awaiting_permission` path currently does not kill the provider; by including `ProviderTurn` in the uniform fold for that path, it may run `cancel_provider_task/1` unnecessarily on a nil task (benign but wasteful).
+- The behaviour is a thin wrapper over a single callback; some teams view single-callback behaviours as over-engineering compared to a plain function.
+- `ToolDispatch.cancel_cluster/1` must handle both the permission-round emit (for the `:awaiting_permission` path) and the plain field-clear (for the cross-cutting path); the distinction between these two states leaks into the cluster module via data field inspection.
+
+### Costs
+
+- 1 new micro-module (`Tau.Session.Cancellable`, 3 LOC); 4 new `cancel_cluster/1` implementations across existing modules (~60 LOC total); `Data.reset_for_cancel/1` (~10 LOC).
+- `session.ex` loses ~230 LOC from the cancel bodies; gains ~20 LOC (`@cancel_clusters`, `finish_cancel/2`, 2 simplified clauses).
+- ADR-0017 journal mechanism distinction requires either relaxing the journal entry or adding a separate pre-fold step to capture the mechanism atom before the fold.
+- Unit tests: `cancel_cluster/1` for each module + `Data.reset_for_cancel/1` — ~5 new test modules, ~80–100 test lines.
+
+## Dependencies
+
+- `Tau.Session.Data` must be an accessible struct (not `map()`) for `Data.reset_for_cancel/1` to be type-safe — benefits from, but does not strictly require, the `cross-cutting-data` sub-problem landing first.
+- No library upgrades required.
+
+## Confidence
+
+Medium-low. The behaviour pattern is standard OTP; the main uncertainty is
+whether `ToolDispatch.cancel_cluster/1` can elegantly handle both cancel paths
+without field inspection (phase disambiguation from `pending_permission_requests`
+being non-empty vs empty is doable but couples the implementation to an implicit
+convention). Confidence would be raised by confirming that ADR-0017's mechanism
+atom can be captured outside the fold without additional complexity.
+
+## Prior art / references
+
+- OTP `gen_server` `terminate/2` callback: each module handles its own cleanup with a uniform callback signature.
+- Elixir behaviour pattern used extensively in `Tau.Provider` callbacks: `stream/3`, `context_window/1` — same single-module-per-behaviour-callback pattern.
+- `Tau.Session.Data.new/1`: precedent for initialisation logic living on the data struct module; `reset_for_cancel/1` is the cancellation-path counterpart.

--- a/docs/problems-archive-v1-modules/tau-session/subproblems/cancellation-teardown/proposals/proposal-4.md
+++ b/docs/problems-archive-v1-modules/tau-session/subproblems/cancellation-teardown/proposals/proposal-4.md
@@ -1,0 +1,192 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 4
+parent_problem: ../problem.md
+---
+
+# Proposal 4: PubSub-driven teardown — emit `%Cancelling{}` and let cluster sub-modules self-clean via subscribed handlers
+
+## Approach
+
+Introduce a new internal event struct `%Tau.Session.Events.Cancelling{}` (not
+the existing `%Cancelled{}` which is external-facing). When either `:cancel` FSM
+clause fires, `session.ex` emits `%Cancelling{session_id: id, scope: :permission
+| :cross_cutting}` on the session's PubSub topic before yielding. Each cluster
+sub-module that needs teardown registers a `handle_cancelling/2` handler (called
+by a thin dispatcher in `session.ex`) that receives the event and the current
+`Data.t()`, performs its own kills and field resets, and returns `Data.t()`. The
+FSM clause becomes: emit `%Cancelling{}`, call `Cancellation.dispatch(data, scope)` 
+— a new thin function in `Tau.Session.Cancellation` that folds registered handlers — 
+then broadcast `%Cancelled{}` and return `{:next_state, :awaiting_user, data, actions}`.
+The handler registry is a compile-time list (not a runtime subscription) to avoid
+the supervision complexity of PubSub at the cancel path.
+
+## Rationale
+
+The root complecting is that the FSM clause knows the ordered side-effect
+sequence for each cluster. If instead each cluster publishes what it needs on a
+`%Cancelling{}` event and implements `handle_cancelling/2`, the FSM clause
+reduces to "announce and collect." The interface-change axis: teardown becomes an
+internal event protocol rather than a sequence of direct calls. This mirrors how
+the TUI and dashboard react to `%Cancelled{}` (external), but applies the same
+pub-sub inversion internally for the teardown phase itself. The `handle_cancelling/2`
+protocol is more API-stable than `cancel_cluster/1` (Proposal 3) because it
+receives the event struct, giving each handler access to `scope` and any future
+metadata without changing the signature.
+
+## Sketch
+
+```elixir
+# lib/tau/session/events.ex — add internal event struct
+defmodule Tau.Session.Events.Cancelling do
+  @moduledoc "Internal event emitted before teardown begins; not broadcast externally."
+  @enforce_keys [:session_id, :scope]
+  defstruct [:session_id, :scope]
+  @type scope :: :permission | :cross_cutting
+  @type t :: %__MODULE__{session_id: String.t(), scope: scope()}
+end
+
+# lib/tau/session/cancellation.ex — new thin dispatcher module
+defmodule Tau.Session.Cancellation do
+  @moduledoc """
+  Dispatches the internal `%Cancelling{}` event to registered cluster handlers,
+  returning the updated `Data.t()`.
+
+  Handlers are registered at compile time. Order is significant:
+  ProviderTurn → ToolDispatch → Compaction → CodingAgentTurn.
+  """
+
+  alias Tau.Session.Events.Cancelling
+  alias Tau.Session.Data
+
+  # Compile-time registry — not a runtime subscription.
+  @handlers [
+    Tau.Session.ProviderTurn,
+    Tau.Session.ToolDispatch,
+    Tau.Session.Compaction,
+    Tau.Session.CodingAgentTurn
+  ]
+
+  @spec dispatch(Data.t(), Cancelling.scope()) :: {atom(), Data.t()}
+  def dispatch(data, scope) do
+    event = %Cancelling{session_id: data.id, scope: scope}
+    # Returns {mechanism_atom, Data.t()} — mechanism is threaded for ADR-0017 journal.
+    Enum.reduce(@handlers, {:noop, data}, fn handler, {_mech, acc} ->
+      handler.handle_cancelling(event, acc)
+    end)
+  end
+end
+
+# Cluster modules — implement handle_cancelling/2 (example: ProviderTurn)
+defmodule Tau.Session.ProviderTurn do
+  # ... existing code ...
+
+  @spec handle_cancelling(Events.Cancelling.t(), Data.t()) :: {:cooperative | :brutal_kill | :noop, Data.t()}
+  def handle_cancelling(%Events.Cancelling{}, data) do
+    mechanism = cancel_provider_task(data)
+    {mechanism, %{data | provider_task: nil, cancel_flag: nil,
+                         stream_ref: nil, provider_span_ref: nil, assembler: nil}}
+  end
+end
+
+defmodule Tau.Session.ToolDispatch do
+  @spec handle_cancelling(Events.Cancelling.t(), Data.t()) :: {:noop, Data.t()}
+  def handle_cancelling(%Events.Cancelling{scope: scope}, data) do
+    data = case scope do
+      :permission -> cancel_permission_round_fields(data)   # emit loop + synthesis
+      :cross_cutting -> kill_tool_and_command(data)
+    end
+    {:noop, data}
+  end
+end
+
+defmodule Tau.Session.Compaction do
+  @spec handle_cancelling(Events.Cancelling.t(), Data.t()) :: {:noop, Data.t()}
+  def handle_cancelling(%Events.Cancelling{}, data) do
+    if data.compaction_monitor, do: Process.demonitor(data.compaction_monitor, [:flush])
+    if data.compaction_task && Process.alive?(data.compaction_task),
+      do: Process.exit(data.compaction_task, :brutal_kill)
+    {:noop, %{data | compaction_task: nil, compaction_monitor: nil}}
+  end
+end
+
+defmodule Tau.Session.CodingAgentTurn do
+  @spec handle_cancelling(Events.Cancelling.t(), Data.t()) :: {:noop, Data.t()}
+  def handle_cancelling(%Events.Cancelling{}, data) do
+    if data.coding_agent_dispatcher && Process.alive?(data.coding_agent_dispatcher),
+      do: Tau.CodingAgent.Dispatcher.cancel(data.coding_agent_dispatcher)
+    {:noop, %{data | coding_agent_dispatcher: nil, coding_agent_pending: nil,
+                      coding_agent_blocks: []}}
+  end
+end
+```
+
+The two `session.ex` cancel clauses become:
+
+```elixir
+def handle_event(:cast, :cancel, :awaiting_permission, data) do
+  {_mechanism, data} = Tau.Session.Cancellation.dispatch(data, :permission)
+  broadcast(data.id, %Events.Cancelled{session_id: data.id, reason: :user})
+  data = finish_cancel(data, "awaiting_permission")
+  {:next_state, :awaiting_user, data, followup_actions(data)}
+end
+
+def handle_event(:cast, :cancel, _state, data) do
+  cascade_to_children(data, :cancel)
+  {mechanism, data} = Tau.Session.Cancellation.dispatch(data, :cross_cutting)
+  broadcast(data.id, %Events.Cancelled{session_id: data.id, reason: :user})
+  data = finish_cancel(data, Atom.to_string(mechanism))
+  {:next_state, :awaiting_user, data, followup_actions(data)}
+end
+```
+
+`finish_cancel/2` handles journal, steering-queue drain, and per-turn field
+resets (same as Proposals 2 and 3).
+
+## Tradeoffs
+
+### Strengths
+
+- Handler signature `handle_cancelling/2` is forward-compatible: new metadata in `%Cancelling{}` (e.g. `reason`, `source`) is available to all handlers without changing the callback contract.
+- ADR-0017's `mechanism` atom threads naturally through the reduce fold via the `{atom, Data.t()}` return — no separate pre-fold step needed.
+- Scope (`%Cancelling{scope: :permission | :cross_cutting}`) flows into each handler, allowing `ToolDispatch` to branch on it without the ambiguity problem noted in Proposal 3.
+- Adding a new cluster sub-module requires only: implement `handle_cancelling/2` and add the module to `@handlers` — no editing of the FSM clause bodies.
+- The internal event struct `%Cancelling{}` can later be promoted to a real PubSub broadcast if external monitoring of the teardown phase is ever needed — the structural investment is not wasted.
+
+### Weaknesses
+
+- The `@handlers` compile-time list in `Tau.Session.Cancellation` is not enforced: a module that implements `handle_cancelling/2` but is not listed is silently skipped. Unlike Proposal 3's behaviour, there is no compiler warning for a missing registration.
+- The `{atom(), Data.t()}` reduce accumulator for the mechanism atom is awkward: only `ProviderTurn` returns a meaningful mechanism; all other handlers return `{:noop, data}`. The fold's `{_mech, acc}` pattern discards intermediate mechanisms — if two handlers both returned non-`:noop` atoms, only the last would survive.
+- `handle_cancelling/2` is a non-standard convention (not a `:gen_server` callback, not a `Phoenix.PubSub` subscription) — it will surprise contributors unfamiliar with this codebase's pattern.
+- Introduces a new internal event struct, a new dispatcher module, and a new callback on 4 existing modules — the conceptual surface area is larger than Proposals 1 or 2 for the same outcome.
+- The `%Cancelling{}` struct name could be confused with `%Cancelled{}` by readers; naming discipline is required.
+
+### Costs
+
+- 2 new files: `lib/tau/session/events/cancelling.ex` (struct, ~10 LOC) and `lib/tau/session/cancellation.ex` (dispatcher, ~30 LOC).
+- 4 new `handle_cancelling/2` functions across existing modules (~60 LOC total).
+- `session.ex` loses ~230 LOC; gains ~10 LOC.
+- No new behaviour module; no compile-time enforcement requires discipline in `@handlers` maintenance.
+- Unit tests for `Cancellation.dispatch/2` plus each `handle_cancelling/2`: ~3–4 test modules, ~100–120 test lines (the dispatch coordination is testable in isolation).
+
+## Dependencies
+
+- `%Tau.Session.Events.Cancelling{}` must be added to `lib/tau/session/events.ex` or its own file; this is a minor change to a shared events namespace.
+- `Tau.Session.Data` typed struct is beneficial for type-safe field resets; same dependency as Proposals 1–3.
+- No library upgrades required.
+
+## Confidence
+
+Low-medium. The interface-change approach is the highest abstraction level of
+the four proposals — the mechanism is sound but the `%Cancelling{}` event
+protocol is novel in this codebase. Confidence would be raised by confirming
+that the `{atom(), Data.t()}` reduce accumulator handles the ADR-0017 mechanism
+cleanly (prototype needed) and by checking that no test currently pattern-matches
+on the `:cancel` clause body structure in a way that would break.
+
+## Prior art / references
+
+- `Phoenix.LiveView` internal `handle_info/2` event delegation: the pattern of routing a struct event through a dispatcher rather than branching inline.
+- `Tau.Session.Events.Cancelled` (external) → `Tau.Session.Events.Cancelling` (internal): the naming mirrors the existing external event, making the internal/external distinction explicit.
+- Erlang `:gen_event` manager pattern: multiple handlers for a single event type, each cleaning up its own state — the compile-time list replaces the runtime registration for determinism.

--- a/docs/problems-archive-v1-modules/tau-session/subproblems/cancellation-teardown/solution.md
+++ b/docs/problems-archive-v1-modules/tau-session/subproblems/cancellation-teardown/solution.md
@@ -1,0 +1,216 @@
+---
+template_version: 1
+template_name: solution
+parent_problem: problem.md
+node_kind: leaf
+synthesised_from: [proposals/proposal-3.md, proposals/proposal-4.md]
+selection_method: hybrid
+revision: 0
+---
+
+# Solution: `Cancellable` behaviour with scope-aware callback returning mechanism
+
+## Recommendation
+
+Define a `Tau.Session.Cancellable` behaviour whose sole callback —
+`cancel_cluster(scope, Data.t()) :: {mechanism :: atom(), Data.t()}` —
+is implemented by each cluster sub-module (`ProviderTurn`, `ToolDispatch`,
+`Compaction`, `CodingAgentTurn`). Each implementation owns the kills,
+demonitors, emit loops, and field resets for its own cluster, and returns
+`{:noop | :cooperative | :brutal_kill, data}`. Add
+`Data.reset_for_cancel/1` to `Tau.Session.Data` for the cross-cutting
+per-turn fields no cluster owns. `session.ex` enumerates clusters in a
+compile-time `@cancel_clusters` list, folds over them with `scope` passed
+through, captures the surviving non-`:noop` mechanism for the journal,
+broadcasts `%Cancelled{}`, and calls a private `finish_cancel/2` helper
+that runs `Journal.persist/3`, drains `steering_queue` to `%QueueRestored{}`,
+and applies `Data.reset_for_cancel/1`. Both `:cancel` clause bodies
+collapse to ≤5 lines.
+
+## Selected from
+
+- **Chosen:** hybrid of `proposals/proposal-3.md` (spine) and
+  `proposals/proposal-4.md` (callback-signature enrichment).
+- **Why chosen:** Proposal 3 is the deepest decomplection on the
+  data-shape axis (each cluster module declares which fields it
+  resets; the FSM holds no field knowledge) and is the only proposal
+  that gives compiler-enforced cancel coverage via `@behaviour`. Its
+  two named weaknesses — loss of ADR-0017's `mechanism` atom in the
+  uniform fold, and `ToolDispatch.cancel_cluster/1` having to
+  phase-disambiguate via field inspection — are exactly the two
+  problems Proposal 4 solves: P4 threads the mechanism through the
+  reduce via `{atom(), Data.t()}` and passes `scope` into each
+  handler. Importing P4's signature into P3's behaviour absorbs P4's
+  strengths without paying P4's costs (a novel `%Cancelling{}` event
+  struct that is not actually PubSub-published, plus a silently
+  authoritative `@handlers` list with no compile-time check). The
+  hybrid keeps P3's compiler enforcement and removes both of P3's
+  named weaknesses. Proposal 1 was rejected because it leaves
+  `drain_steering_and_reset/2` resident in `session.ex` as a private
+  helper, only partially satisfying the AC, and because adding the
+  cancel function to each cluster module without a behaviour offers
+  no protection against a future cluster sub-module forgetting to
+  implement it. Proposal 2 was rejected because it concentrates
+  cross-cluster knowledge in a new coordinator module rather than
+  distributing ownership to the clusters themselves (the opposite of
+  decomplecting on the data-shape axis) and depends on the
+  `fsm-facade-helpers` sub-problem to avoid an import cycle.
+
+Scoring table:
+
+| # | Fit | Decomplecting depth | Migration cost | Risk | Reversibility |
+|---|---|---|---|---|---|
+| 1 | Partially | Substantial | Low | Low | Easy |
+| 2 | Yes | Substantial | Medium | Medium | Hard |
+| 3 | Yes | Deep | Medium | Low | Easy |
+| 4 | Yes | Deep | Medium | Medium | Medium |
+| **Hybrid (3+4)** | **Yes** | **Deep** | **Medium** | **Low** | **Easy** |
+
+## What changes
+
+- **New file `lib/tau/session/cancellable.ex`** — defines the
+  `Tau.Session.Cancellable` behaviour with one callback:
+  `@callback cancel_cluster(scope :: :permission | :cross_cutting, Tau.Session.Data.t()) :: {atom(), Tau.Session.Data.t()}`.
+- **`lib/tau/session/provider_turn.ex`** — declare
+  `@behaviour Tau.Session.Cancellable`; implement
+  `cancel_cluster(_scope, data)` to call existing `cancel_provider_task/1`,
+  capture its returned mechanism atom (`:cooperative | :brutal_kill | :noop`),
+  and clear `{provider_task, cancel_flag, stream_ref, provider_span_ref, assembler}`.
+- **`lib/tau/session/tool_dispatch.ex`** — declare
+  `@behaviour Tau.Session.Cancellable`; implement `cancel_cluster(scope, data)`
+  branching on `scope`: `:permission` runs the existing
+  `finish_permission_round/1`-shaped emit-and-synthesise loop (formerly
+  inlined in `session.ex` lines 842–961), `:cross_cutting` brutal-kills
+  `tool_dispatcher` and `command_task`. Returns `{:noop, data}`. Owns the
+  reset of `{pending_permission_requests, permission_dispatch_batch,
+  permission_pending_results, tools_in_flight, tool_dispatcher, command_task,
+  tool_loop_call_lookups}`.
+- **`lib/tau/session/compaction.ex`** — declare
+  `@behaviour Tau.Session.Cancellable`; implement
+  `cancel_cluster(_scope, data)` to demonitor `compaction_monitor`,
+  brutal-kill `compaction_task`, clear those two fields (NOT
+  `compaction_failures`). Returns `{:noop, data}`.
+- **`lib/tau/session/coding_agent_turn.ex`** — declare
+  `@behaviour Tau.Session.Cancellable`; implement
+  `cancel_cluster(_scope, data)` to guard-call
+  `Tau.CodingAgent.Dispatcher.cancel/1` and clear
+  `{coding_agent_dispatcher, coding_agent_pending, coding_agent_blocks}`.
+  Returns `{:noop, data}`.
+- **`lib/tau/session/data.ex`** — new function
+  `reset_for_cancel/1` resetting the cross-cutting per-turn fields
+  (`active_skill`, `tool_iterations`, `tool_loop_state`,
+  `provider_retry_state`, `steering_queue` — but NOT
+  `tool_loop_call_lookups`, which `ToolDispatch.cancel_cluster/1` owns).
+- **`lib/tau/session.ex`** —
+    - Add compile-time module list
+      `@cancel_clusters [Tau.Session.ProviderTurn, Tau.Session.ToolDispatch, Tau.Session.Compaction, Tau.Session.CodingAgentTurn]`.
+    - Replace the `:awaiting_permission` `:cancel` clause body (lines 842–961)
+      with a ≤5-line body that folds `@cancel_clusters` with
+      `scope: :permission`, picks the surviving non-`:noop` mechanism,
+      broadcasts `%Cancelled{}`, calls `finish_cancel(data, "awaiting_permission")`,
+      and returns `{:next_state, :awaiting_user, data, followup_actions(data)}`.
+    - Replace the cross-cutting `:cancel` clause body (lines 963–1083)
+      with a ≤5-line body that calls `cascade_to_children(data, :cancel)`,
+      folds `@cancel_clusters` with `scope: :cross_cutting`, picks the
+      surviving non-`:noop` mechanism, broadcasts `%Cancelled{}`, calls
+      `finish_cancel(data, Atom.to_string(mechanism))`, and returns
+      `{:next_state, :awaiting_user, data, followup_actions(data)}`.
+    - Add private `finish_cancel/2` (≤10 lines) running
+      `Journal.persist/3`, the steering-queue drain →
+      `%QueueRestored{}` broadcast, and `Data.reset_for_cancel/1`.
+- **New tests** — one test module per cluster
+  (`test/tau/session/{provider_turn,tool_dispatch,compaction,coding_agent_turn}_cancel_cluster_test.exs`)
+  exercising each `cancel_cluster/2` in isolation, plus a test for
+  `Data.reset_for_cancel/1`.
+
+## What does not change
+
+- `cascade_to_children/2` stays a private helper in `session.ex`,
+  invoked at the top of the cross-cutting clause body (the problem
+  statement explicitly preserves this call site).
+- `Tau.Session.Journal.persist/3` is unchanged; cancel paths continue
+  to call it.
+- D-080 / D-082 queue-drain ordering and `%QueueRestored{}` /
+  `%Cancelled{}` broadcast contracts (SPEC-USER-TURN §6) are
+  preserved — they are behavioural, not structural.
+- The external `%Tau.Session.Events.Cancelled{}` struct, its consumers,
+  and the journal `"cancellation"` entry's schema are unchanged.
+- `try/rescue` removal is explicitly out of scope.
+- `ProviderTurn.cancel_provider_task/1` keeps its current signature and
+  contract; the new `cancel_cluster/2` calls it internally.
+- `ToolDispatch.finish_permission_round/1` (the happy-path) is unchanged;
+  the `:permission`-scope `cancel_cluster/2` branch shares structure
+  with it but does not call it.
+- The sibling sub-problems (`fsm-facade-helpers`, `user-message-routing`,
+  `cross-cutting-data`) are not touched by this solution; this solution
+  does NOT depend on any of them landing first.
+
+## Migration sketch
+
+Land in three independently-mergeable PRs to keep blast radius bounded:
+
+1. **PR A — behaviour + cluster implementations + tests.** Add
+   `Tau.Session.Cancellable`, implement `cancel_cluster/2` on the four
+   cluster modules with new unit tests, and add `Data.reset_for_cancel/1`.
+   Nothing in `session.ex` changes; the new code is dead but tested. CI
+   green proves each cluster's teardown is correct in isolation.
+2. **PR B — wire `session.ex`.** Add `@cancel_clusters` and
+   `finish_cancel/2`; replace both `:cancel` clause bodies with the
+   ≤5-line fold. The existing cancellation integration tests
+   (`test/tau/session/cancellation_*` and the TUI cancel smoke) are the
+   regression baseline; they must remain green without modification.
+3. **PR C — delete dead code and inline helpers.** Remove any private
+   helpers in `session.ex` that the new clause bodies no longer call.
+
+If `PR B` reveals an ordering subtlety (e.g. provider kill must precede
+tool dispatcher kill, or vice versa), the fix is a one-line reorder of
+the `@cancel_clusters` list — the order is data, not code structure.
+
+## Open questions
+
+- Does the `:awaiting_permission` `:cancel` path tolerate running
+  `ProviderTurn.cancel_cluster/2` against a nil `provider_task`? The
+  existing `cancel_provider_task/1` already handles the nil case
+  (returns `:noop`), so the uniform fold across both scopes should be
+  safe — but PR A's unit test for `ProviderTurn.cancel_cluster/2` must
+  exercise the nil case explicitly.
+- Is the mechanism atom captured by the fold (last non-`:noop` wins)
+  semantically equivalent to the current cross-cutting clause's
+  recorded mechanism (which today comes only from
+  `cancel_provider_task/1`)? Provider is the only cluster that returns
+  a non-`:noop` mechanism, so "last non-`:noop`" reduces to "provider's
+  return" — but if a future cluster ever returns a meaningful
+  mechanism, the fold's tie-breaking rule must be revisited.
+- Should `finish_cancel/2` be a private helper in `session.ex`, or
+  promoted to `Tau.Session.Data` (or a new `Tau.Session.Cancel.Finish`
+  module) so the FSM owns zero teardown logic? Keeping it inline keeps
+  the PR small; the validator should rule on whether ≤10 inline lines
+  of journal+drain+reset in the FSM module satisfies the AC's "owning
+  sub-modules" clause.
+- `tool_loop_call_lookups` ownership: `ToolDispatch.cancel_cluster/2`
+  owns it for the `:permission` scope (existing inline code mutates it
+  there); does the `:cross_cutting` scope also need to clear it, or
+  does `Data.reset_for_cancel/1`? The current cross-cutting clause
+  resets it; the recommendation places it in `ToolDispatch` (which
+  owns the field) and runs the cluster fold for both scopes, so the
+  reset happens in either case.
+
+## Linked sub-problems / proposals
+
+- `proposals/proposal-1.md` — add `cancel_*` siblings on each cluster
+  module without a behaviour. Rejected: no compile-time enforcement,
+  leaves drain helper in `session.ex`.
+- `proposals/proposal-2.md` — extract both clause bodies into a new
+  `Tau.Session.Cancel` coordinator module. Rejected: concentrates
+  rather than distributes cluster knowledge; import-cycle risk with
+  `session.ex` helpers requires `fsm-facade-helpers` first.
+- `proposals/proposal-3.md` — `Cancellable` behaviour with single-arg
+  `cancel_cluster/1` + `Data.reset_for_cancel/1`. Chosen as the
+  spine.
+- `proposals/proposal-4.md` — `%Cancelling{}` internal event +
+  `handle_cancelling/2` dispatcher. Chosen for the signature
+  enrichment: `scope` argument and `{atom(), Data.t()}` return.
+
+## Revision history
+
+- (revision 0 — initial)

--- a/docs/problems-archive-v1-modules/tau-session/subproblems/cancellation-teardown/validation.md
+++ b/docs/problems-archive-v1-modules/tau-session/subproblems/cancellation-teardown/validation.md
@@ -1,0 +1,581 @@
+---
+template_version: 1
+template_name: validation
+parent_solution: solution.md
+parent_problem: problem.md
+toulmin_complete: true
+falsification_attempted: true
+falsification_outcome: partially_falsified — claim/3
+revision_triggered: none
+---
+
+# Validation: `Cancellable` behaviour with scope-aware callback returning mechanism
+
+## Overview
+
+The solution proposes a `Tau.Session.Cancellable` behaviour with one
+callback `cancel_cluster(scope, Data.t()) :: {atom(), Data.t()}`,
+implemented by four cluster sub-modules. Both `:cancel` clause bodies
+in `session.ex` are claimed to collapse to ≤5 lines via a compile-time
+`@cancel_clusters` fold and a `finish_cancel/2` private helper.
+
+This validation extracts seven distinct, checkable claims from the
+solution's Recommendation and What-changes sections. For each, the
+six Toulmin components are filled, then a falsification strategy is
+chosen from the catalog and executed. Strategies used: counter-example
+construction, edge-case enumeration, dependency check, and
+prior-art / mechanical line-count check.
+
+Outcome: six claims withstood; one (Claim 3 — the ≤5-line collapse of
+the cross-cutting clause) is **partially falsified**. The intent
+survives, but the literal ≤5-line target is tight against the existing
+`cascade_to_children/2` call site plus the mechanism-capturing fold,
+the `Cancelled` broadcast, the `finish_cancel/2` call, and the
+`{:next_state, ...}` return — five non-trivial statements with the
+mechanism rebind embedded. The Qualifier is narrowed to "≤5
+non-trivial expressions, excluding the `{:next_state, ...}` return
+tuple"; no revision triggered.
+
+## Toulmin per claim
+
+### Claim 1: A `Tau.Session.Cancellable` behaviour with a single callback `cancel_cluster(scope, Data.t()) :: {atom(), Data.t()}` is defined in a new `lib/tau/session/cancellable.ex`.
+
+- **Claim (C):** "Define a `Tau.Session.Cancellable` behaviour whose
+  sole callback — `cancel_cluster(scope, Data.t()) :: {mechanism ::
+  atom(), Data.t()}` — is implemented by each cluster sub-module."
+  (solution.md §Recommendation; §What changes bullet 1.)
+- **Grounds (G):** The Tau codebase uses single-callback behaviours
+  routinely — e.g. `Tau.Provider` defines `stream/3`, `context_window/1`
+  (TAU.md non-negotiable #2; `lib/tau/provider.ex`). All four cluster
+  modules already exist as plain modules
+  (`lib/tau/session/{provider_turn,tool_dispatch,compaction,coding_agent_turn}.ex`)
+  with no `@behaviour` declarations (`grep -n "@behaviour"` returns
+  none). Adding one `@behaviour Tau.Session.Cancellable` line is a
+  surface-level change at each call site; the new file is a 3-line
+  module with one `@callback` attribute. `Tau.Session.Data` is
+  already a struct (`lib/tau/session/data.ex:20` `@enforce_keys`,
+  line 41 `@type t :: %__MODULE__{...}`), so the callback's
+  `Data.t()` type is realisable today.
+- **Warrant (W):** OTP non-negotiable #2 (TAU.md): "Extensibility seams
+  MUST be behaviours. … Pattern match on atoms and structs." A new
+  extensibility seam — "what each cluster module does on cancel" — is
+  exactly the situation the non-negotiable mandates a behaviour for.
+- **Qualifier (Q):** Holds for the four cluster modules named in the
+  solution. The behaviour does not constrain non-cluster modules; the
+  `@cancel_clusters` list (Claim 5) is the runtime enumeration that
+  closes the registration gap behaviours alone leave open.
+- **Rebuttal (R):** The behaviour adds a thin layer (3-LOC module +
+  one `@behaviour` declaration per cluster). On the "rules of three"
+  some reviewers may push back on a single-callback behaviour as
+  ceremony, especially when only one site (the fold in `session.ex`)
+  invokes it. Counter: compile-time enforcement is the very point —
+  Proposal 4's `@handlers` list lacks it (P4's named weakness #1).
+- **Backing (B):** TAU.md OTP non-negotiable #2; `Tau.Provider`
+  precedent (`lib/tau/provider.ex` — multiple single-purpose callbacks
+  ship as behaviours today, e.g. `context_window/1`); proposal-3
+  rationale §"Compiler-enforced contract".
+
+#### Falsification attempt for claim 1
+
+- **Strategy:** Type-level + dependency check.
+- **Attempt:** (1) Confirm `Tau.Session.Data` is a struct (so
+  `Data.t()` is a realisable Dialyzer type, not merely `map()`).
+  Verified: `lib/tau/session/data.ex:20–41` defines `@enforce_keys`,
+  `defstruct` (line 138), and `@type t :: %__MODULE__{...}`.
+  (2) Confirm no existing `cancel_cluster/2` collision in any cluster
+  module: `grep -n "def cancel_cluster" lib/tau/session/*.ex` returns
+  empty. (3) Confirm the four cluster modules exist and have no prior
+  `@behaviour`: `grep -n "@behaviour"` returns no hits in any of the
+  four. (4) Confirm the cited helpers the cluster impls would call
+  exist: `ProviderTurn.cancel_provider_task/1`
+  (`lib/tau/session/provider_turn.ex:95–130`) and
+  `Tau.Session.append_message/2` (`lib/tau/session.ex:1345`, public).
+- **Outcome:** Withstood. The behaviour is type-realisable, the
+  callback name is collision-free, and every downstream helper the
+  cluster implementations would call already exists with the right
+  arity and visibility.
+- **Action:** None.
+
+### Claim 2: The two `:cancel` clause bodies' field-reset and emit-loop logic moves out of `session.ex` into the four cluster sub-modules (each owns the kills, demonitors, emit loops, and field resets for its own cluster).
+
+- **Claim (C):** "Each implementation owns the kills, demonitors, emit
+  loops, and field resets for its own cluster." (solution.md
+  §Recommendation, §What changes bullets 2–5.)
+- **Grounds (G):** The current code mixes ownership: the
+  `:awaiting_permission` clause (`session.ex:842–960`) mutates
+  `tool_loop_call_lookups` and `tools_in_flight` (ToolDispatch
+  fields), `permission_pending_results` /
+  `pending_permission_requests` / `permission_dispatch_batch`
+  (ToolDispatch fields), `provider_task` / `assembler` / `stream_ref` /
+  `provider_span_ref` (ProviderTurn fields), and cross-cutting
+  per-turn fields (`active_skill`, `tool_iterations`,
+  `tool_loop_state`, `provider_retry_state`, `steering_queue`) — 14
+  fields total. The cross-cutting clause (`session.ex:963–1083`)
+  resets a similar set plus `compaction_task` /
+  `compaction_monitor` and `coding_agent_*` — 16 fields. The proposed
+  reshuffle places: provider fields on `ProviderTurn` (P3 sketch L46–54);
+  tools/perms fields on `ToolDispatch` (P3 sketch L56–72);
+  compaction fields on `Compaction` (P3 sketch L74–85);
+  coding-agent fields on `CodingAgentTurn` (P3 sketch L87–96); and
+  the cross-cutting non-cluster fields on `Data.reset_for_cancel/1`
+  (P3 sketch L98–107, with `tool_loop_call_lookups` moved to
+  `ToolDispatch` per the solution's explicit clarification).
+- **Warrant (W):** Hickey's decomplecting heuristic: code that
+  *together* implies a hidden contract ("knowing all field owners of
+  all four clusters") should be split so each unit holds only the
+  contract it owns. The behaviour callback gives every cluster a
+  visible site to declare which fields it resets; the FSM no longer
+  needs to know any field.
+- **Qualifier (Q):** Holds insofar as every field of the existing
+  reset maps belongs unambiguously to one cluster or is cross-cutting
+  per-turn. The solution explicitly assigns the ambiguous
+  `tool_loop_call_lookups` to `ToolDispatch` (§What changes bullet 3
+  and §Open questions bullet 4). For unambiguous fields, the mapping
+  is straightforward; the qualifier excludes any future field whose
+  ownership is genuinely shared across two clusters (no such field
+  exists in the current Data struct, verified by inspection of
+  `lib/tau/session/data.ex:41–137`).
+- **Rebuttal (R):** A cluster module that *reads* a field belonging
+  to another cluster on cancel (e.g. ToolDispatch needs the session
+  `id` to broadcast `%ToolEnd{}`) still receives the whole `Data.t()`
+  — read access is preserved; only *write* ownership is moved. Should
+  any cluster need write access across the boundary (e.g. the perms
+  emit loop also needs to mutate `tools_in_flight`, which ToolDispatch
+  owns), that is no problem because the entire mutation lives in
+  ToolDispatch.
+- **Backing (B):** Hickey, "Simple Made Easy" (2011), the data-shape
+  axis of complecting; `tau-architecture` skill §"Behaviours";
+  Proposal 3 rationale paragraph 1.
+
+#### Falsification attempt for claim 2
+
+- **Strategy:** Counter-example construction — try to find a field in
+  the existing reset maps whose ownership is ambiguous or whose
+  owner-module the solution misnames.
+- **Attempt:** Enumerated every field reset by the two `:cancel`
+  clauses (`session.ex:934–952` and `session.ex:1037–1072`) and
+  matched each to its owner per the solution. Findings:
+    - `provider_task`, `cancel_flag`, `stream_ref`, `provider_span_ref`,
+      `assembler` → `ProviderTurn` ✓ (matches `Tau.Session.ProviderTurn`
+      module's existing responsibility for `cancel_provider_task/1`).
+    - `tools_in_flight`, `tool_dispatcher`, `command_task`,
+      `pending_permission_requests`, `permission_dispatch_batch`,
+      `permission_pending_results`, `tool_loop_call_lookups` →
+      `ToolDispatch` ✓ (matches `lib/tau/session/tool_dispatch.ex`
+      ownership of permission rounds and dispatcher lifecycle).
+    - `compaction_task`, `compaction_monitor` → `Compaction` ✓
+      (matches `lib/tau/session/compaction.ex:131,215–216,259–260`
+      which already manages these in success/error paths).
+    - `coding_agent_dispatcher`, `coding_agent_pending`,
+      `coding_agent_blocks` → `CodingAgentTurn` ✓.
+    - `active_skill`, `tool_iterations`, `tool_loop_state`,
+      `provider_retry_state`, `steering_queue` → `Data.reset_for_cancel/1`
+      ✓ (cross-cutting per-turn, no single cluster owner).
+  No ambiguous field surfaced. The `compaction_failures` exemption is
+  preserved by the solution (P3 sketch L84 comment, mirrored in
+  `session.ex:996–997` today).
+- **Outcome:** Withstood. Every field has an unambiguous owner under
+  the proposed mapping; the solution's special handling of
+  `tool_loop_call_lookups` and `compaction_failures` matches the
+  ground-truth.
+- **Action:** None.
+
+### Claim 3: After the change, both `:cancel` clause bodies in `session.ex` are ≤5 lines each.
+
+- **Claim (C):** "Both `:cancel` clause bodies collapse to ≤5 lines."
+  (solution.md §Recommendation; problem.md §Acceptance criterion:
+  "reduced to ≤5 lines each".)
+- **Grounds (G):** Proposal 3's sketch (L120–134) and Proposal 4's
+  sketch (L128–141) both show post-change bodies of 5 statements:
+  (`:awaiting_permission` body) `data = Enum.reduce(...)`,
+  `broadcast(...)`, `data = finish_cancel(...)`,
+  `{:next_state, ...}` — 4 statements. (Cross-cutting body)
+  `cascade_to_children(...)`, `{_mech, data} = Enum.reduce(...)` or
+  `data = Enum.reduce(...)` + a mechanism-extraction step,
+  `broadcast(...)`, `data = finish_cancel(...)`,
+  `{:next_state, ...}` — 5 statements.
+- **Warrant (W):** The acceptance criterion is a numerical bound. If
+  every distinct top-level statement counts as a "line", the proposal
+  sketches satisfy it; if a body must additionally contain inline
+  per-statement comments, blank separators, or multi-line function
+  arguments, the literal line count exceeds 5 even when the statement
+  count does not.
+- **Qualifier (Q):** Holds for "non-trivial statement" counting;
+  partially fails for "physical line including comments and
+  formatter-induced wrapping". The solution itself implicitly
+  acknowledges this in §Recommendation by phrasing "collapse to ≤5
+  lines" rather than "5 physical lines".
+- **Rebuttal (R):** The cross-cutting body must thread the mechanism
+  atom from the fold (Proposal 4 strength #2; absorbed into the
+  hybrid). Threading mechanism via `{mechanism, data} = Enum.reduce(...)`
+  is one statement. Adding a `Atom.to_string(mechanism)` call inside
+  `finish_cancel(data, …)` keeps the count at 5; if a reviewer
+  insists on a separate `reason = Atom.to_string(mechanism)` line,
+  the count becomes 6.
+- **Backing (B):** problem.md §Acceptance criterion (the bound is
+  ≤5 lines); proposal-3 sketch L120–134; proposal-4 sketch L128–141;
+  the `mix format` default does not force comment lines or split
+  args for these statement shapes (`lib/tau/session.ex:842–960`
+  itself shows multi-line `Enum.reduce/3` calls; with the
+  cluster-level encapsulation the fold becomes one line).
+
+#### Falsification attempt for claim 3
+
+- **Strategy:** Edge-case enumeration + counter-example construction.
+- **Attempt:** Hand-counted the statements in both sketched bodies
+  including the `cascade_to_children(data, :cancel)` invocation that
+  problem.md §Out of scope explicitly mandates stay in the
+  cross-cutting clause. Cross-cutting body becomes:
+  (1) `cascade_to_children(data, :cancel)`,
+  (2) `{mechanism, data} = Enum.reduce(@cancel_clusters, {:noop, data}, &elem(&1, :cancel_cluster, [scope, &2]))`,
+  (3) `broadcast(data.id, %Events.Cancelled{...})`,
+  (4) `data = finish_cancel(data, Atom.to_string(mechanism))`,
+  (5) `{:next_state, :awaiting_user, data, drain_followups_action(data)}`.
+  Five non-trivial statements; passes the ≤5 bound *only* if the
+  `{:next_state, ...}` return tuple counts as one line (which `mix
+  format` permits at 98-col line width — the tuple is short enough).
+  The `:awaiting_permission` body drops statement (1) and gains
+  nothing; it is 4 statements (well within bound).
+  Then attempted to break it: if a reviewer requires the mechanism
+  extraction to be split — `data = Enum.reduce(...); mechanism =
+  derive_mechanism(...)` — the count becomes 6. Also: the existing
+  body uses `followup_actions` (a name invented in the solution sketch
+  — verified that no `followup_actions/1` helper exists in
+  `session.ex` today by `grep -n "followup_actions"` returning empty).
+  The actual mechanism today is a 3-line `actions = if :queue.is_empty(...)`
+  block; the solution implicitly assumes this is also extracted to a
+  helper. If it is NOT extracted, the cross-cutting body grows to
+  7 statements and the AC literally fails.
+- **Outcome:** Partially falsified. The AC's ≤5 bound is met under
+  the implicit assumption that (a) the `if :queue.is_empty(...)`
+  follow-up-action block is extracted to a private helper (e.g.
+  `drain_followups_action/1`), and (b) the `{:next_state, ...}` tuple
+  counts as one statement. Neither assumption is structural — both
+  are stylistic — but the AC is sensitive to them.
+- **Action:** Narrow Qualifier in place: "≤5 non-trivial expressions
+  per body, excluding the `{:next_state, …}` return tuple, and
+  presuming the existing `actions = if :queue.is_empty(...)` block
+  is extracted to a one-line helper. The implementation MUST add
+  that helper (the solution's §What changes bullet for `session.ex`
+  is amended to include it)." This is a small editorial extension of
+  what the solution already does for `finish_cancel/2`; no proposal
+  re-run needed.
+
+### Claim 4: `Tau.Session.Data.reset_for_cancel/1` is a new function on `Data` that resets the cross-cutting per-turn fields no single cluster owns.
+
+- **Claim (C):** "Add `Data.reset_for_cancel/1` to `Tau.Session.Data`
+  for the cross-cutting per-turn fields no cluster owns."
+  (solution.md §Recommendation; §What changes bullet 6.)
+- **Grounds (G):** `Data` already hosts initialisation logic
+  (`Data.new/1`, per `data.ex:1–12` moduledoc) — a precedent for
+  shape-modifying helpers living on the data struct module. The
+  fields named — `active_skill`, `tool_iterations`, `tool_loop_state`,
+  `provider_retry_state`, `steering_queue` — are all present in the
+  `Data.t()` typespec (`data.ex:63,67,69,72,87` and equivalents) and
+  all reset inline in the existing cancel clauses
+  (`session.ex:945–951` and `session.ex:1051–1072`).
+- **Warrant (W):** Locality of reference — the function that resets
+  fields on `Data` belongs on `Data`. Same convention as
+  `Tau.Session.Data.new/1`; consistent with Clojure / Hickey's
+  guidance that data shape and shape-transforming functions co-locate.
+- **Qualifier (Q):** "Cross-cutting" means "no cluster owns it". The
+  solution removes `tool_loop_call_lookups` from this set (assigning
+  it to `ToolDispatch.cancel_cluster/2` per §What changes bullet 3
+  clarification and §Open questions bullet 4), making the
+  `reset_for_cancel/1` set strictly the 5 fields named above.
+- **Rebuttal (R):** If `active_skill` is ever moved to a cluster
+  module (e.g. if `Tau.Session.SkillActivation` ever exists as a
+  cluster), `reset_for_cancel/1` would need to shrink. No such cluster
+  exists today (`grep -rn "defmodule Tau.Session.SkillActivation"`
+  returns nothing structural). The Qualifier accepts that boundary
+  shifting is a follow-on PR, not a refutation.
+- **Backing (B):** `data.ex:7` ("`new/1` absorbs the
+  session-initialisation logic previously in `Tau.Session.init/1`") —
+  precedent for data-shape helpers on Data; proposal-3 §Strengths
+  bullet 4.
+
+#### Falsification attempt for claim 4
+
+- **Strategy:** Counter-example construction — does any named field
+  belong to a cluster that should reset it?
+- **Attempt:** Cross-checked each field:
+    - `active_skill` — set by `process_user_message/2` and by
+      `Tau.Session.SkillActivation` helpers, but not bound to a
+      cluster's process lifecycle; resetting at cancel is per-turn
+      hygiene, not cluster cleanup. ✓ Cross-cutting.
+    - `tool_iterations` — D-027 counter; lives on the FSM data, not
+      on a cluster. ✓ Cross-cutting.
+    - `tool_loop_state` — D-060 brake state; per-turn FSM hygiene.
+      ✓ Cross-cutting.
+    - `provider_retry_state` — D-061 counter; per-turn FSM hygiene
+      (it counts retries across the turn, not within a single
+      `ProviderTurn.cancel_provider_task/1` call). ✓ Cross-cutting.
+    - `steering_queue` — D-082; cleared only after the drain →
+      `%QueueRestored{}` broadcast (which `finish_cancel/2` runs).
+      ✓ Cross-cutting.
+  No counter-example surfaced. The named set is exactly the residual
+  after each cluster has been credited with its own fields.
+- **Outcome:** Withstood.
+- **Action:** None.
+
+### Claim 5: `session.ex` enumerates clusters in a compile-time `@cancel_clusters` list and folds over them with `scope` passed through.
+
+- **Claim (C):** "`session.ex` enumerates clusters in a compile-time
+  `@cancel_clusters` list, folds over them with `scope` passed
+  through, captures the surviving non-`:noop` mechanism for the
+  journal, broadcasts `%Cancelled{}`, and calls a private
+  `finish_cancel/2` helper." (solution.md §Recommendation.)
+- **Grounds (G):** A module attribute `@cancel_clusters [Mod1, Mod2,
+  ...]` is standard Elixir; the four cluster modules are stable
+  imports (each is `aliased` or fully qualified throughout
+  `session.ex`, e.g. `Tau.Session.ProviderTurn.cancel_provider_task/1`
+  at `session.ex:978`). `Enum.reduce/3` over the list, invoking
+  `module.cancel_cluster(scope, data)` via apply or via
+  `module.cancel_cluster(scope, acc)`, is type-clean given the
+  behaviour signature in Claim 1.
+- **Warrant (W):** OTP non-negotiable #2 again: pattern match on
+  atoms and structs. The fold is the standard idiom for "apply a
+  uniform operation across a finite known set of modules"; the
+  compile-time list keeps the registration explicit and visible
+  in one place. Combined with `@behaviour Tau.Session.Cancellable`,
+  any module added to the list that doesn't implement the callback
+  is a compile error, and any module that implements it but is not
+  in the list is dead code (caught by `mix xref` / Credo).
+- **Qualifier (Q):** Holds for the four clusters named. The list
+  ordering is data (not code structure) — solution.md §Migration
+  sketch explicitly calls this out. Ordering matters only for the
+  cross-cutting scope (provider stream kill is typically advised to
+  precede tool dispatcher kill so the stream-error landing pad is
+  the right one); the list-order choice
+  `[ProviderTurn, ToolDispatch, Compaction, CodingAgentTurn]`
+  matches the current source-order of operations in
+  `session.ex:978–1010`.
+- **Rebuttal (R):** If a future cluster has a sequencing constraint
+  with an existing cluster (e.g. "Compaction must run before
+  ToolDispatch"), the list must be reordered. The solution accepts
+  this — the fix is a one-line reorder, not a code-structure change.
+- **Backing (B):** TAU.md OTP non-negotiable #2; proposal-3 §Strengths
+  bullet 3; proposal-3 §Sketch L113–125.
+
+#### Falsification attempt for claim 5
+
+- **Strategy:** Dependency check + edge-case enumeration on the fold's
+  invariants.
+- **Attempt:** (1) Confirm the four modules are import-cycle-safe
+  with `session.ex`: each is currently called by `session.ex`
+  (`grep -n "Tau.Session.ProviderTurn\|Tau.Session.ToolDispatch\|Tau.Session.Compaction\|Tau.Session.CodingAgentTurn" lib/tau/session.ex` returns
+  multiple sites), so adding `cancel_cluster/2` calls introduces no
+  new cycle. (2) Confirm `Enum.reduce/3` over `{atom(), Data.t()}`
+  accumulator type-checks: each `cancel_cluster/2` returns
+  `{atom(), Data.t()}` (Claim 1 callback signature), so the reduce's
+  return is the same shape and threadable through the fold.
+  (3) Check "surviving non-`:noop` mechanism" semantics: the solution
+  §Open questions bullet 2 explicitly notes that today only
+  `ProviderTurn` returns a meaningful mechanism, so "last non-`:noop`
+  wins" reduces to "ProviderTurn's return". Verified by inspection of
+  `ProviderTurn.cancel_provider_task/1` (`provider_turn.ex:95–130`)
+  which returns one of `:noop | :cooperative | :brutal_kill`.
+  (4) Edge case: what if `ProviderTurn` returns `:noop` (no provider
+  task active, e.g. in `:awaiting_user` with cancel)? The current
+  cross-cutting clause records `Atom.to_string(cancel_mechanism)` in
+  the journal — `"noop"` is the journal value today
+  (`session.ex:1020`). The post-change behaviour records the same.
+- **Outcome:** Withstood. The fold is type-clean, cycle-free, and
+  preserves the journal semantics.
+- **Action:** None.
+
+### Claim 6: D-080, D-082 queue-drain contracts and `%QueueRestored{}` / `%Cancelled{}` broadcasts are preserved unchanged.
+
+- **Claim (C):** "D-080 / D-082 queue-drain ordering and
+  `%QueueRestored{}` / `%Cancelled{}` broadcast contracts (SPEC-USER-TURN
+  §6) are preserved — they are behavioural, not structural."
+  (solution.md §What does not change bullet 3.)
+- **Grounds (G):** D-080 (SPEC-USER-TURN.md:532) requires
+  `:drain_followups` action on every `{:next_state, :awaiting_user, ...}`
+  when `followup_queue` is non-empty; both sketched bodies preserve
+  this via the `drain_followups_action(data)` (Claim 3's narrowed
+  helper). D-082 (SPEC-USER-TURN.md:534) requires (1) convert
+  `steering_queue` to list, (2) broadcast `%QueueRestored{}` if
+  non-empty, (3) clear `steering_queue`, (4) preserve `followup_queue`.
+  `finish_cancel/2` in the solution explicitly runs the queue drain
+  → broadcast, then `Data.reset_for_cancel/1` clears `steering_queue`;
+  `followup_queue` is in neither cluster reset nor
+  `reset_for_cancel/1`'s field set, so it is preserved.
+  `%Cancelled{}` is broadcast at the same call-site (top of the
+  statement sequence, between fold and `finish_cancel/2`) — identical
+  to today.
+- **Warrant (W):** SPEC-USER-TURN §6 invariants D-080 / D-082 are
+  enforcement contracts; satisfied iff the operations happen in the
+  required order. Re-locating *who* runs each operation does not
+  change *whether* it runs in order, provided every operation moves
+  to a single named caller that preserves the source-order.
+- **Qualifier (Q):** Holds provided `finish_cancel/2` runs `Journal.persist`
+  → steering drain + broadcast → `reset_for_cancel/1` in that order
+  (matching `session.ex:914–952` today). The solution's sketched
+  `finish_cancel/2` (proposal-3 sketch L137–145) does precisely this.
+  Rebuttal: if a future refactor inlines `Data.reset_for_cancel/1`
+  before the drain, D-082 would fail; this is an implementation
+  discipline concern, not a design one.
+- **Rebuttal (R):** The D-082 test (`test/tau/session/message_queue_tiers_test.exs`,
+  cited in SPEC-USER-TURN.md:534) is the regression baseline. The
+  solution's PR B migration explicitly requires existing cancellation
+  integration tests to remain green without modification.
+- **Backing (B):** SPEC-USER-TURN §6 (D-080, D-082);
+  `test/tau/session/cancel_cooperative_test.exs` (existing regression
+  baseline); solution.md §Migration sketch PR B.
+
+#### Falsification attempt for claim 6
+
+- **Strategy:** Integration check — does an existing test exist that
+  would fail if D-080 / D-082 were broken by this refactor?
+- **Attempt:** Verified `test/tau/session/cancel_cooperative_test.exs`
+  exists (`ls test/tau/session/` confirms). Verified
+  `test/tau/session/message_queue_tiers_test.exs` exists and per
+  SPEC-USER-TURN.md:534 contains D-082 cancel-with-steering and
+  cancel-without-steering tests. The PR B migration runs these as
+  the regression baseline. If `finish_cancel/2` reorders the
+  drain-then-clear sequence, the D-082 test
+  ("QueueRestored received, steering cleared, followup preserved")
+  will fail. If `drain_followups_action/1` omits the
+  `:queue.is_empty(followup_queue)` guard, D-080 tests will fail.
+- **Outcome:** Withstood. The mechanical regression coverage is in
+  place; any drift will surface on PR B's test run.
+- **Action:** None.
+
+### Claim 7: The hybrid solution does not depend on the sibling sub-problems (`fsm-facade-helpers`, `user-message-routing`, `cross-cutting-data`) landing first.
+
+- **Claim (C):** "The sibling sub-problems (`fsm-facade-helpers`,
+  `user-message-routing`, `cross-cutting-data`) are not touched by
+  this solution; this solution does NOT depend on any of them landing
+  first." (solution.md §What does not change last bullet.)
+- **Grounds (G):** The proposed change touches only: (1) one new file
+  `lib/tau/session/cancellable.ex`; (2) the four cluster modules in
+  `lib/tau/session/`; (3) `lib/tau/session/data.ex` for
+  `reset_for_cancel/1`; (4) `lib/tau/session.ex` cancel clauses and a
+  new `@cancel_clusters` attribute. No FSM facade refactor is
+  required; the cluster modules continue to be called from
+  `session.ex` directly (the import patterns and call shapes are
+  preserved). No user-message-routing change is implied. The
+  `cross-cutting-data` problem is about the `Data` struct shape itself,
+  which the solution explicitly leverages but does not modify (it adds
+  a function but does not reshape fields).
+- **Warrant (W):** A solution is independent of a sibling iff its
+  change-set is disjoint from the sibling's. Verified by listing each
+  touched file/module and confirming none of the four cluster
+  modules' import structure changes shape.
+- **Qualifier (Q):** Holds for the change-set named in §What changes.
+  Holds independently of whether `cross-cutting-data` ever lands —
+  `Data` is already a struct, so `Data.t()` is a realisable type
+  today (`lib/tau/session/data.ex:41` `@type t`).
+- **Rebuttal (R):** Proposal 3 itself notes (§Dependencies): "benefits
+  from, but does not strictly require, the `cross-cutting-data`
+  sub-problem landing first." The solution narrows this to "does
+  not require" by leveraging the already-realised `Data.t()` type.
+- **Backing (B):** `lib/tau/session/data.ex:41` (`Data.t()` already
+  exists); proposal-3 §Dependencies; proposal-2 §Dependencies
+  (proposal 2 *does* depend on `fsm-facade-helpers` — that is one of
+  the reasons the hybrid rejected proposal 2).
+
+#### Falsification attempt for claim 7
+
+- **Strategy:** Counter-example construction — find one file the
+  solution must touch that is also a dependency of a sibling
+  sub-problem.
+- **Attempt:** Enumerated the solution's change-set: `cancellable.ex`
+  (new), 4 cluster modules (add `@behaviour` + `cancel_cluster/2`),
+  `data.ex` (add `reset_for_cancel/1`), `session.ex` (replace two
+  clause bodies + add `@cancel_clusters` and `finish_cancel/2` +
+  `drain_followups_action/1`). Cross-referenced each against the
+  sibling sub-problems' touched-file lists (per their `problem.md`
+  cross-cutting-data, user-message-routing, fsm-facade-helpers):
+  none of the cluster modules, none of `cancellable.ex` (new),
+  and `data.ex` only at the additive `reset_for_cancel/1` site.
+  `session.ex` is touched by every sub-problem of this tree
+  (they are all leaves of `tau-session`), so concurrent landings
+  would conflict — but the solution's claim is about *blocking*
+  dependencies, not about *concurrent* edits to `session.ex`.
+  No file is a blocking precondition.
+- **Outcome:** Withstood.
+- **Action:** None — though the parent-level (tau-session) selector
+  should track that all four leaves edit `session.ex` and serialize
+  their merges (or accept rebase cost). The solution flags PR
+  sequencing in §Migration sketch.
+
+## Cross-claim consistency
+
+The seven claims are mutually consistent:
+
+- Claims 1, 2, 5 cohere: the behaviour (Claim 1) is the mechanism by
+  which the field-reset ownership moves (Claim 2); the
+  `@cancel_clusters` fold (Claim 5) is the FSM-side consumer of the
+  behaviour.
+- Claim 4 (`Data.reset_for_cancel/1`) and Claim 2 (cluster
+  ownership) are non-overlapping by construction: the solution
+  explicitly partitions fields into "owned by a cluster" (Claim 2)
+  and "cross-cutting" (Claim 4); the falsification under Claim 2
+  verified the partition is complete and disjoint.
+- Claim 3 (≤5-line bodies) and Claim 6 (D-080 / D-082 preserved)
+  are in mild tension: the line-budget pressure on the
+  cross-cutting body (Claim 3) is part of why the
+  `drain_followups_action/1` helper extraction (Claim 3's narrowed
+  qualifier) is needed. The helper extraction is what lets the
+  D-080 action stay correct (Claim 6) without inflating the body to
+  7 statements. Both claims are satisfied by the same editorial
+  decision; no tension remains.
+- Claim 7 (no sibling dependency) is consistent with Claims 1–6;
+  it does not constrain them.
+
+## Falsification summary
+
+| # | Claim (short) | Strategy | Outcome | Action |
+|---|---|---|---|---|
+| 1 | `Cancellable` behaviour exists with `cancel_cluster/2` | Type-level + dependency check | Withstood | None |
+| 2 | Cluster modules own their kills + field resets | Counter-example construction (enumerated fields) | Withstood | None |
+| 3 | Both `:cancel` clause bodies ≤5 lines | Edge-case enumeration + counter-example | Partially falsified | Narrow Qualifier: "≤5 non-trivial expressions excluding the `{:next_state, …}` tuple, presuming `drain_followups_action/1` helper extraction" |
+| 4 | `Data.reset_for_cancel/1` covers cross-cutting per-turn fields | Counter-example construction | Withstood | None |
+| 5 | `@cancel_clusters` fold in `session.ex` | Dependency + edge-case check | Withstood | None |
+| 6 | D-080, D-082 contracts preserved | Integration check (existing regression tests) | Withstood | None |
+| 7 | No blocking dependency on sibling sub-problems | Counter-example construction (file-set disjointness) | Withstood | None |
+
+## Revision required
+
+No full revision triggered. One narrowing in place:
+
+- **Target file:** solution.md (Qualifier on Claim 3 only)
+- **Revision kind:** narrow Qualifier in place — the proposer / selector
+  should record that the `drain_followups_action/1` helper extraction
+  is implicit in the ≤5-line target. This is editorial; it does not
+  change the structural design.
+- **Rationale:** The solution sketch's `followup_actions(data)` is an
+  invented helper name not present in `session.ex` today (verified by
+  `grep`). The existing `if :queue.is_empty(next_data.followup_queue)`
+  block (3 statements at `session.ex:955–958` and `session.ex:1079–1081`)
+  must be extracted to satisfy the ≤5-line AC literally. That helper
+  extraction is a one-line addition to §What changes, not a re-run.
+
+## Outstanding doubts
+
+- The ADR-0017 mechanism atom is captured as "last non-`:noop` wins" in
+  the fold; this happens to equal "ProviderTurn's return" today
+  because no other cluster returns a meaningful mechanism. If a
+  future cluster starts returning `:cooperative | :brutal_kill`
+  semantically, the fold's tie-breaking rule must be revisited
+  (solution.md §Open questions bullet 2 already notes this; the
+  parent-level validator should inherit this as a Qualifier on the
+  parent-level claim about "ADR-0017 mechanism preserved").
+- The solution does not specify whether `finish_cancel/2` lives in
+  `session.ex` (as a private helper, ≤10 lines inline) or is promoted
+  to a separate module. solution.md §Open questions bullet 3 defers
+  this to the validator; the AC's "owning sub-modules" clause is
+  permissive enough to allow either, but the parent-level validator
+  may want to lock this down.
+- The fold ordering is `[ProviderTurn, ToolDispatch, Compaction,
+  CodingAgentTurn]`. The current `session.ex:978–1010` ordering is
+  Provider → ToolDispatcher → CommandTask → Compaction → CodingAgent.
+  The solution's ordering moves Compaction before CodingAgent (no
+  behavioural change since neither is order-sensitive against the
+  other) but `command_task` is now within `ToolDispatch.cancel_cluster/2`.
+  Acceptable, but the migration PR B must verify no test asserts the
+  exact `command_task` kill timing (no such assertion found in
+  `test/tau/session/cancel_cooperative_test.exs` by name; PR B's test
+  run is the regression baseline).

--- a/docs/problems-archive-v1-modules/tau-session/subproblems/cross-cutting-data/problem.md
+++ b/docs/problems-archive-v1-modules/tau-session/subproblems/cross-cutting-data/problem.md
@@ -1,0 +1,84 @@
+---
+template_version: 1
+template_name: problem
+node_kind: leaf
+depth: 1
+parent: ../../problem.md
+status: draft
+---
+
+# Problem: FSM data is an anonymous map rather than a typed defstruct
+
+## Statement
+
+The per-session FSM `data` value is an untyped `map()` with approximately
+45 fields; `Tau.Session.Data.new/1` returns `{:ok, map()}` and the struct
+shape is enforced only by runtime pattern matches in `handle_event/4`
+guards. Sub-modules that access data fields do so with bare map-key access
+(`data.field`) or defensive `Map.get(data, :field, default)` reads;
+Dialyzer cannot verify field existence or type, and adding or renaming a
+field requires a grep-and-replace across all ten sub-modules.
+
+## Context
+
+- `lib/tau/session/data.ex` (369 LOC): `Data.new/1` builds and returns a
+  plain map; there is no `defstruct` or `@type t :: %Tau.Session.Data{}`.
+- `session.ex` cancel clauses (lines 963–1083, 1145–1185): reset maps name
+  all ~16 fields explicitly — `%{data | provider_task: nil, cancel_flag: nil,
+  stream_ref: nil, ...}` — as the only runtime documentation of the data
+  shape.
+- `lib/tau/session/tool_dispatch.ex`, `provider_turn.ex`, `coding_agent_turn.ex`:
+  all access data fields via bare `data.field`; some have defensive
+  `Map.get(data, :tools_in_flight, %{})` reads against a shape that
+  `Data.new/1` fully populates.
+- `lib/tau/session/compaction.ex` and `queue.ex`: contain no defensive reads;
+  those sub-modules were extracted after the data-shape was stabilised, but
+  the struct was never formalised.
+- The flat audit (`02-provider-session.md`) flags: "Pulling this into
+  `defstruct` would (a) give Dialyzer something to check, (b) localise the
+  field-initialisation table that init/1 currently sprawls over 270 lines,
+  (c) eliminate defensive reads."
+- `Tau.Session.Meta` (lines 54–113 of `session.ex`) is an existing `defstruct`
+  for session metadata returned to callers; the internal FSM data has no
+  equivalent.
+
+## Complecting hypothesis
+
+The data field contract is complected with the FSM module because the only
+authoritative list of fields is the flat map literal in `Data.new/1` — there
+is no type declaration that Dialyzer, documentation generators, or
+pattern-match exhaustiveness checks can use; every sub-module must implicitly
+know the shape via convention.
+
+The defensive `Map.get(data, :field, default)` calls are complected with
+sub-module logic because they exist to guard against a data-shape that is not
+statically enforced — once the struct is typed, the defensive reads become
+unnecessary noise that obscures real logic.
+
+## Decomposition strategy
+
+(leaf — no further decomposition; proceed to proposals)
+
+## Acceptance criterion
+
+`Tau.Session.Data` exports a `defstruct` with `@enforce_keys` for every
+required field and an `@type t :: %__MODULE__{}` spec; `Data.new/1` returns
+`{:ok, %Tau.Session.Data{}}` (not `{:ok, map()}`); all sub-modules
+pattern-match on `%Tau.Session.Data{}` in their function heads; and no
+`Map.get(data, :field, default)` defensive reads remain in any sub-module for
+fields the struct guarantees.
+
+## Out of scope
+
+- The semantic meaning or default values of any field — those are
+  behavioural decisions already made.
+- Adding, removing, or renaming fields — the struct should capture the
+  current shape without change.
+- `Tau.Session.Meta` (already a struct; no work needed).
+- `@type` specs for individual field values — desirable but a separate effort.
+- Sibling sub-problems: cancellation-teardown, fsm-facade-helpers,
+  user-message-routing.
+
+## Amendment log
+
+- (none yet)

--- a/docs/problems-archive-v1-modules/tau-session/subproblems/cross-cutting-data/proposals/proposal-1.md
+++ b/docs/problems-archive-v1-modules/tau-session/subproblems/cross-cutting-data/proposals/proposal-1.md
@@ -1,0 +1,136 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 1
+parent_problem: ../problem.md
+---
+
+# Proposal 1: Remove remaining defensive reads; keep existing struct as-is
+
+## Approach
+
+`Tau.Session.Data` already exports a `defstruct`, `@enforce_keys`, and
+`@type t :: %__MODULE__{}`, and `Data.new/1` already returns `{:ok,
+%Tau.Session.Data{}}`. The acceptance criterion is therefore mostly satisfied by
+the existing code. This proposal closes the remaining gaps with minimal
+surgical edits:
+
+1. Replace `Map.get(data, :persona_lifetime, :turn)` in
+   `provider_turn.ex:337` with `data.persona_lifetime` — the struct
+   guarantees the field is always present.
+2. Replace the dynamic-key `Map.get(data, queue_field)` and
+   `Map.put(data, queue_field, new_queue)` in `queue.ex:enqueue/4` with
+   explicit `case` branches that destructure and reconstruct
+   `%Tau.Session.Data{}` by name.
+3. Replace `Map.put(data, key, value)` in `provider_turn.ex:maybe_replace/3`
+   with `struct!(data, [{key, value}])` — preserves the dynamic-key idiom
+   while asserting the key exists in the struct (raises `KeyError` on unknown
+   fields, giving Dialyzer a tighter type).
+4. Add `%Tau.Session.Data{}` struct-match guards to the two public function
+   heads in `queue.ex` and to `provider_turn.ex:179` that currently receive
+   bare `data` with no type annotation at the pattern level.
+
+No module is added or removed; no field is renamed.
+
+## Rationale
+
+The problem statement's complecting hypothesis has already been partially
+resolved: the struct, enforce_keys, and type spec exist. The remaining gaps
+are three callsites where sub-modules treat the struct as a plain map. This
+proposal addresses exactly those three callsites without any structural
+reorganisation. The defensive `Map.get(data, :persona_lifetime, :turn)` is
+dead-code noise — the struct default is `:turn` and `@enforce_keys` does not
+include it, so nil cannot appear. Removing the default signals that the
+contract is now statically enforced. The queue dynamic-key pattern is the
+only legitimate holdout: it dispatches on a runtime-selected field, which is
+not naturally expressible with dot-access; replacing it with explicit branches
+makes the field access visible to Dialyzer and eliminates silent fallback to
+`nil`.
+
+## Sketch
+
+```elixir
+# queue.ex — replace Map.get/Map.put dispatch with explicit branches
+def enqueue(%Tau.Session.Data{} = data, msg, tier, from_state) do
+  {queue, tier_atom} =
+    case tier do
+      :steering -> {data.steering_queue, :steering}
+      _         -> {data.followup_queue, :followup}
+    end
+
+  if :queue.len(queue) >= @queue_cap do
+    # ... existing cap branch unchanged ...
+    {:keep_state_and_data, []}
+  else
+    new_queue = :queue.in(msg, queue)
+    new_data =
+      case tier do
+        :steering -> %{data | steering_queue: new_queue}
+        _         -> %{data | followup_queue: new_queue}
+      end
+    {:keep_state, new_data}
+  end
+end
+
+# provider_turn.ex:337 — remove defensive default
+if msg.stop_reason == :end_turn and data.persona_lifetime == :turn do
+
+# provider_turn.ex:179 — use struct!/2 for dynamic-key update
+def maybe_replace(data, _key, nil), do: data
+def maybe_replace(%Tau.Session.Data{} = data, key, value),
+  do: struct!(data, [{key, value}])
+```
+
+File touches: `lib/tau/session/queue.ex`, `lib/tau/session/provider_turn.ex`.
+
+## Tradeoffs
+
+### Strengths
+
+- Minimal diff: two files, ~10 changed lines; reviewable in one pass.
+- No new modules, no API changes, no test rewrites.
+- Eliminates the only remaining `Map.get(data, :field, default)` defensive
+  read that the struct now makes superfluous (`persona_lifetime`).
+- `struct!/2` in `maybe_replace/3` raises on unknown field names, converting
+  a silent runtime bug into a fast-fail crash — aligns with "let it crash".
+- Fully satisfies the acceptance criterion as written.
+
+### Weaknesses
+
+- Does not address `coding_agent_turn.ex:112` / `coding_agent_turn.ex:504`
+  (`Map.get(data.coding_agent_state, :session_id)`), which are reads into
+  the nested `coding_agent_state` map, not into the `Data` struct itself.
+  The problem statement's acceptance criterion is silent on nested maps, but
+  a reader doing a grep for `Map.get(data` will still find them.
+- `maybe_replace/3` with `struct!/2` still uses runtime key dispatch; Dialyzer
+  cannot verify that `key` names an existing field. The type spec remains
+  `atom()` for `key`, which is weaker than a union of field-name literals.
+- The `case tier` duplication in `enqueue/4` (once for the read, once for
+  the write) is mild redundancy introduced by eliminating the dynamic key.
+
+### Costs
+
+- Estimated diff: ~15 lines changed across two files.
+- No migration cost: the public API of neither module changes.
+- Test surface: no test changes required; the struct has been in place since
+  a prior PR; these edits only tighten existing callsites.
+
+## Dependencies
+
+- `Tau.Session.Data` must export `defstruct` and `@type t` (already done).
+- No other changes required first.
+
+## Confidence
+
+High. The changes are mechanical and local; the struct already exists; the
+three callsites are straightforwardly identified. Prior art: the
+`compaction.ex` and `model_swap.ex` sub-modules already use `data.field`
+notation exclusively with no `Map.get` reads, confirming the pattern is
+already established in the project.
+
+## Prior art / references
+
+- `lib/tau/session/compaction.ex` — uses `data.field` exclusively; exemplar.
+- `lib/tau/session/model_swap.ex` — uses `data.field` and struct-update
+  syntax exclusively; exemplar.
+- Elixir docs: `Kernel.struct!/2` — raises on unknown key.

--- a/docs/problems-archive-v1-modules/tau-session/subproblems/cross-cutting-data/proposals/proposal-2.md
+++ b/docs/problems-archive-v1-modules/tau-session/subproblems/cross-cutting-data/proposals/proposal-2.md
@@ -1,0 +1,146 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 2
+parent_problem: ../problem.md
+---
+
+# Proposal 2: Introduce typed accessor functions in Data to replace dynamic-key access
+
+## Approach
+
+Keep the existing `defstruct` unchanged. Extract all dynamic-map-key access
+patterns that reference `Tau.Session.Data` fields into typed accessor and
+updater functions on `Tau.Session.Data` itself, so that no sub-module ever
+calls `Map.get/3` or `Map.put/3` on the `data` struct. Concretely:
+
+1. Add `Data.get_queue/2 :: (t(), :steering | :followup) -> :queue.queue()` and
+   `Data.put_queue/3 :: (t(), :steering | :followup, :queue.queue()) -> t()` to
+   `data.ex`, replacing the dynamic dispatch currently in `queue.ex:enqueue/4`.
+2. Add `Data.replace_field/3 :: (t(), atom(), term()) -> t()` that wraps
+   `struct!(data, [{key, value}])`, replacing `provider_turn.ex:maybe_replace/3`.
+3. Replace `Map.get(data, :persona_lifetime, :turn)` in `provider_turn.ex:337`
+   with `data.persona_lifetime` (identical to Proposal 1 for this one callsite).
+4. Update callers in `queue.ex` and `provider_turn.ex` to call the new
+   `Data.*` functions.
+
+The dynamic-key dispatch is not eliminated — it is moved into `Data` where it
+is co-located with the struct definition and can be documented and typed.
+
+## Rationale
+
+The complecting hypothesis identifies the field contract as complected with
+each sub-module. By moving dynamic field access into `Data`, the struct becomes
+the single owner of its own field-access contract: sub-modules deal only in
+named, typed functions, not in runtime atom keys. This is the "localise the
+contract to its owner" decomplecting move. `queue.ex` currently knows that
+`data` has two queue fields with specific names — that knowledge belongs in
+`Data`. `provider_turn.ex:maybe_replace/3` knows the struct accepts dynamic
+key updates — that should be a `Data`-level decision. Co-locating accessor
+logic in `Data` also makes it possible to annotate each accessor's return type
+precisely, giving Dialyzer its best chance at coverage.
+
+## Sketch
+
+```elixir
+# lib/tau/session/data.ex — new accessors
+
+@doc "Return the queue for `tier` (:steering or :followup)."
+@spec get_queue(t(), :steering | :followup) :: :queue.queue()
+def get_queue(%__MODULE__{steering_queue: q}, :steering), do: q
+def get_queue(%__MODULE__{followup_queue: q}, _),          do: q
+
+@doc "Replace the queue for `tier` with `new_queue`."
+@spec put_queue(t(), :steering | :followup, :queue.queue()) :: t()
+def put_queue(%__MODULE__{} = data, :steering, q), do: %{data | steering_queue: q}
+def put_queue(%__MODULE__{} = data, _,          q), do: %{data | followup_queue: q}
+
+@doc """
+Replace field `key` with `value`. Raises `KeyError` on unknown key.
+Intended for use only by sub-modules with a runtime-determined key;
+prefer dot-access where the key is statically known.
+"""
+@spec replace_field(t(), atom(), term()) :: t()
+def replace_field(%__MODULE__{} = data, key, value), do: struct!(data, [{key, value}])
+```
+
+```elixir
+# lib/tau/session/queue.ex — updated enqueue/4 (no Map.get/Map.put)
+def enqueue(%Tau.Session.Data{} = data, msg, tier, from_state) do
+  queue = Tau.Session.Data.get_queue(data, tier)
+  queue_size = :queue.len(queue)
+
+  if queue_size >= @queue_cap do
+    # ... cap branch unchanged ...
+  else
+    new_data = Tau.Session.Data.put_queue(data, tier, :queue.in(msg, queue))
+    {:keep_state, new_data}
+  end
+end
+```
+
+```elixir
+# lib/tau/session/provider_turn.ex — updated maybe_replace/3
+@spec maybe_replace(Tau.Session.Data.t(), atom(), term()) :: Tau.Session.Data.t()
+def maybe_replace(data, _key, nil), do: data
+def maybe_replace(data, key, value), do: Tau.Session.Data.replace_field(data, key, value)
+```
+
+File touches: `lib/tau/session/data.ex` (additions), `lib/tau/session/queue.ex`
+(~5 line change), `lib/tau/session/provider_turn.ex` (~2 line change).
+
+## Tradeoffs
+
+### Strengths
+
+- Field-access contract is fully owned by `Data`; no sub-module needs to know
+  the runtime field name of either queue.
+- `get_queue/2` and `put_queue/3` are fully typed with pattern-matched clauses;
+  Dialyzer can verify they return `:queue.queue()` and `t()` respectively.
+- `replace_field/3` is the single, documented, runtime-dispatch escape hatch;
+  its use is easy to audit with a single grep.
+- Minimal churn — total diff is ~25 lines across three files.
+- Accessor test coverage can be added to `data_test.exs` without touching the
+  FSM integration tests.
+
+### Weaknesses
+
+- `replace_field/3` still uses `struct!/2` with a runtime key; Dialyzer cannot
+  verify that `key` is a valid struct field name from the call-site in
+  `provider_turn.ex`. The benefit is that the weakness is now contained inside
+  `Data`, not scattered across sub-modules.
+- Adds public API surface to `Data` (three functions). If the field names change,
+  the accessors must be updated alongside — two places instead of one. This is
+  the expected tradeoff for indirection, but it is a real cost.
+- `maybe_replace/3` in `provider_turn.ex` becomes a thin one-liner delegating
+  to `Data.replace_field/3`; it could be inlined, but that would scatter the
+  dynamic-dispatch call back into `provider_turn.ex`.
+
+### Costs
+
+- ~25 lines added/changed across three files.
+- New public functions on `Data` expand the module's surface — minimal but
+  non-zero documentation burden.
+- No migration cost for callers: both changed functions (`enqueue/4`,
+  `maybe_replace/3`) have stable signatures; only their internals change.
+
+## Dependencies
+
+- `Tau.Session.Data` struct already in place (no prerequisite).
+- No other modules or PRs required before this.
+
+## Confidence
+
+High. The accessor pattern is a standard Elixir idiom for struct field
+encapsulation. The typed pattern-matched clauses in `get_queue/2` and
+`put_queue/3` are straightforward to implement and verify. `struct!/2` is
+well-established for the escape hatch.
+
+## Prior art / references
+
+- Elixir `Kernel.struct!/2` documentation.
+- `Tau.Session.Meta` in `session.ex` — already a typed struct with no external
+  map-key access; the same encapsulation principle applied here.
+- `lib/tau/session/model_swap.ex:maybe_replace/3` — the naming and purpose are
+  identical to `provider_turn.ex:maybe_replace/3`; they could be unified, but
+  that is a separate concern.

--- a/docs/problems-archive-v1-modules/tau-session/subproblems/cross-cutting-data/proposals/proposal-3.md
+++ b/docs/problems-archive-v1-modules/tau-session/subproblems/cross-cutting-data/proposals/proposal-3.md
@@ -1,0 +1,171 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 3
+parent_problem: ../problem.md
+---
+
+# Proposal 3: Split Data into typed sub-structs by concern cluster
+
+## Approach
+
+Replace the single flat 69-field `Tau.Session.Data` struct with a nested
+struct whose top-level fields are typed sub-structs, one per concern cluster.
+`Data.new/1` returns `{:ok, %Tau.Session.Data{}}` as today, but the struct
+now composes:
+
+- `%Data.ProviderState{}` — `provider_task`, `stream_ref`, `provider_span_ref`,
+  `cancel_flag`, `assembler`, `fallback_chain_remaining`, `provider_retry_state`,
+  `provider_retry_max`, `provider_retry_base_delay_ms`
+- `%Data.ToolState{}` — `tools_in_flight`, `tool_dispatcher`, `tool_iterations`,
+  `max_tool_iterations`, `tool_loop_state`, `tool_loop_brake_threshold`,
+  `tool_loop_call_lookups`
+- `%Data.CodingAgentState{}` — all `coding_agent_*` fields (9 fields)
+- `%Data.CompactionState{}` — `compaction_task`, `compaction_monitor`,
+  `compaction_failures`
+- `%Data.QueueState{}` — `steering_queue`, `followup_queue`
+- `%Data.PermissionState{}` — `interactive?`, `pending_permission_requests`,
+  `permission_dispatch_batch`, `permission_pending_results`
+
+The top-level `%Data{}` retains session-identity fields (`id`, `cwd`,
+`provider`, `model`, etc.) as first-class fields. Sub-modules receive the
+relevant sub-struct as an argument where they previously received the full
+`data`; `session.ex` extracts and re-embeds sub-structs at the FSM clause
+boundary.
+
+## Rationale
+
+The flat 69-field struct is itself a mild complecting: all concern clusters
+share a single namespace and update path. Sub-modules that own a cluster (e.g.
+`ProviderTurn`, `ToolDispatch`, `CodingAgentTurn`) currently receive the entire
+`data` and touch only their slice; the dependency on the full struct is wider
+than necessary. Typed sub-structs give each cluster a `defstruct`/`@type t`
+of its own, allowing Dialyzer to verify that `ToolDispatch` never reads
+`compaction_task` and that `CompactionTurn` never reads `tools_in_flight`. The
+dynamic-key queue dispatch in `queue.ex` disappears because `QueueState` has
+only two fields and both are named; the `case tier` branch is a natural
+pattern match on a two-field struct with no dynamic dispatch needed. Defensive
+`Map.get` calls on the outer struct are structurally impossible — sub-modules
+receive typed sub-structs, not maps.
+
+## Sketch
+
+```elixir
+# lib/tau/session/data/queue_state.ex
+defmodule Tau.Session.Data.QueueState do
+  @enforce_keys [:steering_queue, :followup_queue]
+  defstruct [:steering_queue, :followup_queue]
+  @type t :: %__MODULE__{
+          steering_queue: :queue.queue(),
+          followup_queue: :queue.queue()
+        }
+end
+
+# lib/tau/session/data/provider_state.ex
+defmodule Tau.Session.Data.ProviderState do
+  defstruct [provider_task: nil, stream_ref: nil, provider_span_ref: nil,
+             cancel_flag: nil, assembler: nil, fallback_chain_remaining: [],
+             provider_retry_state: %{count: 0}, provider_retry_max: 3,
+             provider_retry_base_delay_ms: 1000]
+  @type t :: %__MODULE__{...}
+end
+
+# lib/tau/session/data.ex — top-level struct composes sub-structs
+defstruct [
+  :id, :cwd, :provider, :original_provider, :model,
+  :persistence, :persist_handle,
+  metadata: %{},
+  provider_ctx: %{},
+  messages: [],
+  skills: [],
+  prompt_templates: [],
+  command_task: nil,
+  active_skill: nil,
+  persona_lifetime: :turn,
+  tools_whitelist: :all,
+  child_session_ids: nil,
+  provider:   %Tau.Session.Data.ProviderState{},
+  tools:      %Tau.Session.Data.ToolState{},
+  coding_agent: %Tau.Session.Data.CodingAgentState{},
+  compaction: %Tau.Session.Data.CompactionState{},
+  queues:     %Tau.Session.Data.QueueState{...},
+  permissions: %Tau.Session.Data.PermissionState{}
+]
+
+# queue.ex — no dynamic dispatch needed
+@spec enqueue(Tau.Session.Data.t(), Tau.Message.t(), :steering | :followup, atom()) ::
+        Tau.Session.Data.fsm_result()
+def enqueue(%Tau.Session.Data{queues: %QueueState{} = qs} = data, msg, tier, from_state) do
+  {queue, update_fn} =
+    case tier do
+      :steering -> {qs.steering_queue, &%{qs | steering_queue: &1}}
+      _         -> {qs.followup_queue, &%{qs | followup_queue: &1}}
+    end
+  # ... cap check ...
+  new_qs = update_fn.(:queue.in(msg, queue))
+  {:keep_state, %{data | queues: new_qs}}
+end
+```
+
+File touches: new files `lib/tau/session/data/provider_state.ex`,
+`tool_state.ex`, `coding_agent_state.ex`, `compaction_state.ex`,
+`queue_state.ex`, `permission_state.ex`; revised `lib/tau/session/data.ex`;
+revised `lib/tau/session/queue.ex`, `provider_turn.ex`, `tool_dispatch.ex`,
+`coding_agent_turn.ex`, `compaction.ex`, `session.ex`.
+
+## Tradeoffs
+
+### Strengths
+
+- Every concern cluster has its own typed struct; Dialyzer coverage is
+  maximised — cross-cluster field access becomes a compile-time type error.
+- Dynamic `Map.get(data, queue_field)` is eliminated structurally, not by
+  adding branches.
+- Sub-modules can specify narrower argument types (e.g.
+  `Tau.Session.Data.ToolState.t()` rather than `Tau.Session.Data.t()`),
+  making their dependencies explicit at the spec level.
+- The `coding_agent_state` nested map (`Map.get(data.coding_agent_state, :session_id)`)
+  disappears because `CodingAgentState` has named fields.
+
+### Weaknesses
+
+- Large scope: ~10 files touched, ~200 lines changed or added. Well outside
+  the "minimal surgical edit" risk profile.
+- The FSM cancel clauses in `session.ex` now reconstruct multiple nested
+  structs instead of one flat map update — verbosity increases.
+- `session.ex` and all sub-modules must be updated simultaneously; no
+  incremental path unless field renaming is done in multiple PRs. This is an
+  API-breaking change to every sub-module's public signatures.
+- Naming collision risk: `data.provider` (a module) and
+  `data.provider` (the sub-struct) would need to be disambiguated — requires
+  renaming one of them (e.g. `data.provider_state`).
+- Review surface is large; the gate must compare a diff touching 10+ files;
+  risk of subtle merge ordering errors.
+
+### Costs
+
+- Estimated diff: ~250–300 lines across 10+ files.
+- Must update all tests that build `Data` structs or access fields directly.
+- Dialyzer PLT rebuild required; first-run PLT analysis on new struct hierarchy
+  can surface false warnings that need suppression annotations.
+
+## Dependencies
+
+- Must be a single atomic PR (no partial delivery is safe).
+- Requires that the sibling `cancellation-teardown` sub-problem NOT be in
+  flight simultaneously — both touch the cancel clauses in `session.ex`.
+
+## Confidence
+
+Medium. The approach is correct in principle; the implementation scope is
+large and the naming collision on `provider` requires careful resolution. A
+prototype of the `QueueState` extraction alone would raise confidence.
+
+## Prior art / references
+
+- Erlang/OTP `:gen_statem` `data` field nesting pattern — state records with
+  typed sub-records per concern cluster are idiomatic in complex state machines.
+- `Tau.Session.Meta` — already a typed struct for session metadata returned to
+  callers; the same principle applied to internal FSM state.
+- Elixir forum: "Nested structs for large GenServer state" — community consensus
+  favours nested structs for state machines with >30 fields.

--- a/docs/problems-archive-v1-modules/tau-session/subproblems/cross-cutting-data/proposals/proposal-4.md
+++ b/docs/problems-archive-v1-modules/tau-session/subproblems/cross-cutting-data/proposals/proposal-4.md
@@ -1,0 +1,175 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 4
+parent_problem: ../problem.md
+---
+
+# Proposal 4: Add a Data behaviour with a typed contract callback
+
+## Approach
+
+Introduce a `Tau.Session.Data.Contract` behaviour that declares one required
+callback: `@callback validate(map()) :: {:ok, t()} | {:error, term()}`. The
+current `Data.new/1` is renamed `Data.build/1` and calls
+`Contract.validate/1` as a post-construction assertion. Every sub-module
+function head that currently takes `data` with no pattern match is annotated
+with `@spec` using the existing `Tau.Session.Data.t()` type; where the
+function previously called `Map.get(data, :field, default)`, the default is
+removed and `data.field` is used, relying on the struct guarantee.
+
+Separately, the two dynamic-key patterns in `queue.ex` and
+`provider_turn.ex:maybe_replace/3` are replaced with typed delegates on `Data`
+(same as Proposal 2's `get_queue/2`, `put_queue/3`, and `replace_field/3`),
+but these are framed as implementing the behaviour's internal contract, not as
+standalone accessors.
+
+The end state: `Data.new/1` (public, unchanged signature) calls `Data.build/1`
+then `Tau.Session.Data.Contract.validate!/1` (raises on invalid shape) before
+returning `{:ok, struct}`.
+
+## Rationale
+
+The acceptance criterion requires that sub-modules "pattern-match on
+`%Tau.Session.Data{}`". This proposal makes that enforceable at runtime on
+the construction path: `validate!/1` confirms the struct is well-formed
+before any FSM clause can observe it. The behaviour adds a seam for testing —
+a test double can implement `Tau.Session.Data.Contract` and inject a
+pre-built struct — and makes explicit that `Data` is not just a dumb struct
+but a typed contract between the FSM and its sub-modules. The tactical edits
+(remove defensive default, typed delegates) are identical to Proposals 1 and 2
+but are now presented as enforcement of the behaviour contract rather than
+isolated fixes.
+
+## Sketch
+
+```elixir
+# lib/tau/session/data/contract.ex
+defmodule Tau.Session.Data.Contract do
+  @moduledoc """
+  Behaviour declaring the invariants that every `Tau.Session.Data` value
+  must satisfy at construction time.
+  """
+  alias Tau.Session.Data
+
+  @doc """
+  Assert that `data` satisfies all structural invariants.
+  Raises `ArgumentError` if any invariant is violated.
+  """
+  @callback validate(Data.t()) :: {:ok, Data.t()} | {:error, term()}
+
+  @doc "Calls validate/1; raises on error."
+  @spec validate!(Data.t()) :: Data.t()
+  def validate!(%Data{} = data) do
+    case Data.DefaultContract.validate(data) do
+      {:ok, d} -> d
+      {:error, reason} -> raise ArgumentError, "Data invariant violated: #{inspect(reason)}"
+    end
+  end
+end
+
+# lib/tau/session/data/default_contract.ex
+defmodule Tau.Session.Data.DefaultContract do
+  @behaviour Tau.Session.Data.Contract
+
+  @impl true
+  def validate(%Tau.Session.Data{} = data) do
+    with :ok <- assert_queues_initialised(data),
+         :ok <- assert_child_session_ids(data) do
+      {:ok, data}
+    end
+  end
+
+  defp assert_queues_initialised(%{steering_queue: q, followup_queue: q2})
+       when not is_nil(q) and not is_nil(q2), do: :ok
+  defp assert_queues_initialised(_), do: {:error, :queues_not_initialised}
+
+  defp assert_child_session_ids(%{child_session_ids: %MapSet{}}), do: :ok
+  defp assert_child_session_ids(_), do: {:error, :child_session_ids_not_mapset}
+end
+
+# lib/tau/session/data.ex — new/1 calls validate! at the end
+def new(opts) do
+  # ... existing build logic ...
+  data = %__MODULE__{...}
+  {:ok, Tau.Session.Data.Contract.validate!(data)}
+end
+```
+
+```elixir
+# Removing the defensive default in provider_turn.ex:337 — same as Proposal 1
+if msg.stop_reason == :end_turn and data.persona_lifetime == :turn do
+
+# queue.ex — same get_queue/put_queue delegates as Proposal 2
+# (framed as part of the Contract enforcement surface)
+```
+
+File touches: new files `lib/tau/session/data/contract.ex`,
+`lib/tau/session/data/default_contract.ex`; minor edits to `data.ex`,
+`queue.ex`, `provider_turn.ex`.
+
+## Tradeoffs
+
+### Strengths
+
+- Makes the data invariants explicit and machine-checked at construction time,
+  not just statically documented in the type spec.
+- The `Contract` behaviour provides a testing seam: tests can inject a
+  `MockContract` that skips expensive validation for unit tests.
+- Any future invariant (e.g. "tool_iterations must be ≤ max_tool_iterations
+  at init") can be added to `DefaultContract.validate/1` without touching
+  `Data` itself.
+- The acceptance criterion's "no `Map.get(data, :field, default)` defensive
+  reads" is enforced by construction — if the struct is always valid,
+  defaults are never needed.
+
+### Weaknesses
+
+- Introduces a behaviour for a concern (construction-time validation) that the
+  existing `@enforce_keys` already addresses structurally. The behaviour adds
+  ceremony without adding correctness beyond what `@enforce_keys` already
+  provides for required fields.
+- `validate!` raises at runtime; Dialyzer cannot verify at compile time that
+  all invariants hold. The primary value is test documentation and fast-fail
+  at session start, not type safety.
+- Two new modules (`Contract`, `DefaultContract`) for what is mechanically a
+  ~10-line change to `data.ex`. The complexity-to-benefit ratio is lower than
+  Proposals 1 and 2 for the stated acceptance criterion.
+- The behaviour callback `validate/1` is not required by OTP non-negotiables
+  (invariant 2): extensibility seams should be behaviours, but a construction
+  validator is not an extensibility seam — it is an internal guard. Using a
+  behaviour here may set a precedent for over-behaviourising internal helpers.
+
+### Costs
+
+- ~60 lines added across two new files plus minor edits to three existing files.
+- Adds a runtime call (the `validate!` invocation in `new/1`) at session
+  construction — trivially fast but measurably present.
+- New modules must be added to the application's compile graph; any tooling
+  that lists `Tau.Session.Data.*` modules (documentation, Credo) sees two
+  additional modules.
+
+## Dependencies
+
+- `Tau.Session.Data` struct already in place (no prerequisite).
+- The `DefaultContract` logic assumes `@enforce_keys` already covers required
+  fields; it only adds invariants beyond what the struct enforces structurally.
+
+## Confidence
+
+Medium. The behaviour-and-contract pattern is well understood in Elixir; the
+specific application here (construction-time validation) is slightly unusual
+and may be seen as over-engineering for the problem. The tactical callsite
+fixes (remove defensive default, typed delegates) are high-confidence; the
+behaviour scaffolding carries medium confidence that it will be accepted as
+proportionate.
+
+## Prior art / references
+
+- `Tau.Provider` behaviour — the project's canonical use of behaviours for
+  extensibility seams; the pattern here is similar but applied to a validation
+  contract rather than an adapter.
+- Ecto changesets — the canonical Elixir pattern for runtime struct validation;
+  the `validate!/1` function mirrors `Ecto.Changeset.apply_action!/2`.
+- OTP non-negotiables §2: "Extensibility seams MUST be behaviours" — the
+  rationale for choosing a behaviour over a plain function.

--- a/docs/problems-archive-v1-modules/tau-session/subproblems/cross-cutting-data/solution.md
+++ b/docs/problems-archive-v1-modules/tau-session/subproblems/cross-cutting-data/solution.md
@@ -1,0 +1,212 @@
+---
+template_version: 1
+template_name: solution
+parent_problem: problem.md
+node_kind: leaf
+synthesised_from: [proposals/proposal-1.md, proposals/proposal-2.md]
+selection_method: hybrid
+revision: 1
+---
+
+# Solution: Typed accessors on Data + full struct-match expansion across every sub-module head touching session data
+
+## Recommendation
+
+Adopt Proposal 2's typed accessor functions (`get_queue/2`, `put_queue/3`,
+`replace_field/3`) on `Tau.Session.Data` and Proposal 1's surgical callsite
+fixes (`persona_lifetime` dot-access; `model_swap.ex:maybe_replace/3` parity
+with `provider_turn.ex`). Combine these with the work the prior revision
+disclaimed: add `%Tau.Session.Data{} = data` to EVERY public-and-private
+function head that names `data` as a parameter across the nine session
+sub-modules — 101 heads in total — so that AC clause (d) ("all sub-modules
+pattern-match on `%Tau.Session.Data{}` in their function heads") holds by
+inspection on a single grep. The expansion is mechanical: each head's
+existing `data` parameter is rewritten as `%Tau.Session.Data{} = data`,
+with the four heads that already destructure via a bare map pattern
+(`%{field: ...} = data`) widened to `%Tau.Session.Data{field: ...} = data`.
+No body changes, no API changes, no new modules.
+
+## Selected from
+
+- **Chosen:** hybrid of `proposals/proposal-2.md` (accessor functions) and
+  `proposals/proposal-1.md` (direct callsite fixes), with scope expanded
+  beyond what either proposal stated to include a full struct-match sweep of
+  every `data`-bearing function head across `lib/tau/session/*.ex`.
+- **Why chosen:** Proposal 2 owns the field-access contract from `Data`
+  itself (deepest decomplecting at low cost). Proposal 1 contributes the
+  surgical fixes for `persona_lifetime` and for the `model_swap.ex`/
+  `provider_turn.ex` `maybe_replace/3` duplication. Proposal 3 (sub-structs)
+  was rejected on migration cost, irreversibility, and atomic-PR conflict
+  with sibling sub-problems. Proposal 4 (behaviour + validator) was rejected
+  as disproportionate to the AC and in tension with OTP non-negotiables §2.
+  The prior revision selected the same proposals but added the struct-match
+  to only two heads (`enqueue/4`, `provider_turn.maybe_replace/3`) and
+  explicitly disclaimed the rest — falsifying AC clause (d). This revision
+  closes that gap by committing to the full sweep, with the per-file head
+  inventory below.
+
+### Scoring table
+
+| # | Fit | Decomplecting depth | Migration cost | Risk | Reversibility |
+|---|-----|--------------------:|:--------------:|:----:|:-------------:|
+| 1 | Yes | Surface             | Low            | Low  | Easy          |
+| 2 | Yes | Substantial         | Low-Medium     | Low  | Easy          |
+| 3 | Yes | Deep                | High           | Medium | Hard        |
+| 4 | Partially | Surface      | Low            | Low  | Easy          |
+
+Proposal 2 is rescored at Low-Medium cost (versus the prior revision's Low)
+to reflect the full-head sweep this revision commits to: ~105 head edits
+across nine files rather than two. The work remains mechanical and
+reversible; it is not High-cost.
+
+## What changes
+
+### A. New accessor functions in `lib/tau/session/data.ex` (additions)
+
+- `get_queue/2 :: (t(), :steering | :followup) -> :queue.queue()` — two
+  pattern-matched clauses on `%__MODULE__{}` destructuring the queue field.
+- `put_queue/3 :: (t(), :steering | :followup, :queue.queue()) -> t()` —
+  two pattern-matched clauses producing struct-updated `t()`.
+- `replace_field/3 :: (t(), atom(), term()) -> t()` — wraps `struct!/2`;
+  documented as the single auditable escape hatch for dynamic-key updates.
+
+### B. Defensive-read / dynamic-key elimination (3 fixes)
+
+- `lib/tau/session/queue.ex:43, 63` — replace `Map.get(data, queue_field)`
+  / `Map.put(data, queue_field, new_queue)` with
+  `Tau.Session.Data.get_queue(data, tier)` /
+  `Tau.Session.Data.put_queue(data, tier, new_queue)`.
+- `lib/tau/session/provider_turn.ex:179` — replace
+  `Map.put(data, key, value)` with
+  `Tau.Session.Data.replace_field(data, key, value)`.
+- `lib/tau/session/provider_turn.ex:337` — replace
+  `Map.get(data, :persona_lifetime, :turn)` with `data.persona_lifetime`.
+- `lib/tau/session/model_swap.ex:94` — replace
+  `Map.put(data, key, value)` with
+  `Tau.Session.Data.replace_field(data, key, value)` (parity with
+  `provider_turn.ex:179`; closes Validator Claim 4's partial falsification).
+
+### C. Full struct-match sweep across every sub-module function head taking `data`
+
+Add `%Tau.Session.Data{} = data` to every `def` / `defp` head that names
+`data` as a parameter. Where a head currently destructures `data` via a
+bare map pattern (`def f(%{field: x} = data, ...)`), widen to the struct
+form (`def f(%Tau.Session.Data{field: x} = data, ...)`).
+
+Per-file head inventory (verified by
+`grep -cE '^\s*defp?\s+\w+\(.*\bdata\b'`):
+
+| File | Heads taking `data` | Notes |
+|------|--------------------:|-------|
+| `lib/tau/session/tool_dispatch.ex` | 16 | All currently bare `data` |
+| `lib/tau/session/coding_agent_turn.ex` | 22 | 3 use `%{...} = data` (lines 42, 46, 383) → widen to `%Tau.Session.Data{...} = data` |
+| `lib/tau/session/provider_turn.ex` | 20 | 2 use `%{...} = data` (lines 97, 777) → widen |
+| `lib/tau/session/model_swap.ex` | 11 | All bare |
+| `lib/tau/session/compaction.ex` | 7 | All bare |
+| `lib/tau/session/queue.ex` | 7 | All bare; includes `enqueue/4` from §B |
+| `lib/tau/session/slash_command.ex` | 6 | All bare |
+| `lib/tau/session/skill_activation.ex` | 6 | All bare |
+| `lib/tau/session/journal.ex` | 6 | All bare |
+| **Total** | **101** | 5 of which are widened-map (not bare-add) edits |
+
+For convenience, each sub-module gains `alias Tau.Session.Data` at the top
+(currently absent across all nine files; verified by
+`grep -nE "alias\b.*Data" lib/tau/session/*.ex` returning zero matches)
+so the head edits read `%Data{} = data` rather than the fully-qualified
+`%Tau.Session.Data{} = data`. The alias is purely cosmetic; it does not
+affect the structural guarantee.
+
+## What does not change
+
+- `Tau.Session.Data` struct fields, `@enforce_keys`, `@type t`, defaults —
+  no field added, removed, renamed, or re-defaulted.
+- `Data.new/1` signature and return type (`{:ok, %Tau.Session.Data{}}`).
+- Public arities and `@spec` of every modified sub-module function
+  (`enqueue/4`, `maybe_replace/3` in both `provider_turn.ex` and
+  `model_swap.ex`, and the 101 swept heads).
+- `Tau.Session.Meta` (already a typed struct; out of scope per problem.md).
+- `lib/tau/session.ex` itself (the FSM module, not a sub-module per the
+  problem statement's "sub-modules" framing; out of scope).
+- Nested-map reads (e.g.
+  `Map.get(data.tool_loop_state, key)`,
+  `Map.get(data.tools_in_flight, call_id)`,
+  `Map.get(data.coding_agent_state, :session_id)`,
+  `Map.get(data.metadata, key)`) — these read into sub-maps, not into
+  the `Data` struct itself; explicitly out of scope per
+  `problem.md` "Out of scope".
+- All tests — no test changes required. A grep over `test/` for bare-map
+  calls into the modified functions (`grep -rnE
+  "(enqueue|maybe_replace|dispatch_tools|finish_permission_round|run_tool|
+  handle_tool_done)\(%\{" test/`) returns zero matches; tests use real
+  `Data.new/1`-built structs throughout (this addresses Validator Claim 5's
+  residual-doubt note as it applies to the expanded scope).
+
+## Migration sketch
+
+Single PR, four conceptual commits to keep review manageable:
+
+1. **Add accessors to `data.ex`.** New `get_queue/2`, `put_queue/3`,
+   `replace_field/3` with `@spec`s. Compiles cleanly with no callers yet.
+2. **Defensive-fix sweep.** Update `queue.ex:enqueue/4`,
+   `provider_turn.ex:179, 337`, and `model_swap.ex:94` to use the new
+   accessors / dot-access (§B). Includes the struct-match on those four
+   heads.
+3. **Add `alias Tau.Session.Data` to the eight sub-modules that don't yet
+   have it.** Mechanical; touches imports only.
+4. **Full head sweep (§C).** Add `%Data{} = data` to the remaining
+   97 heads (101 total − 4 already covered in commit 2) across the nine
+   files. This commit is large in line-count (≈97 single-line edits) but
+   trivial in semantic content; the reviewer reads it as a single
+   mechanical transformation.
+
+After the PR: `mix compile --warnings-as-errors` is unaffected (no
+warnings are introduced by adding a struct match to a parameter — the
+match either succeeds or surfaces a real bug). `mix dialyzer` gains
+tighter type information at every call site because every entry point now
+asserts the struct shape; this may surface latent bugs in callers that
+pass non-struct maps, which is the desired outcome (fast-fail at the
+boundary). No PLT rebuild is required.
+
+## Open questions
+
+- `replace_field/3` accepts `atom()` for `key`; Dialyzer cannot verify at
+  the call site that `key` names a valid struct field. The "auditable
+  escape hatch" property (one function to grep) is the intended trade.
+  Documented in Open Questions of the prior revision; carried forward.
+- The full-head sweep (§C) creates a uniform `%Data{} = data` head shape
+  across the codebase. If a future refactor extracts a sub-struct (as
+  Proposal 3 would have done), every swept head becomes a re-edit site —
+  the cost of decomplecting now is paid again then. This is a known
+  trade and is acceptable: the sub-struct refactor is not in scope for
+  this sub-problem and is the natural successor node if revisited.
+- Heads in sub-modules that do not currently name `data` (because they
+  take a different argument shape) are unaffected. AC clause (d) speaks of
+  "function heads touching session data"; a head that does not receive
+  `data` does not touch it. The 101-head figure is therefore the
+  exhaustive scope.
+
+## Linked sub-problems / proposals
+
+- `proposals/proposal-1.md` — "Remove remaining defensive reads; keep
+  existing struct as-is": contributes the `persona_lifetime` dot-access fix
+  and motivates the `model_swap.ex` parity fix.
+- `proposals/proposal-2.md` — "Introduce typed accessor functions in Data":
+  primary shape; contributes `get_queue`/`put_queue`/`replace_field`.
+- `proposals/proposal-3.md` — "Split Data into typed sub-structs by concern
+  cluster": rejected on migration cost, risk, and atomic-PR conflict with
+  sibling sub-problems; remains the natural successor if revisited.
+- `proposals/proposal-4.md` — "Add a Data behaviour with a typed contract
+  callback": rejected as disproportionate to the AC and in tension with
+  OTP non-negotiables §2 (behaviours are for extensibility seams, not
+  construction guards).
+
+## Revision history
+
+- (revision 0 — initial) hybrid of proposals 1 + 2; added struct-match to
+  only two heads; falsified by validator on AC clause (d).
+- (revision 1 — current) scope expanded to commit to the full 101-head
+  struct-match sweep across nine sub-modules, with per-file inventory.
+  Adds `model_swap.ex:maybe_replace/3` parity fix to close Validator
+  Claim 4's partial falsification. Adds `alias Tau.Session.Data` to the
+  eight sub-modules currently without it, purely to keep head syntax
+  compact. No body logic changes; no test changes.

--- a/docs/problems-archive-v1-modules/tau-session/subproblems/cross-cutting-data/validation.md
+++ b/docs/problems-archive-v1-modules/tau-session/subproblems/cross-cutting-data/validation.md
@@ -1,0 +1,407 @@
+---
+template_version: 1
+template_name: validation
+parent_solution: solution.md
+parent_problem: problem.md
+toulmin_complete: true
+falsification_attempted: true
+falsification_outcome: partially_falsified — claim/6
+revision_triggered: none
+---
+
+# Validation: Typed accessors + full 101-head struct-match sweep
+
+## Overview
+
+The revised solution makes six checkable propositions: (1) add three typed
+accessor functions to `Tau.Session.Data`; (2) eliminate four named
+defensive-read / dynamic-key call sites; (3) sweep every `data`-bearing
+function head across the nine session sub-modules (101 in total, per a
+per-file inventory) to `%Tau.Session.Data{} = data`; (4) the test suite
+needs no changes because no test invokes the touched functions via bare-map
+arguments; (5) public arities and `@spec`s do not change; (6) the
+migration is mechanical and reversible (four conceptual commits, no PLT
+rebuild). The validation strategy is dependency-check + counter-example
+construction for the load-bearing factual claims (per-file head counts,
+named line citations, absence of `alias`, absence of bare-map test calls);
+edge-case enumeration for the AC-coverage claim. Five of six claims
+withstand; claim 6 is partially falsified by an arithmetic off-by-one in
+the migration sketch (101 − 3 heads covered in commit 2, not 101 − 4) —
+the narrowing is local and does not require solution or problem revision.
+
+## Toulmin per claim
+
+The MITRE empirical study on Toulmin formalism found that "participants
+found it difficult to generate Toulmin structures, and their structures
+varied greatly even though they started with the same content"
+(https://www.mitre.org/news-insights/publication/empirical-evaluation-structured-argumentation-using-toulmin-argument).
+This template enforces all six components explicitly with prompts to
+counter that variance.
+
+### Claim 1: Add three typed accessor functions `get_queue/2`, `put_queue/3`, `replace_field/3` to `Tau.Session.Data`
+
+- **Claim (C):** "Adopt Proposal 2's typed accessor functions
+  (`get_queue/2`, `put_queue/3`, `replace_field/3`) on `Tau.Session.Data`"
+  (solution.md §Recommendation, §A).
+- **Grounds (G):** `Tau.Session.Data` is a real module with an existing
+  `defstruct` and `@type t :: %__MODULE__{}` (verified at
+  `lib/tau/session/data.ex:20` (`@enforce_keys`), `:41` (`@type t`), `:96`
+  (`defstruct`)). Adding three module-level functions with `@spec` is a
+  standard, low-cost extension. The two-clause shape of `get_queue/2` /
+  `put_queue/3` mirrors the only two queue tiers actually accessed
+  (`:steering` / `:followup`) at the only caller, `queue.ex:43, 63`
+  (verified by direct read).
+- **Warrant (W):** OTP non-negotiable #2 ("Extensibility seams MUST be
+  behaviours; pattern match on atoms and structs"). A struct-owning module
+  is the right home for its own typed accessors; this localises the
+  field-shape contract to one module rather than leaving it implicit at
+  every call site.
+- **Qualifier (Q):** Universal within the stated scope (the three
+  accessor functions, on the existing `Data` struct, called from the four
+  named sites in §B). Does NOT extend to nested-map accessors (e.g. into
+  `data.tool_loop_state`, `data.tools_in_flight`, `data.metadata`,
+  `data.coding_agent_state`) — those are explicitly out of scope.
+- **Rebuttal (R):** Would not hold if `Data` did not already have a
+  `defstruct`; the problem.md statement asserts no `defstruct` exists,
+  but inspection shows one does (`lib/tau/session/data.ex:96`). The
+  problem.md framing is partially obsolete on this point — the solution
+  correctly works from current code state.
+- **Backing (B):** `.claude/rules/otp-non-negotiables.md` §2; the
+  existing `Tau.Session.Meta` precedent (cited in problem.md as a
+  comparable in-module struct contract).
+
+#### Falsification attempt for claim 1
+
+- **Strategy:** Dependency check — verify the modules and shapes the
+  accessors depend on actually exist.
+- **Attempt:** Ran `grep -nE "defstruct|@enforce_keys|@type t "
+  lib/tau/session/data.ex`: results at lines 20, 41, 96 confirm `Data`
+  already has the full struct shape. Verified §B citations exist
+  (`queue.ex:43` shows `Map.get(data, queue_field)`, `:63` shows
+  `Map.put(data, queue_field, new_queue)` — both match the solution's
+  text verbatim).
+- **Outcome:** withstood. The accessors land in a real, struct-bearing
+  module against real callers.
+- **Action:** none.
+
+### Claim 2: Replace four named defensive-read / dynamic-key call sites
+
+- **Claim (C):** Four edits — `queue.ex:43, 63` → typed queue accessors;
+  `provider_turn.ex:179` → `replace_field/3`; `provider_turn.ex:337` →
+  `data.persona_lifetime` direct access; `model_swap.ex:94` →
+  `replace_field/3` (solution.md §B).
+- **Grounds (G):** All four line citations verified by direct read:
+  - `queue.ex:43`: `queue = Map.get(data, queue_field)`.
+  - `queue.ex:63`: `new_data = Map.put(data, queue_field, new_queue)`.
+  - `provider_turn.ex:179`: `def maybe_replace(data, key, value), do:
+    Map.put(data, key, value)`.
+  - `provider_turn.ex:337`: `if msg.stop_reason == :end_turn and
+    Map.get(data, :persona_lifetime, :turn) == :turn do`.
+  - `model_swap.ex:94`: `def maybe_replace(data, key, value), do:
+    Map.put(data, key, value)` (verbatim parity with `provider_turn.ex:179`).
+- **Warrant (W):** Hickey decomplecting principle as cited in the
+  problem's complecting hypothesis: defensive `Map.get(..., default)`
+  reads exist only because the shape is not statically enforced; once
+  the struct match holds at the head, the default becomes dead defence
+  and obscures real intent.
+- **Qualifier (Q):** Holds for the four cited sites; the solution
+  explicitly excludes nested-map reads via `data.<sub>` (e.g. into
+  `tool_loop_state`, `tools_in_flight`, `metadata`,
+  `coding_agent_state`), which inspection at `coding_agent_turn.ex:112,
+  504`, `tool_dispatch.ex:79, 501, 869`, `slash_command.ex:359`
+  confirms are still `Map.get(...)` reads and remain so by design.
+- **Rebuttal (R):** Would not hold if any of the four lines named a
+  function head whose body already destructures the field in a way the
+  edit would break. Verified by reading the surrounding context: each
+  edit substitutes one expression for an equivalent one, with no body
+  invariant disturbed.
+- **Backing (B):** ADR-0012 / ADR-0013 / ADR-0015 (referenced in the
+  `provider_turn.ex:337` neighbourhood) constrain the surrounding
+  control flow, not the persona_lifetime read itself; the read's
+  default of `:turn` matches the struct's documented default, so direct
+  field access is semantically identical.
+
+#### Falsification attempt for claim 2
+
+- **Strategy:** Counter-example construction — try to construct a
+  runtime state where each of the four edits changes behaviour.
+- **Attempt:**
+  - `queue.ex` accessors: `Data.new/1` populates both
+    `steering_queue` and `followup_queue` at init (per problem.md context
+    line 33–34: "the struct that `Data.new/1` fully populates"); no code
+    path nils them; therefore `Map.get` and a struct-field access return
+    the same value.
+  - `provider_turn.ex:179` / `model_swap.ex:94` `maybe_replace/3`: both
+    are identical one-liners; replacing `Map.put` with
+    `Data.replace_field/3` (which wraps `struct!/2`) changes only the
+    failure mode for an unknown key (`struct!/2` raises `KeyError`
+    instead of silently widening the struct shape with a stray atom
+    key). Stricter failure is the desired outcome (fast-fail at the
+    boundary, as the solution acknowledges in §Migration sketch).
+  - `provider_turn.ex:337`: `data.persona_lifetime` has default
+    `:turn` per the struct (the `Map.get` default matches); behaviour
+    is identical for the struct case.
+- **Outcome:** withstood. No counter-example found within current code
+  shape.
+- **Action:** none.
+
+### Claim 3: The per-file head inventory of 101 `data`-bearing function heads is accurate
+
+- **Claim (C):** "Per-file head inventory (verified by `grep -cE
+  '^\s*defp?\s+\w+\(.*\bdata\b'`): tool_dispatch.ex 16,
+  coding_agent_turn.ex 22, provider_turn.ex 20, model_swap.ex 11,
+  compaction.ex 7, queue.ex 7, slash_command.ex 6, skill_activation.ex 6,
+  journal.ex 6, total 101" (solution.md §C).
+- **Grounds (G):** Re-ran the exact regex against each file:
+  - `tool_dispatch.ex: 16`
+  - `coding_agent_turn.ex: 22`
+  - `provider_turn.ex: 20`
+  - `model_swap.ex: 11`
+  - `compaction.ex: 7`
+  - `queue.ex: 7`
+  - `slash_command.ex: 6`
+  - `skill_activation.ex: 6`
+  - `journal.ex: 6`
+  - Sum: 16+22+20+11+7+7+6+6+6 = **101**.
+  Every per-file count matches the table to the integer.
+- **Warrant (W):** A grep with a fixed regex is deterministic over a
+  fixed file set; reproducing the same query on the same files yields
+  the same count.
+- **Qualifier (Q):** Holds at HEAD (`main` at `origin/main` as of this
+  validation). A later commit that adds or removes a `data`-bearing
+  head invalidates the table — but the solution will be implemented
+  before that drift accumulates, and the grep is fast to re-run.
+- **Rebuttal (R):** The regex `^\s*defp?\s+\w+\(.*\bdata\b` matches any
+  head where `data` appears as a *word* anywhere after the opening
+  paren. A head with `metadata` (containing the substring `data`) and
+  no `data` parameter could in principle match; `\b` excludes that
+  (`\bdata\b` requires word boundaries on both sides). A head with
+  `data` as a non-first parameter would still match — which is the
+  correct semantics (any head receiving `data` should be swept). No
+  false positive identified.
+- **Backing (B):** Standard POSIX ERE semantics; `git grep` /`grep -E`
+  documented determinism.
+
+#### Falsification attempt for claim 3
+
+- **Strategy:** Dependency check — re-execute the cited grep and
+  compare to the published table, entry by entry.
+- **Attempt:** Executed `for f in tool_dispatch coding_agent_turn
+  provider_turn model_swap compaction queue slash_command
+  skill_activation journal; do count=$(grep -cE
+  '^\s*defp?\s+\w+\(.*\bdata\b' lib/tau/session/$f.ex); echo "$f.ex:
+  $count"; done`. Output matched the published per-file table on every
+  line. Also verified the five widened-map line citations
+  (`coding_agent_turn.ex:42, 46, 383`, `provider_turn.ex:97, 777`) by
+  direct `sed -n` read: every cited line is a `def` or `defp` head with
+  a bare-map destructure of `data`, exactly as the solution describes.
+- **Outcome:** withstood. Per-file counts match to the integer; total
+  is 101.
+- **Action:** none.
+
+### Claim 4: No `alias Tau.Session.Data` exists in any of the nine sub-modules today
+
+- **Claim (C):** "each sub-module gains `alias Tau.Session.Data` at the
+  top (currently absent across all nine files; verified by `grep -nE
+  "alias\b.*Data" lib/tau/session/*.ex` returning zero matches)"
+  (solution.md §C).
+- **Grounds (G):** Re-ran `grep -nE "alias\b.*Data" lib/tau/session/*.ex`:
+  zero matches. The eight sub-modules (plus `data.ex` itself, which
+  needs no alias to its own type) all currently reference `data` only
+  as a parameter name; none alias the module.
+- **Warrant (W):** A `grep` over a closed file set returning zero
+  matches is direct evidence of absence; for this narrow proposition
+  no further inference is required.
+- **Qualifier (Q):** Holds at HEAD. Adding an `alias` to any one of
+  the nine files between this validation and the implementing PR would
+  not invalidate the solution — the §C migration commits the alias
+  edits with idempotent intent; the grep would then return one match
+  instead of zero, which is the post-migration steady state.
+- **Rebuttal (R):** The regex `alias\b.*Data` is permissive — it would
+  match `alias Foo.Bar.Data`, `alias Data`, `alias Tau.Session.Data`,
+  etc. Zero matches against this permissive regex is therefore strong
+  evidence; a more restrictive regex would only further confirm.
+- **Backing (B):** Standard `grep -E` semantics.
+
+#### Falsification attempt for claim 4
+
+- **Strategy:** Dependency check — re-execute the cited grep.
+- **Attempt:** Ran `grep -nE "alias\b.*Data" lib/tau/session/*.ex`:
+  empty output (zero matches).
+- **Outcome:** withstood.
+- **Action:** none.
+
+### Claim 5: No test in `test/` invokes the touched functions with a bare-map argument; therefore no test changes are required
+
+- **Claim (C):** "A grep over `test/` for bare-map calls into the
+  modified functions (`grep -rnE
+  "(enqueue|maybe_replace|dispatch_tools|finish_permission_round|run_tool|handle_tool_done)\(%\{"
+  test/`) returns zero matches; tests use real `Data.new/1`-built
+  structs throughout" (solution.md §What does not change).
+- **Grounds (G):** Re-ran the exact grep: zero matches.
+- **Warrant (W):** Adding `%Tau.Session.Data{} = data` to a function
+  head changes the matching set only if a caller passes a value that is
+  not a `Tau.Session.Data` struct. If no test invokes the function with
+  a bare map literal, no test is broken by the tightened head pattern.
+- **Qualifier (Q):** Holds for the named function set. Does NOT prove
+  that other tests don't pass *plain maps built by other means* (e.g. a
+  test helper that returns a map). The grep is necessary but not fully
+  sufficient — see Rebuttal.
+- **Rebuttal (R):** A test that constructs `data` via a helper function
+  returning `map()` rather than `%Tau.Session.Data{}` (e.g.
+  `build_test_data()` returning a plain map) would not be caught by the
+  literal `%{` grep. The solution acknowledges this gap implicitly by
+  citing the grep as the test of choice; a broader audit of test/
+  helpers is the residual doubt.
+- **Backing (B):** Convention in this repo's test suite, evidenced by
+  `Tau.Session.Meta` being constructed via real structs throughout
+  (Validator Claim 5 in the prior revision's history; the residual
+  doubt was carried forward into this revision's §What does not change).
+
+#### Falsification attempt for claim 5
+
+- **Strategy:** Counter-example construction — search for test helpers
+  that might return a non-struct map for the `data` argument.
+- **Attempt:** Ran the cited grep over `test/`: zero matches. (A wider
+  audit of `test/support/` for helper functions returning a non-struct
+  `data` map was not exhaustively performed within this validation; the
+  solution treats this as residual doubt rather than a closed
+  question.)
+- **Outcome:** withstood for the cited grep; the residual doubt about
+  non-literal test-helper construction remains and is noted in
+  Outstanding doubts below.
+- **Action:** none for solution; flagged in Outstanding doubts for the
+  parent validator's awareness.
+
+### Claim 6: The migration sketch's commit decomposition is accurate (four commits; commit 4 covers 97 heads = 101 − 4)
+
+- **Claim (C):** "Full head sweep (§C). Add `%Data{} = data` to the
+  remaining 97 heads (101 total − 4 already covered in commit 2)
+  across the nine files" (solution.md §Migration sketch step 4).
+- **Grounds (G):** Commit 2 names four edits (per solution §B):
+  `queue.ex:enqueue/4`, `provider_turn.ex:179`, `provider_turn.ex:337`,
+  `model_swap.ex:94`. Inspection shows three of these are function
+  heads: `queue.ex:enqueue/4` (head; widened-map style at the existing
+  `enqueue/4` head), `provider_turn.ex:179` (head of `maybe_replace/3`),
+  `model_swap.ex:94` (head of `maybe_replace/3`). The fourth,
+  `provider_turn.ex:337`, is a *body* expression inside a larger
+  function (the `if msg.stop_reason == :end_turn and Map.get(data,
+  :persona_lifetime, :turn) == :turn do` clause); it does not add a
+  struct match to a head.
+- **Warrant (W):** Arithmetic on a closed set: the head-sweep total of
+  101 is established (Claim 3); commit 2 covers exactly the heads that
+  contain the §B edits; a non-head edit does not advance the head
+  sweep.
+- **Qualifier (Q):** The 101 figure stands. The arithmetic "101 − 4 =
+  97 heads in commit 4" is off by one: only 3 of the §B edits are
+  head-level. Commit 4 therefore covers **98** heads, not 97.
+- **Rebuttal (R):** One could interpret commit 2 as "implicitly adding
+  the struct match to *the head containing* the `provider_turn.ex:337`
+  body edit as well" — but the §B text does not promise that, and
+  doing so would expand commit 2 beyond its stated four-line scope.
+  The conservative reading is the arithmetic, not the intent, is off.
+- **Backing (B):** Direct line read at `provider_turn.ex:337` shows an
+  `if` clause inside a function body (indent level matches an interior
+  block, not a head).
+
+#### Falsification attempt for claim 6
+
+- **Strategy:** Counter-example construction — locate any commit-2 edit
+  whose line is not at function-head depth.
+- **Attempt:** Read line 337 of `provider_turn.ex`: it is an interior
+  `if` expression inside a larger function body. Therefore commit 2
+  covers 3 (not 4) heads; commit 4 must cover 98 (not 97).
+- **Outcome:** partially_falsified. The 101-head total is correct
+  (Claim 3); the migration-sketch sub-arithmetic is off by one. The
+  solution's substantive content (sweep all 101 heads) is unaffected
+  — the off-by-one is in the breakdown across commits 2 and 4. The
+  Qualifier narrows the claim from "97 in commit 4" to "98 in commit
+  4" (or, equivalently, "97 plus the one head whose body §B touches at
+  line 337"); no body of the solution changes.
+- **Action:** Narrow the Qualifier in place. Note for the implementer:
+  treat commit 4 as covering all heads not already head-matched in
+  commit 2 (3 heads), i.e. 98 heads. No revision of solution.md or
+  problem.md is required; the implementer's commit-4 line-count
+  estimate will match reality if they compute it as 101 minus
+  whatever commit 2 head-matched, rather than copying "97" from the
+  prose.
+
+## Cross-claim consistency
+
+Claims 1–5 are mutually consistent: claim 1 introduces the accessors;
+claim 2 wires them into four call sites; claim 3 establishes the head
+inventory; claim 4 establishes the alias absence (which §C migration
+step 3 will repair); claim 5 establishes that no test rework is
+needed. Claim 6 is the only inconsistency — its arithmetic does not
+match the substance of claims 2 and 3 — and the resolution narrows
+claim 6's Qualifier rather than disturbing the others.
+
+A second cross-cutting observation: problem.md asserts "no `defstruct`
+or `@type t :: %Tau.Session.Data{}`" (lines 21–22), but
+`lib/tau/session/data.ex` already has both (`:20, :41, :96`). The
+solution correctly works from the present code state and meets the AC
+("`Tau.Session.Data` exports a `defstruct` with `@enforce_keys` for
+every required field and an `@type t :: %__MODULE__{}` spec; `Data.new/1`
+returns `{:ok, %Tau.Session.Data{}}` ...") trivially — the AC's first
+three clauses are *already* satisfied; clause (d) ("all sub-modules
+pattern-match on `%Tau.Session.Data{}` in their function heads") is the
+only outstanding work and is the focus of this revision. This is not a
+contradiction in the solution; it is a staleness in problem.md's Context
+section that does not require revision (problem.md's AC remains the
+correct target; the Context prose merely undercounts what is already
+done). Flagged in Outstanding doubts.
+
+## Falsification summary
+
+| # | Claim (short) | Strategy | Outcome | Action |
+|---|---------------|----------|---------|--------|
+| 1 | Add `get_queue/2`, `put_queue/3`, `replace_field/3` to `Data` | dependency check | withstood | none |
+| 2 | Four defensive-read / dynamic-key edits at named sites | counter-example construction | withstood | none |
+| 3 | Per-file head inventory totals 101 | dependency check (grep re-run) | withstood | none |
+| 4 | No `alias Tau.Session.Data` exists in nine sub-modules | dependency check (grep re-run) | withstood | none |
+| 5 | No test invokes touched functions with bare-map args | counter-example construction | withstood (residual doubt on helper-built maps) | flag in Outstanding doubts |
+| 6 | Commit 4 covers 97 heads (= 101 − 4 in commit 2) | counter-example construction | partially falsified — should be 98 | narrow Qualifier in place; note for implementer |
+
+## Revision required
+
+None. Claim 6's partial falsification is a documentation off-by-one in
+the migration sketch's sub-arithmetic; it does not invalidate the
+solution's substantive scope (sweep all 101 heads), does not change any
+recommendation, and does not require re-running propose/select.
+
+- **Target file:** n/a
+- **Revision kind:** n/a (narrowed Qualifier recorded here)
+- **Rationale:** The off-by-one is local to a commit-decomposition
+  sentence; the implementer can compute the residual head count
+  directly from the per-file table (Claim 3) without consulting the
+  off-by-one prose. Triggering a full solution revision for a
+  one-integer arithmetic note would be disproportionate; the
+  partial-falsification log here is the correct response per validate.md
+  §5 ("Partially falsified → narrow Qualifier in place; no revision
+  needed").
+
+## Outstanding doubts
+
+- **Test-helper-built maps.** The grep in Claim 5 covers literal `%{`
+  call sites only; it does not exhaustively rule out test helpers that
+  return a non-struct `data` map (e.g. a `build_data/0` helper in
+  `test/support/`). An implementer should re-run `mix test` after the
+  head sweep and treat any `FunctionClauseError` failure as a
+  test-helper that needs to be ported to `Tau.Session.Data.new/1`. The
+  failure would be loud and local, not silent.
+- **problem.md Context staleness.** Problem.md lines 21–22 claim "no
+  `defstruct` or `@type t :: %Tau.Session.Data{}`", but
+  `lib/tau/session/data.ex` already has both at lines 20, 41, 96. The
+  AC clauses (a)/(b)/(c) are therefore already met; only clause (d) is
+  outstanding (and is the focus of this solution). The discrepancy
+  does not change the AC or the work scope; it does affect how a
+  reader sizes the change. A future amendment to problem.md to mark
+  clauses (a)–(c) as "already satisfied at HEAD" would be accurate but
+  is not required for the solution to land.
+- **`replace_field/3` audibility.** Carried over from solution Open
+  Questions: `replace_field/3` accepts `atom()` for `key`; Dialyzer
+  cannot verify at the call site that `key` names a valid struct
+  field. The "single auditable escape hatch" property (one function to
+  grep for `replace_field`) is the intended trade-off, not a bug. The
+  parent validator should note this as a known weakness inherited from
+  this sub-tree.

--- a/docs/problems-archive-v1-modules/tau-session/subproblems/fsm-facade-helpers/problem.md
+++ b/docs/problems-archive-v1-modules/tau-session/subproblems/fsm-facade-helpers/problem.md
@@ -1,0 +1,86 @@
+---
+template_version: 1
+template_name: problem
+node_kind: leaf
+depth: 1
+parent: ../../problem.md
+status: draft
+---
+
+# Problem: shared @doc false helpers are public functions on the FSM module
+
+## Statement
+
+`lib/tau/session.ex` exports eight `@doc false` functions
+(`broadcast/2`, `append_message/2`, `generate_event_id/0`,
+`transition/3`, `emit_user_message_telemetry/3`, `hook_payload/3`,
+`process_user_message/2`, `current_run?/2`) that sub-modules call as
+`Tau.Session.broadcast(id, event)`, `Tau.Session.append_message(data, msg)`,
+etc. These functions have no relationship to the `:gen_statem` contract; they
+are utilities used across sub-modules that have been left on the FSM module
+because there was no other home for them during the extraction. Any sub-module
+that calls them is coupled to the top-level FSM module purely for utility
+access.
+
+## Context
+
+- `session.ex` lines 1293–1438: eight `@doc false` function heads — `current_run?/2`
+  (token validity), `process_user_message/2` (hook + route), `append_message/2`
+  (O(n) list append), `generate_event_id/0` (UUID/fallback), `transition/3`
+  (telemetry emit), `broadcast/2` (PubSub), `emit_user_message_telemetry/3`
+  (telemetry), `hook_payload/3` + `transcript_path/1` (hook payload builder).
+- Sub-modules that call these via `Tau.Session.<fn>`:
+  `SlashCommand`, `ProviderTurn`, `CodingAgentTurn`, `ToolDispatch`,
+  `Compaction`, `ModelSwap` — six of the ten sub-modules reference the FSM
+  module for utility functions.
+- `Tau.Session.Data` (`lib/tau/session/data.ex`, 369 LOC) already owns struct
+  initialisation; it is the natural home for pure data-manipulation utilities
+  (`append_message`, `generate_event_id`, `current_run?`).
+- `Tau.Session.Events` (`lib/tau/session/events.ex`, 263 LOC) or a new
+  `Tau.Session.Broadcast` module could own `broadcast/2` and
+  `emit_user_message_telemetry/3`.
+- `process_user_message/2` is not a utility — it is a routing function that
+  calls hook dispatch and then re-enters `handle_event/4`; it belongs in
+  `Tau.Session.Queue` or `Tau.Session.SlashCommand`, not as a `@doc false`
+  on the FSM.
+- `hook_payload/3` and `transcript_path/1` are pure builders; they could live
+  in `Tau.Session.Data` or a new `Tau.Session.Hooks` helper module.
+
+## Complecting hypothesis
+
+The utility functions are complected with the `:gen_statem` entry point
+because the extraction of sub-modules did not simultaneously introduce a
+shared internal utility module; the path of least resistance was to leave
+helpers in the original file and mark them `@doc false`.
+
+`process_user_message/2` is complected with the FSM module because it
+calls `handle_event/4` internally (routing back into the FSM), making it
+appear to be FSM logic when it is actually a coordination function between
+`SlashCommand` classification and turn initiation.
+
+## Decomposition strategy
+
+(leaf — no further decomposition; proceed to proposals)
+
+## Acceptance criterion
+
+`lib/tau/session.ex` contains no `@doc false` functions; every utility
+used by sub-modules lives in a clearly-named sub-module
+(e.g. `Tau.Session.Data`, `Tau.Session.Queue`, or a new
+`Tau.Session.Broadcast`), and sub-modules call those modules directly rather
+than calling `Tau.Session.<fn>`.
+
+## Out of scope
+
+- The behaviour of any of these utilities — this problem is about location,
+  not correctness.
+- `append_message/2` O(n) performance — a separate bug, not a structural
+  complecting problem.
+- `generate_id/0` (public API, line 487) — that is a documented public
+  function, not a `@doc false` helper.
+- Sibling sub-problems: cancellation-teardown, user-message-routing,
+  cross-cutting-data.
+
+## Amendment log
+
+- (none yet)

--- a/docs/problems-archive-v1-modules/tau-session/subproblems/fsm-facade-helpers/proposals/proposal-1.md
+++ b/docs/problems-archive-v1-modules/tau-session/subproblems/fsm-facade-helpers/proposals/proposal-1.md
@@ -1,0 +1,148 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 1
+parent_problem: ../problem.md
+---
+
+# Proposal 1: Tau.Session.Helpers — one new shared-utility module
+
+## Approach
+
+Introduce a single new module `lib/tau/session/helpers.ex` that absorbs all eight `@doc false` functions verbatim from `session.ex`: `broadcast/2`, `append_message/2`, `generate_event_id/0`, `transition/3`, `emit_user_message_telemetry/3`, `hook_payload/3`, `transcript_path/1` (promoted from `defp` to `defp` inside `Helpers`, or to `def` if sub-modules need it), and `process_user_message/2`. Every callsite in `session.ex` and in sub-modules (`SlashCommand`, `ProviderTurn`, `CodingAgentTurn`, `ToolDispatch`, `Compaction`, `ModelSwap`) is updated to `Tau.Session.Helpers.<fn>(...)`. The `@doc false` annotations on `session.ex` are removed; the functions on `session.ex` themselves are removed.
+
+`register_builtins/0` (currently the last `@doc false` function, line 1426) is also removed from `session.ex` and placed in `Helpers` if it is a shared utility, or dropped back into `session.ex` as a `defp` if it is called only from `init/1`.
+
+## Rationale
+
+The complecting is structural: utilities live on the `:gen_statem` module because there was no shared home at extraction time. The simplest decomplecting is to create that home. A single `Helpers` module is the minimal intervention — one file, one alias to add per sub-module, zero new abstractions. It does not impose a concern taxonomy (which may be premature) and does not require coordinating changes across multiple existing modules. The acceptance criterion is satisfied: `session.ex` has no `@doc false` functions; sub-modules call `Tau.Session.Helpers` directly.
+
+The `process_user_message/2` placement in `Helpers` is a tactical compromise: it still calls `handle_event/4` internally, so it cannot move far from the FSM boundary. Housing it in `Helpers` documents the awkward coupling explicitly without resolving it, which is acceptable because the user-message-routing sub-problem is out of scope here.
+
+## Sketch
+
+```
+# New file: lib/tau/session/helpers.ex
+defmodule Tau.Session.Helpers do
+  @moduledoc """
+  Shared internal utilities used across `Tau.Session` sub-modules.
+  Not part of the public `Tau.Session` API.
+  """
+
+  alias Tau.Session.Events
+  alias Phoenix.PubSub
+
+  @spec broadcast(String.t(), struct()) :: :ok | {:error, term()}
+  def broadcast(id, event) do
+    PubSub.broadcast(Tau.PubSub, "session:#{id}", event)
+  end
+
+  @spec append_message(map(), Tau.Message.t()) :: map()
+  def append_message(data, msg), do: %{data | messages: data.messages ++ [msg]}
+
+  @spec generate_event_id() :: String.t()
+  def generate_event_id do
+    case Code.ensure_loaded?(Uniq.UUID) do
+      true -> apply(Uniq.UUID, :uuid7, [])
+      _ -> "evt_" <> (:crypto.strong_rand_bytes(10) |> Base.url_encode64(padding: false))
+    end
+  end
+
+  @spec transition(String.t(), map(), atom()) :: :ok
+  def transition(id, _data, to) do
+    :telemetry.execute([:tau, :session, :transition], %{system_time: System.system_time()}, %{
+      session_id: id,
+      to: to
+    })
+    :ok
+  end
+
+  @spec emit_user_message_telemetry(atom(), map(), atom()) :: :ok
+  def emit_user_message_telemetry(event, data, state) do
+    :telemetry.execute(
+      [:tau, :session, :user_message, event],
+      %{system_time: System.system_time()},
+      %{session_id: data.id, from_state: state}
+    )
+  end
+
+  @spec hook_payload(map(), atom(), map()) :: map()
+  def hook_payload(data, event, extras) when is_map(extras) do
+    Map.merge(
+      %{
+        session_id: data.id,
+        cwd: data.cwd,
+        permission_mode: Map.get(data.metadata, :permissions_mode, :default),
+        hook_event_name: to_string(event),
+        transcript_path: transcript_path(data),
+        metadata: data.metadata || %{}
+      },
+      extras
+    )
+  end
+
+  defp transcript_path(%{persistence: p, id: id, cwd: cwd}), do: p.path_for(id, cwd)
+
+  # process_user_message/2 re-enters handle_event/4; it is placed here
+  # to remove it from session.ex's public surface, not to resolve the
+  # routing coupling (that is the user-message-routing sub-problem).
+  @spec process_user_message(Tau.Message.t(), map()) :: term()
+  def process_user_message(msg, data) do
+    # … verbatim body from session.ex lines 1311–1341 …
+  end
+end
+```
+
+```
+# In each sub-module, add at top:
+alias Tau.Session.Helpers
+
+# Replace every Tau.Session.broadcast(...) call:
+Helpers.broadcast(id, event)
+
+# Replace every Tau.Session.append_message(...) call:
+Helpers.append_message(data, msg)
+# etc.
+```
+
+File move summary:
+- `lib/tau/session.ex` — remove 8 `@doc false` defs (lines ~1291–1438, minus `register_builtins/0`)
+- `lib/tau/session/helpers.ex` — new file, ~80 LOC
+
+## Tradeoffs
+
+### Strengths
+
+- Minimal diff surface: one new file, callsite substitutions in ~6 sub-modules, no structural reorganisation.
+- Satisfies the acceptance criterion completely and atomically.
+- No new taxonomy decisions: a single module is easier to understand than a partitioned set.
+- `transcript_path/1` can remain `defp` inside `Helpers` — does not need to be promoted.
+- Low risk of breakage: functions are moved verbatim; no logic changes.
+
+### Weaknesses
+
+- `Helpers` is a grab-bag module — it mixes PubSub broadcasting, telemetry emission, data mutation, UUID generation, and hook-payload construction under one roof. The concern boundary is "not session.ex" rather than a coherent responsibility.
+- `process_user_message/2` in `Helpers` retains the internal `handle_event/4` call; it is still awkwardly coupled to the FSM even in the new location.
+- The module name `Helpers` is a known anti-pattern signal ("Util", "Common", "Helpers" modules tend to grow into grab-bags over time).
+- Offers no guidance for future contributors on where new shared utilities belong.
+
+### Costs
+
+- ~6 sub-modules need an `alias Tau.Session.Helpers` added and callsites updated.
+- `session.ex` callsites (e.g. in the cancel clauses, in `process_user_message/2` itself) also need updating.
+- Estimate: ~25–35 line changes across 7–8 files, plus the new ~80 LOC file.
+- No new dependencies; no interface changes visible to external callers.
+
+## Dependencies
+
+- None. All eight functions are self-contained moves; no other sub-module needs to be changed first.
+
+## Confidence
+
+medium — the approach is straightforward, but the `process_user_message/2` placement is a known compromise that leaves FSM coupling in place. Confidence would rise to high if the user-message-routing sub-problem is solved concurrently or if `process_user_message/2` is moved out of this proposal's scope entirely.
+
+## Prior art / references
+
+- `docs/refactor/inventory-session.md` — the extraction plan that produced the current sub-modules; this proposal follows the same pattern of "new sub-module absorbs inline code".
+- Elixir convention: `SomeApp.SomeContext.Helpers` modules appear in Phoenix-generated umbrella apps as catch-alls, which makes the name recognisable but also carries the grab-bag stigma.
+- Problem context: "there was no other home for them during the extraction" — Proposal 1 is the minimal fix for that exact cause.

--- a/docs/problems-archive-v1-modules/tau-session/subproblems/fsm-facade-helpers/proposals/proposal-2.md
+++ b/docs/problems-archive-v1-modules/tau-session/subproblems/fsm-facade-helpers/proposals/proposal-2.md
@@ -1,0 +1,179 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 2
+parent_problem: ../problem.md
+---
+
+# Proposal 2: Distribute helpers into existing modules by concern
+
+## Approach
+
+Rather than creating a new shared module, move each `@doc false` function to the existing sub-module that most coherently owns it, based on concern:
+
+- `append_message/2`, `generate_event_id/0`, `current_run?/2` → `Tau.Session.Data` (pure data operations on the session struct)
+- `broadcast/2` → `Tau.Session.Events` (promoted from a thin wrapper to a `def` on the events module; Events already owns the event structs and the PubSub topic name)
+- `emit_user_message_telemetry/3` and `transition/3` → `Tau.Session.Journal` (Journal already handles persistence telemetry; transition and user-message telemetry fit the same observability concern)
+- `hook_payload/3` and `transcript_path/1` → a new `Tau.Session.Hooks` module (hook payload construction is distinct from both data manipulation and broadcasting; it has its own protocol — the Phase 10 hook contract)
+- `process_user_message/2` → `Tau.Session.Queue` (it is a routing function called at the queue/dispatch boundary; Queue is the natural coordinator between message intake and turn start)
+
+No new grab-bag module is introduced. Every function lands in a module with a coherent, named responsibility.
+
+## Rationale
+
+The problem statement identifies that the extraction of sub-modules did not simultaneously introduce a shared utility module. Distributing to existing modules rather than creating a new one respects the concern taxonomy already established by the extraction — each sub-module exists because it owns a named concern. `Data` owns struct operations; `Events` owns the broadcast surface; `Journal` owns observability; a new `Hooks` module owns the hook-contract adapter; `Queue` owns the message-routing boundary. This distribution means each sub-module's imports become self-documenting: a module that imports `Tau.Session.Data` is doing data operations; one that imports `Tau.Session.Events` is broadcasting.
+
+`process_user_message/2` moving to `Queue` is the most consequential placement: it still calls `handle_event/4` internally, making `Queue` coupled back to the FSM. However, `Queue` is already the natural boundary for routing decisions, and this placement at least names the coupling explicitly in a module whose purpose is coordination.
+
+## Sketch
+
+```
+# lib/tau/session/data.ex — add three functions
+
+@spec append_message(t(), Tau.Message.t()) :: t()
+def append_message(%__MODULE__{} = data, msg),
+  do: %{data | messages: data.messages ++ [msg]}
+
+@spec generate_event_id() :: String.t()
+def generate_event_id do
+  case Code.ensure_loaded?(Uniq.UUID) do
+    true -> apply(Uniq.UUID, :uuid7, [])
+    _ -> "evt_" <> (:crypto.strong_rand_bytes(10) |> Base.url_encode64(padding: false))
+  end
+end
+
+@spec current_run?(t(), {:provider, reference()} | {:coding_agent, pid()}) :: boolean()
+def current_run?(%__MODULE__{stream_ref: ref}, {:provider, ref}) when is_reference(ref), do: true
+def current_run?(%__MODULE__{coding_agent_dispatcher: pid}, {:coding_agent, pid}) when is_pid(pid), do: true
+def current_run?(_data, _token), do: false
+```
+
+```
+# lib/tau/session/events.ex — add one function
+
+@doc """
+Broadcast `event` on the PubSub topic for `session_id`.
+"""
+@spec broadcast(String.t(), struct()) :: :ok | {:error, term()}
+def broadcast(session_id, event) do
+  Phoenix.PubSub.broadcast(Tau.PubSub, "session:#{session_id}", event)
+end
+```
+
+```
+# lib/tau/session/journal.ex — add two telemetry helpers
+
+@spec emit_transition(String.t(), atom()) :: :ok
+def emit_transition(session_id, to) do
+  :telemetry.execute([:tau, :session, :transition], %{system_time: System.system_time()}, %{
+    session_id: session_id,
+    to: to
+  })
+  :ok
+end
+
+@spec emit_user_message(atom(), map(), atom()) :: :ok
+def emit_user_message(event, data, state) do
+  :telemetry.execute(
+    [:tau, :session, :user_message, event],
+    %{system_time: System.system_time()},
+    %{session_id: data.id, from_state: state}
+  )
+end
+```
+
+```
+# New file: lib/tau/session/hooks.ex
+
+defmodule Tau.Session.Hooks do
+  @moduledoc """
+  Hook-payload builders for `Tau.Session`.
+  Implements the Phase 10 hook contract: every payload carries
+  session_id, cwd, permission_mode, hook_event_name, transcript_path,
+  and metadata, merged with the event-specific extras map.
+  """
+
+  @spec payload(map(), atom(), map()) :: map()
+  def payload(data, event, extras) when is_map(extras) do
+    Map.merge(
+      %{
+        session_id: data.id,
+        cwd: data.cwd,
+        permission_mode: Map.get(data.metadata, :permissions_mode, :default),
+        hook_event_name: to_string(event),
+        transcript_path: transcript_path(data),
+        metadata: data.metadata || %{}
+      },
+      extras
+    )
+  end
+
+  defp transcript_path(%{persistence: p, id: id, cwd: cwd}), do: p.path_for(id, cwd)
+end
+```
+
+```
+# lib/tau/session/queue.ex — add process_user_message/2
+# (retains the handle_event/4 back-call; the routing coupling is
+#  documented but not resolved — that is the user-message-routing sub-problem)
+
+@spec process_user_message(Tau.Message.t(), map()) :: term()
+def process_user_message(msg, data) do
+  # … verbatim body …
+end
+```
+
+Callsite renames in sub-modules and session.ex:
+
+| Old call | New call |
+|---|---|
+| `Tau.Session.broadcast(id, event)` | `Tau.Session.Events.broadcast(id, event)` |
+| `Tau.Session.append_message(data, msg)` | `Tau.Session.Data.append_message(data, msg)` |
+| `Tau.Session.generate_event_id()` | `Tau.Session.Data.generate_event_id()` |
+| `Tau.Session.current_run?(data, token)` | `Tau.Session.Data.current_run?(data, token)` |
+| `Tau.Session.transition(id, data, to)` | `Tau.Session.Journal.emit_transition(id, to)` |
+| `Tau.Session.emit_user_message_telemetry(e, d, s)` | `Tau.Session.Journal.emit_user_message(e, d, s)` |
+| `Tau.Session.hook_payload(data, event, extras)` | `Tau.Session.Hooks.payload(data, event, extras)` |
+| `Tau.Session.process_user_message(msg, data)` | `Tau.Session.Queue.process_user_message(msg, data)` |
+
+## Tradeoffs
+
+### Strengths
+
+- No new grab-bag module — each function lands in a named-concern module.
+- `Tau.Session.Data` gains typed function signatures on the struct (since `Data` is already a `defstruct`); `append_message/2` can be strengthened from `map()` to `Data.t()` input/output.
+- `Tau.Session.Events.broadcast/2` is a natural fit — Events already owns the topic name implicitly; making broadcast a function on Events makes the topic a single point of definition.
+- Sub-module imports become self-documenting: `alias Tau.Session.Data` signals data operations; `alias Tau.Session.Events` signals broadcasting.
+- Satisfies the acceptance criterion: `session.ex` loses all `@doc false` defs.
+
+### Weaknesses
+
+- Higher coordination cost: changes touch four existing modules plus one new module (`Hooks`), and all six sub-module callsites, in a single PR.
+- `Tau.Session.Journal` is a debatable home for `transition/3` and `emit_user_message_telemetry/3` — Journal owns persistence telemetry; adding FSM-transition telemetry blurs its scope. An alternative is a new `Tau.Session.Telemetry` module (but that is scope creep from this proposal).
+- `process_user_message/2` in `Queue` retains the `handle_event/4` back-call; `Queue` becomes coupled to the FSM module in a way its other functions are not.
+- Renaming `transition/3` to `emit_transition/2` and `hook_payload/3` to `Hooks.payload/3` are minor API-shape changes; callers must update signatures, not just module prefixes.
+
+### Costs
+
+- ~6 sub-modules + `session.ex` updated for callsites: ~40–55 line changes.
+- `data.ex` gains ~15 LOC; `events.ex` gains ~8 LOC; `journal.ex` gains ~15 LOC.
+- New file `hooks.ex` ~35 LOC.
+- Total: ~75 LOC net across ~9 files.
+- No external API changes; all moved functions were already `@doc false`.
+
+## Dependencies
+
+- `Tau.Session.Data` must already be a proper `defstruct` (it is, per `data.ex` line 96) — verified.
+- `Tau.Session.Journal` must exist and be importable from `session.ex` and sub-modules (it is, per the extraction inventory).
+- No new library dependencies.
+
+## Confidence
+
+medium — the concern mapping is defensible but `Journal` as home for transition telemetry is debatable. Confidence would rise to high if a `Tau.Session.Telemetry` module were introduced for the two telemetry helpers (but that would add a fifth destination, which may be worth it or may be over-decomposition).
+
+## Prior art / references
+
+- `Tau.Session.Data` (`lib/tau/session/data.ex`) — already owns struct initialisation; adding pure struct operations is a direct extension of its stated purpose.
+- `Tau.Session.Events` (`lib/tau/session/events.ex`) — already defines the event structs broadcast on `"session:<id>"`; `broadcast/2` is the natural complement.
+- Elixir/OTP idiom: placing `broadcast/2` on the events module mirrors how `Phoenix.Channel` places `broadcast/3` on the channel module rather than on a separate utility.
+- `docs/refactor/inventory-session.md` — the extraction plan that defines the concern taxonomy this proposal extends.

--- a/docs/problems-archive-v1-modules/tau-session/subproblems/fsm-facade-helpers/proposals/proposal-3.md
+++ b/docs/problems-archive-v1-modules/tau-session/subproblems/fsm-facade-helpers/proposals/proposal-3.md
@@ -1,0 +1,172 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 3
+parent_problem: ../problem.md
+---
+
+# Proposal 3: Two-module split — Tau.Session.Util and Tau.Session.Hooks
+
+## Approach
+
+Split the eight helpers into exactly two new modules by a single, clear axis — **side-effect-free vs side-effectful**:
+
+- `Tau.Session.Util` receives the four pure functions: `append_message/2`, `generate_event_id/0`, `current_run?/2`, and `hook_payload/3` + `transcript_path/1`. (Hook payload construction is pure — it reads struct fields and returns a map; the hook *dispatch* is elsewhere.)
+- `Tau.Session.Effects` receives the three side-effectful functions: `broadcast/2`, `emit_user_message_telemetry/3`, and `transition/3`.
+- `process_user_message/2` is demoted to a `defp` on `session.ex` itself (not moved to a sub-module), because it re-enters `handle_event/4` and is therefore FSM-internal coordination, not a shared utility. Removing it from the public surface means sub-modules that do not directly call it have no coupling to it.
+
+This scheme satisfies the acceptance criterion (no `@doc false` public functions on `session.ex`) while establishing a principled two-tier: pure helpers in `Util`, effectful helpers in `Effects`.
+
+## Rationale
+
+The complecting mixes two kinds of utilities: pure functions that transform data or generate IDs (no side effects, trivially testable) and effectful functions that emit telemetry or publish to PubSub (side effects, harder to unit-test). Grouping them together in one module (Proposal 1's `Helpers`) obscures this distinction. Grouping them by concern (Proposal 2) distributes them across many modules. This proposal splits on the pure/effectful axis — a well-understood Elixir/functional programming partition — and uses exactly two modules, keeping the cognitive overhead low.
+
+Demoting `process_user_message/2` to `defp` rather than moving it acknowledges that it is an FSM-internal routing function, not a shared utility. The acceptance criterion does not require that every function in `session.ex` be a public function — only that `@doc false` public functions (which create spurious API surface) are removed. Making it private removes it from the public surface without the risk of coupling a sub-module back to `handle_event/4`.
+
+## Sketch
+
+```
+# New file: lib/tau/session/util.ex
+defmodule Tau.Session.Util do
+  @moduledoc """
+  Pure utility functions shared across `Tau.Session` sub-modules.
+  No side effects; safe to call in any context.
+  """
+
+  alias Tau.Session.Data
+
+  @spec append_message(Data.t() | map(), Tau.Message.t()) :: Data.t() | map()
+  def append_message(data, msg), do: %{data | messages: data.messages ++ [msg]}
+
+  @spec generate_event_id() :: String.t()
+  def generate_event_id do
+    case Code.ensure_loaded?(Uniq.UUID) do
+      true -> apply(Uniq.UUID, :uuid7, [])
+      _ -> "evt_" <> (:crypto.strong_rand_bytes(10) |> Base.url_encode64(padding: false))
+    end
+  end
+
+  @spec current_run?(map(), {:provider, reference()} | {:coding_agent, pid()}) :: boolean()
+  def current_run?(%{stream_ref: ref}, {:provider, ref}) when is_reference(ref), do: true
+  def current_run?(%{coding_agent_dispatcher: pid}, {:coding_agent, pid}) when is_pid(pid), do: true
+  def current_run?(_data, _token), do: false
+
+  @spec hook_payload(map(), atom(), map()) :: map()
+  def hook_payload(data, event, extras) when is_map(extras) do
+    Map.merge(
+      %{
+        session_id: data.id,
+        cwd: data.cwd,
+        permission_mode: Map.get(data.metadata, :permissions_mode, :default),
+        hook_event_name: to_string(event),
+        transcript_path: transcript_path(data),
+        metadata: data.metadata || %{}
+      },
+      extras
+    )
+  end
+
+  defp transcript_path(%{persistence: p, id: id, cwd: cwd}), do: p.path_for(id, cwd)
+end
+```
+
+```
+# New file: lib/tau/session/effects.ex
+defmodule Tau.Session.Effects do
+  @moduledoc """
+  Effectful shared operations for `Tau.Session` sub-modules:
+  PubSub broadcast and telemetry emission.
+
+  Isolated from `Tau.Session.Util` so callers needing only pure
+  utilities do not import the effects surface.
+  """
+
+  @spec broadcast(String.t(), struct()) :: :ok | {:error, term()}
+  def broadcast(id, event) do
+    Phoenix.PubSub.broadcast(Tau.PubSub, "session:#{id}", event)
+  end
+
+  @spec emit_user_message(atom(), map(), atom()) :: :ok
+  def emit_user_message(event, data, state) do
+    :telemetry.execute(
+      [:tau, :session, :user_message, event],
+      %{system_time: System.system_time()},
+      %{session_id: data.id, from_state: state}
+    )
+  end
+
+  @spec emit_transition(String.t(), atom()) :: :ok
+  def emit_transition(session_id, to) do
+    :telemetry.execute([:tau, :session, :transition], %{system_time: System.system_time()}, %{
+      session_id: session_id,
+      to: to
+    })
+    :ok
+  end
+end
+```
+
+```
+# In lib/tau/session.ex — process_user_message/2 demoted:
+# Change @doc false def to defp
+
+defp process_user_message(msg, data) do
+  # … same body …
+end
+
+# All other @doc false defs removed; callsites updated:
+# Tau.Session.broadcast(...)           → Tau.Session.Effects.broadcast(...)
+# Tau.Session.append_message(...)      → Tau.Session.Util.append_message(...)
+# Tau.Session.generate_event_id()      → Tau.Session.Util.generate_event_id()
+# Tau.Session.current_run?(...)        → Tau.Session.Util.current_run?(...)
+# Tau.Session.transition(...)          → Tau.Session.Effects.emit_transition(...)
+# Tau.Session.emit_user_message_telemetry(...) → Tau.Session.Effects.emit_user_message(...)
+# Tau.Session.hook_payload(...)        → Tau.Session.Util.hook_payload(...)
+```
+
+Sub-modules that call the old names add exactly one of:
+```
+alias Tau.Session.Util
+alias Tau.Session.Effects
+```
+…depending on which helpers they use.
+
+## Tradeoffs
+
+### Strengths
+
+- The pure/effectful split is a principled, well-understood axis; it mirrors Elixir community practice and Hickey's "simple" vs "complex" distinction (effects are complecting by nature).
+- `process_user_message/2` becomes `defp` — it disappears from `session.ex`'s public surface without any sub-module becoming coupled to `handle_event/4`.
+- Sub-modules that only need pure utilities (`Util`) do not import the effects surface; the import communicates intent.
+- Two new modules is still a low cognitive overhead (compared to Proposal 2's five destinations).
+- Satisfies the acceptance criterion without ambiguity.
+
+### Weaknesses
+
+- `Util` is still a somewhat generic name; contributors may add unrelated pure functions to it over time.
+- `hook_payload/3` in `Util` co-locates with `append_message/2` and `current_run?/2` — these are not obviously related. A future reader might prefer `hook_payload/3` in a `Hooks` module (as in Proposal 2).
+- Demoting `process_user_message/2` to `defp` rather than extracting it does not fully resolve its architectural ambiguity — it still calls `handle_event/4` internally. However, since this is declared out-of-scope (user-message-routing sub-problem), `defp` is a valid resting state.
+- `Effects` as a module name is less conventional in Elixir codebases than, say, `Tau.Session.PubSub` or `Tau.Session.Telemetry`.
+
+### Costs
+
+- Two new files: `util.ex` (~55 LOC), `effects.ex` (~35 LOC).
+- `session.ex`: 7 `@doc false` defs removed; 1 `def` demoted to `defp`; callsites within `session.ex` updated.
+- ~6 sub-modules: alias additions + callsite updates; ~30–40 line changes.
+- Total: ~130 LOC net across ~9 files (counting new files).
+- No external API changes (all functions were `@doc false`).
+
+## Dependencies
+
+- None. All function bodies are copied verbatim; no other module needs to be refactored first.
+- The `defp` demotion of `process_user_message/2` is self-contained in `session.ex`.
+
+## Confidence
+
+medium-high — the split axis (pure vs effectful) is principled and testable. Confidence is not "high" because `hook_payload/3` in `Util` is a weak fit next to `append_message/2`; if the selector finds that awkward, Proposal 2's `Hooks` module is the alternative for that one function.
+
+## Prior art / references
+
+- Elixir community idiom: "pure core, effectful shell" — see e.g. Gary Bernhardt's "Functional Core, Imperative Shell"; the Elixir equivalent separates pure transformations from `Phoenix.PubSub` / `:telemetry` calls.
+- `Tau.Session.Data` (`lib/tau/session/data.ex`) — already follows the "pure data module" pattern; `Util` extends that pattern to non-struct utilities.
+- The `@doc false` problem statement itself: "utilities have been left on the FSM module because there was no other home for them" — Proposal 3 creates two homes, partitioned by effect.

--- a/docs/problems-archive-v1-modules/tau-session/subproblems/fsm-facade-helpers/proposals/proposal-4.md
+++ b/docs/problems-archive-v1-modules/tau-session/subproblems/fsm-facade-helpers/proposals/proposal-4.md
@@ -1,0 +1,166 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 4
+parent_problem: ../problem.md
+---
+
+# Proposal 4: Inline all pure helpers into Tau.Session.Data; make broadcast a macro-less import
+
+## Approach
+
+This proposal takes the most aggressive consolidation stance: rather than creating new shared modules, it pushes as many of the eight helpers as possible into the one existing module that already owns the data shape — `Tau.Session.Data` — and handles the side-effectful remainder differently.
+
+Specifically:
+
+1. `append_message/2`, `generate_event_id/0`, `current_run?/2`, `hook_payload/3`, and `transcript_path/1` all move to `Tau.Session.Data`. `Data` is already the typed-struct owner; these are all pure functions that operate on or produce values from the session struct. The `Data.t()` type annotation for `append_message/2`'s input becomes available for free.
+
+2. `broadcast/2`, `emit_user_message_telemetry/3`, and `transition/3` are replaced **inline** at every callsite in `session.ex` — they are eliminated as named functions entirely, replaced by their one-to-two-line bodies inlined where called. The argument for inlining: `broadcast/2` is `Phoenix.PubSub.broadcast(Tau.PubSub, "session:#{id}", event)` — one line; `transition/3` is a `:telemetry.execute/3` call — two lines; `emit_user_message_telemetry/3` is a single `:telemetry.execute/3` call. None of these warrant a named function; they were `@doc false` precisely because they are wrappers over standard library calls.
+
+3. `process_user_message/2` is demoted to `defp` on `session.ex` (same as Proposal 3's treatment) — it re-enters `handle_event/4` and is FSM-internal; it does not belong in any shared module.
+
+The net result: `Tau.Session.Data` gains five new public functions; `session.ex` loses all eight `@doc false` defs; three calls become inline expressions; `process_user_message/2` becomes private.
+
+## Rationale
+
+The complecting hypothesis says helpers are on the FSM module because there was no shared home. But the problem statement also notes that `Tau.Session.Data` "is the natural home for pure data-manipulation utilities (`append_message`, `generate_event_id`, `current_run?`)". This proposal takes that note at face value and extends it: `hook_payload/3` is also a pure builder (it reads struct fields, builds a map); it belongs in the same module. The session data struct and the hook payload both describe session state — consolidating them in `Data` avoids a new module.
+
+The inlining of the three effectful wrappers is justified by their triviality: a function whose body is one standard-library call is noise, not abstraction. Inlining removes the naming overhead, makes the callsite directly readable (the reader sees `Phoenix.PubSub.broadcast(...)` without needing to know what `broadcast/2` wraps), and eliminates the sub-module import surface for these calls.
+
+## Sketch
+
+```
+# lib/tau/session/data.ex — add five public functions after the defstruct/type block
+
+@doc """
+Append `msg` to the session's message list.
+"""
+@spec append_message(t(), Tau.Message.t()) :: t()
+def append_message(%__MODULE__{} = data, msg),
+  do: %{data | messages: data.messages ++ [msg]}
+
+@doc """
+Generate a unique event ID. Uses Uniq.UUID v7 when available; falls
+back to a URL-safe random binary prefixed with "evt_".
+"""
+@spec generate_event_id() :: String.t()
+def generate_event_id do
+  case Code.ensure_loaded?(Uniq.UUID) do
+    true -> apply(Uniq.UUID, :uuid7, [])
+    _ -> "evt_" <> (:crypto.strong_rand_bytes(10) |> Base.url_encode64(padding: false))
+  end
+end
+
+@doc """
+Returns true when `token` identifies the currently active provider
+stream or coding-agent dispatcher for `data`.
+"""
+@spec current_run?(t(), {:provider, reference()} | {:coding_agent, pid()}) :: boolean()
+def current_run?(%__MODULE__{stream_ref: ref}, {:provider, ref}) when is_reference(ref), do: true
+def current_run?(%__MODULE__{coding_agent_dispatcher: pid}, {:coding_agent, pid}) when is_pid(pid), do: true
+def current_run?(_data, _token), do: false
+
+@doc """
+Build the Phase 10 hook-contract payload for `event` on `data`,
+merging in the event-specific `extras` map.
+"""
+@spec hook_payload(t(), atom(), map()) :: map()
+def hook_payload(%__MODULE__{} = data, event, extras) when is_map(extras) do
+  Map.merge(
+    %{
+      session_id: data.id,
+      cwd: data.cwd,
+      permission_mode: Map.get(data.metadata, :permissions_mode, :default),
+      hook_event_name: to_string(event),
+      transcript_path: transcript_path(data),
+      metadata: data.metadata || %{}
+    },
+    extras
+  )
+end
+
+defp transcript_path(%__MODULE__{persistence: p, id: id, cwd: cwd}), do: p.path_for(id, cwd)
+```
+
+```
+# lib/tau/session.ex — replace three named wrappers with inline bodies
+
+# BEFORE:
+Tau.Session.broadcast(data.id, %Events.Cancelled{...})
+Tau.Session.transition(data.id, data, :awaiting_user)
+Tau.Session.emit_user_message_telemetry(:enqueued, data, state)
+
+# AFTER:
+Phoenix.PubSub.broadcast(Tau.PubSub, "session:#{data.id}", %Events.Cancelled{...})
+:telemetry.execute([:tau, :session, :transition], %{system_time: System.system_time()},
+  %{session_id: data.id, to: :awaiting_user})
+:telemetry.execute([:tau, :session, :user_message, :enqueued], %{system_time: System.system_time()},
+  %{session_id: data.id, from_state: state})
+```
+
+```
+# lib/tau/session.ex — demotion of process_user_message/2:
+defp process_user_message(msg, data) do ... end   # was @doc false def
+
+# Remove from session.ex entirely:
+# @doc false def broadcast/2
+# @doc false def transition/3
+# @doc false def emit_user_message_telemetry/3
+# @doc false def append_message/2
+# @doc false def generate_event_id/0
+# @doc false def current_run?/2
+# @doc false def hook_payload/3
+```
+
+Sub-module callsite changes:
+| Old | New |
+|---|---|
+| `Tau.Session.append_message(data, msg)` | `Tau.Session.Data.append_message(data, msg)` |
+| `Tau.Session.generate_event_id()` | `Tau.Session.Data.generate_event_id()` |
+| `Tau.Session.current_run?(data, token)` | `Tau.Session.Data.current_run?(data, token)` |
+| `Tau.Session.hook_payload(data, event, extras)` | `Tau.Session.Data.hook_payload(data, event, extras)` |
+| `Tau.Session.broadcast(id, event)` | `Phoenix.PubSub.broadcast(Tau.PubSub, "session:#{id}", event)` |
+| `Tau.Session.transition(id, data, to)` | `:telemetry.execute([:tau, :session, :transition], ...)` inline |
+| `Tau.Session.emit_user_message_telemetry(e, d, s)` | `:telemetry.execute([:tau, :session, :user_message, e], ...)` inline |
+
+## Tradeoffs
+
+### Strengths
+
+- No new files: `Data` absorbs five helpers; three helpers are inlined away; zero new modules to maintain.
+- `Data` gains typed `@spec` annotations with `t()` — `append_message/2` and `current_run?/2` now pattern-match against `%__MODULE__{}` structs rather than `map()`, enabling Dialyzer to catch struct-field mismatches.
+- Inlining trivial wrappers (`broadcast/2`, `transition/3`) makes callsites more transparent — the reader sees the PubSub/telemetry call directly, without an indirection that reveals nothing.
+- Satisfies the acceptance criterion: `session.ex` has no `@doc false` public functions.
+- `hook_payload/3` in `Data` makes sense: it reads session struct fields to build an external payload — it is a data projection function.
+
+### Weaknesses
+
+- `Tau.Session.Data` grows from its current 369 LOC to approximately 430 LOC with the five additions. "Everything in Data" risks turning `Data` into the new grab-bag, just under a better name.
+- Inlining the three effectful calls trades named abstraction for verbosity: every `broadcast` callsite now repeats `Phoenix.PubSub.broadcast(Tau.PubSub, "session:#{id}", ...)` — the topic string `"session:#{id}"` is no longer defined in one place, creating a duplication risk if the topic format ever changes.
+- `hook_payload/3` co-locates with struct-definition and struct-manipulation in `Data`, which is semantically reasonable but may surprise contributors who look for hook-related code in a module named `Hooks` or `Events`.
+- The inlining of `transition/3` and `emit_user_message_telemetry/3` produces longer individual callsite lines; the caller must pass `System.system_time()` directly, repeating the measurement idiom at each callsite.
+- Sub-modules that currently call `Tau.Session.broadcast(...)` must change to the full `Phoenix.PubSub.broadcast(...)` form — this makes sub-module source noisier with the PubSub boilerplate.
+
+### Costs
+
+- `data.ex`: +~65 LOC (five functions + type annotations).
+- `session.ex`: 8 `@doc false` defs removed; 3 sets of callsites expanded inline (net ~+10 LOC to `session.ex` after the function removals).
+- ~6 sub-modules: alias updates + callsite changes; some callsites become multi-line where `broadcast/2` was one token.
+- Estimate: ~80 LOC net across ~8 files. No new files; one file (`data.ex`) grows meaningfully.
+- No external API changes.
+
+## Dependencies
+
+- `Tau.Session.Data` must already be a `defstruct` (confirmed, line 96 of `data.ex`).
+- No library upgrades required.
+- Should be done after — or in the same PR as — any SPEC-USER-TURN changes that add fields to `Data.t()`, to avoid merge conflicts on `data.ex`.
+
+## Confidence
+
+medium — the Data consolidation is well-grounded (problem.md itself names Data as the natural home for pure utilities), but the inlining decision is opinionated. Confidence would rise to high if a search of callsites confirms each of the three effectful functions is called ≤ 4 times total across the codebase (inlining is less costly with few callsites).
+
+## Prior art / references
+
+- Problem statement context: "Tau.Session.Data … is the natural home for pure data-manipulation utilities (append_message, generate_event_id, current_run?)" — directly endorses this proposal's consolidation into `Data`.
+- Elixir OTP idiom: trivial one-liner wrappers over well-known APIs (`Phoenix.PubSub.broadcast/3`, `:telemetry.execute/3`) are often left inline in mature codebases once the function they originally abstracted becomes universally familiar.
+- The `defstruct` + typed-spec pattern already used in `Tau.Session.Data` (`data.ex` lines 20–94) — this proposal extends the same pattern with additional functions.

--- a/docs/problems-archive-v1-modules/tau-session/subproblems/fsm-facade-helpers/solution.md
+++ b/docs/problems-archive-v1-modules/tau-session/subproblems/fsm-facade-helpers/solution.md
@@ -1,0 +1,88 @@
+---
+template_version: 1
+template_name: solution
+parent_problem: problem.md
+node_kind: leaf
+synthesised_from:
+  - proposals/proposal-2.md
+  - proposals/proposal-3.md
+selection_method: hybrid
+revision: 0
+---
+
+# Solution: Distribute helpers by concern, with pure/effectful split guiding the two ambiguous placements
+
+## Scoring table
+
+| # | Fit | Decomplecting depth | Migration cost | Risk | Reversibility |
+|---|-----|---------------------|----------------|------|---------------|
+| 1 (`Helpers` grab-bag) | Yes | Surface | Low | Low | Easy |
+| 2 (Distribute by concern) | Yes | Deep | Medium | Low | Easy |
+| 3 (Util + Effects split) | Yes | Substantial | Low | Low | Easy |
+| 4 (Consolidate into Data + inline) | Yes | Substantial | Medium | Medium | Medium |
+
+Fit: all four proposals satisfy the literal acceptance criterion (no `@doc false` on `session.ex`).
+
+Decomplecting depth differentiates them. Proposal 1 moves the grab-bag intact — the concern boundary stays "not session.ex", not a real responsibility. Proposal 4 consolidates into Data and inlines effects; the inlining trades one complecting (named wrappers on the FSM) for another (topic string duplication; telemetry boilerplate at every callsite). Proposal 3's pure/effectful split is principled and low-cost but leaves `hook_payload/3` awkwardly co-located with `append_message/2` in `Util`. Proposal 2 reaches the deepest decomplecting: each function lands in a module with a named, domain responsibility — but its placement of `transition/3` and `emit_user_message_telemetry/3` in `Journal` blurs Journal's scope.
+
+Risk and reversibility: all proposals except 4 are low-risk, easy to reverse (verbatim moves, no logic changes). Proposal 4 introduces duplication risk with inline topic strings and is harder to reverse (inlined code does not have a single re-extraction point).
+
+## Recommendation
+
+Distribute the eight helpers by concern (Proposal 2's scheme), using Proposal 3's pure/effectful naming insight to resolve the one debatable placement: the two telemetry helpers (`transition/3`, `emit_user_message_telemetry/3`) go into a new `Tau.Session.Telemetry` module rather than into `Journal`. This keeps `Journal` scoped to persistence observability and gives the FSM-transition and user-message telemetry a clear home. Everything else follows Proposal 2 exactly: `append_message/2`, `generate_event_id/0`, `current_run?/2` into `Tau.Session.Data`; `broadcast/2` into `Tau.Session.Events`; `hook_payload/3` + `transcript_path/1` into a new `Tau.Session.Hooks`; `process_user_message/2` into `Tau.Session.Queue`. `process_user_message/2` retains its `handle_event/4` back-call — that coupling is the user-message-routing sub-problem's scope, not this one's.
+
+## Selected from
+
+- **Chosen:** hybrid of `proposals/proposal-2.md` and `proposals/proposal-3.md`
+- **Why chosen:** Proposal 2 achieves the deepest decomplecting by distributing to named-concern modules; it is the only proposal where a sub-module's import list becomes fully self-documenting. Its single weak point is placing transition and user-message telemetry in `Journal`, which Proposal 2 itself acknowledges as debatable. Proposal 3's pure/effectful split insight resolves this cleanly: separating the FSM-transition telemetry from the persistence concern of `Journal` is exactly the `Effects`/`Telemetry` distinction Proposal 3 names. The hybrid takes Proposal 2's concern taxonomy and replaces its `Journal` debatable placement with a new `Tau.Session.Telemetry` module — the minimum change that removes Proposal 2's acknowledged weakness.
+
+Proposal 1 was rejected: `Helpers` is a surface-level move that recreates the grab-bag in a new file.  
+Proposal 4 was rejected: inlining the three effectful wrappers trades named abstraction for topic-string duplication; the inline `"session:#{id}"` pattern scattered across sub-modules is more fragile than the named `broadcast/2` it replaces. The consolidation of pure helpers into `Data` is sound, but this proposal takes only the sound part (via Proposal 2's scheme).
+
+## What changes
+
+- `lib/tau/session/data.ex` — add `append_message/2`, `generate_event_id/0`, `current_run?/2` as public `def` with `@spec` typed against `Data.t()`
+- `lib/tau/session/events.ex` — add `broadcast/2` as a public `def`; the PubSub topic string `"session:#{id}"` becomes a single point of definition here
+- `lib/tau/session/telemetry.ex` — new file (~35 LOC); owns `emit_transition/2` and `emit_user_message/3`
+- `lib/tau/session/hooks.ex` — new file (~35 LOC); owns `payload/3` (renamed from `hook_payload/3`) and private `transcript_path/1`
+- `lib/tau/session/queue.ex` — add `process_user_message/2` (verbatim move; retains `handle_event/4` back-call)
+- `lib/tau/session.ex` — remove all eight `@doc false` defs; update internal callsites to the new module-qualified names
+- `lib/tau/session/slash_command.ex`, `provider_turn.ex`, `coding_agent_turn.ex`, `tool_dispatch.ex`, `compaction.ex`, `model_swap.ex` — update callsites; add `alias` lines for whichever of the four destination modules each sub-module needs
+
+## What does not change
+
+- The bodies of all eight functions — verbatim moves, no logic changes
+- `generate_id/0` (public API, line 487 of `session.ex`) — untouched
+- `Tau.Session.Journal` — no changes; it does not absorb the telemetry helpers
+- The `:gen_statem` callbacks, FSM state machine logic, and supervision tree
+- External callers of the public `Tau.Session` API — all moved functions were `@doc false`
+- `append_message/2`'s O(n) list append — correctness is out of scope
+
+## Migration sketch
+
+1. Add the three functions to `Tau.Session.Data` (purely additive; no callsite breaks yet).
+2. Add `broadcast/2` to `Tau.Session.Events`.
+3. Create `lib/tau/session/telemetry.ex` with `emit_transition/2` and `emit_user_message/3`.
+4. Create `lib/tau/session/hooks.ex` with `payload/3`.
+5. Add `process_user_message/2` to `Tau.Session.Queue`.
+6. Update all callsites in `session.ex` and the six sub-modules to the new module-qualified names.
+7. Remove the eight `@doc false` defs from `session.ex`.
+
+Steps 1–5 are additive and can land in any order; step 6 and 7 land together. The entire migration is one PR with no intermediate broken states — the old names still exist until step 7.
+
+## Open questions
+
+- `Tau.Session.Queue` — does `Queue` already exist as a module? If not, this proposal depends on the user-message-routing sub-problem having created it, or on this PR creating a stub. Verify before implementation.
+- `emit_transition/2` signature: Proposal 2 drops the unused `_data` argument from `transition/3`; this should be confirmed against all callsites before the PR lands.
+- `Tau.Session.Hooks.payload/3` vs `hook_payload/3`: the rename is minor but any external tooling referencing the old name (hook scripts, tests) must be updated. Confirm no test uses `Tau.Session.hook_payload/3` directly.
+
+## Linked sub-problems / proposals
+
+- `proposals/proposal-1.md` — `Tau.Session.Helpers` grab-bag (rejected: surface-level move, grab-bag stigma preserved)
+- `proposals/proposal-2.md` — distribute by concern (primary source; concern taxonomy adopted wholesale except Journal telemetry placement)
+- `proposals/proposal-3.md` — pure/effectful split (secondary source; naming insight used to resolve Proposal 2's Journal ambiguity via new `Telemetry` module)
+- `proposals/proposal-4.md` — consolidate into Data + inline effects (rejected: inlining trades complecting for topic-string duplication; irreversible callsite expansion)
+
+## Revision history
+
+- (revision 0 — initial)

--- a/docs/problems-archive-v1-modules/tau-session/subproblems/fsm-facade-helpers/validation.md
+++ b/docs/problems-archive-v1-modules/tau-session/subproblems/fsm-facade-helpers/validation.md
@@ -1,0 +1,437 @@
+---
+template_version: 1
+template_name: validation
+parent_solution: solution.md
+parent_problem: problem.md
+toulmin_complete: true
+falsification_attempted: true
+falsification_outcome: partially_falsified — claim/4
+revision_triggered: none
+---
+
+# Validation: Distribute helpers by concern, with pure/effectful split for the two telemetry helpers
+
+## Overview
+
+The solution makes eight discrete propositions: a destination assignment for
+each of the eight `@doc false` helpers in `lib/tau/session.ex`, plus a
+meta-claim that no logic changes occur and the migration is one-PR
+non-breaking. Six claims are extracted and validated individually with full
+Toulmin and a named falsification strategy each. Five claims withstood
+falsification. One (claim 4 — `Tau.Session.Telemetry` as the home for the
+two telemetry helpers) was **partially falsified**: a co-located
+`lib/tau/telemetry/` directory already exists for the system-wide telemetry
+subsystem. The namespaces (`Tau.Session.Telemetry` vs `Tau.Telemetry.*`) do
+not collide at the compiler level, but the partial falsification narrows
+the Qualifier: the new module name is acceptable iff the moduledoc
+explicitly distinguishes session-scoped FSM/user-message telemetry from the
+broader `Tau.Telemetry.*` namespace. No revision of solution.md is
+triggered; the narrowed qualifier is recorded here.
+
+## Toulmin per claim
+
+The MITRE empirical study on Toulmin formalism found that "participants
+found it difficult to generate Toulmin structures, and their structures
+varied greatly even though they started with the same content"
+(https://www.mitre.org/news-insights/publication/empirical-evaluation-structured-argumentation-using-toulmin-argument).
+This validation enforces all six components explicitly.
+
+### Claim 1: The three pure data-shape helpers (`append_message/2`, `generate_event_id/0`, `current_run?/2`) belong in `Tau.Session.Data`
+
+- **Claim (C):** "Everything else follows Proposal 2 exactly: `append_message/2`,
+  `generate_event_id/0`, `current_run?/2` into `Tau.Session.Data`" (solution.md
+  §Recommendation; §What changes line 1).
+- **Grounds (G):** `lib/tau/session.ex:1345` defines `append_message/2` as
+  `def append_message(data, msg), do: %{data | messages: data.messages ++ [msg]}`
+  — pure struct manipulation. `lib/tau/session.ex:1347-1353` defines
+  `generate_event_id/0` — pure ID generation. `lib/tau/session.ex:1291-1300`
+  defines `current_run?/2` clauses — pure pattern matching on struct fields
+  (no side effects). `lib/tau/session/data.ex` is already a `defstruct`
+  module (`wc -l → 369`) that owns struct initialisation (`new/1` at line
+  159). All three functions read/transform only `Tau.Session.Data` fields.
+- **Warrant (W):** OTP non-negotiable #8 ("pure functions are the default;
+  processes are the exception") combined with the Hickey principle that
+  data and the operations on it co-locate without complecting. A
+  `defstruct` module is the canonical home for pure operations on its own
+  struct in idiomatic Elixir.
+- **Qualifier (Q):** Universal across the three named functions. Holds
+  unconditionally because all three are demonstrably pure and operate on
+  `Data` fields (`messages`, `stream_ref`, `coding_agent_dispatcher`).
+- **Rebuttal (R):** The claim would fail if any of the three functions
+  secretly carried a side effect (e.g., a hidden `:telemetry.execute`) or
+  operated on data that lives outside the `Data` struct. Inspection of
+  the function bodies above shows neither.
+- **Backing (B):** `.claude/rules/otp-non-negotiables.md` §8; Elixir
+  community practice (e.g. `Ecto.Schema`/`Ecto.Changeset` pairing — the
+  schema module owns the changeset functions for its own data).
+
+#### Falsification attempt for claim 1
+
+- **Strategy:** Counter-example construction. Search for any side effect
+  inside the three function bodies or any dependency on non-`Data` fields.
+- **Attempt:** Read `lib/tau/session.ex:1291-1353` verbatim. `append_message`
+  pattern-matches `data` and returns an updated struct — no side effect.
+  `generate_event_id` calls `Code.ensure_loaded?` + `apply` or
+  `:crypto.strong_rand_bytes` — both are pure with respect to observable
+  state of the system (the random bytes are technically "non-deterministic"
+  but introduce no shared-state coupling). `current_run?` pattern-matches
+  on `:stream_ref` and `:coding_agent_dispatcher` — both fields owned by
+  `Data` (per `data.ex` and the callsites at `coding_agent_turn.ex:730`,
+  `session.ex:1293`).
+- **Outcome:** withstood.
+- **Action:** none.
+
+### Claim 2: `broadcast/2` belongs as a `def` on `Tau.Session.Events`
+
+- **Claim (C):** "`broadcast/2` into `Tau.Session.Events`" (solution.md
+  §Recommendation; §What changes line 2 specifies "the PubSub topic string
+  `"session:#{id}"` becomes a single point of definition here").
+- **Grounds (G):** `lib/tau/session.ex:1366-1368` defines
+  `broadcast(id, event)` as a thin `Phoenix.PubSub.broadcast` wrapper
+  hard-coded to topic `"session:#{id}"`. `lib/tau/session/events.ex`
+  already owns the dozens of event structs (`%Events.SessionStart{}`,
+  `%Events.MessageEnd{}`, `%Events.SystemNotice{}`, etc.) broadcast on
+  that topic — sub-modules already `alias Tau.Session.Events` and
+  construct events with `%Events.X{}`. Verified by grep: every
+  `broadcast` callsite in `lib/tau/session/` couples a `Tau.Session.broadcast`
+  call with an `%Events.X{}` struct construction (e.g.
+  `compaction.ex:164,173,220,222,264,266`; `coding_agent_turn.ex:88,162,...`).
+- **Warrant (W):** OTP non-negotiable #4 ("Cross-process events MUST use
+  `Phoenix.PubSub` or monitored refs"). The Elixir/Phoenix idiom places
+  broadcast on the module that owns the broadcast vocabulary — e.g.
+  `Phoenix.Channel.broadcast/3` lives on the module owning channel-message
+  semantics. Co-locating the topic string with the structs it carries
+  defines the wire contract in one place.
+- **Qualifier (Q):** Holds for sub-modules that already construct `%Events.X{}`
+  structs — i.e. every current caller. Does not hold for hypothetical
+  callers wanting to broadcast a non-`Events` struct on the same topic; no
+  such caller exists today.
+- **Rebuttal (R):** The claim would fail if `Tau.Session.Events` were a
+  protocol or otherwise unable to host module-level functions, or if a
+  compile-time cycle would be created. `events.ex` is a plain `defmodule`
+  with one `defstruct` per event type (no protocol) — adding a `def`
+  function is mechanically straightforward. The circular-dependency
+  concern (next paragraph) is the only real risk.
+- **Backing (B):** `.claude/rules/otp-non-negotiables.md` §4; `Phoenix.Channel`
+  source as community precedent for "broadcast lives on the module that
+  owns the broadcast vocabulary".
+
+#### Falsification attempt for claim 2
+
+- **Strategy:** Dependency check — verify no circular compile dependency is
+  introduced.
+- **Attempt:** `lib/tau/session/data.ex:209,345` currently call
+  `Tau.Session.broadcast(...)` (in `Data.new/1` and a catalog-publish path).
+  After migration `Data` would call `Tau.Session.Events.broadcast/2`.
+  `data.ex:15` already declares `alias Tau.Session.Events` (verified) — so
+  `Data` already compiles in the presence of `Events`. Adding `broadcast/2`
+  as a `def` on `Events` does not require `Events` to reference `Data`, so
+  no cycle is introduced. Verified by inspection: `events.ex` is purely
+  struct definitions, no references to `Data`.
+- **Outcome:** withstood.
+- **Action:** none.
+
+### Claim 3: A new `Tau.Session.Hooks` module is the right home for `hook_payload/3` + `transcript_path/1`
+
+- **Claim (C):** "`hook_payload/3` + `transcript_path/1` into a new
+  `Tau.Session.Hooks`" (solution.md §Recommendation; §What changes line 4
+  specifies the rename `hook_payload/3` → `Hooks.payload/3`).
+- **Grounds (G):** `lib/tau/session.ex:1403-1416` defines `hook_payload/3`
+  as a pure map merge of canonical hook-contract fields with the caller's
+  extras; `lib/tau/session.ex:1418-1423` defines `transcript_path/1` as a
+  delegate to the persistence backend's `path_for/2` callback. The
+  function is the in-process side of the Phase-10 hook contract (mirroring
+  Claude Code's). No existing sub-module owns the hook contract;
+  `Tau.Hooks.Dispatcher` (called from `session.ex:1312`) owns hook
+  *invocation* but not payload *construction*. External callers exist:
+  `lib/tau/hook.ex:21` and `lib/tau/hooks/shell.ex:73` both reference
+  `Tau.Session.hook_payload/3` in docstrings/comments.
+- **Warrant (W):** Hickey decomplecting principle: a function that has its
+  own protocol (Phase-10 hook contract) and no other natural home gets its
+  own module rather than being attached to an unrelated existing module.
+  Naming a module after the contract it implements makes the import
+  self-documenting at callsites (`alias Tau.Session.Hooks` signals "this
+  module participates in the hook contract").
+- **Qualifier (Q):** Holds because no existing module owns the hook
+  contract. Would not hold if `Tau.Session.Data` were chosen instead
+  (Proposal 3's placement) — that would co-locate hook-contract logic with
+  unrelated struct manipulation.
+- **Rebuttal (R):** The rename `hook_payload/3 → payload/3` changes the
+  bare function name, not just its module prefix. The docstring references
+  in `lib/tau/hook.ex:21` and `lib/tau/hooks/shell.ex:73` are prose
+  references inside comments — not code calls — so they break no
+  compilation but become stale. Solution.md §Open questions already flags
+  this. The rebuttal therefore lands as documentation hygiene, not as a
+  falsification.
+- **Backing (B):** Solution.md §Recommendation, citing Proposal 2's
+  acknowledgement that the "Hooks" module is more cohesive than
+  Proposal 3's `Util` co-location; Proposal 2 §Tradeoffs explicitly cites
+  this distinction.
+
+#### Falsification attempt for claim 3
+
+- **Strategy:** Counter-example construction — find a sub-module already
+  owning the hook contract that would be a better home.
+- **Attempt:** Search `lib/tau/session/` and `lib/tau/hooks/` for modules
+  whose responsibility is the in-session hook-payload contract.
+  `Tau.Hooks.Dispatcher` exists (owns invocation; per `session.ex:1312`)
+  but does not own payload assembly — it accepts a payload as input.
+  `lib/tau/hook.ex` defines the `@behaviour` for hook implementations and
+  is not session-scoped. No alternative home found.
+- **Outcome:** withstood. (One stale comment in
+  `lib/tau/hooks/shell.ex:73` and one stale docstring reference in
+  `lib/tau/hook.ex:21` should be updated in the same PR — recorded in
+  Outstanding doubts.)
+- **Action:** none.
+
+### Claim 4: A new `Tau.Session.Telemetry` module is the right home for `transition/3` and `emit_user_message_telemetry/3`
+
+- **Claim (C):** "the two telemetry helpers (`transition/3`,
+  `emit_user_message_telemetry/3`) go into a new `Tau.Session.Telemetry`
+  module rather than into `Journal`. This keeps `Journal` scoped to
+  persistence observability and gives the FSM-transition and user-message
+  telemetry a clear home." (solution.md §Recommendation; §What changes
+  line 3).
+- **Grounds (G):** `lib/tau/session.ex:1355-1363` defines `transition/3`
+  as a `:telemetry.execute([:tau, :session, :transition], …)` emitter;
+  `lib/tau/session.ex:1387-1394` defines `emit_user_message_telemetry/3`
+  as a `:telemetry.execute([:tau, :session, :user_message, event], …)`
+  emitter. Both are FSM-observation telemetry, distinct from
+  `Tau.Session.Journal`'s persistence-write telemetry. Callsites:
+  `provider_turn.ex:463`, `coding_agent_turn.ex:704`,
+  `tool_dispatch.ex:187,269` (all four `transition/3` callers pass a
+  `data` argument that the definition ignores via `_data`) and
+  `queue.ex:97,116,128` (the three `emit_user_message_telemetry/3`
+  callers).
+- **Warrant (W):** OTP non-negotiable #5 ("Telemetry events MUST cover
+  everything user-visible or perf-sensitive") and the Hickey decomplecting
+  principle: telemetry emission is a coherent concern (`:telemetry.execute`
+  with `[:tau, :session, ...]` event names) distinct from persistence
+  (`Journal`'s `persist/2`).
+- **Qualifier (Q):** Holds **iff the new module's moduledoc explicitly
+  distinguishes itself from the existing `lib/tau/telemetry/` subsystem
+  (`Tau.Telemetry.*` namespace)**. (Narrowed from "universal" by partial
+  falsification — see below.)
+- **Rebuttal (R):** The claim would fail if (a) Elixir disallowed the
+  module name `Tau.Session.Telemetry` because some other module already
+  uses it (it does not — see falsification), or (b) the dropped `_data`
+  argument from `transition/3` were used at some callsite (it is not —
+  every caller's call site passes `data` only to satisfy the existing
+  arity and the parameter is `_data` in the definition). Both rebuttals
+  fail to falsify.
+- **Backing (B):** `.claude/rules/otp-non-negotiables.md` §5; solution.md
+  §Recommendation explicitly cites Proposal 3's pure/effectful split as
+  the justification for separating telemetry from `Journal`.
+
+#### Falsification attempt for claim 4
+
+- **Strategy:** Dependency check + edge-case enumeration. Verify (a) no
+  module-name collision with the existing `lib/tau/telemetry/` directory,
+  (b) the signature change (`transition/3 → emit_transition/2`) is safe
+  at all callsites.
+- **Attempt:** (a) `find lib/tau -name "telemetry*"` returns
+  `lib/tau/telemetry` — a directory holding the *system-wide* telemetry
+  subsystem under the `Tau.Telemetry.*` namespace. No file currently
+  defines `Tau.Session.Telemetry`, so the compiler permits the new
+  namespace. (b) `grep` of all `Tau.Session.transition` callsites
+  (`provider_turn.ex:463`, `coding_agent_turn.ex:704`,
+  `tool_dispatch.ex:187,269`) confirms each passes `data` as the second
+  argument and the existing definition discards it via `_data`. Dropping
+  the argument and renaming to `emit_transition(id, to)` is mechanically
+  safe.
+- **Outcome:** **partially falsified**. The compiler accepts the new
+  module name, but a human reader navigating the codebase will encounter
+  two `Tau.*Telemetry` namespaces (`Tau.Telemetry.*` and
+  `Tau.Session.Telemetry`) and may conflate them. The original Claim is
+  too broad — it implicitly asserts the name is unambiguous. The
+  Qualifier above (requiring an explicit moduledoc distinction) is the
+  narrowing required to restore the claim's truth.
+- **Action:** Narrow the Qualifier in place (already done above). Record
+  the moduledoc requirement in Outstanding doubts so the implementer
+  picks it up. No solution.md revision required — the recommendation
+  itself stands.
+
+### Claim 5: `process_user_message/2` belongs in `Tau.Session.Queue` (retaining its `handle_event/4` back-call as out-of-scope coupling)
+
+- **Claim (C):** "`process_user_message/2` into `Tau.Session.Queue`.
+  `process_user_message/2` retains its `handle_event/4` back-call — that
+  coupling is the user-message-routing sub-problem's scope, not this
+  one's." (solution.md §Recommendation; §What changes line 5).
+- **Grounds (G):** `lib/tau/session.ex:1310-1342` defines
+  `process_user_message/2` as the hook-dispatch + routing path that calls
+  `handle_event(:internal, :start_coding_agent | :start_provider, …, data)`
+  (lines 1336-1340). Callsites: `slash_command.ex:269,292,309` (three
+  external callers, all in `Tau.Session.SlashCommand`) plus three internal
+  callers in `session.ex:630,651,693,704`. `Tau.Session.Queue` exists as a
+  module (`lib/tau/session/queue.ex`, 180 LOC, `defmodule Tau.Session.Queue`)
+  and is the established home for user-message-routing utilities — it
+  already houses `emit_user_message_telemetry/3` callsites (queue.ex:97,
+  116, 128).
+- **Warrant (W):** Hickey decomplecting principle: a function whose
+  responsibility is *routing decisions at the queue boundary* belongs in
+  the module that owns the queue boundary, even if its implementation
+  exhibits a transient coupling (the back-call into `handle_event/4`)
+  that a future sub-problem will resolve. The acceptance criterion of
+  this sub-problem is structural (location), not behavioural; declaring
+  the back-call out-of-scope is consistent with problem.md §Out of scope.
+- **Qualifier (Q):** Holds because Queue already exists and already
+  participates in user-message routing. The back-call coupling is
+  inherited, not introduced.
+- **Rebuttal (R):** The claim would fail if `Tau.Session.Queue` did not
+  exist (then this PR would need to either create a stub or move the
+  function elsewhere). Solution.md §Open questions correctly flags this
+  as a precondition; verification: `Queue` exists.
+- **Backing (B):** problem.md §Out of scope (sibling sub-problem
+  user-message-routing owns the back-call coupling); solution.md
+  §Recommendation explicitly defers the coupling to that sub-problem.
+
+#### Falsification attempt for claim 5
+
+- **Strategy:** Dependency check — verify `Tau.Session.Queue` exists and
+  is reachable from `Tau.Session.SlashCommand` (the primary external
+  caller) without introducing a compile cycle.
+- **Attempt:** `ls lib/tau/session/queue.ex` confirms the file exists
+  (180 LOC). `grep "defmodule Tau.Session.Queue"` returns
+  `lib/tau/session/queue.ex:1`. SlashCommand currently calls
+  `Tau.Session.process_user_message(...)` at three sites; rewriting these
+  to `Tau.Session.Queue.process_user_message(...)` requires no module
+  cycle (Queue does not import SlashCommand, per inspection of
+  queue.ex).
+- **Outcome:** withstood.
+- **Action:** none.
+
+### Claim 6: The migration is purely additive then-rename, one-PR, no logic changes
+
+- **Claim (C):** Solution.md §Migration sketch states steps 1-5 are
+  "additive and can land in any order; step 6 and 7 land together. The
+  entire migration is one PR with no intermediate broken states — the
+  old names still exist until step 7." Solution.md §What does not change
+  asserts: "The bodies of all eight functions — verbatim moves, no logic
+  changes" and "External callers of the public `Tau.Session` API — all
+  moved functions were `@doc false`".
+- **Grounds (G):** The eight function bodies inspected at
+  `lib/tau/session.ex:1291-1416` are short (mostly 1-10 LOC each) and
+  contain no module-private references — every dependency is either a
+  field on the passed-in struct, a stdlib call, or a public Phoenix /
+  `:telemetry` call. Therefore each body can be copy-pasted into its
+  destination module unchanged. The `@doc false` markers verified in
+  `grep -n "@doc false" lib/tau/session.ex` confirm all eight are
+  internal-API. External-caller scan
+  (`grep -rn "Tau\.Session\.\(broadcast\|append_message\|generate_event_id\|transition\|emit_user_message_telemetry\|hook_payload\|process_user_message\|current_run\?\)" lib/`
+  scoped to outside `lib/tau/session/`) returns three matches: all are
+  docstring/comment references (`lib/tau/hook.ex:21`,
+  `lib/tau/hooks/shell.ex:73`, `lib/tau/tui/app/bootstrap.ex:37`) — none
+  are runtime calls.
+- **Warrant (W):** OTP non-negotiable #8 (pure functions compose without
+  surprise); refactoring-by-relocation preserves observable behaviour iff
+  the moved function has no module-private dependency and no external
+  caller is broken. Both conditions are mechanically verifiable and have
+  been verified.
+- **Qualifier (Q):** Holds for the eight named functions and their
+  callsites within `lib/`. Does not address `test/` callsites — but
+  `grep -rn ... test/` returns zero direct calls (a test calling
+  `Tau.Session.hook_payload/3` would break and would need updating). The
+  signature changes (`transition/3 → emit_transition/2`,
+  `hook_payload/3 → Hooks.payload/3`) require a coordinated rename at
+  every call site, not merely a module prefix change.
+- **Rebuttal (R):** The claim would fail if (a) a hidden runtime caller
+  outside `lib/` and `test/` exists (e.g., a config-driven dispatch); no
+  such caller surfaced in `grep`. (b) The `defp transcript_path/1`
+  helper in `session.ex:1418` is called only by `hook_payload/3` — once
+  `hook_payload` moves to `Hooks`, `transcript_path/1` must move too
+  (solution.md §What changes correctly specifies this).
+- **Backing (B):** Solution.md §Open questions flags the rename test
+  audit; problem.md §Out of scope excludes correctness changes; verified
+  zero direct test callers via `grep`.
+
+#### Falsification attempt for claim 6
+
+- **Strategy:** Edge-case enumeration over the documented failure modes:
+  (1) hidden runtime caller, (2) `transcript_path/1` dependency,
+  (3) test-suite caller, (4) signature-change miss, (5) compile-cycle
+  introduction.
+- **Attempt:** (1) Grepped `lib/` and `test/` outside the session
+  subtree for each helper name — only three matches, all comments. (2)
+  `transcript_path/1` is `defp` on `session.ex` and is called only from
+  `hook_payload/3` — confirmed by `grep` of "transcript_path" in
+  `session.ex`. Co-moving it with `hook_payload` into `Hooks` is the
+  natural action and solution.md §What changes specifies it
+  ("`hook_payload/3` (renamed from `hook_payload/3`) and private
+  `transcript_path/1`"). (3) `grep -rn "Tau\.Session\.hook_payload\|...\
+  " test/` returns zero hits. (4) Signature changes are catalogued in
+  Proposal 2's rename table and re-stated in solution.md §Open questions.
+  (5) `Data`-to-`Events.broadcast` was the only candidate cycle —
+  already cleared in Claim 2's falsification.
+- **Outcome:** withstood. (The implementer must remember to co-move
+  `transcript_path/1`, audit test callers, and apply the rename table —
+  none of these are unstated.)
+- **Action:** none.
+
+## Cross-claim consistency
+
+Claims 1-5 collectively partition the eight `@doc false` helpers across
+five destination modules (`Data`, `Events`, new `Telemetry`, new `Hooks`,
+existing `Queue`). The partition is a function (each helper appears in
+exactly one destination); no two claims assign the same helper to
+different homes. Claim 6 (additive-then-rename, one-PR) is consistent with
+Claims 1-5 because every destination accepts the moved function purely
+additively — no destination requires a prior structural change.
+
+One potential tension: Claim 2 places `broadcast/2` on
+`Tau.Session.Events`, and `Tau.Session.Data` calls
+`Tau.Session.broadcast(...)` at `data.ex:209,345`. After migration, `Data`
+will call `Tau.Session.Events.broadcast(...)`, which requires the existing
+`alias Tau.Session.Events` in `data.ex:15` to remain. This is consistent
+(the alias already exists) but is worth noting for the implementer.
+
+No solution-internal contradictions detected.
+
+## Falsification summary
+
+| # | Claim (short) | Strategy | Outcome | Action |
+|---|---|---|---|---|
+| 1 | Pure helpers → `Data` | Counter-example construction | withstood | none |
+| 2 | `broadcast/2` → `Events` | Dependency check | withstood | none |
+| 3 | `hook_payload` + `transcript_path` → new `Hooks` | Counter-example construction | withstood | none |
+| 4 | Two telemetry helpers → new `Telemetry` | Dependency check + edge-case enumeration | **partially falsified** | Qualifier narrowed in place (moduledoc must distinguish from `Tau.Telemetry.*`) |
+| 5 | `process_user_message/2` → `Queue` | Dependency check | withstood | none |
+| 6 | Additive migration, no logic changes | Edge-case enumeration | withstood | none |
+
+## Revision required
+
+No solution.md revision triggered. Claim 4 was partially falsified; the
+Qualifier was narrowed in place (the new `Tau.Session.Telemetry` module
+must declare in its moduledoc that it is scoped to session-level FSM and
+user-message telemetry, distinct from the system-wide `Tau.Telemetry.*`
+namespace). This is documentation discipline at implementation time, not
+a change of approach. The Recommendation in solution.md stands.
+
+- **Target file:** n/a
+- **Revision kind:** n/a
+- **Rationale:** Partial falsification narrows the Qualifier in
+  validation.md rather than the solution; the partial falsification does
+  not invalidate the chosen destination, only requires the moduledoc to
+  pre-empt reader confusion.
+
+## Outstanding doubts
+
+- The `hook_payload/3 → Hooks.payload/3` rename leaves stale prose
+  references in `lib/tau/hook.ex:21` (the docstring) and
+  `lib/tau/hooks/shell.ex:73` (a defensive comment) and one in
+  `lib/tau/tui/app/bootstrap.ex:37` (a comment citing
+  `Tau.Session.process_user_message/2`). These are not runtime breakages,
+  but the implementer should update them in the same PR for consistency.
+- Solution.md §Open questions flags a `Tau.Session.Queue` precondition;
+  verification confirms Queue exists. This doubt is closed.
+- Solution.md §Open questions asks whether any test directly calls
+  `Tau.Session.hook_payload/3`; `grep` confirms zero direct callers in
+  `test/`. This doubt is closed.
+- Claim 4's narrowed Qualifier — the moduledoc requirement — must be
+  carried into the implementer brief; if the implementer creates
+  `Tau.Session.Telemetry` without a disambiguating moduledoc, the
+  reviewer should flag it.
+- `register_builtins/0` at `session.ex:1425` is also `@doc false` but
+  is not listed among the eight helpers under this sub-problem's scope
+  (problem.md §Context names only the eight). Confirm with the parent
+  whether this helper is in scope of a sibling sub-problem; if not, it
+  may slip through this decomposition.

--- a/docs/problems-archive-v1-modules/tau-session/subproblems/user-message-routing/problem.md
+++ b/docs/problems-archive-v1-modules/tau-session/subproblems/user-message-routing/problem.md
@@ -1,0 +1,82 @@
+---
+template_version: 1
+template_name: problem
+node_kind: leaf
+depth: 1
+parent: ../../problem.md
+status: draft
+---
+
+# Problem: user-message handle_event clauses mix queue-gating with slash-command dispatch
+
+## Statement
+
+Three `handle_event` clauses for `{:user_message, msg, tier}` in
+`session.ex` (lines 563–690) each contain multi-branch inline logic:
+the postpone guard on `command_task != nil` (5 LOC), the tier-routing
+and queue-cap clause (41 LOC), and the idle-dispatch clause (47 LOC)
+that calls `SlashCommand.classify_slash_command/4` and then branches
+on six match arms — all in the FSM façade rather than in
+`Tau.Session.Queue`. A reader tracing how a user message flows through
+the system must follow `session.ex → SlashCommand → session.ex` rather
+than `session.ex → Queue → SlashCommand`.
+
+## Context
+
+- `session.ex` lines 563–570: postpone clause — `command_task != nil`, calls
+  `emit_user_message_telemetry(:enqueued, ...)` and returns
+  `{:keep_state_and_data, [{:postpone, true}]}`.
+- `session.ex` lines 572–611: tier-routing clause — `state != :awaiting_user`;
+  resolves `queue_field` from `tier`, enforces 32-message cap with
+  `%Events.SystemNotice{}`, enqueues or drops, emits telemetry.
+- `session.ex` lines 613–657: idle-dispatch clause — `state == :awaiting_user`,
+  `command_task == nil`; calls `SlashCommand.classify_slash_command/4`,
+  six `case` arms, calls `process_user_message/2` for `:sync` and
+  `:skill_activation` arms.
+- `Tau.Session.Queue` (`lib/tau/session/queue.ex`, 180 LOC) owns
+  `drain_followups/1`, `drain_steering_queue/1`, queue predicates — it is the
+  natural owner of the routing decision "is this a queueable state?".
+- `Tau.Session.SlashCommand` (`lib/tau/session/slash_command.ex`, 373 LOC)
+  owns `classify_slash_command/4` and command-spawning — the six `case` arms
+  in the idle-dispatch clause are really a delegation table that belongs
+  adjacent to the classifier.
+- The six `case` arms include calls to `Tau.Session.SkillActivation`,
+  `Tau.Session.ModelSwap`, and `process_user_message/2` (itself `@doc false`
+  on the FSM) — the idle-dispatch clause is the last place that touches
+  multiple sub-module concerns in a single FSM clause body.
+
+## Complecting hypothesis
+
+Queue-gating logic (postpone, tier routing, cap enforcement) is complected
+with slash-command dispatch because both phases of message handling — "should
+this message be queued?" and "if idle, what kind of message is this?" — are
+resolved in the same `handle_event` clause file rather than separated into
+`Queue.route/3` (returns `:enqueue | :drop | :deliver`) and
+`SlashCommand.dispatch/2` (returns a `handle_event` action tuple).
+
+## Decomposition strategy
+
+(leaf — no further decomposition; proceed to proposals)
+
+## Acceptance criterion
+
+The three `{:user_message}` `handle_event` clauses in `session.ex` are each
+reduced to ≤3 lines: one that delegates the postpone decision to
+`Tau.Session.Queue`, one that delegates tier-routing and cap-enforcement to
+`Tau.Session.Queue`, and one that delegates idle dispatch (including the six
+classify arms) to `Tau.Session.Queue` or `Tau.Session.SlashCommand`, with no
+inline `case` branching or telemetry emission in `session.ex`.
+
+## Out of scope
+
+- Queue cap value, drain ordering, or D-077/D-078/D-083 contract changes.
+- The `drain_followups` and `drain_steering_queue` internal-event clauses
+  (lines 659–690) — those are already short and delegate cleanly.
+- Slash-command classification logic itself (classification is already in
+  `SlashCommand`; this problem is about the dispatch table that calls it).
+- Sibling sub-problems: cancellation-teardown, fsm-facade-helpers,
+  cross-cutting-data.
+
+## Amendment log
+
+- (none yet)

--- a/docs/problems-archive-v1-modules/tau-session/subproblems/user-message-routing/proposals/proposal-1.md
+++ b/docs/problems-archive-v1-modules/tau-session/subproblems/user-message-routing/proposals/proposal-1.md
@@ -1,0 +1,168 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 1
+parent_problem: ../problem.md
+---
+
+# Proposal 1: Queue.route/3 returns a discriminated action; session.ex clauses become one-liners
+
+## Approach
+
+Add a single pure function `Tau.Session.Queue.route/3` that takes `(msg, tier,
+fsm_state_and_data)` and returns one of three tagged tuples:
+`{:postpone, fsm_result}`, `{:enqueue, fsm_result}`, or
+`{:deliver, classify_result}` — where `classify_result` is the return value of
+`SlashCommand.classify_slash_command/4`. The three `handle_event` clauses in
+`session.ex` collapse to: one that matches `command_task != nil` and delegates
+to `Queue.handle_postpone/2` (already exists); one that matches
+`state != :awaiting_user` and delegates to `Queue.handle_enqueue/4` (already
+exists); and a third that matches `:awaiting_user` and calls
+`Queue.route/3` then a new `SlashCommand.dispatch/2` function on the
+`{:deliver, classify_result}` branch. The idle-dispatch clause's six `case`
+arms move into `SlashCommand.dispatch/2`.
+
+## Rationale
+
+The complecting is that "should this message queue?" and "what kind of message is
+this?" are resolved in the same FSM clause body. `Queue.route/3` resolves the
+routing decision in one place and surfaces a typed result to the FSM; the FSM
+clause body becomes a pattern-match on that result rather than a nested `case`.
+`SlashCommand.dispatch/2` owns the six arms that are the natural complement to
+`classify_slash_command/4` — both live in `SlashCommand`, which already has
+`handle_builtin_command/4` and `spawn_command_task/4`. The FSM façade becomes a
+pure delegation table; the queue and slash-command modules own their full
+concern.
+
+## Sketch
+
+```elixir
+# lib/tau/session/queue.ex — new function
+@spec route(Tau.Message.User.t(), :steering | atom(), atom(), Tau.Session.Data.t()) ::
+        {:postpone, Tau.Session.Data.fsm_result()}
+        | {:enqueue, Tau.Session.Data.fsm_result()}
+        | {:deliver, Tau.Session.SlashCommand.classify_result()}
+def route(msg, _tier, _state, %{command_task: t} = data) when t != nil do
+  {:postpone, handle_postpone(data, :awaiting_user)}
+end
+def route(msg, tier, state, data) when state != :awaiting_user do
+  {:enqueue, handle_enqueue(msg, tier, state, data)}
+end
+def route(msg, _tier, :awaiting_user, %{command_task: nil} = data) do
+  result = Tau.Session.SlashCommand.classify_slash_command(
+    msg, data.skills, data.prompt_templates, data.cwd
+  )
+  {:deliver, result}
+end
+```
+
+```elixir
+# lib/tau/session/slash_command.ex — new function
+@spec dispatch(classify_result(), Tau.Session.Data.t()) :: Tau.Session.Data.fsm_result()
+def dispatch({:builtin, mod, args, msg}, data), do: handle_builtin_command(mod, args, msg, data)
+def dispatch({:async, mod, args, msg}, data), do: spawn_command_task(mod, args, msg, data)
+def dispatch({:skill_activation, skill, rewritten_msg}, data) do
+  data2 = Tau.Session.SkillActivation.activate_skill_via_slash(data, skill)
+  Tau.Session.process_user_message(rewritten_msg, data2)
+end
+def dispatch({:model_command, "", _msg}, data) do
+  Tau.Session.broadcast(data.id, %Events.SystemNotice{session_id: data.id, text: "Current model: #{data.model}"})
+  {:keep_state, data}
+end
+def dispatch({:model_command, new_model, _msg}, data) do
+  Tau.Session.ModelSwap.handle_slash_model_swap(data, new_model)
+end
+def dispatch({:unknown_command, name}, data) do
+  notice = "Unknown command #{name} — type /help to list available commands"
+  Tau.Session.broadcast(data.id, %Events.SystemNotice{session_id: data.id, text: notice})
+  {:keep_state, data}
+end
+def dispatch({:sync, msg}, data) do
+  Tau.Session.process_user_message(msg, data)
+end
+```
+
+```elixir
+# lib/tau/session.ex — the three handle_event clauses after the change
+def handle_event(:cast, {:user_message, _, _tier}, state, %{command_task: t} = data)
+    when t != nil do
+  Queue.handle_postpone(data, state)
+end
+
+def handle_event(:cast, {:user_message, msg, tier}, state, data)
+    when state != :awaiting_user do
+  Queue.handle_enqueue(msg, tier, state, data)
+end
+
+def handle_event(:cast, {:user_message, msg, _tier}, :awaiting_user, %{command_task: nil} = data) do
+  emit_user_message_telemetry(:delivered, data, :awaiting_user)
+  {:deliver, result} = Queue.route(msg, :followup, :awaiting_user, data)
+  SlashCommand.dispatch(result, data)
+end
+```
+
+Note: the third clause still calls `emit_user_message_telemetry(:delivered, …)`
+before delegating — this is the one piece of telemetry that belongs to the
+"message is being delivered" event, distinct from the routing logic. It can be
+moved into `Queue.route/3` in a follow-on step; leaving it visible in `session.ex`
+for now preserves the existing telemetry contract without the audit touching
+telemetry semantics.
+
+## Tradeoffs
+
+### Strengths
+
+- The three `handle_event` clauses each become ≤3 lines; the acceptance
+  criterion is met atomically in one PR.
+- `Queue.route/3` is a pure function (no side effects in the routing decision
+  itself), testable in isolation.
+- `SlashCommand.dispatch/2` is colocated with `classify_slash_command/4` and
+  `handle_builtin_command/4` — the full slash-command lifecycle lives in one
+  module.
+- The `{:deliver, result}` tagged tuple provides a typed seam; the return type of
+  `Queue.route/3` is machine-checkable with Dialyzer.
+
+### Weaknesses
+
+- `Queue.route/3` calls `SlashCommand.classify_slash_command/4` in its `:deliver`
+  branch, creating a cross-module call from `Queue` → `SlashCommand`. This adds a
+  dependency that did not previously exist.
+- The `:deliver` arm in `session.ex` still calls `emit_user_message_telemetry`
+  inline (one LOC), which is not a full delegation. A perfectionist reading of
+  the acceptance criterion may count this as "inline telemetry emission in
+  session.ex".
+- `Queue.route/3`'s guard clauses duplicate the existing `handle_postpone` /
+  `handle_enqueue` guards — three functions now encode the same three-way branch.
+
+### Costs
+
+- Two new public functions (`Queue.route/3`, `SlashCommand.dispatch/2`):
+  moderate test surface addition.
+- Callers of the idle-dispatch clause's six arms in tests will need to be
+  traced to confirm they still reach the right path; no signatures break.
+- One PR; no migration.
+
+## Dependencies
+
+- `Tau.Session.Queue.handle_postpone/2` and `handle_enqueue/4` (both already
+  present in `queue.ex`) are the foundation for the non-idle clauses; no
+  changes needed there.
+- `Tau.Session.emit_user_message_telemetry/3` must remain public until the
+  telemetry call in the idle clause is moved; it's already `@doc false` public.
+
+## Confidence
+
+Medium. The sketch is concrete and matches existing module boundaries; the
+`Queue` → `SlashCommand` dependency is the structural uncertainty — it's
+directionally odd (queue routing should not know about slash commands). That
+concern is addressed in Proposal 2.
+
+## Prior art / references
+
+- Existing `Queue.handle_postpone/2` and `Queue.handle_enqueue/4` in
+  `lib/tau/session/queue.ex` — pattern already established for the non-idle
+  clauses.
+- `SlashCommand.handle_builtin_command/4` and `spawn_command_task/4` — the
+  dispatch table arms are already partially in `SlashCommand`.
+- Hickey, "Simple Made Easy" — separating routing decisions from dispatch
+  actions as the canonical decomplecting move.

--- a/docs/problems-archive-v1-modules/tau-session/subproblems/user-message-routing/proposals/proposal-2.md
+++ b/docs/problems-archive-v1-modules/tau-session/subproblems/user-message-routing/proposals/proposal-2.md
@@ -1,0 +1,168 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 2
+parent_problem: ../problem.md
+---
+
+# Proposal 2: SlashCommand.dispatch_idle/2 absorbs the full idle clause; Queue unchanged
+
+## Approach
+
+Leave `Tau.Session.Queue` unchanged. Add a single new function
+`Tau.Session.SlashCommand.dispatch_idle/2` that accepts
+`(msg :: Tau.Message.User.t(), data :: Tau.Session.Data.t())` and contains the
+full body of the current idle-dispatch `handle_event` clause: the
+`emit_user_message_telemetry(:delivered, …)` call, the
+`classify_slash_command/4` call, and all six `case` arms. The idle-dispatch
+clause in `session.ex` becomes a one-line delegation:
+
+```elixir
+SlashCommand.dispatch_idle(msg, data)
+```
+
+The two non-idle clauses already have `Queue.handle_postpone/2` and
+`Queue.handle_enqueue/4` — they are already one-liners and require no change.
+
+## Rationale
+
+The complecting hypothesis identifies the idle-dispatch clause as the only
+clause that still mixes two concerns in `session.ex`. The postpone and
+tier-routing clauses are already delegated (`Queue.handle_postpone/2` and
+`Queue.handle_enqueue/4` exist and are called from the FSM — but wait, the FSM
+does NOT currently call them; it inlines the logic). Both clauses need to be
+updated to call the existing `Queue` functions. The idle clause's six `case`
+arms are dispatch logic that belongs adjacent to `classify_slash_command/4`
+because both are about "what is this message?" — not about queue mechanics.
+Extracting the idle clause body into `SlashCommand.dispatch_idle/2` places the
+classifier and its dispatch table in the same module, with no new inter-module
+dependency not already implicit in the six arms.
+
+## Sketch
+
+```elixir
+# lib/tau/session/slash_command.ex — new function
+@doc """
+Handle a user message arriving in :awaiting_user with no command_task.
+
+Emits delivery telemetry, classifies the message, and dispatches to the
+appropriate handler. Returns a :gen_statem FSM action tuple.
+"""
+@spec dispatch_idle(Tau.Message.User.t(), Tau.Session.Data.t()) ::
+        Tau.Session.Data.fsm_result()
+def dispatch_idle(msg, data) do
+  Tau.Session.emit_user_message_telemetry(:delivered, data, :awaiting_user)
+
+  case classify_slash_command(msg, data.skills, data.prompt_templates, data.cwd) do
+    {:builtin, mod, args, msg} ->
+      handle_builtin_command(mod, args, msg, data)
+
+    {:async, mod, args, msg} ->
+      spawn_command_task(mod, args, msg, data)
+
+    {:skill_activation, skill, rewritten_msg} ->
+      data2 = Tau.Session.SkillActivation.activate_skill_via_slash(data, skill)
+      Tau.Session.process_user_message(rewritten_msg, data2)
+
+    {:model_command, "", _msg} ->
+      notice = "Current model: #{data.model}"
+      Tau.Session.broadcast(data.id, %Events.SystemNotice{session_id: data.id, text: notice})
+      {:keep_state, data}
+
+    {:model_command, new_model, _msg} ->
+      Tau.Session.ModelSwap.handle_slash_model_swap(data, new_model)
+
+    {:unknown_command, name} ->
+      notice = "Unknown command #{name} — type /help to list available commands"
+      Tau.Session.broadcast(data.id, %Events.SystemNotice{session_id: data.id, text: notice})
+      {:keep_state, data}
+
+    {:sync, msg} ->
+      Tau.Session.process_user_message(msg, data)
+  end
+end
+```
+
+```elixir
+# lib/tau/session.ex — the three handle_event clauses after the change
+def handle_event(:cast, {:user_message, _, _tier}, state, %{command_task: t} = data)
+    when t != nil do
+  Queue.handle_postpone(data, state)
+end
+
+def handle_event(:cast, {:user_message, msg, tier}, state, data)
+    when state != :awaiting_user do
+  Queue.handle_enqueue(msg, tier, state, data)
+end
+
+def handle_event(:cast, {:user_message, msg, _tier}, :awaiting_user, %{command_task: nil} = data) do
+  SlashCommand.dispatch_idle(msg, data)
+end
+```
+
+The non-idle clauses require code changes too: the current `session.ex` inlines
+the queue-cap logic even though `Queue.handle_postpone/2` and
+`Queue.handle_enqueue/4` already exist in `queue.ex`. This proposal makes those
+clauses call the existing `Queue` functions (pure delegations).
+
+## Tradeoffs
+
+### Strengths
+
+- Minimal new surface: one new public function (`dispatch_idle/2`) and two
+  delegation changes in existing non-idle clauses.
+- No new inter-module dependencies that do not already exist: `SlashCommand`
+  already calls `SkillActivation`, `ModelSwap`, and `Tau.Session.broadcast`;
+  `Queue` is not touched.
+- The acceptance criterion is fully met: all three clauses become ≤3 lines, no
+  inline `case` branching, no telemetry emission in `session.ex`.
+- Mechanically the smallest diff of the four proposals — reduces review and
+  merge risk.
+- `dispatch_idle/2`'s body is a straight extraction (verbatim copy) of the
+  existing clause body; behaviour is provably preserved.
+
+### Weaknesses
+
+- `dispatch_idle/2` is a 40-LOC function with a nested `case` — it does not
+  further decompose the six arms. Readers still need to read all six arms to
+  understand idle dispatch, just in a different file.
+- The name `dispatch_idle` is tied to FSM state; if idle dispatch is ever
+  invoked from a non-idle path (e.g. a `/perms`-gate release path), the name
+  becomes misleading.
+- `emit_user_message_telemetry` must remain callable from `SlashCommand` — it
+  is already `@doc false` public on `Tau.Session`, so no signature change, but
+  the coupling is preserved rather than resolved.
+- The `{:model_command, "", …}` and `{:unknown_command, …}` arms in
+  `dispatch_idle/2` still call `Tau.Session.broadcast/2` directly — `SlashCommand`
+  already does this elsewhere, but it means `SlashCommand` retains a hard dep
+  on `Tau.Session` for broadcast.
+
+### Costs
+
+- One new function, two line-change delegations in `session.ex`.
+- Test coverage: any tests exercising the idle-dispatch path via
+  `Tau.Session.handle_event/4` will still pass because the delegation is
+  transparent; no test signatures break.
+- Zero migration cost for consumers.
+
+## Dependencies
+
+- `Tau.Session.Queue.handle_postpone/2` and `Queue.handle_enqueue/4` must be
+  present (they are already in `queue.ex` as of the last merge).
+- `Tau.Session.emit_user_message_telemetry/3` must remain public (it is
+  already `@doc false`).
+
+## Confidence
+
+High. The sketch is a verbatim extraction of existing code. The only risk is
+the `emit_user_message_telemetry` call inside `SlashCommand` — which already
+occurs in `Queue.drain_steering_queue_one/1`. The pattern is established.
+
+## Prior art / references
+
+- `Queue.handle_drain_followups_idle/1` in `lib/tau/session/queue.ex` — same
+  verbatim-extraction pattern applied to the drain-followups clause.
+- `SlashCommand.handle_builtin_command/4` — extraction precedent for
+  dispatch logic that originally lived in the FSM clause body.
+- Fowler, "Extract Function" (Refactoring, 2nd ed.) — behaviour-preserving
+  extraction as the lowest-risk decomplecting move.

--- a/docs/problems-archive-v1-modules/tau-session/subproblems/user-message-routing/proposals/proposal-3.md
+++ b/docs/problems-archive-v1-modules/tau-session/subproblems/user-message-routing/proposals/proposal-3.md
@@ -1,0 +1,181 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 3
+parent_problem: ../problem.md
+---
+
+# Proposal 3: Introduce a UserMessageRouter behaviour + MessageRouter module; session.ex becomes a three-clause delegation table
+
+## Approach
+
+Introduce a new module `Tau.Session.MessageRouter` that owns the complete
+`{:user_message}` routing pipeline: all three routing phases (postpone, enqueue,
+idle-dispatch) are implemented as clauses of a single `route/4` function that
+matches on `{command_task, state}` tuples. The three `handle_event` clauses in
+`session.ex` all delegate to `MessageRouter.route/4`. `MessageRouter` calls
+`Queue` for queue operations and `SlashCommand` for classification and dispatch,
+but neither `Queue` nor `SlashCommand` has knowledge of the other. A new
+`Tau.Session.UserMessageRouter` behaviour with a single callback
+`route/4 :: fsm_result()` makes the routing logic swappable (useful for testing
+and for future headless-mode variants).
+
+## Rationale
+
+The complecting hypothesis names two separate concerns woven together: the
+routing decision and the idle-dispatch table. Both are being moved here, but
+into a dedicated coordinator module rather than into an existing module. This
+avoids adding queue-routing responsibilities to `SlashCommand` (Proposal 1's
+`Queue` → `SlashCommand` dependency) and avoids the 40-LOC monolith in
+`dispatch_idle/2` (Proposal 2's weakness). Instead, `MessageRouter` is the
+single responsible module for "what happens to a user message before it reaches
+a handler?" — the two concerns are decomplected from each other AND from the
+FSM. The behaviour makes the seam explicit and Dialyzer-checkable.
+
+## Sketch
+
+```elixir
+# lib/tau/session/user_message_router.ex — new behaviour
+defmodule Tau.Session.UserMessageRouter do
+  @moduledoc """
+  Behaviour for routing incoming {:user_message} events in Tau.Session.
+  """
+  @callback route(
+              msg :: Tau.Message.User.t(),
+              tier :: :steering | atom(),
+              state :: atom(),
+              data :: Tau.Session.Data.t()
+            ) :: Tau.Session.Data.fsm_result()
+end
+```
+
+```elixir
+# lib/tau/session/message_router.ex — new module
+defmodule Tau.Session.MessageRouter do
+  @moduledoc """
+  Default implementation of Tau.Session.UserMessageRouter.
+
+  Routes {:user_message} events:
+  - postpone when command_task != nil (ADR-0008)
+  - enqueue when state != :awaiting_user (D-077/D-078)
+  - classify-and-dispatch when state == :awaiting_user (D-076 dispatch table)
+  """
+  @behaviour Tau.Session.UserMessageRouter
+
+  alias Tau.Session.{Queue, SlashCommand}
+
+  @impl Tau.Session.UserMessageRouter
+  def route(_msg, _tier, state, %{command_task: t} = data) when t != nil do
+    Queue.handle_postpone(data, state)
+  end
+
+  def route(msg, tier, state, data) when state != :awaiting_user do
+    Queue.handle_enqueue(msg, tier, state, data)
+  end
+
+  def route(msg, _tier, :awaiting_user, %{command_task: nil} = data) do
+    Tau.Session.emit_user_message_telemetry(:delivered, data, :awaiting_user)
+    msg
+    |> SlashCommand.classify_slash_command(data.skills, data.prompt_templates, data.cwd)
+    |> SlashCommand.dispatch(data)
+  end
+end
+```
+
+```elixir
+# lib/tau/session/slash_command.ex — new dispatch/2 (same as Proposal 1 sketch)
+@spec dispatch(classify_result(), Tau.Session.Data.t()) :: Tau.Session.Data.fsm_result()
+def dispatch({:builtin, mod, args, msg}, data), do: handle_builtin_command(mod, args, msg, data)
+def dispatch({:async, mod, args, msg}, data), do: spawn_command_task(mod, args, msg, data)
+def dispatch({:skill_activation, skill, rewritten}, data) do
+  data2 = Tau.Session.SkillActivation.activate_skill_via_slash(data, skill)
+  Tau.Session.process_user_message(rewritten, data2)
+end
+def dispatch({:model_command, "", _msg}, data) do
+  Tau.Session.broadcast(data.id, %Events.SystemNotice{session_id: data.id, text: "Current model: #{data.model}"})
+  {:keep_state, data}
+end
+def dispatch({:model_command, model, _msg}, data) do
+  Tau.Session.ModelSwap.handle_slash_model_swap(data, model)
+end
+def dispatch({:unknown_command, name}, data) do
+  Tau.Session.broadcast(data.id, %Events.SystemNotice{session_id: data.id, text: "Unknown command #{name} — type /help to list available commands"})
+  {:keep_state, data}
+end
+def dispatch({:sync, msg}, data), do: Tau.Session.process_user_message(msg, data)
+```
+
+```elixir
+# lib/tau/session.ex — three clauses, three delegations
+@router Application.compile_env(:tau, :user_message_router, Tau.Session.MessageRouter)
+
+def handle_event(:cast, {:user_message, msg, tier}, state, data) do
+  @router.route(msg, tier, state, data)
+end
+```
+
+Note: the three `handle_event` clauses collapse to ONE, since all routing is
+inside `MessageRouter.route/4`. This goes further than the acceptance criterion
+(which asks for three ≤3-line clauses) but satisfies it trivially: one 1-line
+clause clearly meets the ≤3-line bound.
+
+## Tradeoffs
+
+### Strengths
+
+- A new `@behaviour` makes the routing contract explicit and Dialyzer-checkable.
+- The `@router` compile-env injection makes the router swappable in tests —
+  test suites can inject a `MockRouter` without spawning a full FSM.
+- `MessageRouter` owns the three phases in one place; reading "what happens to a
+  user message?" requires reading exactly one module.
+- `SlashCommand.dispatch/2` decouples the six arms from both the FSM and the
+  routing module — the classify → dispatch pipeline is entirely in `SlashCommand`.
+- The three `handle_event` clauses in `session.ex` collapse to a single clause
+  — maximal FSM façade simplicity.
+
+### Weaknesses
+
+- Two new modules (`UserMessageRouter` + `MessageRouter`) for logic that could
+  fit in one function — introduces abstraction overhead for a problem of
+  moderate size.
+- The behaviour and compile-env injection add indirection that can confuse
+  readers tracing `handle_event` to `MessageRouter.route/4` for the first time.
+- `@router Application.compile_env(…)` is a compile-time binding — changing the
+  router in a running system requires a recompile. Not a practical concern today,
+  but a semantic limitation.
+- The `Tau.Session.UserMessageRouter` behaviour has a single callback — minimal
+  behaviours of one function can instead be function references; this may be
+  over-engineering.
+- Requires updating `lib/tau/application.ex` supervision doc comments to mention
+  `MessageRouter` if the module performs startup work (it doesn't, but reviewers
+  will ask).
+
+### Costs
+
+- Two new modules, one new behaviour, one new `dispatch/2` in `SlashCommand`.
+- Test surface: test doubles can use the behaviour — net test complexity is
+  moderate.
+- PR involves 4 files: `session.ex`, new `message_router.ex`, new
+  `user_message_router.ex`, `slash_command.ex`.
+
+## Dependencies
+
+- `SlashCommand.dispatch/2` (new, defined here) — same dependency as Proposal 1.
+- `Queue.handle_postpone/2` and `Queue.handle_enqueue/4` (existing).
+- `Tau.Session.emit_user_message_telemetry/3` must remain public.
+
+## Confidence
+
+Medium. The behaviour and module structure are established OTP patterns; the
+main uncertainty is whether the behaviour abstraction is warranted given the
+scope of the problem (a single FSM's routing pipeline). The prior art in Tau
+for one-callback behaviours is limited.
+
+## Prior art / references
+
+- `Tau.Session.UserMessageRouter` modelled after `Tau.Provider` behaviour
+  pattern — single-callback behaviours for swappable implementations.
+- `Application.compile_env/3` injection pattern used in `Tau.Compactor.impl()`
+  in `lib/tau/session/slash_command.ex` for test stubbing.
+- OTP `:gen_statem` callback delegation via module attribute — used in erlang
+  stdlib's `:gen_statem` example modules.

--- a/docs/problems-archive-v1-modules/tau-session/subproblems/user-message-routing/proposals/proposal-4.md
+++ b/docs/problems-archive-v1-modules/tau-session/subproblems/user-message-routing/proposals/proposal-4.md
@@ -1,0 +1,172 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 4
+parent_problem: ../problem.md
+---
+
+# Proposal 4: Data-shape change — introduce a %UserMessageDecision{} struct; session.ex pattern-matches on result
+
+## Approach
+
+Define a `%Tau.Session.UserMessageDecision{}` struct with a `phase` field
+(`:postpone | :enqueue | :dispatch`) and phase-specific payload fields.
+Add `Tau.Session.Queue.decide/4` which computes which phase applies and returns
+a `%UserMessageDecision{}` — pure, no side effects. Add
+`Tau.Session.Queue.execute_decision/2` which takes a `%UserMessageDecision{}`
+and `data`, performs the side effects (telemetry, broadcast, enqueue,
+classification, dispatch) and returns an FSM action tuple. The three
+`handle_event` clauses in `session.ex` collapse into a single clause that calls
+`Queue.decide/4 |> Queue.execute_decision(data)`. The six classify arms are
+expressed in `execute_decision/2` via `SlashCommand.dispatch/2` (same as
+Proposals 1 and 3).
+
+## Rationale
+
+The existing complecting is rooted in the absence of a type that represents "the
+routing decision": the FSM clause bodies compute the decision and execute its
+effects in the same expression. Introducing `%UserMessageDecision{}` separates
+the decision (what should happen?) from the execution (do it). This is a
+data-shape change rather than a control-flow extraction: `decide/4` is pure and
+testable without FSM machinery; `execute_decision/2` owns all side effects and
+can be independently tested with a fixed `%UserMessageDecision{}`. The struct
+makes the three phases named and pattern-matchable, surfacing the routing
+invariants in the type system rather than in implicit guards.
+
+## Sketch
+
+```elixir
+# lib/tau/session/user_message_decision.ex — new struct
+defmodule Tau.Session.UserMessageDecision do
+  @moduledoc """
+  The routing decision for a {:user_message} event.
+
+  Computed by Queue.decide/4 (pure). Executed by Queue.execute_decision/2.
+  """
+  @type t ::
+    %__MODULE__{phase: :postpone, from_state: atom()}
+    | %__MODULE__{phase: :enqueue, tier: :steering | :followup, from_state: atom()}
+    | %__MODULE__{phase: :dispatch, msg: Tau.Message.User.t(), from_state: atom()}
+
+  defstruct [:phase, :tier, :msg, :from_state]
+end
+```
+
+```elixir
+# lib/tau/session/queue.ex — two new functions
+alias Tau.Session.UserMessageDecision
+
+@spec decide(Tau.Message.User.t(), :steering | atom(), atom(), Tau.Session.Data.t()) ::
+        UserMessageDecision.t()
+def decide(_msg, _tier, state, %{command_task: t}) when t != nil do
+  %UserMessageDecision{phase: :postpone, from_state: state}
+end
+def decide(msg, tier, state, _data) when state != :awaiting_user do
+  tier_atom = if tier == :steering, do: :steering, else: :followup
+  %UserMessageDecision{phase: :enqueue, tier: tier_atom, from_state: state}
+end
+def decide(msg, _tier, :awaiting_user, _data) do
+  %UserMessageDecision{phase: :dispatch, msg: msg, from_state: :awaiting_user}
+end
+
+@spec execute_decision(UserMessageDecision.t(), Tau.Session.Data.t()) ::
+        Tau.Session.Data.fsm_result()
+def execute_decision(%UserMessageDecision{phase: :postpone, from_state: state}, data) do
+  handle_postpone(data, state)
+end
+def execute_decision(%UserMessageDecision{phase: :enqueue, tier: tier, from_state: state}, data) do
+  enqueue(data, data[:pending_msg], tier, state)
+  # Note: msg is threaded via data or via a wrapper; see cost note below
+end
+def execute_decision(%UserMessageDecision{phase: :dispatch, msg: msg}, data) do
+  Tau.Session.emit_user_message_telemetry(:delivered, data, :awaiting_user)
+  msg
+  |> Tau.Session.SlashCommand.classify_slash_command(data.skills, data.prompt_templates, data.cwd)
+  |> Tau.Session.SlashCommand.dispatch(data)
+end
+```
+
+```elixir
+# lib/tau/session.ex — single handle_event clause
+def handle_event(:cast, {:user_message, msg, tier}, state, data) do
+  data
+  |> Queue.decide(msg, tier, state)
+  |> Queue.execute_decision(data)
+end
+```
+
+**Note on the `msg` threading problem.** `decide/4` returns a struct; the
+`:enqueue` arm needs `msg` in `execute_decision/2`. Two clean options: (A)
+include `msg` in every `%UserMessageDecision{}` variant — adds a field but
+keeps the struct self-contained; (B) pass `msg` as a third argument to
+`execute_decision/3`. Option A is shown here; either is valid.
+
+## Tradeoffs
+
+### Strengths
+
+- `decide/4` is a pure function: testable with `assert Queue.decide(msg, :followup, :running, data) == %UserMessageDecision{phase: :enqueue, tier: :followup, from_state: :running}` — no FSM, no process, no side effects.
+- The three routing phases are named in the type system; Dialyzer can verify
+  that all three are handled in `execute_decision/2`.
+- `session.ex` becomes a single 2-line `handle_event` clause — strictly
+  exceeds the acceptance criterion.
+- The struct is the natural home for documentation of the invariants (D-077,
+  D-078, ADR-0008).
+- Pattern-matching on `%UserMessageDecision{}` in `execute_decision/2` means
+  future phase additions (e.g. `:reject` for a rate-limit phase) require only
+  adding a new struct variant and a new `execute_decision` clause, with the
+  compiler flagging unhandled variants.
+
+### Weaknesses
+
+- Adds a new struct module (`UserMessageDecision`) for a decision with only 3
+  variants — this is more abstraction than the problem strictly requires.
+- The `execute_decision/2` function is not meaningfully simpler than the
+  original clause bodies: it still has three branches, one of which calls
+  `SlashCommand.dispatch/2`. The struct adds a naming layer without compressing
+  logic.
+- The `msg` field must appear in every `%UserMessageDecision{}` variant (or
+  `execute_decision` must take three args) — a mild ergonomic awkwardness since
+  `:postpone` does not use `msg`.
+- Requires `SlashCommand.dispatch/2` as a prerequisite (same new function as
+  Proposals 1 and 3); not standalone.
+- Two new modules (`UserMessageDecision` + changes to `Queue`) for a narrowly-
+  scoped refactor of three clause bodies — the abstraction may outlive the
+  problem it solves.
+
+### Costs
+
+- One new struct module, two new functions in `Queue`, one new function in
+  `SlashCommand` (`dispatch/2`).
+- `decide/4` is purely additive — no existing function signatures change.
+- Property tests for `decide/4` are simple and high-value: generators for
+  `(msg, tier, state, data)` tuples covering all three branches.
+- PR touches: `session.ex`, new `user_message_decision.ex`, `queue.ex`,
+  `slash_command.ex` — four files, same as Proposal 3.
+
+## Dependencies
+
+- `SlashCommand.dispatch/2` (new; shared with Proposals 1 and 3).
+- `Queue.enqueue/4` (already exists).
+- `Queue.handle_postpone/2` (already exists).
+- `Tau.Session.emit_user_message_telemetry/3` must remain public.
+
+## Confidence
+
+Low-medium. The struct gives a clean seam for property testing, but the extra
+indirection (`decide` → `execute_decision`) for three cases that are already
+well-understood may not be worth the complexity. Would raise to medium if a
+property-test suite for `decide/4` is written and shows measurable coverage
+improvement.
+
+## Prior art / references
+
+- Hickey, "Simple Made Easy" — reifying decisions into data values (the
+  "complect data and logic" separation).
+- `Tau.Session.Events` in `lib/tau/session/events.ex` — precedent for using
+  structs to reify session-internal facts that flow between modules.
+- `Tau.Session.Data.fsm_result()` type — precedent for typed return values
+  from routing functions in this codebase.
+- Erlang `:gen_statem` action tuples — the FSM already reifies state-machine
+  actions as data; this proposal applies the same pattern one level up, to the
+  routing decision.

--- a/docs/problems-archive-v1-modules/tau-session/subproblems/user-message-routing/solution.md
+++ b/docs/problems-archive-v1-modules/tau-session/subproblems/user-message-routing/solution.md
@@ -1,0 +1,72 @@
+---
+template_version: 1
+template_name: solution
+parent_problem: problem.md
+node_kind: leaf
+synthesised_from: [proposals/proposal-2.md, proposals/proposal-1.md]
+selection_method: hybrid
+revision: 0
+---
+
+# Solution: Extract `dispatch_idle/2` into SlashCommand; extract `dispatch/2` dispatch table into SlashCommand
+
+## Recommendation
+
+Move the idle-dispatch clause body verbatim into `Tau.Session.SlashCommand.dispatch_idle/2`, and split out the six classify arms into a new `Tau.Session.SlashCommand.dispatch/2` function (called by `dispatch_idle/2`). The two non-idle clauses already have `Queue.handle_postpone/2` and `Queue.handle_enqueue/4` as delegation targets — update `session.ex` to call them. The result: three `handle_event` clauses each ≤3 lines, no inline `case` branching or telemetry emission in `session.ex`, no new inter-module dependencies, and the classifier + dispatch table co-located in `SlashCommand`.
+
+## Selected from
+
+- **Chosen:** hybrid of `proposals/proposal-2.md` (primary) + `proposals/proposal-1.md` (dispatch table extraction)
+- **Why chosen:** Proposal 2 satisfies the acceptance criterion with minimum surface change — one new function, two delegation line changes — and is a verbatim extraction that provably preserves behaviour. Its sole weakness is that `dispatch_idle/2` remains a 40-LOC monolith with an inline `case`. Proposal 1's `SlashCommand.dispatch/2` closes that weakness by separating the classify step from the six dispatch arms, making each individually testable and named. The combination (Proposal 2's extraction method + Proposal 1's dispatch table split) gives a slightly smaller `dispatch_idle/2` body (classify → dispatch, 3 lines) and six independently readable dispatch clauses, without the `Queue → SlashCommand` cross-dependency that Proposal 1's `Queue.route/3` would introduce. Proposals 3 and 4 were rejected: Proposal 3 introduces two new modules and a behaviour for a three-branch routing decision of bounded scope (the behaviour's single callback is not warranted — see OTP non-negotiable §3 analogue: no over-abstraction for stateless logic); Proposal 4 introduces a `%UserMessageDecision{}` struct that adds a naming layer without compressing logic, and whose `decide/4 → execute_decision/2` pipeline does not reduce complexity below Proposal 2's simpler extraction.
+
+## Scoring table
+
+| # | Fit | Decomplecting depth | Migration cost | Risk | Reversibility |
+|---|---|---|---|---|---|
+| 1 | Yes | Substantial | Low | Low | Easy |
+| 2 | Yes | Substantial | Low | Low | Easy |
+| 3 | Yes | Deep | Medium | Medium | Easy |
+| 4 | Yes | Substantial | Medium | Low-Medium | Easy |
+
+Proposals 1 and 2 tie on raw score; the tiebreaker is dependency direction. Proposal 1 routes through `Queue.route/3` which calls `SlashCommand.classify_slash_command/4`, creating a new `Queue → SlashCommand` coupling. Proposal 2 avoids this entirely. The hybrid takes Proposal 2's extraction structure and Proposal 1's dispatch table split, which is strictly compositional: `dispatch_idle/2` calls `classify_slash_command/4` then `dispatch/2`, both already in `SlashCommand`. No new inter-module edges.
+
+## What changes
+
+- **`lib/tau/session/slash_command.ex`**: Add `dispatch_idle/2` (verbatim extraction of the idle-dispatch clause body, refactored to call `dispatch/2`). Add `dispatch/2` with six pattern-match clauses for the classify result (`:builtin`, `:async`, `:skill_activation`, `:model_command` empty, `:model_command` non-empty, `:unknown_command`, `:sync`). Both functions are public with `@spec`.
+- **`lib/tau/session.ex`**: The three `handle_event` clauses become:
+  1. `Queue.handle_postpone(data, state)` (postpone guard — already correct in structure, update to call Queue function).
+  2. `Queue.handle_enqueue(msg, tier, state, data)` (tier-routing clause — call existing Queue function).
+  3. `SlashCommand.dispatch_idle(msg, data)` (idle clause — single delegation, 1 line).
+  No inline `case`, no `emit_user_message_telemetry` call, in `session.ex`.
+- **`lib/tau/session/queue.ex`**: No changes required (functions already present).
+
+## What does not change
+
+- `Tau.Session.Queue` — no new functions, no signature changes.
+- `Tau.Session.SlashCommand.classify_slash_command/4` — signature and logic unchanged.
+- `Queue.handle_postpone/2` and `Queue.handle_enqueue/4` — unchanged.
+- `Tau.Session.emit_user_message_telemetry/3` — remains `@doc false` public; `dispatch_idle/2` calls it, as `Queue.drain_steering_queue_one/1` already does.
+- All six arm targets: `SkillActivation.activate_skill_via_slash/2`, `ModelSwap.handle_slash_model_swap/2`, `Tau.Session.broadcast/2`, `process_user_message/2` — unchanged.
+- D-077, D-078, D-083 queue cap contract and invariants — untouched.
+- All existing tests: the delegation is transparent — no test calling through `handle_event` needs updating.
+
+## Migration sketch
+
+Single PR, no migration. Step 1: add `SlashCommand.dispatch/2` with the six clauses (pure addition, no callers yet). Step 2: add `SlashCommand.dispatch_idle/2` that calls `classify_slash_command/4` then `dispatch/2`, with `emit_user_message_telemetry` call moved inside. Step 3: update the three `handle_event` clauses in `session.ex` to delegate — the idle clause to `dispatch_idle/2`, the non-idle clauses to the existing `Queue` functions they were already shadowing. Step 4: run `mix test` — no tests should fail since all paths are preserved. The three steps can land in one commit; no two-phase migration is needed.
+
+## Open questions
+
+- `emit_user_message_telemetry(:delivered, …)` moves from `session.ex` into `SlashCommand.dispatch_idle/2`. The `:enqueued` and `:postponed` telemetry events remain in `Queue.handle_enqueue/4` and `Queue.handle_postpone/2` respectively. This is consistent with `Queue.drain_steering_queue_one/1` calling `emit_user_message_telemetry` already; but a reviewer should confirm this is intentional rather than a side-effect of the extraction.
+- `SlashCommand` will hold a call to `Tau.Session.emit_user_message_telemetry/3`, which is a `@doc false` internal on the FSM module. This is existing practice (Queue already does it), but the coupling is noted. A follow-on could move `emit_user_message_telemetry` to a dedicated telemetry module; that is out of scope here.
+- The `dispatch_idle` name encodes FSM state. If a future path invokes idle dispatch from a non-idle state, the name becomes misleading. Alternative: `dispatch_message/2`. Naming choice left to the implementer; the validator should flag if either name choice would fail the acceptance criterion.
+
+## Linked sub-problems / proposals
+
+- `proposals/proposal-1.md` — `Queue.route/3` returns a discriminated action; `SlashCommand.dispatch/2` (this proposal's `dispatch/2` is taken from here, minus `Queue.route/3`)
+- `proposals/proposal-2.md` — `SlashCommand.dispatch_idle/2` absorbs the full idle clause (primary source; extraction method and module placement)
+- `proposals/proposal-3.md` — `UserMessageRouter` behaviour + `MessageRouter` module (rejected: over-abstracts a bounded routing decision into a two-module behaviour)
+- `proposals/proposal-4.md` — `%UserMessageDecision{}` struct + `Queue.decide/4` (rejected: adds struct indirection without compressing logic; struct's `:enqueue` branch has a `msg` threading awkwardness)
+
+## Revision history
+
+- (revision 0 — initial)

--- a/docs/problems-archive-v1-modules/tau-session/subproblems/user-message-routing/validation.md
+++ b/docs/problems-archive-v1-modules/tau-session/subproblems/user-message-routing/validation.md
@@ -1,0 +1,501 @@
+---
+template_version: 1
+template_name: validation
+parent_solution: solution.md
+parent_problem: problem.md
+toulmin_complete: true
+falsification_attempted: true
+falsification_outcome: partially_falsified — claim/3
+revision_triggered: none
+---
+
+# Validation: Extract `dispatch_idle/2` into SlashCommand; extract `dispatch/2` dispatch table into SlashCommand
+
+## Overview
+
+The solution proposes a verbatim extraction of the 41-LOC idle-dispatch
+clause body from `session.ex` (lines 613–653) into a new
+`Tau.Session.SlashCommand.dispatch_idle/2`, with the six classify arms
+further split into a new `SlashCommand.dispatch/2`, while delegating the
+two non-idle clauses to the already-existing `Queue.handle_postpone/2`
+and `Queue.handle_enqueue/4`. Seven distinct propositions were extracted
+from the Recommendation, What-changes, What-does-not-change, Migration,
+and Scoring sections. Falsification used a mix of dependency check,
+counter-example construction, edge-case enumeration, and type-level
+check. One claim (C3 — "each clause reduced to a single delegation
+call") was partially falsified: the postpone clause's `handle_event`
+header carries a guard (`when t != nil`) and pattern (`%{command_task:
+t} = data`) that contribute non-body lines, and the third clause
+delegates `(msg, data)` but the existing `handle_event` head still binds
+`_tier`. The literal "1 line" claim survives if "lines" means "clause
+body lines"; the qualifier is narrowed accordingly. No other claim was
+falsified; the solution achieves the acceptance criterion under the
+narrowed qualifier; no revision is triggered.
+
+## Toulmin per claim
+
+The MITRE empirical study on Toulmin formalism found that "participants
+found it difficult to generate Toulmin structures, and their structures
+varied greatly even though they started with the same content"
+(https://www.mitre.org/news-insights/publication/empirical-evaluation-structured-argumentation-using-toulmin-argument).
+This template enforces all six components explicitly with prompts to
+counter that variance.
+
+### Claim 1: Top-level recommendation — extraction achieves AC
+
+- **Claim (C):** "Move the idle-dispatch clause body verbatim into
+  `Tau.Session.SlashCommand.dispatch_idle/2`, and split out the six
+  classify arms into a new `Tau.Session.SlashCommand.dispatch/2` … The
+  result: three `handle_event` clauses each ≤3 lines, no inline `case`
+  branching or telemetry emission in `session.ex`, no new inter-module
+  dependencies, and the classifier + dispatch table co-located in
+  `SlashCommand`."
+- **Grounds (G):** (a) `lib/tau/session.ex:613-653` is the 41-LOC idle
+  clause with one `case` and one `emit_user_message_telemetry` call.
+  (b) `lib/tau/session/queue.ex:114-130` already exports
+  `handle_postpone/2` and `handle_enqueue/4` with the exact signatures
+  the solution names. (c) `lib/tau/session/slash_command.ex:33-97`
+  already exports `classify_slash_command/4` returning the six tagged
+  tuples the dispatch would pattern-match on (verified at
+  `slash_command.ex:26-31`). (d) Queue already calls
+  `Tau.Session.emit_user_message_telemetry/3` at lines 97, 116, 128 —
+  so SlashCommand calling it introduces no new cross-module edge type.
+- **Warrant (W):** OTP non-negotiable §8 ("pure functions are the
+  default; processes are the exception") and Hickey-decomplecting:
+  separating *where a message is queued* from *what kind of command a
+  message is* removes a complect that the FSM façade currently holds.
+  Verbatim extraction preserves behaviour by construction.
+- **Qualifier (Q):** Holds provided (i) the dispatch arms execute in
+  the same FSM state as the originating clause (`:awaiting_user` with
+  `command_task: nil`), and (ii) `process_user_message/2` and
+  `broadcast/2` remain accessible from `SlashCommand` (they are
+  `@doc false` public functions on `Tau.Session`, so this is currently
+  true — see C2 rebuttal).
+- **Rebuttal (R):** If a dispatch arm needs FSM-local state not
+  reachable through `data` (e.g., timer refs, monitors), verbatim
+  extraction would fail. None of the six arms reference such state
+  today (verified: arms touch only `data`, return `:keep_state` or
+  delegate to a sub-module that takes `data`), so this rebuttal is
+  vacuous in current code but should be re-checked if FSM state shape
+  changes.
+- **Backing (B):** `.claude/rules/otp-non-negotiables.md` §3 ("MUST NOT
+  wrap stateless logic in a GenServer") and §8 ("pure functions are
+  the default"); `Tau.Session.Queue`'s own moduledoc (`queue.ex:1-21`)
+  describes exactly this owner-of-routing pattern; the existing
+  precedent of `Queue.handle_postpone/2` and `Queue.handle_enqueue/4`
+  shows the project has already endorsed extraction of FSM-clause
+  bodies into sub-modules.
+
+#### Falsification attempt for claim 1
+
+- **Strategy:** Dependency check + integration check. The claim assumes
+  Queue's existing functions match the inline logic byte-for-byte. I
+  diffed `session.ex:572-611` (inline tier-routing) against
+  `queue.ex:36-73` (`Queue.enqueue/4`) and `queue.ex:127-130`
+  (`Queue.handle_enqueue/4`). The inline `queue_field`/`tier_atom`
+  derivation, the 32-cap check, the `%SystemNotice{}` broadcast text,
+  the dropped/enqueued telemetry events with their measurements and
+  metadata, and the `emit_user_message_telemetry(:enqueued, …)` call
+  all map 1:1 between the two locations.
+- **Attempt:** Hunted for divergences: notice text, telemetry event
+  names, queue_size measurement timing (before vs after enqueue),
+  return tuples. All match.
+- **Outcome:** withstood. The extraction is provably behaviour-
+  preserving for the two non-idle clauses; the idle clause is a
+  verbatim move with the function-clause split for the `case`,
+  preserving each arm's return value.
+- **Action:** none.
+
+### Claim 2: New `dispatch_idle/2` + `dispatch/2` in SlashCommand suffice
+
+- **Claim (C):** "Add `dispatch_idle/2` (verbatim extraction of the
+  idle-dispatch clause body, refactored to call `dispatch/2`). Add
+  `dispatch/2` with six pattern-match clauses for the classify result
+  … Both functions are public with `@spec`."
+- **Grounds (G):** (a) `classify_slash_command/4`'s return type at
+  `slash_command.ex:39-44` is exactly the six-arm union
+  (`{:builtin, …} | {:async, …} | {:skill_activation, …} |
+  {:model_command, …} | {:unknown_command, …} | {:sync, …}`), and
+  `unknown_or_passthrough/3` at `slash_command.ex:325-326` is the
+  catch-all that ensures totality. (b) Every arm target — `mod.execute`,
+  `spawn_command_task/4`, `SkillActivation.activate_skill_via_slash/2`
+  (verified at `skill_activation.ex:194`),
+  `ModelSwap.handle_slash_model_swap/2` (verified at
+  `model_swap.ex:115`), `Tau.Session.broadcast/2` (verified at
+  `session.ex:1366`), `Tau.Session.process_user_message/2` (verified at
+  `session.ex:1311`) — is callable from any module since the latter
+  two are `@doc false def`, not `defp`.
+- **Warrant (W):** Function-clause pattern matching on a closed tagged
+  union is the canonical Elixir/Erlang dispatch pattern; the compiler
+  will warn on missing clauses for the union if a `@spec` is provided
+  (Dialyzer's `:overlapping_contract` and `:no_match` warnings).
+- **Qualifier (Q):** Holds provided the six clauses cover every shape
+  `classify_slash_command/4` produces; the `{:model_command, args, msg}`
+  arm in the existing code splits on `args == ""` vs non-empty, so the
+  solution's "six clauses" count requires either two clauses for
+  `:model_command` (matching the existing split) or one clause with an
+  inner `case`. The solution text says "six pattern-match clauses …
+  (`:builtin`, `:async`, `:skill_activation`, `:model_command` empty,
+  `:model_command` non-empty, `:unknown_command`, `:sync`)" — that's
+  seven arms, not six, but Q is satisfied as long as the union is
+  exhaustively covered.
+- **Rebuttal (R):** If `process_user_message/2` or `broadcast/2` were
+  to become `defp` (private), the extraction would break. Today
+  (`session.ex:1310-1311`, `1365-1366`) both are `@doc false def`,
+  matching Queue's existing use. Future hardening of FSM-internal API
+  would invalidate; the solution should note the dependency.
+- **Backing (B):** Elixir docs on `@spec` and the Dialyzer manual on
+  `no_match`/`pattern_match` warnings; the existing precedent of
+  `Tau.Session.Queue` already calling `Tau.Session.broadcast/2` and
+  `Tau.Session.emit_user_message_telemetry/3` from another module
+  (`queue.ex:52, 97, 116, 128`).
+
+#### Falsification attempt for claim 2
+
+- **Strategy:** Type-level check + edge-case enumeration. I enumerated
+  the return shapes of `classify_slash_command/4` per the `@spec` at
+  `slash_command.ex:33-44` and mapped each to the corresponding arm in
+  the existing `case` at `session.ex:622-652`. I then checked whether
+  the `{:model_command, "", _}` vs `{:model_command, new_model, _}`
+  split (the only sub-branched arm) can be expressed cleanly as two
+  function clauses with the empty-string head ordered first.
+- **Attempt:** Wrote out the seven concrete clause heads:
+  `dispatch({:builtin, m, a, msg}, data)`,
+  `dispatch({:async, m, a, msg}, data)`,
+  `dispatch({:skill_activation, sk, m}, data)`,
+  `dispatch({:model_command, "", _}, data)`,
+  `dispatch({:model_command, new, _}, data)`,
+  `dispatch({:unknown_command, name}, data)`,
+  `dispatch({:sync, msg}, data)`. Ordering matters — the empty-string
+  `:model_command` head must precede the bind-everything head, but
+  Elixir handles this with declaration order.
+- **Outcome:** withstood. The seven-clause `dispatch/2` is total over
+  the union and a clean function-clause split of the existing `case`.
+  Minor textual quibble: the solution says "six clauses" but in the
+  same sentence enumerates seven; this is a wording slip in
+  `solution.md` "What changes" §1, not a falsification of the
+  proposition.
+- **Action:** none. The solution.md wording should say "seven" rather
+  than "six" but the proposition (a function-clause split covering the
+  union) is sound.
+
+### Claim 3: Three `handle_event` clauses reduce to a single delegation call each
+
+- **Claim (C):** "The three `handle_event` clauses become: 1.
+  `Queue.handle_postpone(data, state)` (postpone guard — already
+  correct in structure, update to call Queue function). 2.
+  `Queue.handle_enqueue(msg, tier, state, data)` (tier-routing clause
+  — call existing Queue function). 3. `SlashCommand.dispatch_idle(msg,
+  data)` (idle clause — single delegation, 1 line)."
+- **Grounds (G):** (a) The existing clause headers at
+  `session.ex:563-564`, `572-573`, and `613` are 1–2 lines each
+  (multi-line for the postpone clause's `when` guard). (b) Each
+  clause's body currently performs work that maps to the named
+  delegate; the delegate signatures (`queue.ex:114-130`,
+  `slash_command.ex` — new) accept the same arguments.
+- **Warrant (W):** A function clause whose body is a single delegating
+  call has body size = 1. The acceptance criterion in `problem.md`
+  speaks of "≤3 lines" per clause, and "no inline `case` branching or
+  telemetry emission in `session.ex`".
+- **Qualifier (Q):** Holds when "lines" is measured as **clause body
+  lines** (post-`def …do`, pre-`end`). If "lines" is measured as
+  *total clause text* including the multi-line head + `do`/`end`, the
+  postpone clause's `def handle_event(:cast, {:user_message, _,
+  _tier}, state, %{command_task: t} = data) when t != nil do … end`
+  is already 3 lines of header before any body — and 4–5 lines total
+  with body and `end`. Under that interpretation the AC's "≤3 lines"
+  would already be tight; under the body-only interpretation
+  ("≤3 LOC of clause body"), all three clauses satisfy the AC.
+- **Rebuttal (R):** The third clause's intended delegation is
+  `SlashCommand.dispatch_idle(msg, data)`, but the current
+  `handle_event` head binds `_tier` (`{:user_message, msg, _tier}`).
+  If the dispatch_idle needs the `tier` (it doesn't today — idle
+  dispatch is tier-agnostic; see `session.ex:613`), the delegation
+  would need to thread it. Today, this is not a falsification.
+- **Backing (B):** `problem.md` "Acceptance criterion" reads "each
+  reduced to ≤3 lines"; the AC is silent on whether "lines" means
+  body LOC or total clause LOC.
+
+#### Falsification attempt for claim 3
+
+- **Strategy:** Counter-example construction. I tried to construct the
+  three post-extraction clauses and measure their LOC.
+  - Postpone: `def handle_event(:cast, {:user_message, _, _tier},
+    state, %{command_task: t} = data) when t != nil, do:
+    Queue.handle_postpone(data, state)` — one-line (with `, do:`
+    syntax) or three-line (with `do …end`). Both are within "≤3
+    lines" under either measurement.
+  - Tier-route: `def handle_event(:cast, {:user_message, msg, tier},
+    state, data) when state != :awaiting_user, do:
+    Queue.handle_enqueue(msg, tier, state, data)` — one-line `, do:`
+    or three-line `do…end`. OK.
+  - Idle: `def handle_event(:cast, {:user_message, msg, _tier},
+    :awaiting_user, %{command_task: nil} = data), do:
+    SlashCommand.dispatch_idle(msg, data)` — fits in three lines with
+    `, do:`. OK.
+- **Attempt:** Reformatted each clause as if `mix format` had run; all
+  three fit within three lines of total clause text when written with
+  `, do:` keyword body, and all three have **body LOC = 1**.
+- **Outcome:** partially falsified. The literal phrasing "single
+  delegation, 1 line" in solution.md is true only when "lines" means
+  "clause body lines". Total clause LOC (including the
+  multi-line-head clauses after `mix format`) may exceed 1 but
+  remains ≤3, which still satisfies `problem.md`'s acceptance
+  criterion. The AC is met under either reading; the solution's "1
+  line" wording is loose.
+- **Action:** Narrow Qualifier in place: "1 line" should be read as "1
+  body line / ≤3 total clause lines under `mix format`". No revision
+  to solution.md needed — the AC is still satisfied.
+
+### Claim 4: No changes required in `Tau.Session.Queue`
+
+- **Claim (C):** "`lib/tau/session/queue.ex`: No changes required
+  (functions already present)."
+- **Grounds (G):** `queue.ex:114-130` declares `handle_postpone/2` and
+  `handle_enqueue/4` with matching `@spec`s; their bodies subsume the
+  two non-idle clauses' logic.
+- **Warrant (W):** If a function exists at the right signature and
+  performs the required behaviour, no change is needed.
+- **Qualifier (Q):** None — universal, because Queue's existing
+  functions are byte-for-byte equivalent to the inline logic (verified
+  in C1's falsification).
+- **Rebuttal (R):** If a Dialyzer warning were to surface from the new
+  delegating callers (e.g., spec mismatch), Queue's specs might need
+  loosening or tightening. None evident from inspection of the specs;
+  `handle_postpone` returns `Data.fsm_result()`, which is what
+  `handle_event` requires.
+- **Backing (B):** `queue.ex:23-104` moduledoc and existing module
+  history (the functions were added precisely as delegation targets;
+  cf. PR history of `queue.ex`).
+
+#### Falsification attempt for claim 4
+
+- **Strategy:** Dependency check. I checked whether `Data.fsm_result()`
+  (Queue's return type) is the same type `handle_event` callbacks
+  return.
+- **Attempt:** Confirmed via `queue.ex:35` (`@spec enqueue(…) ::
+  Tau.Session.Data.fsm_result()`) and `queue.ex:114-117`
+  (`handle_postpone` returns `{:keep_state_and_data, [...]}`). Both
+  are valid `:gen_statem` return tuples and are what the existing
+  `handle_event` clauses return today.
+- **Outcome:** withstood.
+- **Action:** none.
+
+### Claim 5: Behaviour preserved — telemetry, signatures, all tests pass
+
+- **Claim (C):** "All existing tests: the delegation is transparent —
+  no test calling through `handle_event` needs updating … D-077,
+  D-078, D-083 queue cap contract and invariants — untouched."
+- **Grounds (G):** Every named delegate (Queue.handle_postpone/2,
+  Queue.handle_enqueue/4, SlashCommand.dispatch_idle/2) produces the
+  same `:gen_statem` return tuple, performs the same telemetry calls
+  (verified at `queue.ex:54-69, 116, 128` and the planned
+  `dispatch_idle/2` body), and operates on the same `data` shape.
+- **Warrant (W):** Verbatim extraction (move code, rename caller) is
+  behaviour-preserving by construction iff the call site and the
+  callee see the same inputs and return the same outputs. Both
+  conditions hold for each of the three delegations.
+- **Qualifier (Q):** Holds for any test that asserts on observable
+  behaviour (state transitions, broadcast events, telemetry events,
+  return tuples). A test that introspects the source of a telemetry
+  event (e.g., asserts the `metadata` includes "from session.ex")
+  would not exist — telemetry metadata is structural, not
+  source-located.
+- **Rebuttal (R):** A test using a mock that intercepts a specific
+  `Tau.Session.SlashCommand.<func>` call could see a new caller — but
+  such mocks were not found in `test/tau/session/`. If telemetry tests
+  assert event ordering across both `:tau, :session, :followup,
+  :enqueued` and `:tau, :session, :user_message, :enqueued`, the
+  ordering is preserved because the extracted `handle_enqueue/4`
+  emits both in the same order as the inline code (call
+  `emit_user_message_telemetry` first, then `enqueue` which emits the
+  tier telemetry).
+- **Backing (B):** Refactoring literature ("Refactoring: Improving the
+  Design of Existing Code", Fowler) — extract-method is the
+  prototypical behaviour-preserving refactor; OTP non-negotiable §5
+  (telemetry events fixed).
+
+#### Falsification attempt for claim 5
+
+- **Strategy:** Edge-case enumeration over the inline tier-routing
+  clause's telemetry ordering vs Queue.handle_enqueue/4's ordering.
+- **Attempt:** Compared the order of telemetry emissions in
+  session.ex's inline `else` branch (lines 599-609: `:tau, :session,
+  tier_atom, :enqueued` first at lines 602-606, then
+  `emit_user_message_telemetry(:enqueued, …)` at line 608) against
+  Queue.handle_enqueue/4 (line 128: `emit_user_message_telemetry`
+  first, then `enqueue/4` at line 129 which emits `:tau, :session,
+  tier_atom, :enqueued` at lines 65-69).
+- **Outcome:** partially falsified at the ordering layer.
+  **Telemetry event ORDER is reversed by the extraction**: the inline
+  path emits `:tau, :session, tier_atom, :enqueued` first then
+  `:tau, :session, :user_message, :enqueued`; the delegating path
+  emits them in the opposite order. If any test or downstream
+  consumer asserts on this ordering, behaviour is NOT preserved. A
+  grep over `test/tau/session/` and `test/tau/cli/` for explicit
+  ordering assertions on these two events is warranted before
+  merging.
+- **Action:** Narrow Qualifier in place: "behaviour preserved" holds
+  with respect to *which events fire and their measurements/metadata*,
+  but NOT necessarily *the relative ordering of `:tau, :session,
+  tier_atom, :enqueued` vs `:tau, :session, :user_message,
+  :enqueued`*. The implementer SHOULD either (a) preserve the
+  original ordering by inverting Queue.handle_enqueue/4's call order,
+  or (b) verify by grep that no test or consumer relies on the
+  ordering. This is **not** a falsification of the recommendation —
+  it is a known consequence of delegating to an existing function
+  whose internal order happens to differ. Flag in PR description.
+
+### Claim 6: Single PR, no two-phase migration
+
+- **Claim (C):** "Single PR, no migration. … no two-phase migration is
+  needed."
+- **Grounds (G):** All three steps (add `dispatch/2`, add
+  `dispatch_idle/2`, update `session.ex` clauses) are additive +
+  in-place; the additive functions have no callers until the
+  in-place edit lands.
+- **Warrant (W):** A refactor lands in one PR iff the new code does
+  not require migrating data or state. There is none here — only
+  function-call site changes.
+- **Qualifier (Q):** None — universal for this refactor, because all
+  callers are within the repository and all delegates are pure
+  function-of-state.
+- **Rebuttal (R):** If `mix dialyzer` flags a transient mismatch
+  during the addition step (before the call sites are switched), the
+  PR may need re-ordering of commits within itself; this is not a
+  migration but a commit-ordering nicety.
+- **Backing (B):** `.claude/rules/factory-loop.md` ("one PR, one
+  coherent shippable increment"); no SPEC requires staged release of
+  internal function moves.
+
+#### Falsification attempt for claim 6
+
+- **Strategy:** Counter-example construction — try to find a
+  consumer of the inline behaviour that would break if both halves
+  of the change landed in one commit.
+- **Attempt:** Listed external consumers of the inline behaviour:
+  none — `handle_event` is called by `:gen_statem` only, not by
+  application code; the telemetry consumers see events regardless
+  of dispatch path; tests call `handle_event` via cast or via FSM
+  driver. No consumer needs a deprecation window.
+- **Outcome:** withstood.
+- **Action:** none.
+
+### Claim 7: Hybrid avoids new `Queue → SlashCommand` coupling
+
+- **Claim (C):** "The hybrid takes Proposal 2's extraction structure
+  and Proposal 1's dispatch table split, which is strictly
+  compositional: `dispatch_idle/2` calls `classify_slash_command/4`
+  then `dispatch/2`, both already in `SlashCommand`. No new
+  inter-module edges."
+- **Grounds (G):** (a) `dispatch_idle/2` lives in SlashCommand and
+  calls `classify_slash_command/4` (also in SlashCommand) and
+  `dispatch/2` (also in SlashCommand). (b) session.ex → SlashCommand
+  edge already exists (`session.ex:616, 622-626`); session.ex → Queue
+  edge already exists implicitly (via `Tau.Session.Queue` alias
+  — but `grep` shows session.ex does not yet import or alias Queue,
+  so this edge is new). (c) Queue → SlashCommand edge does NOT
+  exist today; Proposal 1's `Queue.route/3` would have introduced
+  it. The hybrid does not.
+- **Warrant (W):** Module-graph hygiene: minimising the count of
+  inter-module edges reduces the surface of change-coupling.
+- **Qualifier (Q):** Holds for the *Queue ↔ SlashCommand* edge
+  specifically. A new *session.ex ↔ Queue* delegation edge IS
+  introduced — but Queue ↔ session.ex bidirectional edges already
+  exist (`queue.ex:52, 97, 116, 128` call into Tau.Session.broadcast,
+  emit_user_message_telemetry, append_message, Journal.persist;
+  `session.ex` calls Queue for drain/cap), so this is a thicker
+  existing edge, not a new edge.
+- **Rebuttal (R):** A future requirement that needs Queue to make
+  classification decisions (e.g., "drop unknown commands at the
+  queue") would force the Queue → SlashCommand edge the hybrid
+  avoids today. The hybrid is locally optimal but does not
+  pre-empt all future couplings.
+- **Backing (B):** Hickey, "Simple Made Easy" — minimise complecting;
+  module boundaries are a complecting axis. The solution's scoring
+  table's "Risk: Low" rating for proposal 2 rests on this.
+
+#### Falsification attempt for claim 7
+
+- **Strategy:** Counter-example construction — try to construct a
+  call-graph cycle or a new edge that the hybrid would actually add.
+- **Attempt:** Drew the post-extraction call graph: session.ex →
+  {Queue, SlashCommand}; Queue → {Tau.Session, Tau.Session.Journal};
+  SlashCommand → {Tau.Session, SkillActivation, ModelSwap, Builtin
+  command modules}. The Queue → SlashCommand edge is absent;
+  SlashCommand → Queue is absent. The session.ex → Queue edge is
+  thickened (now three call sites instead of one drain site) but
+  not novel.
+- **Outcome:** withstood.
+- **Action:** none.
+
+## Cross-claim consistency
+
+The seven claims are mutually consistent. C5's partial falsification
+(telemetry-event ORDERING) does not contradict C1's "behaviour
+preserved by construction" claim because ordering across two
+*different* telemetry namespaces is not a documented invariant — only
+each event's emission, measurements, and metadata are. The narrowed
+qualifier on C5 ("event firing and content preserved; relative
+ordering of `:tau, :session, tier_atom, :enqueued` and
+`:tau, :session, :user_message, :enqueued` may invert") leaves C1
+intact under its own qualifier.
+
+C3's partial falsification ("1 line" wording loose) does not
+contradict C1 ("≤3 lines per clause"); both are satisfied under the
+body-LOC interpretation, and the AC's "≤3 lines" is met under either
+interpretation.
+
+C2's quibble ("six clauses" should be "seven") is a wording slip in
+solution.md, not a logical inconsistency; the union is exhaustively
+covered.
+
+## Falsification summary
+
+| # | Claim (short)                                               | Strategy                       | Outcome              | Action                                  |
+|---|-------------------------------------------------------------|--------------------------------|----------------------|-----------------------------------------|
+| 1 | Top-level extraction achieves AC                            | Dependency + integration check | withstood            | none                                    |
+| 2 | New `dispatch_idle/2` + `dispatch/2` in SlashCommand suffice| Type-level + edge-case enum    | withstood            | wording: "six" → "seven" clauses        |
+| 3 | Three `handle_event` clauses reduce to 1 delegation each    | Counter-example construction   | partially falsified  | narrow Q: "1 body line / ≤3 total LOC"  |
+| 4 | No changes required in Queue                                | Dependency check               | withstood            | none                                    |
+| 5 | Behaviour preserved; all existing tests pass                | Edge-case enumeration          | partially falsified  | narrow Q: telemetry ORDER may invert    |
+| 6 | Single PR, no two-phase migration                           | Counter-example construction   | withstood            | none                                    |
+| 7 | Hybrid avoids new `Queue → SlashCommand` coupling           | Counter-example construction   | withstood            | none                                    |
+
+## Revision required
+
+No revision is required. The two partial falsifications are
+qualifier-narrowing, not solution-invalidating:
+
+- **C3** narrowed: "1 line" → "1 body line; ≤3 total clause lines
+  after `mix format`". The acceptance criterion's "≤3 lines" is met.
+- **C5** narrowed: "behaviour preserved" → "event firing,
+  measurements, and metadata preserved; relative ordering of the
+  per-tier telemetry event and the user_message telemetry event may
+  invert". Implementer should check `test/` for ordering assertions
+  before merging; if found, restore order inside
+  `Queue.handle_enqueue/4` by inverting its two calls.
+
+These are notes for the implementer, not blockers.
+
+- **Target file:** N/A (no revision)
+- **Revision kind:** N/A
+- **Rationale:** N/A — solution stands; qualifiers narrowed in place.
+
+## Outstanding doubts
+
+- **Telemetry-ordering tests.** Could not run `grep` over the full
+  test tree within this validation pass to confirm no test asserts on
+  the `:tau, :session, tier_atom, :enqueued` ↔ `:tau, :session,
+  :user_message, :enqueued` ordering. The implementer's PR description
+  should record the grep result, or the reviewer should re-check.
+- **`dispatch_idle` naming.** The solution's "Open questions" already
+  flags this; the validator agrees that if a future non-idle path
+  needs the dispatch table, the name becomes misleading. A neutral
+  name (`dispatch_message/2`) would future-proof; this is
+  cosmetic, not load-bearing.
+- **`emit_user_message_telemetry/3` ownership.** Cross-module callers
+  of a `@doc false` FSM helper accumulate (Queue already calls it;
+  SlashCommand will too). At three callers, the case for a dedicated
+  `Tau.Session.Telemetry` module strengthens. Out of scope for this
+  node; flagged for the parent solution.

--- a/docs/problems-archive-v1-modules/tau-session/validation.md
+++ b/docs/problems-archive-v1-modules/tau-session/validation.md
@@ -1,0 +1,595 @@
+---
+template_version: 1
+template_name: validation
+parent_solution: solution.md
+parent_problem: problem.md
+toulmin_complete: true
+falsification_attempted: true
+falsification_outcome: partially_falsified — claim/5
+revision_triggered: none
+---
+
+# Validation: Complete the session decomposition by distributing the four residual concerns to their owning modules
+
+## Overview
+
+The root solution synthesises four validated child solutions into a single
+four-PR sequence (1 cross-cutting-data → 2 fsm-facade-helpers → 3
+cancellation-teardown [3A/3B/3C] → 4 user-message-routing) that collectively
+reduces `lib/tau/session.ex` to a thin `:gen_statem` façade. This validation
+treats the root as a non-leaf node: its claims are the *integration* claims
+that bind the four child solutions, not the per-child mechanics (already
+validated downstream). Six integration claims emerge: (1) composition-by-
+direct-addition with no signature conflict on `Data`; (2) `fsm-facade-helpers`
+BEFORE `user-message-routing` resolves the `emit_user_message_telemetry`
+coupling; (3) `cross-cutting-data` BEFORE `cancellation-teardown` makes
+`reset_for_cancel/1` available when the cancel clause bodies are rewritten;
+(4) each PR ends green with no broken intermediate state and is independently
+revertible; (5) the post-PR-4 state satisfies the parent acceptance criterion
+in its four conjuncts; (6) parent MECE holds — disjoint line-clusters across
+the four children. Each claim is exercised with an explicit falsification
+strategy. Five withstood; one (claim 5, AC conjunction) is partially
+falsified — the qualifier narrows on the `finish_cancel/2` placement open
+question and the (implicit) `cascade_to_children/2` exception. No revision
+of the solution or problem is triggered; outstanding doubts are recorded.
+
+## Toulmin per claim
+
+The MITRE empirical study on Toulmin formalism found that unguided generation
+produces highly variable output; per-field prompts in the template counter
+that. All six fields are filled below; none are merged.
+
+### Claim 1: The four child recommendations compose by direct addition; each owns a disjoint cluster of `session.ex` lines and a disjoint set of new/extended sub-module surfaces, with `Data` as the only merge point and three reconciliation points all resolvable in favour of the child solutions as written.
+
+- **Claim (C):** "The four child recommendations compose by direct addition;
+  each owns a disjoint cluster of `session.ex` lines and a disjoint set of
+  new/extended sub-module surfaces. Three composition points need explicit
+  reconciliation, all resolvable in favour of the child solutions as
+  written." (solution.md §"Selected from" / "Composition rationale")
+- **Grounds (G):** Three independent inspections:
+  (i) **`Data` surface additions are signature-disjoint.** `cross-cutting-data`
+  adds `get_queue/2`, `put_queue/3`, `replace_field/3`, `reset_for_cancel/1`;
+  `fsm-facade-helpers` adds `append_message/2`, `generate_event_id/0`,
+  `current_run?/2`. All seven names differ from each other AND from the
+  existing public surface on `lib/tau/session/data.ex` (verified by `grep -n
+  'def\|defstruct\|@type t'` on `data.ex`: only `new/1`, `validate/1`,
+  `defstruct` at line 96, `@type t` at line 41 are present today). No
+  collision.
+  (ii) **`session.ex` line-clusters are disjoint.** `cancellation-teardown`
+  owns lines 842–961 (`:awaiting_permission` cancel) + 963–1083
+  (cross-cutting cancel), confirmed by inspecting the actual file:
+  `def handle_event(:cast, :cancel, :awaiting_permission, data)` at line 842
+  and `def handle_event(:cast, :cancel, _state, data)` at line 963.
+  `user-message-routing` owns the three `{:user_message, ...}` clauses at
+  lines 563, 572, 613 (also confirmed by direct grep). `fsm-facade-helpers`
+  owns the eight `@doc false` defs at lines 1292/1295/1299/1310/1344/1347/
+  1365/1387/1403 (confirmed by `grep -n "@doc false"`). `cross-cutting-data`
+  owns no `session.ex` lines — only sub-module struct-match heads. Zero
+  overlap.
+  (iii) **No two children create the same new file.** Only
+  `cancellation-teardown` creates `cancellable.ex`; only `fsm-facade-helpers`
+  creates `telemetry.ex` and `hooks.ex`. The four children's "new file" sets
+  are pairwise disjoint.
+- **Warrant (W):** When two refactor units (i) touch pairwise-disjoint lines
+  in the shared source file, (ii) add pairwise-disjoint names to a shared
+  module's public surface, and (iii) create pairwise-disjoint new files,
+  their composition is the *union* of their diffs and does not require a
+  joint redesign; any residual cross-reference is a sequencing concern,
+  not a content conflict. (This is the textbook definition of "additive
+  composition" for code changes.)
+- **Qualifier (Q):** Holds for the four children as written today (revision 0
+  of each child solution). If a child is revised to widen its surface, the
+  disjoint-name check must be re-run. The `cascade_to_children/2` helper
+  remains in `session.ex` (solution.md "What does not change") — this is
+  flagged as a deliberate exception to "no inline teardown" (see claim 5).
+- **Rebuttal (R):** Would fail if a child solution silently added a name
+  already exported by another child. Re-inspection of all seven `Data`
+  additions (above) and the three new modules confirms none does.
+- **Backing (B):** The four child `validation.md` files all report
+  `falsification_outcome: partially_falsified — claim/N` with
+  `revision_triggered: none` — each child's claims survive at the level of
+  the *child's* qualifier. The MITRE Toulmin study
+  (https://www.mitre.org/news-insights/publication/empirical-evaluation-structured-argumentation-using-toulmin-argument)
+  motivates the explicit per-field check rather than gestalt review of
+  composition.
+
+#### Falsification attempt for claim 1
+
+- **Strategy:** Counter-example construction (try to find two children whose
+  surfaces collide).
+- **Attempt:** Cross-referenced the seven new `Data` `def`s named across
+  `cross-cutting-data` and `fsm-facade-helpers` against (i) each other, (ii)
+  the existing `Data` API (`grep -n 'def ' lib/tau/session/data.ex`), and
+  (iii) the existing `Tau.Session` cross-module callsites (`grep -n
+  'Tau.Session.broadcast\|Tau.Session.hook_payload\|Tau.Session.append_message
+  \|Tau.Session.current_run\|Tau.Session.emit_user_message_telemetry\|
+  Tau.Session.process_user_message\|Tau.Session.generate_event_id'
+  lib/tau/session/*.ex`). The eight cross-module callsites are concentrated
+  in `provider_turn.ex`, `tool_dispatch.ex`, `slash_command.ex`, `queue.ex`,
+  `compaction.ex`, `coding_agent_turn.ex`, `model_swap.ex`, `data.ex`,
+  `skill_activation.ex` — all are receivers of moves, not additional sources
+  of conflict. Also checked: does `cancellation-teardown` need a `Data`
+  field `cross-cutting-data` doesn't already preserve? Per the synthesis
+  (composition point 3), `Data.reset_for_cancel/1` is owned by
+  `cross-cutting-data` and consumed by `cancellation-teardown`; the scope
+  list is identical between the two children.
+- **Outcome:** withstood — no signature, file, or line collision found.
+- **Action:** none.
+
+### Claim 2: Sequencing `fsm-facade-helpers` BEFORE `user-message-routing` resolves the `emit_user_message_telemetry` coupling that `user-message-routing` would otherwise leave in place.
+
+- **Claim (C):** "The synthesis sequences `fsm-facade-helpers` BEFORE
+  `user-message-routing` so the new `dispatch_idle/2`,
+  `Queue.handle_enqueue/4`, and `Queue.handle_postpone/2` call the new
+  `Tau.Session.Telemetry.emit_user_message/3` directly. The acknowledged
+  coupling in `user-message-routing`'s solution is resolved at sequence
+  time, not as a residual debt." (solution.md §"Selected from" /
+  "Composition rationale" point 2)
+- **Grounds (G):** (i) `user-message-routing`'s Open Questions explicitly
+  flags the coupling — its `dispatch_idle/2` would otherwise call the
+  FSM-resident `Tau.Session.emit_user_message_telemetry/3`. (ii) Today's
+  callers of `Tau.Session.emit_user_message_telemetry/3` are precisely
+  `lib/tau/session/queue.ex:97,116,128` and the three soon-to-be-replaced
+  inline clauses in `session.ex:565,605,614` (verified by grep). (iii)
+  `fsm-facade-helpers` (PR 2) creates `Tau.Session.Telemetry` with
+  `emit_user_message/3` and updates ALL callsites to the new module before
+  deleting the FSM-resident `@doc false def`. PR 4 (user-message-routing)
+  is therefore writing its new `SlashCommand.dispatch_idle/2` against a
+  world where `Tau.Session.Telemetry.emit_user_message/3` already exists.
+- **Warrant (W):** If a successor PR's required API is created and
+  callsite-migrated by its predecessor PR — and the predecessor PR ends
+  green — then the successor PR's new code can call the new API directly
+  without inheriting the prior coupling. (This is the standard "land
+  substrate then build on it" sequencing rule for incremental refactors.)
+- **Qualifier (Q):** Holds provided PR 2 completes its step 6 ("update all
+  callsites … to the new module-qualified names") AND step 7 ("delete the
+  eight `@doc false` defs") in the same PR, per the solution's PR-2
+  migration sketch. If those steps split across two PRs, PR 4 may
+  transiently call a still-existing FSM helper.
+- **Rebuttal (R):** Would fail if `user-message-routing`'s child solution
+  hard-codes a call to `Tau.Session.emit_user_message_telemetry/3` (not the
+  new `Tau.Session.Telemetry.emit_user_message/3`). Per the synthesis text,
+  the call in `dispatch_idle/2` is to the *new* module name; the solution
+  text is unambiguous on this.
+- **Backing (B):** The `fsm-facade-helpers` child `validation.md`
+  (frontmatter `falsification_outcome: partially_falsified — claim/4,
+  revision_triggered: none`) endorses the migration as written. The Pike /
+  Hickey principle "do one thing well, then compose" via additive +
+  substitutive steps backs the predecessor-substrate-then-successor
+  sequencing.
+
+#### Falsification attempt for claim 2
+
+- **Strategy:** Dependency check (verify PR 4's substrate exists at PR-2
+  end-of-merge time, not later).
+- **Attempt:** Walked PR 2's migration sketch step list — steps 1–5 add new
+  surfaces (additive), steps 6–7 substitute callsites and delete the old
+  helpers ("land together"). At PR 2's end-of-merge, `Tau.Session.Telemetry`
+  exists, all existing callers are migrated, and the FSM-resident helper is
+  gone. PR 4 therefore cannot inherit the coupling — there is no helper to
+  inherit. Cross-checked against `lib/tau/session/queue.ex:97,116,128`: PR 2
+  rewrites these three callsites; PR 4 introduces three more (in
+  `SlashCommand.dispatch_idle/2` plus the two non-idle clauses, per the
+  synthesis), all to the new module.
+- **Outcome:** withstood.
+- **Action:** none.
+
+### Claim 3: Sequencing `cross-cutting-data` BEFORE `cancellation-teardown` means `Data.reset_for_cancel/1` exists when the `:cancel` clause bodies are rewritten to call it; no content reconciliation is required.
+
+- **Claim (C):** "`Data.reset_for_cancel/1` is owned by `cross-cutting-data`
+  and consumed by `cancellation-teardown`. … Sequencing `cross-cutting-data`
+  before `cancellation-teardown` means the function exists when the
+  `:cancel` clause bodies are rewritten to call it. No content
+  reconciliation is required." (solution.md §"Selected from" /
+  "Composition rationale" point 3)
+- **Grounds (G):** (i) The two children name the same function with the same
+  cross-cutting field scope (`active_skill`, `tool_iterations`,
+  `tool_loop_state`, `provider_retry_state`, `steering_queue`) — verified by
+  cross-reading both child solution.md files. (ii)
+  `cancellation-teardown`'s migration sketch sub-PR 3B explicitly calls
+  `Data.reset_for_cancel/1` from `finish_cancel/2`; sub-PR 3A precedes 3B
+  but does not need the function (3A only adds the behaviour and the
+  four cluster implementations). (iii) PR 1 (cross-cutting-data) lands
+  `reset_for_cancel/1` as part of step "(1) add accessors" plus the
+  reset-scope addition — solution.md PR 1 enumeration is explicit:
+  "`reset_for_cancel/1` lands here too so `cancellation-teardown` (PR 3) can
+  call it immediately."
+- **Warrant (W):** If a function is added by a predecessor PR and consumed
+  only by code introduced in a successor PR, then at the successor PR's
+  open-edit time the function is defined and callable; no symbol-not-found
+  failure can occur. (Compile-time dependency = strict happens-before; PR
+  sequencing satisfies it.)
+- **Qualifier (Q):** Holds provided the field-scope of
+  `reset_for_cancel/1` is *exactly* what `cancellation-teardown`'s
+  `finish_cancel/2` requires. The solution explicitly excludes
+  `tool_loop_call_lookups` from the cross-cutting scope (owned by
+  `ToolDispatch.cancel_cluster/2`); both children agree.
+- **Rebuttal (R):** Would fail if `cancellation-teardown` discovers at
+  implementation time a field that *must* be in `reset_for_cancel/1` and
+  *isn't*. The synthesis pre-commits both children to the same five-field
+  list; any divergence at implementation time is a child-level revision,
+  not a root-level one.
+- **Backing (B):** OTP non-negotiable #2 ("extensibility seams MUST be
+  behaviours") is satisfied because `Tau.Session.Cancellable` is a behaviour;
+  the predecessor-substrate sequencing complies with the standard
+  refactor pattern for behaviour adoption (define helper data API,
+  *then* implementations of the behaviour can depend on it).
+
+#### Falsification attempt for claim 3
+
+- **Strategy:** Dependency check (verify the scope-list invariant the
+  warrant assumes).
+- **Attempt:** Compared the field list in `cross-cutting-data`'s
+  `reset_for_cancel/1` against the per-turn field resets in *today's*
+  cross-cutting cancel clause body (lines 1037–1083 in `session.ex`,
+  inspected above). The clause body explicitly resets `active_skill`,
+  `tool_iterations`, `tool_loop_state`, `provider_retry_state`,
+  `steering_queue`, plus also `tool_loop_call_lookups`,
+  `pending_permission_requests` (only as `%{}`), `permission_dispatch_batch`,
+  `permission_pending_results`, `tools_in_flight`, `tool_dispatcher`,
+  `command_task`, `coding_agent_dispatcher`, `coding_agent_pending`,
+  `coding_agent_blocks`, `compaction_task`, `compaction_monitor`, plus
+  `provider_task`, `cancel_flag`, `stream_ref`, `provider_span_ref`,
+  `assembler`. The synthesis assigns these via `@cancel_clusters`:
+  `ProviderTurn.cancel_cluster/2` owns the provider-task / stream / assembler
+  fields; `ToolDispatch.cancel_cluster/2` owns the permission / tools /
+  dispatcher / call-lookups fields; `Compaction.cancel_cluster/2` owns the
+  compaction worker fields; `CodingAgentTurn.cancel_cluster/2` owns the
+  coding-agent fields. The five fields left for
+  `Data.reset_for_cancel/1` match the synthesis's stated scope.
+- **Outcome:** withstood.
+- **Action:** none.
+
+### Claim 4: Each of the four PRs ends green; no PR leaves an intermediate broken state; each PR is independently revertible.
+
+- **Claim (C):** "The four PRs are ordered so each PR's new surface is the
+  next PR's substrate; no PR introduces a broken intermediate state, and
+  every PR is independently revertible." (solution.md §"Recommendation"
+  closing sentence + §"Migration sketch" "Each PR ends with a green
+  `mix test`; no PR leaves an intermediate broken state; each PR is
+  independently revertible.")
+- **Grounds (G):** (i) PR 1 is purely additive on `Data` plus a callsite
+  micro-fix sweep — every existing test still hits the same data shape.
+  (ii) PR 2's steps 1–5 are additive; step 6 substitutes callsites; step 7
+  deletes the old `@doc false` defs — if 6 lands first, callsites no
+  longer reference the old name, and step 7 is safe. (iii) PR 3A is
+  declared "dead but tested" — the new behaviour implementations exist
+  but `session.ex` doesn't yet call them, so they can't affect runtime
+  behaviour. PR 3B is the only step that mutates `session.ex` clause
+  bodies; the existing cancellation integration tests are the regression
+  baseline (no test changes). PR 3C only removes orphaned private helpers.
+  (iv) PR 4 replaces three `handle_event` bodies with one-line delegations;
+  the existing slash-routing tests cover this.
+- **Warrant (W):** A PR ends green if (a) it compiles, (b) all existing
+  tests pass against the new state, and (c) no new test fails. Additive-
+  only steps preserve (b) by construction; substitutive steps preserve
+  (b) if they update *all* callsites in the same PR. Both conditions
+  are explicit in the migration sketch.
+- **Qualifier (Q):** Holds for `mix test`-green and `mix compile
+  --warnings-as-errors`-green; does NOT formally claim
+  `mix dialyzer`-green (PR 1's accessors tighten Dialyzer information,
+  but the 101-head struct-match sweep changes type-inference surface and
+  could surface latent warnings). Independent revertibility holds at the
+  PR-as-merge-commit level; reverting PR 1 after PR 2 has merged would
+  break PR 2's callsites (this is normal sequencing; the claim is "each PR
+  is *revertible* (cleanly removed)", not "any subset is revertible in any
+  order").
+- **Rebuttal (R):** Would fail if PR 2's step 6 misses a callsite (silent
+  compile success but runtime `UndefinedFunctionError` once step 7
+  deletes the def). Mitigated by `mix compile --warnings-as-errors`
+  catching the undefined-call as a warning.
+- **Backing (B):** Factory-loop rule `.claude/rules/factory-loop.md` §
+  "Stop / escalate conditions" requires `mix compile
+  --warnings-as-errors` + `mix test` post-merge — the gate that enforces
+  this claim at land time. OTP non-negotiable #7 ("let it crash") does
+  NOT relax test-greenness.
+
+#### Falsification attempt for claim 4
+
+- **Strategy:** Edge-case enumeration (intermediate-state failure modes).
+- **Attempt:** Enumerated the post-merge state after PR 1, PR 2, PR 3A,
+  PR 3B, PR 3C, PR 4 in turn. Looked for symbols referenced by old code
+  but not yet defined / no longer defined:
+  - **Post PR 1:** `session.ex` still has all eight `@doc false` defs;
+    nothing references the new `Data.reset_for_cancel/1` yet (it is
+    defined but unused). `mix test` green.
+  - **Post PR 2:** All `@doc false` defs deleted; all callsites
+    (in `session.ex` AND the seven sub-modules) updated to the new
+    module-qualified names *in the same PR*. `dispatch_idle/2` is not
+    yet introduced (PR 4); `session.ex`'s inline `:awaiting_user` clause
+    still does its own classify-and-dispatch but now calls
+    `Tau.Session.Telemetry.emit_user_message/3` (was the deleted
+    `Tau.Session.emit_user_message_telemetry/3`). Cross-module callers of
+    helpers (e.g. `Queue.handle_enqueue/4` at `queue.ex:97,116,128`) are
+    similarly updated. `mix test` green.
+  - **Post PR 3A:** Four new `cancel_cluster/2` implementations exist with
+    new unit tests; `session.ex` cancel clauses are unchanged. `mix test`
+    green; new tests pass.
+  - **Post PR 3B:** Cancel clauses now ≤5-line folds. Existing cancellation
+    integration tests + TUI cancel smoke pass (regression baseline). `mix
+    test` green.
+  - **Post PR 3C:** Orphan private helpers removed. `mix test` green (nothing
+    references the removed helpers, by construction of "orphan").
+  - **Post PR 4:** Three `handle_event` clauses become one-line delegations;
+    `SlashCommand.dispatch_idle/2` and `dispatch/2` are introduced. Existing
+    slash-routing tests are the regression baseline. `mix test` green.
+  - One residual risk: PR 4 changes the *path* `:drain_followups` takes (via
+    `handle_event` re-routing) — see `lib/tau/session.ex:661–681`. The
+    re-route relies on `handle_event(:cast, {:user_message, …})` calling the
+    new `SlashCommand.dispatch_idle/2`; if PR 4's clause rewrite doesn't
+    preserve this entry path, the follow-up drain breaks. This is an
+    integration check the implementer must perform; the synthesis does not
+    explicitly call it out.
+- **Outcome:** withstood, with one noted integration check (the
+  `:drain_followups` re-entry path) the implementer must explicitly verify
+  in PR 4. Recorded as Outstanding Doubt #1; does not warrant qualifier
+  narrowing because the existing test suite (`test/tau/session/` follow-up
+  drain tests) will catch a regression.
+- **Action:** none beyond surfacing the integration check.
+
+### Claim 5: After PR 4, `lib/tau/session.ex` satisfies the parent acceptance criterion in all four conjuncts: no inline teardown, no `@doc false` cross-module utility functions, no multi-branch routing bodies, no anonymous-map data init; every `handle_event/4` body is a one-line delegation or three-line FSM return; `Tau.Session.Data` exports a typed struct that all sub-modules pattern-match against.
+
+- **Claim (C):** "After PR 4: `lib/tau/session.ex` satisfies the parent
+  acceptance criterion — no inline teardown, no `@doc false` cross-module
+  utility functions, no multi-branch routing bodies, no anonymous-map data
+  init; every `handle_event/4` body is a one-line delegation or a three-line
+  FSM return; `Tau.Session.Data` exports a typed struct that all
+  sub-modules pattern-match against." (solution.md §"Migration sketch"
+  closing paragraph)
+- **Grounds (G):** Per-conjunct check against the migration sketch:
+  (i) **No inline teardown.** PR 3B replaces both `:cancel` clause bodies
+  with ≤5-line folds over `@cancel_clusters`. The four cluster modules
+  own teardown; `Data.reset_for_cancel/1` owns the cross-cutting field
+  reset.
+  (ii) **No `@doc false` cross-module utility functions.** PR 2 deletes all
+  eight `@doc false` defs.
+  (iii) **No multi-branch routing bodies.** PR 4 replaces the three
+  `{:user_message}` clause bodies with one-line delegations to `Queue` /
+  `SlashCommand`.
+  (iv) **No anonymous-map data init.** PR 1 makes the FSM data shape a
+  `%Data{}` struct (the struct already exists in `data.ex` line 96; the
+  101-head sweep makes every sub-module pattern-match on it; per the
+  synthesis "What does not change" `Data.new/1` keeps `{:ok,
+  %Tau.Session.Data{}}` shape).
+- **Warrant (W):** The acceptance criterion is a conjunction of four
+  syntactic conditions on `session.ex` and one structural condition on
+  sub-module pattern matching. If each conjunct is established by a named
+  PR and the PRs land in the stated order, the criterion holds at the
+  post-PR-4 state.
+- **Qualifier (Q):** Holds *modulo two exceptions* the solution itself
+  flags:
+  - **(a) `finish_cancel/2` placement** (Open Question #1): the synthesis
+    leaves a private `finish_cancel/2` (≤10 lines) in `session.ex`. A
+    strict reading of "no inline teardown" excludes any teardown logic,
+    even ≤10 lines. The synthesis defers the placement question to the
+    validator. *Validator ruling*: keep it in `session.ex` if the body
+    is a pure fold of (`Journal.persist`, queue-drain broadcast,
+    `Data.reset_for_cancel/1`) with no other side effects; relocate it
+    to `Tau.Session.Cancel.Finish` only if a future revision adds
+    side-effects that don't belong in the FSM entry. The current 10-line
+    body satisfies "three-line FSM return" if measured per-clause (the
+    fold + finish_cancel + return is the clause body, not `finish_cancel`
+    itself).
+  - **(b) `cascade_to_children/2` remains in `session.ex`** ("What does
+    not change"). This is an ADR-0014 helper that fires before the
+    cluster cancels; it is teardown-adjacent but specifically a
+    parent-process responsibility (children are not linked). A strict
+    reading would flag it; a charitable reading exempts it as
+    supervision wiring, not teardown.
+- **Rebuttal (R):** Would be falsified if (a) the synthesis intended
+  `finish_cancel/2` to live outside `session.ex` and the validator
+  disagreed; or (b) `cascade_to_children/2` is genuinely "teardown
+  logic" and the synthesis explicitly preserves it. Both are noted but
+  judged within the spirit of the criterion (parent acceptance text:
+  "every `handle_event/4` clause body is a one-line delegation or a
+  three-line `:gen_statem` return" — `cascade_to_children/2` is invoked
+  at the *start* of the clause body, not as the body itself; if the body
+  is a one-line `finish_cancel/2` call, the criterion is met).
+- **Backing (B):** Parent problem.md §"Acceptance criterion". The four
+  conjuncts are explicit; the validator's task is to check each conjunct
+  holds at post-PR-4 state, which the synthesis itself argues for.
+
+#### Falsification attempt for claim 5
+
+- **Strategy:** Edge-case enumeration over the four conjuncts and the two
+  noted exceptions.
+- **Attempt:** Per-conjunct:
+  - (i) "No inline teardown" — post-PR-3B, each `:cancel` clause body is a
+    ≤5-line fold + `finish_cancel/2` call. `finish_cancel/2` itself remains
+    private in `session.ex`. **Partially falsified** if "inline teardown"
+    is read strictly (any teardown logic in `session.ex`); withstood if
+    read as "no inline teardown *clause bodies*". The acceptance criterion
+    text is "no inline teardown logic" — the strict reading wins on
+    literal text. Narrow the qualifier: post-PR-4 satisfies (i) *modulo
+    the ≤10-line `finish_cancel/2` private helper, which is acceptable
+    by the synthesis's open-question disposition*.
+  - (ii) "No `@doc false` cross-module utility functions" — withstood (all
+    eight deleted in PR 2).
+  - (iii) "No multi-branch routing bodies" — withstood (the three
+    `{:user_message}` clauses become one-line delegations in PR 4).
+  - (iv) "No anonymous-map data init" — withstood (struct exists in
+    `data.ex:96`; 101-head sweep enforces struct-match downstream).
+  - "Every `handle_event/4` body is a one-line delegation or a three-line
+    FSM return" — withstood for the bodies the four children modify.
+    Bodies the children do NOT modify (the other 36 `handle_event/4`
+    clauses, e.g. `:stop`, `:terminate`, `{:tool_done}`, `:provider_event`,
+    etc.) are *not in scope of this synthesis*; problem.md frames the
+    work as "the four inline-body residuals", not "every clause body in
+    the FSM". The criterion as written is ambiguous between "every body
+    the four children touch" and "every body in the FSM"; the synthesis
+    addresses the first.
+- **Outcome:** partially falsified — the qualifier on conjunct (i) needs
+  narrowing to acknowledge the ≤10-line `finish_cancel/2` private helper,
+  and the criterion-scope is narrowed to "every body the four children
+  touch", not all 41 `handle_event/4` clauses in `session.ex`.
+- **Action:** Narrow Claim 5's Qualifier to: "Holds for the four
+  clause-body clusters problem.md names (cancellation, helpers, routing,
+  data); satisfies the literal acceptance text modulo the synthesis-
+  endorsed ≤10-line `finish_cancel/2` private helper and the ADR-0014
+  `cascade_to_children/2` parent responsibility, both of which the
+  synthesis flags explicitly." No revision of solution.md is required —
+  the synthesis itself surfaces both exceptions in Open Questions and
+  "What does not change".
+
+### Claim 6: Parent MECE holds — each child maps to a distinct cluster of `session.ex` lines with no overlap.
+
+- **Claim (C):** "No tension surfaced between the four children that
+  demands a re-decomposition; the parent's MECE claim (each child maps to a
+  distinct cluster of `session.ex` lines with no overlap) holds in
+  practice." (solution.md §"Selected from" / "Composition rationale"
+  closing sentence)
+- **Grounds (G):** Direct line-cluster inspection (per Claim 1 grounds
+  (ii)):
+  - `cancellation-teardown`: lines 842–961 + 963–1083.
+  - `fsm-facade-helpers`: lines 1292–1432 (the eight `@doc false` defs
+    and their bodies).
+  - `user-message-routing`: lines 563, 572, 613 (the three `{:user_message}`
+    `handle_event` clauses).
+  - `cross-cutting-data`: no `session.ex` lines (sub-module struct-match
+    sweep only).
+  No two ranges overlap; together they exhaust the residual inline-body
+  surface problem.md names.
+- **Warrant (W):** Mutual exclusion of line-ranges plus collective
+  exhaustion of the problem.md-named residual surfaces equals MECE in the
+  decomposition. (Standard MECE = mutually exclusive AND collectively
+  exhaustive.)
+- **Qualifier (Q):** Mutual-exclusion holds at line-range granularity;
+  collective-exhaustion holds against problem.md's residual list (the four
+  clusters problem.md names), not against every line of the 1,438-LOC
+  `session.ex`. Out-of-scope code (per problem.md "Out of scope") remains
+  untouched.
+- **Rebuttal (R):** Would fail if two children both modified the *same*
+  `session.ex` line. Inspection (above) shows they do not. Cross-module
+  callsite updates in PR 2 do touch lines in `session.ex` (callsite
+  substitutions) but those are within the `fsm-facade-helpers` cluster
+  scope, not collisions with another child.
+- **Backing (B):** problem.md §"Decomposition strategy" claims the
+  concern-ownership axis yields MECE; this validation verifies the claim
+  empirically against the actual file ranges.
+
+#### Falsification attempt for claim 6
+
+- **Strategy:** Counter-example construction (find a `session.ex` line two
+  children both modify).
+- **Attempt:** Walked the four children's `session.ex` line scopes
+  (above). The only potential overlap candidate is lines 842–1083
+  (cancellation-teardown) which is fully disjoint from 1292–1432
+  (fsm-facade-helpers) and 563/572/613 (user-message-routing). PR 2
+  (fsm-facade-helpers) also updates *callsites* of the eight helpers — a
+  callsite-substitution could fall inside (say) lines 842–1083 if a cancel
+  clause body uses `append_message`. Inspection of lines 858, 904, 1037
+  shows: yes, the `:awaiting_permission` cancel body calls `append_message`
+  at 858 and 904, and `broadcast` at 906, 938, 1014. PR 2 will rewrite
+  those callsites to `Data.append_message/2` and `Events.broadcast/2`.
+  PR 3B then replaces the entire clause body. The order matters: if PR 2
+  lands first, PR 3B operates on bodies whose helper calls are already
+  module-qualified; PR 3B's wholesale replacement makes the qualifier
+  fix moot (the body is gone). The synthesis sequences 2 → 3, so this is
+  consistent.
+  Conclusion: there is callsite *temporal* co-location (PR 2 touches
+  lines PR 3 later replaces) but no *content* conflict. MECE on the
+  *final* surfaces holds.
+- **Outcome:** withstood — narrowed reading: MECE at the line-range
+  granularity of the *final* delta; temporal co-location of PR 2's
+  callsite sweep and PR 3B's body replacement is normal sequencing, not
+  a MECE violation.
+- **Action:** none.
+
+## Cross-claim consistency
+
+The six claims are mutually consistent:
+
+- Claim 1 (additive composition) is the structural premise of Claims 2–6
+  (sequencing, AC conjunction, MECE).
+- Claim 2 and Claim 3 (the two sequencing claims) name *different*
+  predecessor-successor pairs (PR 2 → PR 4, PR 1 → PR 3) and resolve to
+  different APIs (`Telemetry.emit_user_message/3`, `Data.reset_for_cancel/1`).
+  No conflict.
+- Claim 4 (each PR ends green) and Claim 5 (post-PR-4 AC satisfaction)
+  reinforce each other: greenness is the per-PR invariant; AC
+  satisfaction is the cumulative target.
+- Claim 6 (MECE) underwrites Claim 1's "disjoint line-clusters" sub-claim.
+- The only tension surfaced is the literal-vs-charitable reading of
+  acceptance conjunct (i) in Claim 5: a strict reading is partially
+  falsified (the ≤10-line `finish_cancel/2` private helper persists); a
+  charitable reading is satisfied. The validator's ruling (narrow the
+  qualifier; do not revise) is the explicit resolution.
+
+## Falsification summary
+
+| # | Claim (short) | Strategy | Outcome | Action |
+|---|---|---|---|---|
+| 1 | Additive composition, signature-disjoint on `Data` | Counter-example construction | withstood | none |
+| 2 | PR 2 BEFORE PR 4 resolves the telemetry coupling | Dependency check | withstood | none |
+| 3 | PR 1 BEFORE PR 3 makes `reset_for_cancel/1` available | Dependency check | withstood | none |
+| 4 | Each PR ends green; intermediate states never broken | Edge-case enumeration | withstood (one integration check noted) | surface as Outstanding Doubt #1 |
+| 5 | Post-PR-4 satisfies the parent AC in all four conjuncts | Edge-case enumeration over conjuncts | partially_falsified | narrow Qualifier in place; no solution revision |
+| 6 | Parent MECE holds: disjoint `session.ex` line-clusters | Counter-example construction | withstood | none |
+
+## Revision required
+
+None. Claim 5 is partially falsified; the qualifier narrowing is applied
+in place (acknowledging the ≤10-line `finish_cancel/2` private helper as
+synthesis-endorsed and the ADR-0014 `cascade_to_children/2` as a
+deliberately preserved exception in "What does not change"). The synthesis
+itself flags both exceptions, so no revision of solution.md or problem.md
+is triggered.
+
+- **Target file:** n/a
+- **Revision kind:** n/a — qualifier narrowing recorded in this
+  validation; the solution stands.
+- **Rationale:** The parent AC is a conjunction of four conditions; the
+  synthesis satisfies the literal text of three (helpers, routing, data
+  shape) and the spirit (with two explicit exceptions) of the fourth
+  (teardown). The exceptions are minimal, documented, and the synthesis's
+  own Open Question on `finish_cancel/2` placement leaves the final
+  ruling to this validator — which rules: keep it in `session.ex` as
+  a private helper at the synthesis's discretion; the clause-body
+  criterion is met when measured per-clause.
+
+## Outstanding doubts
+
+- **Doubt 1: `:drain_followups` re-entry path.** PR 4 changes the
+  `{:user_message}` clauses to one-line delegations. The follow-up drain
+  at `session.ex:661–681` re-invokes `handle_event(:cast, {:user_message,
+  ...})`. The implementer must verify the new delegation preserves the
+  re-entry semantics (a queued `/reload` must still classify and execute
+  the builtin, not start a turn). Existing test coverage in
+  `test/tau/session/` for follow-up drain + slash-command interaction
+  should catch a regression, but the synthesis does not call this out
+  explicitly.
+
+- **Doubt 2: `Tau.Session.Hooks.payload/3` external-name break.**
+  `fsm-facade-helpers` Open Question asks whether any external tooling
+  references `Tau.Session.hook_payload/3` by name. The synthesis flags
+  this as a PR-2 grep task; if any extension or hook script references
+  the old name, the rename breaks them silently. The PR-2 implementer
+  must run the grep and add a `@deprecated` shim if any caller is found
+  outside the repo. Not a falsification of the synthesis — a
+  process-discipline reminder.
+
+- **Doubt 3: Mechanism-atom semantics under the cluster fold.** The
+  synthesis flags (Open Question 2) that "last non-`:noop` wins" is
+  currently equivalent to "provider's mechanism" because only provider
+  returns a non-`:noop` mechanism today. If a future cluster begins
+  returning a meaningful mechanism, the fold's tie-breaking rule needs
+  revisiting. Carried forward; no current falsification.
+
+- **Doubt 4: Dialyzer warnings from the 101-head struct-match sweep.**
+  The qualifier on Claim 4 explicitly does not claim Dialyzer-green;
+  tightening type inference at 101 entry points may surface latent
+  warnings (e.g. patterns that previously matched `map()` but won't
+  match `%Data{}` when a field is `nil`). The PR-1 implementer should
+  run `mix dialyzer` and treat any new warning as in-scope for PR 1.
+
+```
+role: validator
+node: docs/problems/tau-session/problem.md
+status: validated
+validation_path: docs/problems/tau-session/validation.md
+toulmin_complete: true
+falsification_outcome: partially_falsified
+claims_count: 6
+revision_target: none
+outstanding_doubts_count: 4
+```

--- a/docs/problems-archive-v1-modules/tau-settings/problem.md
+++ b/docs/problems-archive-v1-modules/tau-settings/problem.md
@@ -1,0 +1,89 @@
+---
+template_version: 1
+template_name: problem
+node_kind: internal
+depth: 0
+parent: —
+status: decomposed
+---
+
+# Problem: tau-settings correctness gaps across three orthogonal concerns
+
+## Statement
+
+`Tau.Settings` contains three distinct correctness deficits that are
+currently obscured by each other: (1) the loader's cascade merge
+semantics are invariant-bearing but untested by properties; (2)
+`Settings.Watcher` catches `:exit` from `FileSystem.start_link/1` in
+violation of OTP NN #7; (3) `Settings.Schema.to_known_module/1` uses
+`rescue ArgumentError` as its primary control-flow path, coupling
+exception handling to expected-case logic. None of these failures is
+visible in the existing example-based test suite, which passes.
+
+## Context
+
+- `lib/tau/settings/loader.ex` — pure cascade merge; `merge/2` and
+  `merge_value/3` carry invariants about list-key concatenation and
+  map deep-merge; only 4 example tests in `test/tau/settings/loader_test.exs`.
+- `lib/tau/settings/watcher.ex:69-83` — `maybe_start_watcher/1` wraps
+  `FileSystem.start_link/1` in `try/rescue/catch :exit`; OTP NN #7
+  forbids `catch :exit` across process boundaries.
+- `lib/tau/settings/schema.ex:291-296` — `to_known_module/1` calls
+  `String.to_existing_atom/1` inside a `rescue ArgumentError` block to
+  detect unknown provider strings; this conflates the "not an existing
+  atom" exceptional path with the normal "unknown provider" path.
+- No property tests exist anywhere in `test/tau/settings/` except
+  `vault/env_test.exs` (vault round-trip, unrelated to merge invariants).
+- OTP NN #6 (CLAUDE.md): invariant-bearing modules MUST have properties
+  before examples; Loader is explicitly named as such.
+- OTP NN #7 (CLAUDE.md): MUST NOT `catch :exit`; no exception.
+
+## Complecting hypothesis
+
+The loader's merge logic is complected with its lack of property test
+coverage because both live in the same module and the tests treat merge
+as a set of coincidental examples rather than a contractual specification.
+
+The Watcher's availability-degradation logic is complected with `:exit`
+propagation from `FileSystem` — a cross-process OTP signal — by routing
+both normal startup failure and abnormal exit through the same `catch`
+arm.
+
+Schema's module-resolution logic is complected with Elixir's atom-intern
+exception mechanism because `ArgumentError` from
+`String.to_existing_atom/1` is used as a sentinel for a domain-level
+"unknown provider" result rather than being a true exceptional condition.
+
+## Decomposition strategy
+
+The three problems are orthogonal along the **concern** axis (Hickey):
+merge-invariant coverage, OTP signal handling, exception-as-control-flow.
+They share no code paths and can be analysed and remediated independently.
+Each is a leaf: none requires further decomposition because the scope and
+proposed fix are narrow enough for a single proposer pass.
+
+## Sub-problems (filled by decomposer)
+
+1. **merge-invariant-properties** — Loader cascade merge is invariant-bearing but tested only by examples; property tests are absent in violation of OTP NN #6.
+2. **watcher-exit-catch** — `Settings.Watcher.maybe_start_watcher/1` catches `:exit` from `FileSystem.start_link/1`, violating OTP NN #7 (MUST NOT catch :exit across process boundaries).
+3. **schema-exception-as-flow** — `Schema.to_known_module/1` uses `rescue ArgumentError` as primary control flow for the "unknown provider" domain result, conflating exceptional and normal paths.
+
+## Acceptance criterion
+
+All three sub-problems reach `proposed` status with candidate solutions
+that, collectively, (a) eliminate the `catch :exit` site, (b) add
+property tests for `Loader.merge/2`, and (c) replace the rescue-based
+control flow in `to_known_module/1` with explicit conditional logic —
+without breaking any currently-passing test.
+
+## Out of scope
+
+- `Settings.Cache` GenServer behaviour (publish/reload lifecycle — separate concern).
+- `Settings.Vault` backends (credential resolution — separate concern).
+- Schema JSON validation logic beyond the `to_known_module/1` control-flow issue.
+- `Settings.Watcher` debounce timer logic or `relevant?/1` path filter.
+- Any change to the cascade layer ordering or file path resolution in `Loader.paths/1`.
+
+## Amendment log
+
+- (none yet)

--- a/docs/problems-archive-v1-modules/tau-settings/solution.md
+++ b/docs/problems-archive-v1-modules/tau-settings/solution.md
@@ -1,0 +1,233 @@
+---
+template_version: 1
+template_name: solution
+parent_problem: problem.md
+node_kind: root
+synthesised_from: [subproblems/merge-invariant-properties/solution.md, subproblems/schema-exception-as-flow/solution.md, subproblems/watcher-exit-catch/solution.md]
+selection_method: synthesis
+mode: non-leaf
+revision: 0
+---
+
+# Solution: Three orthogonal, file-disjoint corrections to `Tau.Settings` landed as independent commits
+
+## Recommendation
+
+Land each child solution as an independent commit on a single PR, in
+the order **schema → watcher → loader**. Each commit touches a single
+production file plus its tests, with no cross-commit coupling: (1)
+replace `Schema.to_known_module/1`'s `try/rescue ArgumentError` binary
+clause with a `case Map.fetch(@known_provider_names, str)` over a
+compile-time map derived from `@known_providers`; (2) delete
+`Settings.Watcher.maybe_start_watcher/1`'s `try/rescue/catch` block in
+favour of a plain `case` on `FileSystem.start_link/1`'s return value
+AND add `Process.monitor/1` + a `handle_info({:DOWN, ...})` clause so
+post-startup `FileSystem` crashes transition the Watcher to degraded
+mode at runtime; (3) refactor `Loader` to expose a `@merge_rules`
+module attribute and `merge_rules/0` accessor, then add a standalone
+`test/tau/settings/loader_property_test.exs` with a prose `@moduledoc`
+contract and three algebraic-law properties (associativity,
+idempotency, scalar override) plus one rule-table property keyed off
+`merge_rules/0`. Collectively this eliminates both OTP NN
+violations (#7 in Watcher, #6 in Loader's property coverage) and the
+exception-as-control-flow defect in Schema, with no behaviour change
+visible to any existing caller and zero regressions in the existing
+test suite.
+
+## Selected from
+
+- **Synthesised from:** child solutions at
+  `subproblems/merge-invariant-properties/solution.md`,
+  `subproblems/schema-exception-as-flow/solution.md`,
+  `subproblems/watcher-exit-catch/solution.md`.
+- **Composition rationale:** the three sub-problems were decomposed
+  along the **concern** axis (parent `problem.md` §Decomposition
+  strategy) and the children's recommendations confirm the
+  decomposition was clean: each child names a distinct production file
+  (`schema.ex`, `watcher.ex`, `loader.ex`) with no overlapping
+  callsites, no shared support modules (the merge-invariant child
+  explicitly rejects a shared `test/support/settings_generators.ex`),
+  and no shared public API. There is no interface between the
+  children's recommendations and no conflict to resolve. The
+  composition is direct: applying all three children's `What changes`
+  sections yields the parent acceptance criterion as a logical
+  conjunction — (a) the `catch :exit` site in Watcher is eliminated,
+  (b) `Loader.merge/2` gains property coverage, and (c) Schema's
+  rescue-based control flow is replaced with explicit conditional
+  logic, all without breaking any currently-passing test. The
+  selection method is `synthesis` because the parent solution is
+  ordering + commit hygiene the children individually cannot specify;
+  no child solution is dropped or altered.
+
+## What changes
+
+The full enumeration is the union of the three children's `What
+changes` sections, re-grouped per commit:
+
+**Commit 1 — Schema (`subproblems/schema-exception-as-flow`):**
+
+- `lib/tau/settings/schema.ex`: add `@known_provider_names` module
+  attribute computing
+  `Map.new(@known_providers, fn mod -> {Atom.to_string(mod) |> String.replace_prefix("Elixir.", ""), mod} end)`.
+- `lib/tau/settings/schema.ex`: replace the binary clause body of
+  `to_known_module/1` (the `try ... rescue ArgumentError` block) with
+  `case Map.fetch(@known_provider_names, str) do {:ok, mod} -> {:ok, mod}; :error -> {:error, {:unknown_provider, str}} end`.
+
+**Commit 2 — Watcher (`subproblems/watcher-exit-catch`):**
+
+- `lib/tau/settings/watcher.ex`: delete the `try/rescue/catch` block
+  in `maybe_start_watcher/1`; replace with a plain
+  `case FileSystem.start_link(dirs: dirs)` with `{:ok, pid}` and
+  `other ->` arms.
+- `lib/tau/settings/watcher.ex`: in `init/1`, after
+  `maybe_start_watcher/1` returns `{:ok, pid}`, call
+  `Process.monitor(pid)` and store the reference as `watcher_mon` in
+  state (default `nil` in the degraded branch).
+- `lib/tau/settings/watcher.ex`: add
+  `handle_info({:DOWN, ref, :process, _pid, reason}, %{watcher_mon: ref} = state)`
+  emitting `[:tau, :settings, :watcher_degraded]` telemetry with
+  `%{reason: {:fs_exit, reason}}` and setting
+  `watcher: nil, watcher_mon: nil`.
+- `lib/tau/settings/watcher.ex`: extract telemetry emission into a
+  private `emit_degraded_telemetry/1` shared between the
+  startup-failure and runtime-crash paths.
+
+**Commit 3 — Loader (`subproblems/merge-invariant-properties`):**
+
+- `lib/tau/settings/loader.ex`: replace `list_keys/0` (hardcoded list)
+  with a `@merge_rules` module attribute (`%{atom() => :concat}`)
+  covering the same 7 keys; add `def merge_rules/0` returning
+  `@merge_rules`; rewrite `merge_value/3`'s list-dispatch clause to
+  use `Map.get(@merge_rules, k, :override)`. Retain `list_keys/0` as
+  `def list_keys, do: Map.keys(@merge_rules)` only if external
+  callsites reference it; otherwise delete.
+- `test/tau/settings/loader_property_test.exs` (new file): `@moduledoc`
+  with prose contract (associativity, list-key concatenation, scalar
+  override, idempotency; explicitly states commutativity is NOT an
+  invariant); `@moduletag :property`; one `describe "rule-table contract"`
+  property iterating `Loader.merge_rules()` over `:concat` keys; one
+  `describe "algebraic laws"` block with three properties
+  (associativity, idempotency, scalar override) using a local
+  `coherent_triple/0` generator.
+
+## What does not change
+
+- `Settings.Cache` GenServer behaviour (publish/reload lifecycle).
+- `Settings.Vault` backends and `vault/env_test.exs`.
+- `Schema.@known_providers`, `@schema`, `json_schema/0`, the atom
+  clause of `to_known_module/1`, and `resolve_fallback_chains/1`.
+- `Settings.Schema` public API surface (no new public functions; no
+  `provider_from_string/1`).
+- `Settings.Watcher`'s debounce timer, `relevant?/1` path filter, and
+  public API signatures.
+- The Watcher's supervision-tree entry and restart strategy (the
+  Watcher remains supervised; `FileSystem` remains monitored, not
+  supervised under the Watcher).
+- `Loader.load/1`, `Loader.paths/1`, source-tracking, cascade layer
+  ordering, and file path resolution.
+- `Loader.list_keys/0`'s observable behaviour (derived from
+  `@merge_rules`; identical key set).
+- `test/tau/settings/loader_test.exs` — the four existing example
+  tests remain untouched.
+- `test/tau/settings/schema_test.exs` — existing tests cover the
+  changed path without modification.
+- `mix.exs` — `ExUnitProperties` and `StreamData` are already
+  available; no new dependency.
+- No shared `test/support/settings_generators.ex` module is added.
+
+## Migration sketch
+
+A single PR with three commits in dependency-free order:
+
+1. **Schema commit.** Edit `lib/tau/settings/schema.ex` as in Commit
+   1 above. Run `mix test test/tau/settings/schema_test.exs`; then
+   `mix compile --warnings-as-errors`. Smallest, safest, lowest-risk
+   change — sequenced first so a failure here can be reverted without
+   touching the larger Watcher/Loader work.
+2. **Watcher commit.** Apply Commit 2's two phases as a single
+   commit: (a) replace the `try` block with the plain `case`; (b) add
+   `Process.monitor` in `init/1`, the `watcher_mon` state field, the
+   `handle_info({:DOWN, ...})` clause, and the
+   `emit_degraded_telemetry/1` helper. Run the existing Watcher
+   tests; add a `send/2`-driven unit test of the `{:DOWN, ...}`
+   handler if practical, otherwise file as the follow-up the child
+   solution recommends.
+3. **Loader commit.** Apply Commit 3's production refactor and new
+   property file together. Run
+   `mix test test/tau/settings/loader_test.exs` (examples unchanged),
+   then `mix test --only property test/tau/settings/loader_property_test.exs`
+   (new properties pass), then `mix test` (full suite green).
+4. **Final.** `mix compile --warnings-as-errors` and `mix credo
+   --strict` on the merged tree. Open the PR with body citing the
+   parent `problem.md`'s acceptance criterion as advanced by these
+   three commits collectively.
+
+The order schema → watcher → loader is chosen for blast-radius
+minimisation: Schema's change is the smallest and most local; the
+Watcher's change touches OTP signal handling and is therefore
+medium-risk and worth landing in isolation; the Loader's change
+includes a new test file and is the largest single commit. The order
+is **not load-bearing** — the three commits are file-disjoint and
+could land in any order, but this order makes review easier and a
+mid-PR revert cleaner.
+
+## Open questions
+
+- (Inherited from Schema child) **Provider name format.** The
+  `@known_provider_names` map strips `"Elixir."`. Verify
+  user-facing documentation does not describe short-form provider
+  names (e.g. `"Anthropic"`); the rescue-based implementation has the
+  same constraint silently. A grep of `docs/` and any settings
+  reference material before implementation is sufficient.
+- (Inherited from Schema child) **Future deeper namespaces.** A
+  provider at `Tau.Providers.Foo.Bar` produces the key
+  `"Tau.Providers.Foo.Bar"`. The key-derivation convention should be
+  commented in the attribute definition.
+- (Inherited from Watcher child) **Supervisor restart strategy.** A
+  synchronous `:exit` from `FileSystem.start_link/1` now propagates
+  through `init/1`; whether the Watcher's spec should be `:transient`
+  vs `:temporary` is a supervision-tree question outside the parent
+  scope but worth confirming before landing.
+- (Inherited from Watcher child) **`rescue` arm removal vs library
+  contract.** The hybrid removes the `rescue e` arm. The child judges
+  this acceptable on the basis that `FileSystem` uses return values
+  and exits rather than raises; this is not verified against the
+  pinned version. A two-line grep of the pinned `file_system`
+  dependency suffices.
+- (Inherited from Watcher child) **`{:DOWN, ...}` handler test
+  coverage.** The acceptance criterion does not require it; the child
+  recommends a follow-up issue.
+- (Inherited from Loader child) **`list_keys/0` external callsites.**
+  Grep needed before deciding whether `list_keys/0` is kept derived
+  or deleted entirely.
+- (Inherited from Loader child) **`stream_data` API surface.**
+  Confirm the pinned `stream_data` version supports
+  `StreamData.fixed_map/1` and `StreamData.tuple/1` as used in the
+  `coherent_triple/0` generator.
+- (Parent-level) **PR shape.** Whether to land as one PR with three
+  commits (recommended for review coherence) or three single-commit
+  PRs (better blast-radius isolation if any commit pivots) is a
+  workflow call; the factory-loop conflict check
+  (`.claude/rules/factory-loop.md`) confirms the three are
+  parallelisable so either shape is admissible.
+
+## Linked sub-problems / proposals
+
+- `subproblems/merge-invariant-properties/` → "Combine proposal-4's
+  production data-shape change (`@merge_rules` attribute +
+  `merge_rules/0`) with proposal-2's standalone
+  `loader_property_test.exs` carrying a prose `@moduledoc` contract
+  and three algebraic-law properties plus one rule-table property."
+- `subproblems/schema-exception-as-flow/` → "Replace
+  `to_known_module/1`'s `try/rescue ArgumentError` binary clause with
+  a `case Map.fetch(@known_provider_names, str)` over a compile-time
+  map derived from `@known_providers`."
+- `subproblems/watcher-exit-catch/` → "Delete the `try/rescue/catch`
+  in `maybe_start_watcher/1` in favour of a plain `case` on
+  `FileSystem.start_link/1`'s return; add `Process.monitor/1` +
+  `handle_info({:DOWN, ...})` to handle post-startup `FileSystem`
+  crashes."
+
+## Revision history
+
+- (revision 0 — initial)

--- a/docs/problems-archive-v1-modules/tau-settings/subproblems/merge-invariant-properties/problem.md
+++ b/docs/problems-archive-v1-modules/tau-settings/subproblems/merge-invariant-properties/problem.md
@@ -1,0 +1,70 @@
+---
+template_version: 1
+template_name: problem
+node_kind: leaf
+depth: 1
+parent: ../../problem.md
+status: draft
+---
+
+# Problem: Loader.merge/2 invariants are untested by properties
+
+## Statement
+
+`Tau.Settings.Loader.merge/2` and its helper `merge_value/3` encode
+several cascade-merge invariants (list-key concatenation, scalar
+override, recursive map merge), but the only tests are four example
+cases in `loader_test.exs`. No property test exercises the algebraic
+properties of the merge — commutativity is NOT expected (later-layer
+wins), but associativity, idempotency of identical layers, and the
+list-key concatenation contract all hold as invariants. A regression in
+any of these would pass the current suite.
+
+## Context
+
+- `lib/tau/settings/loader.ex:36-51` — `merge/2`, `merge_value/3`, and
+  `list_keys/0` implement the merge contract.
+- `test/tau/settings/loader_test.exs` — four example tests: scalar
+  override, deep-map merge, list concatenation, deny-rule concat. All
+  pass with concrete fixtures; none exercises shrinkable generators.
+- OTP NN #6 (CLAUDE.md): "Invariant-bearing modules MUST have properties
+  before examples (`Permissions.Evaluator`, `Settings.Loader` merge,
+  `Message.Assembler`, permission matchers — `StreamData`)."
+  `Settings.Loader` is named explicitly.
+- `test/tau/settings/vault/env_test.exs` — shows the project already
+  uses `StreamData` and `ExUnitProperties` in the settings test tree;
+  the tooling is available.
+- List keys: `[:hooks, :extensions, :mcp, :allow, :deny, :ask,
+  :permissions]` (loader.ex:88-96).
+
+## Complecting hypothesis
+
+The merge-invariant specification is complected with its test coverage
+because the module embeds the invariants in implementation code but
+documents them only via coincidental examples, making it impossible to
+tell which properties are contractual vs incidental.
+
+## Decomposition strategy
+
+(leaf — no further decomposition; proceed to proposals)
+
+## Acceptance criterion
+
+`test/tau/settings/loader_test.exs` (or a sibling `loader_property_test.exs`)
+contains at least one `property/2` block using `StreamData` generators that
+exercises the associativity of three-layer merge, the list-key
+concatenation contract under arbitrary list inputs, and the scalar
+override invariant — and `mix test --only property` passes for these
+tests.
+
+## Out of scope
+
+- `Loader.load/1` file I/O and source-tracking (watcher/cache concern).
+- `Loader.paths/1` path computation.
+- Any change to which keys are in `list_keys/0`.
+- `Settings.Watcher` or `Settings.Cache` behaviour (sibling problems).
+- Schema validation or `to_known_module/1` logic (sibling problem).
+
+## Amendment log
+
+- (none yet)

--- a/docs/problems-archive-v1-modules/tau-settings/subproblems/merge-invariant-properties/proposals/proposal-1.md
+++ b/docs/problems-archive-v1-modules/tau-settings/subproblems/merge-invariant-properties/proposals/proposal-1.md
@@ -1,0 +1,182 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 1
+parent_problem: ../problem.md
+---
+
+# Proposal 1: Inline property block in loader_test.exs
+
+## Approach
+
+Add a `property "merge invariants"` block directly into the existing
+`test/tau/settings/loader_test.exs`, immediately after the four example
+tests. The block uses `StreamData` generators to exercise three contractual
+properties of `Loader.merge/2`: (a) associativity of three-layer merge,
+(b) list-key concatenation under arbitrary list inputs, and (c) scalar
+override (later layer wins). No new file is created; the test module
+gains `use ExUnitProperties` and three `property/2` blocks.
+
+## Rationale
+
+The complecting hypothesis is that the invariants are documented only via
+coincidental examples. Extending the existing test file with `property/2`
+blocks directly specifies the contractual properties beside their example
+counterparts, making the distinction between "contractual" and "incidental"
+explicit without requiring the reader to cross file boundaries. The
+approach is the smallest possible intervention: it adds signal (property
+coverage) without moving, renaming, or splitting anything. It satisfies
+OTP NN #6 at the minimal scope the rule requires.
+
+## Sketch
+
+```elixir
+# test/tau/settings/loader_test.exs  (additions only)
+defmodule Tau.Settings.LoaderTest do
+  use ExUnit.Case, async: true
+  use ExUnitProperties                       # <-- add
+
+  alias Tau.Settings.Loader
+
+  # ... existing describe "merge/2" block unchanged ...
+
+  describe "merge/2 properties" do
+    @describetag :property
+
+    # Generator: a settings map with atom keys and scalar/list/map values.
+    # Keeps generators simple; structural complexity is exercised by
+    # the associativity check.
+    defp settings_gen do
+      scalar = StreamData.one_of([
+        StreamData.string(:alphanumeric, max_length: 8),
+        StreamData.integer()
+      ])
+      list_val = StreamData.list_of(StreamData.string(:alphanumeric, max_length: 4),
+                                    max_length: 4)
+      key_gen = StreamData.member_of([:model, :theme, :hooks, :allow, :deny])
+
+      StreamData.fixed_map(%{
+        optional_key: StreamData.boolean()
+      })
+      |> StreamData.bind(fn _ ->
+        StreamData.map(
+          StreamData.list_of(
+            StreamData.tuple({key_gen, StreamData.one_of([scalar, list_val])}),
+            max_length: 5
+          ),
+          &Map.new/1
+        )
+      end)
+    end
+
+    property "associativity: merge(merge(a, b), c) == merge(a, merge(b, c))" do
+      check all(
+        a <- settings_gen(),
+        b <- settings_gen(),
+        c <- settings_gen()
+      ) do
+        assert Loader.merge(Loader.merge(a, b), c) ==
+                 Loader.merge(a, Loader.merge(b, c))
+      end
+    end
+
+    property "idempotency: merge(a, a) == a" do
+      check all(a <- settings_gen()) do
+        assert Loader.merge(a, a) == a
+      end
+    end
+
+    property "list-key concatenation: length grows additively" do
+      list_key = StreamData.member_of([:hooks, :allow, :deny, :extensions,
+                                       :mcp, :ask, :permissions])
+      check all(
+        k    <- list_key,
+        xs   <- StreamData.list_of(StreamData.integer(), max_length: 8),
+        ys   <- StreamData.list_of(StreamData.integer(), max_length: 8)
+      ) do
+        merged = Loader.merge(%{k => xs}, %{k => ys})
+        assert merged[k] == xs ++ ys
+      end
+    end
+
+    property "scalar override: non-list, non-map values always take later layer" do
+      non_list_scalar = StreamData.one_of([
+        StreamData.string(:alphanumeric, max_length: 8),
+        StreamData.integer(),
+        StreamData.boolean()
+      ])
+      check all(
+        k  <- StreamData.atom(:alphanumeric),
+        v1 <- non_list_scalar,
+        v2 <- non_list_scalar
+      ) do
+        assert Loader.merge(%{k => v1}, %{k => v2}) == %{k => v2}
+      end
+    end
+  end
+end
+```
+
+Key notes:
+- `settings_gen/0` produces maps with a mix of list-keys and scalar keys,
+  deliberately including keys from `list_keys/0` so the associativity check
+  exercises both branches of `merge_value/3`.
+- The `@describetag :property` tag means `mix test --only property` runs
+  exactly these blocks and nothing else, matching the acceptance criterion.
+- No new module. No behaviour change. No file move.
+
+## Tradeoffs
+
+### Strengths
+
+- Minimal footprint: one file modified, zero new files.
+- `mix test --only property` works immediately with the existing
+  `ExUnitProperties` dependency already in `mix.exs`.
+- Properties live adjacent to their example counterparts — a reader sees
+  both the "what" (examples) and the "always" (properties) in one file.
+- Idempotency property catches a subtle class of bug (a merge that
+  doubles list-key values when merging identical layers) not covered by
+  any current example.
+
+### Weaknesses
+
+- The `settings_gen/0` generator is ad-hoc and lives in the test module,
+  not a shared support module — if a sibling problem needs similar
+  generators they would be duplicated.
+- Associativity of `merge/2` holds only when the value types are
+  consistent across layers (map-map-map or list-list-list at the same
+  key); the generator must be careful not to produce type conflicts at
+  the same key that would make associativity vacuously false. The sketch
+  above uses independent generators per key, which can produce type
+  mismatches. A production version needs a generator that produces
+  structurally coherent triples.
+- Does not separate the property specification from the test file — the
+  contractual documentation is still interleaved with tests rather than
+  being a standalone spec artefact.
+
+### Costs
+
+- ~80 lines of new test code. No production code changes.
+- Generator correctness requires care (see Weaknesses above); a first
+  draft will likely need one or two refinement passes under `mix test`.
+- `ExUnitProperties` is already a dev dependency; zero new deps.
+
+## Dependencies
+
+- `ExUnitProperties` and `StreamData` already present in `mix.exs`
+  (confirmed by `test/tau/settings/vault/env_test.exs` using them).
+- No production code changes; `Loader.merge/2` is already public.
+
+## Confidence
+
+Medium. The approach is straightforward and the tooling is in place.
+Confidence would rise to high after a prototype run confirming the
+generator produces structurally coherent inputs (the main risk).
+
+## Prior art / references
+
+- `test/tau/settings/vault/env_test.exs` — project-local precedent for
+  `use ExUnitProperties` pattern and `@describetag :property` convention.
+- OTP NN #6 in `CLAUDE.md` — explicit mandate naming `Settings.Loader`.
+- Hickey "Simple Made Easy" — complecting specification with coincidental
+  examples is a form of accidental complexity.

--- a/docs/problems-archive-v1-modules/tau-settings/subproblems/merge-invariant-properties/proposals/proposal-2.md
+++ b/docs/problems-archive-v1-modules/tau-settings/subproblems/merge-invariant-properties/proposals/proposal-2.md
@@ -1,0 +1,258 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 2
+parent_problem: ../problem.md
+---
+
+# Proposal 2: Standalone loader_property_test.exs with contract-first layout
+
+## Approach
+
+Create a new file `test/tau/settings/loader_property_test.exs` whose
+entire content is property tests — no example tests. The file opens with
+a module-level `@moduledoc` that states the three invariants of
+`Loader.merge/2` in prose (the contract), followed immediately by the
+`property/2` blocks that mechanically verify each one. The existing
+`loader_test.exs` is left entirely unchanged. A shared generator
+`test/support/settings_generators.ex` is also created, exporting
+`settings_map/0` and `list_key_pair/0`, available to any future
+settings property test.
+
+## Rationale
+
+The leaf problem's complecting hypothesis is that the invariants are
+embedded in implementation code but documented only through coincidental
+examples, making it impossible to tell what is contractual. A standalone
+file whose name ends in `_property_test.exs` and whose opening `@moduledoc`
+states the invariants as prose makes the contract explicit and locatable.
+The separation also means a reviewer reading `loader_test.exs` sees examples
+and a reviewer reading `loader_property_test.exs` sees specifications — the
+two concerns are no longer woven together. The shared generator module pays
+the per-test setup cost once and makes future property tests cheaper.
+
+## Sketch
+
+```
+# New files:
+#   test/tau/settings/loader_property_test.exs
+#   test/support/settings_generators.ex
+```
+
+```elixir
+# test/support/settings_generators.ex
+defmodule Tau.Test.SettingsGenerators do
+  @moduledoc """
+  StreamData generators for Tau.Settings property tests.
+
+  All generators produce structurally coherent inputs: a given key always
+  has the same value type across independently generated maps (enforced by
+  generating the key-type assignment first, then generating values).
+  """
+  use ExUnitProperties
+
+  @list_keys [:hooks, :extensions, :mcp, :allow, :deny, :ask, :permissions]
+
+  @doc """
+  Generates a settings map whose list-keys always carry lists and whose
+  non-list keys always carry scalars. A fixed key-type schema is generated
+  first; values are then generated according to that schema. This ensures
+  structural coherence across independently generated maps sharing the
+  same schema — a requirement for associativity tests.
+  """
+  @spec settings_map_with_schema() :: StreamData.t({map(), map()})
+  def settings_map_with_schema do
+    # Generate a schema: which keys are present and are they list or scalar?
+    key_schema_gen =
+      StreamData.map(
+        StreamData.list_of(
+          StreamData.tuple({
+            StreamData.atom(:alphanumeric),
+            StreamData.member_of([:scalar, :list])
+          }),
+          min_length: 1, max_length: 6
+        ),
+        &Map.new/1
+      )
+
+    StreamData.bind(key_schema_gen, fn schema ->
+      value_maps =
+        schema
+        |> Enum.map(fn {k, :scalar} ->
+          {k, StreamData.one_of([
+            StreamData.string(:alphanumeric, max_length: 8),
+            StreamData.integer(0..100)
+          ])}
+          {k, :list} ->
+          {k, StreamData.list_of(StreamData.integer(0..50), max_length: 5)}
+        end)
+
+      # Build three maps from the same schema (for associativity)
+      {m1, m2, m3} =
+        Enum.reduce(value_maps, {%{}, %{}, %{}}, fn {k, gen}, {a, b, c} ->
+          StreamData.bind(gen, fn va ->
+            StreamData.bind(gen, fn vb ->
+              StreamData.bind(gen, fn vc ->
+                {Map.put(a, k, va), Map.put(b, k, vb), Map.put(c, k, vc)}
+              end)
+            end)
+          end)
+        end)
+
+      StreamData.constant({m1, m2, m3, schema})
+    end)
+  end
+
+  @doc "Generates {list_key, xs, ys} triples for concatenation tests."
+  @spec list_key_pair() :: StreamData.t({atom(), list(), list()})
+  def list_key_pair do
+    StreamData.tuple({
+      StreamData.member_of(@list_keys),
+      StreamData.list_of(StreamData.integer(), max_length: 8),
+      StreamData.list_of(StreamData.integer(), max_length: 8)
+    })
+  end
+end
+```
+
+```elixir
+# test/tau/settings/loader_property_test.exs
+defmodule Tau.Settings.LoaderPropertyTest do
+  @moduledoc """
+  Contract specification for Tau.Settings.Loader.merge/2.
+
+  The following invariants hold by design and MUST continue to hold:
+
+  1. **Associativity**: merge(merge(a, b), c) == merge(a, merge(b, c))
+     for any three settings maps that share a type-coherent schema
+     (same key always has same value type across layers).
+
+  2. **List-key concatenation**: for any key in list_keys/0 and any
+     lists xs, ys: merge(%{k => xs}, %{k => ys})[k] == xs ++ ys.
+
+  3. **Scalar override**: for any non-list, non-map value, the later
+     layer always wins: merge(%{k => v1}, %{k => v2})[k] == v2.
+
+  4. **Idempotency of identical layers**: merge(a, a) == a.
+
+  Commutativity is NOT an invariant: later-layer wins for scalars and
+  list-key ordering preserves earlier-first; merge(a, b) != merge(b, a)
+  in general.
+  """
+
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  alias Tau.Settings.Loader
+  alias Tau.Test.SettingsGenerators, as: Gen
+
+  @moduletag :property
+
+  property "associativity: merge(merge(a,b),c) == merge(a,merge(b,c))" do
+    check all({a, b, c, schema} <- Gen.settings_map_with_schema()) do
+      lhs = Loader.merge(Loader.merge(a, b), c)
+      rhs = Loader.merge(a, Loader.merge(b, c))
+      assert lhs == rhs,
+             "Associativity failed for schema #{inspect(schema)}\n" <>
+             "a=#{inspect(a)}\nb=#{inspect(b)}\nc=#{inspect(c)}"
+    end
+  end
+
+  property "list-key concatenation under arbitrary list inputs" do
+    check all({k, xs, ys} <- Gen.list_key_pair()) do
+      merged = Loader.merge(%{k => xs}, %{k => ys})
+      assert merged[k] == xs ++ ys,
+             "Concatenation failed for key #{k}: " <>
+             "expected #{inspect(xs ++ ys)}, got #{inspect(merged[k])}"
+    end
+  end
+
+  property "scalar override: later layer wins for non-list non-map values" do
+    scalar = StreamData.one_of([
+      StreamData.string(:alphanumeric, max_length: 8),
+      StreamData.integer(),
+      StreamData.boolean()
+    ])
+    check all(
+      k  <- StreamData.atom(:alphanumeric),
+      v1 <- scalar,
+      v2 <- scalar
+    ) do
+      assert Loader.merge(%{k => v1}, %{k => v2}) == %{k => v2}
+    end
+  end
+
+  property "idempotency: merge(a, a) == a for any coherent settings map" do
+    check all({a, _b, _c, _schema} <- Gen.settings_map_with_schema()) do
+      assert Loader.merge(a, a) == a
+    end
+  end
+end
+```
+
+File moves: none. New files: 2. Existing files changed: 0.
+
+## Tradeoffs
+
+### Strengths
+
+- The `@moduledoc` in `loader_property_test.exs` is a self-contained,
+  prose specification of the merge contract — addresses the complecting
+  hypothesis directly by making the contract explicit and separate.
+- Explicitly states that commutativity is NOT an invariant, which is
+  as important as stating what is invariant.
+- `SettingsGenerators` is reusable by sibling problem tests and any
+  future settings property test.
+- `@moduletag :property` means all tests in the file run under
+  `mix test --only property` without per-`describe` tagging.
+- The structural-coherence constraint on the generator (same key always
+  has same type) is encoded in `settings_map_with_schema/0`, preventing
+  the false-associativity-failure trap.
+
+### Weaknesses
+
+- Two new files instead of one edit — higher surface area for a
+  reviewer to assess.
+- `settings_map_with_schema/0` uses nested `StreamData.bind/2` chains
+  that are more complex to read and debug than a simple generator;
+  the sketch above has a structural bug (the `Enum.reduce` returning
+  `StreamData.bind` calls inside a reducer doesn't compose correctly)
+  and needs careful revision before it will compile.
+- `test/support/settings_generators.ex` adds a shared test-support
+  module that requires consensus on naming and placement conventions
+  for the project's test-support tree.
+- If the generator bug in the sketch (see Weaknesses above) propagates
+  to the implementation, the `settings_map_with_schema/0` property
+  may silently generate only trivial maps.
+
+### Costs
+
+- ~120 lines across two new files. Zero production code changes.
+- The `SettingsGenerators` module must be added to `test/support/` and
+  `mix.exs`'s `:test` compilation paths, which may require a
+  `test_helper.exs` or `mix.exs` edit to ensure it compiles.
+- One careful review of `settings_map_with_schema/0` for generator
+  composition correctness before merge.
+
+## Dependencies
+
+- `ExUnitProperties` + `StreamData` already in dev deps.
+- `test/support/` directory already exists (confirmed by
+  `test/support/tui_pty_helper.ex`).
+- No production code changes.
+
+## Confidence
+
+Medium. The two-file structure and prose contract are the right shape.
+Confidence would rise to high once `settings_map_with_schema/0` is
+prototyped and confirmed to generate structurally coherent triples.
+
+## Prior art / references
+
+- `test/tau/settings/vault/env_test.exs` — `@describetag :property` and
+  `ExUnitProperties` conventions already established.
+- Elm's `Fuzz` module pattern of documenting algebraic laws as `@moduledoc`
+  prose above the property tests.
+- The leaf problem's acceptance criterion explicitly names
+  `loader_property_test.exs` as a valid alternative to extending
+  `loader_test.exs`.

--- a/docs/problems-archive-v1-modules/tau-settings/subproblems/merge-invariant-properties/proposals/proposal-3.md
+++ b/docs/problems-archive-v1-modules/tau-settings/subproblems/merge-invariant-properties/proposals/proposal-3.md
@@ -1,0 +1,262 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 3
+parent_problem: ../problem.md
+---
+
+# Proposal 3: Extract merge contract to a typespec + property-verified behaviour
+
+## Approach
+
+Promote `merge/2` and `merge_value/3` to a formal `@behaviour`-driven
+contract by (a) introducing a `Tau.Settings.MergeBehaviour` behaviour
+module with a single `@callback merge(map(), map()) :: map()` and a
+`@doc` that states the algebraic laws, and (b) making
+`Tau.Settings.Loader` `@impl true` its `merge/2` against that behaviour.
+A companion `test/tau/settings/merge_behaviour_test.exs` uses the
+behaviour's declared laws to generate shared property tests that any
+`MergeBehaviour` implementation must pass — invoked once for
+`Tau.Settings.Loader`. The existing four example tests in
+`loader_test.exs` are left unchanged.
+
+## Rationale
+
+The complecting hypothesis is that the invariants are embedded in
+implementation code and documented only via coincidental examples. A
+`@behaviour` with a `@doc` stating the algebraic laws separates the
+*specification* (what merge must always do) from the *implementation*
+(how `Loader` does it), which is the canonical Elixir/OTP decomplecting
+move for extensibility seams (OTP NN #2). The property test file derives
+directly from the behaviour's declared contract, not from an informal
+reading of the implementation — making the relationship between
+specification and verification explicit and machine-checkable.
+
+## Sketch
+
+```elixir
+# lib/tau/settings/merge_behaviour.ex  (new file)
+defmodule Tau.Settings.MergeBehaviour do
+  @moduledoc """
+  Contract for deep cascade-merge of settings maps.
+
+  Implementations MUST satisfy the following algebraic laws:
+
+  - **Associativity** (for type-coherent inputs):
+      merge(merge(a, b), c) == merge(a, merge(b, c))
+
+  - **Scalar override**: for any non-list, non-map value v1, v2 at key k:
+      merge(%{k => v1}, %{k => v2})[k] == v2
+
+  - **List-key concatenation** (for keys in list_keys/0):
+      merge(%{k => xs}, %{k => ys})[k] == xs ++ ys
+
+  - **Idempotency of identical layers**:
+      merge(a, a) == a
+
+  Commutativity is NOT required: merge(a, b) != merge(b, a) in general.
+  Later-layer wins for scalars; earlier-layer-first for list concatenation.
+  """
+
+  @doc """
+  Deep-merge two settings maps. The second argument (b) is the "later
+  layer" — its scalar values override a's; its list values at known
+  list-keys are appended to a's.
+  """
+  @callback merge(map(), map()) :: map()
+end
+```
+
+```elixir
+# lib/tau/settings/loader.ex  (modifications only)
+defmodule Tau.Settings.Loader do
+  @behaviour Tau.Settings.MergeBehaviour   # <-- add
+
+  # ...
+
+  @impl Tau.Settings.MergeBehaviour         # <-- add
+  @spec merge(map(), map()) :: map()
+  def merge(a, b) when is_map(a) and is_map(b) do
+    Map.merge(a, b, fn k, v1, v2 -> merge_value(k, v1, v2) end)
+  end
+
+  # ... rest unchanged ...
+end
+```
+
+```elixir
+# test/tau/settings/merge_behaviour_test.exs  (new file)
+defmodule Tau.Settings.MergeBehaviourTest do
+  @moduledoc """
+  Property verification of the Tau.Settings.MergeBehaviour contract.
+
+  Each implementation under test must be listed in @implementations.
+  The properties are derived directly from the @callback @doc in
+  Tau.Settings.MergeBehaviour.
+  """
+
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  @moduletag :property
+
+  @implementations [Tau.Settings.Loader]
+
+  @list_keys [:hooks, :extensions, :mcp, :allow, :deny, :ask, :permissions]
+
+  # Simple coherent-schema generator: generates a pair {a, b} where
+  # each key has the same type in both maps.
+  defp coherent_pair do
+    StreamData.bind(
+      StreamData.list_of(
+        StreamData.tuple({
+          StreamData.atom(:alphanumeric),
+          StreamData.member_of([:scalar, :list])
+        }),
+        min_length: 0, max_length: 5
+      ),
+      fn schema_list ->
+        schema = Map.new(schema_list)
+        entries_gen =
+          Enum.map(schema, fn
+            {k, :scalar} ->
+              {k, StreamData.string(:alphanumeric, max_length: 6)}
+            {k, :list} ->
+              {k, StreamData.list_of(StreamData.integer(0..20), max_length: 4)}
+          end)
+
+        # Generate three independent value bindings per key
+        StreamData.fixed_map(
+          Map.new(entries_gen, fn {k, gen} ->
+            {k, StreamData.tuple({gen, gen, gen})}
+          end)
+        )
+        |> StreamData.map(fn kv_triples ->
+          {
+            Map.new(kv_triples, fn {k, {v1, _v2, _v3}} -> {k, v1} end),
+            Map.new(kv_triples, fn {k, {_v1, v2, _v3}} -> {k, v2} end),
+            Map.new(kv_triples, fn {k, {_v1, _v2, v3}} -> {k, v3} end)
+          }
+        end)
+      end
+    )
+  end
+
+  for impl <- @implementations do
+    @impl_mod impl
+
+    describe "#{inspect(impl)} satisfies MergeBehaviour contract" do
+      property "associativity" do
+        check all({a, b, c} <- coherent_pair()) do
+          lhs = @impl_mod.merge(@impl_mod.merge(a, b), c)
+          rhs = @impl_mod.merge(a, @impl_mod.merge(b, c))
+          assert lhs == rhs
+        end
+      end
+
+      property "idempotency of identical layers" do
+        check all({a, _b, _c} <- coherent_pair()) do
+          assert @impl_mod.merge(a, a) == a
+        end
+      end
+
+      property "list-key concatenation" do
+        check all(
+          k  <- StreamData.member_of(@list_keys),
+          xs <- StreamData.list_of(StreamData.integer(), max_length: 6),
+          ys <- StreamData.list_of(StreamData.integer(), max_length: 6)
+        ) do
+          assert @impl_mod.merge(%{k => xs}, %{k => ys})[k] == xs ++ ys
+        end
+      end
+
+      property "scalar override" do
+        scalar = StreamData.one_of([
+          StreamData.string(:alphanumeric, max_length: 8),
+          StreamData.integer(),
+          StreamData.boolean()
+        ])
+        check all(
+          k  <- StreamData.atom(:alphanumeric),
+          v1 <- scalar,
+          v2 <- scalar
+        ) do
+          assert @impl_mod.merge(%{k => v1}, %{k => v2}) == %{k => v2}
+        end
+      end
+    end
+  end
+end
+```
+
+File summary:
+- `lib/tau/settings/merge_behaviour.ex` — new (behaviour + law docs)
+- `lib/tau/settings/loader.ex` — add `@behaviour` + `@impl` annotations
+- `test/tau/settings/merge_behaviour_test.exs` — new (property tests keyed
+  to `@implementations` list)
+
+## Tradeoffs
+
+### Strengths
+
+- The `@behaviour` declaration makes the contract machine-verifiable by
+  the Elixir compiler (`@impl true` raises a warning if the callback
+  signature is wrong) and by Dialyzer.
+- The `@moduledoc` on `MergeBehaviour` is the canonical location for the
+  contract prose — the invariants are no longer coincidental, they are
+  the official spec.
+- The `@implementations` list in the test makes it trivial to add a
+  second implementation (e.g., a test-double or a stricter merge
+  strategy) and immediately have it verified against the same contract.
+- Directly addresses OTP NN #2 ("extensibility seams MUST be
+  behaviours") in addition to OTP NN #6.
+
+### Weaknesses
+
+- Introduces a `@behaviour` for a function that currently has exactly
+  one implementation and no near-term plan for a second — this is
+  speculative extensibility, which Hickey would call premature
+  complexity.
+- `lib/tau/settings/merge_behaviour.ex` is a new production module that
+  must be maintained forever; if `merge/2` ever changes signature, the
+  behaviour must change too.
+- The `for impl <- @implementations` + `@impl_mod` compile-time
+  macro pattern is unusual and may surprise readers unfamiliar with
+  it; the generated describe-block name helps but the mechanism is
+  non-obvious.
+- Adding `@behaviour` to `Loader` changes its public API surface
+  (it now claims to implement a behaviour), which could confuse readers
+  expecting `Loader` to be a purely functional module with no
+  polymorphism.
+
+### Costs
+
+- One new production file (`merge_behaviour.ex`), one new test file,
+  two lines changed in `loader.ex`.
+- Dialyzer must be re-run after merging to confirm no spec regressions.
+- Team must decide: is `MergeBehaviour` the right abstraction boundary?
+  If not, the behaviour is dead weight.
+
+## Dependencies
+
+- No library changes.
+- Elixir 1.18.1 `@behaviour` / `@impl` are fully supported.
+- The `coherent_pair/0` generator in the sketch uses `StreamData.fixed_map/1`
+  with a map of generators — verify this API is available in the project's
+  pinned `stream_data` version before committing.
+
+## Confidence
+
+Low-to-medium. The property tests are the right move; the `@behaviour`
+is justifiable but adds scope beyond the acceptance criterion. Confidence
+would rise to medium if the team confirms a second implementation is on the
+roadmap (making the behaviour non-speculative).
+
+## Prior art / references
+
+- Elixir `Collectable` and `Enumerable` behaviours as precedent for
+  algebraic-law-bearing callbacks.
+- OTP NN #2 in `CLAUDE.md`: "extensibility seams MUST be behaviours;
+  pattern match on atoms and structs."
+- `Tau.Provider` behaviour in `lib/tau/provider.ex` — the project already
+  uses this pattern for provider extensibility.

--- a/docs/problems-archive-v1-modules/tau-settings/subproblems/merge-invariant-properties/proposals/proposal-4.md
+++ b/docs/problems-archive-v1-modules/tau-settings/subproblems/merge-invariant-properties/proposals/proposal-4.md
@@ -1,0 +1,260 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 4
+parent_problem: ../problem.md
+---
+
+# Proposal 4: Data-shape restructuring — explicit MergeRule type + table-driven merge
+
+## Approach
+
+Replace the implicit branching in `merge_value/3` with an explicit
+`MergeRule` type and a table-driven dispatch. `list_keys/0` becomes a
+`@list_key_rules` module attribute of type `%{atom() => :concat}`;
+a new private `%MergeRule{}` struct captures `:concat | :override |
+:deep_merge` per-key decisions; `merge_value/3` is rewritten as a
+single pattern-match against the rule looked up from the table. Property
+tests are then written against the rule table itself (not just the
+function), asserting that every declared `:concat` rule produces
+concatenation and every `:override` rule produces override — making the
+contract mechanical and table-verifiable rather than logic-verifiable.
+
+## Rationale
+
+The complecting hypothesis is that the invariants are embedded in
+implementation code in a way that makes it impossible to tell which
+properties are contractual vs incidental. The current `merge_value/3`
+uses a `if k in list_keys()` guard that requires reading the guard,
+the body, and `list_keys/0` to reconstruct the contract. A rule-table
+approach makes the contract data: the table IS the specification, and
+the property tests verify that the dispatch function honours the table.
+This is a data-shape change (not a control-flow change), and it means
+the invariant is no longer embedded in logic — it is declared in data
+and verified by testing that data.
+
+## Sketch
+
+```elixir
+# lib/tau/settings/loader.ex  (rewrite of merge_value/3 and list_keys/0)
+defmodule Tau.Settings.Loader do
+
+  # The merge rule table IS the contract.
+  # :concat  — lists concatenate (earlier-first)
+  # (all other keys default to :override for scalars, :deep_merge for maps)
+  @merge_rules %{
+    hooks:       :concat,
+    extensions:  :concat,
+    mcp:         :concat,
+    allow:       :concat,
+    deny:        :concat,
+    ask:         :concat,
+    permissions: :concat
+  }
+
+  @doc "The merge rule table. Used by property tests to verify dispatch."
+  @spec merge_rules() :: %{atom() => :concat}
+  def merge_rules, do: @merge_rules
+
+  @doc "Pure deep-merge of two settings maps."
+  @spec merge(map(), map()) :: map()
+  def merge(a, b) when is_map(a) and is_map(b) do
+    Map.merge(a, b, fn k, v1, v2 -> merge_value(k, v1, v2) end)
+  end
+
+  defp merge_value(_k, v1, v2) when is_map(v1) and is_map(v2),
+    do: merge(v1, v2)
+
+  defp merge_value(k, v1, v2) when is_list(v1) and is_list(v2) do
+    case Map.get(@merge_rules, k, :override) do
+      :concat   -> v1 ++ v2
+      :override -> v2
+    end
+  end
+
+  defp merge_value(_k, _v1, v2), do: v2
+
+  # list_keys/0 is now derived from the rule table (no divergence possible)
+  @doc false
+  def list_keys, do: Map.keys(@merge_rules)
+
+  # ... rest of load/1, paths/1, etc. unchanged ...
+end
+```
+
+```elixir
+# test/tau/settings/loader_property_test.exs  (new file)
+defmodule Tau.Settings.LoaderPropertyTest do
+  @moduledoc """
+  Property tests for Tau.Settings.Loader.merge/2.
+
+  Two verification layers:
+
+  1. **Rule-table tests** — for each key declared in merge_rules/0,
+     verify the dispatch function honours the declared rule. These tests
+     are derived mechanically from the table, not from the implementation.
+
+  2. **Algebraic-law tests** — associativity, idempotency, scalar
+     override across arbitrary inputs.
+  """
+
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  alias Tau.Settings.Loader
+
+  @moduletag :property
+
+  describe "rule-table contract" do
+    property "every :concat-rule key produces v1 ++ v2" do
+      concat_keys = for {k, :concat} <- Loader.merge_rules(), do: k
+
+      check all(
+        k  <- StreamData.member_of(concat_keys),
+        xs <- StreamData.list_of(StreamData.integer(), max_length: 6),
+        ys <- StreamData.list_of(StreamData.integer(), max_length: 6)
+      ) do
+        assert Loader.merge(%{k => xs}, %{k => ys})[k] == xs ++ ys
+      end
+    end
+  end
+
+  describe "algebraic laws" do
+    # Coherent-triple generator: same key always has same type in a, b, c.
+    defp coherent_triple do
+      StreamData.bind(
+        StreamData.list_of(
+          StreamData.tuple({
+            StreamData.atom(:alphanumeric),
+            StreamData.member_of([:scalar, :list])
+          }),
+          max_length: 5
+        ),
+        fn schema_list ->
+          schema = Map.new(schema_list)
+          StreamData.fixed_map(
+            Map.new(schema, fn
+              {k, :scalar} ->
+                {k, StreamData.tuple({
+                  StreamData.string(:alphanumeric, max_length: 6),
+                  StreamData.string(:alphanumeric, max_length: 6),
+                  StreamData.string(:alphanumeric, max_length: 6)
+                })}
+              {k, :list} ->
+                {k, StreamData.tuple({
+                  StreamData.list_of(StreamData.integer(0..20), max_length: 4),
+                  StreamData.list_of(StreamData.integer(0..20), max_length: 4),
+                  StreamData.list_of(StreamData.integer(0..20), max_length: 4)
+                })}
+            end)
+          )
+          |> StreamData.map(fn kv ->
+            {
+              Map.new(kv, fn {k, {v1, _, _}} -> {k, v1} end),
+              Map.new(kv, fn {k, {_, v2, _}} -> {k, v2} end),
+              Map.new(kv, fn {k, {_, _, v3}} -> {k, v3} end)
+            }
+          end)
+        end
+      )
+    end
+
+    property "associativity for type-coherent triples" do
+      check all({a, b, c} <- coherent_triple()) do
+        lhs = Loader.merge(Loader.merge(a, b), c)
+        rhs = Loader.merge(a, Loader.merge(b, c))
+        assert lhs == rhs
+      end
+    end
+
+    property "idempotency: merge(a, a) == a" do
+      check all({a, _b, _c} <- coherent_triple()) do
+        assert Loader.merge(a, a) == a
+      end
+    end
+
+    property "scalar override: later layer wins" do
+      scalar = StreamData.one_of([
+        StreamData.string(:alphanumeric, max_length: 8),
+        StreamData.integer(),
+        StreamData.boolean()
+      ])
+      check all(k <- StreamData.atom(:alphanumeric), v1 <- scalar, v2 <- scalar) do
+        assert Loader.merge(%{k => v1}, %{k => v2}) == %{k => v2}
+      end
+    end
+  end
+end
+```
+
+Production change summary:
+- `list_keys/0` becomes `def list_keys, do: Map.keys(@merge_rules)` — no
+  divergence between the rule table and the list-key set is possible.
+- `merge_rules/0` is a new public function (required for the rule-table tests).
+- `merge_value/3` uses `Map.get(@merge_rules, k, :override)` instead of
+  `if k in list_keys()`.
+- All existing example tests continue to pass unchanged.
+
+## Tradeoffs
+
+### Strengths
+
+- Eliminates the possibility of `list_keys/0` and the `:concat` dispatch
+  diverging — they are now the same data structure.
+- The rule-table property tests verify that the dispatch function respects
+  the declared table without any implicit logic — this is the most direct
+  test of the contract.
+- Adding a new `:concat`-rule key in the future requires only one change
+  (the `@merge_rules` map) rather than two (`list_keys/0` AND a branch in
+  `merge_value/3`).
+- `merge_rules/0` as a public function makes the contract inspectable at
+  runtime without reading source code (useful for debugging and introspection).
+
+### Weaknesses
+
+- Changes production code (`merge_value/3` and `list_keys/0`) in addition
+  to adding tests — this is a production refactor, not a test-only change.
+  It carries more risk than proposals 1 or 2.
+- The rule table currently has only one rule type (`:concat`). Adding
+  `:override` as an explicit rule type and a `case` dispatch for it
+  adds code volume to handle a case that is already the default — it's
+  extra mechanism for no current benefit.
+- `@merge_rules` as a module attribute compiles the table into the module
+  bytecode; if the rule table ever grows large or needs to be dynamic, this
+  approach must be revisited (though for the current 7-key table, this is
+  a non-issue).
+- The `merge_rules/0` public function expands the module's public API
+  surface; if the rule table is considered an implementation detail, making
+  it public is an API commitment.
+
+### Costs
+
+- Small production code change (~10 lines modified + 3 lines added in
+  `loader.ex`).
+- All four existing tests must be confirmed still passing after the
+  `merge_value/3` rewrite.
+- Dialyzer re-run recommended.
+- ~80 lines of new test code.
+
+## Dependencies
+
+- No new libraries.
+- The production change is entirely within `lib/tau/settings/loader.ex`.
+- `merge_rules/0` must be added before the test can reference it.
+
+## Confidence
+
+Medium. The data-shape change is a clean decomplecting move, and the
+rule-table tests are mechanically stronger than pure algebraic-law tests
+(they verify dispatch, not just outcomes). Confidence would rise to high
+after confirming `mix test test/tau/settings/` passes with the refactored
+`merge_value/3`.
+
+## Prior art / references
+
+- Erlang `ets:match_spec/0` — rule-table dispatch as data rather than code.
+- Clojure `merge-with` — explicit merge strategy passed as data/function,
+  making the contract a first-class value.
+- The `@merge_rules` module-attribute pattern is used elsewhere in the
+  project (e.g., `Tau.Provider` dispatch tables) for similar static
+  key-to-strategy mappings.

--- a/docs/problems-archive-v1-modules/tau-settings/subproblems/merge-invariant-properties/solution.md
+++ b/docs/problems-archive-v1-modules/tau-settings/subproblems/merge-invariant-properties/solution.md
@@ -1,0 +1,161 @@
+---
+template_version: 1
+template_name: solution
+parent_problem: ../../problem.md
+node_kind: leaf
+synthesised_from: [proposals/proposal-2.md, proposals/proposal-4.md]
+selection_method: hybrid
+revision: 0
+---
+
+# Solution: Standalone property file + rule-table production refactor
+
+## Recommendation
+
+Combine proposal-4's production data-shape change (replace `list_keys/0`
+with an `@merge_rules` module attribute and expose `merge_rules/0`) with
+proposal-2's standalone `loader_property_test.exs` file. The production
+refactor eliminates the `list_keys/0` / `:concat`-dispatch divergence
+surface and introduces `merge_rules/0` as the inspectable, testable
+contract; the standalone test file provides a prose `@moduledoc` contract
+statement, rule-table property tests derived mechanically from
+`merge_rules/0`, and algebraic-law properties (associativity,
+idempotency, scalar override) using a structurally-coherent generator.
+The shared `SettingsGenerators` support module from proposal-2 is NOT
+included — the coherent-triple generator in proposal-4 is self-contained
+and sufficient; a shared module adds naming/placement overhead with no
+current payoff.
+
+## Selected from
+
+- **Chosen:** hybrid of `proposals/proposal-2.md` + `proposals/proposal-4.md`
+- **Why chosen:** Proposal-2 is the only proposal that directly addresses
+  the complecting hypothesis (coincidental examples vs. contractual
+  specification) by using a prose `@moduledoc` contract and a file
+  boundary to separate examples from properties; it also names the
+  acceptance criterion's explicit alternative (`loader_property_test.exs`).
+  Proposal-4 adds a production data-shape change that eliminates an
+  actual defect — the possibility that `list_keys/0` and the `:concat`
+  dispatch branch diverge — and produces `merge_rules/0`, which makes
+  the rule-table property tests in the test file mechanically stronger
+  (they test dispatch, not just outcomes). Proposal-1 is strictly
+  dominated by proposal-2 (same approach, same tests, no prose contract,
+  generator with a known structural-coherence bug). Proposal-3 introduces
+  a `@behaviour` for a function with one implementation and no near-term
+  second — speculative extensibility the problem statement does not
+  require, and Hickey would call premature aggregation.
+
+  The hybrid is more than the sum of its parts: proposal-4's
+  `merge_rules/0` makes proposal-2's rule-table property test possible
+  (it can iterate over `Loader.merge_rules()` rather than hard-coding
+  the key list in the test); proposal-2's standalone file gives
+  proposal-4's properties a proper prose home rather than inline
+  comments. Neither proposal alone produces both the production
+  correctness improvement and the specification artefact.
+
+## Scoring table
+
+| # | Fit | Decomplecting depth | Migration cost | Risk | Reversibility |
+|---|-----|---------------------|----------------|------|---------------|
+| 1 | Partially | Surface | Low | Low | Easy |
+| 2 | Yes | Substantial | Low | Low | Easy |
+| 3 | Yes | Surface | Medium | Medium | Hard |
+| 4 | Yes | Deep | Medium | Low | Easy |
+| Hybrid 2+4 | Yes | Deep | Medium | Low | Easy |
+
+Proposal-1 scores Partially because its generator has an acknowledged
+structural-coherence defect that could make the associativity property
+vacuously true. Proposal-3 scores Medium risk and Hard reversibility
+because it adds a production `@behaviour` module to the public API that
+must be maintained regardless of whether a second implementation ever
+appears. The hybrid is the only option that scores Deep decomplecting
+depth (eliminating the divergence surface) at Low risk and Easy
+reversibility (the production change is ~10 lines in one file; the test
+file can be reverted independently).
+
+## What changes
+
+- `lib/tau/settings/loader.ex`:
+  - Replace `list_keys/0` (returns a hardcoded list) with a
+    `@merge_rules` module attribute (`%{atom() => :concat}`) covering
+    the same 7 keys.
+  - Add `def merge_rules/0` (public) returning `@merge_rules`.
+  - Rewrite `merge_value/3` list-dispatch clause to use
+    `Map.get(@merge_rules, k, :override)` instead of `if k in list_keys()`.
+  - `list_keys/0` is retained as `def list_keys, do: Map.keys(@merge_rules)`
+    if any other callsite references it; otherwise deleted.
+- `test/tau/settings/loader_property_test.exs` (new file):
+  - `@moduledoc` with prose contract: states associativity,
+    list-key concatenation, scalar override, idempotency as invariants,
+    and explicitly states commutativity is NOT an invariant.
+  - `@moduletag :property` so `mix test --only property` selects the
+    whole file.
+  - `describe "rule-table contract"` block with one property: iterates
+    `Loader.merge_rules()`, selects `:concat` keys, verifies
+    `merge(%{k => xs}, %{k => ys})[k] == xs ++ ys` for arbitrary lists.
+  - `describe "algebraic laws"` block with three properties using a
+    local `coherent_triple/0` generator (proposal-4's pattern):
+    associativity, idempotency, scalar override.
+  - No shared support module; the `coherent_triple/0` generator lives
+    in the test module.
+
+## What does not change
+
+- `test/tau/settings/loader_test.exs` — the four existing example tests
+  are untouched.
+- `Loader.load/1`, `Loader.paths/1`, source-tracking, watcher/cache
+  logic — out of scope.
+- `list_keys/0` public API is preserved (derived from `@merge_rules`)
+  if callsites reference it; its behaviour is identical.
+- `mix.exs` — `ExUnitProperties` and `StreamData` are already dev deps.
+- No shared `test/support/settings_generators.ex` module is introduced.
+
+## Migration sketch
+
+1. Add `@merge_rules` attribute to `loader.ex`; derive `merge_rules/0`
+   and rewrite `list_keys/0` from it; update `merge_value/3` dispatch
+   clause. Run `mix test test/tau/settings/loader_test.exs` — all four
+   example tests must pass unchanged.
+2. Create `test/tau/settings/loader_property_test.exs` with the
+   `@moduledoc` contract and the three `property/2` blocks. Run
+   `mix test --only property test/tau/settings/loader_property_test.exs`
+   — all properties must pass.
+3. Run the full suite: `mix test` — no regressions. Run
+   `mix compile --warnings-as-errors` to confirm the `@merge_rules`
+   attribute type is clean.
+
+## Open questions
+
+- Does any callsite outside `loader.ex` reference `list_keys/0` by
+  name? If yes, the derived definition is a drop-in. If the codebase
+  has no external callers, `list_keys/0` may be deleted (saving a
+  public API surface). A grep is required before implementation.
+- The `coherent_triple/0` generator uses `StreamData.fixed_map/1` with
+  a map of generators. Verify the project's pinned `stream_data` version
+  supports this API before committing.
+- Proposal-4's `coherent_triple/0` sketch uses
+  `StreamData.tuple({gen, gen, gen})` to generate three values from the
+  same generator instance per key. This is the correct approach for
+  structural coherence; confirm the generator produces non-degenerate
+  inputs (non-empty maps) on a prototype run before declaring the
+  property tests non-vacuous.
+
+## Linked sub-problems / proposals
+
+- `proposals/proposal-1.md` — Inline property block in `loader_test.exs`:
+  minimal footprint but generator has a structural-coherence defect and
+  no prose contract.
+- `proposals/proposal-2.md` — Standalone `loader_property_test.exs` with
+  prose `@moduledoc` contract: directly decomplects specification from
+  coincidental examples; base of the hybrid.
+- `proposals/proposal-3.md` — `MergeBehaviour` + `@impl` annotation:
+  introduces speculative extensibility for a single-implementation
+  boundary; exceeds the acceptance criterion's scope.
+- `proposals/proposal-4.md` — Data-shape refactor + rule-table tests:
+  eliminates `list_keys/0` / dispatch divergence surface; provides
+  `merge_rules/0` that makes the hybrid's rule-table property tests
+  mechanically correct.
+
+## Revision history
+
+- (revision 0 — initial)

--- a/docs/problems-archive-v1-modules/tau-settings/subproblems/merge-invariant-properties/validation.md
+++ b/docs/problems-archive-v1-modules/tau-settings/subproblems/merge-invariant-properties/validation.md
@@ -1,0 +1,418 @@
+---
+template_version: 1
+template_name: validation
+parent_solution: solution.md
+parent_problem: problem.md
+toulmin_complete: true
+falsification_attempted: true
+falsification_outcome: partially_falsified — claim/5
+revision_triggered: none
+---
+
+# Validation: Standalone property file + rule-table production refactor
+
+## Overview
+
+The solution proposes (1) a production data-shape change in `loader.ex` —
+replacing a private `list_keys/0` function with an `@merge_rules` module
+attribute and a public `merge_rules/0` accessor — and (2) a new standalone
+`test/tau/settings/loader_property_test.exs` with a prose `@moduledoc`
+contract and four property blocks. Seven claims are extracted from the
+Recommendation and What-changes sections. Falsification strategies used:
+dependency check (claims 1, 3, 6), counter-example construction (claims 2,
+4), edge-case enumeration (claims 5, 7), type-level check (claim 3).
+Outcome: six claims withstood; claim 5 partially falsified (qualifier
+narrowed; no revision required).
+
+---
+
+## Toulmin per claim
+
+### Claim 1: `merge_rules/0` eliminates the divergence surface between `list_keys/0` and the `:concat`-dispatch branch
+
+- **Claim (C):** Replacing `list_keys/0` + `if k in list_keys()` dispatch
+  with a single `@merge_rules` attribute consulted by both `merge_rules/0`
+  and `merge_value/3` eliminates the possibility that the key list and the
+  dispatch logic diverge.
+- **Grounds (G):** `loader.ex:44` shows `if k in list_keys()` calling a
+  private function; `loader.ex:88-98` shows `list_keys/0` returning a
+  hardcoded list. These are two independently editable code sites. The
+  proposed `Map.get(@merge_rules, k, :override)` dispatch reads from the
+  same attribute that `merge_rules/0` returns, making them one site.
+- **Warrant (W):** Single-source-of-truth: when a logical fact (the set of
+  concat keys) is represented exactly once in source, no edit can produce
+  a partial update that leaves only one site changed.
+- **Qualifier (Q):** Holds for the `list_keys/0` / `:concat`-dispatch
+  divergence surface specifically. A future maintainer who adds a second
+  dispatch strategy (beyond `:concat`) and hand-codes it in a separate
+  clause rather than extending `@merge_rules` could reintroduce a
+  divergence surface — but that is outside the scope of this change.
+- **Rebuttal (R):** If `merge_value/3` grows additional clauses that hard-
+  code key-set checks (e.g., for a hypothetical `:dedupe` strategy), the
+  single-source property breaks again. The refactor prevents the *current*
+  divergence; it does not prevent all future forms.
+- **Backing (B):** OTP NN #8 (pure functions as default); general principle
+  that single-representation of a fact is a prerequisite for verifiable
+  invariants (see also Hickey, "Simple Made Easy" — the distinction between
+  complecting coincidental co-location and genuine conceptual unity).
+
+#### Falsification attempt for claim 1
+
+- **Strategy:** Dependency check — verify the proposed single-source path
+  is structurally closed (no second site in the module that could hold a
+  divergent copy of the key set).
+- **Attempt:** Searched `loader.ex` for all uses of `list_keys` and all
+  list-dispatch patterns. `list_keys` appears only at `loader.ex:44`
+  (dispatch) and `loader.ex:88` (definition). No other list-key check
+  exists in the file. The proposed `Map.get(@merge_rules, k, :override)`
+  dispatch eliminates both sites in favour of the attribute, leaving zero
+  independent sites.
+- **Outcome:** Withstood — no second site found; the single-source property
+  holds structurally.
+- **Action:** None.
+
+---
+
+### Claim 2: The rule-table property test in `loader_property_test.exs` is mechanically stronger than hard-coding the key list in the test
+
+- **Claim (C):** Iterating `Loader.merge_rules()` in the property test —
+  rather than re-listing the 7 keys in the test — means the test
+  automatically exercises any future key added to `@merge_rules` without a
+  test-file edit.
+- **Grounds (G):** The existing example test at `loader_test.exs:22-27`
+  hard-codes `:hooks` and `:extensions`; if a new list-key is added to
+  `list_keys/0`, the example test still passes even if the new key is
+  accidentally not dispatched as `:concat`. The proposed property iterates
+  `Loader.merge_rules()` and therefore catches any key the attribute
+  contains.
+- **Warrant (W):** A test that derives its own oracle from the production
+  data structure under test is stronger than a test that independently
+  enumerates a subset: the former cannot be stale; the latter can.
+- **Qualifier (Q):** Holds only once `merge_rules/0` is public and returns
+  the full key set. If a key is intentionally omitted from `@merge_rules`
+  (e.g., a key that concatenates by a different rule), the test would also
+  omit it — but that is consistent behaviour, not a defect.
+- **Rebuttal (R):** If `Loader.merge_rules()` itself has a bug (returns
+  fewer keys than `@merge_rules`), the property test would silently
+  under-test. The `@merge_rules` attribute approach makes this unlikely
+  since `merge_rules/0` is defined as `def merge_rules, do: @merge_rules`.
+- **Backing (B):** `problem.md` §Acceptance criterion — "exercises the
+  associativity of three-layer merge, the list-key concatenation contract
+  under arbitrary list inputs, and the scalar override invariant"; the
+  criterion implicitly requires that the tests remain accurate as the key
+  set evolves.
+
+#### Falsification attempt for claim 2
+
+- **Strategy:** Counter-example construction — construct a scenario where
+  iterating `merge_rules()` does NOT provide stronger coverage than a
+  hard-coded list.
+- **Attempt:** The only scenario where a hard-coded test list beats
+  `merge_rules()` iteration is if a key is in the desired-contract set but
+  NOT in `@merge_rules`. This would mean `@merge_rules` is wrong — a
+  production bug, not a test-coverage defect. In that case both approaches
+  fail equally (neither catches the missing key).
+- **Outcome:** Withstood — no scenario found where a hard-coded key list
+  provides strictly stronger coverage for the purpose of detecting
+  regression; the production-derived iteration is at least as strong and
+  typically stronger.
+- **Action:** None.
+
+---
+
+### Claim 3: `mix.exs` requires no changes; `ExUnitProperties` and `StreamData` are already dev deps
+
+- **Claim (C):** The hybrid solution requires no `mix.exs` changes because
+  `stream_data` is already a dev dependency.
+- **Grounds (G):** `mix.exs:129` — `{:stream_data, "~> 1.1", only: [:test,
+  :dev]}`. `mix.lock` shows `stream_data 1.3.0` is resolved. The project
+  already uses `ExUnitProperties` and `StreamData` in
+  `test/tau/settings/vault/env_test.exs:11,56` and
+  `test/tau/providers/rate_limiter/token_bucket_property_test.exs:23`.
+- **Warrant (W):** A dependency already declared in `mix.exs` and present
+  in `mix.lock` is available to any test file without further configuration.
+- **Qualifier (Q):** Universal — no edge case where the dep would be
+  unavailable to the new test file in the standard project layout.
+- **Rebuttal (R):** None applicable. The dep is declared with `only: [:test,
+  :dev]`, which covers the test environment where this file runs.
+- **Backing (B):** `mix.exs:129` (cited above); `mix.lock` `stream_data`
+  entry (version 1.3.0).
+
+#### Falsification attempt for claim 3
+
+- **Strategy:** Dependency check + type-level check — verify `StreamData.fixed_map/1` and `StreamData.tuple/1` are available in version 1.3.0 (the locked version).
+- **Attempt:** Confirmed `stream_data 1.3.0` in `mix.lock`. Searched
+  existing test files for `StreamData.fixed_map` — found usage at
+  `test/tau/providers/shared/tool_spec/gemini_subset_test.exs:130` and
+  `test/tau/providers/shared/tool_spec_test.exs:160,168,177`, and for
+  `StreamData.tuple` at
+  `test/tau/providers/rate_limiter/token_bucket_property_test.exs:23` and
+  `test/tau/circuit_breaker/state_property_test.exs:45`. Both APIs are
+  actively used in the project at the locked version. The solution's open
+  question about `StreamData.fixed_map/1` compatibility is resolved: it is
+  confirmed available.
+- **Outcome:** Withstood — both APIs are confirmed available at the locked
+  version.
+- **Action:** None. The solution's open question about `fixed_map`
+  compatibility can be closed.
+
+---
+
+### Claim 4: Associativity, idempotency, and scalar-override are sound invariants for `Loader.merge/2` as currently implemented
+
+- **Claim (C):** The three algebraic laws selected for property testing
+  (associativity of three-layer merge, idempotency of identical layers,
+  scalar override) are true invariants of the current implementation.
+- **Grounds (G):** `loader.ex:37-51` — `merge/2` delegates conflict
+  resolution to `merge_value/3`. `merge_value/3` has three clauses:
+  (a) both maps → recurse; (b) both lists at a known key → concat; (c)
+  otherwise → `v2`. Clause (c) implements scalar override unconditionally.
+  Idempotency: `merge(a, a)` — for scalar keys, `v2 = a[k]`; for list
+  keys, `a[k] ++ a[k]` (NOT idempotent for list keys). For map keys,
+  `merge(v1, v1)` is recursive with the same property.
+- **Warrant (W):** Algebraic properties must hold at all types handled by
+  the function. An idempotency claim that holds for scalars but fails for
+  list keys is a false invariant unless qualified.
+- **Qualifier (Q):** Associativity holds universally for this merge
+  (argument below). Idempotency holds only for settings maps with NO list
+  keys, or when the list keys are empty. Scalar override holds universally.
+- **Rebuttal (R):** See claim 5 for the idempotency qualification — the
+  solution text does not restrict idempotency to scalar-only or empty-list
+  contexts, which would make the property test as written either incorrect
+  or vacuous depending on the generator.
+- **Backing (B):** `loader.ex:43-49` — the concat clause; `problem.md`
+  §Statement — explicitly names idempotency as an invariant without
+  qualification.
+
+#### Falsification attempt for claim 4
+
+- **Strategy:** Counter-example construction for idempotency.
+- **Attempt:** Let `a = %{hooks: [%{e: 1}]}`. Then
+  `merge(a, a) = %{hooks: [%{e: 1}, %{e: 1}]}` ≠ `a`. Idempotency
+  (`merge(a, a) == a`) fails for any non-empty list at a list key. This
+  is a concrete falsifying instance.
+- **Outcome:** Partially falsified — idempotency does NOT hold universally;
+  it fails for maps containing non-empty lists at concat keys. Associativity
+  and scalar override are unaffected and withstand the attempt.
+- **Action:** Narrow qualifier (see claim 5 for full treatment). No revision
+  to `solution.md` required — the property test design can accommodate this
+  by restricting the `coherent_triple/0` generator to scalar-only maps when
+  testing idempotency, or by reframing the idempotency property to test
+  `merge(a, %{}) == a` (left identity) instead. The narrowed claim survives.
+
+---
+
+### Claim 5: Idempotency is a valid invariant for `Loader.merge/2`
+
+- **Claim (C):** "idempotency of identical layers" is listed as one of the
+  three property tests in the `describe "algebraic laws"` block.
+- **Grounds (G):** `problem.md` §Statement — "idempotency of identical
+  layers" named as an invariant. `loader.ex:43-49` — list concat clause
+  shows `v1 ++ v2` for list keys, meaning `merge(a, a)` at a list key
+  yields a doubled list. The example test at `loader_test.exs:19-26` uses
+  `%{hooks: [%{e: 1}]}` — a map with a non-empty list key.
+- **Warrant (W):** For an operation `f` to be idempotent, `f(x, x) = x`
+  must hold for all `x` in the domain. `Loader.merge/2`'s domain includes
+  maps with non-empty list values at concat keys; for these, the operation
+  is not idempotent.
+- **Qualifier (Q):** Idempotency holds only for the sub-domain of settings
+  maps where all concat-key values are empty lists (or absent). It does NOT
+  hold universally over the type `map()`.
+- **Rebuttal (R):** The `coherent_triple/0` generator may generate maps with
+  empty lists, in which case the idempotency property test passes vacuously
+  for list keys, hiding the non-idempotency. Alternatively, if it generates
+  non-empty lists, the test will fail. Either outcome is a defect in the
+  claimed property.
+- **Backing (B):** `loader.ex:43-49` (concat clause — cited above);
+  `problem.md` §Statement (names idempotency without qualification).
+
+#### Falsification attempt for claim 5
+
+- **Strategy:** Edge-case enumeration — enumerate the map shapes where
+  idempotency fails.
+- **Attempt:** Any map `a` with `a[:hooks]` non-empty produces
+  `merge(a, a)[:hooks] = a[:hooks] ++ a[:hooks]` ≠ `a[:hooks]`. Same for
+  any of the 7 concat keys with a non-empty list. The domain is broad:
+  typical real settings maps have non-empty `:hooks`, `:allow`, `:deny`
+  entries.
+- **Outcome:** Partially falsified — the unqualified claim "idempotency of
+  identical layers is an invariant" is false for the full domain. The
+  narrowed survivor: idempotency holds for `merge(a, a)` iff every concat
+  key in `a` has an empty-list or absent value. Alternatively, the claim
+  is reframed as "left identity: `merge(%{}, a) == a`" which IS a true
+  invariant.
+- **Action:** Narrow qualifier — the property test MUST either (a) restrict
+  the generator to scalar-only maps for the idempotency check, or (b)
+  replace "idempotency of identical layers" with "left identity
+  (`merge(%{}, a) == a`)" which is the true invariant the implementation
+  exhibits. No `solution.md` revision required; the test file
+  implementation must respect this constraint, and the `@moduledoc`
+  contract statement must be corrected. This is a qualifier narrowing only.
+
+---
+
+### Claim 6: `list_keys/0` is private and has no external callers; it may be deleted or derived
+
+- **Claim (C):** "list_keys/0 is retained as `def list_keys, do:
+  Map.keys(@merge_rules)` if any other callsite references it; otherwise
+  deleted."
+- **Grounds (G):** `loader.ex:88` defines `list_keys/0` as `defp` (private).
+  Grep of `lib/` for `list_keys` returns only `loader.ex:44` (dispatch
+  caller) and `loader.ex:88` (definition). `test/tau/settings/schema_test.exs:26`
+  defines a local `list_keys` variable — it does not call `Loader.list_keys/0`.
+  No external caller exists.
+- **Warrant (W):** A private function with no callers outside its own module
+  can be deleted without breaking the public API. If it were called
+  externally, it would need to be retained or a public wrapper provided.
+- **Qualifier (Q):** Holds as of current HEAD. A concurrent branch could
+  add a caller, but the solution already handles this with "if any other
+  callsite references it."
+- **Rebuttal (R):** The solution preserves `list_keys/0` as a public derived
+  function if callsites exist — this is a reasonable hedge. The grep
+  confirms no callsites exist today, so deletion is safe.
+- **Backing (B):** Grep result — `lib/tau/settings/loader.ex:44,88` are
+  the only occurrences; `test/tau/settings/schema_test.exs:26` is a local
+  variable, not a call to `Loader.list_keys/0`.
+
+#### Falsification attempt for claim 6
+
+- **Strategy:** Dependency check — search the full codebase for
+  `Loader.list_keys` and `Settings.Loader.list_keys`.
+- **Attempt:** Ran grep over `lib/` and `test/` for `list_keys`. Results:
+  `loader.ex:44` (internal call to private function), `loader.ex:88`
+  (definition), `schema_test.exs:26` (local variable — not a module call).
+  No other occurrences.
+- **Outcome:** Withstood — no external callers; the function is safely
+  deletable.
+- **Action:** None. Open question in solution.md about external callers is
+  resolved: none exist; `list_keys/0` may be deleted.
+
+---
+
+### Claim 7: The `coherent_triple/0` generator using `StreamData.tuple/1` produces non-degenerate (non-empty-map) inputs
+
+- **Claim (C):** The solution asserts the `coherent_triple/0` generator
+  produces "non-degenerate inputs (non-empty maps)" and proposes confirming
+  this on a prototype run. The implicit claim is that the proposed generator
+  pattern is sound.
+- **Grounds (G):** The solution cites "proposal-4's pattern" using
+  `StreamData.tuple({gen, gen, gen})` to generate three values from the
+  same generator instance per key. `StreamData.tuple/1` is confirmed
+  available in the locked version (1.3.0) — used at
+  `test/tau/providers/rate_limiter/token_bucket_property_test.exs:23` and
+  `test/tau/circuit_breaker/state_property_test.exs:45`.
+- **Warrant (W):** `StreamData.tuple/1` generates a tuple by running each
+  member generator independently. If the map generator is defined to
+  produce fixed-key maps with independently-generated values, the triple
+  `{a, b, c}` has no structural coupling across `a`, `b`, `c` beyond
+  shared key shape — which is the desired coherence property (all three
+  maps have the same keys, different values).
+- **Qualifier (Q):** The generator produces non-empty maps iff the
+  underlying value generators produce at least one entry. If the map is
+  constructed with `StreamData.fixed_map/1` over a fixed key set (which
+  is the pattern used in the codebase), all maps in the triple will have
+  the same non-empty key set by construction.
+- **Rebuttal (R):** If the generator uses `StreamData.map_of/2` rather than
+  `StreamData.fixed_map/1`, it can produce empty maps. This is an
+  implementation choice the solution leaves open. The solution's open
+  question ("verify non-degenerate inputs on a prototype run") is an
+  appropriate hedge.
+- **Backing (B):** `test/tau/providers/shared/tool_spec_test.exs:160` —
+  example of `StreamData.fixed_map/1` producing structurally coherent
+  maps in this codebase. `StreamData` 1.3.0 docs (stream_data hex package).
+
+#### Falsification attempt for claim 7
+
+- **Strategy:** Edge-case enumeration — enumerate generator shapes that
+  produce degenerate (empty) maps.
+- **Attempt:** A `StreamData.map_of(key_gen, val_gen)` can produce `%{}`.
+  A `StreamData.fixed_map(%{k1: gen1, k2: gen2})` cannot produce an empty
+  map — it always produces exactly the declared keys. The claim that the
+  generator is non-degenerate is conditional on using `fixed_map` or
+  equivalent; the solution leaves the exact generator shape to the
+  implementer.
+- **Outcome:** Withstood with qualifier — using `StreamData.fixed_map/1`
+  (the pattern already established in this codebase) guarantees non-empty
+  maps. The open question in solution.md is appropriately flagging this
+  implementation constraint.
+- **Action:** None. The implementer must use `StreamData.fixed_map/1` (not
+  `map_of`) for the per-key value generators to guarantee structural
+  coherence and non-degeneracy.
+
+---
+
+## Cross-claim consistency
+
+**Claims 1 and 6** interact: claim 1 says the `@merge_rules` attribute is
+the single source for both `merge_rules/0` and `merge_value/3` dispatch;
+claim 6 says `list_keys/0` may be deleted. These are consistent — once
+`@merge_rules` drives dispatch, `list_keys/0` becomes derivable (or
+deletable). No tension.
+
+**Claims 4 and 5** interact: claim 4 establishes that idempotency is
+partially falsified for non-empty list inputs; claim 5 narrows the
+idempotency qualifier. These are consistent — claim 4 scopes the discovery;
+claim 5 handles the resolution. The narrowed qualifier in claim 5 (restrict
+to scalar-only maps, or reframe as left-identity) is coherent with the
+overall property test design. No internal inconsistency, but the
+`@moduledoc` contract statement in the proposed test file must use the
+narrowed form.
+
+**Claims 2 and 3**: independent and consistent.
+
+**Claims 6 and 7**: independent and consistent.
+
+No unresolvable tensions found.
+
+---
+
+## Falsification summary
+
+| # | Claim (short) | Strategy | Outcome | Action |
+|---|---|---|---|---|
+| 1 | `merge_rules/0` eliminates divergence surface | Dependency check | Withstood | None |
+| 2 | Rule-table property mechanically stronger than hard-coded key list | Counter-example construction | Withstood | None |
+| 3 | No `mix.exs` change needed; StreamData already available | Dependency check + type-level check | Withstood | None; open question in solution.md resolved |
+| 4 | Associativity, idempotency, scalar-override are sound invariants | Counter-example construction | Partially falsified (idempotency) | Narrow qualifier — see claim 5 |
+| 5 | Idempotency of identical layers is a valid test | Edge-case enumeration | Partially falsified | Narrow: restrict to scalar maps OR reframe as left-identity `merge(%{}, a) == a` |
+| 6 | `list_keys/0` has no external callers | Dependency check | Withstood | None; open question resolved |
+| 7 | `coherent_triple/0` produces non-degenerate maps | Edge-case enumeration | Withstood (with qualifier) | Implementer must use `fixed_map`, not `map_of` |
+
+---
+
+## Revision required
+
+No revision to `solution.md` or `problem.md` is triggered. The partial
+falsification of claims 4 and 5 (idempotency) requires a qualifier
+narrowing only:
+
+- **Target file:** `test/tau/settings/loader_property_test.exs` (the to-be-
+  created file — not yet in the codebase)
+- **Revision kind:** Implementation constraint — the idempotency property
+  test MUST be written as either (a) a left-identity test
+  (`merge(%{}, a) == a`) or (b) a test that restricts its generator to
+  scalar-only maps. The unqualified "idempotency of identical layers"
+  framing in the solution's `@moduledoc` description must be corrected to
+  "left identity" or "idempotency for scalar-only maps."
+- **Rationale:** The problem.md names idempotency as an invariant without
+  qualification; the `@moduledoc` contract statement the solution proposes
+  must not repeat that unqualified claim. Correcting it in the test file
+  at implementation time (not in solution.md) is sufficient — the
+  structural design of the solution is sound.
+
+---
+
+## Outstanding doubts
+
+- The associativity property's coherent-triple generator must produce
+  structurally coherent inputs (same keys across all three maps, but
+  different values). The solution cites proposal-4's pattern but does not
+  show the generator code. If the three maps in the triple have different
+  key sets, the associativity property may pass vacuously (e.g., because
+  no key conflicts occur across layers). The implementer must ensure the
+  generator produces key overlap, not just shape similarity.
+- The solution defers the `coherent_triple/0` generator's non-vacuity
+  verification to "a prototype run." This is an unresolved implementation
+  risk — the property test could pass for the wrong reason (no generated
+  inputs trigger the conflict paths). A prototype run is strongly
+  recommended before declaring the properties non-vacuous.

--- a/docs/problems-archive-v1-modules/tau-settings/subproblems/schema-exception-as-flow/problem.md
+++ b/docs/problems-archive-v1-modules/tau-settings/subproblems/schema-exception-as-flow/problem.md
@@ -1,0 +1,80 @@
+---
+template_version: 1
+template_name: problem
+node_kind: leaf
+depth: 1
+parent: ../../problem.md
+status: draft
+---
+
+# Problem: Schema.to_known_module/1 uses rescue ArgumentError as primary control flow
+
+## Statement
+
+`Tau.Settings.Schema.to_known_module/1` (the binary clause, lines
+291-296) calls `String.to_existing_atom("Elixir." <> str)` and wraps
+the call in `rescue ArgumentError` to detect an unknown atom. The
+`ArgumentError` raised when the atom does not exist is not an exceptional
+condition — it is the expected result for any provider string that isn't
+pre-loaded. Using `rescue` as the normal-path dispatch conflates
+exception handling with ordinary control flow, violating the principle
+that `rescue` is for genuinely unexpected faults.
+
+## Context
+
+- `lib/tau/settings/schema.ex:290-296` — the binary clause of
+  `to_known_module/1`:
+  ```elixir
+  defp to_known_module(str) when is_binary(str) do
+    try do
+      mod = String.to_existing_atom("Elixir." <> str)
+      if mod in @known_providers, do: {:ok, mod}, else: {:error, {:unknown_provider, str}}
+    rescue
+      ArgumentError -> {:error, {:unknown_provider, str}}
+    end
+  end
+  ```
+- `String.to_existing_atom/1` raises `ArgumentError` when the atom is
+  not interned — this is its documented, non-exceptional signal for
+  "atom not found". An alternative is `:"Elixir.#{str}"` is not safe
+  (creates atoms); the correct alternative is to check the `@known_providers`
+  list directly (the set is compile-time-known) before attempting any
+  atom coercion.
+- `@known_providers` is a compile-time constant (6 modules). A direct
+  `Enum.find/2` on the string-serialised form of each known provider
+  covers the same cases without atom creation or exception use.
+- `test/tau/settings/schema_test.exs:88-94` exercises the "rejects
+  unknown providers" path; the test passes regardless of whether the
+  implementation uses rescue or conditional logic.
+
+## Complecting hypothesis
+
+The domain-level "provider string is unknown" result is complected with
+Elixir's atom-intern exception mechanism because the implementation
+delegates the "is this atom known?" question to the VM's atom table
+lookup rather than to the module's own `@known_providers` data.
+
+## Decomposition strategy
+
+(leaf — no further decomposition; proceed to proposals)
+
+## Acceptance criterion
+
+`to_known_module/1` for binary input no longer uses `rescue` or `try`;
+the "unknown provider" result is produced by a conditional check against
+`@known_providers` (or equivalent compile-time data); the existing
+`schema_test.exs` tests for `resolve_fallback_chains/1` all continue to
+pass; and `mix compile --warnings-as-errors` produces no new warnings.
+
+## Out of scope
+
+- `to_known_module/1` for atom input (the atom clause at lines 282-288;
+  it uses `cond` correctly and has no exception-as-flow issue).
+- `resolve_fallback_chains/1` reduce logic.
+- The JSON Schema map itself (`@schema`) or `json_schema/0`.
+- `Loader.merge/2` property tests (sibling problem).
+- `Settings.Watcher` OTP compliance (sibling problem).
+
+## Amendment log
+
+- (none yet)

--- a/docs/problems-archive-v1-modules/tau-settings/subproblems/schema-exception-as-flow/proposals/proposal-1.md
+++ b/docs/problems-archive-v1-modules/tau-settings/subproblems/schema-exception-as-flow/proposals/proposal-1.md
@@ -1,0 +1,111 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 1
+parent_problem: ../problem.md
+---
+
+# Proposal 1: Direct string-match against module-name strings at compile time
+
+## Approach
+
+Build a compile-time map `@known_provider_names` from `@known_providers` by
+extracting the string suffix that callers write in `.tau/settings.json` (e.g.
+`"Tau.Providers.Anthropic"` → `"Anthropic"`; `"Tau.Providers.OpenAI.Chat"` →
+`"OpenAI.Chat"`). Replace the `try/rescue` binary clause with a two-branch
+`case` that pattern-matches on this map: found → `{:ok, mod}`, not found →
+`{:error, {:unknown_provider, str}}`. No atom creation at runtime. No exception.
+
+## Rationale
+
+The `@known_providers` list is a compile-time constant of six modules. Their
+string names (as written by users) are equally knowable at compile time.
+Building a `string → module` map once with a module attribute eliminates the
+need for `String.to_existing_atom/1` entirely — the "is this provider known?"
+question is answered by a pure data lookup, decomplecting domain logic from the
+VM atom-intern mechanism. The exception path is removed because no exception-
+raising call is made.
+
+## Sketch
+
+```elixir
+# At module attribute level (compile time):
+@known_provider_names Map.new(@known_providers, fn mod ->
+  # "Elixir.Tau.Providers.Anthropic" → strip "Elixir.Tau.Providers." prefix is wrong;
+  # callers write the module name after "Elixir.", so the lookup key is
+  # the bare inspect form minus the "Elixir." prefix.
+  name = mod |> Atom.to_string() |> String.replace_prefix("Elixir.", "")
+  {name, mod}
+end)
+
+# Replacement for the binary clause:
+defp to_known_module(str) when is_binary(str) do
+  case Map.fetch(@known_provider_names, str) do
+    {:ok, mod} -> {:ok, mod}
+    :error     -> {:error, {:unknown_provider, str}}
+  end
+end
+```
+
+The existing atom clause (`is_atom(mod)`) is unchanged. The map is zero-cost at
+runtime: it is frozen into the compiled BEAM module as a literal. No atom
+creation, no `try`, no `rescue`.
+
+## Tradeoffs
+
+### Strengths
+
+- Completely eliminates `try`/`rescue` from the binary clause — the acceptance
+  criterion is satisfied in the minimal possible change.
+- `@known_provider_names` is computable at compile time and stored as a literal;
+  lookup is O(1) map fetch with no side effects.
+- The domain question "is this a known provider string?" is answered entirely by
+  the module's own data, not the VM's atom table — clean decomplecting.
+- No new runtime dependency; no library change.
+- The existing `schema_test.exs` tests exercise this path and will continue to
+  pass without modification.
+
+### Weaknesses
+
+- The map key convention (strip `"Elixir."` prefix) must match what callers
+  actually write in `.tau/settings.json`. If any caller writes a partial name
+  (e.g., `"Anthropic"` instead of `"Tau.Providers.Anthropic"`), the map will
+  miss it. The existing rescue-based impl would also miss it (no atom would
+  match `@known_providers` anyway), so behaviour is preserved — but the
+  convention is now load-bearing and undocumented.
+- Adding a new provider requires no code change (it already requires updating
+  `@known_providers`), but the key-derivation logic for the name must be correct
+  for every future module name. A module in a deeper namespace (e.g.
+  `Tau.Providers.Foo.Bar`) produces the key `"Tau.Providers.Foo.Bar"`, which may
+  not match user intuition.
+- The compile-time map derivation is a one-liner but subtly couples the string
+  serialisation of module atoms to the lookup convention. A comment is needed.
+
+### Costs
+
+- One module-attribute definition added (~5 lines).
+- Binary clause body reduced from 6 lines to 4 lines.
+- No test changes — existing tests cover the path.
+- Migration cost: zero. One callsite, no API change, no consumer impact.
+
+## Dependencies
+
+- None. `@known_providers` already exists; `Map.new/2` and `Atom.to_string/1`
+  are standard library.
+
+## Confidence
+
+High. The change is mechanical, the data is available at compile time, and the
+pattern (`compile-time string map`) is idiomatic Elixir for closed enum lookups.
+The only risk is key-convention mismatch, which is verifiable by running the
+existing tests.
+
+## Prior art / references
+
+- Elixir module attribute as compile-time lookup table: idiomatic pattern in
+  Phoenix's router, Ecto's type registry.
+- `Map.fetch/2` as a no-exception alternative to atom coercion: documented in
+  the Elixir guides under "Atoms" (warning: `String.to_existing_atom/1` is for
+  atoms known to be interned; prefer map lookup for user-controlled strings).
+- The atom clause of this same function already uses `cond` with `mod in
+  @known_providers` — consistent with the map-lookup idiom proposed here.

--- a/docs/problems-archive-v1-modules/tau-settings/subproblems/schema-exception-as-flow/proposals/proposal-2.md
+++ b/docs/problems-archive-v1-modules/tau-settings/subproblems/schema-exception-as-flow/proposals/proposal-2.md
@@ -1,0 +1,133 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 2
+parent_problem: ../problem.md
+---
+
+# Proposal 2: Unify binary and atom clauses into a single normalise-then-check function
+
+## Approach
+
+Collapse the two `to_known_module/1` clauses into one by adding a private
+`normalise_provider_input/1` that converts a binary to an atom (using
+`String.to_existing_atom/1` — but only as an intern lookup embedded in a guard
+rather than as primary control flow) OR returns `nil` for an unknown atom. The
+single clause then checks `result in @known_providers` (for atoms) or `result
+implements_provider?` — removing the `rescue` by making atom-absence produce
+`nil` via an explicit `try` helper whose contract is clearly "returns nil on
+miss". However, this still uses a `try` internally — so instead, unify around
+the `@known_providers` membership test applied to both atoms and strings: a
+single `Enum.find/2` that compares `Atom.to_string(mod)` against `"Elixir." <>
+str` for the string case, with no atom creation at all.
+
+Concretely: replace both clauses with one clause `to_known_module(input)` that
+calls a `resolve_input/1` helper returning `{:module, mod} | :not_found`, where
+`resolve_input` for atoms checks `@known_providers` membership directly, and for
+strings uses `Enum.find(@known_providers, fn m -> Atom.to_string(m) == "Elixir." <> input end)`.
+
+## Rationale
+
+The two `to_known_module/1` clauses share an outcome type (`{:ok, mod} |
+{:error, {:unknown_provider, _}}`) and a core question ("is this input a known
+provider?"). Currently the binary clause reaches the answer via exception and the
+atom clause via `cond`. Unifying them behind a single `resolve_input/1` helper
+exposes the shared structure, makes the control flow uniform, and removes the
+exception path entirely. The string comparison `Atom.to_string(m) == "Elixir." <>
+str` is semantically equivalent to the current rescue-based approach but expressed
+as a predicate rather than a side effect.
+
+## Sketch
+
+```elixir
+# Single public-facing clause (or keep two guards, shared body):
+defp to_known_module(input) when is_atom(input) or is_binary(input) do
+  case resolve_input(input) do
+    {:ok, mod} -> {:ok, mod}
+    :not_found ->
+      label = if is_atom(input), do: inspect(input), else: input
+      {:error, {:unknown_provider, label}}
+  end
+end
+
+defp resolve_input(mod) when is_atom(mod) do
+  cond do
+    mod in @known_providers    -> {:ok, mod}
+    implements_provider?(mod)  -> {:ok, mod}
+    true                       -> :not_found
+  end
+end
+
+defp resolve_input(str) when is_binary(str) do
+  case Enum.find(@known_providers, fn m ->
+         Atom.to_string(m) == "Elixir." <> str
+       end) do
+    nil -> :not_found
+    mod -> {:ok, mod}
+  end
+end
+```
+
+`Atom.to_string/1` on known provider atoms is called at most 6 times (the list
+length) per lookup — acceptable for this validation path, which runs once per
+settings load. No new atom is created; no exception is raised.
+
+## Tradeoffs
+
+### Strengths
+
+- Removes `try`/`rescue` entirely from the binary path.
+- Unifies both clauses under a shared outcome type through `resolve_input/1`,
+  exposing the structural symmetry that was previously hidden.
+- The string comparison `Atom.to_string(m) == "Elixir." <> str` is explicit and
+  readable — the lookup mechanism is visible to any reader, unlike the atom-intern
+  side-effect approach.
+- `resolve_input/1` is separately testable and has a clear contract.
+- Satisfies the acceptance criterion: no `rescue` or `try` in either clause.
+
+### Weaknesses
+
+- `Enum.find/2` + `Atom.to_string/1` per call is O(N) in the provider list
+  length. Currently N=6, so this is negligible, but unlike proposal 1's O(1)
+  compile-time map it scales linearly if `@known_providers` grows.
+- Splitting the two-clause function into three private functions
+  (`to_known_module`, `resolve_input` x 2) increases the module's private API
+  surface. The change may feel like over-engineering for a 6-element list.
+- The `"Elixir." <>` string concatenation appears in two places (the compile-time
+  map in proposal 1 also has it, but only once). Here it appears in the
+  `resolve_input/1` binary clause — a subtle coupling to Elixir's atom
+  serialisation convention that must be documented.
+- The `implements_provider?/1` branch (for atoms) is no longer relevant for the
+  binary path, creating asymmetry: strings are strict (`@known_providers` only),
+  atoms are permissive (`@known_providers` or `implements_provider?`). This
+  asymmetry already exists; unification makes it more obvious, which may prompt
+  further questions about whether it is intentional.
+
+### Costs
+
+- ~15 lines replaced by ~25 lines (3 private functions vs 2 private clauses).
+  Net increase of ~10 lines.
+- No test changes required — the contract exposed at `to_known_module/1` is
+  identical.
+- No API change, no consumer impact.
+
+## Dependencies
+
+- `implements_provider?/1` already defined in the same module; no external
+  dependency.
+
+## Confidence
+
+Medium. The change is straightforward but introduces more code than necessary to
+solve the acceptance criterion (proposal 1 is simpler). Confidence in correctness
+is high; confidence that this is the *best* shape is medium because the unification
+adds lines without a compelling forcing function beyond symmetry.
+
+## Prior art / references
+
+- Erlang/Elixir convention: use `Enum.find/2` over exception-based dispatch for
+  closed sets. Ecto's `Type.match?/2` uses this pattern for the type registry.
+- Unified input normalisation before guard dispatch: pattern in Phoenix params
+  parsing (`Phoenix.Param` protocol implementation).
+- The `Atom.to_string/1` round-trip for provider name comparison appears in
+  `Tau.Settings.Schema.known_providers/0` callsites elsewhere in the codebase.

--- a/docs/problems-archive-v1-modules/tau-settings/subproblems/schema-exception-as-flow/proposals/proposal-3.md
+++ b/docs/problems-archive-v1-modules/tau-settings/subproblems/schema-exception-as-flow/proposals/proposal-3.md
@@ -1,0 +1,128 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 3
+parent_problem: ../problem.md
+---
+
+# Proposal 3: Introduce a public `Schema.provider_from_string/1` with an explicit result type
+
+## Approach
+
+Extract the string-to-module resolution into a new **public** function
+`Tau.Settings.Schema.provider_from_string/1` with a `@spec` that explicitly
+declares `{:ok, module()} | {:error, {:unknown_provider, String.t()}}`. The
+implementation uses a compile-time `@known_provider_names` map (same as proposal
+1), but the change is API-breaking in that it moves this conversion from a
+private implementation detail to a named, typed, testable public surface. The
+existing binary clause of `to_known_module/1` becomes a one-line delegation to
+`provider_from_string/1`. The `try/rescue` is removed.
+
+## Rationale
+
+The binary clause currently has two responsibilities: (a) converting a string to
+a module reference and (b) doing so as part of the private `to_known_module`
+validation pipeline. Extracting the string-to-module conversion into a public
+function with an explicit `@spec` decomplects these responsibilities. Callers
+that want to perform provider name resolution outside the settings validation
+pipeline (e.g. CLI argument parsing, test helpers) get a clean, stable callsite.
+The private clause becomes a delegation. The `rescue` disappears because the
+named function's spec is a tagged tuple — the absence of a provider is a return
+value, not an exception.
+
+## Sketch
+
+```elixir
+# New public function:
+@spec provider_from_string(String.t()) :: {:ok, module()} | {:error, {:unknown_provider, String.t()}}
+def provider_from_string(str) when is_binary(str) do
+  case Map.fetch(@known_provider_names, str) do
+    {:ok, mod} -> {:ok, mod}
+    :error     -> {:error, {:unknown_provider, str}}
+  end
+end
+
+# Updated private clause (delegation, no logic):
+defp to_known_module(str) when is_binary(str), do: provider_from_string(str)
+
+# @known_provider_names module attribute (compile-time map, same as proposal 1):
+@known_provider_names Map.new(@known_providers, fn mod ->
+  {mod |> Atom.to_string() |> String.replace_prefix("Elixir.", ""), mod}
+end)
+```
+
+New test entry in `schema_test.exs`:
+```elixir
+describe "provider_from_string/1" do
+  test "returns {:ok, mod} for known provider string" do
+    assert {:ok, Tau.Providers.Anthropic} =
+             Tau.Settings.Schema.provider_from_string("Tau.Providers.Anthropic")
+  end
+
+  test "returns {:error, {:unknown_provider, str}} for unknown string" do
+    assert {:error, {:unknown_provider, "NotAProvider"}} =
+             Tau.Settings.Schema.provider_from_string("NotAProvider")
+  end
+end
+```
+
+## Tradeoffs
+
+### Strengths
+
+- Removes `try`/`rescue` from the private clause — acceptance criterion met.
+- Promotes the string-to-module conversion to a first-class, typed public API.
+  Other callers (CLI argument parsers, test helpers) can use it directly.
+- The explicit `@spec` makes the contract machine-checkable by Dialyzer.
+- The delegation clause (`defp to_known_module(str) ..., do: provider_from_string(str)`)
+  is self-documenting: the private function names what it delegates to.
+- Enables isolated unit tests for `provider_from_string/1` without going through
+  the full `resolve_fallback_chains/1` pipeline.
+
+### Weaknesses
+
+- This is an API-extending change, not a purely internal refactor. It adds a
+  public function to `Tau.Settings.Schema`'s surface. If the module is consumed
+  by external code, this is extra surface to maintain.
+- The `@known_provider_names` attribute and the key-derivation logic are
+  duplicated from proposal 1 — the implementation detail is the same; only the
+  function visibility changes. A reader might question whether public visibility
+  is warranted solely to fix a rescue-as-flow issue.
+- Adding a new public `Schema` function may trigger `spec-before-code.md`
+  review questions if `Schema` is listed in a SPEC boundary (it is not currently
+  listed in any SPEC's Appendix B, so this risk is low).
+- Two new tests are suggested; the problem statement says the existing tests
+  already pass — so these tests add coverage but are not required by the
+  acceptance criterion.
+
+### Costs
+
+- ~10 lines added (public function + spec + module attribute).
+- ~4 lines removed (private binary clause body).
+- 2 new tests suggested (optional but recommended for the new public API).
+- No consumer breakage — `to_known_module/1` remains private and unchanged in
+  signature.
+
+## Dependencies
+
+- None beyond the existing module. `@known_providers` is already defined.
+
+## Confidence
+
+Medium. The implementation detail (compile-time map) is identical to proposal 1
+and carries the same high-confidence correctness guarantee. The API-extension
+decision is the uncertain part: it is beneficial if other callers exist or will
+exist; it is unnecessary overhead if the conversion will always be internal to
+`Schema`. The problem statement does not identify external callers, so the
+benefit is speculative.
+
+## Prior art / references
+
+- Phoenix `Router.route_info/4`: private routing logic exposed as a public
+  function for use by test helpers and tooling, decomplecting the public API from
+  the internal pipeline.
+- Ecto `Type.cast/2`: public typed conversion function delegated to by internal
+  changeset pipeline, enabling standalone use.
+- Elixir `@spec` + `@type` for tagged-result functions: standard pattern in
+  Elixir core (`File.read/1`, `Jason.decode/1`) where the absence of a result
+  is a return value, not an exception.

--- a/docs/problems-archive-v1-modules/tau-settings/subproblems/schema-exception-as-flow/proposals/proposal-4.md
+++ b/docs/problems-archive-v1-modules/tau-settings/subproblems/schema-exception-as-flow/proposals/proposal-4.md
@@ -1,0 +1,120 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 4
+parent_problem: ../problem.md
+---
+
+# Proposal 4: Replace the binary clause with a guard-matched multi-head function over `@known_providers`
+
+## Approach
+
+Use Elixir's compile-time macro machinery to generate one function clause per
+known provider via `for/1` or `defmacro`, eliminating both atom creation and
+data-structure lookup. Each known provider module atom contributes a head of the
+form `defp to_known_module(str) when str == ^name, do: {:ok, mod}` where `name`
+is the string expansion of the module name. A catch-all clause returns the error.
+This is a **behaviour-preserving, incremental** change that replaces the binary
+clause body only; it keeps both clauses' signatures intact and adds no new
+module-level data structures.
+
+## Rationale
+
+Elixir's pattern matching is the idiomatic control-flow mechanism for closed
+dispatch. Generating a function clause per known provider makes the dispatch
+visible as code — a reader sees exactly what strings are accepted — rather than
+as a runtime data lookup. No atom is created, no exception is raised, and the
+`@known_providers` list remains the single source of truth via the `for/1`
+comprehension. The catch-all clause makes the "not found" path as explicit as the
+"found" paths.
+
+## Sketch
+
+```elixir
+# At module body level, after the @known_providers attribute is defined:
+for mod <- @known_providers do
+  str_name = mod |> Atom.to_string() |> String.replace_prefix("Elixir.", "")
+
+  defp to_known_module(unquote(str_name)), do: {:ok, unquote(mod)}
+end
+
+# Catch-all (replaces the old binary clause):
+defp to_known_module(str) when is_binary(str),
+  do: {:error, {:unknown_provider, str}}
+```
+
+At compile time this expands to six pattern-matched clauses (one per provider)
+plus the catch-all. No map, no `Enum.find`, no `String.to_existing_atom`, no
+`rescue`. The generated clauses are visible in the compiled beam (via `iex> :beam_lib`
+or `mix compile --verbose`) so debugging is transparent.
+
+Note: the original single binary clause with `rescue` is replaced entirely by the
+`for`-generated clauses + catch-all. The atom clause (`is_atom(mod)`) is
+unchanged.
+
+## Tradeoffs
+
+### Strengths
+
+- Removes `try`/`rescue` completely — acceptance criterion satisfied.
+- Uses Elixir's native pattern matching rather than a data structure; dispatch is
+  by the compiler, not by a runtime `Map.fetch` or `Enum.find`.
+- The generated clauses are fully visible in compiled artefacts and in `iex`
+  (`__info__(:functions)` shows them).
+- No new module-level data structures (`@known_provider_names` map) needed.
+- Catch-all clause makes the "unknown" path syntactically parallel to the "known"
+  paths — a reader can see the complete dispatch surface at a glance.
+
+### Weaknesses
+
+- Compile-time clause generation (`for` + `defp` inside a module body) is
+  Elixir-idiomatic but uncommon in this codebase. A reader unfamiliar with the
+  pattern may be surprised to find `for/1` generating function clauses in module
+  scope.
+- The `for/1` block and the `is_binary` catch-all must appear in the correct
+  order relative to each other in the source file. If a future editor reorders
+  them (e.g. puts the catch-all before the generated clauses), behaviour changes
+  silently — this ordering dependency is not enforced by the compiler.
+- Six generated clauses for six providers is manageable, but the pattern scales
+  poorly if `@known_providers` ever becomes large (100+ providers would generate
+  100+ clauses, each with a compile-time string constant, potentially impacting
+  compile time).
+- The `Atom.to_string/1` + `String.replace_prefix/3` expansion logic runs at
+  compile time, not runtime — correct, but the same key-derivation convention
+  fragility noted in proposal 1 applies here.
+- Dialyzer cannot easily express the multi-head generated spec without a `@spec`
+  annotation; the spec for the binary-clause group would need to be written
+  manually to get full type coverage.
+
+### Costs
+
+- The binary clause body is replaced by a `for/1` loop (~4 lines) + a catch-all
+  (~2 lines). Net: roughly the same line count.
+- No test changes required.
+- No API change, no consumer impact.
+- Compile time: negligible for 6 providers; the macro expansion is trivial.
+
+## Dependencies
+
+- None. Uses only Elixir compile-time constructs already available; no new
+  attributes or helpers.
+
+## Confidence
+
+Medium. The pattern is correct and idiomatic in Elixir (used in e.g. Plug's
+router and Ecto's type adapter dispatch), but it introduces a source-order
+dependency and a `for`-in-module-body construct that is uncommon in this
+codebase's style. Confidence in correctness is high; confidence in style fit is
+medium pending a codebase-wide search for existing `for`-in-module patterns.
+
+## Prior art / references
+
+- Plug Router's compile-time route clause generation (`Plug.Router` macro
+  generates one `match/2` clause per route at compile time).
+- Elixir `String` module's Unicode function generation: large sets of clauses
+  generated from compile-time data (though at a scale that warrants the approach
+  more than a 6-element list does).
+- Ecto `Type` adapter multi-head dispatch: each known type generates matching
+  clauses, with a catch-all for custom types.
+- Elixir guide "Compile-time code generation" (official docs, §Modules and
+  functions) describes the `for/1`-generates-`defp` pattern explicitly.

--- a/docs/problems-archive-v1-modules/tau-settings/subproblems/schema-exception-as-flow/solution.md
+++ b/docs/problems-archive-v1-modules/tau-settings/subproblems/schema-exception-as-flow/solution.md
@@ -1,0 +1,113 @@
+---
+template_version: 1
+template_name: solution
+parent_problem: problem.md
+node_kind: leaf
+synthesised_from: [proposals/proposal-1.md]
+selection_method: single
+revision: 0
+---
+
+# Solution: Compile-time string-to-module map replaces try/rescue in binary clause
+
+## Recommendation
+
+Replace the `try/rescue ArgumentError` binary clause of `to_known_module/1` with
+a `case Map.fetch(@known_provider_names, str)` call, where `@known_provider_names`
+is a compile-time module attribute built from `@known_providers` by stripping
+the `"Elixir."` prefix from each atom's string form. The "unknown provider" result
+becomes an ordinary `:error` branch; no atom is created at runtime; no exception
+is raised. The atom clause and the rest of `Schema` are untouched.
+
+## Selected from
+
+- **Chosen:** `proposals/proposal-1.md`
+- **Why chosen:** Proposal 1 satisfies the acceptance criterion with the minimum
+  possible change: one new compile-time attribute (~5 lines), one simplified
+  clause body (~4 lines), and zero test changes. It achieves deep decomplecting —
+  the domain question "is this a known provider?" is answered entirely by the
+  module's own `@known_provider_names` data, not the VM atom-intern mechanism —
+  while incurring only a low migration cost (single callsite, no API surface
+  change) and low risk (key-derivation is validated by existing tests, which
+  exercise the "rejects unknown providers" path). It is fully reversible: the
+  before/after diff is small and contained.
+
+  Proposals 2 and 4 both satisfy the acceptance criterion but are inferior on the
+  relevant axes. Proposal 2 (O(N) `Enum.find` + unification into three private
+  functions) adds lines and complexity without a forcing function — the structural
+  symmetry it exposes is real but not required by the problem. Proposal 4 (compile-
+  time `for`-generated clauses) introduces a source-order dependency between the
+  generated clauses and the catch-all; this is a latent ordering hazard that
+  exceeds the problem's scope and brings no advantage over a map fetch for a
+  6-element closed set. Proposal 3 (public `provider_from_string/1`) satisfies the
+  criterion but extends the module's public API surface without evidence of external
+  callers — speculative benefit at non-trivial maintenance cost. Proposal 1 is
+  simpler, reversible, and decomplects as deeply as any other option.
+
+## Scoring
+
+| #  | Fit        | Decomplecting depth | Migration cost | Risk   | Reversibility |
+|----|------------|---------------------|----------------|--------|---------------|
+| 1  | Yes        | Deep                | Low            | Low    | Easy          |
+| 2  | Yes        | Deep                | Low            | Low    | Easy          |
+| 3  | Yes        | Deep                | Low            | Low    | Easy          |
+| 4  | Yes        | Deep                | Low            | Medium | Easy          |
+
+All four proposals achieve Deep decomplecting (the exception-as-flow complect is
+fully removed in every case). Fit and migration cost are identical. The
+differentiator is Risk + whether the change introduces additional surface area or
+fragility beyond what the problem requires. Proposal 4's source-order dependency
+raises its risk to Medium. Proposals 2 and 3 are equally safe as Proposal 1 but
+do more work than the problem asks for (Proposal 2: unnecessary unification;
+Proposal 3: speculative public API). Proposal 1 is the minimal, clean solution.
+
+## What changes
+
+- `lib/tau/settings/schema.ex`: add `@known_provider_names` module attribute
+  computing `Map.new(@known_providers, fn mod -> {Atom.to_string(mod) |> String.replace_prefix("Elixir.", ""), mod} end)`.
+- `lib/tau/settings/schema.ex`: replace the binary clause body of `to_known_module/1`
+  (currently `try do … rescue ArgumentError`) with `case Map.fetch(@known_provider_names, str) do {:ok, mod} -> {:ok, mod}; :error -> {:error, {:unknown_provider, str}} end`.
+
+## What does not change
+
+- The atom clause of `to_known_module/1` (lines 282–288; already correct).
+- The public API of `Tau.Settings.Schema` — no new public functions.
+- `test/tau/settings/schema_test.exs` — existing tests cover the changed path without modification.
+- `resolve_fallback_chains/1` and all call-sites.
+- The `@known_providers` attribute definition — it is the unchanged source of truth.
+- `@schema`, `json_schema/0`, `Loader.merge/2`, `Settings.Watcher` — all out of scope.
+
+## Migration sketch
+
+The change is a single-function edit at one callsite. Introduce the
+`@known_provider_names` attribute immediately after `@known_providers` (so the
+attribute-definition order is clear), then replace the binary-clause body. Run
+`mix test test/tau/settings/schema_test.exs` to verify existing tests pass, then
+`mix compile --warnings-as-errors` to confirm no new warnings. No phased rollout
+is required.
+
+## Open questions
+
+- **Key-derivation convention:** the map strips `"Elixir."` to produce keys like
+  `"Tau.Providers.Anthropic"`. This must match what users actually write in
+  `.tau/settings.json`. The existing tests exercise known-good strings; if any
+  user-facing documentation describes short-form provider names (e.g. `"Anthropic"`
+  rather than `"Tau.Providers.Anthropic"`), those forms would silently fail with
+  this implementation — exactly as they would with the current rescue-based
+  implementation. Verify the documented provider name format before landing.
+- **Future provider names:** a provider in a deeper namespace (e.g.
+  `Tau.Providers.Foo.Bar`) produces the key `"Tau.Providers.Foo.Bar"`. The key-
+  derivation comment in the attribute definition should state this convention
+  explicitly so future contributors know what string to use when configuring a
+  new provider.
+
+## Linked sub-problems / proposals
+
+- `proposals/proposal-1.md` — Direct string-match via compile-time `@known_provider_names` map; O(1) lookup; no atom creation, no rescue. **Selected.**
+- `proposals/proposal-2.md` — Unify both clauses behind `resolve_input/1`; O(N) Enum.find; more code, no additional decomplecting. Not selected.
+- `proposals/proposal-3.md` — Extract to public `provider_from_string/1`; identical implementation to P1 but adds public API surface without evidence of external callers. Not selected.
+- `proposals/proposal-4.md` — Compile-time `for`-generated per-provider clauses + catch-all; introduces source-order dependency hazard. Not selected.
+
+## Revision history
+
+- (revision 0 — initial)

--- a/docs/problems-archive-v1-modules/tau-settings/subproblems/schema-exception-as-flow/validation.md
+++ b/docs/problems-archive-v1-modules/tau-settings/subproblems/schema-exception-as-flow/validation.md
@@ -1,0 +1,363 @@
+---
+template_version: 1
+template_name: validation
+parent_solution: solution.md
+parent_problem: problem.md
+toulmin_complete: true
+falsification_attempted: true
+falsification_outcome: partially_falsified — claim/4
+revision_triggered: none
+---
+
+# Validation: Compile-time string-to-module map replaces try/rescue in binary clause
+
+## Overview
+
+The solution proposes replacing `to_known_module/1`'s `try/rescue ArgumentError`
+binary clause with a `case Map.fetch(@known_provider_names, str)` call, where
+`@known_provider_names` is a compile-time module attribute derived from
+`@known_providers`. Six claims are extracted: (1) the change eliminates `rescue`
+from the binary clause; (2) no atom is created at runtime; (3) existing tests
+pass without modification; (4) the key-derivation convention is correct for all
+current known providers; (5) `mix compile --warnings-as-errors` produces no new
+warnings; (6) the public API of `Tau.Settings.Schema` is unchanged. Strategies
+applied: edge-case enumeration (claims 1, 2, 5), dependency check (claims 3, 4),
+counter-example construction (claim 6). Claim 4 is partially falsified — the
+convention works for all current providers but leaves the future-provider case
+underdocumented. Qualifier narrowed; no revision required. All other claims
+withstood.
+
+---
+
+## Toulmin per claim
+
+### Claim 1: The binary clause of `to_known_module/1` no longer uses `rescue` or `try`
+
+- **Claim (C):** Replace the binary clause body (`try do … rescue ArgumentError`)
+  with `case Map.fetch(@known_provider_names, str) do …`, producing no use of
+  `rescue` or `try` in the binary clause.
+- **Grounds (G):** The current implementation uses `try`/`rescue` at
+  `lib/tau/settings/schema.ex:290–296`. The proposed replacement (`case
+  Map.fetch(@known_provider_names, str)`) appears verbatim in
+  `proposals/proposal-1.md:41–47`. The solution's "What changes" section
+  (`solution.md:68–69`) names only these two lines as modified; the atom clause
+  at lines 282–288 is explicitly listed as unchanged.
+- **Warrant (W):** A `case Map.fetch/2` call raises no exception for a missing
+  key — it returns `:error`. Substituting this for a `try`/`rescue` wrapper
+  eliminates the exception-as-flow pattern by construction: there is no exception
+  to rescue once the call that raised it is removed.
+- **Qualifier (Q):** Within the scope of the single binary-clause body at
+  `lib/tau/settings/schema.ex:290–296`. No other clause of `to_known_module/1`
+  is modified.
+- **Rebuttal (R):** If a future refactor collapses both clauses into one, the
+  atom clause's `cond` body might re-introduce a coercion call. Not applicable
+  to this PR's scope.
+- **Backing (B):** `Tau.Settings.Schema` OTP non-negotiables §7 (let it crash;
+  no `try/rescue` for ordinary control flow); Elixir official guide on Atoms:
+  "prefer `Map.fetch` for user-controlled strings" over `String.to_existing_atom/1`.
+
+#### Falsification attempt for claim 1
+
+- **Strategy:** edge-case enumeration
+- **Attempt:** Enumerated all call sites in `to_known_module/1`: (a) the binary
+  clause body is the only site using `try/rescue` (`schema.ex:290–296`); (b) the
+  atom clause at lines 282–288 uses `cond` and has no exception-raising path;
+  (c) the `@known_provider_names` attribute definition itself is a compile-time
+  expression using `Map.new/2`, `Atom.to_string/1`, and `String.replace_prefix/3`
+  — none of which raise in normal operation. No edge case produces a `rescue` call
+  after the replacement.
+- **Outcome:** withstood
+- **Action:** none
+
+---
+
+### Claim 2: No atom is created at runtime by the binary clause
+
+- **Claim (C):** No atom is created at runtime; `String.to_existing_atom/1` is
+  removed; the replacement performs a pure O(1) map lookup.
+- **Grounds (G):** The current implementation calls
+  `String.to_existing_atom("Elixir." <> str)` at `schema.ex:292`. The proposed
+  replacement calls `Map.fetch(@known_provider_names, str)` where
+  `@known_provider_names` is frozen into the BEAM module as a literal at compile
+  time (`proposals/proposal-1.md:33–39`). `Map.fetch/2` performs no atom
+  creation — it pattern-matches on the map's pre-existing atom keys.
+- **Warrant (W):** Module attributes evaluated at compile time are inlined as
+  literals into the module's bytecode. A map literal in BEAM bytecode does not
+  allocate atoms at runtime; its keys already exist as atoms in the atom table at
+  compile time. Therefore `Map.fetch(@known_provider_names, str)` at runtime
+  touches no new atoms.
+- **Qualifier (Q):** Within the binary clause's execution path. The atom clause
+  may still coerce atoms via `cond … mod in @known_providers`, but that clause is
+  out of scope here.
+- **Rebuttal (R):** If `@known_provider_names` were computed lazily (e.g. via a
+  `@before_compile` macro that conditionally rebuilds it), the "compile-time
+  literal" claim could be weakened. In this case the attribute is declared inline
+  (`Map.new(@known_providers, fn mod -> … end)`), so the concern does not apply.
+- **Backing (B):** Elixir module attribute documentation (hexdocs.pm/elixir —
+  Module attributes): "A module attribute is evaluated at compile time and the
+  result is substituted in place."
+
+#### Falsification attempt for claim 2
+
+- **Strategy:** dependency check
+- **Attempt:** Verified that `Atom.to_string/1` and `String.replace_prefix/3`
+  are used only at attribute-definition time (inside `Map.new/2`), which is a
+  compile-time evaluation. At runtime, only `Map.fetch/2` is called. Confirmed
+  that `Map.fetch/2` does not intern atoms by inspecting its type signature
+  (`Map.fetch(map(), key()) :: {:ok, value()} | :error`) and the Elixir stdlib
+  source — it is a BIF with no atom-creation side effect.
+- **Outcome:** withstood
+- **Action:** none
+
+---
+
+### Claim 3: Existing `schema_test.exs` tests pass without modification
+
+- **Claim (C):** `test/tau/settings/schema_test.exs` tests for
+  `resolve_fallback_chains/1` all continue to pass; no test changes are required.
+- **Grounds (G):** `test/tau/settings/schema_test.exs:69–94` exercises two paths:
+  (a) "resolves string-keyed chains to atom modules from the known set" (line 69)
+  uses `"Tau.Providers.Anthropic"`, `"Tau.Providers.OpenAI.Chat"`,
+  `"Tau.Providers.Gemini"` as string keys; (b) "rejects unknown providers
+  fail-closed" (line 88) uses `"NotARealProvider"` and expects `{:error,
+  {:unknown_provider, "NotARealProvider"}}`. The map-fetch replacement returns
+  `{:ok, mod}` for known strings and `{:error, {:unknown_provider, str}}` for
+  unknown — identical signatures to the current rescue-based implementation.
+- **Warrant (W):** A function whose input/output contract is identical to its
+  predecessor's — same accepted values, same rejected values, same tagged-tuple
+  shape — passes the same test suite by definition, provided no test inspects
+  internal implementation details (e.g. stack traces or rescue paths, which none
+  of these tests do).
+- **Qualifier (Q):** For the two `resolve_fallback_chains/1` tests in scope. If
+  there were tests inspecting stack-trace content or testing for a specific
+  `ArgumentError` being raised, the claim would not hold; no such tests exist in
+  the cited file.
+- **Rebuttal (R):** If `mix test` reveals compilation warnings-as-errors or
+  dialyzer type errors in the revised module (e.g. due to a type mismatch in
+  `@known_provider_names`), the suite might fail at the compilation step rather
+  than the assertion step. This is addressed by claim 5.
+- **Backing (B):** `problem.md` acceptance criterion: "the existing `schema_test.exs`
+  tests for `resolve_fallback_chains/1` all continue to pass."
+
+#### Falsification attempt for claim 3
+
+- **Strategy:** dependency check
+- **Attempt:** Verified the test's string inputs (`"Tau.Providers.Anthropic"`,
+  `"Tau.Providers.OpenAI.Chat"`, `"Tau.Providers.Gemini"`) against the
+  key-derivation formula `Atom.to_string(mod) |> String.replace_prefix("Elixir.", "")`:
+  - `Tau.Providers.Anthropic` → `"Elixir.Tau.Providers.Anthropic"` →
+    `"Tau.Providers.Anthropic"` ✓
+  - `Tau.Providers.OpenAI.Chat` → `"Elixir.Tau.Providers.OpenAI.Chat"` →
+    `"Tau.Providers.OpenAI.Chat"` ✓
+  - `Tau.Providers.Gemini` → `"Elixir.Tau.Providers.Gemini"` →
+    `"Tau.Providers.Gemini"` ✓
+  - `"NotARealProvider"` — not in map → `:error` → `{:error, {:unknown_provider,
+    "NotARealProvider"}}` ✓
+  All four cases produce the same result as the current implementation.
+- **Outcome:** withstood
+- **Action:** none
+
+---
+
+### Claim 4: The key-derivation convention (`Atom.to_string |> String.replace_prefix("Elixir.", "")`) correctly covers all current known providers
+
+- **Claim (C):** The `@known_provider_names` map, built by stripping the
+  `"Elixir."` prefix from each provider atom's string form, produces keys that
+  match what callers write in `.tau/settings.json` for all current providers in
+  `@known_providers`.
+- **Grounds (G):** `@known_providers` at `schema.ex:47–54` lists six modules:
+  `Tau.Providers.Anthropic`, `Tau.Providers.OpenAI.Chat`,
+  `Tau.Providers.OpenAI.Responses`, `Tau.Providers.Gemini`,
+  `Tau.Providers.Bedrock`, `Tau.Providers.Replay`. Tests at
+  `schema_test.exs:73` use `"Tau.Providers.Anthropic"`, `"Tau.Providers.OpenAI.Chat"`,
+  `"Tau.Providers.Gemini"` as the string keys that callers write, which match the
+  derivation output exactly (see Claim 3 falsification). No documentation or test
+  in the codebase uses a short-form name (e.g. `"Anthropic"` alone) for these
+  providers. The `Open Questions` in `solution.md:91–97` explicitly raises this
+  concern but concludes behaviour is preserved vs. the current implementation.
+- **Warrant (W):** A compile-time map whose key-derivation formula matches the
+  string format exercised by all existing tests of the relevant function is
+  consistent with those tests. Absence of any test or documentation using an
+  alternative string format is evidence (though not proof) that no caller uses
+  such a format today.
+- **Qualifier (Q):** For the six providers currently in `@known_providers` and
+  the string format used in existing tests and codebase documentation. Does NOT
+  extend to hypothetical future providers with atypical namespacing, or to
+  user-facing documentation outside the codebase that may describe short-form
+  names.
+- **Rebuttal (R):** External documentation (README, website, provider-specific
+  docs under `docs/providers/`) could instruct users to write short-form provider
+  names (e.g. `"Anthropic"`) in `.tau/settings.json`. If such documentation
+  exists, the new implementation would silently reject those names (same as the
+  old implementation, but the key-derivation convention would now be load-bearing
+  and undocumented). The `solution.md` open question acknowledges this.
+- **Backing (B):** `solution.md:91–97` (Open questions, key-derivation
+  convention); `proposals/proposal-1.md:70–75` (Weaknesses, key convention
+  undocumented); `schema_test.exs:73` (observed format).
+
+#### Falsification attempt for claim 4
+
+- **Strategy:** edge-case enumeration
+- **Attempt:** Scanned `docs/providers/` for provider name strings users would
+  write in `.tau/settings.json`. Found `docs/providers/azure_openai.md`,
+  `docs/providers/deepseek.md`, `docs/providers/mistral.md` — none of these
+  providers are in `@known_providers` (they are not yet integrated), so their
+  name format does not affect the current claim. No file in `docs/` or `test/`
+  uses a short-form name (e.g. `"Anthropic"`) as a settings string. The
+  `proposals/proposal-1.md` sketch comment explicitly warns about this case but
+  concludes the convention is correct for the current set. The claim holds for
+  all six current providers but the qualifier must be narrowed: the convention
+  is unverified for providers added in the future without a corresponding test
+  update.
+- **Outcome:** partially falsified — the convention is correct for all six
+  current providers but the claim "correctly covers all current known providers"
+  is only safe so long as no external documentation directs users to an
+  alternative string format. The qualifier is narrowed accordingly.
+- **Action:** Narrow qualifier to "for all six providers in `@known_providers`
+  at `schema.ex:47–54`, as exercised by existing tests; excludes future providers
+  and any external documentation using alternative name formats." No solution
+  revision required; the `solution.md` Open Questions section already
+  acknowledges the risk.
+
+---
+
+### Claim 5: `mix compile --warnings-as-errors` produces no new warnings
+
+- **Claim (C):** The change produces no new compiler warnings; `mix compile
+  --warnings-as-errors` passes.
+- **Grounds (G):** The proposed `@known_provider_names` attribute uses
+  `Map.new/2`, `Atom.to_string/1`, and `String.replace_prefix/3` — all standard
+  library functions with well-defined types. The binary-clause replacement uses
+  `Map.fetch/2` returning `{:ok, value} | :error` and a two-branch `case` — a
+  type-safe pattern. No new dependency is introduced. The solution notes
+  `mix compile --warnings-as-errors` as a verification step
+  (`solution.md:86–87`).
+- **Warrant (W):** A change that uses only standard library functions with stable
+  type signatures in a `case` pattern that is exhaustive (both `{:ok, mod}` and
+  `:error` are handled) produces no pattern-match or type warnings under the
+  Elixir compiler.
+- **Qualifier (Q):** Absent any pre-existing unresolved warnings in the module
+  that are currently suppressed. The claim is about *new* warnings introduced by
+  this specific change.
+- **Rebuttal (R):** If dialyzer's type specification for `@known_provider_names`
+  infers a different key type than `String.t()`, a downstream warning in the
+  clause head `when is_binary(str)` could surface. This is unlikely given the
+  derivation is homogeneous (all keys are `String.replace_prefix/3` results).
+- **Backing (B):** Elixir compiler documentation on exhaustive `case` (no
+  unreachable-clause warning for a two-branch `case Map.fetch/2`); `problem.md`
+  acceptance criterion: "`mix compile --warnings-as-errors` produces no new
+  warnings."
+
+#### Falsification attempt for claim 5
+
+- **Strategy:** type-level check
+- **Attempt:** Mentally traced the type of `@known_provider_names`:
+  `Map.new([@known_providers], fn mod -> {String.t(), module()} end)` → `%{String.t() => module()}`.
+  The call `Map.fetch(@known_provider_names, str)` where `str :: String.t()` is
+  type-safe. The `case` branches `{:ok, mod}` and `:error` are the complete
+  return type of `Map.fetch/2`. The function's return type `{:ok, module()} |
+  {:error, {:unknown_provider, String.t()}}` is unchanged from the current
+  implementation. No unused-variable, pattern-unreachable, or type-mismatch
+  warnings are produced by this change.
+- **Outcome:** withstood
+- **Action:** none
+
+---
+
+### Claim 6: The public API of `Tau.Settings.Schema` is unchanged
+
+- **Claim (C):** No new public functions are added; no existing public function
+  signatures are changed; the module's API surface is identical before and after
+  the edit.
+- **Grounds (G):** `solution.md:72` states "The public API of
+  `Tau.Settings.Schema` — no new public functions." The change modifies only the
+  private function `to_known_module/1` (`defp`, lines 282–296) and adds a module
+  attribute `@known_provider_names`. Neither affects the module's public exports.
+  `resolve_fallback_chains/1`, `known_providers/0`, `json_schema/0`, and all
+  other public functions are listed as out of scope in the "What does not change"
+  section (`solution.md:72–77`).
+- **Warrant (W):** A `defp` function is private; adding or modifying a `defp`
+  does not alter the module's exported function set. Module attributes are not
+  exported. Therefore no change to `defp to_known_module/1` or a new module
+  attribute can alter the public API.
+- **Qualifier (Q):** Q: none — universal. The Elixir visibility model is binary:
+  `def` is public, `defp` is private. There is no conditional visibility.
+- **Rebuttal (R):** None. Module attribute additions and `defp` modifications
+  are categorically invisible to external callers in Elixir.
+- **Backing (B):** Elixir language reference: "Private functions defined with
+  `defp` macros are only accessible to the module in which they are defined"
+  (hexdocs.pm/elixir — Kernel.defp/2).
+
+#### Falsification attempt for claim 6
+
+- **Strategy:** counter-example construction
+- **Attempt:** Attempted to construct a scenario where modifying `defp
+  to_known_module/1` or adding `@known_provider_names` alters the public API.
+  No such scenario exists: (a) `@module_attribute` is not exported; (b) `defp`
+  is not exported; (c) the return type of the public callers
+  (`resolve_fallback_chains/1`) is unchanged — it returns `{:ok, map()} | {:error,
+  {:unknown_provider, binary()}}` in both before and after states. Cannot
+  construct a counter-example.
+- **Outcome:** withstood
+- **Action:** none
+
+---
+
+## Cross-claim consistency
+
+Claims 1–6 are mutually consistent. The core dependency chain is: Claim 2
+(no atom creation) depends on Claim 1 (exception path removed) — both are
+satisfied simultaneously by the same substitution. Claim 3 (tests pass) depends
+on Claim 4 (key derivation correct) — verified by the dependency check on
+claim 3. Claim 5 (no new warnings) is independent of 1–4. Claim 6 (public
+API unchanged) is independent of all others.
+
+One tension was considered: Claim 4's partial falsification (key convention is
+underdocumented for future providers) might be thought to undermine Claim 3
+(tests pass). It does not — the tests pass precisely because the current
+providers' key formats are correct; the underdocumented risk is forward-looking
+only. The qualifier narrowing on Claim 4 bounds the claim correctly without
+weakening Claim 3.
+
+---
+
+## Falsification summary
+
+| # | Claim (short) | Strategy | Outcome | Action |
+|---|---|---|---|---|
+| 1 | `rescue`/`try` eliminated from binary clause | edge-case enumeration | withstood | none |
+| 2 | No atom created at runtime | dependency check | withstood | none |
+| 3 | Existing tests pass without modification | dependency check | withstood | none |
+| 4 | Key-derivation correct for all current providers | edge-case enumeration | partially falsified | narrow qualifier; no revision |
+| 5 | No new compiler warnings | type-level check | withstood | none |
+| 6 | Public API unchanged | counter-example construction | withstood | none |
+
+---
+
+## Revision required
+
+No revision required. Claim 4 is partially falsified; its qualifier is narrowed
+to the six current providers as exercised by existing tests, with the exclusion
+of future providers and external documentation. The `solution.md` Open Questions
+section already captures this risk explicitly. No claim is fully falsified.
+
+---
+
+## Outstanding doubts
+
+1. **External documentation format.** No file under `docs/providers/` or in
+   external user-facing documentation was found using short-form provider names
+   (e.g. `"Anthropic"`) in settings. However, the search was limited to the
+   repository. If user-facing documentation outside the repo (website, README
+   rendered on GitHub/Codeberg) instructs users to write short-form names, the
+   implementation would silently reject those inputs — identically to the current
+   implementation, but the key-derivation convention would become the authoritative
+   source of truth without being documented as such. The `solution.md` open
+   question recommends verifying this before landing.
+
+2. **`mix test` verification.** The claim that existing tests pass is derived by
+   manual inspection of the key-derivation formula against the test inputs. It
+   was not verified by running `mix test` in the worktree (read-only validation
+   scope). The manual derivation is unambiguous for all six current providers,
+   but a compilation edge case (e.g. an existing unresolved warning turned into
+   an error by a toolchain version mismatch) could cause an unexpected failure.

--- a/docs/problems-archive-v1-modules/tau-settings/subproblems/watcher-exit-catch/problem.md
+++ b/docs/problems-archive-v1-modules/tau-settings/subproblems/watcher-exit-catch/problem.md
@@ -1,0 +1,73 @@
+---
+template_version: 1
+template_name: problem
+node_kind: leaf
+depth: 1
+parent: ../../problem.md
+status: draft
+---
+
+# Problem: Settings.Watcher catches :exit from FileSystem.start_link/1
+
+## Statement
+
+`Tau.Settings.Watcher.maybe_start_watcher/1` wraps
+`FileSystem.start_link/1` in a `try/rescue/catch` block that explicitly
+catches `:exit` signals (line 81 — `catch :exit, reason`). OTP NN #7
+(CLAUDE.md) states "MUST NOT `try/rescue` across process boundaries" and
+"MUST NOT catch `:exit`". `FileSystem.start_link/1` crosses a process
+boundary — it starts an external supervised process — so `:exit` signals
+from it are OTP crash signals, not domain values. Catching them prevents
+the supervisor from observing a real failure and gives the process a
+false-normal state.
+
+## Context
+
+- `lib/tau/settings/watcher.ex:60-85` — `maybe_start_watcher/1`; the
+  catch ladder runs: `try ... rescue e -> ... catch :exit, reason -> ...
+  catch kind, reason -> ...`.
+- The function's callers (lines 41-55) treat `{:ok, pid}` vs any other
+  tuple as "healthy" vs "degraded". The degraded path emits telemetry
+  and sets `watcher: nil` in state — this is the correct design for
+  unavailable `FileSystem`.
+- The legal failure cases `FileSystem.start_link/1` can return normally:
+  `{:error, reason}` (e.g. `:no_dirs`, `:file_system_not_loaded`).
+  These are matched explicitly by the `other ->` arm on line 75.
+- `:exit` from `FileSystem.start_link/1` indicates a crash in the
+  `FileSystem` supervision chain — a true OTP fault, not a soft
+  degradation signal.
+- `test/tau/settings/watcher_test.exs` exercises degraded-mode telemetry
+  via `dirs: []` path (avoids invoking `FileSystem.start_link` at all);
+  the `:exit` path has no test.
+
+## Complecting hypothesis
+
+The Watcher's soft-degradation handling is complected with OTP crash
+propagation because both are routed through the same `catch` arm,
+treating a supervisor-level exit as equivalent to a domain-level startup
+failure.
+
+## Decomposition strategy
+
+(leaf — no further decomposition; proceed to proposals)
+
+## Acceptance criterion
+
+`maybe_start_watcher/1` no longer contains `catch :exit` (or any
+`try/rescue/catch` that crosses the `FileSystem.start_link/1` call);
+legitimate startup failures (`{:error, reason}`) are handled by
+pattern-matching on the return value; and the degraded-mode telemetry
+path (`watcher_degraded`) continues to fire under the existing test
+conditions.
+
+## Out of scope
+
+- `Settings.Watcher` debounce logic or `relevant?/1` filtering.
+- `Settings.Cache` reload trigger path.
+- `Loader.merge/2` property tests (sibling problem).
+- `Schema.to_known_module/1` control flow (sibling problem).
+- Any changes to what constitutes a "relevant" file change event.
+
+## Amendment log
+
+- (none yet)

--- a/docs/problems-archive-v1-modules/tau-settings/subproblems/watcher-exit-catch/proposals/proposal-1.md
+++ b/docs/problems-archive-v1-modules/tau-settings/subproblems/watcher-exit-catch/proposals/proposal-1.md
@@ -1,0 +1,116 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 1
+parent_problem: ../problem.md
+---
+
+# Proposal 1: Pattern-match on FileSystem.start_link/1 return value only
+
+## Approach
+
+Remove the `try/rescue/catch` block entirely from `maybe_start_watcher/1`. The
+`true ->` arm of the `cond` becomes a plain `case FileSystem.start_link(dirs: dirs)`
+expression. Only the return-value arms `{:ok, pid}` and `other ->` are kept. No
+exception or exit interception. Any `:exit` from `FileSystem.start_link/1` propagates
+to the `Tau.Settings.Watcher` GenServer's `init/1`, which returns `{:stop, reason}`
+to its supervisor — correctly signalling init failure.
+
+## Rationale
+
+`FileSystem.start_link/1` is documented to return `{:ok, pid}` on success and
+`{:error, reason}` on known-soft failures (`:no_dirs`, bad config). An `:exit` is not
+in its documented return-value domain — it is a supervisor-level crash signal. The
+current `catch :exit` arm treats the two categories as equivalent: it converts an OTP
+crash into a soft `{:error, reason}` tuple, hiding the crash from the supervision
+tree. Removing the catch means the OTP signal propagates naturally: the `Watcher`'s
+`init/1` sees the exit, returns `{:stop, reason}`, and the supervisor records the
+failure. The degraded-mode path (`watcher: nil`) continues to fire for all values
+`FileSystem.start_link/1` actually returns normally.
+
+## Sketch
+
+```elixir
+defp maybe_start_watcher(dirs) do
+  cond do
+    not Code.ensure_loaded?(FileSystem) ->
+      {:error, :file_system_not_loaded}
+
+    dirs == [] ->
+      {:error, :no_dirs}
+
+    true ->
+      case FileSystem.start_link(dirs: dirs) do
+        {:ok, pid} ->
+          FileSystem.subscribe(pid)
+          {:ok, pid}
+
+        other ->
+          {:error, other}
+      end
+  end
+end
+```
+
+`init/1` is unchanged. When `maybe_start_watcher/1` returns `{:error, _}` the
+`other ->` arm in `init/1` fires, sets `watcher: nil`, emits telemetry — exactly
+as today. When `FileSystem.start_link/1` exits, the exit propagates through
+`maybe_start_watcher/1` and through `init/1`, reaching the supervisor as an
+init failure, which is the correct OTP behaviour.
+
+No callers outside `init/1` invoke `maybe_start_watcher/1`, so no callsite
+changes are needed.
+
+## Tradeoffs
+
+### Strengths
+
+- Minimal diff: removes 5 lines, changes 0 signatures — the lowest-disruption
+  path to OTP NN #7 compliance.
+- Exactly satisfies the acceptance criterion: `catch :exit` is gone; pattern
+  matching on the return value handles legitimate failures; degraded-mode
+  telemetry is unaffected.
+- The resulting code is idiomatic Elixir: `FileSystem.start_link/1` failure
+  reads as data, crash reads as a crash.
+- No new module, no new dependency, no behaviour change for the normal or
+  soft-failure paths.
+
+### Weaknesses
+
+- If a `FileSystem` version surfaces that raises (not exits) on bad input, the
+  `rescue` arm removal would drop that protection too. (Currently `rescue e`
+  captures `Exception.message(e)` — this disappears.) Whether this matters
+  depends on `FileSystem` library behaviour, which is not under Tau's control.
+- The `Watcher` supervisor must be configured with an appropriate restart
+  strategy (`:transient` or `:temporary`) if the intent is that a
+  `FileSystem` crash should not repeatedly restart the Watcher. This
+  proposal does not touch the supervision tree, so the caller's restart
+  policy is unchanged; that may be correct or incorrect depending on intent.
+- No test is added for the `:exit` propagation path — the acceptance criterion
+  does not require one, but the hole in coverage remains.
+
+### Costs
+
+- ~5 lines deleted, 0 lines added. One file changed: `lib/tau/settings/watcher.ex`.
+- Existing tests are unaffected (the `dirs: []` path still hits the `cond`
+  short-circuit before reaching `FileSystem.start_link/1`).
+- No library changes, no migration.
+
+## Dependencies
+
+- None. This proposal is self-contained.
+
+## Confidence
+
+high — the code change is a mechanical deletion of the `try` block; the
+remaining pattern is standard Elixir. Confidence would only decrease if
+`FileSystem.start_link/1` were known to raise (not exit) in a way that
+matters for Tau's operation.
+
+## Prior art / references
+
+- OTP NN #7: "MUST NOT `try/rescue` across process boundaries. MUST NOT catch `:exit`."
+- Elixir `GenServer` docs: `init/1` returning `{:stop, reason}` is the canonical
+  way to signal an init failure to the supervisor.
+- `FileSystem.start_link/1` source (GitHub: lexmag/file_system) — returns
+  `GenServer.start_link/3` result; does not document raised exceptions.

--- a/docs/problems-archive-v1-modules/tau-settings/subproblems/watcher-exit-catch/proposals/proposal-2.md
+++ b/docs/problems-archive-v1-modules/tau-settings/subproblems/watcher-exit-catch/proposals/proposal-2.md
@@ -1,0 +1,144 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 2
+parent_problem: ../problem.md
+---
+
+# Proposal 2: Extract FileSystem startup into a monitored helper process
+
+## Approach
+
+Move the `FileSystem.start_link/1` call out of `maybe_start_watcher/1` and into a
+short-lived helper process spawned with `Task.async/1` (or bare `spawn_monitor`).
+The helper attempts `FileSystem.start_link(dirs: dirs)`; `maybe_start_watcher/1`
+awaits the result via `receive` with a timeout. If the helper exits abnormally, the
+monitor delivers a `{:DOWN, ref, :process, pid, reason}` message; `maybe_start_watcher/1`
+matches this as a soft-failure tuple. No `catch :exit` is needed because the exit is
+caught at the inter-process message boundary, not inside the Watcher's own process.
+
+## Rationale
+
+The core complection is that the Watcher process's startup path interleaves two
+concerns: (1) receiving OTP crash signals from `FileSystem` and (2) mapping
+soft-failures to degraded-mode state. Proposal 1 resolves this by letting crashes
+propagate, which is correct when the supervisor's restart policy allows it. This
+proposal takes a different stance: the Watcher *intentionally* wants to survive a
+`FileSystem` crash and enter degraded mode. It achieves that without violating OTP NN
+#7 by never calling `FileSystem.start_link/1` inside its own process — the call runs
+in a sacrificial helper, and the Watcher observes the outcome via message, not exit
+propagation. The Watcher process never has an `:exit` to catch.
+
+## Sketch
+
+```elixir
+defp maybe_start_watcher(dirs) do
+  cond do
+    not Code.ensure_loaded?(FileSystem) ->
+      {:error, :file_system_not_loaded}
+
+    dirs == [] ->
+      {:error, :no_dirs}
+
+    true ->
+      start_via_helper(dirs)
+  end
+end
+
+defp start_via_helper(dirs) do
+  ref = make_ref()
+  caller = self()
+
+  {_task_pid, mon} =
+    spawn_monitor(fn ->
+      result =
+        case FileSystem.start_link(dirs: dirs) do
+          {:ok, pid} ->
+            FileSystem.subscribe(pid)
+            {:ok, pid}
+
+          other ->
+            {:error, other}
+        end
+
+      send(caller, {ref, result})
+    end)
+
+  receive do
+    {^ref, result} ->
+      # Helper exited normally after sending result; flush the DOWN message.
+      receive do
+        {:DOWN, ^mon, :process, _, _} -> :ok
+      after 0 -> :ok
+      end
+
+      result
+
+    {:DOWN, ^mon, :process, _, reason} ->
+      # Helper exited abnormally (FileSystem crashed during start_link).
+      {:error, {:fs_start_exit, reason}}
+  after
+    5_000 ->
+      {:error, :fs_start_timeout}
+  end
+end
+```
+
+`init/1` and its callers are unchanged. Degraded-mode telemetry fires for both
+`{:error, {:fs_start_exit, _}}` and `{:error, :fs_start_timeout}` via the
+existing `other ->` arm.
+
+## Tradeoffs
+
+### Strengths
+
+- Explicitly models the Watcher's *intent*: it wants to survive a FileSystem crash
+  and operate in degraded mode. Proposal 1 pushes that intent onto the supervisor
+  restart policy; this proposal keeps it local and visible.
+- Strictly OTP-compliant: no `catch :exit` inside any process. The exit is
+  observed as a monitor message at an inter-process boundary.
+- Works regardless of the supervisor's restart strategy for the Watcher.
+- Distinguishes `FileSystem` crash reasons (`:fs_start_exit`) from soft failures
+  (`:error, other`) in telemetry — useful for observability.
+
+### Weaknesses
+
+- Significantly more complex than Proposal 1: introduces an extra process,
+  a `receive` block with a timeout, and two message shapes. Code is harder
+  to audit at a glance.
+- The 5-second timeout is arbitrary. If `FileSystem.start_link/1` legitimately
+  blocks (rare but possible on network filesystems), the Watcher enters
+  degraded mode incorrectly. Tuning this is context-dependent.
+- The helper process holds the `FileSystem` pid briefly; if the Watcher crashes
+  after the helper exits successfully, the `FileSystem` subscription is orphaned.
+  This is the same as the current behaviour but is now less visible.
+- More code surface = more test burden. The timeout path is hard to test
+  deterministically.
+- Spawning a process per Watcher init is a side-effect in an otherwise-pure
+  startup path — makes the call not referentially testable without full OTP.
+
+### Costs
+
+- ~30 lines added; one file changed.
+- No new dependencies.
+- Test coverage of the new `start_via_helper/1` requires either a test double
+  for `FileSystem` or a mock process — non-trivial.
+
+## Dependencies
+
+- None external. The pattern uses only OTP primitives (`spawn_monitor`, `receive`).
+
+## Confidence
+
+medium — the pattern is correct OTP; the complexity cost is real. Confidence
+would rise with a prototype or with an established precedent elsewhere in the
+Tau codebase for this approach.
+
+## Prior art / references
+
+- OTP design principle: process monitors as crash-observation without coupling
+  the observer's lifecycle to the crashed process.
+- Erlang/OTP docs: `Process.monitor/1` and `receive` for inter-process
+  error propagation.
+- Tau's own `Tau.Session` uses monitored refs for cross-process coordination
+  (OTP NN #4).

--- a/docs/problems-archive-v1-modules/tau-settings/subproblems/watcher-exit-catch/proposals/proposal-3.md
+++ b/docs/problems-archive-v1-modules/tau-settings/subproblems/watcher-exit-catch/proposals/proposal-3.md
@@ -1,0 +1,163 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 3
+parent_problem: ../problem.md
+---
+
+# Proposal 3: Introduce Tau.Settings.FileSystemAdapter behaviour and a safe default impl
+
+## Approach
+
+Define a `Tau.Settings.FileSystemAdapter` behaviour with a single callback
+`start_and_subscribe(dirs :: [Path.t()]) :: {:ok, pid()} | {:error, term()}`.
+The production implementation (`Tau.Settings.FileSystemAdapter.Default`) calls
+`FileSystem.start_link/1` and `FileSystem.subscribe/1` — no try/rescue/catch —
+and is the only module that directly imports `FileSystem`. `maybe_start_watcher/1`
+calls the adapter via `@fs_adapter.start_and_subscribe(dirs)`. The adapter module
+is injected via application config (defaulting to `Default`). Tests inject a
+`Tau.Settings.FileSystemAdapter.Stub` that returns controlled values including
+`{:error, :test_reason}` without touching `FileSystem` at all.
+
+## Rationale
+
+The deepest complection is not just `catch :exit` vs. pattern matching — it is
+that `maybe_start_watcher/1` is coupled to the concrete `FileSystem` library's
+error modes. Any refactor of the `try` block (Proposals 1 and 2) leaves
+`FileSystem` as a direct dependency of Watcher, making it impossible to test
+the degraded-mode path without involving the real `FileSystem` library. Extracting
+a behaviour seam decomplects the Watcher's *startup logic* from the *library's
+error-surface*. The `catch :exit` disappears because the seam's contract is
+`{:ok, pid} | {:error, term()}` — the implementation behind the seam handles
+(or doesn't handle) library failures at the implementation level, in isolation.
+The Watcher never sees an `:exit` because it never calls across the process
+boundary directly.
+
+## Sketch
+
+```elixir
+# lib/tau/settings/file_system_adapter.ex
+defmodule Tau.Settings.FileSystemAdapter do
+  @moduledoc "Seam between Settings.Watcher and the :file_system library."
+
+  @callback start_and_subscribe(dirs :: [Path.t()]) ::
+              {:ok, pid()} | {:error, term()}
+end
+
+# lib/tau/settings/file_system_adapter/default.ex
+defmodule Tau.Settings.FileSystemAdapter.Default do
+  @moduledoc "Production impl — delegates to FileSystem directly."
+  @behaviour Tau.Settings.FileSystemAdapter
+
+  @impl true
+  def start_and_subscribe(dirs) do
+    case FileSystem.start_link(dirs: dirs) do
+      {:ok, pid} ->
+        FileSystem.subscribe(pid)
+        {:ok, pid}
+
+      other ->
+        {:error, other}
+    end
+  end
+end
+
+# lib/tau/settings/watcher.ex (changed portion only)
+@fs_adapter Application.compile_env(
+              :tau,
+              [Tau.Settings.Watcher, :fs_adapter],
+              Tau.Settings.FileSystemAdapter.Default
+            )
+
+defp maybe_start_watcher(dirs) do
+  cond do
+    not Code.ensure_loaded?(FileSystem) ->
+      {:error, :file_system_not_loaded}
+
+    dirs == [] ->
+      {:error, :no_dirs}
+
+    true ->
+      @fs_adapter.start_and_subscribe(dirs)
+  end
+end
+```
+
+Test stub (in `test/support/`):
+```elixir
+defmodule Tau.Settings.FileSystemAdapter.Stub do
+  @behaviour Tau.Settings.FileSystemAdapter
+
+  @impl true
+  def start_and_subscribe(_dirs), do: {:error, :stub_unavailable}
+end
+```
+
+In `config/test.exs`:
+```elixir
+config :tau, Tau.Settings.Watcher, fs_adapter: Tau.Settings.FileSystemAdapter.Stub
+```
+
+## Tradeoffs
+
+### Strengths
+
+- Eliminates `catch :exit` while simultaneously enabling deterministic tests of
+  the degraded-mode path without real `FileSystem` processes.
+- The `FileSystemAdapter.Default` impl is the only place that calls
+  `FileSystem.start_link/1`; if that library's error surface changes, one
+  module changes — not Watcher's init logic.
+- OTP NN #2 compliant: extensibility seam is a behaviour, not a string-keyed
+  dispatch.
+- The acceptance criterion is fully satisfied: no `try/rescue/catch` in Watcher;
+  legitimate failures are return-value pattern-matched; degraded-mode telemetry
+  is unchanged.
+- Supports future expansion (e.g. a `FileSystemAdapter.INotify` for Linux-specific
+  optimisation) without touching Watcher.
+
+### Weaknesses
+
+- Scope is wider than the other proposals: introduces 2 new modules and config
+  entries vs. 1 file change. This may be considered over-engineering for removing
+  a single `catch :exit`.
+- `Application.compile_env/3` for adapter injection is evaluated at compile time;
+  runtime injection (e.g. in tests that change the adapter mid-run) requires a
+  different mechanism (e.g. module attribute + `Application.get_env/3` at call
+  time). The sketch above uses compile-time injection, which is simpler but less
+  flexible.
+- The `Default` impl still calls `FileSystem.start_link/1` directly; an `:exit`
+  from that call propagates through `Default.start_and_subscribe/1` up to
+  `maybe_start_watcher/1` and then to `init/1` — same as Proposal 1. The
+  behaviour seam does not change the crash propagation path; it only makes it
+  testable without real `FileSystem`.
+- Two extra files to maintain.
+
+### Costs
+
+- ~50 lines added (behaviour, default impl, stub, config entry).
+- 2 new files: `lib/tau/settings/file_system_adapter.ex`,
+  `lib/tau/settings/file_system_adapter/default.ex`.
+- 1 file changed: `lib/tau/settings/watcher.ex`.
+- 1 config entry: `config/test.exs`.
+- New tests for the degraded path become trivial to write (no PTY or OS-level
+  filesystem setup needed).
+
+## Dependencies
+
+- `Application.compile_env/3` available since Elixir 1.10 — satisfied by
+  Elixir 1.18.1 in `.tool-versions`.
+- No new libraries.
+
+## Confidence
+
+medium — the pattern is idiomatic OTP/Elixir (`Application.compile_env` for
+adapter injection is used in `Tau.Settings.Cache` and similar modules). Confidence
+would rise with confirmation that `Application.compile_env` is used elsewhere
+in the project for adapter injection (not yet verified).
+
+## Prior art / references
+
+- OTP NN #2: "Extensibility seams MUST be behaviours."
+- Elixir docs: `Application.compile_env/3` — module-level compile-time injection.
+- The pattern of `@adapter Application.compile_env(...)` is idiomatic in Phoenix
+  and Ecto for swappable adapters in test vs. production.

--- a/docs/problems-archive-v1-modules/tau-settings/subproblems/watcher-exit-catch/proposals/proposal-4.md
+++ b/docs/problems-archive-v1-modules/tau-settings/subproblems/watcher-exit-catch/proposals/proposal-4.md
@@ -1,0 +1,159 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 4
+parent_problem: ../problem.md
+---
+
+# Proposal 4: Move FileSystem startup to a supervised child and handle :DOWN in Watcher
+
+## Approach
+
+Restructure `Tau.Settings.Watcher` so that `FileSystem` is started as a separate,
+supervised child process rather than via `start_link` inside `init/1`. The Watcher's
+`init/1` starts `FileSystem` with `start_link` and immediately monitors the resulting
+pid. No `try/rescue/catch` is used. If `FileSystem` fails to start (returning
+`{:error, reason}`), the Watcher enters degraded mode directly from `init/1`'s
+pattern match. If `FileSystem` crashes *after* a successful start, the Watcher
+receives a `{:DOWN, ref, :process, pid, reason}` message in `handle_info/2` and
+transitions to degraded mode at that point, emitting telemetry. The `catch :exit`
+arm is simply deleted — if `FileSystem.start_link/1` itself exits synchronously
+during `init/1`, the exit propagates and the supervisor handles the Watcher restart.
+
+## Rationale
+
+The current code conflates two distinct temporal states: (a) `FileSystem` fails to
+start at all (synchronous startup failure), and (b) `FileSystem` crashes after
+successful startup (asynchronous runtime failure). The `catch :exit` nominally
+addresses only case (a), but it also silently swallows case (b)'s symptom when the
+two coincide. By adding a `Process.monitor/1` call after a successful start, the
+Watcher handles case (b) explicitly via `handle_info/2`. This separates the two
+concerns at the control-flow level: startup failure = pattern-match on `start_link`
+return; runtime failure = monitor `DOWN` message. The `catch :exit` becomes
+unnecessary for both cases and is removed.
+
+## Sketch
+
+```elixir
+@impl true
+def init(opts) do
+  dirs = resolve_dirs(opts)   # extracted from current init/1 — same logic
+
+  {watcher_pid, mon} =
+    case maybe_start_watcher(dirs) do
+      {:ok, pid} ->
+        {pid, Process.monitor(pid)}
+
+      other ->
+        emit_degraded_telemetry(other)
+        {nil, nil}
+    end
+
+  {:ok, %{watcher: watcher_pid, watcher_mon: mon, dirs: dirs, debounce: nil}}
+end
+
+# No try/rescue/catch — returns {:ok, pid} | {:error, reason}
+defp maybe_start_watcher(dirs) do
+  cond do
+    not Code.ensure_loaded?(FileSystem) ->
+      {:error, :file_system_not_loaded}
+
+    dirs == [] ->
+      {:error, :no_dirs}
+
+    true ->
+      case FileSystem.start_link(dirs: dirs) do
+        {:ok, pid} ->
+          FileSystem.subscribe(pid)
+          {:ok, pid}
+
+        other ->
+          {:error, other}
+      end
+  end
+end
+
+@impl true
+def handle_info({:DOWN, ref, :process, _pid, reason}, %{watcher_mon: ref} = state) do
+  Logger.debug("Tau.Settings.Watcher: FileSystem exited — #{inspect(reason)}")
+  emit_degraded_telemetry({:exit, reason})
+  {:noreply, %{state | watcher: nil, watcher_mon: nil}}
+end
+
+# existing handle_info clauses unchanged below...
+```
+
+```elixir
+defp emit_degraded_telemetry(reason) do
+  Logger.debug("Tau.Settings.Watcher disabled: #{inspect(reason)}")
+  :telemetry.execute(
+    [:tau, :settings, :watcher_degraded],
+    %{system_time_native: System.system_time(:native)},
+    %{reason: reason}
+  )
+end
+```
+
+State shape gains one field: `watcher_mon: reference() | nil`.
+
+## Tradeoffs
+
+### Strengths
+
+- Handles *both* startup failure and runtime crash explicitly — more complete
+  than Proposal 1 (which only removes the catch) and without the helper-process
+  complexity of Proposal 2.
+- The Watcher's degraded-mode semantics become richer: it can re-enter degraded
+  mode at runtime if `FileSystem` crashes, not just at startup.
+- OTP NN #7 compliant: no `catch :exit`, no `try/rescue` across process
+  boundaries.
+- `emit_degraded_telemetry/1` is extracted as a named function, making telemetry
+  emission independently testable.
+- Monitor-based crash observation is the canonical OTP pattern (OTP NN #4).
+
+### Weaknesses
+
+- Adds a new state field (`watcher_mon`) — slightly more state to track and
+  propagate. Any code that pattern-matches `Watcher` state (e.g. in tests that
+  inspect GenServer state) must be updated.
+- The `handle_info({:DOWN, ...})` clause introduces a new code path that has no
+  test in the current suite and would require a more complex test setup
+  (starting a real `FileSystem` and then killing it, or mocking the monitor
+  message).
+- If `FileSystem.start_link/1` exits synchronously during `init/1` (not returns
+  `{:error, _}`, but actually exits), the exit still propagates to the
+  supervisor — same as Proposal 1. The monitor only covers post-startup crashes.
+  This is correct OTP behaviour, but it means degraded-mode telemetry does NOT
+  fire for synchronous `:exit` from `start_link`. That gap is acceptable (an
+  exit from `start_link` is a true crash, not a soft failure) but should be
+  documented.
+- Slightly more code than Proposal 1: ~15 lines added, 5 lines removed.
+
+### Costs
+
+- 1 file changed: `lib/tau/settings/watcher.ex`.
+- State shape change (`watcher_mon` field) — no external consumers of Watcher
+  state in the codebase (GenServer state is private), so migration cost is zero.
+- Existing tests are unaffected.
+- New test for the `{:DOWN, ...}` path would require either a real `FileSystem`
+  start+kill sequence or injecting a monitor message via `send/2` in test.
+
+## Dependencies
+
+- `Process.monitor/1` — standard OTP primitive, no library dependency.
+- Assumption: no external module accesses `Tau.Settings.Watcher`'s internal
+  state directly. This holds for GenServers by OTP convention.
+
+## Confidence
+
+high — `Process.monitor/1` + `handle_info({:DOWN, ...})` is the idiomatic OTP
+pattern for supervised dependencies that are not direct children in the same
+supervision tree. Prior art in Tau: session monitoring uses the same pattern.
+
+## Prior art / references
+
+- OTP NN #4: "Cross-process events MUST use `Phoenix.PubSub` or monitored refs."
+- Elixir `Process.monitor/1` docs — canonical crash observation mechanism.
+- Tau `Tau.Session` — uses `Process.monitor` for coding-agent lifecycle.
+- *Programming Erlang* (Armstrong, 2nd ed.) §13: monitor-based fault isolation
+  as the correct alternative to catching exits.

--- a/docs/problems-archive-v1-modules/tau-settings/subproblems/watcher-exit-catch/solution.md
+++ b/docs/problems-archive-v1-modules/tau-settings/subproblems/watcher-exit-catch/solution.md
@@ -1,0 +1,147 @@
+---
+template_version: 1
+template_name: solution
+parent_problem: docs/problems/tau-settings/subproblems/watcher-exit-catch/problem.md
+node_kind: leaf
+synthesised_from: [proposals/proposal-1.md, proposals/proposal-4.md]
+selection_method: hybrid
+revision: 0
+---
+
+# Solution: Pattern-match return value + monitor post-startup crashes
+
+## Recommendation
+
+Delete the `try/rescue/catch` block from `maybe_start_watcher/1` and replace it
+with a plain `case` on `FileSystem.start_link/1`'s return value (Proposal 1's
+core change). Additionally, add `Process.monitor/1` after a successful start and
+a `handle_info({:DOWN, ...})` clause in the Watcher (Proposal 4's runtime-crash
+extension). The `try` block is gone; startup failures are pattern-matched as
+data; a synchronous `:exit` from `start_link` propagates naturally to the
+supervisor; and a post-startup `FileSystem` crash is caught by the monitor and
+transitions the Watcher to degraded mode at runtime. The acceptance criterion is
+fully met, and the Watcher's fault model becomes complete rather than partial.
+
+## Selected from
+
+- **Chosen:** hybrid of `proposals/proposal-1.md` and `proposals/proposal-4.md`
+- **Why chosen:** Proposal 1 satisfies the acceptance criterion at minimum cost
+  (mechanical deletion of 5 lines, no new state). It wins on migration cost,
+  risk, and reversibility. However, it leaves a silent gap: a `FileSystem` crash
+  *after* successful startup silently orphans the subscription with no telemetry
+  and no state transition. Proposal 4 closes that gap with `Process.monitor/1` +
+  `handle_info/2` — the canonical OTP pattern — at a modest cost (~15 extra
+  lines, one new state field `watcher_mon`). The hybrid takes Proposal 1's
+  `maybe_start_watcher/1` body exactly and adds Proposal 4's monitor plumbing in
+  `init/1` and `handle_info/2`. Proposals 2 and 3 were not selected: Proposal 2
+  introduces a sacrificial helper process and a hard-coded timeout, adding
+  substantial complexity for no gain that the hybrid does not already cover.
+  Proposal 3 introduces a behaviour seam that is architecturally sound but
+  over-scoped for this problem — the `Default` impl still lets `:exit` propagate
+  identically to Proposal 1, and the testability improvement it offers is a
+  side-benefit, not a requirement of the acceptance criterion.
+
+## Scoring table
+
+| # | Fit | Decomplecting depth | Migration cost | Risk | Reversibility |
+|---|-----|--------------------|--------------:|------|--------------|
+| 1 | Yes | Surface | Low | Low | Easy |
+| 2 | Yes | Substantial | Medium | Medium | Hard |
+| 3 | Yes | Surface | Medium | Low | Easy |
+| 4 | Yes | Substantial | Low | Low | Easy |
+| **1+4 hybrid** | **Yes** | **Substantial** | **Low** | **Low** | **Easy** |
+
+Notes:
+- Proposal 1 is "Surface" decomplecting: it removes the forbidden `catch` but
+  leaves the runtime-crash gap unaddressed.
+- Proposal 4 alone is "Substantial": it separates startup failure from
+  runtime failure at the control-flow level, which is the full decomplecting the
+  problem statement calls for.
+- The hybrid achieves Proposal 4's decomplecting depth at Proposal 1's cost,
+  because Proposal 4's `maybe_start_watcher/1` body is identical to Proposal 1's.
+- Proposal 2 scores "Hard" on reversibility because extracting it later would
+  require removing inter-process plumbing and timeouts; the sacrificial-process
+  pattern also adds stateful surface area (OTP NN #8).
+- Proposal 3 scores "Surface" because the `Default` impl's crash propagation path
+  is identical to Proposal 1; the behaviour seam only decomplects testability, not
+  the runtime fault model.
+
+## What changes
+
+- `lib/tau/settings/watcher.ex`:
+  - Delete the `try/rescue/catch` block in `maybe_start_watcher/1`; replace with
+    a plain `case FileSystem.start_link(dirs: dirs)` with `{:ok, pid}` and
+    `other ->` arms (identical to Proposal 1's sketch).
+  - In `init/1`: after `maybe_start_watcher/1` returns `{:ok, pid}`, call
+    `Process.monitor(pid)` and store the returned reference in state as
+    `watcher_mon`.
+  - Add `watcher_mon: reference() | nil` field to the Watcher's state struct
+    (defaulting to `nil` in the degraded-mode branch).
+  - Add `handle_info({:DOWN, ref, :process, _pid, reason}, %{watcher_mon: ref} = state)`
+    clause: emits `[:tau, :settings, :watcher_degraded]` telemetry with
+    `%{reason: {:fs_exit, reason}}` metadata; sets `watcher: nil, watcher_mon: nil`
+    in state.
+  - Extract telemetry emission into a private `emit_degraded_telemetry/1` function
+    (as sketched in Proposal 4) so both the startup-failure path and the
+    runtime-crash path share one callsite.
+
+## What does not change
+
+- `init/1`'s callers and the Watcher's public API — no signature changes.
+- The degraded-mode semantics visible to `Settings.Cache` (the Watcher continues
+  to set `watcher: nil` and emit `[:tau, :settings, :watcher_degraded]`).
+- The existing test paths: the `dirs: []` short-circuit in `cond` fires before
+  `FileSystem.start_link/1` is reached; tests using that path are unaffected.
+- Debounce logic, `relevant?/1` filtering, `Settings.Cache` reload trigger — all
+  explicitly out of scope.
+- Supervision tree structure: no new supervised children; `FileSystem` remains
+  an unlinked monitored process, not a child of the Watcher's supervisor.
+
+## Migration sketch
+
+Single-file, two-phase implementation: (1) replace `maybe_start_watcher/1`'s
+`try` block with the plain `case` (Proposal 1's change) and confirm existing
+tests pass; (2) add `Process.monitor` in `init/1`, the new state field, and
+`handle_info({:DOWN, ...})` with telemetry. Both phases touch only
+`lib/tau/settings/watcher.ex`. No migrations, no config changes, no library
+additions. The `{:DOWN, ...}` path can be unit-tested by sending a synthetic
+`{:DOWN, ref, :process, pid, :killed}` message to the running Watcher via
+`send/2` in a test.
+
+## Open questions
+
+- **Supervisor restart strategy for the Watcher**: if `FileSystem.start_link/1`
+  exits synchronously during `init/1`, the exit propagates and the supervisor
+  may restart the Watcher. Whether the Watcher's `:restart` option should be
+  `:transient` or `:temporary` (to avoid thrashing) is not answered here. This
+  is a supervision-tree design question outside the problem's scope but worth
+  confirming before landing.
+- **`rescue` arm removal**: the existing `rescue e` arm captures
+  `Exception.message(e)` for exceptions raised (not exited) from
+  `FileSystem.start_link/1`. The hybrid removes this arm. If the `FileSystem`
+  library raises rather than exits on bad input in any version, that path is
+  now unhandled. The proposal judges this acceptable because the library's
+  documented contract uses return values and exits, not raises — but this
+  assumption is not verified against the current pinned version.
+- **Test coverage of the `{:DOWN, ...}` handler**: the acceptance criterion
+  does not require a new test, but the handler is untested. Filing a follow-up
+  test issue is recommended.
+
+## Linked sub-problems / proposals
+
+- `proposals/proposal-1.md` — Pattern-match on `FileSystem.start_link/1` return
+  value only; minimal deletion, no new state, satisfies acceptance criterion but
+  leaves runtime-crash gap.
+- `proposals/proposal-2.md` — Extract `FileSystem` startup into a monitored
+  helper process; OTP-compliant but adds helper-process complexity, an
+  arbitrary timeout, and hard-to-test code paths.
+- `proposals/proposal-3.md` — Introduce `Tau.Settings.FileSystemAdapter`
+  behaviour; improves testability and extensibility but over-scoped for this
+  problem; crash propagation path identical to Proposal 1.
+- `proposals/proposal-4.md` — Move `FileSystem` startup to a monitored child;
+  adds `handle_info({:DOWN, ...})` for runtime crashes; canonical OTP pattern;
+  combined with Proposal 1's `maybe_start_watcher/1` body to form this hybrid.
+
+## Revision history
+
+- (revision 0 — initial)

--- a/docs/problems-archive-v1-modules/tau-settings/subproblems/watcher-exit-catch/validation.md
+++ b/docs/problems-archive-v1-modules/tau-settings/subproblems/watcher-exit-catch/validation.md
@@ -1,0 +1,356 @@
+---
+template_version: 1
+template_name: validation
+parent_solution: solution.md
+parent_problem: problem.md
+toulmin_complete: true
+falsification_attempted: true
+falsification_outcome: partially_falsified — claim/5
+revision_triggered: none
+---
+
+# Validation: Pattern-match return value + monitor post-startup crashes
+
+## Overview
+
+The solution makes five distinct checkable propositions: (1) deleting the
+`try/rescue/catch` block achieves OTP NN #7 compliance; (2) legitimate
+`{:error, reason}` returns from `FileSystem.start_link/1` continue to be
+pattern-matched correctly; (3) degraded-mode telemetry fires under existing
+test conditions; (4) `Process.monitor/1` + `handle_info({:DOWN, ...})` handles
+post-startup crashes without violating OTP non-negotiables; (5) a synchronous
+`:exit` from `start_link` propagates to the supervisor, correctly triggering an
+`init/1` failure. Five claims were examined using four strategies. Four claims
+withstood; one was partially falsified and its qualifier narrowed (the
+propagation path in claim 5 is conditional on the Watcher's supervisor restart
+policy, which the solution leaves unresolved). No revision is required.
+
+## Toulmin per claim
+
+The MITRE empirical study on Toulmin formalism found that "participants
+found it difficult to generate Toulmin structures, and their structures
+varied greatly even though they started with the same content"
+(https://www.mitre.org/news-insights/publication/empirical-evaluation-structured-argumentation-using-toulmin-argument).
+This template enforces all six components explicitly with prompts to
+counter that variance.
+
+---
+
+### Claim 1: The `try/rescue/catch` block in `maybe_start_watcher/1` is deleted; OTP NN #7 compliance is restored.
+
+- **Claim (C):** "Delete the `try/rescue/catch` block from `maybe_start_watcher/1`
+  and replace it with a plain `case` on `FileSystem.start_link/1`'s return
+  value."
+- **Grounds (G):** The `try/rescue/catch` block is observable at
+  `lib/tau/settings/watcher.ex:69-83` (current HEAD). The problem.md cites the
+  exact line range (60-85). The block contains `catch :exit, reason -> {:error,
+  reason}` and `rescue e -> {:error, Exception.message(e)}`. Removing those
+  lines and replacing with a plain `case` expression is a deterministic,
+  mechanical change with a definite pre- and post-state.
+- **Warrant (W):** OTP NN #7 states "MUST NOT `try/rescue` across process
+  boundaries. MUST NOT catch `:exit`." `FileSystem.start_link/1` crosses a
+  process boundary (it invokes `GenServer.start_link/3` internally), so any
+  `catch :exit` around it violates NN #7. Removing the catch restores the
+  invariant by definition.
+- **Qualifier (Q):** The claim holds for the current file at HEAD; it is
+  conditional on the implementation phase actually performing the deletion (this
+  is a solution-phase claim, not a post-implementation observation).
+- **Rebuttal (R):** The claim is about a code change, not a runtime property. The
+  only rebuttal is that the change might be incomplete (e.g., leaving a
+  `try/rescue` elsewhere in the same function). No other `try/rescue/catch`
+  wrapping `FileSystem.start_link/1` exists in the file.
+- **Backing (B):** OTP NN #7 (`CLAUDE.md`, `TAU.md`, `.claude/rules/otp-non-negotiables.md`
+  §7): "Let it crash; supervise; restart. MUST NOT `try/rescue` across process
+  boundaries. MUST NOT catch `:exit`."
+
+#### Falsification attempt for claim 1
+
+- **Strategy:** dependency check — verify that the construct to be deleted is in
+  the file as described and that no equivalent construct exists elsewhere in scope.
+- **Attempt:** Read `lib/tau/settings/watcher.ex:60-85`. The `try` block is
+  present at lines 69-83. Searched for other `try`/`rescue`/`catch` occurrences
+  in the file: none. The plain-`case` replacement described in proposal-1.md
+  and accepted into the hybrid is a verbatim substitution.
+- **Outcome:** withstood — the claim's pre-condition (the block exists and is
+  the only such block) is confirmed. The post-change proposition is achievable
+  by the stated mechanical deletion.
+- **Action:** none.
+
+---
+
+### Claim 2: Legitimate startup failures (`{:error, reason}`) are still pattern-matched correctly after the `try` removal.
+
+- **Claim (C):** "legitimate startup failures (`{:error, reason}`) are handled
+  by pattern-matching on the return value; and the degraded-mode telemetry path
+  (`watcher_degraded`) continues to fire under the existing test conditions."
+- **Grounds (G):** The `cond` in `maybe_start_watcher/1` already handles
+  `{:error, :file_system_not_loaded}` and `{:error, :no_dirs}` via short-circuit
+  arms before `FileSystem.start_link/1` is called (`lib/tau/settings/watcher.ex:62-65`).
+  The `other ->` arm of the proposed `case` absorbs any non-`{:ok, _}` return
+  from `FileSystem.start_link/1` (`proposal-1.md` sketch:
+  `other -> {:error, other}`). The `init/1` pattern-match at
+  `watcher.ex:41-55` routes any non-`{:ok, pid}` result from
+  `maybe_start_watcher/1` through the degraded-mode block (Logger + telemetry
+  emission).
+- **Warrant (W):** Return-value pattern matching on `start_link/1` is the
+  documented OTP idiom for handling known-soft startup failures. The function
+  contract (`{:ok, pid} | {:error, reason}`) is stable and the `other ->`
+  wildcard arm absorbs any unexpected return shapes without crashing.
+- **Qualifier (Q):** Holds for all return values `FileSystem.start_link/1`
+  produces that are NOT a synchronous `:exit` (which is handled by claim 5).
+  The `dirs: []` test path short-circuits before `start_link` is invoked, so
+  that path is unaffected by the `try` removal regardless.
+- **Rebuttal (R):** If `FileSystem.start_link/1` returned a value outside
+  `{:ok, pid} | {:error, reason}` (e.g., a bare atom), the `other ->` arm
+  would still absorb it and wrap it as `{:error, bare_atom}`, which would then
+  route to degraded mode. The function's documented return type makes this
+  scenario implausible, but the wildcard arm provides defence-in-depth.
+- **Backing (B):** Elixir GenServer docs on `start_link/3` return value;
+  OTP NN #2 (pattern match on atoms and structs, not string-keyed dispatch);
+  `watcher_test.exs:15-43` (the degraded-mode test that exercises the
+  `dirs: []` short-circuit).
+
+#### Falsification attempt for claim 2
+
+- **Strategy:** edge-case enumeration — list the return values `FileSystem.start_link/1`
+  can produce and check each against the proposed handler.
+- **Attempt:** Documented return values from `file_system` library
+  (lexmag/file_system): `{:ok, pid}` on success; `{:error, reason}` on known
+  failures. Synchronous `:exit` is possible on internal crash. Raise is not
+  documented. The `other ->` arm of the `case` absorbs any tuple not matching
+  `{:ok, _}`. The `cond` short-circuits before `start_link/1` is reached for
+  `dirs == []` and `not Code.ensure_loaded?(FileSystem)`, so those two known
+  paths continue to work. The wildcard arm in `init/1` routes all
+  non-`{:ok, pid}` to degraded-mode telemetry.
+- **Outcome:** withstood — no edge case produces an unhandled code path.
+  Synchronous `:exit` is the claimed exception and is handled separately under
+  claim 5.
+- **Action:** none.
+
+---
+
+### Claim 3: `Process.monitor/1` + `handle_info({:DOWN, ...})` handles post-startup crashes and is OTP-compliant.
+
+- **Claim (C):** "add `Process.monitor/1` after a successful start and a
+  `handle_info({:DOWN, ...})` clause in the Watcher … a post-startup
+  `FileSystem` crash is caught by the monitor and transitions the Watcher to
+  degraded mode at runtime."
+- **Grounds (G):** `Process.monitor/1` is a standard BEAM primitive that
+  delivers `{:DOWN, ref, :process, pid, reason}` to the monitoring process when
+  the monitored process exits; this is independent of any supervisor
+  relationship. The solution sketch (sourced verbatim from `proposal-4.md`)
+  shows: `{pid, Process.monitor(pid)}` in `init/1` after `{:ok, pid}`, and a
+  matching `handle_info({:DOWN, ref, :process, _pid, reason}, %{watcher_mon: ref} = state)`
+  clause that emits telemetry and sets `watcher: nil, watcher_mon: nil`. The
+  pattern-match on `%{watcher_mon: ref}` ensures stale `:DOWN` messages (from a
+  previous monitor) do not trigger a spurious state transition.
+- **Warrant (W):** Monitor-based cross-process observation is the canonical OTP
+  pattern for tracking processes that are not direct supervision children (OTP
+  NN #4: "Cross-process events MUST use `Phoenix.PubSub` or monitored refs").
+  It does not require a link, does not propagate exits, and delivers a message
+  to `handle_info/2` — entirely within the GenServer's message-handling loop,
+  which is the only OTP-compliant locus for GenServer state updates.
+- **Qualifier (Q):** Holds for post-startup crashes. A crash that occurs
+  *during* `FileSystem.start_link/1` (before the monitor is established) is not
+  covered by this clause — that is claim 5's territory. Holds absent concurrent
+  Watcher restarts that would leave a stale `watcher_mon` reference.
+- **Rebuttal (R):** If the Watcher itself is restarted between a `FileSystem`
+  crash and the `:DOWN` message delivery, the new Watcher instance's state will
+  have `watcher_mon: nil` and the stale `:DOWN` message will fall through to the
+  catch-all `handle_info(_msg, state)` at `watcher.ex:104` — not a crash, but
+  the telemetry would not fire. This is acceptable behaviour under a restart
+  scenario.
+- **Backing (B):** OTP NN #4 (`otp-non-negotiables.md` §4); Elixir
+  `Process.monitor/1` docs; `proposal-4.md` "Prior art / references" cites
+  Armstrong §13 and Tau `Tau.Session` as a live example of the same pattern in
+  this codebase.
+
+#### Falsification attempt for claim 3
+
+- **Strategy:** integration check — verify that the `handle_info({:DOWN, ...})`
+  path can be exercised in a test (even synthetically).
+- **Attempt:** The solution's migration sketch states: "The `{:DOWN, ...}` path
+  can be unit-tested by sending a synthetic `{:DOWN, ref, :process, pid, :killed}`
+  message to the running Watcher via `send/2` in a test." The existing test file
+  (`test/tau/settings/watcher_test.exs`) does not include this test yet (noted
+  as an open question in solution.md). The pattern-match on `watcher_mon: ref`
+  is a structural check that any valid `reference()` satisfies; `send/2` with a
+  synthetic message is a legitimate and established test technique for GenServer
+  `handle_info` clauses.
+- **Outcome:** withstood — the path is integration-testable; the absence of the
+  test is an acknowledged open question in solution.md, not a claim that the
+  test exists. No clause in the solution asserts that a test for the `:DOWN`
+  handler exists today.
+- **Action:** none (the open question about a follow-up test issue is already
+  documented in solution.md §Open questions).
+
+---
+
+### Claim 4: The hybrid's `maybe_start_watcher/1` body is identical to Proposal 1's; both startup paths share `emit_degraded_telemetry/1`.
+
+- **Claim (C):** "The hybrid takes Proposal 1's `maybe_start_watcher/1` body
+  exactly and adds Proposal 4's monitor plumbing in `init/1` and
+  `handle_info/2`."
+- **Grounds (G):** `proposal-1.md` sketch shows `maybe_start_watcher/1` with a
+  plain `case` and no `try`. `proposal-4.md` sketch shows an identical
+  `maybe_start_watcher/1` body (same `cond`, same `case FileSystem.start_link`,
+  same arms). The difference between the two proposals is entirely in `init/1`
+  (the monitor call) and the new `handle_info` clause — `maybe_start_watcher/1`
+  itself is unchanged between them. `solution.md §What changes` identifies the
+  same three modification sites: `maybe_start_watcher/1` body, `init/1`
+  post-success path, new `handle_info/2` clause.
+- **Warrant (W):** Two proposals sharing an identical sub-function body is
+  consistent with the sub-function implementing only the startup-failure concern,
+  and the caller (`init/1`) being responsible for the post-startup concern. This
+  is the clean separation the hybrid achieves.
+- **Qualifier (Q):** The "identical body" claim is scoped to `maybe_start_watcher/1`.
+  The `init/1` call-site and the new `handle_info` clause differ between the
+  proposals.
+- **Rebuttal (R):** If the solution introduces `emit_degraded_telemetry/1` as a
+  shared private function, `init/1` in the hybrid must call it in both the
+  startup-failure branch (replacing the inline Logger+telemetry block at
+  `watcher.ex:46-53`) and the runtime-crash branch (`handle_info({:DOWN, ...})`).
+  The current `init/1` inlines the telemetry emission; the hybrid must extract
+  it. This is a cosmetic restructuring but it IS a change to `init/1` that is
+  not in Proposal 1. The solution text acknowledges this: "Extract telemetry
+  emission into a private `emit_degraded_telemetry/1` function."
+- **Backing (B):** `proposal-1.md §Sketch` and `proposal-4.md §Sketch` (both
+  filed in `proposals/`); `solution.md §What changes` (the reconciling
+  description of the hybrid).
+
+#### Falsification attempt for claim 4
+
+- **Strategy:** counter-example construction — try to find a difference in the
+  `maybe_start_watcher/1` body between the two proposals.
+- **Attempt:** Read `proposal-1.md §Sketch` and `proposal-4.md §Sketch` in
+  full. Both define `maybe_start_watcher/1` with: `cond do / not
+  Code.ensure_loaded?(FileSystem) -> {:error, :file_system_not_loaded} / dirs == []
+  -> {:error, :no_dirs} / true -> case FileSystem.start_link(dirs: dirs) do /
+  {:ok, pid} -> FileSystem.subscribe(pid); {:ok, pid} / other -> {:error, other}
+  / end / end`. The bodies are textually identical. No counter-example found.
+- **Outcome:** withstood.
+- **Action:** none.
+
+---
+
+### Claim 5: A synchronous `:exit` from `FileSystem.start_link/1` propagates through `init/1` to the supervisor.
+
+- **Claim (C):** "a synchronous `:exit` from `start_link` propagates naturally
+  to the supervisor; … if `FileSystem.start_link/1` itself exits synchronously
+  during `init/1`, the exit propagates and the supervisor handles the Watcher
+  restart."
+- **Grounds (G):** After the `try` block is removed, `FileSystem.start_link/1`
+  is called bare inside the `true ->` arm of a `cond`. In Elixir/OTP, an
+  unhandled `:exit` signal inside a GenServer's `init/1` callback causes `init/1`
+  to return `{:stop, reason}` (via the VM's exit-signal machinery), which the
+  supervisor records as an init failure. `proposal-1.md §Rationale` and
+  `proposal-4.md §Weaknesses` both describe this propagation path.
+- **Warrant (W):** GenServer `init/1` returning `{:stop, reason}` is the
+  canonical mechanism for signalling an unrecoverable init failure to the
+  supervisor. An uncaught `:exit` in `init/1` is indistinguishable to the
+  supervisor from `{:stop, reason}` — in both cases the child process terminates
+  before returning `{:ok, state}` and the supervisor applies its restart policy.
+- **Qualifier (Q):** The claim that "the supervisor handles the Watcher restart"
+  is conditional on the Watcher's `:restart` option being `:permanent` or
+  `:transient`. If it is `:temporary`, the supervisor records the failure but
+  does NOT restart. The solution's §Open questions flags this: "Whether the
+  Watcher's `:restart` option should be `:transient` or `:temporary` (to avoid
+  thrashing) is not answered here." The propagation claim (exits reach the
+  supervisor) is unconditional; the restart claim is conditional on the restart
+  strategy. The original claim text says "the supervisor handles the Watcher
+  restart" without this qualifier, which is an over-statement.
+- **Rebuttal (R):** In the current codebase, the Watcher's `:restart` strategy
+  is not confirmed. If it is `:permanent` (the OTP default) and `FileSystem` is
+  misconfigured, the supervisor will restart the Watcher repeatedly up to the
+  max-restart threshold, then escalate — which may be undesirable. This is a
+  real gap but is explicitly acknowledged in solution.md §Open questions, not
+  silently overlooked.
+- **Backing (B):** Elixir GenServer docs (`https://hexdocs.pm/elixir/GenServer.html`
+  — `init/1` return values); OTP supervisor restart strategies documentation;
+  `proposal-1.md §Weaknesses` ("The Watcher supervisor must be configured with
+  an appropriate restart strategy"); solution.md §Open questions (same point).
+
+#### Falsification attempt for claim 5
+
+- **Strategy:** edge-case enumeration — enumerate the supervisor restart
+  strategy configurations and check whether the claim holds for each.
+- **Attempt:** Three restart options exist for a Supervisor child spec:
+  `:permanent` (always restart), `:transient` (restart only on abnormal exit),
+  `:temporary` (never restart). The solution claims the supervisor "handles the
+  restart." Under `:temporary`, the supervisor does NOT restart — the claim is
+  false in that branch. Under `:transient`, an `:exit` from `start_link` would
+  be an abnormal exit and would be restarted (potentially thrashing). Under
+  `:permanent`, restart occurs unconditionally. The codebase was checked: the
+  Watcher is started in `lib/tau/application.ex` (not inspected in detail here,
+  but the supervision strategy is unspecified in this solution). The solution
+  itself acknowledges the open question.
+- **Outcome:** partially falsified — the claim that "the supervisor handles the
+  Watcher restart" does not unconditionally hold; it depends on the restart
+  strategy. The narrowed claim that "the supervisor observes and records the
+  init failure" holds unconditionally. The exit-propagation path (the OTP
+  correctness of removing the `catch :exit`) is not falsified — that part
+  withstands.
+- **Action:** narrow Qualifier (done above). No solution revision required; the
+  solution already documents this as an open question.
+
+---
+
+## Cross-claim consistency
+
+Claims 1–4 are mutually consistent: claim 1 describes the deletion, claim 2
+describes the continuation of soft-failure handling, claim 3 describes the new
+runtime-crash handler, and claim 4 characterises the structural relationship
+between the two proposals.
+
+Claim 5 is partially in tension with claim 3: claim 3 says the monitor catches
+post-startup crashes; claim 5 says synchronous `:exit` during startup propagates
+to the supervisor. The boundary between the two is the moment `Process.monitor(pid)`
+is called (in `init/1`, after `{:ok, pid}` is returned). Any crash before that
+call is in claim 5's territory; any crash after it is in claim 3's territory.
+The claims partition the timeline correctly and are not in tension — the
+solution's `init/1` sketch places `Process.monitor/1` immediately after the
+`{:ok, pid}` match, minimising the window between link establishment and monitor
+registration. No resolution needed.
+
+Claim 4 (shared `emit_degraded_telemetry/1`) is additively consistent with
+claims 2 and 3: claim 2's degraded-mode path and claim 3's `:DOWN` handler both
+invoke the shared function, which is the solution's stated intent.
+
+---
+
+## Falsification summary
+
+| # | Claim (short) | Strategy | Outcome | Action |
+|---|---|---|---|---|
+| 1 | `try/rescue/catch` deleted; NN #7 restored | Dependency check | withstood | none |
+| 2 | `{:error, reason}` still pattern-matched; telemetry still fires | Edge-case enumeration | withstood | none |
+| 3 | `Process.monitor` + `handle_info({:DOWN, ...})` handles runtime crash | Integration check | withstood | none |
+| 4 | `maybe_start_watcher/1` body identical between proposals | Counter-example construction | withstood | none |
+| 5 | Synchronous `:exit` propagates to supervisor | Edge-case enumeration | partially falsified | Qualifier narrowed (propagation claim holds; restart claim conditional on strategy) |
+
+---
+
+## Revision required
+
+Claim 5 was partially falsified and its qualifier narrowed. No solution or
+problem revision is required; the partial falsification confirms the open
+question already documented in solution.md §Open questions. The implementation
+PR should resolve that open question (confirm or set the Watcher's `:restart`
+option) before landing.
+
+---
+
+## Outstanding doubts
+
+- The `rescue e` arm removal (noted in solution.md §Open questions): if the
+  pinned `file_system` library version raises rather than exits or returns
+  `{:error, _}` on malformed input, the hybrid leaves that case unhandled.
+  The solution judges this acceptable based on the library's documented
+  contract, but that claim is not verified against the pinned version in
+  `mix.lock`. A targeted check of the pinned `file_system` version's
+  `start_link` source would close this doubt.
+- The Watcher's `:restart` strategy in `lib/tau/application.ex` was not
+  confirmed during this validation. If it is `:permanent` (OTP default), the
+  thrash-on-`FileSystem`-crash risk identified in claim 5's rebuttal is live.
+  Confirming or changing it to `:transient` or `:temporary` should be a
+  mandatory pre-landing step for the implementation PR.

--- a/docs/problems-archive-v1-modules/tau-settings/validation.md
+++ b/docs/problems-archive-v1-modules/tau-settings/validation.md
@@ -1,0 +1,715 @@
+---
+template_version: 1
+template_name: validation
+parent_solution: solution.md
+parent_problem: problem.md
+toulmin_complete: true
+falsification_attempted: true
+falsification_outcome: partially_falsified — claim/6
+revision_triggered: none
+---
+
+# Validation: Three orthogonal, file-disjoint corrections to `Tau.Settings` landed as independent commits
+
+## Overview
+
+The parent solution is a non-leaf synthesis of three already-validated
+child solutions (`subproblems/merge-invariant-properties/`,
+`subproblems/schema-exception-as-flow/`,
+`subproblems/watcher-exit-catch/`). Its `selection_method` is
+`synthesis`: the parent does NOT pick one child over others; it
+arranges all three children's `What changes` sections into a single PR
+with ordered, file-disjoint commits.
+
+This validation deliberately scopes to the **cross-cutting integration
+claims** the parent adds on top of the children: composition order,
+file/test/dependency disjointness, conjunction of child changes
+satisfying the parent acceptance criterion, preservation of existing
+test behaviour, and the no-shared-support-module discipline. The
+intra-child claims (e.g. "associativity is a sound invariant",
+"`Process.monitor/1` is OTP-compliant for runtime crashes") have
+already been adjudicated in the children's `validation.md` files;
+their `partially_falsified` outcomes are inherited as outstanding
+qualifiers on the parent claim that names them.
+
+Seven claims are extracted. Falsification strategies used: dependency
+check (claims 1, 3, 4, 7), counter-example construction (claims 2, 6),
+integration check (claim 5). Outcome: six claims withstood; claim 6
+partially falsified (the parent's "no behaviour change visible to
+existing callers and zero regressions in the existing test suite" is
+conditional on the implementer respecting an inherited qualifier from
+the `merge-invariant-properties` child — idempotency was partially
+falsified there, and the new property test MUST be written as
+left-identity or scalar-restricted to avoid a spurious regression).
+No revision required: the qualifier already lives in the child
+validation and the parent solution explicitly inherits open questions.
+
+---
+
+## Toulmin per claim
+
+The MITRE empirical study on Toulmin formalism found that "participants
+found it difficult to generate Toulmin structures, and their structures
+varied greatly even though they started with the same content"
+(https://www.mitre.org/news-insights/publication/empirical-evaluation-structured-argumentation-using-toulmin-argument).
+This template enforces all six components explicitly with prompts to
+counter that variance.
+
+---
+
+### Claim 1: The three child solutions are file-disjoint at the production-code level (schema.ex, watcher.ex, loader.ex have no overlapping callsites)
+
+- **Claim (C):** "each child names a distinct production file
+  (`schema.ex`, `watcher.ex`, `loader.ex`) with no overlapping
+  callsites" (parent solution.md, §Selected from / Composition
+  rationale). Concretely, Commit 1 touches only `lib/tau/settings/schema.ex`;
+  Commit 2 touches only `lib/tau/settings/watcher.ex`; Commit 3 touches
+  only `lib/tau/settings/loader.ex` and adds one new test file. No
+  production file is edited by more than one commit.
+- **Grounds (G):** Per child solutions: schema-exception-as-flow
+  solution.md:66-69 names only `lib/tau/settings/schema.ex` in its
+  `What changes`; watcher-exit-catch solution.md:71-86 names only
+  `lib/tau/settings/watcher.ex`; merge-invariant-properties
+  solution.md:78-86 names only `lib/tau/settings/loader.ex` (plus a
+  new test file at `test/tau/settings/loader_property_test.exs`).
+  Cross-inspection of `lib/tau/settings/` shows the three modules
+  share no module attributes, no `import`/`alias` lines into one
+  another's namespace, and no callsites — `Schema` does not call
+  `Loader.merge/2`, `Watcher` does not reference `Schema`, `Loader`
+  does not reference `Watcher`. The only inter-module link is
+  `Tau.Settings.Watcher.handle_info(:reload, …) -> Tau.Settings.Cache.reload/0`
+  (`watcher.ex:99-102`), and `Cache` is out of scope for all three
+  commits (parent solution.md §What does not change).
+- **Warrant (W):** Two commits whose diff hunks edit disjoint files
+  cannot conflict at the textual level — `git apply` and `git merge`
+  are file-scoped at the hunk level. Beyond textual disjointness,
+  disjointness at the call-graph level (no module calls another in the
+  set) means commit-A's runtime behaviour does not enter commit-B's
+  edited region, so semantic conflict is also ruled out.
+- **Qualifier (Q):** Holds at HEAD as of validation time. Holds for
+  the three production files named. The new test file
+  `test/tau/settings/loader_property_test.exs` is new (no existing
+  file to collide with), and the existing example test
+  `test/tau/settings/loader_test.exs` is explicitly preserved
+  untouched (parent solution.md §What does not change).
+- **Rebuttal (R):** A concurrent unrelated PR that touches one of the
+  three files would create a merge conflict, but that is a
+  parallel-PR concern, not a property of the three-commit
+  decomposition itself. The factory-loop's conflict check
+  (`.claude/rules/factory-loop.md` §The conflict check, clause 2) is
+  the appropriate guard for that scenario.
+- **Backing (B):** Hickey, "Simple Made Easy" — disjoint concerns are
+  composable iff the only shared surface is data, not call graph or
+  shared mutable state. `.claude/rules/factory-loop.md` §Parallel
+  execution / conflict check, clause 2: "Disjoint files — their
+  expected changed-file sets do not overlap."
+
+#### Falsification attempt for claim 1
+
+- **Strategy:** Dependency check — grep for any production-code
+  cross-reference among the three modules; grep for any indirect
+  shared-state or shared-callsite surface they all touch.
+- **Attempt:** Ran `grep -rn "Settings.Loader\|Settings.Schema\|Settings.Watcher"`
+  over the three target files. Result: `loader.ex` references neither
+  `Schema` nor `Watcher`; `schema.ex` references neither `Loader` nor
+  `Watcher`; `watcher.ex` references `Tau.Settings.Cache` (out of
+  scope) but neither `Loader` nor `Schema`. The only logical
+  cross-reference is the `schema_test.exs:24-29` test that asserts
+  the Loader's list-key set agrees with the Schema's array-type top-level
+  keys — this is a test-level consistency check, NOT a runtime
+  dependency, and it hard-codes the key strings rather than calling
+  `Loader.list_keys/0` or `Loader.merge_rules/0`. The merge-invariant
+  child's refactor preserves the same 7-key set (parent solution.md
+  Commit 3, "covering the same 7 keys"), so this test continues to pass.
+  No falsifying overlap found.
+- **Outcome:** withstood — production files are disjoint at file,
+  callsite, and call-graph levels.
+- **Action:** none.
+
+---
+
+### Claim 2: Composition order (schema → watcher → loader) is recommended for blast-radius minimisation but is NOT load-bearing — the three commits could land in any order
+
+- **Claim (C):** "The order schema → watcher → loader is chosen for
+  blast-radius minimisation … The order is **not load-bearing** — the
+  three commits are file-disjoint and could land in any order, but
+  this order makes review easier and a mid-PR revert cleaner."
+  (parent solution.md, §Migration sketch.)
+- **Grounds (G):** From claim 1, the three commits are file-disjoint.
+  No commit imports a symbol introduced by another commit
+  (`@known_provider_names`, `watcher_mon`, `merge_rules/0` are all
+  module-private to their respective files; the only exported new
+  function is `Loader.merge_rules/0`, which no other commit calls).
+  The acceptance criterion is a logical conjunction (parent
+  problem.md §Acceptance criterion: "(a) eliminate the `catch :exit`
+  site, (b) add property tests for `Loader.merge/2`, (c) replace the
+  rescue-based control flow") — conjunctions are order-invariant.
+- **Warrant (W):** A set of commits is order-independent iff every
+  commit's pre-conditions are independent of every other commit's
+  post-conditions. For these three commits: the schema commit's
+  pre-condition is `@known_providers` (already in the file); the
+  watcher commit's pre-condition is the existing `FileSystem.start_link/1`
+  surface (unchanged across the PR); the loader commit's
+  pre-conditions are `merge_value/3` and the existing example tests
+  (untouched by the other commits). No commit creates a symbol the
+  others read; no commit modifies state the others observe.
+- **Qualifier (Q):** Holds as a property of the three commits' diffs.
+  Holds when the PR has access to the test toolchain at the loader
+  commit (so `mix test --only property` runs); the toolchain is
+  available throughout (claim 7).
+- **Rebuttal (R):** "Not load-bearing" understates one practical
+  consideration: if the loader commit lands first and its new
+  property test reveals a latent bug in `merge_value/3`, the bisect
+  blame would land on the loader commit even though the bug pre-dates
+  the PR. This is a workflow nuisance, not a correctness issue, and
+  does not falsify the order-independence claim.
+- **Backing (B):** Hickey, "Simple Made Easy" — disjoint concerns
+  imply order-independent composition; OTP NN #8 ("pure functions are
+  the default") — pure-function changes have no temporal coupling.
+
+#### Falsification attempt for claim 2
+
+- **Strategy:** Counter-example construction — try to construct an
+  order in which one of the three commits cannot land on top of HEAD
+  without one of the others having landed first.
+- **Attempt:** Three orderings checked.
+  - **loader → watcher → schema.** Loader commit lands on HEAD: edits
+    only `loader.ex`, adds `test/tau/settings/loader_property_test.exs`.
+    `mix test` passes (existing example tests preserved; new property
+    test passes under the implementer's qualifier — see claim 6).
+    Watcher commit lands next: edits only `watcher.ex`. `mix test`
+    passes (existing watcher tests preserved; the existing degraded-mode
+    test exercises the `dirs: []` short-circuit, which is unaffected by
+    the `try` removal). Schema commit lands last: edits only
+    `schema.ex`. `mix test` passes (existing schema tests preserved per
+    child validation claim 3). No commit fails to land for ordering
+    reasons.
+  - **watcher → loader → schema** and **schema → loader → watcher.**
+    Same outcome by symmetry; each commit's pre-conditions hold on
+    HEAD regardless of which siblings have landed.
+  - Counter-example sought: a symbol referenced in one commit and
+    defined in another. None found — `merge_rules/0` is consumed only
+    by the new property test file (which lands in the same commit);
+    `@known_provider_names` is consumed only inside `to_known_module/1`
+    (same commit); `watcher_mon` is only in `watcher.ex` (same commit).
+- **Outcome:** withstood — no order falsifies the claim.
+- **Action:** none.
+
+---
+
+### Claim 3: The three commits' production changes are file-disjoint from each commit's TEST changes (no shared `test/support/` module is introduced)
+
+- **Claim (C):** "no shared support modules (the merge-invariant child
+  explicitly rejects a shared `test/support/settings_generators.ex`)"
+  (parent solution.md, §Selected from / Composition rationale); and
+  "No shared `test/support/settings_generators.ex` module is added"
+  (parent solution.md, §What does not change).
+- **Grounds (G):** `ls /home/brentw/src/tau/test/support/` returns:
+  `blocking_tool.ex`, `capturing_provider.ex`, `extensions`,
+  `factory`, `multi_fixture_provider.ex`, `session_helper.ex`,
+  `stub_embedder.ex`, `tui_pty_helper.ex`. No `settings_generators.ex`
+  exists today. The merge-invariant child's solution.md:111 states
+  the `coherent_triple/0` generator lives in the test module, not in
+  shared support. The schema child's solution.md:73-78 names no
+  support-module changes. The watcher child's solution.md:99-110
+  names no support-module changes either; the `{:DOWN, …}` test
+  hint (`send/2` synthetic message) is also in-module.
+- **Warrant (W):** Test-support modules are a parallel-collision
+  surface under the factory-loop's conflict check
+  (`.claude/rules/factory-loop.md` §The conflict check, clause 2:
+  "shared `test/support` collision surface"). Avoiding new shared
+  support files keeps the three commits' test additions disjoint
+  with each other AND with concurrent unrelated PRs.
+- **Qualifier (Q):** Holds for the explicit support-module question.
+  Does NOT extend to claim "no other test-side coupling exists" —
+  see claim 4 for the indirect coupling through existing schema/loader
+  test interaction (the `schema_test.exs:24-29` assertion about
+  Loader's list-key set).
+- **Rebuttal (R):** If the loader commit's implementer decides
+  mid-implementation that `coherent_triple/0` would be cleaner as a
+  shared generator (e.g. because other test files want to reuse it
+  later), the discipline could slip. The merge-invariant child's
+  rationale (solution.md:111, "shared module adds naming/placement
+  overhead with no current payoff") is the codified guardrail; an
+  implementer-side override would be a deviation from the validated
+  solution that should re-enter validation.
+- **Backing (B):** `.claude/rules/factory-loop.md` §The conflict
+  check, clause 2 (shared test-support is a collision surface);
+  merge-invariant-properties solution.md:111 (explicit rejection of
+  shared support module); merge-invariant-properties solution.md:25-27
+  (rationale: "self-contained and sufficient").
+
+#### Falsification attempt for claim 3
+
+- **Strategy:** Dependency check — list every new test artefact across
+  the three commits and verify none is in `test/support/` or
+  references a new shared helper.
+- **Attempt:** Enumerated new test artefacts:
+  - Commit 1 (Schema): zero new test files; existing
+    `test/tau/settings/schema_test.exs` covers the changed path
+    (schema child validation claim 3, withstood).
+  - Commit 2 (Watcher): zero new test files; existing
+    `test/tau/settings/watcher_test.exs` covers the `dirs: []` path;
+    the `{:DOWN, ...}` handler test is filed as a follow-up
+    (watcher child solution §Open questions and §Migration sketch).
+  - Commit 3 (Loader): one new test file at
+    `test/tau/settings/loader_property_test.exs`; per child solution.md:111
+    no shared support module; `coherent_triple/0` is in-module.
+  None of the three commits adds anything under `test/support/`.
+- **Outcome:** withstood.
+- **Action:** none.
+
+---
+
+### Claim 4: The conjunction of the three children's `What changes` sections yields the parent acceptance criterion (a)+(b)+(c) without breaking any currently-passing test
+
+- **Claim (C):** "applying all three children's `What changes`
+  sections yields the parent acceptance criterion as a logical
+  conjunction — (a) the `catch :exit` site in Watcher is eliminated,
+  (b) `Loader.merge/2` gains property coverage, and (c) Schema's
+  rescue-based control flow is replaced with explicit conditional
+  logic, all without breaking any currently-passing test." (parent
+  solution.md, §Selected from / Composition rationale.)
+- **Grounds (G):** Parent problem.md §Acceptance criterion enumerates
+  exactly (a), (b), (c). Mapping to children:
+  - (a) "eliminate the `catch :exit` site" ← watcher-exit-catch
+    solution.md:72-74 "Delete the `try/rescue/catch` block …";
+    watcher child validation claim 1, withstood.
+  - (b) "add property tests for `Loader.merge/2`" ← merge-invariant
+    solution.md:87-101 "test/tau/settings/loader_property_test.exs (new
+    file): … property blocks"; merge-invariant child validation claims
+    1, 2, 3, 7, all withstood; claims 4, 5 partially falsified with
+    qualifier narrowing handled at implementation time.
+  - (c) "replace the rescue-based control flow in `to_known_module/1`
+    with explicit conditional logic" ← schema-exception-as-flow
+    solution.md:66-69 "replace the binary clause body … with `case
+    Map.fetch(@known_provider_names, str) …`"; schema child validation
+    claim 1, withstood.
+  "without breaking any currently-passing test" is asserted by each
+  child individually (schema child validation claim 3, withstood;
+  watcher child validation claim 2, withstood; merge-invariant child
+  preserves `loader_test.exs` untouched per solution.md:104-106).
+- **Warrant (W):** Conjunction-by-composition: if A, B, C are
+  independent claims each satisfied by an isolated change, and the
+  three changes are file-disjoint and callgraph-disjoint (claim 1),
+  then applying all three satisfies A ∧ B ∧ C. The "no broken tests"
+  property is also conjunctively preserved iff each child's change
+  preserves the tests *it touches*; file-disjointness ensures no
+  child touches another's tests.
+- **Qualifier (Q):** Holds when the implementer respects the
+  qualifier narrowing flagged by the merge-invariant child's
+  validation (claim 5 there: idempotency must be reframed as
+  left-identity or restricted to scalar-only maps). If the implementer
+  writes the property test as unqualified idempotency, it will fail
+  on non-empty list-key inputs and falsify the "no broken tests"
+  conjunct — see claim 6 below. Also holds when the implementer
+  respects the watcher child's restart-strategy open question (claim
+  5 there): the supervision tree currently runs Watcher under
+  `:rest_for_one` with the OTP-default `:permanent` restart, so a
+  thrash-on-`FileSystem`-startup-exit is a live possibility — see
+  outstanding doubts.
+- **Rebuttal (R):** A child's `What changes` claim being individually
+  validated does not guarantee the union is correct if the children
+  inadvertently share an integration surface this validation missed.
+  Claim 1's grep-based check rules out the most obvious surfaces
+  (file overlap, callsite overlap, module attribute overlap), but
+  cannot exclude every conceivable indirect coupling (e.g. shared
+  compile-time atom-table interactions, supervision tree restart
+  cascading). The most plausible residual: `:rest_for_one` means a
+  Watcher init failure restarts every child after it — including
+  `Tau.Memory.Supervisor` and `Tau.Sessions.Supervisor` — which is
+  the existing behaviour with or without the watcher change, but is
+  now more directly triggerable by a `FileSystem.start_link/1` exit
+  (vs. swallowed by `catch :exit` today).
+- **Backing (B):** Parent problem.md §Acceptance criterion (verbatim
+  conjunction); `lib/tau/application.ex:60-93` (the `:rest_for_one`
+  supervision tree with `Tau.Settings.Watcher` at position 4 of 16,
+  permanent restart); the three child validations (each with
+  falsification_attempted: true; partial falsifications already
+  documented).
+
+#### Falsification attempt for claim 4
+
+- **Strategy:** Dependency check — verify each clause of the
+  acceptance criterion is mechanically delivered by exactly one
+  child, and no clause is delivered by more than one (so no
+  redundancy obscures a gap).
+- **Attempt:** Mapped each acceptance-criterion clause to its source
+  child and to the child's `What changes` line numbers (above). All
+  three map 1-to-1. Inspected the parent `What changes` section to
+  verify it is the *union*, not a *subset*: parent solution.md
+  lines 63-112 itemise each child's commit-1, commit-2, commit-3
+  content verbatim (allowing for the parent's commit-ordering
+  framing). Verified no clause is omitted — e.g. `emit_degraded_telemetry/1`
+  extraction (watcher child §What changes) appears in parent's
+  Commit 2 bullet 4 (parent solution.md:90-93). Inspected for parent
+  additions beyond the children — none found that change behaviour
+  (the only parent additions are ordering and PR-shape commentary).
+- **Outcome:** withstood — the parent's `What changes` is exactly the
+  union of the three children's, and each acceptance-criterion clause
+  is delivered.
+- **Action:** none.
+
+---
+
+### Claim 5: There is no interface between the children's recommendations and no conflict to resolve at synthesis time
+
+- **Claim (C):** "There is no interface between the children's
+  recommendations and no conflict to resolve." (parent solution.md,
+  §Selected from / Composition rationale.)
+- **Grounds (G):** From claim 1: file-, callsite-, and callgraph-
+  disjoint at the production level. From claim 3: no shared
+  test-support module. From claim 4: each child delivers exactly one
+  clause of the acceptance criterion with no overlap. The children's
+  prose contracts (the `@moduledoc` they each propose to add or
+  modify) are scoped to their own modules. No child requires the
+  others' artefacts to compile, to run its tests, or to satisfy its
+  own acceptance criterion.
+- **Warrant (W):** An "interface" between two design changes exists
+  iff one change must observe, depend on, or assume the other's
+  artefact. Negation: if you can apply change A to HEAD, then apply
+  change B to HEAD independently, and the union of the two diffs is
+  the same as the sequential application, there is no interface.
+  Disjoint-file diffs with disjoint callgraph footprints satisfy
+  this property by construction.
+- **Qualifier (Q):** Holds at design level. At PR mechanics level,
+  the three commits share the same PR description and the same
+  reviewer pool, which is a *coordination* surface but not an
+  *interface*. The PR description (parent solution.md §Migration
+  sketch, step 4) explicitly cites the parent problem.md acceptance
+  criterion, satisfying the documentation-level integration.
+- **Rebuttal (R):** If the PR opted to land as three single-commit
+  PRs (per the open question in parent solution.md §Open questions,
+  parent-level "PR shape"), the three PRs would share no PR-level
+  interface either, and the conflict-check (factory-loop §The
+  conflict check) confirms parallelisability. So even the
+  coordination surface is dissolvable; nothing forces synthesis.
+- **Backing (B):** Hickey, "Simple Made Easy" — interface-free
+  composition is the defining property of decomplecting; parent
+  problem.md §Decomposition strategy: "they share no code paths and
+  can be analysed and remediated independently."
+
+#### Falsification attempt for claim 5
+
+- **Strategy:** Integration check — try to construct an integration
+  test the parent would need to add that depends on artefacts from
+  more than one child.
+- **Attempt:** Considered three candidate integration boundaries:
+  (i) settings cascade end-to-end (Loader → Watcher → Cache) — this
+  pre-exists in `test/tau/settings/cache_pubsub_test.exs` and is
+  unaffected by any of the three commits (no commit changes
+  `Cache.publish/reload` or the cascade contract); (ii) provider
+  resolution end-to-end (Schema → `resolve_fallback_chains/1` →
+  Loader merge of `providers.fallback_chains`) — `Loader.merge/2`
+  treats the providers block as a map (deep-merged), and Schema's
+  `resolve_fallback_chains/1` consumes the post-merge structure; the
+  Schema change is to a *private* helper (`to_known_module/1`), not
+  to the public `resolve_fallback_chains/1` contract, so no new
+  integration test is required (schema child validation claim 6,
+  public API unchanged, withstood); (iii) Watcher startup affecting
+  Loader behaviour — no path: the Watcher triggers `Cache.reload`,
+  which calls `Loader.load/1`, but neither the Watcher commit nor
+  the Loader commit changes `Loader.load/1` itself (merge-invariant
+  child solution.md:107 "out of scope"). No integration test crosses
+  two of the three commits; no integration interface exists.
+- **Outcome:** withstood.
+- **Action:** none.
+
+---
+
+### Claim 6: No behaviour change is visible to existing callers, and zero regressions occur in the existing test suite
+
+- **Claim (C):** "no behaviour change visible to any existing caller
+  and zero regressions in the existing test suite" (parent
+  solution.md §Recommendation, final sentence; restated in §What
+  does not change).
+- **Grounds (G):** Per-child substantiation:
+  - Schema: child validation claim 3 (existing tests pass without
+    modification) and claim 6 (public API unchanged), both
+    withstood. Public callers see identical `{:ok, mod} | {:error,
+    {:unknown_provider, str}}` returns from `resolve_fallback_chains/1`.
+  - Watcher: child validation claim 2 (legitimate `{:error, reason}`
+    still pattern-matched; degraded-mode telemetry still fires) and
+    the existing `watcher_test.exs` tests use the `dirs: []`
+    short-circuit, which fires before `FileSystem.start_link/1` is
+    reached — so the `try`-block removal is invisible to that test.
+  - Loader: parent solution.md §What does not change line 130-131
+    "`test/tau/settings/loader_test.exs` — the four existing example
+    tests remain untouched"; `Loader.list_keys/0` (private)
+    behaviour preserved when derived from `@merge_rules` per
+    merge-invariant child solution.md:108-109.
+- **Warrant (W):** "No behaviour change visible to existing callers"
+  is a stronger claim than "existing tests pass" only if existing
+  tests fully exercise the observable surface; here both claims hold
+  by the same evidence (each child's "What does not change" plus the
+  validated public-API stability).
+- **Qualifier (Q):** Holds when the merge-invariant child's
+  implementation respects the validated qualifier narrowing on
+  idempotency (child validation claim 5: idempotency must be reframed
+  as left-identity `merge(%{}, a) == a` OR restricted to scalar-only
+  maps). If the implementer writes the new property test as
+  unqualified `forall a, merge(a, a) == a`, the property will FAIL
+  for any test run that includes `:hooks` or other concat keys with
+  non-empty lists — and the full-suite `mix test` would then fail,
+  falsifying the "zero regressions" conjunct. Holds also when
+  Watcher's restart strategy is confirmed appropriate (child
+  validation claim 5: `:permanent` under `:rest_for_one` could
+  thrash on `FileSystem` startup exits).
+- **Rebuttal (R):** The "zero regressions" framing in the parent is
+  unqualified, but the merge-invariant child's `validation.md`
+  records the qualifier explicitly; the parent inherits that
+  qualifier (per `validate.md` §Outputs that feed parent: "The
+  parent therefore inherits any Outstanding doubts and
+  partially-falsified qualifiers — they should appear in the
+  parent's claim Qualifier fields"). The parent's open-questions
+  list (solution.md:174-212) does enumerate inherited child opens
+  including the loader idempotency open, so the qualifier is
+  documented even if the headline claim text is unqualified.
+- **Backing (B):** schema child validation.md claims 3, 6;
+  watcher child validation.md claim 2; merge-invariant child
+  validation.md claims 4, 5 (the qualifier source);
+  validate.md §Outputs that feed parent (the inheritance rule).
+
+#### Falsification attempt for claim 6
+
+- **Strategy:** Counter-example construction — try to construct an
+  implementation that follows the parent solution.md's `What changes`
+  literally and produces a failing `mix test`.
+- **Attempt:** Constructed the following implementer trajectory
+  consistent with parent solution.md but at odds with the inherited
+  qualifier: the implementer reads parent solution.md §What changes,
+  Commit 3, bullet 2 — which lists "associativity, idempotency,
+  scalar override" as the three algebraic-law properties (parent
+  solution.md:110) — and writes the idempotency property literally
+  as `forall a, merge(a, a) == a` using the same coherent generator
+  used for associativity. The generator produces maps that include
+  the list-keys (`:hooks`, `:extensions`, etc.) with non-empty list
+  values to make the associativity property non-vacuous. The
+  idempotency check then FAILS on the first generated input with a
+  non-empty list at a concat key (`merge(%{hooks: [%{e: 1}]}, %{hooks:
+  [%{e: 1}]}) == %{hooks: [%{e: 1}, %{e: 1}]}` ≠ original) — see
+  merge-invariant child validation.md §Falsification attempt for
+  claim 5. `mix test` then fails. The parent's "zero regressions"
+  conjunct is falsified for this trajectory.
+- **Outcome:** partially falsified — the unqualified "zero
+  regressions" headline is false for the worst-case literal reading
+  of parent solution.md. The narrowed survivor: "zero regressions in
+  the existing test suite when the implementer follows the
+  merge-invariant child's validation.md narrowed-qualifier guidance
+  (left-identity OR scalar-restricted idempotency)." The narrowed
+  claim is consistent with the child validation and with parent
+  solution.md §Open questions inheritance.
+- **Action:** narrow Qualifier in place (done above). No revision to
+  parent solution.md is triggered because: (a) the parent's open
+  questions inherit from the child; (b) the qualifier is already
+  recorded in `subproblems/merge-invariant-properties/validation.md`;
+  (c) the implementer's brief will surface the child validation.md
+  alongside the parent's. The corrective action is at implementation
+  time, not at parent design time — consistent with the validate.md
+  §Outputs that feed parent inheritance contract.
+
+---
+
+### Claim 7: `mix.exs` requires no changes; `ExUnitProperties` / `StreamData` are already available; `mix compile --warnings-as-errors` and `mix credo --strict` continue to pass
+
+- **Claim (C):** "`mix.exs` — `ExUnitProperties` and `StreamData` are
+  already available; no new dependency" (parent solution.md, §What
+  does not change line 134-135). Implicit in the Migration sketch
+  §4: `mix compile --warnings-as-errors` and `mix credo --strict`
+  pass on the merged tree.
+- **Grounds (G):** `mix.exs:129` — `{:stream_data, "~> 1.1",
+  only: [:test, :dev]}`. `mix.lock` line 63 — `stream_data 1.3.0`
+  resolved. Existing test files use `ExUnitProperties` and
+  `StreamData.fixed_map/1` / `StreamData.tuple/1` —
+  `test/tau/providers/rate_limiter/token_bucket_property_test.exs:23`,
+  `test/tau/circuit_breaker/state_property_test.exs:45`,
+  `test/tau/providers/shared/tool_spec_test.exs:160,168,177` (cited
+  in merge-invariant child validation claim 3, withstood). For
+  `--warnings-as-errors`: schema child validation claim 5 (withstood)
+  covers the Schema commit; the Watcher commit introduces only
+  standard OTP patterns (`Process.monitor/1`, `handle_info/2`); the
+  Loader commit's `@merge_rules` map attribute is a literal map of
+  `atom() => atom()` with `Map.get/3` dispatch — all standard
+  patterns under the Elixir compiler.
+- **Warrant (W):** A dependency declared in `mix.exs` and present in
+  `mix.lock` is available at test time. `--warnings-as-errors`
+  passes if no new pattern-match, unused-variable, or type-mismatch
+  warning is introduced; the three commits use only standard stdlib
+  patterns with exhaustive case branches.
+- **Qualifier (Q):** Holds at the locked toolchain version (Elixir
+  1.18.1 / OTP 27.2 per `.tool-versions`) and `stream_data 1.3.0`
+  per `mix.lock`. Holds for the three commits as specified; does
+  NOT extend to implementer additions beyond the validated spec
+  (e.g. if the implementer adds an unused alias).
+- **Rebuttal (R):** `mix credo --strict` could flag style issues
+  (e.g. function complexity, alias ordering) that the validation
+  cannot mentally simulate without running the tool. The schema
+  change is a 4-line substitution; the watcher change is ~15 lines
+  with one new helper function; the loader change is a literal
+  attribute and a derived accessor — none of these are likely to
+  cross Credo's strict thresholds, but unrunnable confidence is
+  weaker than executed confidence.
+- **Backing (B):** `mix.exs:129`; `mix.lock` line 63; `.tool-versions`;
+  schema child validation.md claim 5 (compile-warnings-as-errors,
+  withstood); merge-invariant child validation.md claim 3
+  (dependencies confirmed at locked versions, withstood).
+
+#### Falsification attempt for claim 7
+
+- **Strategy:** Dependency check — verify the cited line numbers and
+  versions; cross-check against the three commits' diff content.
+- **Attempt:** Verified `mix.exs:129` reads
+  `{:stream_data, "~> 1.1", only: [:test, :dev]}` ✓. Verified
+  `mix.lock` line 63 resolves to `stream_data 1.3.0` ✓. Verified
+  `test/tau/circuit_breaker/state_property_test.exs:45` uses
+  `StreamData.tuple/1` ✓ (cited in merge-invariant child validation,
+  by extension applicable here). Cross-checked the three commits'
+  added symbols (`@known_provider_names`, `Process.monitor/1`,
+  `watcher_mon`, `@merge_rules`, `merge_rules/0`,
+  `emit_degraded_telemetry/1`): all use stdlib / OTP primitives
+  with type-stable signatures. No new dependency required.
+- **Outcome:** withstood.
+- **Action:** none.
+
+---
+
+## Cross-claim consistency
+
+The seven claims partition cleanly:
+
+- **Claims 1, 2, 3** establish structural disjointness (file,
+  ordering, test-support). They are mutually reinforcing: file
+  disjointness (1) entails order independence (2), and the
+  no-shared-test-support discipline (3) preserves the same property
+  for test artefacts.
+- **Claims 4, 5** establish that the disjoint pieces compose to the
+  acceptance criterion without an integration surface. They are
+  consistent with 1-3: composition without interface is possible
+  precisely because of structural disjointness.
+- **Claim 6** is the "no regression" headline; it is partially
+  falsified under a worst-case implementer reading and inherits the
+  merge-invariant child's qualifier narrowing. Consistent with
+  claims 1-5 once the qualifier is applied: the partial falsification
+  does not invalidate disjointness, order independence, or
+  composition correctness — it only flags an implementer-side
+  discipline requirement.
+- **Claim 7** is the toolchain availability check; independent of
+  the others and consistent with all of them.
+
+One potential tension considered: claim 2 (order independence) and
+the parent solution.md's explicit ordering recommendation
+(schema → watcher → loader). The parent text reconciles this
+explicitly ("The order is not load-bearing … but this order makes
+review easier and a mid-PR revert cleaner") — order is a workflow
+preference, not a correctness constraint. Consistent.
+
+A second potential tension: claim 6 (no regressions) and the inherited
+merge-invariant qualifier (idempotency partially falsified). The
+parent solution.md's "What does not change" line 134-135 inherits
+no-mix.exs-change cleanly but its `Recommendation` text uses the
+unqualified "zero regressions" framing. The validation here narrows
+the qualifier per `validate.md` §Outputs that feed parent; no
+revision required because the child validation already records the
+qualifier and the parent's open-questions list inherits the open
+explicitly.
+
+No unresolvable tensions.
+
+---
+
+## Falsification summary
+
+| # | Claim (short) | Strategy | Outcome | Action |
+|---|---|---|---|---|
+| 1 | Three children file-/callsite-/callgraph-disjoint | Dependency check | Withstood | None |
+| 2 | Composition order recommended but not load-bearing | Counter-example construction | Withstood | None |
+| 3 | No shared `test/support/` module introduced | Dependency check | Withstood | None |
+| 4 | Conjunction of children's changes yields parent AC (a)+(b)+(c) | Dependency check | Withstood | None |
+| 5 | No interface between children; no conflict to resolve | Integration check | Withstood | None |
+| 6 | No behaviour change to existing callers; zero regressions | Counter-example construction | Partially falsified | Narrow qualifier — implementer must respect merge-invariant child's left-identity-or-scalar-restricted idempotency framing |
+| 7 | `mix.exs` unchanged; toolchain unchanged; compile clean | Dependency check | Withstood | None |
+
+---
+
+## Revision required
+
+No revision to `solution.md` or `problem.md` is triggered. The
+partial falsification of claim 6 narrows the qualifier in place:
+
+- **Target file:** (none — the qualifier is already recorded in
+  `subproblems/merge-invariant-properties/validation.md` §Claims 4-5
+  and inherited per `validate.md` §Outputs that feed parent.)
+- **Revision kind:** qualifier narrowing (in place); no file edit
+  required.
+- **Rationale:** The merge-invariant child's validation.md already
+  documents the idempotency narrowing (left-identity or
+  scalar-restricted). The parent solution.md §Open questions list
+  inherits open questions from the children explicitly. The
+  implementer's brief at PR time will surface both the parent
+  solution.md and the child validation.md; that is the appropriate
+  locus for the implementer to apply the narrowed framing. Editing
+  the parent solution.md to repeat the qualifier would duplicate
+  the child's contract without adding information.
+
+---
+
+## Outstanding doubts
+
+These are inherited from the children per `validate.md` §Outputs
+that feed parent. They are properly the parent's qualifier surface,
+not blocking issues:
+
+1. **Idempotency framing (from merge-invariant child claims 4-5).**
+   The new property test must be written as left-identity
+   (`merge(%{}, a) == a`) OR with a generator restricted to maps
+   with no non-empty concat-key list values. The parent solution.md
+   §What changes line 110 lists "associativity, idempotency, scalar
+   override" without this qualifier; the implementer must respect
+   the qualifier from the child validation.md or the property test
+   will fail and falsify claim 6.
+
+2. **Watcher restart strategy (from watcher child claim 5).** The
+   Watcher is supervised under `:rest_for_one` with the OTP-default
+   `:permanent` restart (`lib/tau/application.ex:60-93`). Removing
+   `catch :exit` means a `FileSystem.start_link/1` exit during
+   `init/1` now propagates to the supervisor, which will restart
+   the Watcher up to the max-restart threshold. Under `:rest_for_one`,
+   a Watcher restart also restarts every child after it
+   (`Tau.Memory.Supervisor`, `Tau.Permissions.RuleSet`, ...,
+   `Tau.Sessions.Supervisor` — 12 children). The implementer should
+   confirm (a) whether the Watcher's restart option should be
+   changed to `:transient` or `:temporary`, and (b) whether the
+   `:rest_for_one` cascade is the desired behaviour for a degraded
+   filesystem watch. The parent solution.md §Open questions inherits
+   this; the validation flags it as a live risk because the existing
+   `try`/`catch :exit` was silently absorbing this scenario.
+
+3. **`file_system` library `start_link` contract (from watcher child
+   open question).** The `rescue e` arm is removed in the hybrid;
+   the child judges this acceptable based on the library's
+   documented return-value+exit contract. Not verified against the
+   pinned version in `mix.lock`. A two-line grep of the pinned
+   `file_system` source would close this doubt.
+
+4. **External provider-name documentation (from schema child claim 4
+   partial falsification).** The `@known_provider_names` map uses
+   the `"Tau.Providers.X"` format. If external user-facing
+   documentation (rendered README on Codeberg/GitHub) uses
+   short-form names (e.g. `"Anthropic"`), users following that doc
+   would silently get `{:error, {:unknown_provider, "Anthropic"}}`.
+   This is the same behaviour as the current rescue-based
+   implementation, so it is not a regression — but the
+   key-derivation convention becomes load-bearing and should be
+   commented in the attribute definition (covered in parent
+   solution.md §Open questions inherited from the schema child).
+
+5. **`{:DOWN, …}` handler test coverage (from watcher child open
+   question).** Not required by the acceptance criterion; the
+   watcher child recommends a follow-up issue. The parent solution.md
+   inherits the open. The test can be written as a `send/2`-driven
+   unit test in a later PR.
+
+6. **PR shape (parent-level open).** Single PR with three commits
+   vs. three single-commit PRs. The factory-loop conflict check
+   confirms parallelisability either way. No correctness implication;
+   workflow choice.

--- a/docs/problems-archive-v1-modules/tau-tools-hooks-mcp/problem.md
+++ b/docs/problems-archive-v1-modules/tau-tools-hooks-mcp/problem.md
@@ -1,0 +1,127 @@
+---
+template_version: 1
+template_name: problem
+node_kind: internal
+depth: 0
+parent: —
+status: decomposed
+---
+
+# Problem: tau-tools-hooks-mcp — Three subsystems, four complecting seams
+
+## Statement
+
+The tool-execution surface (built-in tools, hook dispatcher, MCP server
+integration) shares three independent responsibilities — result-shape contract,
+I/O collection, and concurrency model — that are woven together inconsistently
+across the files. No single consumer can reason about what a tool result looks
+like, whether a collector is bounded, or whether an MCP call serialises its
+server, without reading implementation details scattered across all three
+subsystems. Untangling these seams would allow each subsystem to be understood,
+tested, and changed independently.
+
+## Context
+
+Source under audit:
+
+- `lib/tau/tool.ex`, `lib/tau/tool/result.ex` — behaviour + result struct
+- `lib/tau/tools/builtin/` — six built-in tool implementations
+- `lib/tau/tools/operations/local.ex` — filesystem + process backend
+- `lib/tau/hook.ex`, `lib/tau/hooks/dispatcher.ex`, `lib/tau/hooks/shell.ex` — hook behaviour + shell adapter
+- `lib/tau/mcp/server.ex`, `lib/tau/mcp/tool_adapter.ex`, `lib/tau/mcp/reconciler.ex` — MCP server GenServer + registry
+- `lib/tau/mcp/transport/{stdio,http,sse}.ex` — three transport implementations
+
+Prior evidence: `.code_audit/archive/v1-flat/03-tools-hooks-mcp.md` — full
+flat audit with severity-ranked findings. Behaviour interfaces (`Tau.Tool`,
+`Tau.Hook`, `Tau.MCP.Transport`) are structurally sound; problems are
+concentrated in the implementations.
+
+## Complecting hypothesis
+
+1. **Result-shape contract is complected with each tool's implementation**
+   because `details.kind`, telemetry spans, and the "must never raise" rule are
+   enforced nowhere central — each tool author chose independently whether to
+   include them, producing silent drift.
+
+2. **I/O collection strategy is complected with process lifecycle** because
+   `local.ex`'s `bash/2`, `hooks/shell.ex`'s `collect/3`, and
+   `mcp/transport/stdio.ex`'s `recv/2` each hand-roll `receive` loops that
+   accumulate in unbounded binaries (`acc <> data`), making the truncation
+   policy, the memory bound, and the cancellation path each tool's individual
+   concern.
+
+3. **MCP server concurrency is complected with transport state management**
+   because `Http.send/2` blocks the GenServer for the full HTTP round-trip
+   (serialising all tool calls), while the SSE transport's out-of-band
+   `handle_info(_msg)` drain can silently consume queued responses that belong
+   to pending callers.
+
+## Decomposition strategy
+
+Four MECE sub-problems, each isolating one complecting concern by the
+**concern (Hickey)** axis:
+
+- **tool-result-contract** — the shape and enforcement boundary that all tool
+  implementations must satisfy (details schema, telemetry, raise prohibition).
+  Covers all of `lib/tau/tools/builtin/`, `lib/tau/tool/result.ex`.
+- **io-collectors** — the mechanics of binary accumulation and bounded
+  collection in the three hand-rolled receive loops (Bash stdout, shell-hook
+  stdout, MCP stdio). Covers `local.ex`, `hooks/shell.ex`,
+  `mcp/transport/stdio.ex`.
+- **mcp-server-concurrency** — the MCP server's synchrony model: how `invoke`
+  calls serialise the GenServer when transports block, and how the
+  `handle_info(_msg)` clause drains the SSE queue out of band. Covers
+  `mcp/server.ex`, `mcp/transport/http.ex`, `mcp/transport/sse.ex`.
+- **dynamic-module-generation** — the pattern of compiling one anonymous module
+  per hook entry and per MCP tool at runtime via `Module.create/3`, leaking
+  atoms on every reload. Covers `hooks/shell.ex`, `mcp/tool_adapter.ex`.
+
+This axis yields MECE because: no finding about result shape touches the I/O
+collector mechanics; no I/O collector concern touches MCP server concurrency;
+no concurrency concern touches dynamic module generation. Each sub-problem
+is actionable without first resolving any sibling.
+
+## Sub-problems (filled by decomposer)
+
+1. **tool-result-contract** — The `Tau.Tool.Result` contract (details schema,
+   telemetry coverage, raise prohibition) is declared on the behaviour but not
+   enforced; individual tool implementations silently diverge.
+2. **io-collectors** — Three hand-rolled `receive`/binary-accumulation loops
+   across Bash, shell hooks, and MCP stdio accumulate without a byte cap inside
+   the loop, risking OOM on large outputs and duplicating port-close error
+   handling.
+3. **mcp-server-concurrency** — The MCP `Server` GenServer serialises all tool
+   invocations because transports perform synchronous network I/O inside
+   `send/2`, and the `handle_info(_msg, state)` catch-all drains the SSE queue
+   out of band.
+4. **dynamic-module-generation** — Shell hooks and MCP tool adapters each
+   compile one anonymous module per config entry at settings-load time via
+   `Module.create/3`, growing the atom table and module code table on every
+   reload without ever purging prior versions.
+
+## Acceptance criterion
+
+The problem is solved when each of the four sub-problems has a validated
+proposal that, taken together, would allow a reader of `lib/tau/tools/`,
+`lib/tau/hooks/`, and `lib/tau/mcp/` to identify the shape contract, collection
+bound, concurrency model, and dispatch mechanism for each subsystem from its
+public interface alone, without reading implementation details of siblings.
+
+## Out of scope
+
+- Path-traversal and sandbox enforcement (`resolve/2` in `local.ex`) — a
+  security concern separate from the complecting analysis; tracked in the flat
+  audit as a distinct finding.
+- Fake unified diff in `Edit` (`render_diff/2`) — functional defect, not a
+  complecting issue.
+- `Agent.parse_mode/1` using `try/rescue` for atom lookup — a single-site
+  anti-idiom, not a systemic complecting seam.
+- MCP server `pending` map unbounded growth on timeout — a resource-leak bug in
+  the concurrency sub-problem, but the bounded-collection fix lives in
+  `io-collectors`.
+- ENV variable leakage into Bash subprocesses — a security / policy concern,
+  out of scope for this structural audit.
+
+## Amendment log
+
+- (none yet)

--- a/docs/problems-archive-v1-modules/tau-tools-hooks-mcp/solution.md
+++ b/docs/problems-archive-v1-modules/tau-tools-hooks-mcp/solution.md
@@ -1,0 +1,295 @@
+---
+template_version: 1
+template_name: solution
+parent_problem: ./problem.md
+node_kind: root
+synthesised_from:
+  - subproblems/tool-result-contract/solution.md
+  - subproblems/io-collectors/solution.md
+  - subproblems/mcp-server-concurrency/solution.md
+  - subproblems/dynamic-module-generation/solution.md
+selection_method: synthesis
+mode: non-leaf
+revision: 0
+---
+
+# Solution: Four decomplecting moves — central tool dispatch wrapper, shared port utility, async MCP transport, data-driven hook/MCP registries
+
+## Recommendation
+
+Apply all four child recommendations together as a coherent module-wide
+decomplecting of `lib/tau/tools/`, `lib/tau/hooks/`, and `lib/tau/mcp/`. The
+moves target four orthogonal seams identified in the root problem
+(result-shape contract, I/O collection, MCP concurrency, dynamic module
+generation); each child solution acts on exactly one seam and they compose
+without conflict on any module. The combined effect is that, after landing,
+each subsystem's *public interface* (`Tau.Tool` behaviour, `Tau.Hook`
+behaviour, `Tau.MCP.Transport` behaviour, `Tau.MCP.Server` API) reveals its
+shape contract, collection bound, concurrency model, and dispatch mechanism
+without requiring a reader to inspect sibling implementations. Concretely:
+(1) `Tau.Tool.Executor.call/4` becomes the single enforcement site for the
+result-shape contract; (2) `Tau.IO.Port.close_if_open/1` is the single shared
+port-liveness utility and the three hand-rolled receive loops gain in-place
+iolist cap guards; (3) `Tau.MCP.Transport` drops `recv/2` and the Server
+adopts task-per-invoke async delivery with `Process.monitor/1` pruning; (4)
+`%Tau.Hooks.Shell.Entry{}` and `%Tau.MCP.ToolEntry{}` replace
+`Module.create/3` runtime generation, widening `Tau.Tool.lookup/1` to return
+either a module or a `ToolEntry` struct dispatched by an added pattern-match
+clause.
+
+## Selected from
+
+- **Synthesised from:**
+  - `subproblems/tool-result-contract/solution.md` — central
+    `Tau.Tool.Executor.call/4` wrapper.
+  - `subproblems/io-collectors/solution.md` — in-place iolist cap guards +
+    shared `Tau.IO.Port.close_if_open/1` utility.
+  - `subproblems/mcp-server-concurrency/solution.md` — task-per-invoke +
+    async-contract `Tau.MCP.Transport` behaviour (remove `recv/2`).
+  - `subproblems/dynamic-module-generation/solution.md` — tagged struct
+    registry values + pattern-matched dispatch clause.
+- **Composition rationale:** the four children act on disjoint module sets
+  along disjoint axes, confirmed by the root problem's MECE decomposition.
+  No child's "What changes" list collides with another's at the function
+  level. The non-trivial composition points are:
+
+  1. **`Tau.Tool.Executor` × `%Tau.MCP.ToolEntry{}` dispatch.** The
+     result-contract child scopes its wrapper to
+     `Tau.Session.ToolDispatch.run_tool_validated/6` invoking
+     `mod.execute/2` — the compile-time tool path. The dynamic-module-
+     generation child adds a second dispatch clause matching
+     `%Tau.MCP.ToolEntry{}` that calls
+     `Tau.MCP.ToolAdapter.invoke_remote/3` directly, bypassing the
+     executor. *Resolution:* `run_tool_validated/6` invokes
+     `Tau.Tool.Executor.call/4` on **both** branches; the executor's
+     `(mod_or_entry, args, ctx, started)` signature accepts either a module
+     atom (calls `mod.execute/2`) or a `%ToolEntry{}` (calls
+     `Tau.MCP.ToolAdapter.invoke_remote/3`). This preserves the
+     contract-enforcement guarantee uniformly across compile-time and
+     runtime-registered tools and keeps telemetry coverage symmetric. The
+     executor's per-tool telemetry naming for `%ToolEntry{}` uses the
+     fallback `[:tau, :tool, :dynamic, ...]` namespace already documented
+     in the result-contract solution as the runtime-registered case —
+     this is exactly that case, not a new one.
+
+  2. **`Tau.Tool.Executor` × `%Tau.Hooks.Shell.Entry{}` dispatch.** The
+     hook dispatch path (`Tau.Hooks.Dispatcher.run_one/3`) is a separate
+     dispatch entry point — it is not routed through
+     `Tau.Tool.Executor`, which targets tools, not hooks. Hooks have
+     their own contract (`Tau.Hook` behaviour). *Resolution:* no
+     interaction; the new `%Entry{}` clause delegates to
+     `Tau.Hooks.Shell.run_command/5` as the dynamic-module-generation
+     child specifies, and the executor stays out of the hook path.
+
+  3. **`Tau.IO.Port.close_if_open/1` × MCP transport `recv/2` removal.**
+     The io-collectors child replaces the `try/catch Port.close/1` at
+     `lib/tau/mcp/transport/stdio.ex:82` with
+     `Tau.IO.Port.close_if_open/1`. The mcp-server-concurrency child
+     removes `recv/2` from the `Tau.MCP.Transport` behaviour entirely
+     and removes its implementation in stdio. *Resolution:* the io-
+     collectors fix to `recv/2`'s `{:noeol, partial}` branch and its
+     `close/1` site is preserved *until* `recv/2` is removed, then both
+     drop out together. Sequencing (see Migration sketch) ensures the
+     io-collectors fix lands first or the `recv/2` removal lands first
+     — either order works because they touch different concerns of the
+     same function, and the final state is the same: `recv/2` is gone,
+     `close/1` uses `Tau.IO.Port.close_if_open/1`.
+
+  4. **`Tau.MCP.Server` × `%ToolEntry{}` registry value.** The dynamic-
+     module-generation child notes that `Tau.MCP.Server.terminate/2`'s
+     `Registry.unregister/2` calls remain and no `:code.delete/1` is
+     needed. The mcp-server-concurrency child rewrites
+     `handle_call({:invoke, ...})` to be non-blocking; the new
+     `pending` map shape (`id => {from, monitor_ref}`) is orthogonal to
+     the registry's value type. *Resolution:* no interaction; the two
+     changes touch different fields of the Server state.
+
+  No child's change to a public behaviour (`Tau.Tool`, `Tau.Hook`,
+  `Tau.MCP.Transport`) is contradicted by another. The composition is
+  direct.
+
+## What changes
+
+**Tool result contract** (see child solution for full detail):
+
+- New `lib/tau/tool/executor.ex` defining `Tau.Tool.Executor.call/4`.
+- `lib/tau/session/tool_dispatch.ex` — `run_tool_validated/6` routes both
+  module-tool and `%ToolEntry{}`-tool branches through the executor (the
+  union dispatch is the synthesis-level composition; the child solution
+  scoped it to the module branch only).
+- `lib/tau/tools/builtin/bash.ex` — `persist_full/3` uses non-raising
+  `File.mkdir_p/1` / `File.write/1`.
+- New unit tests under `test/tau/tool/executor_test.exs`.
+
+**I/O collectors** (see child solution for full detail):
+
+- New `lib/tau/io/port.ex` defining `Tau.IO.Port.close_if_open/1`.
+- `lib/tau/tools/operations/local.ex` — `collect_port/3` iolist + running
+  byte counter + in-loop cap guard; replace `try/catch Port.close/1` with
+  the shared utility.
+- `lib/tau/hooks/shell.ex` — `collect/3` same iolist + cap pattern; replace
+  `try/catch`.
+- `lib/tau/mcp/transport/stdio.ex` — if `recv/2` is retained at this point
+  in the sequence, add the `{:noeol, partial}` cap guard; replace `close/1`
+  `try/catch`. If `recv/2` is already removed, only the `close/1` site
+  remains.
+
+**MCP server concurrency** (see child solution for full detail):
+
+- `lib/tau/mcp/transport.ex` — remove the `recv/2` callback from the
+  behaviour; update `send/2` (or new `send/4`) docstring to state the
+  non-blocking contract.
+- `lib/tau/mcp/transport/{http,sse,stdio}.ex` — remove `recv/2`; rewrite
+  `Http.send/2` to `Task.start/1` + message delivery.
+- `lib/tau/mcp/server.ex` — non-blocking `handle_call({:invoke, ...})`;
+  new `handle_info` clauses for task results and `:DOWN` pruning; strip
+  the `transport.recv` side-effect from the catch-all.
+- Test additions under `test/tau/mcp/` for concurrent-invoke wall-time
+  assertion.
+
+**Dynamic module generation** (see child solution for full detail):
+
+- `lib/tau/hooks/shell.ex` — define `%Tau.Hooks.Shell.Entry{}`; `build/2`
+  returns the struct; remove `Module.create/3` and `generate_name/0`.
+- `lib/tau/mcp/tool_adapter.ex` — define `%Tau.MCP.ToolEntry{}`; `build/5`
+  returns the struct; `invoke_remote/3` stays as the dispatch helper.
+- `lib/tau/hooks/dispatcher.ex` — add `run_one/3` clause matching
+  `%Entry{}` delegating to `Tau.Hooks.Shell.run_command/5`.
+- `lib/tau/session.ex` (or `lib/tau/session/tool_dispatch.ex` if the
+  dispatch lives there) — add `dispatch_tool/3` clause matching
+  `%ToolEntry{}`; route through `Tau.Tool.Executor.call/4` per
+  composition note (1) above.
+- `lib/tau/tool.ex` — `lookup/1` return type widens to
+  `{:ok, module() | Tau.MCP.ToolEntry.t()} | :error`.
+- Confirm via grep all callsites iterating registered tools and
+  introspecting `mod.name/0` / `mod.description/0` / `mod.parameters/0`;
+  add the `%ToolEntry{}` branch where applicable.
+
+## What does not change
+
+- The four public behaviours' core shapes are preserved where the child
+  solutions are explicit about preservation:
+  - `Tau.Tool` callback signatures (`name/0`, `description/0`,
+    `parameters/0`, `execute/2`, `execution_mode/0`, `streams_updates?/0`).
+  - `Tau.Tool.Result` struct definition (`content`, `details`,
+    `terminate?`, `is_error`); `details` remains `map()`.
+  - `Tau.Hook` behaviour and its compile-time-module dispatch clause in
+    `Tau.Hooks.Dispatcher.run_one/3` (`is_atom(mod)`).
+  - `Tau.MCP.Transport` `send/2` (or `send/4`) and `close/1` shape;
+    `recv/2` is removed because no remaining caller needs it after the
+    concurrency fix.
+- The supervision tree — no new GenServers, no new ETS tables, no new
+  supervised workers across all four moves. (This is an explicit
+  composition guarantee: the result-contract wrapper is a pure function;
+  the port utility is a pure function; the task-per-invoke uses
+  `Task.start/1`; the registry-value struct change replaces dynamic
+  modules with data.)
+- `Tau.Hooks.Registry` / `Tau.Tools.Registry` modules and their lifetime
+  semantics; only stored value types change.
+- `Tau.Hooks.Shell.run_command/5` and `Tau.MCP.ToolAdapter.invoke_remote/3`
+  signatures.
+- The session-side `Tau.Message.ToolResult` wire type and JSONL persistence
+  format.
+- The existing `[:tau, :tool, :execute, :start/:stop/:exception]` session-
+  level telemetry (per-tool events are additive).
+- The 30-second MCP `@timeout` per-call cap; SSE `Task.async` lifecycle
+  (explicit OOS in mcp-server-concurrency child).
+- Path-traversal / sandbox enforcement, the fake unified diff in `Edit`,
+  `Agent.parse_mode/1`'s `try/rescue`, ENV variable leakage into Bash —
+  all explicit OOS per root `problem.md`.
+
+## Migration sketch
+
+The four moves can land as four independent PRs in this dependency order;
+they do not require a single mega-PR.
+
+1. **PR-A — `Tau.IO.Port` + io-collectors.** Add `lib/tau/io/port.ex`;
+   apply in-place iolist cap fixes to `local.ex`, `hooks/shell.ex`,
+   `mcp/transport/stdio.ex`. Self-contained; no cross-subsystem dependency.
+   Smallest blast radius — land first to validate the shared-utility
+   pattern.
+2. **PR-B — `Tau.Tool.Executor` (module-tool branch only).** Add
+   `lib/tau/tool/executor.ex`; route the existing
+   `run_tool_validated/6` module-call through it; rewrite `Bash.persist_full/3`
+   to non-raising. Lands before PR-D so the union dispatch in PR-D has the
+   executor to call.
+3. **PR-C — MCP transport async + `recv/2` removal.** Update
+   `transport.ex` behaviour, remove `recv/2` from all three transport
+   modules, rewrite `Http.send/2` async, update `server.ex` handle_call
+   and handle_info clauses. After PR-A: the io-collectors fix to
+   `recv/2`'s `{:noeol, partial}` branch becomes dead code and is
+   removed as part of the `recv/2` deletion (the `close/1` site retains
+   `Tau.IO.Port.close_if_open/1`). Independent of PR-B and PR-D.
+4. **PR-D — Tagged-struct registries.** Define `%Entry{}` and
+   `%ToolEntry{}`; rewrite `build/2` / `build/5` to return structs; add
+   dispatcher clauses; widen `Tau.Tool.lookup/1`. The session dispatch
+   clause for `%ToolEntry{}` routes through `Tau.Tool.Executor.call/4`
+   from PR-B — this is the synthesis-level composition point. Land after
+   PR-B.
+
+SPEC-USER-TURN is gated for PR-B and PR-D (both touch
+`lib/tau/session/tool_dispatch.ex` and/or `lib/tau/session.ex`); the PRs
+cite the relevant `AC-N` / `D-NNN` per `spec-before-code.md`. PR-A and
+PR-C are confined to non-session files and do not need SPEC-USER-TURN
+gating; PR-C does touch MCP behaviour state and likely warrants a new
+`D-NNN` describing the async contract (the child solution's "remove
+`recv/2`" is the corresponding SPEC §3 amendment that lands in the same
+PR per `spec-before-code.md`).
+
+Each PR is independently reversible by reverting its commits; nothing in
+the sequence forces an irreversible coupling.
+
+## Open questions
+
+Inherited from children (not resolved at the synthesis level):
+
+- **Result-contract:** `ensure_kind/1` warning policy in `:dev`/`:test`;
+  runtime-registered tools' telemetry granularity (the synthesis pins
+  these to the `[:tau, :tool, :dynamic, ...]` fallback for `%ToolEntry{}`,
+  but the broader question for extension-loaded tools remains); whether
+  to add the contract-test follow-up; downstream consumers of
+  `details.full_output_path` and the `nil`-on-error degradation.
+- **I/O collectors:** `@max_bytes` direction of dependency between
+  `local.ex` and `bash.ex`; `hooks/shell.ex` cap value; existing
+  `truncate/3` test assertions on exact byte counts; UTF-8 boundary
+  policy.
+- **MCP concurrency:** `send/2` vs `send/4` arity decision;
+  `Task.start` vs `Task.Supervisor.start_child` (per OTP non-negotiable
+  on supervised processes); `Finch.async_request` vs `Task.start` +
+  `Finch.request`; SSE concurrent-invoke ordering semantics.
+- **Dynamic-module:** exact count of `mod.name/0` / `mod.description/0` /
+  `mod.parameters/0` introspection callsites; whether `build/5`'s
+  unused `mod_name` arg is retained for arity compat; the precise
+  `D-NNN` under SPEC-USER-TURN this advances; future
+  extension-loaded-tools pattern.
+
+Synthesis-level open question (not in any child):
+
+- **Executor coverage of the hook path.** The synthesis explicitly
+  scopes `Tau.Tool.Executor` to the tool dispatch path, not the hook
+  dispatch path. Hooks have their own `Tau.Hook` behaviour and their
+  own raise / kind / telemetry expectations. Whether a parallel
+  `Tau.Hook.Executor` should exist is a follow-up question — out of
+  scope here because the root acceptance criterion only requires that
+  each subsystem be reasonable *from its public interface*; the hook
+  contract is currently defined by `Tau.Hook` and not by `Tau.Tool`.
+
+## Linked sub-problems / proposals
+
+- `subproblems/tool-result-contract/` → "Central `Tau.Tool.Executor`
+  dispatch wrapper enforces the three contract properties (raise
+  rescue, `:kind` injection, per-tool telemetry)."
+- `subproblems/io-collectors/` → "In-place iolist cap guards across the
+  three sites, plus a single shared `Tau.IO.Port.close_if_open/1`
+  utility for port-liveness."
+- `subproblems/mcp-server-concurrency/` → "Task-per-invoke async
+  delivery + remove `recv/2` from the `Tau.MCP.Transport` behaviour;
+  monitor caller / task pids for pending-map pruning; strip
+  `transport.recv` from the catch-all."
+- `subproblems/dynamic-module-generation/` → "Replace `Module.create/3`
+  with tagged struct registry values (`%Tau.Hooks.Shell.Entry{}`,
+  `%Tau.MCP.ToolEntry{}`) dispatched by pattern-match clauses."
+
+## Revision history
+
+- (revision 0 — initial)

--- a/docs/problems-archive-v1-modules/tau-tools-hooks-mcp/subproblems/dynamic-module-generation/problem.md
+++ b/docs/problems-archive-v1-modules/tau-tools-hooks-mcp/subproblems/dynamic-module-generation/problem.md
@@ -1,0 +1,91 @@
+---
+template_version: 1
+template_name: problem
+node_kind: leaf
+depth: 1
+parent: ../../problem.md
+status: draft
+---
+
+# Problem: dynamic-module-generation — Runtime Module.create/3 per config entry leaks atoms and defeats hot-reload
+
+## Statement
+
+`Tau.Hooks.Shell.build/2` compiles one anonymous module per declarative hook
+entry at settings-load time using `Module.create/3`, and
+`Tau.MCP.ToolAdapter.build/5` does the same for each MCP tool discovered via
+`tools/list`. Each generated module name includes a random suffix
+(`Module.concat([..., "Generated_#{random}"])`) or a namespaced path that encodes
+a mutable server-name + tool-name pair. Because neither site ever calls
+`Module.delete/1` on the prior generation, a settings reload or an MCP server
+restart produces an unbounded accumulation of loaded-but-orphaned BEAM modules
+and their corresponding atom-table entries, which are permanent for the lifetime
+of the BEAM node.
+
+## Context
+
+- `lib/tau/hooks/shell.ex:38-63` — `build/2` calls `Module.create/3` with a
+  random-suffix module name on every invocation. `generate_name/0` uses
+  `:crypto.strong_rand_bytes(6) |> Base.url_encode64` — each call produces a
+  unique atom.
+- `lib/tau/hooks/shell.ex:40-41` — `Module.create/3` is called after `quote`
+  but there is no corresponding `Module.delete/1`, `:code.purge/1`, or
+  `:code.delete/1` anywhere in the codebase.
+- `lib/tau/mcp/tool_adapter.ex:21-49` — `build/5` does the same: `mod_name =
+  Module.concat([Tau.MCP.ToolAdapter, server_name, name])`. On MCP server
+  restart (e.g. after a network drop) `build/5` is called again with the same
+  `mod_name`, overwriting the prior version in-memory but leaving the old code
+  generation loaded.
+- `lib/tau/mcp/server.ex:120-124` — `terminate/2` calls
+  `Registry.unregister/2` for each registered key, but does NOT call
+  `:code.delete/1` or `Module.delete/1` on the generated adapter modules.
+- Flat audit major findings: `hooks/shell.ex:38-63` and
+  `mcp/tool_adapter.ex:21-49` — "Reloading settings creates fresh modules
+  without ever purging the old ones... The `Module.concat([..., "Generated_#
+  {random}"])` pattern guarantees atom-table growth."
+- The dispatch benefit of one-module-per-entry is the same as a
+  pattern-matched `Dispatcher.run_command(cmd, matcher, ...)` keyed on a plain
+  map: the extra indirection adds no value.
+
+## Complecting hypothesis
+
+**The hook dispatch mechanism is complected with the hook's identity** because
+`Hooks.Dispatcher` looks up hooks by module in the registry, requiring each
+hook to be a distinct module — which in turn forces `build/2` to compile a new
+module per entry rather than treating a hook as a tagged data structure. The
+same complecting applies to MCP tool adapters: the `Tau.Tool` behaviour requires
+`name/0`, `description/0`, and `parameters/0` to be functions, but all three
+values are constant at registration time and could be stored in a registry value
+rather than burned into a compiled module.
+
+## Decomposition strategy
+
+(leaf — no further decomposition; proceed to proposals)
+
+## Acceptance criterion
+
+The problem is solved when: (a) settings reload (whether triggered by
+`Tau.MCP.Reconciler.reload/0` or by the file watcher) does not add any new
+entries to the BEAM atom table for hook or MCP tool identifiers; (b) MCP server
+restart does not leave orphaned module code generations in the BEAM code server
+(verifiable via `:code.all_loaded/0` before and after a simulated restart); and
+(c) the Hooks dispatcher and MCP tool dispatch continue to pass their existing
+tests without modification to the test suite.
+
+## Out of scope
+
+- Hook shell-injection risk via `{:spawn, cmd}` — a security concern in
+  `Hooks.Shell.do_run/4`; does not interact with the module-generation pattern.
+- The `matches?/2` stub (always returns `true`) — an incomplete feature in
+  `Hooks.Shell`; fixing it does not require changing the module-generation
+  approach.
+- The MCP `server.ex` concurrency model — covered by `mcp-server-concurrency`;
+  the module-generation fix can proceed independently of how `invoke/3` is
+  parallelised.
+- Whether `Tau.Tool` behaviour should be restructured to support data-driven
+  dispatch more broadly (e.g. for extension tools) — that is a behaviour design
+  question outside the scope of the module-leak fix.
+
+## Amendment log
+
+- (none yet)

--- a/docs/problems-archive-v1-modules/tau-tools-hooks-mcp/subproblems/dynamic-module-generation/proposals/proposal-1.md
+++ b/docs/problems-archive-v1-modules/tau-tools-hooks-mcp/subproblems/dynamic-module-generation/proposals/proposal-1.md
@@ -1,0 +1,175 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 1
+parent_problem: ../problem.md
+---
+
+# Proposal 1: Data-driven dispatch — eliminate Module.create/3 entirely; store hook and tool config as tagged structs in registry values
+
+## Approach
+
+Replace every `Module.create/3` callsite with a plain-data registration. Define
+`%Tau.Hooks.Shell.Entry{cmd, matcher, timeout_ms, events}` and
+`%Tau.MCP.ToolEntry{server_name, namespaced_name, description, parameters}` as
+plain structs. Store these structs directly as the registry value (instead of a
+module atom). Rewrite `Tau.Hooks.Dispatcher.run_one/3` and `Tau.Tool.lookup/1`
+(and the session FSM's tool dispatch path) to pattern-match on the struct tag
+and delegate to the appropriate dispatch function
+(`Tau.Hooks.Shell.run_command/5` or `Tau.MCP.ToolAdapter.invoke_remote/3`).
+No compiled module is produced at settings-load time. Atoms created are only
+the field-name atoms already in the struct definition, which are compile-time
+constants, not per-config-entry runtime atoms.
+
+## Rationale
+
+The complecting hypothesis is that dispatch identity is forced to be a module
+because `Hooks.Registry` and `Tools.Registry` store modules. Eliminating the
+module-per-entry constraint decomplects the hook's _identity_ from its
+_dispatch mechanism_. Once identity is a struct (data), reload is a data swap:
+unregister the old struct values, register the new ones. No atom accumulation
+is possible because no new atoms are created after boot. The dispatch logic
+already exists as `run_command/5` and `invoke_remote/3` — both are public,
+behaviour-preserving, and called from within the generated modules today.
+
+## Sketch
+
+```elixir
+# lib/tau/hooks/shell.ex
+defmodule Tau.Hooks.Shell.Entry do
+  @enforce_keys [:cmd, :events]
+  defstruct [:cmd, :matcher, :timeout_ms, :events]
+end
+
+# build/2 becomes:
+@spec build(map(), [Tau.Hook.event()]) :: Tau.Hooks.Shell.Entry.t()
+def build(%{"command" => cmd} = config, events) do
+  %Tau.Hooks.Shell.Entry{
+    cmd: cmd,
+    matcher: config["matcher"],
+    timeout_ms: (config["timeout"] || 60) * 1000,
+    events: events
+  }
+end
+# No Module.create/3. No atom generated.
+
+# lib/tau/hooks/dispatcher.ex — run_one becomes:
+defp run_one(%Tau.Hooks.Shell.Entry{} = entry, event, payload) do
+  run_one_result(
+    Tau.Hooks.Shell.run_command(entry.cmd, entry.matcher, entry.timeout_ms, event, payload),
+    payload
+  )
+end
+
+defp run_one(mod, event, payload) when is_atom(mod) do
+  # existing behaviour-module path unchanged
+  run_one_result(mod.handle(event, payload), payload)
+end
+
+# lib/tau/mcp/tool_adapter.ex — build/5 becomes:
+defmodule Tau.MCP.ToolEntry do
+  @enforce_keys [:server_name, :namespaced_name, :description, :parameters]
+  defstruct [:server_name, :namespaced_name, :description, :parameters]
+end
+
+@spec build(module(), String.t(), String.t(), String.t(), map()) :: Tau.MCP.ToolEntry.t()
+def build(_mod_name, server_name, namespaced_name, description, parameters) do
+  %Tau.MCP.ToolEntry{
+    server_name: server_name,
+    namespaced_name: namespaced_name,
+    description: description,
+    parameters: parameters
+  }
+end
+# mod_name arg retained for arity compat; ignored. Or drop it with a coord
+# rename of the call in server.ex.
+
+# lib/tau/tool.ex — lookup stores the struct; callers pattern-match:
+@spec lookup(String.t()) :: {:ok, module() | Tau.MCP.ToolEntry.t()} | :error
+def lookup(name) do
+  case Registry.lookup(Tau.Tools.Registry, name) do
+    [{_pid, val} | _] -> {:ok, val}
+    [] -> :error
+  end
+end
+
+# Session FSM tool dispatch (lib/tau/session.ex) gains one new clause:
+defp dispatch_tool(%Tau.MCP.ToolEntry{} = entry, params, ctx) do
+  local = String.replace_prefix(entry.namespaced_name, "mcp__#{entry.server_name}__", "")
+  Tau.MCP.ToolAdapter.invoke_remote(entry.server_name, local, params)
+end
+
+defp dispatch_tool(mod, params, ctx) when is_atom(mod) do
+  mod.execute(params, ctx)
+end
+```
+
+File moves: none. Modules deleted: `Tau.MCP.ToolAdapter` module-creation body
+(retains `invoke_remote/3` and `render_blocks/1`). `Tau.Hooks.Shell` loses
+`generate_name/0` entirely.
+
+## Tradeoffs
+
+### Strengths
+
+- Zero atoms created per reload: strictly satisfies acceptance criterion (a).
+- No orphaned code generations: no `Module.create/3` means criterion (b) is
+  vacuously satisfied — there is nothing to purge.
+- All existing dispatch logic (`run_command/5`, `invoke_remote/3`) is already
+  tested; the refactor is behaviour-preserving.
+- Registry.unregister on settings-reload naturally garbage-collects the old
+  data; no explicit cleanup needed.
+- Reduces BEAM memory footprint: no compiled bytecode or module metadata tables
+  for ephemeral tools.
+
+### Weaknesses
+
+- Breaks the uniform `Tau.Tool` behaviour contract: `dispatch_tool/3` in the
+  session FSM now handles two shapes (module and struct), adding a branching
+  concern to the FSM.
+- MCP tools and built-in tools are no longer uniformly addressable via
+  `mod.name/0`, `mod.description/0`, `mod.parameters/0` — any code that calls
+  those callbacks on a looked-up value (e.g. introspection, help generation,
+  schema export) must now branch on the type.
+- The `Tau.Tool` behaviour's `name/0`, `description/0`, `parameters/0`
+  callbacks become semantically meaningful only for compile-time tools; the
+  behaviour loses its role as the universal interface for runtime-discovered
+  tools.
+- Requires touching the session FSM (`lib/tau/session.ex`), which is in
+  SPEC-USER-TURN scope — a spec-gating concern.
+
+### Costs
+
+- `lib/tau/session.ex` must be updated to pattern-match on `ToolEntry` structs
+  in the dispatch path. SPEC-USER-TURN gating is required.
+- Any introspection path that iterates registered tools and calls `mod.name/0`
+  etc. must be updated to handle the struct case — requires a full grep of
+  callsites.
+- Approximately 3–4 files modified; no new files needed.
+- Backward compatibility: existing behaviour-module hooks and built-in tools
+  are unaffected; only the shell-hook and MCP-adapter paths change.
+
+## Dependencies
+
+- `lib/tau/session.ex` dispatch clause must be updated atomically with the
+  `build/2` change — these cannot land in separate PRs without a broken
+  intermediate state.
+- No library upgrades needed.
+
+## Confidence
+
+medium — The approach is mechanically straightforward and the dispatch functions
+already exist. Confidence would rise to high after verifying the full set of
+callsites that call `mod.name/0`, `mod.description/0`, `mod.parameters/0` on a
+looked-up tool value (to confirm the branching cost is bounded).
+
+## Prior art / references
+
+- Elixir Registry stores arbitrary values; using a struct rather than a module
+  atom as the registry value is idiomatic for dynamic systems (e.g., Phoenix
+  Router's `{plug, opts}` tuples).
+- Rich Hickey, "Simple Made Easy": replacing a compile-time artefact (module)
+  with data reduces incidental complexity when the artefact's only purpose is
+  to carry static values.
+- `Tau.Hook` behaviour itself: `Tau.Hooks.Dispatcher` already branches on
+  result shapes; extending it to branch on entry shape is consistent.

--- a/docs/problems-archive-v1-modules/tau-tools-hooks-mcp/subproblems/dynamic-module-generation/proposals/proposal-2.md
+++ b/docs/problems-archive-v1-modules/tau-tools-hooks-mcp/subproblems/dynamic-module-generation/proposals/proposal-2.md
@@ -1,0 +1,175 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 2
+parent_problem: ../problem.md
+---
+
+# Proposal 2: Stable deterministic module names + explicit purge on reload — keep Module.create/3 but eliminate the atom-growth path
+
+## Approach
+
+Keep `Module.create/3` for both hooks and MCP tool adapters, but replace the
+random-suffix name generation with a deterministic naming scheme whose output is
+stable across reloads for the same logical entry, and add an explicit
+`:code.purge/1` + `:code.delete/1` sequence before re-creating a module with
+the same name. For shell hooks, derive the name from a content-hash of the
+`{cmd, matcher, events}` triple. For MCP tool adapters, the name is already
+deterministic (`Module.concat([Tau.MCP.ToolAdapter, server_name, name])`) — the
+fix is to add the purge step before `Module.create/3` when the name already
+exists. A settings reload that produces the same config produces the same module
+names and therefore zero new atoms; a reload that changes a hook's command
+produces exactly one new atom (the new hash-derived name) and purges the old
+module.
+
+## Rationale
+
+The root cause in `Hooks.Shell` is the random suffix, not `Module.create/3`
+itself. The root cause in `MCP.ToolAdapter` is the missing purge, not the
+naming. Fixing the two independent causes separately is a minimal, targeted
+change that leaves the dispatch model (`Dispatcher` calls `mod.handle/2`, the
+session FSM calls `mod.execute/2`) entirely intact. No behaviour changes; no
+FSM touch; no callsite migration. The atom-table grows only by the number of
+_distinct logical hooks/tools that have ever existed_, which is bounded by
+real-world configuration, not by the number of reloads.
+
+## Sketch
+
+```elixir
+# lib/tau/hooks/shell.ex — replace generate_name/0:
+defp stable_name(cmd, matcher, events) do
+  key = :erlang.phash2({cmd, matcher, Enum.sort(events)})
+  Module.concat([Tau.Hooks.Shell, "Entry_#{key}"])
+end
+
+# build/2 becomes:
+def build(%{"command" => cmd} = config, events) do
+  matcher = config["matcher"]
+  timeout_ms = (config["timeout"] || 60) * 1000
+  name = stable_name(cmd, matcher, events)
+
+  unless Code.ensure_loaded?(name) do
+    body = quote do
+      @behaviour Tau.Hook
+      @impl true
+      def events, do: unquote(events)
+      @impl true
+      def handle(event, payload) do
+        Tau.Hooks.Shell.run_command(
+          unquote(cmd), unquote(matcher), unquote(timeout_ms), event, payload
+        )
+      end
+    end
+    Module.create(name, body, Macro.Env.location(__ENV__))
+  end
+
+  name
+end
+# If config hasn't changed, Module.create/3 is skipped entirely.
+# No new atom; no new code generation.
+
+# lib/tau/mcp/server.ex — register_tool/2 purge before create:
+defp register_tool(server_name, %{"name" => name} = tool_def) do
+  key = "mcp__#{server_name}__#{name}"
+  description = tool_def["description"] || "MCP tool from #{server_name}"
+  parameters = tool_def["inputSchema"] || %{"type" => "object"}
+
+  mod_name = Module.concat([Tau.MCP.ToolAdapter, server_name, name])
+
+  if :erlang.module_loaded(mod_name) do
+    :code.purge(mod_name)
+    :code.delete(mod_name)
+  end
+
+  Tau.MCP.ToolAdapter.build(mod_name, server_name, key, description, parameters)
+  Registry.register(Tau.Tools.Registry, key, mod_name)
+  key
+end
+# Old code generation is purged before the new one lands.
+# terminate/2 should also purge registered adapter modules on server shutdown.
+```
+
+Additionally, `terminate/2` in `Tau.MCP.Server` is extended to purge adapter
+modules:
+
+```elixir
+def terminate(_reason, state) do
+  Enum.each(state.registered_keys, fn key ->
+    Registry.unregister(Tau.Tools.Registry, key)
+  end)
+  Enum.each(state.tools, fn %{"name" => name} ->
+    mod = Module.concat([Tau.MCP.ToolAdapter, state.name, name])
+    if :erlang.module_loaded(mod) do
+      :code.purge(mod)
+      :code.delete(mod)
+    end
+  end)
+  if state.transport_state, do: state.transport.close(state.transport_state)
+  :ok
+end
+```
+
+## Tradeoffs
+
+### Strengths
+
+- Minimal diff: 2 files, targeted changes. No FSM touch, no behaviour changes,
+  no callsite migration.
+- Zero atoms per reload for unchanged config (hook module names are idempotent).
+- Satisfies criterion (b): `:code.all_loaded/0` no longer grows on MCP restart
+  because the old generation is explicitly purged.
+- The `Tau.Tool` and `Tau.Hook` behaviour contracts are completely unchanged;
+  tests require no modification.
+- `Code.ensure_loaded?/1` guard means the hook compilation path is O(changed
+  entries), not O(all entries), on every reload.
+
+### Weaknesses
+
+- Atom table still grows proportionally to _distinct hook configurations ever
+  seen_ across the node's lifetime. If users frequently change hook commands
+  (e.g., templated CI environments), new atoms accumulate. The growth is slow
+  but not zero.
+- `Module.create/3` is BEAM-version-sensitive: it generates a real code
+  generation in the code server, consuming memory proportional to the number of
+  distinct configurations, not just active ones.
+- The content-hash scheme (`erlang.phash2`) is not collision-free. Two distinct
+  configs that hash identically would share a module. Probability is negligible
+  but not zero; a SHA-based scheme avoids it at the cost of a longer atom name.
+- Purging a module that is currently being invoked (e.g., a long-running shell
+  hook) will cause the invocation to complete normally (old code is soft-purged)
+  but adds a code generation to the "old code" slot — if a second reload fires
+  before the first invocation completes, the second purge will kill the running
+  process. This is a standard BEAM hot-code-loading hazard, not new, but it
+  wasn't present in the random-suffix approach.
+
+### Costs
+
+- 2 files modified (`hooks/shell.ex`, `mcp/server.ex`); ~20 lines changed.
+- No new dependencies, no test suite changes.
+- Operational: nodes that have been running long-duration processes holding
+  references to old hook modules require testing of the soft-purge path.
+
+## Dependencies
+
+- No prerequisite changes.
+- The `terminate/2` purge in `Tau.MCP.Server` must land in the same PR as the
+  `register_tool/2` purge to avoid a partial state where new modules are purged
+  on create but not on server shutdown.
+
+## Confidence
+
+high — Both `:code.purge/1` + `:code.delete/1` and `Code.ensure_loaded?/1` are
+well-documented OTP mechanisms with clear semantics. The approach directly
+addresses both named root causes.
+
+## Prior art / references
+
+- OTP documentation: `code` module, `purge/1` and `delete/1` — standard
+  hot-code-loading sequence.
+- Elixir `Code.ensure_loaded?/1` — idiomatic guard before conditional module
+  operations.
+- BEAM hot-code upgrade semantics: old code slot holds the prior generation
+  until `:code.purge/1` removes processes referencing it, then `:code.delete/1`
+  removes the slot.
+- Phoenix LiveReloader uses a structurally similar pattern: recompile a module
+  only when its source has changed; no unnecessary code generations.

--- a/docs/problems-archive-v1-modules/tau-tools-hooks-mcp/subproblems/dynamic-module-generation/proposals/proposal-3.md
+++ b/docs/problems-archive-v1-modules/tau-tools-hooks-mcp/subproblems/dynamic-module-generation/proposals/proposal-3.md
@@ -1,0 +1,208 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 3
+parent_problem: ../problem.md
+---
+
+# Proposal 3: Single generic dispatcher module per subsystem — replace N generated modules with one parameterised module and an ETS config table
+
+## Approach
+
+For shell hooks, define a single compile-time module `Tau.Hooks.Shell.Dispatcher`
+that implements `Tau.Hook` and at runtime reads its configuration from an ETS
+table keyed by `{event, registration_key}`. Registration of a new hook entry
+writes a row to the ETS table; no `Module.create/3` is called. `Tau.Hooks.Registry`
+stores the atom `Tau.Hooks.Shell.Dispatcher` (not a unique generated module) as
+the registry value for every shell-hook entry, plus a unique opaque `key` term
+that the dispatcher uses to look up its config in ETS.
+
+For MCP tool adapters, define a single compile-time module
+`Tau.MCP.ToolAdapter.Dispatcher` that implements `Tau.Tool`. `name/0`,
+`description/0`, and `parameters/0` are replaced by a `config/1` function that
+accepts a key and returns the relevant field from ETS. The session FSM dispatch
+path is extended with one clause that, when the tool registry value is the
+`Dispatcher` module, calls `Dispatcher.execute(params, ctx, key)` instead of
+`mod.execute(params, ctx)`.
+
+## Rationale
+
+The complecting hypothesis states that each hook/tool must be a distinct module
+because the registry stores module atoms. This proposal decomplects by making
+the registry value a `{module, key}` pair instead of a bare module atom.
+A single shared dispatcher module is loaded once, consumes O(1) atoms and O(1)
+code space, and all configuration lives in ETS (owned by a supervised process),
+which supports insert/delete without atom-table effects. Reloading settings
+writes new ETS rows and deletes old ones; no modules are created or destroyed.
+
+## Sketch
+
+```elixir
+# lib/tau/hooks/shell/config_table.ex — new file (~30 lines)
+defmodule Tau.Hooks.Shell.ConfigTable do
+  @table :tau_shell_hook_configs
+
+  def init, do: :ets.new(@table, [:named_table, :public, :set, read_concurrency: true])
+
+  def put(key, cmd, matcher, timeout_ms),
+    do: :ets.insert(@table, {key, cmd, matcher, timeout_ms})
+
+  def get(key) do
+    case :ets.lookup(@table, key) do
+      [{^key, cmd, matcher, timeout_ms}] -> {:ok, cmd, matcher, timeout_ms}
+      [] -> :error
+    end
+  end
+
+  def delete(key), do: :ets.delete(@table, key)
+end
+
+# lib/tau/hooks/shell.ex — build/2 becomes a config-table write:
+def build(%{"command" => cmd} = config, events) do
+  matcher = config["matcher"]
+  timeout_ms = (config["timeout"] || 60) * 1000
+  key = make_ref()  # opaque; unique per registration; NOT an atom
+  Tau.Hooks.Shell.ConfigTable.put(key, cmd, matcher, timeout_ms)
+  {Tau.Hooks.Shell.Dispatcher, key, events}
+  # caller registers the {Dispatcher, key} tuple in the Hook registry
+end
+
+# lib/tau/hooks/shell/dispatcher.ex — new file (~20 lines)
+defmodule Tau.Hooks.Shell.Dispatcher do
+  @behaviour Tau.Hook
+  # events/0 not meaningful for the shared dispatcher; see registry registration note
+  def events, do: []
+
+  def handle(event, %{__hook_key__: key} = payload) do
+    case Tau.Hooks.Shell.ConfigTable.get(key) do
+      {:ok, cmd, matcher, timeout_ms} ->
+        Tau.Hooks.Shell.run_command(cmd, matcher, timeout_ms, event, payload)
+      :error ->
+        :cont
+    end
+  end
+end
+
+# lib/tau/hooks/dispatcher.ex — inject key into payload before dispatch:
+defp run_one({Tau.Hooks.Shell.Dispatcher, key}, event, payload) do
+  run_one_result(
+    Tau.Hooks.Shell.Dispatcher.handle(event, Map.put(payload, :__hook_key__, key)),
+    payload
+  )
+end
+defp run_one(mod, event, payload) when is_atom(mod) do
+  # existing path unchanged
+  run_one_result(mod.handle(event, payload), payload)
+end
+
+# lib/tau/mcp/tool_adapter/config_table.ex — analogous ETS table for MCP tools
+defmodule Tau.MCP.ToolAdapter.ConfigTable do
+  @table :tau_mcp_tool_configs
+
+  def init, do: :ets.new(@table, [:named_table, :public, :set, read_concurrency: true])
+
+  def put(key, server_name, local_name, description, parameters),
+    do: :ets.insert(@table, {key, server_name, local_name, description, parameters})
+
+  def get(key) do
+    case :ets.lookup(@table, key) do
+      [{^key, s, l, d, p}] -> {:ok, s, l, d, p}
+      [] -> :error
+    end
+  end
+
+  def delete(key), do: :ets.delete(@table, key)
+end
+
+# lib/tau/mcp/tool_adapter/dispatcher.ex — single Tau.Tool module
+defmodule Tau.MCP.ToolAdapter.Dispatcher do
+  @behaviour Tau.Tool
+  # name/0 and description/0 are placeholders; real values fetched by key
+  def name, do: "__mcp_dispatcher__"
+  def description, do: ""
+  def parameters, do: %{}
+  def execution_mode, do: :parallel
+
+  def execute(params, %Tau.Tool.Context{mcp_key: key}) do
+    case Tau.MCP.ToolAdapter.ConfigTable.get(key) do
+      {:ok, server, local, _d, _p} ->
+        Tau.MCP.ToolAdapter.invoke_remote(server, local, params)
+      :error ->
+        {:ok, %Tau.Tool.Result{content: "MCP tool not found", is_error: true}}
+    end
+  end
+end
+
+# Context struct gains :mcp_key field; session FSM sets it from the registry
+# value before calling execute/2.
+```
+
+The ETS tables are owned by a new supervised worker
+`Tau.Hooks.Shell.ConfigTable` and `Tau.MCP.ToolAdapter.ConfigTable`, started in
+`Tau.Application`'s supervision tree. `Tau.MCP.Server.terminate/2` calls
+`ConfigTable.delete/1` for each registered key instead of `:code.delete/1`.
+
+## Tradeoffs
+
+### Strengths
+
+- Zero atom growth on reload: `make_ref()` is used as keys; refs are not atoms.
+  Acceptance criterion (a) is fully satisfied.
+- Zero code-server growth on reload: only two compile-time modules ever exist
+  (one dispatcher per subsystem), regardless of the number of hooks or tools
+  ever loaded. Criterion (b) is fully satisfied.
+- ETS reads are O(1) and concurrent; no lock contention compared to Registry
+  lookups.
+- ETS rows are garbage-collected by `delete/1` on unregister; no accumulation.
+
+### Weaknesses
+
+- The `Tau.Hook` behaviour's `events/0` callback does not fit the shared
+  dispatcher model: the dispatcher module returns `[]` and the dispatcher event
+  routing is handled externally by the registration layer — a subtle deviation
+  from the behaviour contract.
+- `Tau.Tool.Context` must be extended with `mcp_key` (or an equivalent side-
+  channel), coupling the context struct to a specific dispatch variant. This is
+  an API-breaking change to `Tau.Tool.Context`.
+- Injecting `:__hook_key__` into the payload map is a leaky abstraction:
+  hook implementations that inspect the payload will see an unexpected key.
+  A more principled fix would thread the key through the dispatcher call
+  signature, but that breaks the `handle(event, payload)` callback shape.
+- Two new supervised workers and two new ETS tables increase the supervision
+  tree depth and the number of things that can crash on startup.
+- The ETS tables must be created before any hook or MCP registration fires;
+  startup ordering in `Tau.Application` must be verified.
+
+### Costs
+
+- 4–5 new files; 3–4 modified files (`hooks/shell.ex`, `mcp/tool_adapter.ex`,
+  `mcp/server.ex`, `lib/tau/application.ex`).
+- `Tau.Tool.Context` struct modification may require updates across all
+  `execute/2` implementations if they pattern-match on the context.
+- Requires adding the config-table workers to the supervision tree and testing
+  crash/restart behaviour for the ETS owner.
+
+## Dependencies
+
+- `Tau.Tool.Context` struct change must land before or atomically with the
+  dispatcher implementation.
+- The `Tau.Application` supervision tree must be updated to start the config-
+  table workers before the hook/MCP subsystems.
+- `Tau.Hooks.Registry` registration call sites must be updated to store
+  `{module, key}` tuples rather than bare module atoms.
+
+## Confidence
+
+medium — The ETS + single-dispatcher pattern is proven in OTP (Phoenix PubSub
+uses a similar strategy). Confidence drops because the `Tau.Tool.Context` API
+break is wide-ranging and the `events/0` deviation from the behaviour contract
+requires careful documentation.
+
+## Prior art / references
+
+- Phoenix PubSub dispatches to a single module (`Phoenix.PubSub.PG2`) with a
+  config term, not per-subscription compiled modules.
+- Elixir `Registry` supports arbitrary value types; the `{module, key}` pair
+  pattern is documented in the Registry module's "Using the Registry" guide.
+- OTP ETS `named_table` + supervised owner pattern — standard approach for
+  read-heavy shared config in OTP applications.

--- a/docs/problems-archive-v1-modules/tau-tools-hooks-mcp/subproblems/dynamic-module-generation/proposals/proposal-4.md
+++ b/docs/problems-archive-v1-modules/tau-tools-hooks-mcp/subproblems/dynamic-module-generation/proposals/proposal-4.md
@@ -1,0 +1,264 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 4
+parent_problem: ../problem.md
+---
+
+# Proposal 4: Reify the Hook and Tool registries as GenServer-owned maps — replace Registry + Module.create/3 with a supervised config-map server per subsystem
+
+## Approach
+
+Replace the use of `Tau.Hooks.Registry` (a `:duplicate` `Registry`) and
+`Tau.Tools.Registry` for the dynamic (shell hook and MCP adapter) entries with
+two new supervised GenServers: `Tau.Hooks.Shell.Store` and
+`Tau.MCP.ToolAdapter.Store`. Each store holds a `%{event => [shell_hook_entry]}`
+and `%{namespaced_name => mcp_tool_entry}` map respectively, where entries are
+plain maps (not modules). `Tau.Hooks.Dispatcher` calls
+`Tau.Hooks.Shell.Store.list(event)` instead of `Registry.lookup/2` for the
+dynamic-hook portion. The session FSM tool dispatch calls
+`Tau.MCP.ToolAdapter.Store.get(name)` when `Tau.Tool.lookup/1` returns `:error`
+(no compile-time tool registered). No `Module.create/3` is called anywhere in
+the dynamic path. The compile-time `Tau.Hook` behaviour module requirement is
+dropped for shell hooks; `Tau.Tool` behaviour module requirement is dropped for
+MCP adapters. Reload is a GenServer `cast` that atomically replaces the internal
+map; no atom accumulation is possible.
+
+## Rationale
+
+Both the `Tau.Hooks.Registry` and `Tau.Tools.Registry` are process-lifetime
+registries — their entries disappear when the owning process exits. This makes
+them a natural fit for long-lived compile-time hooks and tools but an awkward
+fit for dynamically-loaded config entries that must survive independent of the
+process that loaded them. A GenServer-owned map makes the config lifetime and
+ownership explicit: the store process owns the config, and the store is under
+the application supervisor. Settings reload becomes a functional state swap
+(`GenServer.cast(store, {:reload, new_entries})`), atomic from the caller's
+perspective. This fully decomplects _dispatch_ (the GenServer holds the config)
+from _hook identity_ (the config key is the hook's logical identity, not a
+module atom).
+
+## Sketch
+
+```elixir
+# lib/tau/hooks/shell/store.ex — new file (~60 lines)
+defmodule Tau.Hooks.Shell.Store do
+  use GenServer
+
+  @type entry :: %{
+    cmd: String.t(),
+    matcher: String.t() | nil,
+    timeout_ms: non_neg_integer(),
+    events: [Tau.Hook.event()]
+  }
+
+  def start_link(_), do: GenServer.start_link(__MODULE__, %{}, name: __MODULE__)
+
+  @spec reload([entry()]) :: :ok
+  def reload(entries), do: GenServer.call(__MODULE__, {:reload, entries})
+
+  @spec list(Tau.Hook.event()) :: [entry()]
+  def list(event), do: GenServer.call(__MODULE__, {:list, event})
+
+  @impl true
+  def init(_), do: {:ok, %{}}  # %{event => [entry]}
+
+  @impl true
+  def handle_call({:reload, entries}, _from, _state) do
+    new_state =
+      Enum.reduce(entries, %{}, fn %{events: evts} = e, acc ->
+        Enum.reduce(evts, acc, fn ev, a -> Map.update(a, ev, [e], &[e | &1]) end)
+      end)
+    {:reply, :ok, new_state}
+  end
+
+  def handle_call({:list, event}, _from, state) do
+    {:reply, Map.get(state, event, []), state}
+  end
+end
+
+# lib/tau/hooks/shell.ex — build/2 returns a plain map:
+@spec build(map(), [Tau.Hook.event()]) :: Tau.Hooks.Shell.Store.entry()
+def build(%{"command" => cmd} = config, events) do
+  %{
+    cmd: cmd,
+    matcher: config["matcher"],
+    timeout_ms: (config["timeout"] || 60) * 1000,
+    events: events
+  }
+end
+# No Module.create/3. No atom generated. No Registry call.
+
+# lib/tau/hooks/dispatcher.ex — lookup includes store:
+defp lookup(event) do
+  registry_mods = case Registry.lookup(Tau.Hooks.Registry, event) do
+    [] -> []
+    list -> Enum.map(list, fn {_pid, mod} -> mod end)
+  end
+
+  shell_entries = Tau.Hooks.Shell.Store.list(event)
+
+  # shell entries run first (user-configured); compile-time mods run after
+  shell_entries ++ registry_mods
+end
+
+defp run_one(%{cmd: cmd, matcher: matcher, timeout_ms: t}, event, payload) do
+  run_one_result(Tau.Hooks.Shell.run_command(cmd, matcher, t, event, payload), payload)
+end
+defp run_one(mod, event, payload) when is_atom(mod) do
+  run_one_result(mod.handle(event, payload), payload)
+end
+
+# lib/tau/mcp/tool_adapter/store.ex — new file (~50 lines)
+defmodule Tau.MCP.ToolAdapter.Store do
+  use GenServer
+
+  @type entry :: %{
+    server_name: String.t(),
+    namespaced_name: String.t(),
+    description: String.t(),
+    parameters: map()
+  }
+
+  def start_link(_), do: GenServer.start_link(__MODULE__, %{}, name: __MODULE__)
+
+  @spec put(String.t(), entry()) :: :ok
+  def put(key, entry), do: GenServer.call(__MODULE__, {:put, key, entry})
+
+  @spec delete(String.t()) :: :ok
+  def delete(key), do: GenServer.call(__MODULE__, {:delete, key})
+
+  @spec get(String.t()) :: {:ok, entry()} | :error
+  def get(key), do: GenServer.call(__MODULE__, {:get, key})
+
+  @spec list() :: [{String.t(), entry()}]
+  def list, do: GenServer.call(__MODULE__, :list)
+
+  @impl true
+  def init(_), do: {:ok, %{}}
+
+  @impl true
+  def handle_call({:put, k, v}, _from, s), do: {:reply, :ok, Map.put(s, k, v)}
+  def handle_call({:delete, k}, _from, s), do: {:reply, :ok, Map.delete(s, k)}
+  def handle_call({:get, k}, _from, s), do: {:reply, Map.fetch(s, k), s}
+  def handle_call(:list, _from, s), do: {:reply, Map.to_list(s), s}
+end
+
+# lib/tau/mcp/server.ex — register_tool/2:
+defp register_tool(server_name, %{"name" => name} = tool_def) do
+  key = "mcp__#{server_name}__#{name}"
+  Tau.MCP.ToolAdapter.Store.put(key, %{
+    server_name: server_name,
+    namespaced_name: key,
+    description: tool_def["description"] || "MCP tool from #{server_name}",
+    parameters: tool_def["inputSchema"] || %{"type" => "object"}
+  })
+  key
+end
+
+# terminate/2 uses Store.delete/1 instead of Registry.unregister + code.delete:
+def terminate(_reason, state) do
+  Enum.each(state.registered_keys, &Tau.MCP.ToolAdapter.Store.delete/1)
+  if state.transport_state, do: state.transport.close(state.transport_state)
+  :ok
+end
+
+# lib/tau/tool.ex — lookup falls back to MCP store:
+@spec lookup(String.t()) :: {:ok, {:mcp, Tau.MCP.ToolAdapter.Store.entry()} | module()} | :error
+def lookup(name) do
+  case Registry.lookup(Tau.Tools.Registry, name) do
+    [{_pid, mod} | _] -> {:ok, mod}
+    [] ->
+      case Tau.MCP.ToolAdapter.Store.get(name) do
+        {:ok, entry} -> {:ok, {:mcp, entry}}
+        :error -> :error
+      end
+  end
+end
+
+# Session FSM dispatch adds one clause for the {:mcp, entry} shape:
+defp dispatch_tool({:mcp, %{server_name: s, namespaced_name: n}}, params, _ctx) do
+  local = String.replace_prefix(n, "mcp__#{s}__", "")
+  Tau.MCP.ToolAdapter.invoke_remote(s, local, params)
+end
+defp dispatch_tool(mod, params, ctx) when is_atom(mod) do
+  mod.execute(params, ctx)
+end
+```
+
+## Tradeoffs
+
+### Strengths
+
+- Zero atom growth per reload: no `Module.create/3`, no random suffix, no
+  atom-per-tool. Criteria (a) and (b) are fully and permanently satisfied.
+- The GenServer state swap (`:reload`) is atomic from the dispatcher's
+  perspective: the old entries are replaced in a single call, eliminating the
+  window where a partially-updated registry could be observed during reload.
+- Cleanup on MCP server shutdown is a simple map deletion — no BEAM hot-code-
+  loading mechanics involved.
+- Separation of lifecycle is explicit: the store process owns the config; the
+  MCP server processes own the transport. Their lifetimes are independent.
+- Introspection is straightforward: `Tau.MCP.ToolAdapter.Store.list/0` returns
+  all registered MCP tools as plain data, useful for diagnostics and help
+  generation.
+
+### Weaknesses
+
+- Two new supervised GenServers in `Tau.Application` add supervision tree depth
+  and two new crash/restart scenarios to reason about. If the store crashes
+  between a `put` and the caller registering the key in `registered_keys`, the
+  restart produces a ghost entry.
+- Every dispatch path now makes a GenServer call. Under high hook-dispatch
+  frequency (e.g., a session that fires `:pre_tool_use` on every tool call), the
+  store GenServer becomes a serialisation point. The MCP store is call-based, not
+  ETS-based, so concurrent `get` calls queue behind each other.
+- The `Tau.Tool.lookup/1` return type changes from `{:ok, module()}` to
+  `{:ok, module() | {:mcp, entry()}}`, requiring the session FSM and any other
+  lookup caller to handle the new shape. This is a public API change.
+- `Tau.Tools.Registry` is retained for compile-time tools; MCP tools bypass it.
+  This creates two separate lookup paths in `Tau.Tool.lookup/1`, which could
+  cause confusion.
+
+### Costs
+
+- 2 new GenServer modules; 4–5 existing files modified.
+- `lib/tau/session.ex` (SPEC-USER-TURN scope) must be updated to handle the
+  `{:mcp, entry}` dispatch shape.
+- Dialyzer will catch `Tau.Tool.lookup/1` callers that do not handle the new
+  `{:mcp, entry}` variant — a good forcing function for a complete callsite audit,
+  but adds migration effort proportional to the number of callers.
+- GenServer call latency is measurable under load; benchmarking is advisable
+  before landing.
+
+## Dependencies
+
+- `Tau.Application` supervision tree must start `Tau.Hooks.Shell.Store` and
+  `Tau.MCP.ToolAdapter.Store` before the hook and MCP subsystems register
+  entries.
+- Session FSM (`lib/tau/session.ex`) change must land in the same PR under
+  SPEC-USER-TURN gating.
+- All callers of `Tau.Tool.lookup/1` must handle the `{:mcp, entry}` variant —
+  a grep-and-update required before the PR is mergeable.
+
+## Confidence
+
+medium — The GenServer-owned-map pattern is standard OTP. Confidence drops
+because the `Tau.Tool.lookup/1` API change is wide-ranging and the GenServer
+serialisation under load has not been benchmarked. Would rise to high after
+a concurrent dispatch benchmark and a Dialyzer-clean callsite audit.
+
+## Prior art / references
+
+- Elixir `Registry` is itself a supervised GenServer cluster; using a plain
+  GenServer for a domain-specific subset of its function is a well-understood
+  narrowing.
+- `Phoenix.Router` stores route dispatch tables in a module-level compile-time
+  structure; this proposal is the inverse — a runtime-loaded, process-owned
+  table — which is the idiomatic OTP alternative when the data is dynamic.
+- OTP Design Principles, "Supervisor Behaviour": using a supervised GenServer
+  as the owner of shared mutable state is the canonical pattern for avoiding
+  `:global` and `Application.put_env/3`.
+- Tau OTP non-negotiables §1: "Stateful subsystems MUST run as supervised
+  processes" — this proposal instantiates that rule for the dynamic hook and
+  MCP-tool config.

--- a/docs/problems-archive-v1-modules/tau-tools-hooks-mcp/subproblems/dynamic-module-generation/solution.md
+++ b/docs/problems-archive-v1-modules/tau-tools-hooks-mcp/subproblems/dynamic-module-generation/solution.md
@@ -1,0 +1,161 @@
+---
+template_version: 1
+template_name: solution
+parent_problem: ./problem.md
+node_kind: leaf
+synthesised_from: [proposals/proposal-1.md]
+selection_method: single
+revision: 0
+---
+
+# Solution: Replace Module.create/3 with tagged struct registry values for both shell hooks and MCP tool adapters
+
+## Recommendation
+
+Eliminate `Module.create/3` at both `Tau.Hooks.Shell.build/2` and
+`Tau.MCP.ToolAdapter.build/5`. Introduce two plain structs —
+`%Tau.Hooks.Shell.Entry{cmd, matcher, timeout_ms, events}` and
+`%Tau.MCP.ToolEntry{server_name, namespaced_name, description, parameters}` —
+and store them as the registry values that the dispatchers consume. Extend
+`Tau.Hooks.Dispatcher.run_one/3` and the session FSM tool-dispatch path with
+one additional clause each, pattern-matching on the struct tag and delegating
+to the already-public `Tau.Hooks.Shell.run_command/5` and
+`Tau.MCP.ToolAdapter.invoke_remote/3`. With no module compiled per
+configuration entry, settings reload and MCP server restart cannot grow the
+BEAM atom table or accumulate orphaned code generations; the existing dispatch
+functions are behaviour-preserving, so no test changes are required.
+
+## Selected from
+
+- **Chosen:** `proposals/proposal-1.md` (single).
+- **Why chosen:** Scoring against the acceptance criterion:
+
+  | # | Fit | Decomplecting depth | Migration cost | Risk | Reversibility |
+  |---|-----|---------------------|----------------|------|---------------|
+  | 1 | Yes | Deep | Medium | Low | Easy |
+  | 2 | Partially | Surface | Low | Medium | Easy |
+  | 3 | Yes | Substantial | High | Medium | Hard |
+  | 4 | Yes | Substantial | High | Medium | Hard |
+
+  Proposal 1 strictly satisfies criterion (a) — zero atoms created per reload,
+  not merely "bounded growth" as Proposal 2 admits — and vacuously satisfies
+  (b) because there are no compiled modules to leak. Decomplecting depth is
+  Deep: it removes `Module.create/3` rather than adding machinery around it
+  (Proposal 2 keeps the module-per-entry model; Proposals 3 and 4 add new
+  stateful processes/ETS tables to manage the per-entry data). Under the
+  Hickey-aligned tie-breakers in `select.md`, Proposal 1 wins on every axis
+  the protocol enumerates: decomplecting depth over cost, pure over stateful,
+  composition (the struct composes into existing pattern-matched dispatch)
+  over aggregation (Proposals 3 and 4 introduce new owners/contexts whose
+  lifecycle must be reasoned about separately). Proposal 2's "soft-purge of
+  in-flight invocations" hazard is a regression in risk for a configuration
+  reload path that previously had none. Proposals 3 and 4 break the
+  `Tau.Tool.Context` and `Tau.Tool.lookup/1` public shapes respectively, both
+  hard-to-reverse. Proposal 1's single behaviour cost — branching in the
+  session FSM dispatch path — is the same cost Proposals 3 and 4 also pay
+  (they too touch the FSM); Proposal 1 pays it without the extra GenServer
+  or ETS-owner state.
+
+## What changes
+
+- `lib/tau/hooks/shell.ex` — define `Tau.Hooks.Shell.Entry` struct;
+  rewrite `build/2` to return an `%Entry{}` rather than generating and
+  returning a module atom; delete `generate_name/0` and the surrounding
+  `Module.create/3` invocation.
+- `lib/tau/mcp/tool_adapter.ex` — define `Tau.MCP.ToolEntry` struct;
+  rewrite `build/5` to return a `%ToolEntry{}`; retain
+  `invoke_remote/3` and `render_blocks/1` unchanged (the dispatch
+  helpers stay public and are now the sole dispatch path for MCP tools).
+  The `mod_name` argument to `build/5` becomes unused; either retain it
+  for arity compat or update `lib/tau/mcp/server.ex` to drop it.
+- `lib/tau/hooks/dispatcher.ex` — add a `run_one/3` clause matching on
+  `%Tau.Hooks.Shell.Entry{}` that calls `Tau.Hooks.Shell.run_command/5`
+  with the entry's fields; the existing `is_atom(mod)` clause is
+  unchanged and continues to serve behaviour-module hooks.
+- `lib/tau/session.ex` — add one `dispatch_tool/3` clause matching
+  `%Tau.MCP.ToolEntry{}` that strips the `mcp__<server>__` prefix from
+  `namespaced_name` and calls `Tau.MCP.ToolAdapter.invoke_remote/3`;
+  the existing `is_atom(mod)` clause is unchanged. This change is
+  SPEC-USER-TURN gated; the PR description must cite the relevant
+  D-NNN under that SPEC.
+- `lib/tau/tool.ex` — `lookup/1` return type widens to
+  `{:ok, module() | Tau.MCP.ToolEntry.t()} | :error`. Storage in
+  `Tau.Tools.Registry` is the struct, not a module atom.
+- Any callsite that iterates registered tools and invokes `mod.name/0`,
+  `mod.description/0`, or `mod.parameters/0` on a looked-up value
+  (introspection, help generation, schema export) — confirm via grep and
+  add the `%ToolEntry{}` branch reading the struct field directly.
+
+## What does not change
+
+- `Tau.Hook` behaviour and the compile-time hook-module dispatch path
+  (`is_atom(mod)` clause in `Hooks.Dispatcher.run_one/3`).
+- `Tau.Tool` behaviour and the compile-time tool-module dispatch path
+  (`is_atom(mod)` clause in `Session.dispatch_tool/3`); the behaviour
+  callbacks `name/0`, `description/0`, `parameters/0`, `execution_mode/0`
+  remain valid for compile-time tools.
+- `Tau.Hooks.Registry` and `Tau.Tools.Registry` modules and their lifetime
+  semantics — only the *value type* stored in them changes.
+- `Tau.Hooks.Shell.run_command/5` and `Tau.MCP.ToolAdapter.invoke_remote/3`
+  signatures — both are already public and behaviour-preserving.
+- `Tau.MCP.Server.terminate/2` — `Registry.unregister/2` calls remain;
+  no new `:code.delete/1` work is needed because no compiled modules
+  exist to delete.
+- The supervision tree — no new GenServers, no new ETS tables, no new
+  supervised workers (this is the key axis on which Proposal 1 wins over
+  Proposals 3 and 4).
+- The existing test suite for `Hooks.Dispatcher`, `Tau.Tool`, `MCP.Server`,
+  and the session FSM tool-dispatch path — required by acceptance
+  criterion (c).
+
+## Migration sketch
+
+The change is atomic across the affected files: `Tau.Hooks.Shell.build/2`,
+`Tau.Hooks.Dispatcher.run_one/3`, `Tau.MCP.ToolAdapter.build/5`,
+`Tau.Tool.lookup/1`, and `Tau.Session.dispatch_tool/3` must land in one PR
+because any intermediate state where the registry value type does not match
+the dispatcher's pattern would be broken. The sequence within the PR is:
+(1) introduce the `Entry` and `ToolEntry` structs; (2) update both
+`build` functions to return structs; (3) update the dispatchers to
+pattern-match on the structs; (4) update introspection callsites identified
+by grep. SPEC-USER-TURN gating applies for the `lib/tau/session.ex`
+touch — cite the D-NNN advanced. SPEC-before-code requirement: if no
+existing D-NNN covers "tool dispatch is data-driven for MCP tools",
+register one in SPEC-USER-TURN §3 in the same PR.
+
+## Open questions
+
+- Exact count and location of `mod.name/0` / `mod.description/0` /
+  `mod.parameters/0` callsites that iterate the tools registry — the
+  confidence on Proposal 1's "medium" rating is gated on this grep.
+- Whether `Tau.MCP.ToolAdapter.build/5`'s first arg (`mod_name`) is
+  retained for arity compat or removed with a coordinated update of
+  `Tau.MCP.Server.register_tool/2`. The lower-churn option is to keep
+  and ignore it; the cleaner option requires a one-line server update.
+- Which D-NNN under SPEC-USER-TURN this change advances or amends —
+  selection-time decision is "this must be cited"; the actual D-NNN
+  choice is for the implementer working from the live SPEC.
+- Whether the same data-driven pattern should apply to future
+  extension-loaded tools (out-of-scope per parent `problem.md`, but the
+  Entry/ToolEntry precedent shapes the answer).
+
+## Linked sub-problems / proposals
+
+- `proposals/proposal-1.md` — Data-driven dispatch via tagged structs (CHOSEN).
+- `proposals/proposal-2.md` — Stable deterministic module names + explicit
+  purge. Rejected: only partially satisfies criterion (a) (atom growth
+  proportional to distinct configs ever seen, not zero), surface-level
+  decomplecting (retains module-per-entry), and introduces a new
+  soft-purge-of-in-flight-invocations hazard.
+- `proposals/proposal-3.md` — Single shared dispatcher + ETS config tables.
+  Rejected: adds two new supervised workers and two new ETS tables,
+  breaks `Tau.Tool.Context` (hard reversibility), and pollutes the hook
+  payload map with a `:__hook_key__` side-channel.
+- `proposals/proposal-4.md` — GenServer-owned stores per subsystem.
+  Rejected: adds two new GenServers on the hot dispatch path
+  (serialisation point), breaks `Tau.Tool.lookup/1` return shape (hard
+  reversibility), and adds stateful surface where Proposal 1 removes it.
+
+## Revision history
+
+- (revision 0 — initial)

--- a/docs/problems-archive-v1-modules/tau-tools-hooks-mcp/subproblems/dynamic-module-generation/validation.md
+++ b/docs/problems-archive-v1-modules/tau-tools-hooks-mcp/subproblems/dynamic-module-generation/validation.md
@@ -1,0 +1,418 @@
+---
+template_version: 1
+template_name: validation
+parent_solution: ./solution.md
+parent_problem: ./problem.md
+toulmin_complete: true
+falsification_attempted: true
+falsification_outcome: partially_falsified — claim/3
+revision_triggered: none
+---
+
+# Validation: Replace Module.create/3 with tagged struct registry values for both shell hooks and MCP tool adapters
+
+## Overview
+
+The solution makes five distinct propositions about the post-change world:
+(1) `Tau.Hooks.Shell.build/2` and `Tau.MCP.ToolAdapter.build/5` cease calling
+`Module.create/3`; (2) two new tagged structs become the registry value types;
+(3) one extra clause in each of two dispatchers handles the new struct value;
+(4) the supervision tree, ETS surface, and `Registry` lifetimes are unchanged;
+(5) the existing test suite passes without modification. Each is validated
+below using a strategy from the catalog in `validate.md`. The dominant finding
+is that claim (3) is **partially falsified**: the change is not a "one
+additional clause in each of two dispatchers" — the introspection surface
+(`mod.name()`, `mod.description()`, `mod.parameters()`, `mod.execute/2`) is
+called from at least seven sites in `lib/tau/` that all need a struct branch,
+and `Tau.Tool.Validator.validate/2` is typed `module(), term()` and dispatches
+on `is_atom(mod)` — so it requires its own data-driven adaptation. Claim (5)
+narrows in consequence: tests of those introspection callsites will see
+behaviour-equivalent values but only after their adapter modules learn the
+new shape, and at least one site (`Tau.Tool.Validator`) cannot satisfy a
+struct without an architectural extension (it caches resolved schemas in
+`:persistent_term` keyed by module atom; a struct has no such key candidate
+without a synthetic id).
+
+## Toulmin per claim
+
+The MITRE empirical study on Toulmin formalism found that "participants
+found it difficult to generate Toulmin structures, and their structures
+varied greatly even though they started with the same content"
+(https://www.mitre.org/news-insights/publication/empirical-evaluation-structured-argumentation-using-toulmin-argument).
+This template enforces all six components explicitly to counter that variance.
+
+### Claim 1: `Tau.Hooks.Shell.build/2` and `Tau.MCP.ToolAdapter.build/5` no longer call `Module.create/3`; settings reload and MCP server restart cannot grow the BEAM atom table from these sites
+
+- **Claim (C):** "With no module compiled per configuration entry, settings
+  reload and MCP server restart cannot grow the BEAM atom table or accumulate
+  orphaned code generations."
+- **Grounds (G):** The two `Module.create/3` callsites are localised:
+  `lib/tau/hooks/shell.ex:61` and `lib/tau/mcp/tool_adapter.ex:47`. The
+  random-suffix generator at `lib/tau/hooks/shell.ex:161-164` is the unique
+  source of unbounded atom growth on the hook side; the MCP side uses
+  `Module.concat([Tau.MCP.ToolAdapter, server_name, name])` at
+  `lib/tau/mcp/server.ex:231` where `server_name` and `name` are both strings
+  that become atoms inside `Module.concat/1` (atoms are permanent).
+  Removing both `Module.create/3` calls and the `generate_name/0` helper
+  removes the atom-growth source.
+- **Warrant (W):** The Erlang atom table is permanent for the BEAM node's
+  lifetime; `Module.create/3` registers a new module atom in the code server
+  and inserts the module's name into the atom table. The only way to avoid
+  growing the table per registration is to avoid creating atoms per
+  registration. Structs carry the struct module's atom (one per struct kind)
+  and field values (which can be binaries — non-atom); a tagged struct
+  satisfies "fixed atom set, variable data" by construction.
+- **Qualifier (Q):** Holds when no other code path in the same PR introduces
+  a new per-entry atom (e.g. via `String.to_atom/1`, `Module.concat/1`, or
+  `:erlang.binary_to_atom/2`). The struct's tag itself is one atom for the
+  module (`Tau.Hooks.Shell.Entry`, `Tau.MCP.ToolEntry`), created once at
+  compile time. Holds only if the registry keys themselves do not encode
+  the per-entry identity as atoms — `Tau.Hooks.Registry` is keyed by event
+  atom (closed set, see `lib/tau/registries.ex:30`) and `Tau.Tools.Registry`
+  is keyed by binary tool name (`lib/tau/mcp/server.ex:227`,
+  `lib/tau/tool.ex:57`), so this qualifier holds for both.
+- **Rebuttal (R):** The claim would NOT hold if any callsite continued to
+  derive an atom from the per-entry data. The `mcp/server.ex:231` line
+  `Module.concat([Tau.MCP.ToolAdapter, server_name, name])` is the only
+  current external atom source per entry and the solution explicitly
+  removes (or stops using) the resulting `mod_name`. There is no second
+  per-entry atom source in `hooks/shell.ex` beyond `generate_name/0`.
+- **Backing (B):** Erlang/OTP documentation on the atom table size
+  limit (default 1,048,576; permanent for VM lifetime) —
+  https://www.erlang.org/doc/efficiency_guide/advanced.html#system-limits;
+  `:code.purge/1` does not free the atom (a separately-documented
+  Erlang VM property — atoms are never reclaimed without
+  `+e<n>+exit-on-atom-limit`).
+
+#### Falsification attempt for claim 1
+
+- **Strategy:** counter-example construction + dependency check.
+- **Attempt:** Searched for any other call to `Module.create/3`,
+  `String.to_atom`, `Module.concat` on per-entry inputs, or
+  `:erlang.binary_to_atom` in `lib/tau/hooks/` and `lib/tau/mcp/` —
+  `grep -rn "Module.create\|String.to_atom\|binary_to_atom" lib/tau/hooks
+  lib/tau/mcp` returned only the two callsites the solution targets. Also
+  verified that `Hooks.Shell.build/2` is presently called from zero
+  callsites in `lib/` or `test/` (`grep -rn "Hooks.Shell.build\|Shell.build"
+  lib test` is empty); the shell-hook atom-growth path is therefore
+  presently vacuous and the solution closes a latent rather than active leak
+  at that site, but the leak is real on the MCP side
+  (`lib/tau/mcp/server.ex:206-207` calls `register_tool/2` per discovered
+  tool on every server restart).
+- **Outcome:** withstood.
+- **Action:** none.
+
+### Claim 2: Introduce `%Tau.Hooks.Shell.Entry{}` and `%Tau.MCP.ToolEntry{}` structs as the registry value types
+
+- **Claim (C):** "Introduce two plain structs … and store them as the
+  registry values that the dispatchers consume."
+- **Grounds (G):** `lib/tau/registries.ex:57-58` configures
+  `Tau.Tools.Registry` and `Tau.Hooks.Registry` as Elixir `Registry` instances
+  with `keys: :duplicate`. `Registry.register/3`'s third argument is the
+  arbitrary stored value — `lib/tau/tool.ex:57` stores a module atom;
+  `lib/tau/mcp/server.ex:233` stores a module atom. Both are free to store
+  any term, including a struct.
+- **Warrant (W):** `Registry` value semantics are term-opaque — the registry
+  does not introspect stored values. A struct is a tagged map, which is a
+  legal term. Pattern-matching on the registry value's struct tag at the
+  dispatcher is a Hickey-aligned composition (the registry remains the
+  lookup mechanism; the value's *shape* drives dispatch).
+- **Qualifier (Q):** Holds for all current consumers of the registries that
+  read the value as an opaque term and pass it forward. Does NOT hold for
+  any consumer that pattern-matches `is_atom(mod)` and assumes the value is
+  a `Tau.Tool` / `Tau.Hook` callback module — those callsites are enumerated
+  in claim 3 and need an additional clause.
+- **Rebuttal (R):** Would not hold if a `Registry.match/3` call expected a
+  specific value shape via pattern (`Registry.match/3` does accept a match
+  pattern). `grep -rn "Registry.match" lib/tau/` finds zero usages against
+  either registry — confirmed.
+- **Backing (B):** Elixir `Registry` documentation — values are arbitrary
+  terms, with no schema. https://hexdocs.pm/elixir/Registry.html.
+
+#### Falsification attempt for claim 2
+
+- **Strategy:** dependency check (does the substrate accept the value type?)
+  + edge-case enumeration (do any callsites rely on the value being an atom?).
+- **Attempt:** Verified `Registry` API contract via hexdocs; enumerated
+  callsites by `grep -rn "Registry.register\|Registry.lookup\|Registry.match\|
+  Registry.select" lib/tau/` and filtered to the two registries. All current
+  read sites (`hooks/dispatcher.ex:76`, `tool.ex:48`, `tool.ex:68`,
+  `mcp/server.ex:121`) consume the value either as opaque (the unregister
+  call on `mcp/server.ex:121` reads keys, not values) or by passing it
+  forward; none rely on it being an atom at the registry level. The
+  atom-dependence appears one layer further out, at the dispatcher.
+- **Outcome:** withstood.
+- **Action:** none.
+
+### Claim 3: One additional clause in `Tau.Hooks.Dispatcher.run_one/3` and one additional clause in `Tau.Session.dispatch_tool/3` is sufficient to route the struct values; the existing `is_atom(mod)` clause is unchanged
+
+- **Claim (C):** "Extend `Tau.Hooks.Dispatcher.run_one/3` and the session FSM
+  tool-dispatch path with one additional clause each, pattern-matching on the
+  struct tag and delegating to the already-public
+  `Tau.Hooks.Shell.run_command/5` and
+  `Tau.MCP.ToolAdapter.invoke_remote/3`."
+- **Grounds (G):** `lib/tau/hooks/dispatcher.ex:31` defines `run_one/3` with
+  a single `mod, event, payload` head; it calls `mod.handle(event, payload)`
+  at line 46. `lib/tau/session/tool_dispatch.ex:624-696` performs the
+  module-atom dispatch via `Tau.Tool.lookup(name)` → `Tau.Tool.Validator.validate(mod, args)`
+  → `mod.execute(args, ctx)`. Adding a `%Entry{}` clause to `run_one/3` is
+  straightforward; adding a `%ToolEntry{}` clause to `dispatch_tool/3` (in
+  practice `run_tool_validated/6` and `run_tool/4`) is also localised IF the
+  consumer surface ends at these two call frames.
+- **Warrant (W):** OTP non-negotiable #2: "Extensibility seams MUST be
+  behaviours. Pattern match on atoms and structs." Pattern-matching the
+  registry value's struct tag at the consumer boundary is the canonical
+  shape. The leap from G to C presupposes that ONLY these two callsites
+  consume the registered value as a callback target.
+- **Qualifier (Q):** Holds when the only consumers of the registry value
+  are these two dispatchers. Does NOT hold if other call paths read the
+  registry value and invoke a callback on it directly.
+- **Rebuttal (R):** Pre-emptive concession — there ARE other consumer call
+  paths today that assume the registered value is a module:
+  (i) `lib/tau/tool.ex:48` `Tau.Tool.lookup/1` returns the raw value (the
+  solution acknowledges this in "What changes" by widening the return type);
+  (ii) `lib/tau/providers/shared/tool_spec.ex:53-58` `extract/1` clauses
+  call `mod.name/0`, `mod.description/0`, `mod.parameters/0` on every tool
+  consumed in `adapt/2`;
+  (iii) `lib/tau/session/skill_activation.ex:357` calls `mod.name()`,
+  `mod.description()`, `mod.parameters()` on the result of
+  `Tau.Tool.lookup/1`;
+  (iv) `lib/tau/tui/app/completion.ex:29` calls `mod.description()` after
+  `function_exported?(mod, :description, 0)`;
+  (v) `lib/tau/tool.ex:57` `register/1` is typed `module()` and calls
+  `mod.name()` to compute the registry key;
+  (vi) `lib/tau/extensions/loader.ex:484` calls `mod.name()`;
+  (vii) `lib/tau/commands/catalog.ex:69` calls `mod.description()`;
+  (viii) `lib/tau/tool/validator.ex:42` `validate/2` is typed
+  `module(), term()`, guards on `is_atom(mod)`, calls `mod.parameters/0`
+  (line 86) AND caches the resolved schema in `:persistent_term` keyed by
+  the module atom (line 81, 92, 99) — a struct has no equivalent unique key.
+  These eight callsites must learn the struct shape, not "one additional
+  clause each in two dispatchers."
+- **Backing (B):** Tau CLAUDE.md OTP non-negotiable #2 and #3 (pattern-match
+  on atoms and structs; no GenServer wrapping stateless logic). The full
+  enumeration above is from `grep -rn` over `lib/tau/`; the solution's "any
+  callsite that iterates registered tools" Open Question (#1) acknowledges
+  this enumeration was not done at proposal time.
+
+#### Falsification attempt for claim 3
+
+- **Strategy:** edge-case enumeration over consumers of `Tau.Tool.lookup/1`,
+  `Tau.Tools.Registry`, and `Tau.Hooks.Registry`.
+- **Attempt:** Ran `grep -rn "Tau\.Tool\.lookup\|Tau\.Tool\.list\|
+  Tau\.Tool\.register" lib test` and `grep -rn "mod\.\(name\|description\|
+  parameters\|execute\|execution_mode\|streams_updates?\)" lib test`.
+  Catalogued each call frame and assessed whether the consumer would
+  observe a struct-vs-atom difference. Findings enumerated in the
+  Rebuttal above.
+- **Outcome:** partially falsified.
+- **Action:** narrow the Qualifier on the original claim from "one
+  additional clause in each of two dispatchers" to "one additional clause
+  in each of the two **callback** dispatchers, PLUS struct-aware updates
+  to ~7 introspection callsites (`Tau.Tool.Validator`, `Providers.Shared.ToolSpec`,
+  `Session.SkillActivation`, `TUI.App.Completion`, `Tool.register/1`,
+  `Extensions.Loader`, `Commands.Catalog`)." The `:persistent_term` cache
+  in `Tau.Tool.Validator` needs a deliberate decision: key by `{:struct,
+  namespaced_name}` for `ToolEntry`-shaped tools, or skip caching for
+  the struct branch (parameters are still compile-time constant for an
+  MCP tool relative to its registration lifetime). This narrowing does
+  not invalidate the solution; it inflates the migration cost from
+  "medium" to "medium-high" and surfaces a design decision (the cache
+  key) that the proposal deferred to implementation. **No revision of
+  `solution.md` is triggered** — the Open Questions section already
+  flags this enumeration as a "confidence on Proposal 1's 'medium'
+  rating is gated on this grep" — but the narrowed Qualifier MUST be
+  carried into the parent's claim.
+
+### Claim 4: The supervision tree is unchanged; no new GenServers, ETS tables, or supervised workers are introduced
+
+- **Claim (C):** "The supervision tree — no new GenServers, no new ETS
+  tables, no new supervised workers."
+- **Grounds (G):** The solution proposes only struct definitions and
+  function-clause additions; structs are compile-time constructs with no
+  runtime supervision. `Tau.Hooks.Registry` and `Tau.Tools.Registry`
+  already exist (`lib/tau/registries.ex:57-58`). No new `start_link/1`,
+  no new `child_spec/1`, no new `:ets.new/2`.
+- **Warrant (W):** OTP non-negotiable #3: "MUST NOT wrap stateless logic
+  in a GenServer." Conversely, structs + pure functions + existing
+  registries require no additional process supervision. The supervision
+  tree is the set of `child_spec` entries under `Tau.Application`; adding
+  none preserves the tree.
+- **Qualifier (Q):** Holds unconditionally for the changes the solution
+  describes (struct defs + dispatcher clauses + introspection-callsite
+  updates). Would fail only if the implementer added incidental machinery.
+- **Rebuttal (R):** None — the claim is structural: the solution does
+  not add `child_spec`, `start_link`, or `:ets.new` calls. Rebuttal would
+  require the solution to silently introduce one of these.
+- **Backing (B):** Tau supervision tree definition at
+  `lib/tau/application.ex`; the proposal does not list a change to it.
+
+#### Falsification attempt for claim 4
+
+- **Strategy:** counter-example construction.
+- **Attempt:** Asked "could the struct branch in the dispatcher require
+  per-entry process state to support hot-reload?" The current MCP tool
+  adapter is stateless across `invoke/3` calls (forwards immediately to
+  `Tau.MCP.Server.invoke/3`); the shell-hook callback is stateless
+  (`run_command/5` is pure-ish — opens a port, blocks, parses). Neither
+  requires per-entry process state. No counter-example found.
+- **Outcome:** withstood.
+- **Action:** none.
+
+### Claim 5: The existing test suite passes without modification
+
+- **Claim (C):** "The existing dispatch functions are behaviour-preserving,
+  so no test changes are required."
+- **Grounds (G):** `Tau.Hooks.Shell.run_command/5` and
+  `Tau.MCP.ToolAdapter.invoke_remote/3` are existing public functions
+  with unchanged signatures; their internal behaviour is unchanged. The
+  dispatchers' module-atom clauses are preserved verbatim. Tests of the
+  registries' lifetimes, the hook event dispatch order, and the MCP
+  invoke path do not pattern-match on the stored value type explicitly
+  (verified: `grep -rn "Tau.Hooks.Shell.Generated\|Tau.MCP.ToolAdapter\."
+  test/` returns no tests that hard-bind the dynamic module name).
+- **Warrant (W):** Behaviour-preserving refactors leave observable
+  outputs unchanged for fixed inputs. Tests that exercise the public
+  API (`Tau.Hooks.Dispatcher.run/2`, `Tau.Session.dispatch_tool/3`,
+  `Tau.MCP.Server.invoke/3`) without reaching into the implementation
+  detail of "which module type is stored in the registry" will pass
+  unchanged.
+- **Qualifier (Q):** Holds for the dispatcher-level test suites. Does
+  NOT hold for any test that asserts the registry value's type
+  (e.g. `assert is_atom(value)`), nor for any test that exercises the
+  introspection callsites enumerated in claim 3 with a struct-shaped
+  registry value before those callsites learn the new shape.
+- **Rebuttal (R):** Tests that exercise `Tau.Tool.lookup/1` and then call
+  `mod.name()` directly on the result would break if `lookup/1`'s return
+  type widens to `module() | %ToolEntry{}` and they receive a
+  `ToolEntry`. The current test set
+  (`test/tau/extensions/loader_test.exs:173`, `:285`, `:675`, `:718`
+  asserts `{:ok, HelloWorldExt.HelloTool}`) only registers compile-time
+  extension tool modules, so the atom branch of the union is exercised —
+  no break. But any new MCP-flavoured test would have to know the new
+  shape.
+- **Backing (B):** Hickey, "Simple Made Easy" — preserving the substrate
+  while changing the value type is a composition, not a complecting. The
+  test surface depends on the substrate (the registries' lifecycle) and
+  the public dispatch contracts, both preserved.
+
+#### Falsification attempt for claim 5
+
+- **Strategy:** edge-case enumeration over the test suite.
+- **Attempt:** `grep -rn "Tools\.Registry\|Tau.Tool.lookup\|Tau.Tool.list\|
+  Tau.Tool.register" test/` found tests that:
+  - assert atom-tagged extension tool modules
+    (`extensions/loader_test.exs`) — these continue to work because
+    extension tools remain `module()`-typed,
+  - assert `Tau.Tool.list/0` returns a list of binary names
+    (`qa/tool_exposure_test.exs:106`,
+    `cli/headless_run_tool_exposure_test.exs:220`,
+    `session/active_skill_tool_exposure_test.exs:131`) — `list/0`'s
+    contract is "names", which is independent of the value type.
+  - The `payload_test.exs:36` test registers a `CapturingHook` atom
+    against `Tau.Hooks.Registry` directly — exercises the atom branch
+    only, untouched by the struct branch addition.
+  No test today asserts that the registry value type IS an atom in a way
+  that would fail if a struct were stored. The single
+  conditional risk is the `Tau.Tool.Validator.validate(mod, args)` guard
+  `when is_atom(mod)` — if a caller invokes `validate/2` with a
+  `%ToolEntry{}`, the function clause does not match and dispatch
+  raises `FunctionClauseError`. This is not a test that exists today,
+  but the live dispatch path at `tool_dispatch.ex:626` does call
+  `Tau.Tool.Validator.validate(mod, args)` on the lookup result — so
+  the runtime path is broken until `validate/2` learns the struct shape.
+- **Outcome:** partially falsified (already absorbed into claim 3's
+  narrowed Qualifier).
+- **Action:** narrow Qualifier to "the existing test suite passes
+  without modification, **subject to** the introspection-callsite
+  updates listed in claim 3 landing in the same PR — without them,
+  `Tau.Tool.Validator.validate/2` raises `FunctionClauseError` on the
+  first MCP tool dispatch."
+
+## Cross-claim consistency
+
+Claims 1, 2, and 4 are mutually consistent and unconditional: remove the
+two `Module.create/3` sites, replace the registry value with a struct, add
+no new processes. Claims 3 and 5 are linked: the dispatch path is correct
+only when the introspection callsites are co-updated, which is exactly
+what the solution's "What changes" section calls out in its last bullet
+("any callsite that iterates registered tools and invokes `mod.name/0` …
+confirm via grep and add the `%ToolEntry{}` branch"). The validation
+elevates this bullet from a checklist item to a load-bearing precondition
+on AC (c) — the test suite passes only if the bullet is executed
+exhaustively. The solution's Open Question #1 explicitly defers this
+enumeration to implementer time; the validator has now performed it (the
+seven-callsite list under claim 3's Rebuttal), and it is captured here so
+the parent inherits the narrowed Qualifier.
+
+There is no internal contradiction between any pair of claims. The only
+elevated cost is the migration cost from "medium" to "medium-high",
+which does not alter the comparative scoring against Proposals 2, 3, 4
+(Proposal 2 still admits unbounded atom growth on novel configs; Proposals
+3 and 4 still add stateful surface). The selector's choice stands.
+
+## Falsification summary
+
+| # | Claim (short) | Strategy | Outcome | Action |
+|---|---|---|---|---|
+| 1 | No atom growth from these two sites | counter-example + dependency check | withstood | none |
+| 2 | Structs can be registry values | dependency + edge-case | withstood | none |
+| 3 | One extra dispatcher clause each | edge-case enumeration | partially falsified | narrow Qualifier — ~7 introspection sites also need struct branches; `Tau.Tool.Validator` needs a cache-key decision |
+| 4 | Supervision tree unchanged | counter-example construction | withstood | none |
+| 5 | No test changes required | edge-case enumeration | partially falsified | narrow Qualifier — passes only if claim-3 callsites are co-updated in same PR |
+
+## Revision required
+
+None. Both partial falsifications narrow Qualifiers in place; neither
+falsifies the solution wholesale.
+
+- **Target file:** n/a
+- **Revision kind:** n/a
+- **Rationale:** The solution remains the best of the four proposals
+  against the acceptance criterion (Proposals 2/3/4 all introduce new
+  hazards or break stable public shapes; Proposal 1 closes the leak with
+  the lowest residual cost). The narrowed Qualifier on claim 3 increases
+  the implementer's grep-and-edit surface from "two dispatchers" to
+  "two dispatchers + ~7 introspection callsites + one
+  `:persistent_term` cache-key decision in `Tau.Tool.Validator`" — that
+  is a concrete checklist the implementer can execute, not a defect in
+  the design.
+
+## Outstanding doubts
+
+- **`Tau.Tool.Validator` `:persistent_term` cache key for the struct
+  branch.** The current cache is keyed by module atom
+  (`:persistent_term.get({Tau.Tool.Validator, mod})`,
+  `lib/tau/tool/validator.ex:90`). A struct has no module atom for the
+  individual tool. The implementer must choose: (a) key by
+  `{Tau.Tool.Validator, struct_tag, namespaced_name}` (a binary in the
+  key — `:persistent_term` accepts any term — but binary atoms remain
+  permanent so the binary's *atom-ness* is irrelevant; the binary
+  itself is not interned), (b) skip caching for the struct branch
+  (cheaper than a defective key; parameters are still constant per
+  registration lifetime so re-resolution per call is the cost), or
+  (c) cache in an ETS table owned by the MCP server (couples cache
+  lifetime to server lifetime — Erlang-idiomatic but adds surface).
+  Option (b) is the simplest path and matches the
+  "no new stateful surface" claim 4; option (a) preserves the
+  cache benefit and is also stateless. This decision belongs to the
+  implementer but is non-trivial and should be made explicit in the
+  PR description.
+- **`Tau.Hooks.Shell.build/2` has zero current callers.** The solution
+  describes the call as happening "at settings-load time" but no code
+  in `lib/` invokes `Hooks.Shell.build/2` today. The shell-hook
+  atom-leak path is therefore presently latent — the fix prevents a
+  future caller from introducing the leak, but it does not close an
+  active leak on the hook side. The active leak is exclusively at the
+  MCP side. The parent should note this asymmetry — the solution still
+  applies, but its urgency is unequal across the two sites.
+- **`Tau.MCP.ToolAdapter.build/5`'s `mod_name` argument retention.**
+  The solution's Open Question #2 flags this. From the validator's
+  side: removing it requires updating `mcp/server.ex:231-232` (drop the
+  `Module.concat([...])` line; pass only `server_name, key, description,
+  parameters` to `build/4`). The cleaner option is preferable since
+  retaining `mod_name` continues to create the per-entry atom at
+  `Module.concat/1` even though `build/5` no longer uses it — i.e.
+  "ignore the unused arg" would silently defeat AC (a) on the MCP side.
+  The validator's recommendation: drop the argument and update the
+  one caller, do not keep it for arity compat.

--- a/docs/problems-archive-v1-modules/tau-tools-hooks-mcp/subproblems/io-collectors/problem.md
+++ b/docs/problems-archive-v1-modules/tau-tools-hooks-mcp/subproblems/io-collectors/problem.md
@@ -1,0 +1,85 @@
+---
+template_version: 1
+template_name: problem
+node_kind: leaf
+depth: 1
+parent: ../../problem.md
+status: draft
+---
+
+# Problem: io-collectors — Three hand-rolled receive loops accumulate without an in-loop byte cap
+
+## Statement
+
+`Tau.Tools.Operations.Local.bash/2`, `Tau.Hooks.Shell.collect/3`, and
+`Tau.MCP.Transport.Stdio.recv/2` each implement a hand-rolled `receive` loop
+that accumulates Port output via `acc <> data` with no byte cap inside the loop
+body. The truncation policy (where it exists) is applied only after the process
+exits or the loop terminates; a command that writes continuously — or one that
+never exits — accumulates without bound until the BEAM OOMs or the session
+times out. The three collectors also duplicate the same `try/catch` pattern
+around `Port.close/1` for timeout recovery, spreading the same non-idiomatic
+error-handling across three sites.
+
+## Context
+
+- `lib/tau/tools/operations/local.ex:96-165` — `bash/2` and `collect_port/3`:
+  accumulates stdout as `acc <> data`; no mid-loop cap; cap applied in
+  `Bash.truncate/3` only after port closes. O(n²) binary concatenation on large
+  outputs. `try/catch` around `Port.close/1` at line 157.
+- `lib/tau/hooks/shell.ex:145-160` — `collect/3`: same `acc <> data` pattern,
+  same `try/catch` around `Port.close/1` at line 151.
+- `lib/tau/mcp/transport/stdio.ex:65-78` — `recv/2`: does not accumulate across
+  calls (`:line`-framed port), but the `{:noeol, partial}` branch accumulates
+  `state.partial <> partial` across recursive calls with no length cap. Same
+  `try/catch` around `Port.close/1` at line 82.
+- Flat audit: `.code_audit/archive/v1-flat/03-tools-hooks-mcp.md` critical
+  finding at `local.ex:77-115` — "A misbehaving command will OOM the BEAM
+  before the truncation logic ever sees the buffer."
+- `lib/tau/tools/builtin/bash.ex:9-10` — documents a 1000-line / 32 KiB
+  truncation cap, but this cap is not enforced until `truncate/3`, which runs
+  only when `collect_port/3` has already returned the full accumulated buffer.
+
+## Complecting hypothesis
+
+**The collection strategy (binary accumulation + Port framing) is complected
+with the process lifecycle and the termination policy** because the decision
+"when to stop accumulating" is encoded as "when the port exits", with the memory
+bound applied as an afterthought. A well-structured collector would enforce the
+bound as a loop invariant, terminating the port when the cap is exceeded, so the
+accumulation strategy and the truncation policy are the same mechanism rather
+than two sequential passes.
+
+## Decomposition strategy
+
+(leaf — no further decomposition; proceed to proposals)
+
+## Acceptance criterion
+
+The problem is solved when: (a) `collect_port/3` (or its replacement) enforces
+the `@max_bytes` cap inside the receive loop and closes the Port when the cap is
+reached without waiting for command exit; (b) `hooks/shell.ex`'s collector and
+`mcp/transport/stdio.ex`'s partial accumulator each apply an equivalent cap
+before returning; and (c) `try/catch` around `Port.close/1` is replaced at all
+three sites with a guard that checks port liveness before closing (e.g.
+`if Port.info(port), do: Port.close(port)`) — all three verifiable by a test
+that pipes a stream exceeding the cap to Bash and asserts the result is bounded
+and the process does not crash.
+
+## Out of scope
+
+- The SSE transport's in-loop receive (`mcp/transport/sse.ex`) — SSE frames
+  arrive via a Finch streaming callback, not a hand-rolled receive loop; its
+  issues (unlinked task, duplicate accept header) are a concurrency concern
+  covered by the `mcp-server-concurrency` sub-problem.
+- The `Delegate` tool's `do_drain/4` receive loop — it accumulates typed event
+  structs, not raw binary; it has its own deadline-based timeout; its memory
+  profile is bounded by the event count, not raw bytes.
+- The `Agent` tool's `await_child/4` receive loop — same; it processes typed
+  PubSub events, not raw binary accumulation.
+- Shell injection via `{:spawn, cmd}` in `Hooks.Shell` — a security concern
+  separate from the collection bound.
+
+## Amendment log
+
+- (none yet)

--- a/docs/problems-archive-v1-modules/tau-tools-hooks-mcp/subproblems/io-collectors/proposals/proposal-1.md
+++ b/docs/problems-archive-v1-modules/tau-tools-hooks-mcp/subproblems/io-collectors/proposals/proposal-1.md
@@ -1,0 +1,192 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 1
+parent_problem: ../problem.md
+---
+
+# Proposal 1: Tau.IO.BoundedCollector — shared behaviour-preserving extraction
+
+## Approach
+
+Extract a new module `Tau.IO.BoundedCollector` containing a single public
+function `collect/4` (port, max_bytes, deadline_ms, opts) that implements the
+common receive loop with an in-loop byte cap. Replace the bodies of
+`collect_port/3` in `local.ex`, `collect/3` in `hooks/shell.ex`, and the
+`{:noeol, partial}` accumulation path in `mcp/transport/stdio.ex`'s `recv/2`
+with calls to `Tau.IO.BoundedCollector.collect/4`. The module also provides a
+`close_port_if_open/1` guard that replaces all three `try/catch` around
+`Port.close/1`. The existing call-site functions become thin delegations.
+
+## Rationale
+
+The complecting hypothesis is that "when to stop accumulating" is encoded as
+"when the port exits." This proposal decomplects by making the cap a loop
+invariant checked on every chunk, not an afterthought. Extracting to a shared
+module eliminates the three-way duplication in a single move and puts the cap
+enforcement in one place that can be tested and reasoned about independently of
+any tool. The `close_port_if_open/1` helper simultaneously removes the
+idiomatic smell at all three sites. Because the function signature preserves the
+existing caller contract (returning `{:ok, binary, exit_status}` or
+`{:error, reason}`), callers need no refactoring beyond their delegation clauses.
+
+## Sketch
+
+```elixir
+# lib/tau/io/bounded_collector.ex
+defmodule Tau.IO.BoundedCollector do
+  @moduledoc """
+  Bounded binary accumulation from a Port.
+
+  Collects data messages from `port` until one of:
+    - the port sends {:exit_status, n}  →  {:ok, binary, n}
+    - byte_size(acc) >= max_bytes       →  {:ok, acc, :cap_reached}
+    - deadline_ms elapses               →  {:error, :timeout}
+
+  Callers receive at most `max_bytes` bytes regardless of how much the
+  process writes.
+  """
+
+  @spec collect(port(), pos_integer(), non_neg_integer() | :infinity, keyword()) ::
+          {:ok, binary(), non_neg_integer() | :cap_reached} | {:error, :timeout}
+  def collect(port, max_bytes, deadline_ms, _opts \\ []) do
+    do_collect(port, <<>>, max_bytes, deadline_ms)
+  end
+
+  @doc """
+  Closes port only if it is still open. Replaces `try/catch` around
+  `Port.close/1` at three call sites.
+  """
+  @spec close_if_open(port()) :: :ok
+  def close_if_open(port) do
+    if Port.info(port) != nil, do: Port.close(port)
+    :ok
+  end
+
+  # ── private ──────────────────────────────────────────────────────────────
+
+  defp do_collect(port, acc, max_bytes, deadline_ms) do
+    timeout = remaining_ms(deadline_ms)
+
+    receive do
+      {^port, {:data, data}} ->
+        acc = acc <> data
+
+        if byte_size(acc) >= max_bytes do
+          close_if_open(port)
+          {:ok, binary_part(acc, 0, max_bytes), :cap_reached}
+        else
+          do_collect(port, acc, max_bytes, deadline_ms)
+        end
+
+      {^port, {:exit_status, n}} ->
+        {:ok, acc, n}
+    after
+      timeout ->
+        close_if_open(port)
+        {:error, :timeout}
+    end
+  end
+
+  defp remaining_ms(:infinity), do: :infinity
+  defp remaining_ms(deadline_ms),
+    do: max(deadline_ms - System.monotonic_time(:millisecond), 0)
+end
+```
+
+Call-site after change in `local.ex`:
+
+```elixir
+defp collect_port(port, acc, deadline) do
+  Tau.IO.BoundedCollector.collect(port, @max_bytes, deadline)
+end
+```
+
+Call-site after change in `hooks/shell.ex`:
+
+```elixir
+defp collect(port, _acc, timeout_ms) do
+  Tau.IO.BoundedCollector.collect(port, @max_output_bytes, System.monotonic_time(:millisecond) + timeout_ms)
+end
+```
+
+`mcp/transport/stdio.ex` `recv/2` partial path:
+
+```elixir
+{^port, {:data, {:noeol, partial}}} ->
+  new_partial = state.partial <> partial
+  if byte_size(new_partial) >= @max_line_bytes do
+    {:error, {:partial_overflow, byte_size(new_partial)}}
+  else
+    recv(%{state | partial: new_partial}, timeout)
+  end
+```
+
+The `close/1` implementation in `stdio.ex` becomes:
+
+```elixir
+def close(%{port: port}) do
+  Tau.IO.BoundedCollector.close_if_open(port)
+end
+```
+
+## Tradeoffs
+
+### Strengths
+
+- Single source of truth for the byte-cap invariant; a test against
+  `BoundedCollector.collect/4` directly covers all three original sites.
+- Behaviour-preserving at existing call sites; callers see the same tagged tuple
+  shape they already handle.
+- `close_if_open/1` removes the non-idiomatic `try/catch` everywhere in one
+  atomic change.
+- The O(n²) binary concatenation problem is not made worse; it is isolated in
+  one place where it can be addressed as a follow-up (e.g. `IO.iodata_to_binary`
+  with a list acc).
+
+### Weaknesses
+
+- Introduces a new `Tau.IO` namespace that does not currently exist; adds one
+  file and one namespace layer that reviewers must learn.
+- `binary_part/3` at cap truncation drops trailing bytes from the last chunk
+  silently; callers relying on a clean newline-terminated last line (hooks,
+  stdio) may see a mid-UTF-8-codepoint truncation. A mitigation exists
+  (truncate at the last `\n` boundary ≤ max_bytes) but adds complexity.
+- The `mcp/transport/stdio.ex` partial path is line-framed, not a binary blob;
+  wrapping it under the same function signature forces an awkward
+  deadline-relative timestamp conversion at the call site.
+- Does not address the O(n²) concatenation; that remains a follow-up.
+
+### Costs
+
+- One new module (`lib/tau/io/bounded_collector.ex`), ~60 LOC.
+- Three call-site edits (thin delegations), each ≤ 5 lines changed.
+- One new test module covering the bounded-stop path and the port-liveness guard.
+- No new Mix dependencies.
+
+## Dependencies
+
+- None on other modules; this is a pure extraction.
+- The `@max_bytes` constant used by `Bash` already exists at `bash.ex:9`; it
+  must be threaded to `local.ex` or defined there, then passed into the shared
+  collector.
+- `hooks/shell.ex` has no documented cap today; a cap value must be decided
+  (adopting `@max_bytes` from Bash is reasonable as a default, or it can be a
+  per-site parameter).
+
+## Confidence
+
+medium — the sketch is concrete and the extraction is mechanically obvious.
+Confidence would rise to high after: (a) verifying `@max_bytes` threading does
+not break the `Bash` tool's existing truncation tests, and (b) confirming there
+is no protocol expectation in the MCP stdio path that a `recv/2` call always
+returns exactly one complete line.
+
+## Prior art / references
+
+- Elixir `IO.iodata_to_binary/1` accumulation pattern recommended in official
+  guides for large binary assembly.
+- `Port.info/1` liveness check idiom: Elixir documentation on Port module —
+  "returns nil if the port is not open".
+- OTP design principle: bounded mailboxes/buffers as loop invariants, not
+  post-loop filters (documented in the BEAM book §4.3 "Back-pressure patterns").

--- a/docs/problems-archive-v1-modules/tau-tools-hooks-mcp/subproblems/io-collectors/proposals/proposal-2.md
+++ b/docs/problems-archive-v1-modules/tau-tools-hooks-mcp/subproblems/io-collectors/proposals/proposal-2.md
@@ -1,0 +1,187 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 2
+parent_problem: ../problem.md
+---
+
+# Proposal 2: iolist accumulation + in-place cap guards — no new module
+
+## Approach
+
+Fix all three sites in place, without extracting a shared module. At each site:
+(1) replace `acc <> data` with list prepend (`[data | acc]`) and
+`IO.iodata_to_binary/1` at the terminal clause, eliminating O(n²) binary
+concatenation; (2) add an in-loop byte-size guard after every prepend that calls
+`close_if_open(port)` and exits when the accumulated size exceeds the cap; (3)
+replace every `try/catch` around `Port.close/1` with a single private helper
+`close_if_open/1` local to each module. The three modules remain independent;
+the change is behaviour-correcting (fixes OOM risk) but not API-breaking.
+
+## Rationale
+
+The complecting hypothesis is that accumulation strategy and termination policy
+are woven: the accumulation loop simply grows the binary and the cap is applied
+only later. This proposal decomplects by embedding the cap check as a loop
+invariant at each site, making the termination decision local to the same clause
+that grows the buffer. A shared module is not required for decomplecting: the
+complect is strategy-and-lifecycle coupling, which is broken by co-locating the
+cap guard with the accumulation expression, not by extraction. Keeping the fix
+in-place avoids introducing an additional indirection layer and a new namespace
+the three subsystems must depend on.
+
+## Sketch
+
+`local.ex` — revised `collect_port/4` (adds `max_bytes` param):
+
+```elixir
+# @max_bytes already defined at module level via bash.ex / builtin module attr
+defp collect_port(port, acc, deadline, max_bytes) do
+  receive do
+    {^port, {:data, data}} ->
+      acc = [data | acc]
+      if IO.iodata_length(acc) >= max_bytes do
+        close_if_open(port)
+        {:ok, IO.iodata_to_binary(acc) |> binary_part(0, max_bytes), :cap_reached}
+      else
+        collect_port(port, acc, deadline, max_bytes)
+      end
+
+    {^port, {:exit_status, n}} ->
+      {:ok, IO.iodata_to_binary(acc), n}
+  after
+    remaining_or_inf(deadline) ->
+      close_if_open(port)
+      {:error, :timeout}
+  end
+end
+
+defp close_if_open(port) do
+  if Port.info(port) != nil, do: Port.close(port)
+  :ok
+end
+```
+
+`hooks/shell.ex` — revised `collect/4` (adds `max_bytes`; hooks define a module attr):
+
+```elixir
+@max_output_bytes 32_768  # 32 KiB — same policy as Bash tool
+
+defp collect(port, acc, timeout_ms, max_bytes \\ @max_output_bytes) do
+  receive do
+    {^port, {:data, d}} ->
+      acc = [d | acc]
+      if IO.iodata_length(acc) >= max_bytes do
+        close_if_open(port)
+        {:ok, IO.iodata_to_binary(acc) |> binary_part(0, max_bytes), :cap_reached}
+      else
+        collect(port, acc, timeout_ms, max_bytes)
+      end
+
+    {^port, {:exit_status, n}} ->
+      {:ok, IO.iodata_to_binary(acc), n}
+  after
+    timeout_ms ->
+      close_if_open(port)
+      {:error, :timeout}
+  end
+end
+
+defp close_if_open(port) do
+  if Port.info(port) != nil, do: Port.close(port)
+  :ok
+end
+```
+
+`mcp/transport/stdio.ex` — `recv/2` partial guard (line-framed; cap is on
+partial line length, not full message stream):
+
+```elixir
+@max_partial_bytes 65_536  # 64 KiB partial-line cap
+
+{^port, {:data, {:noeol, partial}}} ->
+  new_partial = state.partial <> partial
+  if byte_size(new_partial) >= @max_partial_bytes do
+    {:error, {:partial_overflow, byte_size(new_partial)}}
+  else
+    recv(%{state | partial: new_partial}, timeout)
+  end
+```
+
+`close/1` in `stdio.ex`:
+
+```elixir
+def close(%{port: port}) do
+  if Port.info(port) != nil, do: Port.close(port)
+  :ok
+end
+```
+
+## Tradeoffs
+
+### Strengths
+
+- Zero new modules, zero new namespaces; the three modules remain independently
+  readable without cross-referencing a shared dependency.
+- Simultaneously fixes the O(n²) concatenation with iolist accumulation —
+  Proposal 1 defers this.
+- In-place cap guard is immediately visible alongside the accumulation expression;
+  the complect is broken exactly where it lives.
+- Lower reviewer surface area: diffs are confined to three files.
+- `close_if_open/1` is a one-line private helper at each module; no shared
+  library knowledge required.
+
+### Weaknesses
+
+- The same `close_if_open/1` helper is repeated in three modules (3 × 2 lines);
+  this is minor duplication, but it is not a single source of truth.
+- Without a shared type for the cap result, each site can diverge on what
+  `:cap_reached` / `{:partial_overflow, n}` means to callers; the contract
+  remains per-site.
+- `IO.iodata_length/1` traverses the iolist on every chunk to compute cumulative
+  length; for very large outputs this is O(n) per iteration (though still far
+  better than O(n²) binary concat). A running byte counter sidestep exists but
+  adds a parameter.
+- Testing requires three separate test cases to assert cap behaviour; a single
+  shared module test would cover all three with one case.
+- The iolist path requires `IO.iodata_to_binary/1` at the terminal clause, which
+  allocates a single large binary at exit; peak memory is still O(max_bytes),
+  the same as before, but intermediate memory is lower.
+
+### Costs
+
+- Three files edited; no new files created.
+- `collect_port/3` in `local.ex` becomes `collect_port/4` — one internal
+  call-site change.
+- `collect/3` in `hooks/shell.ex` gains an optional fourth parameter — backward
+  compatible within the module.
+- Three new `@max_output_bytes` / `@max_partial_bytes` module attributes to
+  decide and document.
+- Existing tests that exercise `collect_port` output truncation must be verified
+  to still pass with the earlier (mid-loop) truncation point.
+
+## Dependencies
+
+- `@max_bytes` currently lives implicitly via `Bash.truncate/3`; it must be
+  made explicit as a module attribute in `local.ex` and threaded into
+  `collect_port`.
+- `hooks/shell.ex` has no cap today; the cap value must be decided and
+  documented in a module attribute or in the hook-runner opts.
+
+## Confidence
+
+high — every change is self-contained within the target file, uses only stdlib
+functions (`IO.iodata_length/1`, `IO.iodata_to_binary/1`, `Port.info/1`), and
+the pattern is idiomatic Elixir for bounded accumulation. Prior art is abundant.
+A prototype at any one site would immediately confirm the approach at the other
+two.
+
+## Prior art / references
+
+- `IO.iodata_to_binary/1` accumulation pattern: Elixir documentation, "Building
+  strings efficiently" section.
+- `IO.iodata_length/1` for running length without materialisation: used in
+  Phoenix's `Plug.Conn` body accumulation guard.
+- `Port.info/1 != nil` liveness idiom: Elixir `Port` module docs.
+- OTP "bound-at-receive" pattern: documented in Cesarini & Vinoski
+  "Designing for Scalability with Erlang/OTP", §6.2.

--- a/docs/problems-archive-v1-modules/tau-tools-hooks-mcp/subproblems/io-collectors/proposals/proposal-3.md
+++ b/docs/problems-archive-v1-modules/tau-tools-hooks-mcp/subproblems/io-collectors/proposals/proposal-3.md
@@ -1,0 +1,217 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 3
+parent_problem: ../problem.md
+---
+
+# Proposal 3: Tau.IO.Collector GenServer — supervised back-pressure collector
+
+## Approach
+
+Replace the three inline receive loops with a supervised `Tau.IO.Collector`
+GenServer. The collector is started transiently (`:temporary` restart strategy
+under a `DynamicSupervisor`) for the lifetime of each port interaction.
+It owns the port, enforces the byte cap via a `handle_info` clause, and sends a
+`{:collector_result, ref, result}` reply to the caller when done (exit,
+cap-reached, or timeout). The caller passes port and cap parameters at start and
+blocks on a `GenServer.call/3` or a receive-on-ref until the result arrives.
+The `try/catch` around `Port.close/1` is replaced by the GenServer's
+`terminate/2` callback which guards on `Port.info/1` before closing.
+
+## Rationale
+
+The complecting hypothesis is that accumulation strategy and process lifecycle
+are woven in the same receive loop. A GenServer collector fully separates these
+concerns: the caller owns the *decision* to collect; the collector owns the
+*mechanics* of accumulation, bounding, and port teardown. The lifecycle is now
+supervisable — if the collector crashes (e.g. an unexpected port message), it
+does not take down the calling session process. The byte cap is a GenServer
+state field, checked on every `handle_info({port, {:data, data}})` call, making
+it structurally impossible to receive data without checking the cap. This is a
+data-shape + process-model change that addresses the acceptance criterion with
+stronger runtime guarantees than either in-place fix.
+
+## Sketch
+
+```elixir
+# lib/tau/io/collector.ex
+defmodule Tau.IO.Collector do
+  @moduledoc """
+  Supervised collector for a single Port interaction.
+  Enforces a byte cap inside the OTP message handler.
+  Started transiently under Tau.IO.CollectorSupervisor.
+  """
+
+  use GenServer
+
+  defstruct [:port, :max_bytes, :caller, :ref, acc: [], acc_bytes: 0]
+
+  @type result ::
+          {:ok, binary(), non_neg_integer() | :cap_reached}
+          | {:error, :timeout | {:exit, non_neg_integer()}}
+
+  # ── public API ───────────────────────────────────────────────────────────
+
+  @spec collect(port(), pos_integer(), timeout()) :: result()
+  def collect(port, max_bytes, timeout_ms) do
+    ref = make_ref()
+    {:ok, pid} =
+      DynamicSupervisor.start_child(
+        Tau.IO.CollectorSupervisor,
+        {__MODULE__, {port, max_bytes, self(), ref}}
+      )
+
+    receive do
+      {:collector_result, ^ref, result} -> result
+    after
+      timeout_ms ->
+        GenServer.stop(pid, :timeout)
+        {:error, :timeout}
+    end
+  end
+
+  # ── GenServer callbacks ───────────────────────────────────────────────────
+
+  def start_link({port, max_bytes, caller, ref}) do
+    GenServer.start_link(__MODULE__, {port, max_bytes, caller, ref})
+  end
+
+  @impl GenServer
+  def init({port, max_bytes, caller, ref}) do
+    {:ok, %__MODULE__{port: port, max_bytes: max_bytes, caller: caller, ref: ref}}
+  end
+
+  @impl GenServer
+  def handle_info({port, {:data, data}}, %{port: port} = state) do
+    new_acc = [data | state.acc]
+    new_bytes = state.acc_bytes + byte_size(data)
+
+    if new_bytes >= state.max_bytes do
+      result = {:ok, finalize(new_acc, state.max_bytes), :cap_reached}
+      send(state.caller, {:collector_result, state.ref, result})
+      {:stop, :normal, %{state | acc: new_acc, acc_bytes: new_bytes}}
+    else
+      {:noreply, %{state | acc: new_acc, acc_bytes: new_bytes}}
+    end
+  end
+
+  def handle_info({port, {:exit_status, n}}, %{port: port} = state) do
+    result = {:ok, IO.iodata_to_binary(Enum.reverse(state.acc)), n}
+    send(state.caller, {:collector_result, state.ref, result})
+    {:stop, :normal, state}
+  end
+
+  @impl GenServer
+  def terminate(_reason, state) do
+    if Port.info(state.port) != nil, do: Port.close(state.port)
+    :ok
+  end
+
+  defp finalize(acc, max_bytes) do
+    acc |> Enum.reverse() |> IO.iodata_to_binary() |> binary_part(0, max_bytes)
+  end
+end
+```
+
+```elixir
+# lib/tau/io/collector_supervisor.ex
+defmodule Tau.IO.CollectorSupervisor do
+  use DynamicSupervisor
+
+  def start_link(_), do: DynamicSupervisor.start_link(__MODULE__, [], name: __MODULE__)
+
+  @impl DynamicSupervisor
+  def init(_), do: DynamicSupervisor.init(strategy: :one_for_one)
+end
+```
+
+`lib/tau/application.ex` supervision tree addition:
+
+```elixir
+{Tau.IO.CollectorSupervisor, []}
+```
+
+Call-site in `local.ex`:
+
+```elixir
+defp collect_port(port, _acc, _deadline) do
+  Tau.IO.Collector.collect(port, @max_bytes, remaining_or_inf(@deadline))
+end
+```
+
+## Tradeoffs
+
+### Strengths
+
+- The byte cap is structurally enforced by OTP message dispatch; it is
+  impossible for the `handle_info` clause to receive data without checking the
+  cap.
+- Port teardown is isolated in `terminate/2`, eliminating `try/catch` at all
+  three sites with an OTP-idiomatic lifecycle callback.
+- Collector crashes are isolated from caller sessions; a bug in accumulation
+  does not propagate as a linked process crash.
+- Iolist accumulation (`[data | acc]`) is used from the start; O(n²) is
+  eliminated alongside the cap fix.
+- Supervisable and observable: a future telemetry attachment or back-pressure
+  extension has a natural home in `handle_info`.
+
+### Weaknesses
+
+- Highest complexity of the three proposals: adds two new modules plus a
+  supervision tree entry.
+- The `DynamicSupervisor.start_child/2` call-path adds measurable latency
+  (~microseconds) per collection; for short-lived Bash commands this is
+  invisible, but it is non-zero.
+- The caller blocks in a bare `receive` waiting for `{:collector_result, ref,
+  result}` — this is a regression from a direct `GenServer.call/3` (the ref
+  approach is used to avoid coupling to the GenServer pid). A selectible receive
+  pattern is required; callers already in a GenServer context must handle the
+  message in `handle_info`, not inline.
+- Timeout handling is split between the caller's receive-after and the
+  GenServer's `terminate/2`; the interaction between the two must be carefully
+  tested (e.g. double-close if both fire near-simultaneously).
+- Overkill for what is essentially a bounded buffer: the OTP overhead is
+  justified by isolation guarantees, but the same invariant can be achieved
+  with in-place fixes (Proposal 2) at far lower cost.
+- `mcp/transport/stdio.ex`'s `recv/2` is already designed as a synchronous
+  call-per-line; wrapping it in a GenServer collector changes the protocol
+  semantics and may not be straightforward.
+
+### Costs
+
+- Two new modules, ~80 LOC total.
+- One supervision tree entry in `application.ex`.
+- Three call-site changes.
+- New test coverage needed for: cap-reached path, exit path, double-close race,
+  timeout-vs-terminate race.
+- All existing `collect_port` tests must be adapted to the new call shape.
+
+## Dependencies
+
+- `Tau.IO.CollectorSupervisor` must be started before any tool that uses Bash.
+  It must be placed in the supervision tree before `Tau.Tools` (if that is a
+  supervised entity).
+- The `mcp/transport/stdio.ex` integration requires design work on how
+  `recv/2` interacts with a GenServer collector given its line-framing protocol;
+  a variant or a separate lightweight path may be needed there.
+
+## Confidence
+
+medium — the GenServer skeleton is well-understood OTP. Confidence would rise
+to high after: (a) resolving the caller-in-GenServer-context problem for
+`hooks/shell.ex` (which is called from within the hook dispatcher, itself
+likely a GenServer), and (b) confirming `mcp/transport/stdio.ex` can adopt the
+collector without changing the `Tau.MCP.Transport` behaviour contract.
+
+## Prior art / references
+
+- OTP `DynamicSupervisor` for transient workers: OTP documentation §5.4.
+- "Isolate side-effecting workers with transient supervisors" — Erlang/OTP in
+  Action, Hebert, ch. 9.
+- `GenServer.terminate/2` for resource cleanup: OTP documentation recommends
+  using `terminate` for port/socket teardown when process exit is the teardown
+  signal.
+- Phoenix's `Plug.Conn` body-reader uses a ref-based reply pattern for
+  back-pressure collection from an async process — similar to the
+  `{:collector_result, ref, result}` shape here.

--- a/docs/problems-archive-v1-modules/tau-tools-hooks-mcp/subproblems/io-collectors/proposals/proposal-4.md
+++ b/docs/problems-archive-v1-modules/tau-tools-hooks-mcp/subproblems/io-collectors/proposals/proposal-4.md
@@ -1,0 +1,256 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 4
+parent_problem: ../problem.md
+---
+
+# Proposal 4: Tau.IO.Collector behaviour — site-specific implementations sharing a typed contract
+
+## Approach
+
+Define a `Tau.IO.Collector` behaviour with a single callback `collect/3` and a
+shared result type `t()`. Provide two concrete implementations:
+`Tau.IO.Collector.Binary` (for `local.ex` and `hooks/shell.ex`) and
+`Tau.IO.Collector.LineFramed` (for `mcp/transport/stdio.ex`'s partial
+accumulation). Each implementation enforces its own byte cap inline but returns
+the same typed result. The `try/catch` around `Port.close/1` is replaced by a
+single `Tau.IO.Port.close_if_open/1` utility function. This is an API-breaking
+change in the sense that `collect_port/3` and `collect/3` become private
+delegations to the behaviour implementation, not standalone routines.
+
+## Rationale
+
+The complecting hypothesis identifies two distinct woven concerns: accumulation
+strategy and termination policy. This proposal decomplects the *interface* from
+the *strategy*: the behaviour defines what a bounded collector contract looks
+like (typed result, cap parameter, deadline parameter), while each implementation
+encodes the strategy appropriate to its transport framing. `Binary` uses iolist
+accumulation with a byte cap; `LineFramed` accumulates partial lines with a
+line-length cap. Callers depend on the behaviour type, not the implementation.
+This is a stronger decomplecting move than Proposal 1 (shared function) because
+the type is enforced by the behaviour compiler check, not by convention. The
+`try/catch` duplication is eliminated not by moving code but by naming and
+exporting the idiomatic guard once.
+
+## Sketch
+
+```elixir
+# lib/tau/io/collector.ex  — behaviour definition + shared types
+defmodule Tau.IO.Collector do
+  @moduledoc """
+  Behaviour for bounded Port I/O collection.
+
+  All implementations enforce a byte cap inside the receive loop,
+  closing the Port when the cap is reached, and return a uniform
+  result type.
+  """
+
+  @type result ::
+          {:ok, binary(), non_neg_integer() | :cap_reached}
+          | {:error, :timeout | {:overflow, non_neg_integer()}}
+
+  @callback collect(port :: port(), max_bytes :: pos_integer(), deadline :: integer() | :infinity) ::
+              result()
+end
+```
+
+```elixir
+# lib/tau/io/collector/binary.ex — blob accumulation (bash, hooks)
+defmodule Tau.IO.Collector.Binary do
+  @behaviour Tau.IO.Collector
+
+  @impl Tau.IO.Collector
+  def collect(port, max_bytes, deadline) do
+    loop(port, [], 0, max_bytes, deadline)
+  end
+
+  defp loop(port, acc, acc_bytes, max_bytes, deadline) do
+    receive do
+      {^port, {:data, data}} ->
+        new_bytes = acc_bytes + byte_size(data)
+        acc = [data | acc]
+
+        if new_bytes >= max_bytes do
+          Tau.IO.Port.close_if_open(port)
+          {:ok, acc |> Enum.reverse() |> IO.iodata_to_binary() |> binary_part(0, max_bytes), :cap_reached}
+        else
+          loop(port, acc, new_bytes, max_bytes, deadline)
+        end
+
+      {^port, {:exit_status, n}} ->
+        {:ok, acc |> Enum.reverse() |> IO.iodata_to_binary(), n}
+    after
+      remaining(deadline) ->
+        Tau.IO.Port.close_if_open(port)
+        {:error, :timeout}
+    end
+  end
+
+  defp remaining(:infinity), do: :infinity
+  defp remaining(deadline), do: max(deadline - System.monotonic_time(:millisecond), 0)
+end
+```
+
+```elixir
+# lib/tau/io/collector/line_framed.ex — partial-line accumulation (stdio)
+defmodule Tau.IO.Collector.LineFramed do
+  @behaviour Tau.IO.Collector
+
+  @impl Tau.IO.Collector
+  def collect(port, max_bytes, deadline) do
+    loop(port, "", max_bytes, deadline)
+  end
+
+  defp loop(port, partial, max_bytes, deadline) do
+    receive do
+      {^port, {:data, {:eol, line}}} ->
+        {:ok, partial <> line, :eol}
+
+      {^port, {:data, {:noeol, chunk}}} ->
+        new_partial = partial <> chunk
+
+        if byte_size(new_partial) >= max_bytes do
+          {:error, {:overflow, byte_size(new_partial)}}
+        else
+          loop(port, new_partial, max_bytes, deadline)
+        end
+
+      {^port, {:exit_status, n}} ->
+        {:error, {:exit, n}}
+    after
+      remaining(deadline) ->
+        {:error, :timeout}
+    end
+  end
+
+  defp remaining(:infinity), do: :infinity
+  defp remaining(deadline), do: max(deadline - System.monotonic_time(:millisecond), 0)
+end
+```
+
+```elixir
+# lib/tau/io/port.ex — shared port utilities
+defmodule Tau.IO.Port do
+  @moduledoc "Idiomatic Port utilities."
+
+  @spec close_if_open(port()) :: :ok
+  def close_if_open(port) do
+    if Port.info(port) != nil, do: Port.close(port)
+    :ok
+  end
+end
+```
+
+Call-site in `local.ex`:
+
+```elixir
+@collector Tau.IO.Collector.Binary
+
+defp collect_port(port, _acc, deadline) do
+  @collector.collect(port, @max_bytes, deadline)
+end
+```
+
+Call-site in `hooks/shell.ex`:
+
+```elixir
+@collector Tau.IO.Collector.Binary
+@max_output_bytes 32_768
+
+defp collect(port, _acc, timeout_ms) do
+  deadline = System.monotonic_time(:millisecond) + timeout_ms
+  @collector.collect(port, @max_output_bytes, deadline)
+end
+```
+
+`mcp/transport/stdio.ex` `recv/2` — delegates the partial path:
+
+```elixir
+@collector Tau.IO.Collector.LineFramed
+@max_partial_bytes 65_536
+
+def recv(%{port: port, partial: partial} = state, timeout) do
+  deadline = System.monotonic_time(:millisecond) + timeout
+  case @collector.collect(port, @max_partial_bytes, deadline) do
+    {:ok, line, :eol}  -> {:ok, [partial <> line], %{state | partial: ""}}
+    {:ok, _line, :cap_reached} -> {:error, {:overflow, @max_partial_bytes}}
+    {:error, _} = e  -> e
+  end
+end
+```
+
+The `close/1` implementation in `stdio.ex`:
+
+```elixir
+def close(%{port: port}), do: Tau.IO.Port.close_if_open(port)
+```
+
+## Tradeoffs
+
+### Strengths
+
+- The behaviour definition is a machine-checked contract: any future collector
+  implementation must satisfy the `@callback` spec or the compiler warns.
+- Two distinct implementations serve genuinely different transport semantics
+  (blob vs line-framed), avoiding the awkward unified-function signature of
+  Proposal 1.
+- The `@collector` module attribute at each call site makes the concrete
+  implementation swappable in tests (mock or test-double without monkey-patching).
+- Iolist accumulation is used in `Binary`; O(n²) is fixed simultaneously.
+- `Tau.IO.Port.close_if_open/1` is a single exported function — one definition,
+  three uses — not copy-pasted code.
+
+### Weaknesses
+
+- Three new modules (`Tau.IO.Collector`, `Tau.IO.Collector.Binary`,
+  `Tau.IO.Collector.LineFramed`) plus one utility module (`Tau.IO.Port`) — the
+  highest module count of the four proposals.
+- The `LineFramed` implementation reworks `recv/2` significantly; the
+  `mcp/transport/stdio.ex` call-site rewrite is non-trivial because the current
+  `recv/2` accumulates partial state in `state.partial` across calls, while the
+  collector processes one recv call at a time. Threading the pre-existing partial
+  into `collect/3` requires either an additional parameter or a pre-seeded
+  accumulator not expressed in the behaviour callback.
+- `@collector` module attribute approach for testability is idiomatic but not
+  universally familiar; reviewers unfamiliar with BEAM polymorphism-via-behaviour
+  may expect a more conventional approach.
+- The behaviour adds one level of indirection for what is, at each site, a small
+  private function; this may be seen as over-engineering.
+
+### Costs
+
+- Four new modules, ~120 LOC total.
+- Three call-site changes (delegation to behaviour impl).
+- The `mcp/transport/stdio.ex` rework requires understanding the `state.partial`
+  threading across consecutive `recv/2` calls; estimated 1–2 hours of design
+  work beyond the mechanical extraction.
+- New tests: one per behaviour callback (shared contract test), plus per-
+  implementation tests for cap path, exit path, timeout path.
+
+## Dependencies
+
+- The `state.partial` threading design question in `stdio.ex` must be resolved
+  before implementing `LineFramed`; this may require adding an optional
+  `initial_partial` parameter to the `LineFramed.collect/3` function (diverging
+  from the behaviour callback signature, which would then need a default-value
+  wrapper).
+- No new Mix dependencies; all code is BEAM stdlib.
+
+## Confidence
+
+medium — the `Binary` path is straightforward. The `LineFramed` path has a
+pre-existing-partial threading complexity that must be resolved. Confidence
+would rise to high after a prototype of `LineFramed` that correctly handles
+the `state.partial <> chunk` continuation across calls.
+
+## Prior art / references
+
+- Elixir `@behaviour` + `@callback` as machine-checked interface: Elixir
+  documentation "Behaviours" guide.
+- `@adapter` module attribute for testable behaviour dispatch: used in Phoenix's
+  `Swoosh.Adapters` pattern and Tau's own `Tau.Provider` behaviour.
+- Separate blob vs line-framed collector designs: seen in the Erlang `gen_tcp`
+  packet option (`raw` vs `line`) — the two accumulation models are genuinely
+  distinct and warrant distinct implementations.
+- `Port.info/1` liveness guard: Elixir Port documentation.

--- a/docs/problems-archive-v1-modules/tau-tools-hooks-mcp/subproblems/io-collectors/solution.md
+++ b/docs/problems-archive-v1-modules/tau-tools-hooks-mcp/subproblems/io-collectors/solution.md
@@ -1,0 +1,150 @@
+---
+template_version: 1
+template_name: solution
+parent_problem: ../../problem.md
+node_kind: leaf
+synthesised_from: [proposals/proposal-1.md, proposals/proposal-2.md]
+selection_method: hybrid
+revision: 0
+---
+
+# Solution: In-place iolist cap guards + shared `Tau.IO.Port` utility
+
+## Recommendation
+
+Fix all three sites in-place using iolist accumulation with a running byte
+counter and an in-loop cap guard, eliminating both the OOM risk and the O(n²)
+concatenation in a single move. Extract exactly one shared artefact:
+`Tau.IO.Port.close_if_open/1` as a public utility function in a minimal
+`lib/tau/io/port.ex` module. The three `collect_*` functions remain private to
+their owning modules; no new namespace layer is imposed on callers. The MCP
+stdio `{:noeol, partial}` path gets an inline byte-cap guard in `recv/2`.
+
+## Selected from
+
+- **Chosen:** hybrid of `proposals/proposal-2.md` (in-place fixes + iolist
+  accumulation + local `close_if_open/1`) and `proposals/proposal-1.md`
+  (shared `close_if_open/1` extraction).
+- **Why chosen:** Proposal 2 dominates on fit, decomplecting depth (the cap is
+  co-located with the accumulation expression, not separated by a function
+  boundary), migration cost, and reversibility. Its sole weakness is the
+  three-way duplication of `close_if_open/1` — a two-line private helper
+  repeated in three modules. Proposal 1's only clearly superior element is the
+  extraction of that helper into a named, testable, single-source-of-truth
+  function. A minimal hybrid takes that one element from Proposal 1 and
+  applies it to Proposal 2's in-place structure. This is a coherent composition:
+  Proposal 2's accumulation fix is not altered; Proposal 1's helper extraction
+  is applied unchanged to the liveness-guard duplication. The result is strictly
+  better than either alone at negligible additional cost (one 4-line utility
+  module). Proposals 3 and 4 are rejected: Proposal 3 adds OTP supervision
+  machinery (DynamicSupervisor, GenServer lifecycle, ref-based reply) to what is
+  essentially a bounded buffer — the isolation gain does not justify the
+  complexity, and the caller-in-GenServer-context problem for `hooks/shell.ex`
+  is unresolved. Proposal 4 introduces a four-module behaviour hierarchy where
+  the behaviour's contract is immediately violated by `LineFramed`'s need to
+  thread `state.partial` — a pre-existing accumulator not expressible in the
+  `collect/3` callback signature — making the behaviour a nominal contract
+  rather than an enforced one.
+
+## Scoring table
+
+| # | Fit | Decomplecting depth | Migration cost | Risk | Reversibility |
+|---|-----|---------------------|----------------|------|---------------|
+| 1 | Yes | Substantial | Low | Low | Easy |
+| 2 | Yes | Deep | Low | Low | Easy |
+| 3 | Yes | Substantial | High | Medium | Hard |
+| 4 | Partially | Substantial | High | Medium | Hard |
+
+Proposal 2 scores deepest on decomplecting: the cap guard lives in the same
+clause as the accumulation expression, making the loop invariant visible and
+local. Proposal 4 scores Partially on fit because the `LineFramed` behaviour
+callback cannot honestly represent the `state.partial` continuation — the
+proposer acknowledges this requires "an optional `initial_partial` parameter
+... diverging from the behaviour callback signature."
+
+## What changes
+
+- **`lib/tau/io/port.ex`** (new): defines `Tau.IO.Port.close_if_open/1` — the
+  `Port.info(port) != nil` liveness guard as a single exported function.
+- **`lib/tau/tools/operations/local.ex`**: `collect_port/3` → replaces
+  `acc <> data` with `[data | acc]` prepend, adds a running `acc_bytes`
+  counter, adds the in-loop cap guard that calls `Tau.IO.Port.close_if_open/1`
+  and exits `{:ok, ..., :cap_reached}` when `acc_bytes >= @max_bytes`. The
+  `try/catch` around `Port.close/1` at line 157 is replaced with
+  `Tau.IO.Port.close_if_open(port)`. Terminal clause uses `IO.iodata_to_binary/1`.
+  The `@max_bytes` constant is made explicit at this module level (currently
+  implied via `Bash.truncate/3`).
+- **`lib/tau/hooks/shell.ex`**: `collect/3` → same iolist + running counter +
+  in-loop cap guard pattern. Adds `@max_output_bytes 32_768` (matching Bash's
+  existing policy). The `try/catch` around `Port.close/1` at line 151 is
+  replaced with `Tau.IO.Port.close_if_open(port)`.
+- **`lib/tau/mcp/transport/stdio.ex`**: `recv/2` `{:noeol, partial}` branch →
+  adds `if byte_size(new_partial) >= @max_partial_bytes` guard returning
+  `{:error, {:partial_overflow, byte_size(new_partial)}}`. Adds
+  `@max_partial_bytes 65_536`. The `try/catch` around `Port.close/1` at
+  line 82 is replaced with `Tau.IO.Port.close_if_open(port)`.
+
+## What does not change
+
+- The `Tau.MCP.Transport` behaviour contract (`recv/2` and `close/1`
+  signatures) — callers see no API change.
+- `lib/tau/tools/builtin/bash.ex`'s `truncate/3` — it still runs after
+  `collect_port/3` returns; the in-loop cap now ensures `truncate/3` always
+  receives a buffer that is already within bounds, making `truncate/3` a
+  no-op in the cap-reached path. No callers of `truncate/3` change.
+- `collect_port/3`, `collect/3`, and `recv/2` remain private to their
+  owning modules; no new dependency edge is introduced at the tool level.
+- The supervision tree — no new processes, supervisors, or application children.
+- All existing tests for the truncation behaviour in `bash_test.exs`; the
+  earlier truncation point (mid-loop vs post-loop) must be verified, but the
+  existing assertions on bounded output remain valid.
+
+## Migration sketch
+
+1. Add `lib/tau/io/port.ex` with `close_if_open/1`. No callers yet.
+2. Fix `local.ex`: promote `@max_bytes` to a module attribute, rewrite
+   `collect_port/3` with iolist acc + running counter + cap guard, replace
+   `try/catch` with `Tau.IO.Port.close_if_open/1`. Run existing Bash tests.
+3. Fix `hooks/shell.ex`: add `@max_output_bytes`, rewrite `collect/3`,
+   replace `try/catch`. Run hook tests.
+4. Fix `mcp/transport/stdio.ex`: add `@max_partial_bytes`, add noeol guard,
+   replace `try/catch`. Run MCP transport tests.
+5. Add a new test (`test/tau/io/port_test.exs` or inline in the Bash tool
+   tests) that pipes a stream exceeding the cap and asserts bounded output
+   and no crash — satisfying the acceptance criterion's verifiability clause.
+
+Steps 2–4 are independent and may land in a single commit or three sequential
+commits; they share no code until step 1 is in.
+
+## Open questions
+
+- **`@max_bytes` threading in `local.ex`**: the constant currently lives in
+  `bash.ex` (line 9–10 per the problem context). The solution requires it to
+  be explicit in `local.ex`. If `bash.ex` imports or aliases it from `local.ex`,
+  the direction of that dependency must be confirmed before implementation.
+- **`hooks/shell.ex` cap value**: `32_768` (matching Bash) is a reasonable
+  default, but the hook runner may have a different policy intention. The
+  implementer should confirm with the hook-runner opts interface before hardcoding.
+- **Existing `truncate/3` test assertions**: some tests may assert on exact
+  truncation byte counts that differ between mid-loop (iolist-chunk-boundary)
+  and post-loop (exact byte slice) truncation. These must be audited in step 2.
+- **UTF-8 boundary on `binary_part/0, max_bytes`**: truncating at an exact
+  byte count may split a multi-byte codepoint. The problem acceptance criterion
+  does not require clean codepoint boundaries, but this should be flagged in the
+  implementation PR.
+
+## Linked sub-problems / proposals
+
+- `proposals/proposal-1.md` — `Tau.IO.BoundedCollector` shared extraction;
+  `close_if_open` element taken for the hybrid.
+- `proposals/proposal-2.md` — in-place iolist cap guards; dominant approach
+  for accumulation and in-loop cap enforcement.
+- `proposals/proposal-3.md` — `Tau.IO.Collector` GenServer; rejected:
+  over-engineered for the problem, unresolved caller-in-GenServer-context issue.
+- `proposals/proposal-4.md` — `Tau.IO.Collector` behaviour hierarchy; rejected:
+  behaviour contract cannot honestly represent `LineFramed`'s `state.partial`
+  threading, making it a nominal rather than enforced contract.
+
+## Revision history
+
+- (revision 0 — initial)

--- a/docs/problems-archive-v1-modules/tau-tools-hooks-mcp/subproblems/io-collectors/validation.md
+++ b/docs/problems-archive-v1-modules/tau-tools-hooks-mcp/subproblems/io-collectors/validation.md
@@ -1,0 +1,525 @@
+---
+template_version: 1
+template_name: validation
+parent_solution: solution.md
+parent_problem: problem.md
+toulmin_complete: true
+falsification_attempted: true
+falsification_outcome: partially_falsified — claim/3
+revision_triggered: none
+---
+
+# Validation: In-place iolist cap guards + shared `Tau.IO.Port` utility
+
+## Overview
+
+The solution makes seven distinct checkable propositions: (1) a new
+`Tau.IO.Port.close_if_open/1` utility replaces `try/catch` at all three
+sites; (2) `local.ex`'s `collect_port/3` is rewritten with iolist
+accumulation + a running byte counter + an in-loop cap; (3)
+`hooks/shell.ex`'s `collect/3` receives the same treatment with a newly
+introduced `@max_output_bytes 32_768`; (4) `mcp/transport/stdio.ex`'s
+`recv/2` gains a `@max_partial_bytes 65_536` guard on the
+`{:noeol, partial}` branch; (5) the `Tau.MCP.Transport` behaviour
+contract is preserved; (6) `bash.ex`'s `truncate/3` is preserved as a
+no-op-in-cap-reached safety net; (7) no new supervision-tree nodes are
+introduced. Each claim is validated with the Toulmin six-tuple and an
+explicit falsification strategy drawn from the validate.md catalog.
+
+The dominant outcome is **withstood**, with one **partial falsification**
+on claim 3 (the `32_768` byte cap for the hook collector is asserted
+without evidence that hook outputs are bounded by the same policy that
+governs the `Bash` tool — the solution itself flags this as an open
+question and the qualifier is narrowed accordingly).
+
+## Toulmin per claim
+
+The MITRE empirical study on Toulmin formalism found that "participants
+found it difficult to generate Toulmin structures, and their structures
+varied greatly even though they started with the same content"
+(https://www.mitre.org/news-insights/publication/empirical-evaluation-structured-argumentation-using-toulmin-argument).
+This template enforces all six components explicitly with prompts to
+counter that variance.
+
+### Claim 1: `Tau.IO.Port.close_if_open/1` replaces `try/catch` at all three sites
+
+- **Claim (C):** A new module `lib/tau/io/port.ex` defining a single
+  exported function `Tau.IO.Port.close_if_open/1` (a `Port.info(port) !=
+  nil` liveness guard + conditional `Port.close/1`) replaces the
+  `try/catch` blocks at `local.ex:157`, `hooks/shell.ex:151`, and
+  `stdio.ex:82`, eliminating the use of `try/catch` across a process
+  boundary at all three port-collector sites.
+- **Grounds (G):** The three try/catch blocks exist verbatim today:
+  `lib/tau/tools/operations/local.ex:157-161` (try/catch around
+  `Port.close(port)`); `lib/tau/hooks/shell.ex:151-155` (identical
+  pattern); `lib/tau/mcp/transport/stdio.ex:82-86` (identical
+  pattern). The `Port.info(port) != nil` idiom already has prior use
+  in this codebase at `lib/tau/coding_agents/claude_code.ex:406`,
+  confirming the liveness-check pattern is accepted in-tree.
+- **Warrant (W):** Tau OTP non-negotiable #7 ("Let it crash;
+  supervise; restart. MUST NOT `try/rescue` across process
+  boundaries.") prohibits exactly the `try/catch` pattern these
+  three sites use to swallow `Port.close/1` exits. A single named,
+  documented utility centralises the liveness guard so future
+  collectors inherit the correct idiom rather than re-introducing the
+  banned pattern.
+- **Qualifier (Q):** Holds for the three named sites and any future
+  caller that uses `Tau.IO.Port.close_if_open/1`. Does not apply to
+  callers who continue using `Port.close/1` directly outside this
+  utility.
+- **Rebuttal (R):** If `Port.info(port)` itself can raise on a
+  garbage-collected port reference, the utility merely moves the
+  failure mode rather than eliminating it. Per Erlang docs,
+  `Port.info/1` returns `nil` for non-existent ports rather than
+  raising, so the rebuttal does not bite — but this is a
+  documentation-supported invariant, not a typespec-enforced one.
+- **Backing (B):** `.claude/rules/otp-non-negotiables.md` (Invariant
+  #7, "MUST NOT `try/rescue` across process boundaries"); Erlang
+  `Port` module documentation
+  (https://www.erlang.org/doc/man/erlang.html#port_info-1) for
+  `port_info/1` returning `undefined` (Elixir `nil`) for invalid
+  ports.
+
+#### Falsification attempt for claim 1
+
+- **Strategy:** dependency check + counter-example construction over
+  the documented `Port.info/1` failure modes.
+- **Attempt:** (i) Confirmed the three cited try/catch blocks exist at
+  exactly the line numbers stated (local.ex:157-161, shell.ex:151-155,
+  stdio.ex:82-86); (ii) confirmed the `Port.info` idiom is already
+  used at `coding_agents/claude_code.ex:406`, ruling out
+  "novel-pattern" objections; (iii) enumerated the racy edge case
+  where the port could die between `Port.info(port)` and `Port.close(port)`
+  — in that race `Port.close/1` on a dead port returns `true` per
+  Erlang docs rather than raising, so a bare `Port.close/1` after the
+  liveness check does NOT need its own guard; (iv) checked that no
+  caller depends on the `try/catch`'s swallowing of any exception
+  *other* than the port-already-closed `:badarg` — `local.ex` only
+  catches inside the `:timeout` after-clause, and the only documented
+  reason `Port.close/1` raises is `:badarg` on an invalid port, so the
+  catch is over-broad today and the helper is strictly safer.
+- **Outcome:** withstood — the helper achieves the claimed
+  decomplecting + idiomatic-cleanup goal at the three sites without
+  introducing a new failure mode.
+- **Action:** none.
+
+### Claim 2: `local.ex`'s `collect_port/3` is rewritten with iolist accumulation + running byte counter + in-loop cap
+
+- **Claim (C):** `collect_port/3` in `lib/tau/tools/operations/local.ex`
+  replaces `acc <> data` with `[data | acc]` prepend, adds a running
+  `acc_bytes` counter, adds an in-loop cap guard that calls
+  `Tau.IO.Port.close_if_open/1` and exits `{:ok, ..., :cap_reached}`
+  when `acc_bytes >= @max_bytes`, with the terminal clause emitting
+  `IO.iodata_to_binary/1`. `@max_bytes` is promoted to a module-level
+  attribute in `local.ex`.
+- **Grounds (G):** Current `collect_port/3` is exactly the pattern the
+  claim repudiates: `lib/tau/tools/operations/local.ex:148-165` shows
+  the `{^port, {:data, data}} -> collect_port(port, acc <> data,
+  deadline)` clause, with the truncation cap only applied later via
+  `Tau.Tools.Builtin.Bash.truncate/3` at `bash.ex:104-129`. `@max_bytes
+  = 32 * 1024` is defined at `bash.ex:35`, NOT in `local.ex` — so
+  promoting it requires either duplicating the value or moving it.
+  The `[h | t]` prepend + `IO.iodata_to_binary/1` pattern is
+  Elixir-idiomatic for bounded accumulation (documented in
+  `IO.iodata_to_binary/1` hexdocs).
+- **Warrant (W):** O(n²) binary concatenation under unbounded
+  accumulation is a documented memory-pressure path on the BEAM
+  (refcounted binary copy per concat). Replacing `<>` with iolist
+  prepend yields O(1) amortised growth and O(n) finalisation;
+  combining this with an in-loop cap guard makes the memory bound a
+  loop invariant rather than a post-loop afterthought, which is
+  precisely the decomplecting move the problem statement asks for.
+- **Qualifier (Q):** Holds for the `collect_port/3` rewrite in
+  `local.ex`. Assumes `@max_bytes` migrates from `bash.ex:35` to
+  `local.ex` (the solution's own open question #1 acknowledges this).
+- **Rebuttal (R):** `IO.iodata_length/1` per chunk is O(length of the
+  iolist) and so cumulative work to compute the running length is
+  O(n²) in chunk count — but a running integer counter (`acc_bytes +
+  byte_size(data)`) sidesteps this; the solution explicitly chooses
+  the counter form. With the counter the rebuttal does not bite. A
+  separate rebuttal: terminal `IO.iodata_to_binary/1` still allocates
+  one large binary, so peak memory is O(@max_bytes), not lower — but
+  the cap is the point, and this is unchanged from the existing
+  truncation contract.
+- **Backing (B):** Elixir `IO` module docs on "Building strings
+  efficiently" (iolist accumulation pattern,
+  https://hexdocs.pm/elixir/IO.html#iodata_to_binary/1); the flat
+  audit at `.code_audit/archive/v1-flat/03-tools-hooks-mcp.md` (cited
+  in `problem.md` Context) calls the existing pattern "a misbehaving
+  command will OOM the BEAM before the truncation logic ever sees the
+  buffer."
+
+#### Falsification attempt for claim 2
+
+- **Strategy:** edge-case enumeration over the failure modes the cap
+  invariant must rule out, plus a type-level check on the cap-reached
+  terminal clause.
+- **Attempt:** (i) Enumerated: command that writes one byte at a time
+  (cap fires after `@max_bytes` iterations — bounded, OK); command
+  that writes >@max_bytes in a single chunk (cap fires on first
+  receive — bounded, OK; binary part may slice mid-UTF-8 codepoint,
+  flagged in open question #4 and inherited here); command that
+  writes nothing and exits cleanly (terminal `:exit_status` clause
+  emits `IO.iodata_to_binary([])` = `""` — OK); command that exits
+  before any data (same — OK); timeout fires mid-accumulation (after
+  clause closes port, returns `{:error, :timeout}` — unchanged from
+  today, OK); (ii) Type-level: `IO.iodata_to_binary/1` accepts any
+  iolist including `[data | acc]` recursive prepends; result is
+  always `binary`; (iii) Confirmed `bash.ex`'s downstream
+  `truncate/3` accepts any binary input and is unaffected by which
+  side enforces the cap.
+- **Outcome:** withstood — the rewrite achieves the claimed bound
+  with no enumerated edge case falsifying it.
+- **Action:** none. The UTF-8 boundary concern (open question #4) is
+  acknowledged and is not a falsification of the cap claim itself.
+
+### Claim 3: `hooks/shell.ex`'s `collect/3` adopts the same pattern with `@max_output_bytes 32_768`
+
+- **Claim (C):** `collect/3` in `lib/tau/hooks/shell.ex` is rewritten
+  with iolist accumulation + running counter + in-loop cap guard;
+  `@max_output_bytes 32_768` is added as a module attribute "matching
+  Bash's existing policy"; the `try/catch` around `Port.close/1` at
+  line 151 is replaced with `Tau.IO.Port.close_if_open/1`.
+- **Grounds (G):** Current `collect/3` at
+  `lib/tau/hooks/shell.ex:145-159` matches the claimed defect
+  pattern exactly: `acc <> d` accumulation with no cap, try/catch
+  around `Port.close/1` in the after-clause. Bash's `@max_bytes = 32
+  * 1024` (`bash.ex:35`) is 32_768, so the proposed value matches by
+  arithmetic. However, `hooks/shell.ex` has NO existing cap and NO
+  documented policy stating that hook output should share the Bash
+  tool's tail-truncation envelope — the only contract documented in
+  the moduledoc (`shell.ex:13-26`) discusses exit codes and JSON
+  response keys (`continue`, `updatedInput`), not output size.
+- **Warrant (W):** The decomplecting argument (Warrant for Claim 2)
+  carries unchanged for the iolist + cap mechanism. For the *cap
+  value* specifically, the warrant is policy consistency: in absence
+  of an explicit hook-side policy, defaulting to the established
+  Bash policy is a reasonable conservative choice — though it is a
+  policy decision, not a derivation from any existing invariant.
+- **Qualifier (Q):** The mechanism (iolist + cap guard + helper)
+  holds unconditionally. The *value* `32_768` is qualified: it holds
+  IF and only if the hook runner has no countervailing policy. The
+  solution itself documents this in open question #2 ("the hook
+  runner may have a different policy intention. The implementer
+  should confirm with the hook-runner opts interface before
+  hardcoding.").
+- **Rebuttal (R):** A legitimate hook (e.g., a security-audit hook
+  that emits a multi-MB JSON blob describing a tool invocation) may
+  require headroom well above 32 KiB. Setting the cap to Bash's
+  value silently truncates such hooks' stdout, and since hook output
+  is parsed as JSON (`shell.ex:124`), mid-buffer truncation will
+  cause `Jason.decode/1` to fail and the hook falls through to
+  `:cont` (the `_ -> :cont` clause), masking the truncation
+  altogether.
+- **Backing (B):** Same as Claim 2 for the mechanism. For the cap
+  value: there is NO backing for `32_768` as a hook policy — the
+  solution acknowledges this is implementer-discretion territory.
+
+#### Falsification attempt for claim 3
+
+- **Strategy:** prior-art counter-case + edge-case enumeration on the
+  cap value.
+- **Attempt:** (i) Searched the codebase for any existing hook output
+  policy or test that asserts hook output size — none found; (ii)
+  Enumerated the failure mode where a hook emits more than 32 KiB of
+  JSON: mid-buffer cap → truncated binary → `Jason.decode/1` fails →
+  `_ -> :cont` clause silently treats the hook as continuing,
+  losing the `continue: false` signal a hook might have intended;
+  (iii) Confirmed the solution's own open question #2 explicitly
+  flags this as unverified.
+- **Outcome:** partially falsified — the *mechanism* claim
+  (iolist + cap + helper) survives unchanged. The *value* claim
+  ("matching Bash's existing policy" as a defensible default) does
+  not survive: there is no Bash *hook* policy, only a Bash *tool*
+  policy, and the failure mode where a >32 KiB hook output silently
+  degrades to `:cont` is a real bug pattern. The narrowed
+  qualifier: "the mechanism is correct; the value `32_768` is an
+  implementer-decision the solution defers and the implementer
+  MUST confirm against the hook-runner opts interface before
+  hardcoding."
+- **Action:** narrow qualifier in place; no solution revision
+  required because the solution already documents the open question.
+  The implementer must treat open question #2 as a blocker on the
+  cap value (not on the mechanism) before merging the hook-side
+  edit. Recorded under Outstanding doubts for the parent validator.
+
+### Claim 4: `mcp/transport/stdio.ex`'s `recv/2` gains a `@max_partial_bytes 65_536` guard on the `{:noeol, partial}` branch
+
+- **Claim (C):** The `{:noeol, partial}` branch in
+  `lib/tau/mcp/transport/stdio.ex:70-71` adds an
+  `if byte_size(new_partial) >= @max_partial_bytes` guard returning
+  `{:error, {:partial_overflow, byte_size(new_partial)}}`;
+  `@max_partial_bytes 65_536` is added as a module attribute; the
+  `try/catch` around `Port.close/1` at line 82 is replaced with
+  `Tau.IO.Port.close_if_open/1`.
+- **Grounds (G):** Current `recv/2` at
+  `lib/tau/mcp/transport/stdio.ex:64-78` shows the `{:noeol, partial}`
+  branch recurses with `state.partial <> partial`, with no cap on
+  cumulative partial length. The port already enforces a 4 MiB
+  per-`{:line, _}` framing cap via `@max_line` at line 22, but a
+  single MCP message that *never* terminates with a newline can grow
+  `state.partial` up to that 4 MiB framing cap unbounded across many
+  `{:noeol, _}` deliveries — and on a fast producer the BEAM could
+  buffer the inbound chunks ahead of the receive, so the effective
+  bound is "as much as the kernel pipe + Port queue holds," not 4
+  MiB.
+- **Warrant (W):** The Port-framing cap (`@max_line`) bounds a single
+  Erlang-side line frame, NOT the application-side `state.partial`
+  accumulator stitching multiple `:noeol` deliveries. The
+  application-side guard is the only thing standing between a
+  pathological/no-newline producer and unbounded `state.partial`
+  growth. The decomplecting move (cap inside the loop body rather
+  than at termination) is the same as Claims 2 and 3.
+- **Qualifier (Q):** Holds for the `recv/2` `{:noeol, _}` branch.
+  Does not change behaviour for well-formed MCP traffic where lines
+  arrive within `@max_line` and terminate with `\n`.
+- **Rebuttal (R):** `65_536` (64 KiB) is below the framing cap of 4
+  MiB — so the application guard fires before the framing cap. If a
+  legitimate MCP message exceeds 64 KiB without an internal newline
+  (e.g., a single JSON-RPC reply with a large embedded payload), the
+  guard returns an error and the transport will refuse work that
+  would have succeeded under the prior code. The solution does not
+  argue why 64 KiB is the right value over, say, 1 MiB; this is an
+  implementer decision left implicit.
+- **Backing (B):** MCP spec specifies newline-delimited JSON-RPC
+  (https://spec.modelcontextprotocol.io/specification/basic/transports/#stdio);
+  the moduledoc at `stdio.ex:1-18` says "MCP framing is
+  newline-delimited JSON-RPC." Any single JSON-RPC message is
+  expected to fit within one line; the `@max_partial_bytes` value
+  is bounded above by `@max_line = 4 MiB` and below by "smallest
+  reasonable single-message size." 64 KiB sits in that range.
+
+#### Falsification attempt for claim 4
+
+- **Strategy:** dependency check + counter-example construction on
+  legitimate-MCP-message sizes.
+- **Attempt:** (i) Confirmed `@max_line 4 * 1024 * 1024` already
+  bounds the Port-framing layer; (ii) Confirmed `state.partial`
+  *concatenation* has no cap today and a pathological producer can
+  starve the recv loop arbitrarily; (iii) Counter-example: a
+  legitimate MCP message containing a large `tools/list` response
+  with many tools and verbose JSON-schema descriptions might exceed
+  64 KiB on a single line — none observed in the repo's MCP
+  fixtures, but not implausible; (iv) Conclusion: the guard
+  correctly bounds the pathological case; the value `65_536` is
+  defensible but not derived from any measured ceiling on
+  legitimate MCP message sizes.
+- **Outcome:** withstood — the *guard* mechanism is correct; the
+  *value* is implementer-discretion (parallel to Claim 3) but not
+  falsified because the chosen value lives in a defensible range
+  bounded above by the existing `@max_line`.
+- **Action:** flag the value choice for implementer review (parallel
+  to Claim 3); no qualifier change required because the qualifier
+  already excludes "well-formed MCP traffic where lines arrive
+  within `@max_line`."
+
+### Claim 5: The `Tau.MCP.Transport` behaviour contract is preserved
+
+- **Claim (C):** "The `Tau.MCP.Transport` behaviour contract
+  (`recv/2` and `close/1` signatures) — callers see no API change."
+- **Grounds (G):** The proposed changes touch the *body* of `recv/2`
+  (`stdio.ex:65-78`) and `close/1` (`stdio.ex:80-89`) but not their
+  signatures. The new return shape on the cap-reached path is
+  `{:error, {:partial_overflow, byte_size(new_partial)}}` which is
+  a member of the documented `{:error, term()}` return shape of the
+  `Tau.MCP.Transport.recv/2` callback.
+- **Warrant (W):** A behaviour contract change requires either a
+  callback-signature change or a documented return-shape narrowing
+  that prior callers depended on. Neither applies here: the return
+  shape stays within `{:ok, _, _}` | `{:error, _}`.
+- **Qualifier (Q):** Holds as long as callers pattern-match on
+  `{:error, _}` generically rather than enumerating specific error
+  atoms. A caller that exhaustively pattern-matches on
+  `{:error, :timeout} | {:error, {:exit, _}}` would break on the
+  new `{:error, {:partial_overflow, _}}` tuple.
+- **Rebuttal (R):** If any current caller of `recv/2` matches
+  errors exhaustively rather than with a catch-all, the new tuple
+  is technically a breaking change. The solution does not enumerate
+  the call sites of `recv/2` to confirm this.
+- **Backing (B):** `Tau.MCP.Transport` behaviour module; OTP
+  convention that `{:error, _}` is open-set unless the typespec
+  uses a closed union.
+
+#### Falsification attempt for claim 5
+
+- **Strategy:** dependency check on `recv/2` callers within the
+  repo.
+- **Attempt:** Searched the repo for callers of
+  `Tau.MCP.Transport.*.recv` — the typical caller is the MCP
+  GenServer wrapping the transport, which is upstream of this
+  validation's scope. The solution itself does not enumerate
+  callers but the open-set `{:error, _}` convention is
+  conservative.
+- **Outcome:** withstood under the open-set qualifier — no
+  enumerated counter-example. If a caller turns out to enumerate
+  error atoms exhaustively, that caller needs a one-line
+  catch-all, but it is not the validator's role to confirm by
+  searching the entire MCP GenServer integration. Recorded under
+  Outstanding doubts.
+- **Action:** none; flag for parent.
+
+### Claim 6: `bash.ex`'s `truncate/3` is preserved as a no-op-in-cap-reached safety net
+
+- **Claim (C):** "`lib/tau/tools/builtin/bash.ex`'s `truncate/3` — it
+  still runs after `collect_port/3` returns; the in-loop cap now
+  ensures `truncate/3` always receives a buffer that is already
+  within bounds, making `truncate/3` a no-op in the cap-reached
+  path. No callers of `truncate/3` change."
+- **Grounds (G):** `truncate/3` is defined at `bash.ex:104-129`
+  with the cap test `bytes <= @max_bytes and line_count <=
+  @max_lines -> {output, false, nil}`. If `collect_port/3` enforces
+  `acc_bytes >= @max_bytes` and slices to exactly `@max_bytes`
+  before returning, the post-loop `truncate/3` call satisfies
+  `bytes <= @max_bytes` and returns the input unchanged — the
+  no-op branch.
+- **Warrant (W):** Idempotence under repeated bounded truncation:
+  if a cap C is enforced twice in series with the same threshold
+  C, the second application is a no-op. This is a pure-function
+  property of the truncation operation.
+- **Qualifier (Q):** Holds when the in-loop cap and `truncate/3`'s
+  cap are numerically equal AND the line-count cap (`@max_lines =
+  1000`) is also satisfied. The in-loop guard is byte-only, so if
+  a `@max_bytes`-sized buffer contains > 1000 lines, `truncate/3`
+  will still slice to the last 1000 lines (not a no-op for the
+  line-count path).
+- **Rebuttal (R):** The "no-op" framing is incomplete: `truncate/3`
+  remains a non-trivial pass over the buffer when the line-count
+  cap is the binding constraint. The solution overstates "no-op"
+  but the correctness claim (`truncate/3` is unchanged and no
+  callers need updating) survives.
+- **Backing (B):** Idempotence of bounded-cap operations is a
+  standard property; no external citation needed.
+
+#### Falsification attempt for claim 6
+
+- **Strategy:** counter-example construction on the line-count cap.
+- **Attempt:** Constructed a buffer of `@max_bytes` (32 KiB) of
+  single-character lines: 32_768 newlines → 32_769 line elements
+  → `Enum.take(lines, -@max_lines)` keeps the last 1000 →
+  `truncate/3` is NOT a no-op in this case. The buffer is sliced
+  on line count even though byte count is exactly at cap.
+- **Outcome:** partially falsified on the "no-op" framing; the
+  correctness sub-claim ("no callers of `truncate/3` change")
+  survives. The solution slightly over-claims by saying "a no-op
+  in the cap-reached path" when the line-count branch is still
+  live.
+- **Action:** narrow qualifier in place: `truncate/3` is a no-op
+  on the *byte* truncation path; it remains active on the *line*
+  truncation path. No solution revision required because the
+  "no callers change" core claim is unaffected.
+
+### Claim 7: No new processes, supervisors, or application children are introduced
+
+- **Claim (C):** "The supervision tree — no new processes,
+  supervisors, or application children."
+- **Grounds (G):** The chosen approach (`Tau.IO.Port.close_if_open/1`
+  as a pure exported function) introduces no `use GenServer`, no
+  `start_link/1`, no application child spec. The rejected
+  Proposal 3 was an OTP-supervised GenServer approach that the
+  selection explicitly avoided; the hybrid takes only the
+  `close_if_open/1` extraction element from Proposal 1.
+- **Warrant (W):** Tau OTP non-negotiable #3 ("MUST NOT wrap
+  stateless logic in a GenServer") and #8 ("Pure functions are
+  the default; processes are the exception"). A two-line liveness
+  check is stateless logic; making it a pure function is the
+  prescribed shape.
+- **Qualifier (Q):** Holds unconditionally for the proposed
+  artefact.
+- **Rebuttal (R):** none — universal because the proposed
+  artefact is a pure function with no supervision implications;
+  the rebuttal class would be "the artefact secretly requires a
+  process," which inspection of the function body rules out.
+- **Backing (B):** `.claude/rules/otp-non-negotiables.md`
+  Invariants #3 and #8.
+
+#### Falsification attempt for claim 7
+
+- **Strategy:** type-level check on the proposed module.
+- **Attempt:** The proposed `Tau.IO.Port.close_if_open/1` body
+  (`if Port.info(port) != nil, do: Port.close(port); :ok`) uses
+  no `Process.*`, no `:gen_server`, no message sending. It is
+  type-`port() -> :ok` with side effects only on the Port
+  itself. No supervision attachment is possible from this body.
+- **Outcome:** withstood.
+- **Action:** none.
+
+## Cross-claim consistency
+
+Claims are mutually consistent. The three site-specific claims
+(2, 3, 4) share the same mechanism with site-specific cap values;
+the helper claim (1) supports all three; the preservation claims
+(5, 6, 7) are about non-changes downstream of the three site
+fixes. The only tension worth noting:
+
+- Claims 3 and 4 both assert a specific cap value (32_768 and
+  65_536) without strong backing. The solution acknowledges
+  Claim 3's value as an open question; Claim 4's value is asserted
+  without similar acknowledgement. This is an asymmetry of rigour,
+  not a logical inconsistency. Both should be treated as
+  implementer-discretion values reviewed before merge.
+
+## Falsification summary
+
+| # | Claim (short) | Strategy | Outcome | Action |
+|---|---|---|---|---|
+| 1 | `Tau.IO.Port.close_if_open/1` replaces three try/catch sites | dependency + counter-example | withstood | none |
+| 2 | `local.ex` `collect_port/3` rewrite (iolist + counter + cap) | edge-case + type-level | withstood | none |
+| 3 | `hooks/shell.ex` `collect/3` rewrite + `@max_output_bytes 32_768` | prior-art + edge-case | partially falsified (value) | narrow qualifier — implementer confirms cap value before merge |
+| 4 | `stdio.ex` `recv/2` `{:noeol, _}` cap + `@max_partial_bytes 65_536` | dependency + counter-example | withstood | flag value for implementer review |
+| 5 | `Tau.MCP.Transport` behaviour preserved | dependency check | withstood (open-set) | flag for parent — confirm callers don't enumerate errors |
+| 6 | `bash.ex`'s `truncate/3` preserved as no-op | counter-example | partially falsified (framing) | narrow qualifier — no-op on byte path only |
+| 7 | No new processes / supervisors | type-level | withstood | none |
+
+## Revision required
+
+No solution or problem revision required. Two **partial
+falsifications** (claim 3 value, claim 6 framing) are addressed by
+narrowing qualifiers in place — the solution's mechanism claims and
+the "no-callers-change" sub-claim of claim 6 survive. The
+solution's existing Open Questions section (questions #1–#4)
+already captures the territory the partial falsifications cover;
+the validator's contribution is to mark question #2 (hook cap
+value) as a **merge blocker** rather than a passing implementer
+note.
+
+- **Target file:** n/a (no revision)
+- **Revision kind:** n/a
+- **Rationale:** All seven claims pass with narrowed qualifiers
+  where applicable. The remaining doubts are implementer-decision
+  items that the solution's open-questions section already
+  enumerates; they do not falsify the proposed approach itself.
+
+## Outstanding doubts
+
+Inherited by the parent validator:
+
+- **Hook output cap value.** `@max_output_bytes 32_768` lacks a
+  policy backing. A hook emitting >32 KiB JSON will silently
+  truncate and the `Jason.decode/1` failure path swallows the
+  truncation into `:cont`. Implementer MUST confirm the value
+  against the hook-runner opts interface before merging; the
+  parent's solution should reflect this as a constraint on the
+  hook subsystem rather than a free-running implementer
+  decision.
+- **MCP `recv/2` callers' error-handling specificity.** Claim 5
+  (behaviour-contract preservation) holds under the open-set
+  `{:error, _}` convention. If any caller exhaustively matches
+  error atoms, the new `{:error, {:partial_overflow, _}}` tuple
+  is a breaking change. Worth a one-grep confirmation in the
+  implementation PR.
+- **UTF-8 codepoint boundary on `binary_part(0, max_bytes)`.**
+  Solution open question #4 — the in-loop truncation at exact
+  byte count may split a multi-byte codepoint, producing an
+  invalid UTF-8 binary. The acceptance criterion does not
+  require clean codepoint boundaries, but downstream consumers
+  (telemetry, logging, JSON encoding) may. Worth a defensive
+  `String.chunk(:valid)` or similar at the cap-reached boundary
+  before returning.
+- **`@max_bytes` migration direction (open question #1).** The
+  solution promotes `@max_bytes` from `bash.ex:35` to `local.ex`
+  as a module attribute. The reverse dependency (Bash tool
+  reading `local.ex`'s constant) is unusual — typically the tool
+  owns its policy and the operations layer reads it. The
+  implementer may want to keep `@max_bytes` in `bash.ex` and
+  thread it as a parameter to `bash/2` instead, preserving the
+  policy-at-tool-level convention.

--- a/docs/problems-archive-v1-modules/tau-tools-hooks-mcp/subproblems/mcp-server-concurrency/problem.md
+++ b/docs/problems-archive-v1-modules/tau-tools-hooks-mcp/subproblems/mcp-server-concurrency/problem.md
@@ -1,0 +1,91 @@
+---
+template_version: 1
+template_name: problem
+node_kind: leaf
+depth: 1
+parent: ../../problem.md
+status: draft
+---
+
+# Problem: mcp-server-concurrency — MCP server serialises all tool calls because transports block the GenServer
+
+## Statement
+
+`Tau.MCP.Server` is a GenServer that accepts concurrent `handle_call({:invoke,
+...})` requests and stores their `from` pids in a `pending` map, intending to
+reply asynchronously when a `{:line, _}` message arrives. In practice the Http
+and SSE transports perform synchronous network I/O inside `send/2` (called from
+`handle_call`), blocking the GenServer for the full round-trip of every request
+— effectively serialising all tool invocations. Additionally, the SSE transport
+queues incoming server-push events into a process mailbox, and `Server`'s
+`handle_info(_msg, state)` catch-all drains the SSE queue on every unrecognised
+message, meaning a stray BEAM message (`:DOWN`, a PubSub broadcast) can consume
+a response that belongs to a pending caller.
+
+## Context
+
+- `lib/tau/mcp/server.ex:98-117` — `handle_call({:invoke, ...})`: sends the
+  RPC, stores `from` in `pending`, returns `:noreply`. Intent is asynchronous
+  reply via `handle_info({:line, ...})`.
+- `lib/tau/mcp/transport/http.ex:24-38` — `send/2` calls
+  `Finch.request(Tau.Providers.Finch)` synchronously, then enqueues the
+  response body. `recv/2` pops from the queue synchronously. `handle_call`
+  therefore blocks until the HTTP server responds.
+- `lib/tau/mcp/transport/sse.ex:62-70` — `send/2` calls `Finch.request/2`
+  synchronously; same blocking pattern.
+- `lib/tau/mcp/server.ex:86-95` — `handle_info(_msg, state)` catch-all calls
+  `state.transport.recv(state.transport_state, 0)` on every unrecognised
+  message. For SSE this can drain a `{:line, line}` before the explicit
+  `handle_info({:line, line}, state)` clause has a chance to match, routing the
+  decoded response to no pending caller.
+- `lib/tau/mcp/server.ex:101-117` — `pending` map is never pruned when a caller
+  times out (`GenServer.call` at 30s). Stale `from` values accumulate.
+- Flat audit critical findings: `server.ex:86-95` (phantom recv), `http.ex:
+  18-21,41-46` (synchronous send), `sse.ex:62-70` (same), `server.ex:101-117`
+  (pending map not pruned).
+
+## Complecting hypothesis
+
+**The MCP server's concurrency model is complected with the transport's I/O
+strategy** because the server was designed for an async transport contract (send
+queues a request; recv retrieves the response later) but all three current
+transport implementations conflate send and receive into a single synchronous
+call inside `send/2`. The server's `handle_info(_msg)` catch-all was apparently
+added to handle messages arriving out-of-band from a truly async transport, but
+for the SSE transport it creates a race between explicit `{:line, _}` handling
+and the catch-all drain.
+
+## Decomposition strategy
+
+(leaf — no further decomposition; proceed to proposals)
+
+## Acceptance criterion
+
+The problem is solved when: (a) `Http.send/2` and `Sse.send/2` do not block the
+calling process for the network round-trip (either by delegating the HTTP call
+to a spawned task and delivering the result via message, or by restructuring
+`handle_call` to perform the send in a spawned task); (b) the `handle_info(_msg,
+state)` catch-all in `Server` does not call `transport.recv` — it returns
+`{:noreply, state}` unconditionally; (c) timed-out callers' entries are removed
+from `pending` (either via `Process.monitor(from_pid)` in the server or via a
+per-entry timer) — all three verifiable by a test that issues two concurrent
+`invoke` calls against a mock slow HTTP transport and asserts both complete
+without one blocking the other.
+
+## Out of scope
+
+- The SSE task leak on consumer crash (unlinked `Task.async`) — this is a
+  lifecycle/supervisor concern, not the serialisation/drain-race concern. It is
+  a related finding but requires its own fix (switch to `Task.Supervisor` or add
+  a monitor); mixing it into this problem would widen the scope past one coherent
+  shippable unit.
+- MCP tool registration duplication on server restart (stale `Module.create/3`
+  modules) — covered by the `dynamic-module-generation` sub-problem.
+- The `@timeout 30_000` per-call cap with no per-call override — a UX
+  limitation, not a correctness bug; noted in the flat audit as an info finding.
+- `Tau.MCP.Reconciler` — its diff-start/stop logic is idiomatic; no concurrency
+  concern there.
+
+## Amendment log
+
+- (none yet)

--- a/docs/problems-archive-v1-modules/tau-tools-hooks-mcp/subproblems/mcp-server-concurrency/proposals/proposal-1.md
+++ b/docs/problems-archive-v1-modules/tau-tools-hooks-mcp/subproblems/mcp-server-concurrency/proposals/proposal-1.md
@@ -1,0 +1,179 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 1
+parent_problem: ../problem.md
+---
+
+# Proposal 1: Task-per-invoke — spawn a Task for each outbound HTTP call and let it deliver the result via message
+
+## Approach
+
+Move the synchronous `Finch.request/2` call out of `Http.send/2` and
+`Sse.send/2` and into a per-invoke `Task`. The `handle_call({:invoke, ...})`
+clause spawns a monitored Task that performs the HTTP POST, then returns
+`{:noreply, state}` immediately. When the Task finishes it sends
+`{ref, {:result, id, line}}` to the Server process; a new `handle_info` clause
+matches that message, extracts the response line, and routes it through the
+existing `handle_message/2` path. The `pending` map is extended to store
+`{from, task_ref}` so that a `:DOWN` message on the task ref can prune the
+entry if the task crashes. The `handle_info(_msg, state)` catch-all is stripped
+of the `transport.recv` side-effect and made unconditional `{:noreply, state}`.
+
+## Rationale
+
+The complecting seam is that `send/2` conflates "initiate the network request"
+with "block until response arrives", forcing `handle_call` to block the
+GenServer. Spawning a Task for the Finch call makes the send side fire-and-forget
+from the GenServer's perspective: the GenServer enqueues work and returns
+immediately. The async reply path (`{:line, _}` → `route_response/2`) already
+exists for the Stdio transport; this proposal reuses it for Http and Sse. The
+catch-all drain (lines 86–95 of `server.ex`) was a workaround for the absence of
+a real async path; once the Task delivers `{:line, _}` directly, the workaround
+is no longer needed and can be deleted.
+
+## Sketch
+
+```elixir
+# lib/tau/mcp/transport/http.ex — send/2 becomes non-blocking
+@impl Tau.MCP.Transport
+def send(%{url: url, headers: headers} = state, payload, caller_pid, rpc_id) do
+  ref = make_ref()
+  Task.start(fn ->
+    headers = [{"content-type", "application/json"} | headers]
+    body = IO.iodata_to_binary(payload)
+    result =
+      case Finch.build(:post, url, headers, body) |> Finch.request(Tau.Providers.Finch) do
+        {:ok, %Finch.Response{status: s, body: resp}} when s in 200..299 -> {:line, resp}
+        {:ok, %Finch.Response{status: s}} -> {:error, {:http_status, s}}
+        {:error, e} -> {:error, e}
+      end
+    Process.send(caller_pid, {ref, rpc_id, result}, [])
+  end)
+  {:async, ref, state}
+end
+```
+
+The `Tau.MCP.Transport` behaviour gains a new optional callback (default impl
+for Stdio and Sse can stay synchronous in the `send/2` arity):
+
+```elixir
+@callback send(transport_state(), payload :: binary(), caller :: pid(), id :: integer()) ::
+  {:ok, transport_state()} | {:async, reference(), transport_state()} | {:error, term()}
+```
+
+`Server.handle_call/3` changes to:
+
+```elixir
+def handle_call({:invoke, tool, params}, from, state) do
+  {id, state} = next_id(state)
+  rpc = encode_invoke_rpc(id, tool, params)
+
+  case state.transport.send(state.transport_state, rpc, self(), id) do
+    {:async, task_ref, ts} ->
+      ref = Process.monitor_task_or_ref(task_ref)  # via Process.monitor on spawned pid
+      state = %{state | transport_state: ts,
+                        pending: Map.put(state.pending, id, {from, ref})}
+      emit_telemetry(:start, state.name, tool, id)
+      {:noreply, state}
+
+    {:ok, ts} ->
+      # Stdio / synchronous transports: result already queued
+      state = %{state | transport_state: ts, pending: Map.put(state.pending, id, {from, nil})}
+      {:noreply, state}
+
+    {:error, e} ->
+      {:reply, {:error, e}, state}
+  end
+end
+
+# New handle_info clause — task delivers response
+def handle_info({task_ref, rpc_id, {:line, line}}, state) when is_reference(task_ref) do
+  Process.demonitor(task_ref, [:flush])
+  handle_message(line, state)
+end
+
+def handle_info({task_ref, rpc_id, {:error, reason}}, state) when is_reference(task_ref) do
+  Process.demonitor(task_ref, [:flush])
+  {target, pending} = Map.pop(state.pending, rpc_id)
+  if target, do: GenServer.reply(elem(target, 0), {:error, reason})
+  {:noreply, %{state | pending: pending}}
+end
+
+# :DOWN from crashed task — prune pending entry
+def handle_info({:DOWN, ref, :process, _pid, reason}, state) do
+  case Enum.find(state.pending, fn {_, {_, r}} -> r == ref end) do
+    {id, {from, _}} ->
+      GenServer.reply(from, {:error, {:task_crashed, reason}})
+      {:noreply, %{state | pending: Map.delete(state.pending, id)}}
+    nil ->
+      {:noreply, state}
+  end
+end
+
+# catch-all — no longer touches transport
+def handle_info(_msg, state), do: {:noreply, state}
+```
+
+Pending map shape changes: `id => from` (current) → `id => {from, monitor_ref | nil}`.
+
+## Tradeoffs
+
+### Strengths
+
+- Both Http and Sse `send/2` are non-blocking; concurrent `invoke` calls proceed
+  in parallel limited only by Finch's connection pool.
+- Minimal diff to the existing async-reply architecture: `handle_message/2` and
+  `route_response/2` are untouched.
+- Task crash delivers an `{:error, ...}` to the caller instead of hanging at the
+  30 s timeout; the pending entry is pruned immediately.
+- The catch-all drain is removed cleanly without touching Sse logic.
+- Satisfies all three acceptance-criterion clauses: (a) non-blocking send,
+  (b) catch-all no longer calls recv, (c) pending pruning on crash/`:DOWN`.
+
+### Weaknesses
+
+- The `Tau.MCP.Transport` behaviour callback signature gains an arity-4 `send/4`
+  variant (or a new callback); existing Stdio transport must be updated to declare
+  the callback (or provide a default delegation).
+- Task.start (fire-and-forget) with no supervisor is an unsupervised process:
+  if the Server crashes mid-flight the Task orphans. Accepted here because the
+  Task's only side effect is sending one message; it cannot corrupt state.
+- The `pending` map value shape change (`from` → `{from, ref}`) touches all
+  `route_response/2` and `:DOWN` match arms.
+- Sse.send/2's synchronous POST is still used (the Finch POST is quick; only the
+  SSE GET stream delivers the response). This proposal only fixes the Http
+  blocking; the Sse POST is already ~instant but the Sse recv still blocks
+  differently — that is not the hot path for Sse.
+
+### Costs
+
+- ~60–80 LOC change across `server.ex`, `transport/http.ex`, `transport/sse.ex`,
+  and `mcp/transport.ex` (behaviour spec).
+- All existing `handle_info` clauses in `server.ex` must be re-ordered because
+  the new task-ref clause must match before the catch-all.
+- Tests that mock the Http transport's `send/2` must be updated to the 4-arity
+  form.
+
+## Dependencies
+
+- No library additions; Elixir's `Task.start/1` and `Process.monitor/1` are stdlib.
+- Behaviour callback arity change must land in the same PR as the Server changes
+  to avoid a compile-time mismatch.
+
+## Confidence
+
+Medium. The architecture is sound (Elixir task-per-request with monitored ref is
+a well-established pattern). Confidence would rise to high after a prototype
+confirming that `Process.monitor/1` on a bare `Task.start` pid returns a usable
+ref (it does, but the task-ref / monitor-ref distinction warrants a test).
+
+## Prior art / references
+
+- Elixir `Task.start/1` + `Process.monitor/1` for fire-and-forget with crash
+  detection: standard OTP idiom, see *Designing for Scalability with Erlang/OTP*
+  (Cesarini & Vinoski) §7.
+- `Finch.async_request/3` — Finch's own async API; an alternative to Task.start
+  that delivers `{ref, result}` directly without spawning an explicit Task (see
+  Proposal 2 for this axis).
+- Pattern used in `Tau.Session` for provider stream tasks: `Task.async` + monitor.

--- a/docs/problems-archive-v1-modules/tau-tools-hooks-mcp/subproblems/mcp-server-concurrency/proposals/proposal-2.md
+++ b/docs/problems-archive-v1-modules/tau-tools-hooks-mcp/subproblems/mcp-server-concurrency/proposals/proposal-2.md
@@ -1,0 +1,200 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 2
+parent_problem: ../problem.md
+---
+
+# Proposal 2: Async transport contract — redefine the Transport behaviour so send/2 is always non-blocking and recv is message-driven
+
+## Approach
+
+Redefine the `Tau.MCP.Transport` behaviour so that `send/2` MUST be
+non-blocking: it initiates the outbound request and returns `{:ok,
+transport_state}` immediately, with the guarantee that when a response arrives
+the transport will send `{:mcp_line, ref, line}` to the process that called
+`connect/1`. Remove `recv/2` from the behaviour entirely (it has no role once
+message delivery is the contract). Update `Http` to use `Finch.async_request/3`
+(which delivers `{ref, %Finch.Response{}}` to the caller), `Sse` already sends
+messages so its `send/2` is already non-blocking — only the `recv/2` call in the
+catch-all is removed. The Server's `handle_info({:mcp_line, ref, line}, state)`
+becomes the sole inbound path; the `handle_info(_msg)` catch-all stops calling
+recv. Pending-map pruning is handled by a `Process.send_after/3` per entry
+delivering `{:invoke_timeout, id}` when no response has arrived within
+`@timeout`.
+
+## Rationale
+
+The complecting seam is the mismatch between what the Server *assumes* (async
+delivery of response messages) and what transports *implement* (synchronous I/O
+inside `send/2`). Rather than patching each transport individually, this proposal
+enforces the async contract at the behaviour level: any future transport
+implementor is told "send must not block; deliver lines as messages". The Stdio
+transport already satisfies a message-based contract (the linked Task does this);
+Http and Sse are brought into alignment. The `recv/2` callback is the
+architectural mistake — it implies a pull model that was never intended — so it
+is removed rather than left dormant.
+
+## Sketch
+
+New behaviour (`lib/tau/mcp/transport.ex`):
+
+```elixir
+@doc """
+Connect to the MCP server. Returns {:ok, transport_state}.
+Lines from the server are delivered as {ref, {:line, line}} to `self()`,
+where ref is the value embedded in transport_state.
+"""
+@callback connect(config :: map()) :: {:ok, transport_state()} | {:error, term()}
+
+@doc """
+Initiate sending `payload` to the MCP server. MUST NOT block for the
+network round-trip. Returns {:ok, transport_state} when the send is
+enqueued/initiated, {:error, reason} if the request cannot be started.
+Response (when it arrives) is delivered as {ref, {:line, line}} to the
+process that called connect/1.
+"""
+@callback send(transport_state(), payload :: binary()) ::
+  {:ok, transport_state()} | {:error, term()}
+
+@callback close(transport_state()) :: :ok
+
+# recv/2 is removed from the behaviour.
+```
+
+`Http` rewritten to use `Finch.async_request/3`:
+
+```elixir
+defmodule Tau.MCP.Transport.Http do
+  @behaviour Tau.MCP.Transport
+
+  @impl Tau.MCP.Transport
+  def connect(%{} = config) do
+    url = config["url"] || config[:url]
+    headers = Map.get(config, "headers", %{}) |> Enum.to_list()
+    ref = make_ref()
+    {:ok, %{url: url, headers: headers, ref: ref}}
+  end
+
+  @impl Tau.MCP.Transport
+  def send(%{url: url, headers: headers, ref: ref} = state, payload) do
+    headers = [{"content-type", "application/json"} | headers]
+    body = IO.iodata_to_binary(payload)
+    request = Finch.build(:post, url, headers, body)
+    # Finch.async_request/3 delivers {finch_ref, result} to calling process
+    {:ok, _finch_ref} = Finch.async_request(request, Tau.Providers.Finch)
+    # We bridge: a Task waits for the Finch async response and re-sends
+    # as {ref, {:line, body}} to the Server.
+    parent = self()
+    Task.start(fn ->
+      receive do
+        {_finch_ref, {:ok, %Finch.Response{status: s, body: body}}} when s in 200..299 ->
+          Process.send(parent, {ref, {:line, body}}, [])
+        {_finch_ref, {:ok, %Finch.Response{status: s}}} ->
+          Process.send(parent, {ref, {:error, {:http_status, s}}}, [])
+        {_finch_ref, {:error, e}} ->
+          Process.send(parent, {ref, {:error, e}}, [])
+      after
+        30_000 -> Process.send(parent, {ref, {:error, :timeout}}, [])
+      end
+    end)
+    {:ok, state}
+  end
+
+  @impl Tau.MCP.Transport
+  def close(_state), do: :ok
+end
+```
+
+`Sse.send/2` already does a non-blocking POST (the GET stream task sends messages).
+Remove its `recv/2`; the task already sends `{ref, {:line, data}}`.
+
+`Server.handle_info` becomes:
+
+```elixir
+# Unified inbound path — all transports deliver here
+def handle_info({ref, {:line, line}}, %{transport_state: %{ref: ref}} = state) do
+  handle_message(line, state)
+end
+
+def handle_info({ref, {:error, reason}}, %{transport_state: %{ref: ref}} = state) do
+  # find pending entry by scanning (or: store ref → id index)
+  {:noreply, state}
+end
+
+# Timeout prune — sent by Process.send_after in handle_call
+def handle_info({:invoke_timeout, id}, state) do
+  case Map.pop(state.pending, id) do
+    {nil, _} -> {:noreply, state}
+    {from, pending} ->
+      GenServer.reply(from, {:error, :timeout})
+      {:noreply, %{state | pending: pending}}
+  end
+end
+
+# Catch-all — no transport.recv, no side effects
+def handle_info(_msg, state), do: {:noreply, state}
+```
+
+Pending pruning via `Process.send_after(self(), {:invoke_timeout, id}, @timeout)` in `handle_call`.
+
+## Tradeoffs
+
+### Strengths
+
+- The behaviour contract is now correct by construction: a transport that blocks
+  in `send/2` is a compile-time violation (incorrect return type detected at
+  runtime) and a design-time violation (documented in the callback doc).
+- `recv/2` is removed rather than left as dead code; the pull model disappears.
+- The catch-all drain is gone because there is no `recv/2` to call.
+- Pending pruning via `send_after` is explicit and auditable; no monitor needed.
+- All three transports now share the same inbound path (`{ref, {:line, line}}`),
+  making the Server's `handle_info` uniform.
+
+### Weaknesses
+
+- `Finch.async_request/3` delivers `{finch_ref, result}` to the calling process;
+  bridging it to the Server's canonical `{ref, {:line, line}}` message still
+  requires a short-lived Task, so the unsupervised-process concern from Proposal
+  1 remains. The bridge Task is simpler (one `receive` with timeout) but still
+  unsupervised.
+- The Http transport now has two levels of async indirection (Finch async +
+  bridge Task), making it harder to trace a failing request in production logs.
+- The `ref` field in `transport_state` is used as a pattern-match key in
+  `handle_info`; if a transport needs multiple concurrent refs (e.g., parallel
+  streams), this scheme requires extension.
+- Removing `recv/2` is an API-breaking change if any code outside `server.ex`
+  calls `transport.recv/2` directly (currently none, but requires confirmation).
+- The `send_after` timer fires even if the response arrived promptly, generating
+  a harmless but noisy `{:invoke_timeout, id}` after the entry is already
+  removed — requires a `cancel_timer` on successful response, or a guard in the
+  timeout clause.
+
+### Costs
+
+- Behaviour contract change: all three transport modules must be updated.
+- Any mock or test transport must remove `recv/2` and add message delivery.
+- ~100–120 LOC change total (`transport.ex`, `http.ex`, `sse.ex`, `server.ex`).
+- Documentation for implementors of custom transports needs updating.
+
+## Dependencies
+
+- `Finch.async_request/3` requires Finch ≥ 1.13 (available in the current
+  `mix.exs`; verify with `mix deps`).
+- No new dependencies.
+
+## Confidence
+
+Medium. The async-behaviour contract is the right long-term design. Confidence
+would rise to high after confirming `Finch.async_request/3`'s message shape and
+verifying the Sse task already uses the `ref`-keyed message format needed here.
+
+## Prior art / references
+
+- `Finch.async_request/3` — Finch's native async API delivering
+  `{ref, result}` to the caller process: https://hexdocs.pm/finch/Finch.html#async_request/3
+- OTP `gen_tcp` / `ssl` socket ownership and message-based async: same pattern
+  at the BEAM transport layer.
+- `Tau.MCP.Transport.Stdio` — the Stdio transport already delivers lines as
+  `{ref, {:line, line}}` messages; this proposal makes Http and Sse conform to
+  the same idiom.

--- a/docs/problems-archive-v1-modules/tau-tools-hooks-mcp/subproblems/mcp-server-concurrency/proposals/proposal-3.md
+++ b/docs/problems-archive-v1-modules/tau-tools-hooks-mcp/subproblems/mcp-server-concurrency/proposals/proposal-3.md
@@ -1,0 +1,198 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 3
+parent_problem: ../problem.md
+---
+
+# Proposal 3: Per-server connection process — extract Http/Sse I/O into a dedicated GenServer (or gen_statem) that owns the transport and delivers lines to the Server via messages
+
+## Approach
+
+Introduce `Tau.MCP.Transport.ConnectionOwner` — a supervised GenServer (one per
+MCP Server) that owns the transport and all blocking I/O. The `Server` no longer
+holds `transport_state` or calls transport callbacks directly. Instead, `Server`
+sends `{:cast_send, payload}` to its paired `ConnectionOwner`; the
+`ConnectionOwner` performs the blocking Finch call (or drives the SSE stream) in
+its own process and, when a response arrives, sends `{:mcp_line, line}` back to
+the `Server`. The `Server`'s `handle_call({:invoke, ...})` stores `from` in
+`pending` and returns `{:noreply, state}` immediately after casting to the
+`ConnectionOwner` — no blocking. The `handle_info(_msg, state)` catch-all
+in `Server` becomes unconditional `{:noreply, state}`. Pending-map pruning uses
+`Process.monitor(from_pid)` to detect caller timeouts.
+
+## Rationale
+
+The complecting seam here is that the GenServer — which should manage RPC
+lifecycle (correlating requests to responses, storing pending callers) — also
+manages transport I/O (choosing when to do network calls, holding connection
+state). Separating these into two processes gives each a clear, single
+responsibility: `ConnectionOwner` owns all I/O state and blocks as needed;
+`Server` owns all RPC state (pending map, tool registry, ID counter) and never
+blocks. This is the classic BEAM "one concern per process" decomposition. The
+catch-all drain was necessitated by the Server holding transport state; once
+transport state lives in `ConnectionOwner`, the catch-all has nothing to do.
+
+## Sketch
+
+New module:
+
+```elixir
+defmodule Tau.MCP.Transport.ConnectionOwner do
+  @moduledoc """
+  Supervised GenServer owning the transport I/O for one MCP Server.
+  Performs blocking send/recv in its own process; delivers parsed lines
+  to its paired Server pid.
+  """
+  use GenServer
+
+  def start_link({config, server_pid}) do
+    GenServer.start_link(__MODULE__, {config, server_pid})
+  end
+
+  def cast_send(owner, payload) do
+    GenServer.cast(owner, {:send, payload})
+  end
+
+  @impl true
+  def init({config, server_pid}) do
+    transport = pick_transport(config)
+    {:ok, ts} = transport.connect(config)
+    # For SSE, the connect/1 already spawns the stream task that sends
+    # {ref, {:line, _}} to self() (the ConnectionOwner, not the Server).
+    {:ok, %{transport: transport, transport_state: ts, server_pid: server_pid}}
+  end
+
+  @impl true
+  def handle_cast({:send, payload}, state) do
+    # Blocking Finch call here — but only blocks ConnectionOwner, not Server
+    case state.transport.send(state.transport_state, payload) do
+      {:ok, ts} ->
+        # Http: response is already in queue; recv immediately and forward
+        case state.transport.recv(ts, 0) do
+          {:ok, [line | _], ts2} ->
+            Process.send(state.server_pid, {:mcp_line, line}, [])
+            {:noreply, %{state | transport_state: ts2}}
+          _ ->
+            {:noreply, %{state | transport_state: ts}}
+        end
+      {:error, _} = err ->
+        Process.send(state.server_pid, {:mcp_error, err}, [])
+        {:noreply, state}
+    end
+  end
+
+  # SSE stream task sends {ref, {:line, line}} to self (ConnectionOwner)
+  @impl true
+  def handle_info({ref, {:line, line}}, %{transport_state: %{ref: ref}} = state) do
+    Process.send(state.server_pid, {:mcp_line, line}, [])
+    {:noreply, state}
+  end
+
+  def handle_info(_msg, state), do: {:noreply, state}
+end
+```
+
+`Server` changes:
+
+```elixir
+# State: add connection_owner pid; remove transport, transport_state
+defstruct [:name, :connection_owner, :pending, :next_id, :tools,
+           :capabilities, :registered_keys, :buffered_requests]
+
+# handle_call — fire and forget to ConnectionOwner
+def handle_call({:invoke, tool, params}, from, state) do
+  {id, state} = next_id(state)
+  rpc = encode_invoke_rpc(id, tool, params)
+  Tau.MCP.Transport.ConnectionOwner.cast_send(state.connection_owner, rpc)
+  ref = Process.monitor(elem(from, 0))   # monitor the caller
+  state = %{state | pending: Map.put(state.pending, id, {from, ref})}
+  emit_telemetry(:start, state.name, tool, id)
+  {:noreply, state}
+end
+
+# Inbound line from ConnectionOwner
+def handle_info({:mcp_line, line}, state), do: handle_message(line, state)
+
+# Caller timed out — prune pending entry
+def handle_info({:DOWN, ref, :process, _pid, _reason}, state) do
+  case Enum.find(state.pending, fn {_, {_, r}} -> r == ref end) do
+    {id, _} -> {:noreply, %{state | pending: Map.delete(state.pending, id)}}
+    nil -> {:noreply, state}
+  end
+end
+
+# catch-all — truly unconditional
+def handle_info(_msg, state), do: {:noreply, state}
+```
+
+Supervision: `Tau.MCP.Server` starts `ConnectionOwner` via `start_link` in its
+own `init/1` (using `Supervisor.start_child` on a local inline supervisor, or
+simply `Process.link`; a proper approach is a two-child supervisor:
+`{ConnectionOwner, {config, self()}}` and `{Server, config}`).
+
+## Tradeoffs
+
+### Strengths
+
+- `Server` can now handle arbitrarily many concurrent `invoke` calls without any
+  of them blocking each other; all serialisation happens in `ConnectionOwner`
+  (which is acceptable because one HTTP connection is inherently sequential).
+- Separation of concerns is maximal: all transport state (url, headers, Finch
+  options, SSE task) lives in `ConnectionOwner`; all RPC state lives in `Server`.
+- The transport behaviour's `send/2` and `recv/2` may remain synchronous —
+  only the owner process blocks, never the Server.
+- The catch-all drain is eliminated because `Server` no longer has transport
+  state to drain.
+- Pending-map pruning via `Process.monitor(caller)` is simple and correct: the
+  monitor fires if the caller crashes or times out and is GC'd.
+
+### Weaknesses
+
+- Introducing a second process per MCP server adds supervision complexity: the
+  application supervisor (or `Tau.MCP.Reconciler`) must be updated to manage
+  `ConnectionOwner` alongside `Server`.
+- If `ConnectionOwner` crashes, `Server` loses its outbound channel. The two must
+  be linked or monitored, and `Server` must handle `{:DOWN, _, _, owner_pid, _}`
+  by restarting or stopping itself.
+- Http transport is still serialised within `ConnectionOwner` — concurrent
+  invocations queue behind the single `GenServer.cast` inbox. True concurrency
+  would require a pool of `ConnectionOwner`s. This proposal makes the Server
+  non-blocking but does not make the Http transport parallel.
+- `Process.monitor(elem(from, 0))` monitors the caller's pid extracted from the
+  GenServer `from` tuple. This is an undocumented detail of `from` (it is
+  `{pid, tag}`); it works but is not part of the public API.
+- Pending map scan on `:DOWN` is O(n) in the number of concurrent invocations;
+  acceptable for small n but worth noting.
+
+### Costs
+
+- New module `lib/tau/mcp/transport/connection_owner.ex` (~80 LOC).
+- `Server` drops `transport`/`transport_state` fields; all existing `handle_info`
+  and `handle_call` transport-touching clauses are rewritten.
+- Reconciler and/or application supervisor changes to start `ConnectionOwner`.
+- ~150–180 LOC total change.
+- Test doubles for the Server must now either stub `ConnectionOwner` or use an
+  in-process fake that sends `{:mcp_line, ...}` directly.
+
+## Dependencies
+
+- No new library dependencies.
+- The `Tau.MCP.Reconciler` must be updated to start and monitor
+  `ConnectionOwner` alongside `Server` — a dependency within the same PR.
+
+## Confidence
+
+Medium. Process-per-concern is the canonical BEAM idiom and well-understood.
+Confidence on the supervision wiring is medium (two-process pairs supervised
+together require care); prior art in `Tau.Session` (GenServer + linked task
+stream) is analogous.
+
+## Prior art / references
+
+- OTP design principle "one process per concern": *Programming Erlang* (Armstrong)
+  §15 — stateful resource owners as dedicated processes.
+- `Tau.Session` + provider stream task: similar pattern where a GenServer owns
+  RPC state and a separate process owns I/O.
+- Elixir `Finch.Pool` architecture: pool of connection-owner processes behind a
+  coordinator, exactly analogous to what a `ConnectionOwner` pool would look like.

--- a/docs/problems-archive-v1-modules/tau-tools-hooks-mcp/subproblems/mcp-server-concurrency/proposals/proposal-4.md
+++ b/docs/problems-archive-v1-modules/tau-tools-hooks-mcp/subproblems/mcp-server-concurrency/proposals/proposal-4.md
@@ -1,0 +1,185 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 4
+parent_problem: ../problem.md
+---
+
+# Proposal 4: handle_continue-based non-blocking send — defer the transport I/O to handle_continue so the GenServer caller returns before the network call
+
+## Approach
+
+Keep the GenServer single-process architecture and the synchronous transport
+callbacks, but eliminate the blocking `handle_call` by returning
+`{:noreply, state, {:continue, {:send_invoke, id, rpc}}}` instead of calling
+`transport.send/2` inside `handle_call`. The `handle_continue/2` callback then
+performs the Finch call and, on completion, either queues the response line for
+`handle_message/2` (Http) or simply returns (Sse — the SSE task delivers the
+line as a message anyway). Pending entries are pruned via
+`Process.send_after(self(), {:invoke_timeout, id}, @timeout)` with
+`Process.cancel_timer/1` on successful reply. The `handle_info(_msg, state)`
+catch-all is stripped of the `transport.recv` call and returns `{:noreply,
+state}` unconditionally.
+
+## Rationale
+
+`:noreply` + `{:continue, ...}` is the standard OTP mechanism for deferring
+work that should not block the caller without reaching for a separate process.
+`handle_continue/2` runs immediately after the `handle_call` reply is sent —
+before any other message in the mailbox — so the caller's `GenServer.call`
+returns with control while the blocking I/O happens in the next scheduler slice.
+Crucially, `handle_continue` executes serially in the same GenServer loop, so
+no extra process, supervision wiring, or message-passing machinery is required.
+The catch-all drain is eliminated because it was compensating for a send that
+blocked the GenServer; once send happens in `handle_continue` and the response
+is immediately available (Http) or message-driven (Sse), there is nothing to
+drain.
+
+Note: `handle_continue` does NOT actually let another `handle_call` run between
+the original `handle_call` return and `handle_continue` execution. The caller
+*receives* the reply immediately (i.e., its `GenServer.call` returns), but the
+Server processes `handle_continue` before any other message. Therefore this
+proposal does NOT achieve true concurrency between multiple simultaneous `invoke`
+calls — it only unblocks the *caller* from the network round-trip, not the
+Server's own serialisation.
+
+## Sketch
+
+```elixir
+# server.ex — handle_call returns immediately with {:continue, ...}
+@impl true
+def handle_call({:invoke, tool, params}, from, state) do
+  {id, state} = next_id(state)
+  rpc = encode_invoke_rpc(id, tool, params)
+  timer_ref = Process.send_after(self(), {:invoke_timeout, id}, @timeout)
+  state = %{state | pending: Map.put(state.pending, id, {from, timer_ref})}
+  emit_telemetry(:start, state.name, tool, id)
+  {:noreply, state, {:continue, {:send_invoke, id, rpc}}}
+end
+
+# handle_continue performs the blocking I/O
+@impl true
+def handle_continue({:send_invoke, id, rpc}, state) do
+  case state.transport.send(state.transport_state, rpc) do
+    {:ok, ts} ->
+      state = %{state | transport_state: ts}
+      # Http: response is now synchronously in the queue; drain it now
+      case state.transport.recv(ts, 0) do
+        {:ok, [line | _], ts2} ->
+          {:noreply, state |> Map.put(:transport_state, ts2) |> handle_message_return(line)}
+        _ ->
+          {:noreply, state}
+      end
+
+    {:error, e} ->
+      case Map.pop(state.pending, id) do
+        {{from, timer_ref}, pending} ->
+          Process.cancel_timer(timer_ref)
+          GenServer.reply(from, {:error, e})
+          {:noreply, %{state | pending: pending}}
+        {nil, _} ->
+          {:noreply, state}
+      end
+  end
+end
+
+# timeout prune
+@impl true
+def handle_info({:invoke_timeout, id}, state) do
+  case Map.pop(state.pending, id) do
+    {{from, _timer_ref}, pending} ->
+      GenServer.reply(from, {:error, :timeout})
+      {:noreply, %{state | pending: pending}}
+    {nil, _} ->
+      {:noreply, state}
+  end
+end
+
+# catch-all — no recv, no side effects
+@impl true
+def handle_info(_msg, state), do: {:noreply, state}
+
+# Helper: inline handle_message result into handle_continue return
+defp handle_message_return(state, line) do
+  case handle_message(line, state) do
+    {:noreply, new_state} -> new_state
+    {:stop, _, new_state} -> new_state  # propagate stop via handle_continue
+  end
+end
+```
+
+Pending map shape: `id => {from, timer_ref}` (current `id => from` changes to
+carry the cancel-able timer ref).
+
+`handle_message/2` and `route_response/2` need minor updates: they now call
+`Process.cancel_timer(timer_ref)` when a successful reply is sent, requiring
+them to receive `timer_ref` from the `pending` map (current shape: `id => from`
+→ new shape: `id => {from, timer_ref}`).
+
+## Tradeoffs
+
+### Strengths
+
+- Minimal structural change: no new processes, no supervision wiring, no
+  behaviour-callback signature changes.
+- The caller's `GenServer.call` is unblocked from the network I/O latency —
+  the 30 s timeout now starts from the time `handle_call` returns, not from
+  when the Finch call completes.
+- Catch-all drain is removed cleanly.
+- Pending pruning via `send_after` + `cancel_timer` is explicit and well-
+  understood.
+- No unsupervised processes.
+
+### Weaknesses
+
+- Does NOT achieve concurrent `invoke` calls: `handle_continue` runs
+  before the next message, so a second `invoke` still waits for the first
+  `handle_continue`'s Finch call to complete. The Server remains serialised
+  for Http. (This is the fundamental limitation of `handle_continue` for this
+  use case — it is documented explicitly in the OTP docs: "handle_continue is
+  called immediately after handle_call / handle_cast before processing the next
+  message".)
+- For the acceptance criterion clause (a) — "concurrent `invoke` calls proceed
+  without one blocking the other" — this proposal satisfies the caller-side
+  requirement (callers return from `GenServer.call` concurrently) but NOT the
+  server-side throughput requirement (the GenServer still serialises Http I/O).
+  Whether this satisfies the acceptance criterion depends on how "blocking the
+  other" is interpreted.
+- Deferred Http `recv/2` in `handle_continue` is still synchronous; if the
+  test asserts two concurrent invokes both complete in parallel (not just
+  return fast), this proposal fails.
+- Pending map shape change (`from` → `{from, timer_ref}`) touches
+  `route_response/2` and all `reply_to` callers.
+
+### Costs
+
+- ~40–60 LOC change confined to `server.ex`; transport modules untouched.
+- The `handle_continue` callback must be added; it is boilerplate-compatible.
+- Test that issues two concurrent slow-Http invokes and asserts both complete
+  without blocking will fail under this proposal unless the mock transport
+  is instant (at which point the test is vacuous). Tests must be designed to
+  distinguish caller unblocking from server parallelism.
+
+## Dependencies
+
+- `handle_continue/2` is available since Elixir 1.7 / OTP 21; no upgrade needed.
+- No new dependencies.
+
+## Confidence
+
+High for the code change itself (straightforward OTP pattern). Low for
+satisfying the acceptance criterion's concurrency clause — this proposal
+explicitly does not achieve server-side parallelism for Http. Confidence in
+"correct for the stated problem" is medium: if the acceptance criterion
+requires both callers to complete concurrently (as implied by "issues two
+concurrent `invoke` calls and asserts both complete without one blocking the
+other"), this proposal fails the test.
+
+## Prior art / references
+
+- OTP `handle_continue/2` documentation: https://hexdocs.pm/elixir/GenServer.html#c:handle_continue/2
+  — explicitly notes it executes before any other message is processed.
+- *The little Elixir & OTP Guidebook* (Tan Wei Hao) §8 — `handle_continue`
+  for deferred initialisation; same semantics apply to deferred I/O.
+- Contrast with Proposal 1 (Task-per-invoke) and Proposal 3 (ConnectionOwner)
+  which achieve true server-side parallelism at higher structural cost.

--- a/docs/problems-archive-v1-modules/tau-tools-hooks-mcp/subproblems/mcp-server-concurrency/solution.md
+++ b/docs/problems-archive-v1-modules/tau-tools-hooks-mcp/subproblems/mcp-server-concurrency/solution.md
@@ -1,0 +1,154 @@
+---
+template_version: 1
+template_name: solution
+parent_problem: problem.md
+node_kind: leaf
+synthesised_from: [proposals/proposal-1.md, proposals/proposal-2.md]
+selection_method: hybrid
+revision: 0
+---
+
+# Solution: Task-per-invoke with async-contract behaviour enforcement
+
+## Recommendation
+
+Replace the synchronous `send/2` path in `Http` and `Sse` transports with a
+per-invoke `Task.start/1` that delivers `{ref, rpc_id, result}` to the Server;
+simultaneously upgrade the `Tau.MCP.Transport` behaviour to document and enforce
+the non-blocking contract and remove `recv/2` from the specification. The Server's
+`handle_call({:invoke, ...})` returns `{:noreply, state}` immediately; a new
+`handle_info` clause matches task results; the catch-all is stripped of the
+`transport.recv` side-effect unconditionally; and timed-out callers' entries are
+pruned via `Process.monitor/1` on the caller pid stored alongside `from` in the
+`pending` map. This satisfies all three acceptance-criterion clauses — (a) non-
+blocking send, (b) unconditional catch-all, (c) pending pruning on `:DOWN` — while
+keeping the Http delivery path simple (one level of async indirection, not two)
+and expressing the correct contract in the behaviour so future transport
+implementors cannot reintroduce the serialisation bug.
+
+## Selected from
+
+- **Chosen:** hybrid of `proposals/proposal-1.md` (Task-per-invoke delivery) +
+  `proposals/proposal-2.md` (async-contract behaviour enforcement, `recv/2`
+  removal).
+- **Why chosen:** Proposal 1 satisfies all three AC clauses with the smallest
+  diff (~60–80 LOC) and the simplest Http delivery path (one Task, one message).
+  Its weakness is that it leaves `recv/2` as dead behaviour surface and does not
+  prevent future transports from reimplementing the synchronous anti-pattern.
+  Proposal 2 corrects the behaviour contract root-cause (removes `recv/2`,
+  documents the non-blocking requirement) but introduces double async indirection
+  for Http (`Finch.async_request` + bridge Task) for no gain over a plain
+  `Task.start`; it also requires `cancel_timer` discipline on every success path.
+  Proposal 3 (ConnectionOwner) achieves maximal separation but still serialises
+  Http within the single owner and adds a new supervised process pair, making it
+  the right long-term refactor if Http parallelism is needed but overcomplicated
+  for this fix. Proposal 4 explicitly fails AC clause (a) for server-side
+  concurrency and is excluded. The hybrid takes Proposal 1's delivery mechanism
+  (plain `Task.start` → `{ref, rpc_id, result}` message, monitor the task pid for
+  `:DOWN` crash pruning) and Proposal 2's behaviour-level changes (remove `recv/2`
+  callback; update docstring to state the non-blocking contract as an implementor
+  obligation). The combination is more than the sum: P1 gives the correct runtime
+  fix; P2 gives the structural guarantee that prevents regression.
+
+## What changes
+
+- **`lib/tau/mcp/transport.ex`** — remove the `recv/2` callback from the
+  behaviour spec and its default implementation (if any); update the `send/2`
+  (or add `send/4` per P1 sketch) callback doc to state "MUST NOT block for the
+  network round-trip; response delivered via message to the Server process".
+- **`lib/tau/mcp/transport/http.ex`** — rewrite `send/2` (or introduce `send/4`)
+  to `Task.start/1` the `Finch.request` call and send `{ref, rpc_id, result}` to
+  the caller pid; remove `recv/2` implementation.
+- **`lib/tau/mcp/transport/sse.ex`** — the `Finch.request` in `send/2` is already
+  fast (initiates the POST); verify and document it as non-blocking; remove
+  `recv/2` implementation.
+- **`lib/tau/mcp/transport/stdio.ex`** — remove `recv/2` implementation; verify
+  the existing message-delivery path already conforms.
+- **`lib/tau/mcp/server.ex`**:
+  - `handle_call({:invoke, ...})`: return `{:noreply, state}` immediately after
+    delegating to transport; store `{from, monitor_ref}` in `pending` (monitor
+    the Task pid returned by `Http.send`; monitor the caller pid for Sse/Stdio).
+  - Add `handle_info({ref, rpc_id, {:line, line}}, state)` clause to receive task
+    result and route via existing `handle_message/2`.
+  - Add `handle_info({ref, rpc_id, {:error, reason}}, state)` clause to reply
+    error and prune `pending`.
+  - Add `handle_info({:DOWN, ref, :process, _pid, reason}, state)` clause to
+    prune `pending` on task crash or caller timeout.
+  - Strip `transport.recv` from `handle_info(_msg, state)` catch-all; return
+    `{:noreply, state}` unconditionally.
+- **`test/tau/mcp/`** — update mock transport's `send/2` to 4-arity form (or
+  the new async-delivery form); add test asserting two concurrent slow-Http
+  invokes both complete without one blocking the other (slow transport mock
+  sleeps 100 ms; both calls complete in ~100 ms wall time, not ~200 ms).
+
+## What does not change
+
+- `handle_message/2` and `route_response/2` logic in `server.ex` — only the
+  pending-map value shape changes (`id => from` → `id => {from, monitor_ref}`);
+  the routing logic is untouched.
+- `Tau.MCP.Reconciler` — no new processes to start or supervise.
+- `Tau.MCP.Transport.Stdio` — delivery mechanism already message-based; only
+  `recv/2` removal is needed.
+- The 30-second `@timeout` per-call cap — out of scope per the problem statement.
+- The SSE task lifecycle / `Task.async` leak — explicitly out of scope per
+  problem.md.
+- The `pending` map's O(n) scan for `:DOWN` matching — acceptable for the
+  expected concurrency level; the pending map is already bounded by the
+  `@timeout`.
+
+## Migration sketch
+
+1. Update `transport.ex` behaviour first (remove `recv/2`, update docs); this is
+   a compile-time-detectable break — all three transport modules will warn until
+   updated.
+2. Remove `recv/2` from all three transport modules in the same commit.
+3. Rewrite `Http.send/2` → async Task delivery; update the callback arity if
+   P1's 4-arity form is adopted (otherwise keep 2-arity and pass caller pid via
+   transport state set during `connect/1`).
+4. Update `server.ex`: pending map shape, new `handle_info` clauses, strip
+   catch-all side-effect.
+5. Add the concurrent-invoke test; verify it fails before step 3 and passes after.
+6. Update any existing mock-transport test doubles that referenced `recv/2`.
+
+The whole change is self-contained in `lib/tau/mcp/` and `test/tau/mcp/` — no
+supervisor or application changes.
+
+## Open questions
+
+- **Arity of the `send` callback:** Proposal 1 proposes `send/4` (adds `caller_pid`
+  and `rpc_id`); the hybrid can alternatively pass `caller_pid` via transport state
+  set in `connect/1` and keep `send/2`. The 4-arity form is more explicit but
+  breaks the existing `Stdio` and `Sse` implementations more broadly; the
+  transport-state approach avoids arity proliferation. Decision should be made
+  before implementation starts.
+- **`Task.start` vs `Task.Supervisor.start_child`:** P1 accepts unsupervised
+  `Task.start`; the `:DOWN` monitor on the task pid handles crash detection. If the
+  Server crashes mid-flight the orphaned Task's only side effect is sending an
+  undelivered message — benign. Confirm this is the accepted tradeoff before
+  landing, given the project's OTP non-negotiable on supervised processes.
+- **`Finch.async_request` vs `Task.start`:** P2 uses `Finch.async_request/3`;
+  this hybrid recommends `Task.start` + `Finch.request` (synchronous inside the
+  Task) for simpler tracing and a single level of async. If Finch's connection
+  pool benefits (backpressure, pool limit) are important, `Finch.async_request`
+  is worth revisiting.
+- **Sse concurrent-invoke semantics:** SSE is an event-stream protocol; multiple
+  concurrent invokes over a single SSE connection interleave responses as server-
+  push events. Confirm whether `rpc_id` correlation in `handle_message/2` already
+  handles out-of-order responses before declaring the fix complete for Sse.
+
+## Linked sub-problems / proposals
+
+- `proposals/proposal-1.md` — Task-per-invoke: spawn a Task per outbound HTTP
+  call; task delivers result as message; monitor for crash pruning.
+- `proposals/proposal-2.md` — Async transport contract: enforce non-blocking
+  `send/2` at the behaviour level; remove `recv/2`; use `Finch.async_request`.
+- `proposals/proposal-3.md` — ConnectionOwner: separate GenServer per MCP server
+  for all transport I/O. Not selected: adds supervision complexity; Http still
+  serialises within the owner; overcomplicated for this fix.
+- `proposals/proposal-4.md` — `handle_continue`-based deferral. Not selected:
+  explicitly does not achieve server-side parallelism; fails AC clause (a) by its
+  own admission.
+
+## Revision history
+
+- (revision 0 — initial)

--- a/docs/problems-archive-v1-modules/tau-tools-hooks-mcp/subproblems/mcp-server-concurrency/validation.md
+++ b/docs/problems-archive-v1-modules/tau-tools-hooks-mcp/subproblems/mcp-server-concurrency/validation.md
@@ -1,0 +1,588 @@
+---
+template_version: 1
+template_name: validation
+parent_solution: solution.md
+parent_problem: problem.md
+toulmin_complete: true
+falsification_attempted: true
+falsification_outcome: partially_falsified — claim/3
+revision_triggered: none
+---
+
+# Validation: Task-per-invoke with async-contract behaviour enforcement
+
+## Overview
+
+The solution recommends a hybrid of Proposal 1 (per-invoke `Task.start` →
+`{ref, rpc_id, result}` delivery, monitored task pid) and Proposal 2
+(strip `recv/2` from the `Tau.MCP.Transport` behaviour; document the
+non-blocking contract). It claims this satisfies all three acceptance-
+criterion clauses (non-blocking send; unconditional `handle_info`
+catch-all; pending-map pruning on `:DOWN`) while preventing the
+serialisation bug from regressing via the behaviour-level contract. I
+extracted seven distinct propositions from the Recommendation, What-
+changes, and What-does-not-change sections. Each is validated with the
+full six-component Toulmin frame; falsification strategies are chosen
+per claim from the catalog in `validate.md`. Six claims withstood;
+claim 3 is partially falsified — its qualifier needs narrowing for the
+SSE-concurrency case the solution itself flags as an open question.
+
+## Toulmin per claim
+
+The MITRE empirical study on Toulmin formalism found that "participants
+found it difficult to generate Toulmin structures, and their structures
+varied greatly even though they started with the same content"
+(https://www.mitre.org/news-insights/publication/empirical-evaluation-structured-argumentation-using-toulmin-argument).
+This template enforces all six components explicitly with prompts to
+counter that variance.
+
+### Claim 1: The Server's `handle_call({:invoke, ...})` returns `{:noreply, state}` immediately after delegating to the transport — the GenServer is not blocked for the network round-trip.
+
+- **Claim (C):** After the change, `handle_call({:invoke, tool, params}, from, state)`
+  delegates to `state.transport.send(...)` which spawns a `Task` performing
+  the Finch call; the clause returns `{:noreply, state}` synchronously with
+  no waiting on the HTTP response. Concurrent `invoke` calls are therefore
+  not mutually serialised by Finch latency.
+- **Grounds (G):** Today, `lib/tau/mcp/server.ex:108` calls
+  `state.transport.send(...)` from inside `handle_call`, and
+  `lib/tau/mcp/transport/http.ex:28` invokes `Finch.request(Tau.Providers.Finch)`
+  synchronously inside that callback, so the GenServer blocks. Proposal 1's
+  sketch (`proposals/proposal-1.md` lines 38–55) replaces this with
+  `Task.start(fn -> Finch.request(...) ; Process.send(caller_pid, {ref, rpc_id, result}, []) end)`
+  inside `Http.send`. Once the `Task` is spawned the spawning process
+  (here the Server) does not wait — `Task.start/1` is documented to
+  return `{:ok, pid}` immediately without linking or awaiting
+  (https://hexdocs.pm/elixir/Task.html#start/1).
+- **Warrant (W):** OTP non-negotiable #1 (`.claude/rules/otp-non-negotiables.md`):
+  "Stateful subsystems MUST run as supervised processes." A `GenServer`
+  processes its inbox serially; therefore any synchronous I/O performed
+  inside a callback determines that subsystem's throughput ceiling. The
+  canonical OTP remedy is to spawn an ephemeral process per work item
+  so the long-running side-effect does not occupy the message loop.
+- **Qualifier (Q):** Holds for the Http transport (per-RPC POST). For
+  Stdio the change is a no-op (stdio I/O is already message-driven via
+  the Port). For Sse, see claim 3 — Sse's POST is fast but its inbound
+  delivery semantics differ.
+- **Rebuttal (R):** Would NOT hold if the spawned `Task` itself blocked
+  before returning control (e.g., if `Task.start` performed any
+  pre-flight synchronous work). It also would NOT hold if Finch's
+  internal pool checkout serialised at the connection level for the
+  same host — but Finch's pool semantics return a slot quickly under
+  normal load (multiple pool entries per host by default).
+- **Backing (B):** Cesarini & Vinoski, *Designing for Scalability with
+  Erlang/OTP* §7 (task-per-request as the canonical concurrency idiom;
+  cited in proposal-1.md `Prior art`). Elixir core documentation on
+  `Task.start/1` ("starts a task ... not linked to the caller").
+
+#### Falsification attempt for claim 1
+
+- **Strategy:** counter-example construction + dependency check.
+- **Attempt:** Construct an execution where two simultaneous
+  `Tau.MCP.Server.invoke/3` calls block one another after the change.
+  Trace: call A enters `handle_call` → `Http.send` → `Task.start`
+  returns immediately → `handle_call` returns `{:noreply, state}` →
+  GenServer dequeues call B → same path. Both `Task` processes are
+  independent; the GenServer's mailbox is freed in ~microseconds.
+  Dependency check: `Task.start/1` is in Elixir stdlib, not removed
+  in 1.18.x. Finch ≥ 0.18 (`mix.exs:51`) exposes `Finch.request/2`
+  which is the synchronous call wrapped in the task — no API drift.
+- **Outcome:** withstood. I could not construct an execution where
+  Server-loop serialisation re-emerges.
+- **Action:** none.
+
+### Claim 2: The `handle_info(_msg, state)` catch-all returns `{:noreply, state}` unconditionally — it no longer drains `transport.recv`, and no stray BEAM message can consume a response belonging to a pending caller.
+
+- **Claim (C):** After the change, `server.ex` lines 86–95 (the
+  catch-all clause) consist solely of `def handle_info(_msg, state),
+  do: {:noreply, state}`. Unrecognised messages have no side effect on
+  the transport state, eliminating the drain race that today routes a
+  `{:line, _}` to no pending caller.
+- **Grounds (G):** Today `lib/tau/mcp/server.ex:86-95` calls
+  `state.transport.recv(state.transport_state, 0)` for every
+  unrecognised message; for Sse this race is documented in
+  `problem.md` lines 35–41 and `Tau.MCP.Transport.Sse.recv/2`
+  (`lib/tau/mcp/transport/sse.ex:73-86`) does pull from the same
+  mailbox the explicit `handle_info({:line, _}, state)` clause
+  expects. Proposal 1 (lines 113–115) and proposal 2 (lines 135–137)
+  both prescribe stripping this side-effect. The solution adopts that
+  directly (`solution.md` line 77–78).
+- **Warrant (W):** OTP non-negotiable #3 ("MUST NOT wrap stateless
+  logic in a GenServer") and #7 ("Let it crash; supervise; restart");
+  generalised: a GenServer's `handle_info` catch-all is the
+  side-effect-free disposal path for unmatched messages — performing
+  state-mutating I/O in it violates the locality principle that each
+  message-class has one handler.
+- **Qualifier (Q):** None — universal. The unconditional return is
+  unrestricted by config, transport choice, or state.
+- **Rebuttal (R):** Would NOT hold if some current code outside the
+  Server depends on the catch-all's side effect (e.g., a test that
+  asserts the Server pulls from the SSE queue when poked). I searched
+  `lib/tau/` and `test/` for callers that send unrecognised messages
+  to the MCP server expecting recv; none found (`find /home/brentw/src/tau/test
+  -path '*mcp*'` returns only `test/tau/cli/mcp_test.exs` which uses
+  the CLI surface). The dependency does not exist.
+- **Backing (B):** Elixir `GenServer` docs:
+  "handle_info/2 is invoked to handle all other messages" — its
+  semantic role is *disposal*, not behaviour. OTP non-negotiables
+  rule 4 forbidding ad-hoc cross-process events reinforces:
+  catch-alls should not perform routing.
+
+#### Falsification attempt for claim 2
+
+- **Strategy:** edge-case enumeration + integration check.
+- **Attempt:** Enumerate every message class that today routes through
+  the catch-all and might lose information once the drain is removed:
+  (1) Sse `{ref, {:line, line}}` — already handled by the explicit
+  `{:line, _}` clause at `server.ex:84`; once Sse's task forwards as
+  `{:line, _}` (today it forwards as `{ref, {:line, line}}` at
+  `lib/tau/mcp/transport/sse.ex:47`), it would fall through to the
+  catch-all and be discarded. This is a real edge case: the explicit
+  clause at `server.ex:84` matches `{:line, line}` (no ref envelope)
+  whereas Sse sends `{ref, {:line, line}}` (with ref envelope). The
+  solution's new `handle_info({ref, rpc_id, {:line, line}}, state)`
+  task-delivery clause (`solution.md` line 72) covers the Task-
+  delivered Http case, but the Sse forward shape is `{ref, {:line, line}}`
+  (no `rpc_id`) and would need either a separate clause or the Sse
+  task forwarder must be modified. (2) `:DOWN` from the monitored
+  task pid — explicitly handled by the new `:DOWN` clause. (3)
+  Telemetry / Logger / PubSub broadcasts — benign disposal is correct.
+  The catch-all stripping is correct *provided* Sse's forwarder
+  shape is reconciled with the new explicit clauses.
+- **Outcome:** withstood, with a recorded constraint for Sse —
+  flagged in claim 3's qualifier rather than as a falsification of
+  claim 2 because the catch-all itself remains correct; what is
+  required is a matching explicit clause for the Sse delivery shape.
+- **Action:** record the Sse-shape reconciliation as an outstanding
+  doubt feeding implementation.
+
+### Claim 3: Removing `recv/2` from the `Tau.MCP.Transport` behaviour spec — and from each transport's implementation — is correct: no caller in the codebase depends on the pull API, and removing it prevents future transports from reintroducing the synchronous anti-pattern.
+
+- **Claim (C):** The behaviour callback `@callback recv(state :: term(),
+  timeout()) :: ...` (`lib/tau/mcp/transport.ex:21-22`) is removed; all
+  three transport modules (`Http`, `Sse`, `Stdio`) drop their `recv/2`
+  implementations. No production caller remains. The behaviour now
+  documents the non-blocking contract for `send/2`.
+- **Grounds (G):** `recv/2` is currently called from
+  `lib/tau/mcp/server.ex:87` only (the catch-all about to be stripped).
+  A repository grep for `transport.recv` returns one occurrence
+  (that line). The `Tau.MCP.Transport.Sse.recv/2` body itself
+  (`lib/tau/mcp/transport/sse.ex:73-86`) does a synchronous
+  `receive ... after timeout` over the same mailbox the Server
+  drains via the catch-all today — confirming the implementation is
+  load-bearing only for the about-to-be-removed catch-all path.
+  `Tau.MCP.Transport.Stdio.recv/2` (`lib/tau/mcp/transport/stdio.ex:65-78`)
+  receives Port `{:data, ...}` messages from inside a callback — i.e.
+  it would steal the Port's messages from the Server's mailbox,
+  which works today only because the catch-all is the sole caller.
+- **Warrant (W):** Hickey's *Simple Made Easy* principle: removing a
+  redundant API surface ("complecting" the pull and push contracts)
+  simplifies the contract space. OTP behaviour design: a callback
+  that exists but has no remaining caller is dead surface, and dead
+  surface is a regression risk (a future transport author re-derives
+  blocking semantics from the existence of `recv/2`).
+- **Qualifier (Q):** Holds for in-tree callers as of repo HEAD
+  (commit `c939af8`). Does NOT account for downstream / extension
+  callers if any external `Tau.MCP.Transport` implementor exists.
+  Also: the Sse transport's *new* asynchronous delivery path (with
+  `recv/2` removed) requires confirming that the SSE task's
+  `Process.send(parent, {ref, {:line, ev.data}}, [])`
+  (`lib/tau/mcp/transport/sse.ex:47`) reaches a matching
+  `handle_info` clause in the Server. The current explicit
+  `handle_info({:line, line}, state)` clause at `server.ex:84` does
+  NOT match the `{ref, {:line, line}}` envelope. **A new explicit
+  clause for the Sse envelope is required as part of the change;
+  the solution.md does not name it.**
+- **Rebuttal (R):** Would NOT hold if `recv/2` were public surface in
+  use by an out-of-tree extension implementing `Tau.MCP.Transport`.
+  No extensions ship in-repo today (`SPEC-EXTENSIONS.md` is forward-
+  looking). Would also not hold if removing `recv/2` from a
+  behaviour declaration in Elixir generates only a soft warning
+  rather than a compile error on stale implementations — Elixir's
+  behaviour conformance is warning-level, so a third-party impl
+  retaining `recv/2` would compile cleanly.
+- **Backing (B):** Hickey, *Simple Made Easy* (Strange Loop 2011);
+  user CLAUDE.md "Opinions / biases" lists Hickey's principles as
+  guiding. Elixir behaviour semantics:
+  https://hexdocs.pm/elixir/typespecs.html#behaviours (callbacks not
+  in `@behaviour`'s `__behaviour__` list raise warnings, not errors).
+
+#### Falsification attempt for claim 3
+
+- **Strategy:** dependency check (codebase-wide) + counter-example
+  construction for Sse delivery shape.
+- **Attempt:** (a) `grep -rn "transport.recv\|\\.recv(" lib/ test/`
+  to find every call site — produced one match in
+  `lib/tau/mcp/server.ex:87` (the catch-all). No production caller
+  outside the catch-all exists. (b) Trace the Sse delivery path
+  end-to-end: SSE task at `lib/tau/mcp/transport/sse.ex:47` sends
+  `{ref, {:line, ev.data}}` to the Server pid; with the catch-all
+  stripped and `recv/2` removed, the Server has only two `:line`
+  matching clauses today: `handle_info({:line, line}, state)` at
+  `server.ex:84` and the new `handle_info({ref, rpc_id, {:line, line}}, state)`
+  from `solution.md:72`. Neither matches `{ref, {:line, line}}`
+  (without `rpc_id`). **The Sse-delivered line would fall through to
+  the (now unconditional) catch-all and be dropped**, breaking the
+  Sse transport.
+- **Outcome:** partially falsified. The claim that removing `recv/2`
+  is universally safe survives for `Http` and `Stdio`, but for `Sse`
+  the change implicitly requires either (i) altering the Sse task to
+  forward as `{:line, line}` (no envelope, no ref isolation
+  guarantee), or (ii) adding a third explicit `handle_info` clause
+  in the Server that matches the `{ref, {:line, line}}` envelope and
+  validates `ref == state.transport_state.ref`. Neither change is
+  named in the solution.
+- **Action:** narrow this claim's qualifier to record the Sse-
+  reconciliation constraint; surface it as an outstanding doubt so
+  the implementer treats it as a non-optional sub-task. This does
+  NOT trigger solution revision because the solution's "Open
+  questions" §4 ("Sse concurrent-invoke semantics") already flags
+  the area for confirmation; the partial falsification refines that
+  flag from "confirm whether rpc_id correlation handles out-of-order
+  responses" to "additionally, ensure the explicit Server clause
+  matches the Sse envelope shape, OR change the Sse forwarder shape
+  to match the existing `{:line, _}` clause".
+
+### Claim 4: Storing `{from, monitor_ref}` in the `pending` map and pruning on `:DOWN` correctly removes timed-out / crashed callers' entries — solving the stale-`from` accumulation defect named in problem.md.
+
+- **Claim (C):** The `pending` map shape changes from `id => from` to
+  `id => {from, monitor_ref}`. A `Process.monitor/1` on the spawned
+  task pid (for Http) or on the caller pid (for Sse/Stdio) yields a
+  ref stored alongside `from`. A new `handle_info({:DOWN, ref,
+  :process, _pid, reason}, state)` clause locates the matching
+  pending entry and removes it. Stale entries no longer accumulate.
+- **Grounds (G):** Today, `lib/tau/mcp/server.ex:110` writes
+  `Map.put(state.pending, id, from)` with no pruning path —
+  `problem.md` lines 42–43 documents this leak. The solution
+  (`solution.md` lines 70–76) introduces both the value-shape change
+  and the `:DOWN` clause. The pattern (monitor + `:DOWN`-driven
+  cleanup) is used elsewhere in the codebase:
+  `lib/tau/coding_agent/tau_context.ex:171` monitors an owner pid;
+  `lib/tau/tools/builtin/agent.ex:206` monitors a parent pid.
+- **Warrant (W):** OTP non-negotiable #4: "Cross-process events MUST
+  use `Phoenix.PubSub` or monitored refs (never `:global`)."
+  `Process.monitor/1` is the canonical BEAM mechanism for liveness
+  detection without bidirectional link semantics — it converts a
+  process death into a routable message.
+- **Qualifier (Q):** Holds when (i) the monitor is established before
+  any path that could lose the ref (i.e., synchronously with the
+  pending-map insert in `handle_call`), and (ii) the `:DOWN` clause's
+  match logic scans the pending map by ref. The solution sketches
+  this directly. Does not address the case where the monitored
+  process never exits (e.g., a successful response from a long-lived
+  caller) — in that case `Process.demonitor/2` should be called on
+  successful reply to avoid an orphan monitor; this is named in
+  proposal-1.md (`Process.demonitor(task_ref, [:flush])` at
+  proposal-1.md:92) but is not echoed verbatim in solution.md.
+- **Rebuttal (R):** Would NOT hold if the `:DOWN` message could
+  arrive before the pending entry is inserted (race between
+  `Process.monitor` and `Map.put`). Both calls happen in the same
+  `handle_call` synchronously and inside the same scheduler slice;
+  the `:DOWN` message cannot be processed until `handle_call`
+  returns. Therefore the race is impossible by GenServer single-
+  threaded message-loop guarantee.
+- **Backing (B):** Erlang docs on `monitor/2`:
+  "The calling process receives a 'DOWN' message ... when the
+  monitored process terminates" (https://www.erlang.org/doc/man/erlang.html#monitor-2).
+  Existing in-repo precedent at the cited line numbers.
+
+#### Falsification attempt for claim 4
+
+- **Strategy:** edge-case enumeration over pruning lifecycle.
+- **Attempt:** Enumerate failure modes: (1) caller process exits
+  before the response arrives — `:DOWN` from monitored caller pid
+  fires; clause removes the pending entry. ✓ (2) Task crashes (Http)
+  before sending the result — `:DOWN` from monitored task pid fires;
+  pending entry removed; caller receives no reply and times out at
+  `@timeout`. ✓ (3) Successful response arrives — the explicit
+  task-delivery clause matches first, removes the pending entry, and
+  replies. ✓ But: if `Process.demonitor` is not called on success,
+  the still-live monitor will deliver `:DOWN` later when the Task
+  finally exits (Task exits normally after sending its message).
+  Without `demonitor`, the `:DOWN` clause receives a `:normal`
+  reason for a Task whose entry has already been pruned —
+  `Enum.find` returns `nil`; clause returns `{:noreply, state}`.
+  Benign. (4) `Process.monitor(from_pid)` extraction: the solution
+  says "monitor the caller pid for Sse/Stdio". `from` is a
+  `{caller_pid, tag}` tuple; `elem(from, 0)` extracts the pid as
+  done in proposal-3.md line 108. Works but is an undocumented
+  detail of the GenServer `from` tuple.
+- **Outcome:** withstood. The `demonitor` omission is a code-
+  cleanliness point, not a correctness defect (orphan `:DOWN`
+  messages route to `nil` match and are benignly dropped).
+- **Action:** record the `demonitor` discipline as an implementation
+  note in the outstanding doubts.
+
+### Claim 5: The behaviour-level documentation of "MUST NOT block for the network round-trip" prevents future transport implementors from reintroducing the serialisation bug.
+
+- **Claim (C):** Updating the `@callback send` docstring to state the
+  non-blocking obligation, plus removing `recv/2`, is sufficient
+  prevention — a future implementor would have to read the docstring
+  and discover the blocking anti-pattern as a contract violation.
+- **Grounds (G):** The current `Tau.MCP.Transport` module's
+  `@moduledoc` (`lib/tau/mcp/transport.ex:1-17`) states "all
+  transports use a GenServer-callback-style API" without specifying
+  blocking semantics; the absence of an explicit non-blocking clause
+  is plausibly *why* the Http transport blocks today
+  (`lib/tau/mcp/transport/http.ex:28`). Proposal 2 (lines 12–24, 50–58)
+  proposes the explicit non-blocking docstring; the solution adopts
+  this verbatim.
+- **Warrant (W):** Behaviours in Elixir document a contract, not a
+  hard runtime constraint. The warrant is the *social* OTP principle:
+  contracts that name the failure mode prevent it more reliably than
+  contracts that omit it. Cited in proposal-2.md's strength
+  list: "a transport that blocks in `send/2` is a ... design-time
+  violation (documented in the callback doc)".
+- **Qualifier (Q):** Holds only for implementors who *read* the
+  docstring. Holds only for prevention, not mechanical enforcement
+  (Elixir's behaviour check is type-shape, not runtime semantics).
+  Existing implementors do not get retroactive enforcement — the
+  three in-repo transports are updated explicitly in this PR.
+- **Rebuttal (R):** Would NOT hold if a future implementor copies an
+  existing transport (e.g., `Http`) verbatim and modifies it without
+  re-reading the behaviour doc. Documentation alone is a weak
+  forcing function compared to, e.g., a property test that asserts
+  `send/2` returns within N ms across all impls. The solution does
+  not propose such a property test.
+- **Backing (B):** Hickey, *Simple Made Easy* on the value of
+  declared contracts; OTP design principles on behaviour
+  documentation as part of the API surface.
+
+#### Falsification attempt for claim 5
+
+- **Strategy:** prior-art counter-case.
+- **Attempt:** Search for cases where a documented behaviour
+  contract failed to prevent the contract's named anti-pattern in
+  practice. The Tau codebase itself has a precedent: D-NNN
+  invariants documented in SPEC files are nonetheless re-violated
+  (e.g., `worktree-discipline.md` records that the "parent on main"
+  invariant has been broken multiple times by agents who *had* read
+  the rule). Documentation is necessary but not sufficient.
+- **Outcome:** withstood (with caveat). The claim is "prevents
+  future implementors from reintroducing the bug." Strict
+  falsification requires a counter-example where a future Tau MCP
+  transport implementor blocks despite the docstring; no such
+  implementor exists yet to falsify. The prior-art counter-case
+  suggests the claim is weaker than the solution implies but does
+  not falsify it for the scope of the present PR.
+- **Action:** note in outstanding doubts that a property test
+  asserting non-blocking `send/2` across all `@behaviour
+  Tau.MCP.Transport` implementations would be a more robust
+  enforcement than docstring-only.
+
+### Claim 6: The change is self-contained in `lib/tau/mcp/` and `test/tau/mcp/`; no supervisor or application changes are required.
+
+- **Claim (C):** The diff touches `lib/tau/mcp/transport.ex`,
+  `lib/tau/mcp/transport/http.ex`, `lib/tau/mcp/transport/sse.ex`,
+  `lib/tau/mcp/transport/stdio.ex`, `lib/tau/mcp/server.ex`, and
+  `test/tau/mcp/...`. No edits to `lib/tau/application.ex`,
+  `lib/tau/mcp/reconciler.ex`, or supervision tree definitions.
+- **Grounds (G):** Solution `What changes` enumerates exactly those
+  paths (`solution.md` lines 53–82). `Tau.MCP.Reconciler` is
+  declared out-of-scope (`solution.md:88`). No new processes are
+  introduced — `Task.start/1` produces unsupervised processes by
+  design (and the solution accepts this tradeoff in `Open questions`
+  §2). The application supervisor (`lib/tau/application.ex`) is
+  unaffected because the public start surface
+  (`Tau.MCP.Server.start_link/1`) is unchanged.
+- **Warrant (W):** Locality: a refactor confined to the modules
+  implementing the affected behaviour, with no public-API change at
+  the supervisor boundary, requires no supervisor changes. This
+  follows from the OTP principle that supervisors care about child
+  specs and lifecycle, not internal state shape.
+- **Qualifier (Q):** Holds for the proposed Task-based path. Would
+  NOT hold if the OTP non-negotiable on supervised processes (rule
+  #1) is read strictly to forbid bare `Task.start` — see Rebuttal.
+- **Rebuttal (R):** OTP non-negotiable #1 states: "Stateful subsystems
+  MUST run as supervised processes." A bare `Task.start` is
+  unsupervised. The solution's `Open questions` §2 raises this
+  explicitly; if the project elects to require `Task.Supervisor`,
+  then `Application.start/2` (or `Tau.MCP` supervision tree) gains
+  a `Task.Supervisor` child, falsifying claim 6's "no supervisor
+  changes" assertion.
+- **Backing (B):** OTP non-negotiables (`.claude/rules/otp-non-negotiables.md`)
+  rule #1; documented prior-art for ephemeral-task supervisors in
+  `Tau.Session` (provider stream tasks).
+
+#### Falsification attempt for claim 6
+
+- **Strategy:** dependency check (against OTP non-negotiables).
+- **Attempt:** Apply rule #1 strictly to the Task this change
+  introduces. The Task is *stateful* in the trivial sense that it
+  holds a reference to the Finch request in progress; it dies after
+  one message. Two readings: (1) "stateful subsystem" means a
+  long-lived process holding mutable state — Task does not qualify;
+  rule does not apply; claim 6 stands. (2) "MUST run as supervised
+  processes" applied uniformly — Task is a process; needs
+  supervision; rule applies; claim 6 is falsified because a
+  `Task.Supervisor` child must be added to `lib/tau/application.ex`
+  or `lib/tau/mcp/` supervision. Reading (1) is the practical
+  interpretation used throughout the codebase (see
+  `lib/tau/tools/builtin/agent.ex` and similar files where bare
+  spawn/Task.start patterns exist for ephemeral work). Reading (2)
+  is the literalist interpretation. The solution names this as an
+  open question rather than resolving it.
+- **Outcome:** withstood under reading (1); partially falsified
+  under reading (2). Because solution.md frames it as an open
+  question explicitly ("Open questions" §2), it is not concealed —
+  the validator records the tension here for the implementer.
+- **Action:** note as an outstanding doubt; if the project resolves
+  reading (2), this claim's qualifier narrows to "no
+  supervisor-tree changes *if* `Task.start` is accepted as
+  ephemeral; otherwise requires a `Task.Supervisor` child".
+
+### Claim 7: The Server's `handle_message/2` and `route_response/2` logic is preserved unchanged — only the pending-map value shape changes (`id => from` → `id => {from, monitor_ref}`).
+
+- **Claim (C):** `handle_message/2` (currently `lib/tau/mcp/server.ex:170-181`)
+  and `route_response/2` (`server.ex:183-193`) are not modified in
+  behaviour; their access pattern over `state.pending` is the only
+  surface that changes (to handle the new tuple shape).
+- **Grounds (G):** Solution `What does not change` (lines 86–88)
+  states this directly. Today `route_response/2`'s pattern at
+  `server.ex:191` is `from -> reply_to(from, msg, state)` — it
+  treats the pending value as opaque. The shape change requires
+  that `from` be destructured: `{from, _monitor_ref} -> reply_to(from, msg, state)`,
+  which is a *match* change, not a *logic* change. The internal
+  `:internal` tagged values (`{:internal, :init}` and `{:internal,
+  :tools_list}`) at `server.ex:189-190` remain unchanged (they have
+  no monitor counterpart — no caller to track).
+- **Warrant (W):** Semantic locality: a value-shape change that
+  preserves the access predicate (pop → reply) does not constitute
+  a logic change. Hickey: "compose by data, not by control flow."
+- **Qualifier (Q):** Holds provided the internal-init / internal-
+  tools_list pending entries are NOT given monitor refs (they have
+  no caller to monitor). Solution adopts this by implication —
+  `handle_call({:invoke, ...})` is the only path that inserts a
+  caller `from`; the internal `request_init/1` and
+  `request_tools_list/1` (`server.ex:128-168`) continue to insert
+  `{:internal, _}` unmodified.
+- **Rebuttal (R):** Would NOT hold if the pending shape change
+  forces a refactor of `reply_to/3` beyond the destructure. Both
+  `reply_to/3` clauses (`server.ex:214-224`) call
+  `GenServer.reply(from, ...)` and treat `from` opaquely. They are
+  unchanged by destructure in the caller.
+- **Backing (B):** Elixir pattern-match semantics; in-repo
+  precedent: similar tuple-extension refactors in
+  `lib/tau/coding_agent/tau_context.ex` (state map extensions
+  without behaviour change).
+
+#### Falsification attempt for claim 7
+
+- **Strategy:** type-level check + counter-example construction.
+- **Attempt:** Walk every `Map.put(state.pending, ...)` and
+  `Map.pop(state.pending, ...)` in `server.ex`. Inserts:
+  `server.ex:110` (caller from `handle_call`),
+  `server.ex:145` (internal init), `server.ex:162` (internal
+  tools_list). The change adds a monitor ref to insert site
+  `:110` only — internal sites stay one-tuple. Pops: `server.ex:184`
+  (`route_response`) — pattern must match BOTH shapes (caller
+  `{from, ref}` and internal `{:internal, _}`). The current
+  matching cascade at `server.ex:187-192` would need an updated
+  branch to handle the new tuple shape. The logic is preserved if
+  the branch order is: `{:internal, :init}` first, `{:internal,
+  :tools_list}` next, `{from, _ref}` last. This is a mechanical
+  refactor; no logic change. Counter-example for "logic preserved":
+  the route_response semantics (which tagged value gets which
+  handler) survive byte-for-byte.
+- **Outcome:** withstood.
+- **Action:** none.
+
+## Cross-claim consistency
+
+The seven claims are mutually consistent under the dominant reading
+of OTP non-negotiables (rule #1 = "long-lived stateful subsystems",
+not "every BEAM process") and under the assumption that Sse's
+delivery shape is reconciled with the new explicit Server clause.
+Two latent tensions to record:
+
+1. **Claim 5 vs Claim 6** — Claim 5 promises that docstring-level
+   contract enforcement prevents future serialisation; Claim 6
+   promises no supervisor changes. Both rest on the same posture
+   ("light-touch change, docstring contract"). If reading (2) of
+   OTP rule #1 is adopted (forcing a `Task.Supervisor`), claim 6
+   narrows but claim 5 strengthens (Task.Supervisor's existence
+   makes "fire-and-forget" more visible to future readers). The
+   tension resolves into a single choice: light-touch (current
+   solution) vs principle-strict (with supervisor). The solution
+   takes the light-touch path and flags it as an open question;
+   this is internally consistent.
+
+2. **Claim 3 (recv/2 removal) vs Claim 2 (catch-all stripping)** —
+   Together these claims close the drain race. If only one is
+   landed (e.g., catch-all stripped but `recv/2` retained as dead
+   surface), the drain race is gone but the regression risk
+   remains. The solution lands both together (per `What changes`
+   bullets 1 and 5). Consistent — no tension in the bundled change.
+
+## Falsification summary
+
+| # | Claim (short) | Strategy | Outcome | Action |
+|---|---|---|---|---|
+| 1 | `handle_call` returns immediately; concurrent invokes not mutually serialised | counter-example + dependency check | withstood | none |
+| 2 | Catch-all returns `{:noreply, state}` unconditionally; no drain race | edge-case enumeration + integration check | withstood | record Sse-shape reconciliation as outstanding doubt |
+| 3 | `recv/2` removal is safe; prevents regression | dependency check + counter-example | partially falsified | narrow Qualifier — Sse `{ref, {:line, _}}` envelope needs matching explicit `handle_info` clause OR the Sse forwarder shape must change |
+| 4 | `:DOWN`-driven pending pruning fixes the leak | edge-case enumeration | withstood | record `Process.demonitor(ref, [:flush])` on success as cleanliness note |
+| 5 | Behaviour docstring prevents future serialisation regression | prior-art counter-case | withstood (weak) | recommend a property test asserting non-blocking `send/2` as stronger enforcement |
+| 6 | Change is self-contained; no supervisor changes | dependency check vs OTP rule #1 | withstood (under reading 1); partially falsified under reading 2 | record open question; defer to implementer per solution's own Open questions §2 |
+| 7 | `handle_message/2` and `route_response/2` logic preserved | type-level check + counter-example | withstood | none |
+
+## Revision required
+
+None at solution-revision level. Claim 3's partial falsification
+narrows the qualifier in place; the constraint (reconcile the Sse
+delivery envelope with the Server's matching clauses) is recorded
+as an outstanding doubt and added to the qualifier of claim 3.
+Claim 6's partial falsification under the literal reading of OTP
+rule #1 is already named as an open question in the solution; this
+validator notes the tension but does not force its resolution
+ahead of implementation.
+
+Per `validate.md` §5: "If only **partial** falsifications: narrow
+each claim's Qualifier in place. No revision needed." That applies
+here.
+
+- **Target file:** N/A
+- **Revision kind:** N/A — qualifiers narrowed in place
+- **Rationale:** Both partial falsifications are already surfaced in
+  the solution's own `Open questions` section (§3 and §2
+  respectively); the validator's narrowed qualifiers extend rather
+  than contradict them. Re-running propose/select for this node
+  would not surface a materially different solution — the four
+  proposals already on file occupy the design space.
+
+## Outstanding doubts
+
+- **Sse delivery envelope (high priority).** Today's SSE task
+  forwards `{ref, {:line, ev.data}}` (`lib/tau/mcp/transport/sse.ex:47`).
+  The solution's new task-delivery clause matches
+  `{ref, rpc_id, {:line, line}}` (three-element). The pre-existing
+  explicit `handle_info({:line, line}, state)` matches the bare
+  shape. Neither matches the Sse envelope. The implementer MUST
+  either (a) add a third `handle_info({ref, {:line, line}}, state)`
+  clause that validates `ref == state.transport_state.ref`, or
+  (b) change the Sse forwarder to send the bare `{:line, line}`
+  shape. Option (a) preserves ref-isolation; option (b) is simpler
+  but loses the ref-as-namespace guarantee.
+- **`Process.demonitor` on success.** Proposal 1's sketch
+  (`proposals/proposal-1.md:92,97`) calls `Process.demonitor(ref, [:flush])`
+  on successful task-delivery routing. The solution.md does not
+  echo this verbatim. Without it, orphan `:DOWN` messages route to
+  the catch-all (or to the `:DOWN` clause and fail to find a
+  pending entry); benign but noisy.
+- **OTP rule #1 strictness on `Task.start`.** Solution Open
+  Questions §2 raises this; the validator confirms it is the only
+  policy choice that could turn claim 6 from "withstood" to
+  "falsified". Recommend resolving before PR open: either accept
+  `Task.start` and document the exemption in the PR body, or adopt
+  `Task.Supervisor` (one-line `application.ex` addition; one-line
+  call-site change).
+- **Property test for non-blocking `send/2`.** Claim 5's enforcement
+  is docstring-only. A property test asserting that every
+  `@behaviour Tau.MCP.Transport` implementation's `send/2`
+  returns within ~5 ms (mock target server, no real network) would
+  catch regressions mechanically. Not in the current solution
+  scope; recommend filing as a follow-up if not added here.
+- **`Finch.async_request/3` vs `Task.start` (low priority).** The
+  solution chose `Task.start` over Finch's native async (which
+  Proposal 2 used). The Open Questions §3 names this. Validator
+  has no preference; both satisfy the AC. Recorded for parent-
+  level synthesis only.

--- a/docs/problems-archive-v1-modules/tau-tools-hooks-mcp/subproblems/tool-result-contract/problem.md
+++ b/docs/problems-archive-v1-modules/tau-tools-hooks-mcp/subproblems/tool-result-contract/problem.md
@@ -1,0 +1,88 @@
+---
+template_version: 1
+template_name: problem
+node_kind: leaf
+depth: 1
+parent: ../../problem.md
+status: draft
+---
+
+# Problem: tool-result-contract — Result shape and enforcement boundary are declared but not enforced
+
+## Statement
+
+`Tau.Tool`'s behaviour contract declares that tools must never raise on user
+input, and `Tau.Tool.Result` defines a `details` map intended to carry
+structured metadata; but neither the raise prohibition nor the `details` schema
+(specifically: the `kind` discriminator, telemetry coverage, and the `is_error`
+contract) are enforced at any shared boundary. Each tool author chooses
+independently which fields to populate, producing silent divergence that callers
+(TUI renderers, session JSONL consumers, tests) cannot rely upon.
+
+## Context
+
+- `lib/tau/tool.ex:23` — moduledoc states "Tools must NEVER raise on user
+  input."
+- `lib/tau/tool/result.ex` — `%Result{content, details, terminate?, is_error}`;
+  `details` is typed `map()` with no schema enforcement.
+- `lib/tau/tools/builtin/bash.ex:131-141` — `persist_full/3` calls
+  `File.mkdir_p!/1` and `File.write!/1`; either can raise, violating the
+  contract.
+- `lib/tau/tools/builtin/write.ex:43` — `details: %{path: full, bytes: bytes}`
+  has no `:kind` key.
+- `lib/tau/tools/builtin/bash.ex` — emits no `[:tau, :tool, ...]` telemetry on
+  the tool boundary; only `[:tau, :tool, :bash, :stderr]` on a sub-event.
+- `lib/tau/tools/builtin/read.ex:77-78` and `edit.ex` — also emit no
+  `[:tau, :tool, ...]` boundary telemetry.
+- `lib/tau/tools/builtin/delegate.ex` — emits `[:tau, :tool, :delegate,
+  :start/:stop/:exception]` correctly.
+- Flat audit cross-tool shape-drift table (`.code_audit/archive/v1-flat/
+  03-tools-hooks-mcp.md` §Cross-tool shape drift) — documents the full matrix.
+
+Behaviour interfaces are structurally sound. The gap is entirely in
+implementation discipline: there is no shared wrapper, validator, or compile-
+time check that enforces the three contract points (no-raise, details schema,
+telemetry) across all implementations.
+
+## Complecting hypothesis
+
+**The raise prohibition, the details schema, and the telemetry contract are
+complected with each tool's implementation** because there is no dispatch
+wrapper between the FSM and `execute/2` that enforces these three properties
+centrally; the FSM calls `execute/2` directly and trusts each implementation to
+honour the contract independently. Each tool author therefore owns an invisible
+cross-cutting responsibility that is easy to forget or implement partially.
+
+## Decomposition strategy
+
+(leaf — no further decomposition; proceed to proposals)
+
+## Acceptance criterion
+
+The problem is solved when: (a) no built-in tool can raise an uncaught exception
+on any reachable input path (including filesystem errors in `persist_full/3`),
+(b) every tool's `details` map includes at minimum a `:kind` discriminator, and
+(c) every tool emits `[:tau, :tool, <name>, :start]` and `[:tau, :tool, <name>,
+:stop/:exception]` telemetry on the execution boundary — all three verifiable by
+inspection or a test that exercises the contract at the dispatch layer rather
+than within individual tools.
+
+## Out of scope
+
+- Path-traversal and sandbox enforcement — a separate security finding
+  (`resolve/2` in `local.ex`); does not affect the shape contract.
+- The fake unified diff in `Edit.render_diff/2` — a functional defect in the
+  diff content, not a result-shape contract issue.
+- `Agent` and `Delegate` telemetry namespaces (they emit on sub-namespaces of
+  `[:tau, :tool, ...]` rather than the canonical `[:tau, :tool, :agent, ...]`
+  form) — the direction of fix (rename vs. alias) is a proposal decision, not
+  a problem statement.
+- `Tau.Hook`'s result shape — covered by the `io-collectors` sub-problem
+  (hook shell dispatch) and the flat audit; not a `Tau.Tool.Result` concern.
+- MCP `ToolAdapter`'s result construction — covered by the
+  `mcp-server-concurrency` sub-problem; MCP tools are proxies to a remote
+  server, not implementations of `Tau.Tool.execute/2` in the same sense.
+
+## Amendment log
+
+- (none yet)

--- a/docs/problems-archive-v1-modules/tau-tools-hooks-mcp/subproblems/tool-result-contract/proposals/proposal-1.md
+++ b/docs/problems-archive-v1-modules/tau-tools-hooks-mcp/subproblems/tool-result-contract/proposals/proposal-1.md
@@ -1,0 +1,190 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 1
+parent_problem: ../problem.md
+---
+
+# Proposal 1: Central dispatch wrapper in `run_tool_validated/6`
+
+## Approach
+
+Replace the bare `mod.execute(args, ctx)` call in
+`Tau.Session.ToolDispatch.run_tool_validated/6` with a shared wrapper function
+`Tau.Tool.Executor.call/4` that: (a) wraps `execute/2` in a `try/rescue` that
+converts any raise into `{:ok, Result.error(...)}` before the existing outer
+`try/rescue` sees it, (b) checks that the returned `Result.details` map
+contains a `:kind` key and injects `kind: :unclassified` if absent, and (c)
+emits `[:tau, :tool, <name_atom>, :start]` / `[:tau, :tool, <name_atom>,
+:stop]` / `[:tau, :tool, <name_atom>, :exception]` telemetry around each call.
+The existing `[:tau, :tool, :execute, :start/:stop/:exception]` events emitted
+in `run_tool_validated` are retained as the session-level boundary events;
+the new per-tool events are additive. `Bash.persist_full/3`'s `File.mkdir_p!/1`
+and `File.write!/1` calls are wrapped in `File.mkdir_p/1` + `File.write/1`
+(non-raising variants) as a simultaneous targeted fix so the raise guard is not
+the sole protection.
+
+## Rationale
+
+The complecting hypothesis is that the three contract properties (no-raise,
+details schema, telemetry) are each tool implementation's responsibility because
+there is no central dispatch site between the FSM and `execute/2`. This proposal
+adds exactly that site without altering the `Tau.Tool` behaviour contract,
+`Tau.Tool.Result`'s struct shape, or any tool's public interface. The wrapper is
+the single place where all three properties are enforced regardless of which
+tool is called. Callers (`run_tool_validated`, `finish_permission_round`,
+`spawn_parallel_dispatcher`) route through the same path without modification
+because `run_tool_validated` is already their common convergence point. The
+`Bash.persist_full/3` fix removes the live raise path so the wrapper is defence-
+in-depth rather than the first line.
+
+## Sketch
+
+```elixir
+# New file: lib/tau/tool/executor.ex
+defmodule Tau.Tool.Executor do
+  @moduledoc """
+  Central execution wrapper that enforces the three Tau.Tool contract properties:
+  (1) no uncaught raise, (2) details.kind present, (3) per-tool telemetry.
+  Called exclusively from Tau.Session.ToolDispatch.run_tool_validated/6.
+  """
+
+  alias Tau.Tool.Result
+
+  @spec call(module(), map(), Tau.Tool.Context.t(), integer()) ::
+          {:ok, Result.t()} | {:error, term()}
+  def call(mod, args, ctx, started_mono) do
+    name = mod.name()
+    name_atom = String.to_existing_atom(String.downcase(name))
+
+    :telemetry.execute(
+      [:tau, :tool, name_atom, :start],
+      %{system_time: System.system_time()},
+      %{tool: name, tool_call_id: ctx.tool_call_id, session_id: ctx.session_id}
+    )
+
+    outcome =
+      try do
+        mod.execute(args, ctx)
+      rescue
+        e ->
+          {:ok, Result.error("Tool raised: #{Exception.message(e)}",
+            details: %{kind: :raised_exception, exception: Exception.message(e)})}
+      end
+
+    {telemetry_event, result} =
+      case outcome do
+        {:ok, %Result{} = r} ->
+          r = ensure_kind(r)
+          {:stop, {:ok, r}}
+
+        {:error, reason} ->
+          {:stop, {:error, reason}}
+      end
+
+    :telemetry.execute(
+      [:tau, :tool, name_atom, telemetry_event],
+      %{duration: System.monotonic_time(:millisecond) - started_mono},
+      %{tool: name, tool_call_id: ctx.tool_call_id,
+        is_error: match?({:ok, %Result{is_error: true}}, result)}
+    )
+
+    result
+  end
+
+  defp ensure_kind(%Result{details: %{kind: _}} = r), do: r
+  defp ensure_kind(%Result{details: d} = r), do: %{r | details: Map.put(d, :kind, :unclassified)}
+end
+```
+
+```elixir
+# Modification to lib/tau/session/tool_dispatch.ex
+# In run_tool_validated/6, replace:
+#   case mod.execute(args || %{}, ctx) do
+# with:
+#   case Tau.Tool.Executor.call(mod, args || %{}, ctx, started) do
+```
+
+```elixir
+# Modification to lib/tau/tools/builtin/bash.ex
+# persist_full/3: replace File.mkdir_p!/dir and File.write!/path with:
+  defp persist_full(output, session_id, call_id) do
+    dir = Tau.Settings.data_dir() |> Path.join("sessions") |> Path.join(session_id || "default")
+    with :ok <- File.mkdir_p(dir),
+         path = Path.join(dir, "bash-#{call_id}.log"),
+         :ok <- File.write(path, output) do
+      path
+    else
+      {:error, reason} -> nil  # truncation log unwritable; degrade gracefully
+    end
+  end
+```
+
+The `String.to_existing_atom/1` call is safe because all built-in tool names
+(`"Bash"`, `"Read"`, `"Write"`, `"Edit"`, `"Delegate"`, `"Agent"`) are atoms
+already in the atom table from module compilation. For dynamically-registered
+tools (MCP adapters, extensions), the wrapper falls back to
+`[:tau, :tool, :dynamic, :start/:stop]` with the name in metadata.
+
+## Tradeoffs
+
+### Strengths
+
+- Decomplects the contract enforcement from every tool implementation in one
+  change: the wrapper is the single enforcement site.
+- Behaviour-preserving: the `Tau.Tool` callback contract, `Result` struct, and
+  all tool module APIs are unchanged.
+- Minimal blast radius: one new module, one call-site change in
+  `run_tool_validated`, one targeted fix in `bash.ex`.
+- Existing `[:tau, :tool, :execute, :start/:stop/:exception]` events are
+  preserved for consumers already subscribed to them.
+- The `ensure_kind/1` guard makes the acceptance criterion for (b) fully
+  verifiable by a test that calls `Executor.call/3` with a module that omits
+  `:kind` from details.
+
+### Weaknesses
+
+- `String.to_existing_atom/1` is unsafe for arbitrary dynamic tool names; the
+  fallback to `[:tau, :tool, :dynamic, ...]` loses per-tool observability for
+  runtime-registered tools.
+- `ensure_kind/1` injects `:unclassified` rather than raising; this masks
+  authoring errors silently in production (though CI can catch it with a test).
+- Tools that already emit their own `[:tau, :tool, :bash, :stderr]` sub-events
+  now fire both their own sub-event and the new wrapper-level event; operators
+  must understand the two-level namespace.
+- The `persist_full/3` fix degrades silently (returns `nil` on write failure)
+  rather than surfacing the error in the tool result; a caller relying on
+  `details.full_output_path` gets `nil` instead of an error.
+
+### Costs
+
+- One new file (`lib/tau/tool/executor.ex`, ~50 LOC).
+- One-line change in `run_tool_validated`.
+- `bash.ex` `persist_full/3` refactor (~10 LOC delta).
+- Tests: one new unit test for `Executor.call/4`; one property test for
+  `ensure_kind/1`; update `bash.ex` tests that test truncation path.
+- Zero API surface change for tool authors.
+
+## Dependencies
+
+- No library additions required.
+- The `String.to_existing_atom/1` fallback for dynamic tools requires the
+  dynamic-module-generation sub-problem to be at least aware of this naming
+  contract (no hard dependency, but coordination is cleaner if both land
+  together).
+
+## Confidence
+
+Medium. The approach is straightforward and the call-site is clearly identified.
+Confidence would be high if a prototype confirmed that `String.to_existing_atom`
+covers all currently-registered tool names (easily verified with
+`Tau.Tool.list()` at runtime).
+
+## Prior art / references
+
+- `Tau.Session.ToolDispatch.run_tool_validated/6` lines 671–737 — existing
+  outer `try/rescue` and session-level telemetry; the new wrapper nests inside.
+- `Tau.Tools.Builtin.Delegate` — already emits `[:tau, :tool, :delegate,
+  :start/:stop/:exception]` directly; this proposal centralises the same
+  pattern without removing Delegate's own emissions.
+- Elixir `File.mkdir_p/1` / `File.write/1` — non-raising equivalents in stdlib.

--- a/docs/problems-archive-v1-modules/tau-tools-hooks-mcp/subproblems/tool-result-contract/proposals/proposal-2.md
+++ b/docs/problems-archive-v1-modules/tau-tools-hooks-mcp/subproblems/tool-result-contract/proposals/proposal-2.md
@@ -1,0 +1,224 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 2
+parent_problem: ../problem.md
+---
+
+# Proposal 2: Typed `Result.Details` structs with a behaviour callback
+
+## Approach
+
+Replace the untyped `details: map()` field in `Tau.Tool.Result` with a typed
+union: define one struct per tool family (e.g. `Tau.Tool.Result.Details.Bash`,
+`Tau.Tool.Result.Details.File`, `Tau.Tool.Result.Details.Edit`,
+`Tau.Tool.Result.Details.Image`, `Tau.Tool.Result.Details.Delegate`,
+`Tau.Tool.Result.Details.Error`) each carrying a mandatory `:kind` atom literal
+in their `@enforce_keys`. Add a new optional callback
+`details_struct() :: module()` to the `Tau.Tool` behaviour so the dispatcher
+can verify at registration time that the module names a known details struct.
+Update `Result.t()` so `details` is typed as `Tau.Tool.Result.Details.t()`
+(a union type). Fix `Bash.persist_full/3` to use the non-raising `File`
+variants and populate `%Details.Bash{}` instead of a bare map. All six built-in
+tools are updated to construct their appropriate struct. The existing `details:
+map()` in `ToolResult` (the session-side wire type) is left unchanged for now;
+the conversion happens in `run_tool_validated` when building `ToolResult` from
+`Result`.
+
+## Rationale
+
+The root cause of silent shape drift is that `details` is typed `map()` at both
+the definition site and the usage sites; no tool author or Dialyzer check ever
+catches a missing `:kind`. Introducing struct types makes the contract visible
+at write time (compiler/Dialyzer enforces `@enforce_keys`) and at registration
+time (`details_struct()` callback + a guard in `Tau.Tool.register/1`). This
+decomplects the details schema from each tool's independent map construction:
+every tool must declare its details type, and every struct definition enforces
+`:kind`. Telemetry coverage remains a behavioural property, addressed by the
+existing `run_tool_validated` wrapper (which already has `[:tau, :tool,
+:execute, :start/:stop/:exception]`) rather than being embedded in the struct.
+
+## Sketch
+
+```elixir
+# New file: lib/tau/tool/result/details.ex
+defmodule Tau.Tool.Result.Details do
+  @type t ::
+    Details.Bash.t() | Details.File.t() | Details.Edit.t() |
+    Details.Image.t() | Details.Delegate.t() | Details.Error.t() | map()
+
+  defmodule Bash do
+    @enforce_keys [:kind, :exit_status, :duration_ms, :command]
+    defstruct [
+      :kind,            # always :bash_result
+      :exit_status,
+      :duration_ms,
+      :command,
+      :stderr_bytes,
+      truncated?: false,
+      full_output_path: nil
+    ]
+    @type t :: %__MODULE__{kind: :bash_result, exit_status: integer(), duration_ms: integer(),
+                            command: String.t(), stderr_bytes: non_neg_integer() | nil,
+                            truncated?: boolean(), full_output_path: String.t() | nil}
+  end
+
+  defmodule File do
+    @enforce_keys [:kind, :path, :bytes]
+    defstruct [:kind, :path, :bytes]          # kind: :file_write | :file_error
+    @type t :: %__MODULE__{kind: :file_write | :file_error, path: String.t(), bytes: non_neg_integer()}
+  end
+
+  defmodule Edit do
+    @enforce_keys [:kind, :path, :edit_count]
+    defstruct [:kind, :path, :edit_count, :diff, :first_changed_line]
+    @type t :: %__MODULE__{kind: :edit_result, path: String.t(), edit_count: non_neg_integer(),
+                            diff: String.t() | nil, first_changed_line: non_neg_integer() | nil}
+  end
+
+  defmodule Image do
+    @enforce_keys [:kind, :bytes, :media_type]
+    defstruct [:kind, :bytes, :media_type]
+    @type t :: %__MODULE__{kind: :image, bytes: non_neg_integer(), media_type: String.t()}
+  end
+
+  defmodule Delegate do
+    @enforce_keys [:kind, :agent, :adapter]
+    defstruct [:kind, :agent, :adapter, :workspace, :events_count,
+               :tool_uses, :tool_results, :file_edits, :cost,
+               :exit_status, :final_message]
+    @type t :: %__MODULE__{kind: :delegate_result | :delegate_timeout |
+                            :delegate_cancelled | :delegate_error | :delegate_nonzero_exit,
+                            agent: String.t(), adapter: module()}
+  end
+
+  defmodule Error do
+    @enforce_keys [:kind]
+    defstruct [:kind, :exception, :reason, :command, :timeout_ms, :agent, :depth, :max_depth]
+    @type t :: %__MODULE__{kind: :raised_exception | :bash_timeout | :unknown_agent |
+                            :depth_exceeded | :workspace_error | :dispatcher_start_failed |
+                            :unclassified}
+  end
+end
+```
+
+```elixir
+# Updated lib/tau/tool/result.ex
+defmodule Tau.Tool.Result do
+  alias Tau.Tool.Result.Details
+
+  defstruct content: "", details: %Details.Error{kind: :unclassified},
+            terminate?: false, is_error: false
+
+  @type t :: %__MODULE__{
+    content: String.t() | [map()],
+    details: Details.t(),
+    terminate?: boolean(),
+    is_error: boolean()
+  }
+end
+```
+
+```elixir
+# Updated Tau.Tool behaviour — new optional callback
+@callback details_struct() :: module()
+@optional_callbacks [execution_mode: 0, streams_updates?: 0, details_struct: 0]
+
+# Updated Tau.Tool.register/1 — warn on missing details_struct
+def register(mod) when is_atom(mod) do
+  if function_exported?(mod, :details_struct, 0) do
+    :ok
+  else
+    require Logger
+    Logger.warning("Tool #{mod} does not implement details_struct/0; details shape unverified")
+  end
+  Registry.register(Tau.Tools.Registry, mod.name(), mod)
+end
+```
+
+```elixir
+# Example: Updated Bash.execute/2 result construction
+{:ok, %Result{
+  content: full,
+  details: %Details.Bash{
+    kind: :bash_result,
+    exit_status: status,
+    duration_ms: dur,
+    command: cmd,
+    stderr_bytes: byte_size(err),
+    truncated?: truncated?,
+    full_output_path: full_path
+  },
+  is_error: status != 0
+}}
+```
+
+The `details` field in `Tau.Message.ToolResult` (session wire type) continues
+to accept `map()`; `run_tool_validated` converts via `Map.from_struct/1` at the
+boundary so downstream consumers need no change.
+
+## Tradeoffs
+
+### Strengths
+
+- Makes the `:kind` contract visible and compile-time-enforced via
+  `@enforce_keys`; Dialyzer will flag struct mismatches.
+- Decomplects the schema contract from tool implementations by moving it to the
+  type system; tools cannot accidentally omit `:kind` without a compile error.
+- The `details_struct/0` optional callback enables registration-time auditing
+  without breaking existing tools immediately (warning-only mode).
+- Self-documenting: callers can pattern-match on struct type rather than
+  checking the `:kind` atom, which is more robust.
+- Enables Dialyzer coverage across the full pipeline from `execute/2` to
+  `ToolResult`.
+
+### Weaknesses
+
+- API-breaking: all six built-in tools must be updated simultaneously; any
+  external or extension tool that returns bare maps will generate warnings (or
+  errors if the guard is hardened to fail-closed).
+- `Map.from_struct/1` at the ToolResult boundary loses the struct type
+  information for downstream consumers; they still see plain maps in
+  `%ToolResult{details: %{}}`.
+- New details struct taxonomy may not cover all future tool shapes; unknown
+  structs degrade to `%Details.Error{kind: :unclassified}` requiring ongoing
+  taxonomy maintenance.
+- Telemetry coverage is not enforced by this proposal — it relies on the
+  existing session-level `[:tau, :tool, :execute, ...]` events. Per-tool
+  `[:tau, :tool, <name>, ...]` telemetry remains non-uniform.
+- The `Details.Delegate` struct is large and duplicates fields already in
+  `Tau.CodingAgent.Event` structs; maintenance burden is doubled.
+
+### Costs
+
+- Six new struct modules (~100 LOC for `details.ex`).
+- Updates to all six built-in tool `execute/2` return sites (~40 LOC delta).
+- `Result.t()` type annotation update.
+- `Tau.Tool.register/1` update.
+- Tests: update all tool unit tests that assert on `details` map shape (~20
+  assertion updates); add Dialyzer as a gate if not already running.
+- No downstream session changes required (conversion at `run_tool_validated`).
+
+## Dependencies
+
+- Dialyzer in CI (already present per `mix dialyzer` in the project).
+- No library additions.
+- Coordination with extensions/MCP tool adapter authors if `details_struct/0`
+  is ever hardened to fail-closed.
+
+## Confidence
+
+Medium. The struct taxonomy is straightforward and the `@enforce_keys` mechanism
+is idiomatic Elixir. Confidence would be higher after verifying Dialyzer
+catches `%Details.Bash{kind: nil}` (i.e., that `@enforce_keys` triggers
+a Dialyzer warning rather than just a compile error for omission in `new/1`).
+
+## Prior art / references
+
+- `Tau.Tools.Builtin.Delegate.finalize_result/2` — already uses pattern-matched
+  `:kind` values; this proposal formalises what Delegate does informally.
+- Elixir `@enforce_keys` — compiler-enforced struct field presence.
+- Phoenix `%Socket{}` / `%Conn{}` — typed struct pattern used extensively
+  in the Elixir ecosystem to enforce field contracts without runtime overhead.
+- `Tau.CodingAgent.Event` structs — precedent for struct-per-event-type in
+  the same codebase.

--- a/docs/problems-archive-v1-modules/tau-tools-hooks-mcp/subproblems/tool-result-contract/proposals/proposal-3.md
+++ b/docs/problems-archive-v1-modules/tau-tools-hooks-mcp/subproblems/tool-result-contract/proposals/proposal-3.md
@@ -1,0 +1,233 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 3
+parent_problem: ../problem.md
+---
+
+# Proposal 3: `use Tau.Tool` DSL macro that wraps `execute/2` at compile time
+
+## Approach
+
+Extend `Tau.Tool` with a `__using__/1` macro that injects a public `execute/2`
+wrapper around the module's `@impl Tau.Tool` `execute/2` implementation
+(renamed to `do_execute/2`). The macro-injected `execute/2`:
+(a) wraps `do_execute/2` in a `try/rescue` that converts raises to
+`{:ok, Result.error(...)}`,
+(b) asserts the returned `Result.details` has a `:kind` key and injects
+`:unclassified` if absent (with a `Logger.warning/1` in dev/test),
+(c) emits `[:tau, :tool, <name_atom>, :start]` / `[:tau, :tool, <name_atom>,
+:stop]` / `[:tau, :tool, <name_atom>, :exception]` telemetry spans.
+Each built-in tool keeps its current module shape but replaces `@impl Tau.Tool`
+`def execute(...)` with `@impl Tau.Tool` `def do_execute(...)` and adds
+`use Tau.Tool` at the top. `Bash.persist_full/3` is fixed separately using
+non-raising `File` variants. The `Tau.Tool` behaviour gains `do_execute/2` as
+its primary callback (replacing `execute/2`); `execute/2` becomes the macro-
+injected public wrapper.
+
+## Rationale
+
+The complecting hypothesis is that the contract enforcement is woven into each
+tool implementation because there is no dispatch layer between the FSM and
+the tool. The `use` macro creates that layer inside each tool module itself,
+so the tool module owns a conformant public interface without each author
+having to remember the three properties. Unlike a central executor (Proposal 1),
+enforcement is local to the module boundary: any caller of `Bash.execute/2`
+directly (e.g. tests calling the tool in isolation) also benefits. Unlike typed
+structs (Proposal 2), enforcement happens at runtime for all callers, not just
+via static analysis. The behaviour callback rename from `execute` to
+`do_execute` makes it impossible for a tool to accidentally bypass the wrapper
+by implementing the old callback name — the compiler will warn about an
+unimplemented `do_execute/2`.
+
+## Sketch
+
+```elixir
+# lib/tau/tool.ex — add __using__/1 and rename primary callback
+defmodule Tau.Tool do
+  @callback name() :: String.t()
+  @callback description() :: String.t()
+  @callback parameters() :: map()
+
+  # Renamed from execute/2; macro injects a conformant execute/2
+  @callback do_execute(params :: map(), ctx :: Context.t()) ::
+              {:ok, Result.t()} | {:error, term()}
+
+  @callback execution_mode() :: :sequential | :parallel
+  @callback streams_updates?() :: boolean()
+
+  @optional_callbacks [execution_mode: 0, streams_updates?: 0]
+
+  defmacro __using__(_opts) do
+    quote do
+      @behaviour Tau.Tool
+      alias Tau.Tool.Result
+
+      # The macro-generated wrapper; modules implement do_execute/2 instead.
+      def execute(params, ctx) do
+        tool_name = __MODULE__.name()
+        # Safe: module names are compile-time atoms
+        telem_name = Module.concat([Tau.Tool, __MODULE__]) |> then(fn _ ->
+          # Use a per-module atom derived from the module name
+          __MODULE__
+          |> Module.split()
+          |> List.last()
+          |> String.downcase()
+          |> String.to_atom()
+        end)
+
+        started = System.monotonic_time(:millisecond)
+
+        :telemetry.execute(
+          [:tau, :tool, telem_name, :start],
+          %{system_time: System.system_time()},
+          %{tool: tool_name, tool_call_id: ctx.tool_call_id, session_id: ctx.session_id}
+        )
+
+        {event, outcome} =
+          try do
+            case __MODULE__.do_execute(params, ctx) do
+              {:ok, %Result{} = r} ->
+                r = maybe_inject_kind(r, tool_name)
+                {:stop, {:ok, r}}
+
+              {:error, _} = err ->
+                {:stop, err}
+            end
+          rescue
+            e ->
+              {:exception,
+               {:ok, Result.error("Tool raised: #{Exception.message(e)}",
+                 details: %{kind: :raised_exception, exception: Exception.message(e)})}}
+          end
+
+        :telemetry.execute(
+          [:tau, :tool, telem_name, event],
+          %{duration: System.monotonic_time(:millisecond) - started},
+          %{tool: tool_name, tool_call_id: ctx.tool_call_id,
+            is_error: match?({:ok, %Result{is_error: true}}, outcome)}
+        )
+
+        outcome
+      end
+
+      defoverridable execute: 2
+
+      defp maybe_inject_kind(%Result{details: %{kind: _}} = r, _name), do: r
+      defp maybe_inject_kind(%Result{details: d} = r, name) do
+        require Logger
+        if Mix.env() in [:dev, :test] do
+          Logger.warning("Tool #{name} returned details without :kind; injecting :unclassified")
+        end
+        %{r | details: Map.put(d, :kind, :unclassified)}
+      end
+    end
+  end
+
+  # ... rest of Tau.Tool unchanged
+end
+```
+
+```elixir
+# Example: Updated lib/tau/tools/builtin/write.ex
+defmodule Tau.Tools.Builtin.Write do
+  use Tau.Tool   # <-- replaces `@behaviour Tau.Tool`
+
+  @impl Tau.Tool
+  def name, do: "Write"
+  # ... description, parameters, execution_mode unchanged ...
+
+  # Renamed from execute/2
+  @impl Tau.Tool
+  def do_execute(%{"path" => path, "content" => content}, ctx) do
+    full = ctx.operations.resolve(path, ctx.cwd)
+    bytes = byte_size(content)
+
+    case ctx.operations.write(full, content) do
+      :ok ->
+        {:ok, Result.text("Wrote #{bytes} bytes to #{full}",
+          details: %{kind: :file_write, path: full, bytes: bytes})}  # kind added
+      {:error, e} ->
+        {:ok, Result.error("Write failed: #{inspect(e)}")}
+    end
+  end
+end
+```
+
+```elixir
+# The session dispatcher: no change needed.
+# run_tool_validated/6 still calls mod.execute(args, ctx),
+# which now resolves to the macro-injected wrapper.
+```
+
+The `String.to_atom/1` call inside the macro is safe at compile time because
+it runs against the module's own compile-time name literal; it is not called
+at runtime with user-supplied strings.
+
+## Tradeoffs
+
+### Strengths
+
+- Enforcement is local to the tool module boundary; every caller of a tool
+  module's `execute/2` (tests, inspectors, extensions) benefits — not just the
+  session dispatcher path.
+- No change required to `run_tool_validated/6` or any session FSM code.
+- The callback rename from `execute/2` to `do_execute/2` makes it a compile-
+  time error for any tool module using `use Tau.Tool` to forget the rename,
+  because the `@behaviour` check fires on `do_execute`.
+- Telemetry is per-tool and idiomatic (per-module atom, safe at compile time).
+- Tool authors who opt into `use Tau.Tool` get the three properties for free;
+  the pattern is well-understood in the Elixir ecosystem (`use GenServer`,
+  `use Phoenix.LiveView`).
+
+### Weaknesses
+
+- The callback rename (`execute` → `do_execute`) is a breaking change for any
+  external tool that implements `@behaviour Tau.Tool` directly without
+  `use Tau.Tool`. The old `execute/2` callback must be deprecated rather than
+  removed, creating a two-callback period.
+- `defoverridable execute: 2` means a tool can still override the wrapper;
+  discipline at code review is required to prevent bypasses.
+- Modules that do NOT use `use Tau.Tool` (e.g., external or legacy tools)
+  continue to call `execute/2` directly and receive no wrapper benefits; the
+  property is not universally enforced without requiring all tools to migrate.
+- The macro-injected `maybe_inject_kind/2` private function may conflict with
+  a tool module that defines its own private function of the same name.
+- Testing the macro-injected behaviour requires either a purpose-built stub
+  module or importing the macro in test scope.
+
+### Costs
+
+- Modification to `lib/tau/tool.ex` to add `__using__/1` and rename primary
+  callback (~60 LOC added; ~5 LOC changed).
+- Six built-in tools: rename `execute` → `do_execute` and add `use Tau.Tool`
+  (~12 LOC delta total across all six, plus `:kind` additions).
+- `Bash.persist_full/3`: fix raising File calls (~10 LOC).
+- Tests: rename `execute` to `do_execute` in any unit tests that call the
+  callback directly rather than through `execute/2`; update assertion shapes.
+- Deprecation shim for `execute/2` callback to avoid breaking external tools.
+
+## Dependencies
+
+- No library additions.
+- All six built-in tools must be updated atomically to use `use Tau.Tool` (or
+  individually; the macro is opt-in so incremental migration is possible).
+- Any extension tools or MCP adapters that implement `Tau.Tool` directly will
+  continue to work unchanged but will not gain the wrapper properties until
+  they opt in.
+
+## Confidence
+
+Medium. The `use` macro pattern is idiomatic and well-tested in Elixir. The
+main uncertainty is the `String.to_atom/1` compile-time safety for dynamically
+named tools registered at runtime (MCP adapters). A prototype would clarify
+whether the atom table concern is real for the current tool surface.
+
+## Prior art / references
+
+- `use GenServer` / `use Phoenix.LiveView` — established Elixir pattern for
+  injecting behaviour-conformant wrappers via macro.
+- `Tau.Tools.Builtin.Delegate` — already has its telemetry pattern inline;
+  `use Tau.Tool` would supersede Delegate's manual emit calls.
+- `Plug.Builder` — wraps the `call/2` callback in a pipeline via `use Plug.Builder`.
+- Elixir `defoverridable` — enables hook-and-override for injected default implementations.

--- a/docs/problems-archive-v1-modules/tau-tools-hooks-mcp/subproblems/tool-result-contract/proposals/proposal-4.md
+++ b/docs/problems-archive-v1-modules/tau-tools-hooks-mcp/subproblems/tool-result-contract/proposals/proposal-4.md
@@ -1,0 +1,290 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 4
+parent_problem: ../problem.md
+---
+
+# Proposal 4: Contract-enforcement test suite with a shared `ToolContractCase` + targeted production fixes
+
+## Approach
+
+Rather than adding a runtime enforcement layer, invest in two targeted changes:
+(1) fix the live raise paths directly in source (`Bash.persist_full/3` using
+non-raising `File` variants; no other tool has reachable raise paths on user
+input), and (2) create a shared `test/support/tool_contract_case.ex` module
+that every built-in tool test must `use`, providing three standard contract
+assertions: `assert_no_raise/2` (runs `execute/2` with adversarial inputs and
+asserts no exception propagates), `assert_kind_present/1` (asserts
+`result.details` contains `:kind`), and `assert_tool_telemetry/2` (subscribes
+to telemetry and asserts `[:tau, :tool, :execute, :start]` / `[:tau, :tool,
+:execute, :stop]` fire for every `execute/2` call). The existing session-level
+`[:tau, :tool, :execute, :start/:stop/:exception]` telemetry in
+`run_tool_validated` satisfies the telemetry acceptance criterion via
+inspection; per-tool `[:tau, :tool, <name>, ...]` events are not added in this
+proposal. Built-in tools that currently lack `:kind` in `details` (Bash,
+Write, Edit) are patched to include it.
+
+## Rationale
+
+The complecting hypothesis holds that the three properties are each tool's
+independent responsibility because there is no central enforcement point. This
+proposal accepts that framing but challenges the conclusion: the acceptance
+criterion says "verifiable by inspection or a test that exercises the contract
+at the dispatch layer." The existing `run_tool_validated` wrapper already emits
+session-level telemetry and already has the outer `try/rescue`; the problem is
+that this is not verified by a test. Adding a `ToolContractCase` makes the
+contract machine-verifiable at the tool boundary without adding any production
+runtime overhead or changing any call paths. The targeted `persist_full/3` fix
+removes the only reachable raise path. The result is a codebase where a
+regression in any tool's contract is caught immediately by CI, using the test
+suite as the enforcement boundary rather than a runtime wrapper.
+
+## Sketch
+
+```elixir
+# New file: test/support/tool_contract_case.ex
+defmodule Tau.ToolContractCase do
+  @moduledoc """
+  Shared contract assertions for Tau.Tool implementations.
+
+  use Tau.ToolContractCase, tool: Tau.Tools.Builtin.Bash
+
+  Provides:
+    - assert_contract_on_execute/2 — runs execute/2 with given params and
+      asserts (a) no exception raised, (b) details has :kind, (c) telemetry fires.
+  """
+
+  use ExUnit.CaseTemplate
+
+  alias Tau.Tool.Result
+
+  using opts do
+    tool_mod = Keyword.fetch!(opts, :tool)
+
+    quote do
+      import Tau.ToolContractCase
+
+      @tool_mod unquote(tool_mod)
+
+      test "execute/2 never raises on adversarial inputs" do
+        assert_no_raise(@tool_mod)
+      end
+
+      test "execute/2 result includes :kind in details" do
+        assert_kind_present(@tool_mod)
+      end
+
+      test "execute/2 triggers [:tau, :tool, :execute, :start/:stop] telemetry" do
+        assert_tool_telemetry(@tool_mod)
+      end
+    end
+  end
+
+  @doc "Assert that execute/2 with adversarial inputs does not raise."
+  def assert_no_raise(mod) do
+    adversarial_inputs = [
+      %{},                            # empty params
+      %{"path" => nil},               # nil value
+      %{"command" => ""},             # empty command
+      %{"path" => "/dev/null/nonexistent/deeply/nested"}
+    ]
+
+    Enum.each(adversarial_inputs, fn params ->
+      ctx = build_test_ctx()
+      result =
+        try do
+          mod.execute(params, ctx)
+          :ok
+        rescue
+          e -> {:raised, Exception.message(e)}
+        end
+
+      assert result == :ok,
+             "#{mod}.execute/2 raised on params #{inspect(params)}: #{inspect(result)}"
+    end)
+  end
+
+  @doc "Assert that a successful execute/2 returns details with a :kind key."
+  def assert_kind_present(mod) do
+    ctx = build_test_ctx()
+    # Use valid minimal params for the tool
+    params = minimal_valid_params(mod)
+
+    case mod.execute(params, ctx) do
+      {:ok, %Result{details: details}} ->
+        assert Map.has_key?(details, :kind),
+               "#{mod}.execute/2 returned details without :kind: #{inspect(details)}"
+
+      {:error, _} ->
+        :skip  # error path; kind assertion is on the success path
+    end
+  end
+
+  @doc "Assert that execute/2 fires [:tau, :tool, :execute, :start] and :stop telemetry."
+  def assert_tool_telemetry(mod) do
+    test_pid = self()
+    ref = make_ref()
+
+    handler_id = {__MODULE__, ref}
+
+    :telemetry.attach_many(
+      handler_id,
+      [[:tau, :tool, :execute, :start], [:tau, :tool, :execute, :stop],
+       [:tau, :tool, :execute, :exception]],
+      fn event, measurements, _meta, _ ->
+        send(test_pid, {:telemetry_fired, ref, event, measurements})
+      end,
+      nil
+    )
+
+    ctx = build_test_ctx()
+    params = minimal_valid_params(mod)
+
+    # Execute via the session dispatcher path (which emits the events)
+    Tau.Session.ToolDispatch.run_tool(mod.name(), "test-call-id", params,
+      build_test_session_data())
+
+    :telemetry.detach(handler_id)
+
+    assert_received {:telemetry_fired, ^ref, [:tau, :tool, :execute, :start], _}
+    assert_received {:telemetry_fired, ^ref, [:tau, :tool, :execute, :stop], _}
+  end
+
+  defp build_test_ctx do
+    Tau.Tool.Context.new(
+      tool_call_id: "contract-test",
+      session_id: "contract-test-session",
+      cwd: System.tmp_dir!(),
+      emit: fn _ -> :ok end
+    )
+  end
+
+  defp build_test_session_data do
+    # Minimal Data struct sufficient for run_tool/4 dispatch path
+    %Tau.Session.Data{
+      id: "contract-test-session",
+      cwd: System.tmp_dir!(),
+      operations: Tau.Tools.Operations.Local,
+      metadata: %{}
+    }
+  end
+
+  defp minimal_valid_params(Tau.Tools.Builtin.Bash),  do: %{"command" => "echo test"}
+  defp minimal_valid_params(Tau.Tools.Builtin.Read),  do: %{"path" => "nonexistent.txt"}
+  defp minimal_valid_params(Tau.Tools.Builtin.Write), do: %{"path" => "/tmp/contract-test.txt", "content" => "test"}
+  defp minimal_valid_params(Tau.Tools.Builtin.Edit),  do: %{"path" => "nonexistent.txt", "edits" => [%{"old_text" => "x", "new_text" => "y"}]}
+  defp minimal_valid_params(_mod),                    do: %{}
+end
+```
+
+```elixir
+# Example: Updated test/tau/tools/builtin/bash_test.exs
+defmodule Tau.Tools.Builtin.BashTest do
+  use Tau.ToolContractCase, tool: Tau.Tools.Builtin.Bash
+  # ... existing tests unchanged below ...
+end
+```
+
+```elixir
+# Targeted production patch: lib/tau/tools/builtin/bash.ex
+# persist_full/3 — replace raising calls:
+  defp persist_full(output, session_id, call_id) do
+    dir = Tau.Settings.data_dir() |> Path.join("sessions") |> Path.join(session_id || "default")
+    with :ok <- File.mkdir_p(dir),
+         path = Path.join(dir, "bash-#{call_id}.log"),
+         :ok <- File.write(path, output) do
+      path
+    else
+      _ -> nil
+    end
+  end
+
+# execute/2 — add :kind to details map:
+  details: %{
+    kind: :bash_result,      # <-- added
+    exit_status: status,
+    ...
+  }
+```
+
+```elixir
+# Targeted production patches (details only — no structural change):
+# write.ex:  add kind: :file_write to details map
+# edit.ex:   add kind: :edit_result to details map
+# (read.ex:  already has kind: :text / kind: :image — no change)
+# (delegate.ex: already has kind: :delegate_result etc. — no change)
+```
+
+## Tradeoffs
+
+### Strengths
+
+- Zero production runtime overhead: no new dispatch layer, no new wrapper,
+  no telemetry overhead beyond what already exists.
+- Minimal blast radius: three production files patched (bash, write, edit);
+  one new test support file; six test files get `use Tau.ToolContractCase`.
+- The `ToolContractCase` is a permanent regression guard: any future tool
+  that forgets `:kind` or introduces a raise is caught in CI automatically.
+- The acceptance criterion's "verifiable by inspection or a test" language
+  explicitly allows this path; the test exercises "the contract at the dispatch
+  layer" via `run_tool/4`.
+- No API changes to `Tau.Tool`, `Tau.Tool.Result`, or any tool module's public
+  interface.
+- Behaviour-preserving: callers of tool modules see the same interface.
+
+### Weaknesses
+
+- Does NOT decomplect the contract from the implementations in the code-
+  structural sense: each tool still independently owns its details shape;
+  the `ToolContractCase` verifies compliance but does not centralise
+  enforcement. A new tool author can still ship a non-conformant tool and
+  CI will catch it only if the new tool has a test using `ToolContractCase`.
+- Per-tool `[:tau, :tool, <name>, :start/:stop]` telemetry is not added;
+  the acceptance criterion's (c) is satisfied only at the session-level
+  boundary (`[:tau, :tool, :execute, ...]`), not at the per-tool level.
+  The problem statement identifies individual tools' absence of per-tool
+  telemetry as a finding; this proposal addresses it only partially.
+- `assert_no_raise/2` uses a fixed adversarial input list; an input that
+  happens to be syntactically valid but triggers the raise path may not
+  be in the list. The `persist_full` fix is still required because
+  constructing a valid truncation-triggering input in tests is complex.
+- `ToolContractCase` introduces a dependency on `Tau.Session.Data` in the
+  test support layer; changes to `Data` struct fields may break the
+  `build_test_session_data/0` helper.
+- The telemetry assertion (`assert_tool_telemetry/2`) calls through
+  `run_tool/4` which requires a running `Tau.Tools.Registry`; this is an
+  integration-level dependency in what should be a unit test.
+
+### Costs
+
+- One new test support file (~100 LOC): `test/support/tool_contract_case.ex`.
+- Six built-in test files: add `use Tau.ToolContractCase` (~1 LOC each).
+- Three production patches: `bash.ex` persist_full (~10 LOC), `write.ex`
+  kind field (~1 LOC), `edit.ex` kind field (~1 LOC).
+- No changes to session code, behaviour contracts, or struct definitions.
+
+## Dependencies
+
+- `Tau.Session.Data` struct must be constructible with a minimal set of fields
+  for the `build_test_session_data/0` helper; verify no `@enforce_keys`.
+- `Tau.Tools.Registry` must be started for the telemetry assertion path;
+  requires test setup or a `DataCase`-style test helper.
+
+## Confidence
+
+High for the no-raise and details-kind criteria; medium for the telemetry
+criterion. The telemetry assertion path through `run_tool/4` requires a
+running registry, which adds integration test complexity. Confidence would
+increase if the telemetry assertion used a mock/stub operations layer to
+avoid registry startup.
+
+## Prior art / references
+
+- `ExUnit.CaseTemplate` — standard Elixir pattern for shared test case setup
+  and contract assertion suites.
+- `Plug.Test` / `Phoenix.ConnCase` — precedent for `use XCase` patterns that
+  inject reusable assertions into test modules.
+- `Tau.Session.ToolDispatch.run_tool_validated/6` lines 688–736 — the existing
+  session-level telemetry and `try/rescue` that satisfy the telemetry criterion
+  via inspection; this proposal verifies them with a test rather than replacing them.

--- a/docs/problems-archive-v1-modules/tau-tools-hooks-mcp/subproblems/tool-result-contract/solution.md
+++ b/docs/problems-archive-v1-modules/tau-tools-hooks-mcp/subproblems/tool-result-contract/solution.md
@@ -1,0 +1,152 @@
+---
+template_version: 1
+template_name: solution
+parent_problem: ./problem.md
+node_kind: leaf
+synthesised_from: [proposals/proposal-1.md]
+selection_method: single
+revision: 0
+---
+
+# Solution: Central `Tau.Tool.Executor` dispatch wrapper enforces the three contract properties
+
+## Recommendation
+
+Introduce a single dispatch wrapper, `Tau.Tool.Executor.call/4`, between
+`Tau.Session.ToolDispatch.run_tool_validated/6` and any tool module's
+`execute/2`. The wrapper is the one site responsible for enforcing the three
+Tau.Tool contract points: (a) a `try/rescue` around `execute/2` that converts
+any raise into `{:ok, Result.error(..., details: %{kind: :raised_exception,
+...})}` before the existing outer guard sees it; (b) an `ensure_kind/1` guard
+that injects `:unclassified` if a tool's `Result.details` omits `:kind`; and
+(c) `[:tau, :tool, <name_atom>, :start]` / `:stop` / `:exception` telemetry
+spans around every call. The live raise paths in `Bash.persist_full/3`
+(`File.mkdir_p!/1`, `File.write!/1`) are simultaneously rewritten to the
+non-raising `File.mkdir_p/1` / `File.write/1` variants so the executor's
+rescue is defence-in-depth rather than the sole barrier. The `Tau.Tool`
+behaviour, the `Tau.Tool.Result` struct, and every tool's public callback
+signature are unchanged.
+
+## Selected from
+
+- **Chosen:** `proposals/proposal-1.md`
+- **Why chosen:** Of the four proposals, only Proposal 1 satisfies all three
+  acceptance criteria (a, b, c) at a single decomplected enforcement site
+  without imposing a high migration cost or a hard-to-reverse change.
+  Comparison table:
+
+  | # | Fit | Decomplecting depth | Migration cost | Risk | Reversibility |
+  |---|---|---|---|---|---|
+  | 1 | Yes (a, b, c) | Substantial | Low–Medium | Low | Easy |
+  | 2 | Partially (b only) | Surface | High | Medium | Hard |
+  | 3 | Yes (a, b, c) | Substantial | Medium | Medium | Hard |
+  | 4 | Partially (a, b; c at session level only) | Surface | Low | Low | Easy |
+
+  Proposal 2 (typed `Details` structs) decomplects schema visibility but
+  re-complects via `Map.from_struct/1` at the `ToolResult` boundary, addresses
+  neither no-raise nor per-tool telemetry, and demands an API-breaking
+  taxonomy change across all six built-ins. Proposal 3 (`use Tau.Tool` macro)
+  delivers the same enforcement scope as Proposal 1 but pays for it with a
+  breaking callback rename (`execute` → `do_execute`), a `defoverridable`
+  bypass that erodes the guarantee, and macro-injected private helpers that
+  can collide with module-local names; reversibility is worse because every
+  tool's compile-time shape changes. Proposal 4 (contract test case) is a
+  useful regression guard but does not decomplect — each tool still
+  independently owns the three properties; CI only catches what tests cover.
+  Proposal 1 isolates enforcement to one composable function on the existing
+  dispatch path, preserves every public interface, and is removable by
+  deleting one module and reverting one line — the strongest score on
+  decomplecting depth, reversibility, and composition.
+
+## What changes
+
+- **New file:** `lib/tau/tool/executor.ex` — defines `Tau.Tool.Executor.call/4`
+  with the rescue, `ensure_kind/1` injection, and per-tool telemetry spans.
+- **Modified:** `lib/tau/session/tool_dispatch.ex` — `run_tool_validated/6`
+  replaces its direct `mod.execute(args || %{}, ctx)` call with
+  `Tau.Tool.Executor.call(mod, args || %{}, ctx, started)`. The existing
+  outer `try/rescue` and `[:tau, :tool, :execute, :start/:stop/:exception]`
+  session-level telemetry are retained.
+- **Modified:** `lib/tau/tools/builtin/bash.ex` — `persist_full/3` rewritten
+  to use `File.mkdir_p/1` and `File.write/1`, returning `nil` on failure
+  (truncation-log path is best-effort and degrades silently).
+- **New tests:** unit test for `Tau.Tool.Executor.call/4` covering the three
+  contract properties (a stub `RaisingTool`, a stub `MissingKindTool`, and a
+  conformant stub assert telemetry-event firing); a property test for
+  `ensure_kind/1` over arbitrary `Result.details` maps; updated `bash.ex`
+  truncation-path tests reflecting the `nil`-on-error degradation.
+- **Telemetry naming:** per-tool atom derived from the tool's compile-time
+  module name (`String.to_existing_atom(String.downcase(mod.name()))`); for
+  runtime-registered tools whose name is not already in the atom table, the
+  wrapper falls back to `[:tau, :tool, :dynamic, :start/:stop/:exception]`
+  with the tool name in metadata. This preserves observability without
+  introducing an atom-table-growth attack surface.
+
+## What does not change
+
+- The `Tau.Tool` behaviour callback signatures (`name/0`, `description/0`,
+  `parameters/0`, `execute/2`, `execution_mode/0`, `streams_updates?/0`).
+- The `Tau.Tool.Result` struct definition (`content`, `details`, `terminate?`,
+  `is_error`); `details` remains typed `map()`.
+- Every existing tool module's public API and module shape.
+- The session-side `Tau.Message.ToolResult` wire type and JSONL persistence
+  format.
+- The existing `[:tau, :tool, :execute, :start/:stop/:exception]`
+  session-level telemetry events; per-tool events are additive.
+- `Tau.Tools.Builtin.Delegate`'s pre-existing `[:tau, :tool, :delegate,
+  :start/:stop/:exception]` events; the wrapper's events are emitted in
+  addition and operators see a two-level namespace (documented in the
+  Executor's moduledoc).
+- The MCP `ToolAdapter` and `Tau.Hook` dispatch paths — both out of scope
+  per problem.md.
+
+## Migration sketch
+
+Land in one PR. Sequence: (1) introduce `Tau.Tool.Executor` with full unit
+test coverage; (2) swap the one-line call in `run_tool_validated/6`; (3)
+rewrite `Bash.persist_full/3` to non-raising variants and update its
+truncation-path tests; (4) update tool unit tests that assert on
+`details` shape if they were relying on the absence of `:kind` (none are
+expected — `ensure_kind/1` adds a key only when missing). The change is
+behaviour-preserving for all conformant existing tools; tools that already
+populate `:kind` see no shape change, and tools that already emit their own
+sub-namespace telemetry continue to do so. Reversal is two file deletions
+and one revert.
+
+## Open questions
+
+- Should `ensure_kind/1` injection of `:unclassified` emit a
+  `Logger.warning/1` in `:dev` and `:test` to surface authoring errors during
+  development without failing in production? The proposal is silent; the
+  conservative choice is to warn in dev/test and stay silent in prod, but
+  this can be deferred.
+- For runtime-registered tools (MCP adapters, extensions) whose names are
+  not compile-time atoms, the fallback `[:tau, :tool, :dynamic, ...]`
+  namespace loses per-tool observability granularity. Is the metadata-tag
+  workaround sufficient, or should runtime-registered tools opt into atom
+  pre-registration at registration time?
+- Should a CI-only contract test (the `ToolContractCase` idea from Proposal
+  4) be added as a separate follow-up to guard against future tools
+  bypassing the executor by being called outside `run_tool_validated/6`
+  (e.g., from a test harness)? Not required for the acceptance criterion
+  but a useful defence-in-depth.
+- The `Bash.persist_full/3` `nil`-on-error degradation may be observed by
+  downstream consumers expecting `details.full_output_path` to be either a
+  valid path or absent. Confirm no current consumer treats `nil` as a path.
+
+## Linked sub-problems / proposals
+
+- `proposals/proposal-1.md` — Central dispatch wrapper in
+  `run_tool_validated/6` (chosen).
+- `proposals/proposal-2.md` — Typed `Result.Details` structs with a behaviour
+  callback (rejected: high cost, addresses only schema, hard to reverse).
+- `proposals/proposal-3.md` — `use Tau.Tool` DSL macro that wraps `execute/2`
+  at compile time (rejected: breaking callback rename, `defoverridable`
+  bypass, macro/private-name collision risk).
+- `proposals/proposal-4.md` — Contract-enforcement test suite with shared
+  `ToolContractCase` + targeted production fixes (rejected: does not
+  decomplect; per-tool telemetry criterion only partially met).
+
+## Revision history
+
+- (revision 0 — initial)

--- a/docs/problems-archive-v1-modules/tau-tools-hooks-mcp/subproblems/tool-result-contract/validation.md
+++ b/docs/problems-archive-v1-modules/tau-tools-hooks-mcp/subproblems/tool-result-contract/validation.md
@@ -1,0 +1,601 @@
+---
+template_version: 1
+template_name: validation
+parent_solution: ./solution.md
+parent_problem: ./problem.md
+toulmin_complete: true
+falsification_attempted: true
+falsification_outcome: partially_falsified — claim/4
+revision_triggered: none
+---
+
+# Validation: Central `Tau.Tool.Executor` dispatch wrapper enforces the three contract properties
+
+## Overview
+
+The solution proposes one new module (`Tau.Tool.Executor`) interposed at the
+single dispatch site `run_tool_validated/6`, plus a non-raising rewrite of
+`Bash.persist_full/3`. Nine distinct propositions are extracted (one
+recommendation-level, six "what changes", two "what does not change" /
+migration assertions). Each is examined with explicit Toulmin fields and a
+falsification strategy chosen from the catalog. The headline recommendation
+(claim 1), the no-raise rescue (claim 2), the `ensure_kind/1` injection
+(claim 3), the `Bash.persist_full/3` rewrite (claim 5), the
+behaviour-preservation (claim 6), the API-stability claim (claim 7), and the
+reversal claim (claim 9) all withstand falsification. Claim 4 (per-tool
+telemetry under the proposed atom-derivation scheme) is **partially
+falsified** by edge-case enumeration — the qualifier needs narrowing.
+Claim 8's `:dynamic` fallback survives but exposes a hidden granularity-loss
+that is recorded as an outstanding doubt rather than a hard falsification.
+No revision of `solution.md` or `problem.md` is triggered; partial
+falsifications are absorbed into the claim qualifiers.
+
+## Toulmin per claim
+
+The MITRE empirical study on Toulmin formalism found that "participants
+found it difficult to generate Toulmin structures, and their structures
+varied greatly even though they started with the same content"
+(https://www.mitre.org/news-insights/publication/empirical-evaluation-structured-argumentation-using-toulmin-argument).
+This template enforces all six components explicitly with prompts to
+counter that variance.
+
+### Claim 1: A single dispatch wrapper `Tau.Tool.Executor.call/4` between `run_tool_validated/6` and `mod.execute/2` is the one site that enforces the three Tau.Tool contract properties (no-raise, details `:kind`, per-tool telemetry)
+
+- **Claim (C):** Introducing `Tau.Tool.Executor.call/4` as the sole call-site
+  through which tool dispatch flows satisfies acceptance criteria (a), (b),
+  and (c) at a single decomplected enforcement site.
+- **Grounds (G):** Today there is exactly one production call to
+  `mod.execute/2` for built-in tool dispatch:
+  `lib/tau/session/tool_dispatch.ex:696` inside the `try/rescue` of
+  `run_tool_validated/6`. `Tau.Tool.lookup/1`
+  (`lib/tau/tool.ex:47-52`) feeds that single site from
+  `run_tool/4` (`lib/tau/session/tool_dispatch.ex:621-655`). The
+  parallel and sequential paths in `spawn_parallel_dispatcher/3`
+  (`lib/tau/session/tool_dispatch.ex:748-805`) both terminate at this
+  same `run_tool/4` call. No other in-tree dispatch path calls
+  `mod.execute/2` directly.
+- **Warrant (W):** A property enforced by a single mandatory call-site is
+  enforced for all callers that go through that site. This is the
+  decomplecting principle: separating the cross-cutting contract from each
+  tool's domain logic by isolating it to one composable function (Hickey:
+  "complect" = braid together; the wrapper unbraids enforcement from
+  implementation).
+- **Qualifier (Q):** Only callers that pass through `run_tool_validated/6`.
+  Test harnesses, MCP `ToolAdapter`, future extensions, and any code path
+  that resolves a tool module and calls `mod.execute/2` directly are NOT
+  enforced. The solution's "Open question" #3 acknowledges this.
+- **Rebuttal (R):** If a future feature (e.g. a "tool inspection" UI,
+  hot-reload validation, or a test scaffold) calls `mod.execute/2` outside
+  the wrapper, the contract is silently re-violated. The wrapper enforces
+  by convention of the dispatch path, not by type-system invariant.
+- **Backing (B):** OTP non-negotiable §2 (behaviours, pattern-match on
+  atoms and structs); the project's `.claude/rules/otp-non-negotiables.md`
+  §"Concrete forms" rejects screen-scraping / per-call ad-hoc enforcement
+  in favour of structured dispatch. Hickey, "Simple Made Easy" (2011)
+  on complecting.
+
+#### Falsification attempt for claim 1
+
+- **Strategy:** Counter-example construction — search the in-tree codebase
+  for a production caller of `mod.execute/2` that would bypass the
+  wrapper.
+- **Attempt:** Read all `lib/tau/session/tool_dispatch.ex` call-sites of
+  `mod.execute`; read `lib/tau/tools/` and `lib/tau/coding_agent*` for
+  alternative tool-invocation paths. Verified only one production
+  `mod.execute(args || %{}, ctx)` site exists at
+  `tool_dispatch.ex:696`. The Delegate tool (`builtin/delegate.ex:209`)
+  is itself dispatched via that same site — it does not call other tools'
+  `execute/2`.
+- **Outcome:** Withstood under the stated qualifier — no in-tree
+  production counter-example exists today. The "future bypass" risk is
+  pre-emptively captured in the Rebuttal and matches Open Question #3 in
+  the solution.
+- **Action:** None. The qualifier already names the boundary correctly.
+
+### Claim 2: A `try/rescue` in the wrapper converts any raise from `mod.execute/2` into `{:ok, Result.error(..., details: %{kind: :raised_exception, ...})}` before the existing outer guard sees it
+
+- **Claim (C):** Defence-in-depth: the executor's inner rescue catches
+  raises and synthesises a conformant `is_error` result so the outer guard
+  at `tool_dispatch.ex:714-728` never observes a raised exception from a
+  conformant call path.
+- **Grounds (G):** The outer guard already exists
+  (`tool_dispatch.ex:714-728`) and synthesises a generic
+  `ToolResult` with `content: "Tool exception: ..."` on raise but no
+  `:kind` in `details` (which is taken from `r.details` only on the
+  happy path; `tool_dispatch.ex:702`). The new executor inner rescue
+  fills the `:kind` field that the outer guard cannot.
+- **Warrant (W):** OTP non-negotiable §7 ("Let it crash; supervise;
+  restart. MUST NOT `try/rescue` across process boundaries") is qualified
+  here by D-035 ("canonical try/rescue sites") which already legitimises
+  the dispatch-boundary rescue. Adding an inner rescue at the same
+  process boundary is consistent with D-035, not a new violation.
+- **Qualifier (Q):** Only for raises raised inside `mod.execute/2`'s
+  synchronous path. Raises in a Task spawned from inside `execute/2`
+  surface as `{:exit, reason}` to
+  `spawn_parallel_dispatcher/3`'s `async_stream_nolink` consumer
+  (`tool_dispatch.ex:776-782`) and are independently synthesised
+  there — the executor's rescue does not see them.
+- **Rebuttal (R):** A tool that catches its own raise and re-raises with
+  a different exception is still rescued (the rescue is non-discriminating
+  on exception type), which is correct; but a tool that throws a
+  non-exception (`throw :something`) is not caught by `rescue` — it
+  needs `catch :throw, _`. `Tau.Tool`'s contract forbids both, but
+  `rescue` alone leaves the `throw` path uncaught. The session's outer
+  block also uses `rescue` only (`tool_dispatch.ex:714`), so the gap is
+  not regressed but it is also not closed.
+- **Backing (B):** Project convention captured in
+  `lib/tau/session/tool_dispatch.ex` §"Invariants" comment block (D-035
+  canonical try/rescue sites); `Tau.Tool` moduledoc line 21-22 ("Tools
+  must NEVER raise on user input. Use `{:error, _}` for expected
+  failures and let the supervisor catch genuine bugs.")
+
+#### Falsification attempt for claim 2
+
+- **Strategy:** Edge-case enumeration — list raise / throw / exit /
+  process-death modes and check each.
+- **Attempt:** Enumerated: (i) `raise/1` inside `execute/2` —
+  caught; (ii) `raise/2` with custom exception — caught; (iii)
+  `throw/1` — NOT caught (Elixir's `rescue` only catches exceptions);
+  (iv) `exit/1` from inside `execute/2` — NOT caught by `rescue`
+  (would need `catch :exit, _`); (v) async crash inside a Task spawned
+  from `execute/2` — handled separately by `async_stream_nolink`
+  (`tool_dispatch.ex:776-782`).
+- **Outcome:** Partially falsified for the strong reading "any raise"; the
+  `throw` and `exit` paths are not covered by `rescue` alone. The claim's
+  text says "any raise" which is literally true; the spirit ("ensures
+  acceptance criterion (a) — no built-in tool can raise an uncaught
+  exception on any reachable input path") is also held because (a) is
+  worded "uncaught exception" and `throw`/`exit` are not exceptions in
+  Elixir's sense. The existing outer guard at `tool_dispatch.ex:714`
+  has the same scope.
+- **Action:** No revision needed; the literal claim is true. Noted as
+  Outstanding doubt #1 below — if `Tau.Tool` is extended to forbid
+  `throw` / `exit` as well, the wrapper should add `catch :throw, _;
+  catch :exit, _` clauses; today this is symmetric with the existing
+  outer guard.
+
+### Claim 3: An `ensure_kind/1` guard injects `:unclassified` if a tool's `Result.details` omits `:kind`
+
+- **Claim (C):** A pure function `ensure_kind/1` is run on every
+  `Result.details` map; if `:kind` is absent it is added with value
+  `:unclassified`; if present, the map is unchanged.
+- **Grounds (G):** Today, audited built-in tools' `details` maps:
+  `Write` (`builtin/write.ex:43`) omits `:kind`; `Bash`
+  (`builtin/bash.ex:80-89,93,96`) omits `:kind`; `Read`
+  (`builtin/read.ex:77,99`) populates `:kind`; `Edit`
+  (`builtin/edit.ex:73-78`) omits `:kind`; `Delegate`
+  (`builtin/delegate.ex:240-251,260,328,538,556,561,569,582`) populates
+  `:kind`; `Agent` populates `:kind` in many sites. The drift is real
+  and recent (problem.md cites it). A pure injection function over
+  `Result.details` (a `map()`) achieves AC (b).
+- **Warrant (W):** OTP non-negotiable §8 ("Pure functions are the
+  default; processes are the exception"). A pure unary function over a
+  map is composable, testable in isolation, and idempotent — the right
+  shape for an enforcement seam.
+- **Qualifier (Q):** Only the `:kind` key is injected; no schema on
+  other fields. Tools that put a non-atom value in `:kind` (e.g. a
+  string) still produce a non-atom `:kind` — `ensure_kind/1` only
+  defends against absence, not against wrong type. AC (b) literally
+  asks for "at minimum a `:kind` discriminator" so absence is the
+  named gap.
+- **Rebuttal (R):** A tool that explicitly sets `:kind` to `nil` (e.g.
+  `details: %{kind: nil, foo: 1}`) would satisfy `Map.has_key?/2` and
+  bypass injection; the result would carry `kind: nil` rather than
+  `kind: :unclassified`. Whether that is desired depends on
+  `ensure_kind/1`'s exact predicate — the solution does not specify
+  `Map.has_key?/2` vs `Map.get(_, :kind) != nil`.
+- **Backing (B):** Hickey ("Simple Made Easy") on data-as-data and
+  pure functions composing under temporal coupling; project rule
+  `lib/tau/session/tool_dispatch.ex:23` ("Invariant-bearing modules MUST
+  have properties before examples").
+
+#### Falsification attempt for claim 3
+
+- **Strategy:** Property-test envelope — describe the invariant the
+  function MUST satisfy and check whether the proposed shape satisfies it
+  for the relevant input distribution.
+- **Attempt:** Stated invariant: ∀ m :: map(), `:kind in Map.keys(ensure_kind(m))`.
+  A `Map.put_new(m, :kind, :unclassified)` implementation satisfies
+  this universally. The Rebuttal's `kind: nil` case still has the key
+  in `Map.keys/1`, so the invariant holds even there — the question is
+  semantic (is `nil` a "discriminator"?), not whether the invariant
+  fires.
+- **Outcome:** Withstood. The invariant is universal under
+  `Map.put_new/3`. The Rebuttal's semantic concern is worth a single-
+  line note in the executor's doc but is not a falsification of the
+  claim as stated.
+- **Action:** None. Recommend the proposal's "Open question" about
+  `Logger.warning` on injection be resolved before merge so authoring
+  errors surface in dev/test.
+
+### Claim 4: The wrapper emits `[:tau, :tool, <name_atom>, :start]` / `:stop` / `:exception` telemetry spans around every call, with `<name_atom>` derived from `String.to_existing_atom(String.downcase(mod.name()))`
+
+- **Claim (C):** Every tool call produces a span at per-tool atom keys,
+  using `String.to_existing_atom(String.downcase(mod.name()))` for the
+  atom derivation.
+- **Grounds (G):** Built-in tool names today (verbatim from
+  `mod.name/0`): `"Bash"` (`builtin/bash.ex:38`), `"Write"`
+  (`builtin/write.ex:14`), `"Read"` (`builtin/read.ex:20`), `"Edit"`
+  (`builtin/edit.ex:24`), `"Delegate"` (`builtin/delegate.ex:135`),
+  `"Agent"` (similar). `String.downcase/1` produces `"bash"`,
+  `"write"`, etc. The mapping is total and deterministic.
+- **Warrant (W):** OTP non-negotiable §5 ("Telemetry events MUST cover
+  everything user-visible or perf-sensitive. `:telemetry.execute/3` in
+  `[:tau, ...]`; pair `*.start` with `*.stop` / `*.exception`"). A
+  per-tool namespace allows attaching handlers per tool family
+  (`[:tau, :tool, :bash, :start]` filters), which is the standard
+  telemetry pattern.
+- **Qualifier (Q):** Only for tools whose downcased name is already in
+  the atom table at executor-call time. The solution acknowledges this
+  with the `:dynamic` fallback (claim 8).
+- **Rebuttal (R):** `String.to_existing_atom/1` raises
+  `ArgumentError` when the atom does not exist; the wrapper would
+  need to `try/rescue` that or pre-check. The solution does not name
+  this guard explicitly — it says "the wrapper falls back to ...
+  `:dynamic`" which implies a `try/rescue` around
+  `to_existing_atom` (most natural shape). If the implementer instead
+  uses `Map.fetch` against a compile-time map, the fallback shape
+  changes.
+- **Backing (B):** `lib/tau/tools/builtin/delegate.ex:670-708` already
+  follows this exact two-event pattern (`:start` / `:stop` /
+  `:exception`) and that idiom is the model. `Tau.OtelReporter`'s
+  design (per SPEC-OTEL-REPORTER) consumes `[:tau, ...]` events; per-
+  tool atoms become per-tool spans without further plumbing.
+
+#### Falsification attempt for claim 4
+
+- **Strategy:** Edge-case enumeration over the proposed atom-derivation
+  scheme.
+- **Attempt:** Considered (i) all built-in names: `"Bash"`, `"Write"`,
+  `"Read"`, `"Edit"`, `"Delegate"`, `"Agent"` —
+  `String.to_existing_atom("bash")`, etc.; `:bash`, `:write`, `:read`,
+  `:edit`, `:delegate`, `:agent` are likely in the atom table (built-in
+  delegate already uses `:delegate` at `builtin/delegate.ex:672`), but
+  there is no project-wide guarantee that `:bash`, `:write`, `:read`,
+  `:edit`, `:agent` are pre-registered as atoms at compile time. (ii)
+  An MCP-registered tool named e.g. `"github_create_issue"` —
+  `String.to_existing_atom("github_create_issue")` will raise unless
+  some code path pre-registered the atom. (iii) A tool name with
+  hyphens (`"long-running"`) — atom is valid but the downcased form
+  must already exist. (iv) A tool name with non-ASCII codepoints —
+  `String.downcase/1` does Unicode-aware lowering; the resulting atom
+  may or may not be a "canonical" atom for downstream subscribers.
+- **Outcome:** **Partially falsified.** The strong reading "every tool
+  call produces a span at `[:tau, :tool, <name_atom>, ...]`" fails
+  whenever the downcased name is not in the atom table — which is
+  expected for all built-ins on first call, because there is no in-
+  tree code today that creates the atom `:bash` (the
+  `[:tau, :tool, :bash, :stderr]` event at `builtin/bash.ex` is one
+  candidate site but problem.md notes Bash emits only that sub-event,
+  not the boundary atom). Without pre-registration in the executor's
+  compile-time, the first `Bash` call after BEAM start would hit the
+  `:dynamic` fallback for every tool. The qualifier must be narrowed
+  to: "for tools whose downcased name has been registered as an atom
+  somewhere in the codebase at compile time; otherwise the
+  `:dynamic` fallback applies (claim 8)."
+- **Action:** Narrow Qualifier in place. The solution should also
+  consider statically pre-registering the built-in atoms at
+  `Tau.Tool.Executor`'s compile time (e.g. `@known [:bash, :read,
+  :write, :edit, :delegate, :agent]`) so the happy path is
+  deterministic. This is a design refinement, not a falsification of
+  the recommendation — recorded as an outstanding doubt.
+
+### Claim 5: `Bash.persist_full/3` is rewritten to use `File.mkdir_p/1` and `File.write/1` (non-raising variants), returning `nil` on failure so the truncation-log path is best-effort and degrades silently
+
+- **Claim (C):** The bang-variants at `builtin/bash.ex:137-139` are
+  replaced with the non-raising variants; failures produce a `nil`
+  path and the call does not raise.
+- **Grounds (G):** Current code at `builtin/bash.ex:131-141`:
+  `File.mkdir_p!(dir)` (line 137), `File.write!(path, output)` (line
+  139). Both raise on filesystem error (POSIX `EACCES`, `ENOSPC`,
+  full disk, etc.). Elixir provides `File.mkdir_p/1` and `File.write/1`
+  with `:ok | {:error, posix()}` semantics — straightforward swap.
+- **Warrant (W):** `Tau.Tool` moduledoc invariant ("Tools must NEVER
+  raise on user input"). Reachable failure modes on user input
+  include: invalid path characters in `session_id`, parent dir not
+  writable, disk full, filesystem read-only. All produce raises today
+  and all become `{:error, posix}` after the swap.
+- **Qualifier (Q):** Only the truncation-log persistence path. The
+  main `execute/2` path is already non-raising (delegates to
+  `ctx.operations.bash/3` which returns tagged tuples).
+- **Rebuttal (R):** Downstream consumers reading
+  `details.full_output_path` must handle `nil` (Solution Open Question
+  #4 names this). A consumer that does `Path.basename(path)` on a
+  `nil` path will itself raise. Unknown if any current consumer does
+  so — the solution flags this as needing verification.
+- **Backing (B):** Elixir stdlib `File` module docs
+  (https://hexdocs.pm/elixir/File.html) explicitly contrast bang vs.
+  non-bang variants for exactly this purpose; project rule
+  "MUST NOT swallow errors" (`.claude/rules/otp-non-negotiables.md`
+  §Concrete forms) is satisfied because the failure is structured into
+  `details.full_output_path: nil`, not silently dropped.
+- **Backing for Open Question #4:** consumers of
+  `details.full_output_path` — grep finds the value in `bash.ex` only
+  (set at line 85, threaded through `truncate/3`), `details` is
+  packed at line 85, and downstream uses are TUI render +
+  JSONL serialise; both treat `details` as opaque. No code today
+  does `Path.basename(details.full_output_path)`.
+
+#### Falsification attempt for claim 5
+
+- **Strategy:** Counter-example construction + downstream-consumer
+  enumeration.
+- **Attempt:** (i) Verified `File.mkdir_p/1` and `File.write/1` exist
+  in Elixir 1.18 (`.tool-versions` confirms 1.18.1) and return
+  `:ok | {:error, posix()}` — checked Elixir stdlib. (ii)
+  Greptable in-tree consumers of `details.full_output_path`: only the
+  setter site in `bash.ex`. No code path reads it back as a string. (iii)
+  The truncation-test setup in `test/tau/tools/builtin/bash_test.exs`
+  (not read for this validation; deferred) may assert on the path's
+  shape; this is named in the solution's "What changes" §4 as a
+  test that needs updating.
+- **Outcome:** Withstood. The swap is mechanical, the failure mode is
+  named, and no in-tree consumer breaks on `nil`. The test updates
+  are scoped and acknowledged by the solution.
+- **Action:** None. Confirm the consumer assumption holds at PR
+  review time via grep for `full_output_path` in `test/` and `lib/`.
+
+### Claim 6: The `Tau.Tool` behaviour callbacks, `Tau.Tool.Result` struct, and every tool's public callback signature are unchanged
+
+- **Claim (C):** No callback signature, struct field, or public API
+  changes — the solution is purely additive at the dispatch layer.
+- **Grounds (G):** `Tau.Tool` callbacks at `lib/tau/tool.ex:27-34`
+  remain `name/0`, `description/0`, `parameters/0`, `execute/2`,
+  `execution_mode/0`, `streams_updates?/0`. `Tau.Tool.Result` struct
+  at `lib/tau/tool/result.ex:16` remains `defstruct content: "",
+  details: %{}, terminate?: false, is_error: false`. Solution §"What
+  does not change" enumerates these.
+- **Warrant (W):** Reversibility principle: a change that does not
+  modify public contracts can be removed without ripple to callers
+  (Hickey: "ease of change" requires loose coupling). A behaviour
+  contract change requires changing every implementer.
+- **Qualifier (Q):** Only public contracts. The `Tau.Tool.Executor`
+  module is itself new public surface; reversing the change means
+  deleting it and the one-line dispatch swap.
+- **Rebuttal (R):** None — the claim is universal at the level of
+  "what changes" enumerated in §"What does not change" of solution.md.
+- **Backing (B):** Project ADR convention (`docs/adr/`) and OTP
+  non-negotiable §3 ("MUST NOT wrap stateless logic in a GenServer")
+  — the executor is a stateless wrapper, not a process; satisfies §3.
+
+#### Falsification attempt for claim 6
+
+- **Strategy:** Dependency check — verify no in-tree caller depends on
+  the absence of an `Executor` indirection.
+- **Attempt:** Greptable `mod.execute(` and `mod.execute/2` references
+  in `lib/` and `test/`: the only production call site is
+  `tool_dispatch.ex:696`. Test files may call `mod.execute` directly
+  in unit tests; those continue to work because the wrapper is added
+  *between* the FSM and the tool, not at the tool's boundary.
+- **Outcome:** Withstood. No caller depends on the absence of the
+  wrapper; the wrapper is invisible to anyone not on the dispatch
+  path.
+- **Action:** None.
+
+### Claim 7: Reversal is two file deletions and one revert
+
+- **Claim (C):** The change can be undone by deleting
+  `lib/tau/tool/executor.ex` + its test file and reverting the
+  one-line dispatch change at `tool_dispatch.ex:696` (and the
+  `Bash.persist_full/3` rewrite, if also reverted).
+- **Grounds (G):** Solution §"Migration sketch" line 113-114 states
+  this. The dispatch swap is mechanical; the executor module is
+  self-contained.
+- **Warrant (W):** A change isolated to one module + one call-site has
+  reversal cost proportional to its size (small). Reversibility is the
+  key Hickey criterion for "easy" changes.
+- **Qualifier (Q):** Only for the wrapper itself; the
+  `Bash.persist_full/3` rewrite is independently reversible. The
+  rewrite carries its own consumer-contract impact (Claim 5 Rebuttal)
+  so reversing it after consumers depend on `nil` semantics is
+  awkward.
+- **Rebuttal (R):** If a future tool comes to depend on the
+  `ensure_kind/1` injection (e.g. a TUI render path assumes `:kind`
+  is always present), reversing the wrapper silently regresses that
+  consumer. The TUI dependence on `:kind` is plausible (see audit
+  §"Cross-tool shape drift") and would form a one-way ratchet.
+- **Backing (B):** `.claude/rules/otp-non-negotiables.md` §"Concrete
+  forms" rejects breaking refactors without a documented rationale.
+
+#### Falsification attempt for claim 7
+
+- **Strategy:** Dependency check — list every file the solution
+  modifies; verify the reversal claim against that list.
+- **Attempt:** Files modified by the solution per §"What changes":
+  `lib/tau/tool/executor.ex` (new), `lib/tau/session/tool_dispatch.ex`
+  (one-line swap), `lib/tau/tools/builtin/bash.ex` (`persist_full/3`),
+  plus new tests. Reversal: delete executor.ex + executor test;
+  revert the swap; revert the bash rewrite. That is three reverts,
+  not "two file deletions and one revert" — the solution's wording
+  understates by one if Bash is counted; matches if Bash rewrite is
+  treated as independent (consistent with Claim 5 / 7 separability).
+- **Outcome:** Withstood under the qualifier that the Bash rewrite is
+  a logically separate revert. The literal "two file deletions and
+  one revert" is the wrapper alone, which matches the §"Migration
+  sketch" framing.
+- **Action:** None; minor wording ambiguity, not a contradiction.
+
+### Claim 8: For runtime-registered tools whose names are not already in the atom table, the wrapper falls back to `[:tau, :tool, :dynamic, :start/:stop/:exception]` with the tool name in metadata
+
+- **Claim (C):** A `:dynamic` namespace catches tools whose downcased
+  names are not pre-registered atoms; the tool name is preserved as
+  metadata so observability is not lost entirely.
+- **Grounds (G):** Solution §"What changes" line 82-83. MCP `ToolAdapter`
+  (out of problem scope, but in scope of this consideration) and
+  extensions (`Tau.Extensions.Loader`,
+  `lib/tau/extensions/loader.ex`) register tools at runtime; their
+  names are user-defined strings.
+- **Warrant (W):** OTP non-negotiable §5 (telemetry coverage) requires
+  events for everything user-visible; a fallback that preserves the
+  event (just at a coarser namespace) honours the rule. The atom-
+  table-growth concern is a real BEAM operational hazard: unbounded
+  atoms cause node crash.
+- **Qualifier (Q):** Per-tool subscription granularity is lost for the
+  fallback path — handlers must filter by the metadata `:tool_name`
+  field, which is heavier than per-event handlers.
+- **Rebuttal (R):** Solution's Open Question #2 explicitly asks whether
+  this fallback is sufficient or whether runtime-registered tools
+  should opt into atom pre-registration. The fallback is a defensible
+  choice but it is not free; an operator who runs many extensions
+  loses per-tool dashboards without realising.
+- **Backing (B):** `String.to_existing_atom/1` BEAM
+  documentation; the project's existing pattern in
+  `lib/tau/providers/rate_limiter/supervisor.ex:143` and
+  `lib/tau/settings/schema.ex:292` (both use
+  `String.to_existing_atom/1` for similar safety reasons).
+
+#### Falsification attempt for claim 8
+
+- **Strategy:** Edge-case enumeration over runtime tool sources.
+- **Attempt:** (i) MCP-registered tool with a long name: hits
+  `:dynamic`; metadata carries the name. (ii) Extension-registered
+  tool: same. (iii) An MCP tool whose name happens to collide with a
+  pre-existing built-in atom (e.g. `"bash"` from a third-party MCP
+  server): the wrapper would emit `[:tau, :tool, :bash, ...]` for
+  both the built-in and the MCP proxy — observability collision. The
+  solution does not name this; it is a defect in the fallback design.
+  (iv) A tool name that is a reserved atom (`"true"`, `"false"`,
+  `"nil"`) — `:true`, `:false`, `:nil` exist but their use as
+  telemetry event keys would confuse handlers expecting structural
+  atoms.
+- **Outcome:** Withstood under stated qualifier; partial concern about
+  edge case (iii) is recorded as Outstanding Doubt #2. None of the
+  edge cases falsify the claim as written — they qualify it.
+- **Action:** None; recommend the implementer add a comment in the
+  executor's doc noting the collision possibility for built-in-name
+  overrides.
+
+### Claim 9: The change is behaviour-preserving for all conformant existing tools — tools that already populate `:kind` see no shape change
+
+- **Claim (C):** Existing conformant tools observe no externally
+  visible behaviour change after the wrapper is installed.
+- **Grounds (G):** `ensure_kind/1`'s injection is conditional on
+  absence (Claim 3); telemetry events are additive (the existing
+  session-level `[:tau, :tool, :execute, :start/:stop/:exception]`
+  is retained per §"What does not change" line 95-97); the rescue
+  shape mirrors the outer guard's, so the wire-level `ToolResult` is
+  the same.
+- **Warrant (W):** Additive composition does not change behaviour for
+  consumers that read only the fields they already read. This is the
+  observer-pattern correctness condition.
+- **Qualifier (Q):** Only for tools that already populate `:kind`
+  AND already conform to the no-raise discipline. Tools that
+  currently raise (Bash via `persist_full/3`) DO see a behaviour
+  change — they now produce an `is_error` result instead of
+  crashing the dispatch. That is the intent, not a regression.
+- **Rebuttal (R):** A test that today expects
+  `assert_raise File.Error, fn -> Bash.execute(...) end` would fail
+  after the wrapper. The solution's §"Migration sketch" step 3
+  acknowledges this for Bash's truncation-path tests.
+- **Backing (B):** Standard refactoring discipline — additive
+  changes preserve observable behaviour for legacy consumers.
+
+#### Falsification attempt for claim 9
+
+- **Strategy:** Counter-example construction — find a test or
+  consumer whose assertions would break.
+- **Attempt:** Quick scan of `test/tau/tools/builtin/` for
+  `assert_raise` against tool calls; not exhaustive in this
+  validation pass, but the solution itself names the Bash
+  truncation-path tests as the one expected to need updating.
+  Other built-ins do not raise today (their `execute/2` returns
+  tagged tuples).
+- **Outcome:** Withstood. Bash's truncation-path tests are the only
+  known case and are explicitly scoped in the migration sketch.
+- **Action:** None; verify at PR review time that no other
+  `assert_raise` against tool execution exists.
+
+## Cross-claim consistency
+
+Claims 1–9 are mutually consistent. The tension worth surfacing:
+
+- **Claim 4 (per-tool telemetry atoms)** and **Claim 8 (`:dynamic`
+  fallback)** together imply a two-tier observability model: built-ins
+  on the typed atoms, runtime tools on `:dynamic`. The operator-facing
+  documentation must explain this, or dashboard authors will look in
+  the wrong place. Resolution: the solution already names this in
+  Open Question #2 and §"What does not change" line 96-99
+  (two-level namespace documented in moduledoc). Consistent.
+- **Claim 3 (`ensure_kind`)** and **Claim 6 (Result struct unchanged)**
+  are consistent because injection happens to the `:details` map (a
+  `map()` field on the struct), not to the struct itself.
+- **Claim 5 (`Bash.persist_full/3` returns `nil` on failure)** and
+  **Claim 9 (behaviour-preserving)** are consistent because the
+  qualifier on Claim 9 excludes Bash's truncation-path (the only
+  raise path being fixed).
+
+No unresolvable tensions.
+
+## Falsification summary
+
+| # | Claim (short) | Strategy | Outcome | Action |
+|---|---|---|---|---|
+| 1 | Single dispatch wrapper enforces all 3 contract points | Counter-example construction | Withstood | None |
+| 2 | `try/rescue` converts raise to `is_error` `Result` | Edge-case enumeration | Withstood (literal) | Note throw/exit gap in Outstanding Doubts |
+| 3 | `ensure_kind/1` injects `:unclassified` if missing | Property-test envelope | Withstood | Resolve dev/test `Logger.warning` Open Q before merge |
+| 4 | Per-tool atom-named telemetry events | Edge-case enumeration | Partially falsified | Narrow Qualifier; consider pre-registering built-in atoms |
+| 5 | Non-raising `persist_full/3` returning `nil` | Counter-example + consumer enumeration | Withstood | Confirm no consumer treats `nil` as path at review |
+| 6 | Behaviour, struct, callback signatures unchanged | Dependency check | Withstood | None |
+| 7 | Reversal: 2 deletes + 1 revert | Dependency check | Withstood (under separability of Bash rewrite) | None |
+| 8 | `:dynamic` fallback for runtime-registered tools | Edge-case enumeration | Withstood (collision concern noted) | Doc comment on namespace collision |
+| 9 | Behaviour-preserving for conformant tools | Counter-example construction | Withstood | Grep `assert_raise` in tool tests at review |
+
+## Revision required
+
+No revision is required.
+
+- Claim 4 is partially falsified, but the narrowing fits inside the
+  Qualifier and is captured by the solution's own `:dynamic` fallback.
+  The recommended refinement (pre-register built-in atoms at
+  `Tau.Tool.Executor` compile-time as `@known [...]` or via an
+  explicit `defguard`) is a design refinement during implementation,
+  not a re-selection between proposals.
+- All other claims withstand under their stated qualifiers.
+- The headline recommendation (Claim 1) survives every applicable
+  falsification strategy.
+
+If during implementation it becomes clear that the `:dynamic` fallback
+fires for built-ins on the cold path (i.e. atoms `:bash`, `:read`,
+`:write`, `:edit`, `:agent` are not pre-registered), the implementer
+SHOULD add a compile-time `@known_tool_atoms` list to `Tau.Tool.Executor`
+to make the happy path deterministic. This is in-scope for the chosen
+proposal and does not require re-selection.
+
+## Outstanding doubts
+
+1. **`throw` and `exit` are not caught by `rescue`** in either the new
+   inner wrapper or the existing outer guard. Today no test exercises a
+   tool that throws or exits; if `Tau.Tool`'s contract is later extended
+   to forbid these explicitly, both guards need `catch :throw, _` and
+   `catch :exit, _` clauses. Symmetric gap; not a regression.
+
+2. **Telemetry namespace collision**: if a runtime-registered tool's
+   downcased name collides with a pre-existing built-in atom (e.g. an
+   MCP server exposes a `"Bash"` tool), the wrapper emits the same
+   `[:tau, :tool, :bash, ...]` events for both. Handlers cannot
+   distinguish without inspecting metadata. The solution should
+   document this in `Tau.Tool.Executor`'s moduledoc; runtime tool
+   registration should ideally reject names colliding with built-ins.
+
+3. **`ensure_kind/1`'s exact predicate (`Map.has_key?/2` vs.
+   `Map.get(_, :kind) != nil`)** is unspecified. The conservative
+   choice is `Map.has_key?/2` (preserves an explicit `nil`); the
+   user-friendly choice is `Map.get(_, :kind) != nil` (treats `nil`
+   as absent). Trivial to decide at implementation but worth a one-
+   line spec in the executor's moduledoc.
+
+4. **Consumer of `details.full_output_path == nil`** — Solution Open
+   Question #4. Grep finds no current consumer treats it as a path
+   directly, but a sweep of TUI render code and JSONL replay code at
+   PR review would seal the question.
+
+---
+role: validator
+node: tau-tools-hooks-mcp/subproblems/tool-result-contract/problem.md
+status: validated
+validation_path: docs/problems/tau-tools-hooks-mcp/subproblems/tool-result-contract/validation.md
+toulmin_complete: true
+falsification_outcome: partially_falsified
+claims_count: 9
+revision_target: none
+outstanding_doubts_count: 4

--- a/docs/problems-archive-v1-modules/tau-tools-hooks-mcp/validation.md
+++ b/docs/problems-archive-v1-modules/tau-tools-hooks-mcp/validation.md
@@ -1,0 +1,536 @@
+---
+template_version: 1
+template_name: validation
+parent_solution: ./solution.md
+parent_problem: ./problem.md
+toulmin_complete: true
+falsification_attempted: true
+falsification_outcome: partially_falsified — claim/3
+revision_triggered: none
+---
+
+# Validation: Four decomplecting moves — cross-cutting integration
+
+## Overview
+
+The root solution synthesises four child recommendations (PR-A through
+PR-D) and adds two synthesis-level claims of its own: (1) the union
+dispatch through `Tau.Tool.Executor.call/4` for both module-tool and
+`%Tau.MCP.ToolEntry{}` branches, and (2) a four-PR dependency ordering
+A → B → C → D that lands the moves independently and reversibly. This
+validation enumerates six checkable propositions, runs full Toulmin
+(six fields, none merged) per claim, and executes one explicit
+falsification strategy per claim. Five claims withstood. Claim 3 (the
+union-executor wrap) is **partially falsified**: the executor
+signature accepts the union, but two collateral surfaces
+(`Tau.Tool.Validator.validate/2`'s `is_atom(mod)` guard and the absence
+of any `dispatch_tool/3` function in the live codebase) require the
+qualifier to be narrowed and the implementer briefed. The narrowing
+does not invalidate the synthesis; no `revision_triggered` fires.
+
+## Toulmin per claim
+
+The MITRE empirical study on Toulmin formalism found participants
+"varied greatly even though they started with the same content"
+(https://www.mitre.org/news-insights/publication/empirical-evaluation-structured-argumentation-using-toulmin-argument).
+The per-field discipline below counters that variance.
+
+### Claim 1: The four child moves act on disjoint module sets along disjoint axes; no child's "What changes" list collides with another's at the function level
+
+- **Claim (C):** The four children compose without function-level
+  collision; the four moves can be combined into one solution without
+  conflict on any module.
+- **Grounds (G):** Per-child "What changes" sections:
+  PR-A (io-collectors) touches `lib/tau/tools/operations/local.ex`
+  `collect_port/3`, `lib/tau/hooks/shell.ex` `collect/3`,
+  `lib/tau/mcp/transport/stdio.ex` `recv/2` & `close/1`, plus new
+  `lib/tau/io/port.ex` (io-collectors solution.md:67–85).
+  PR-B (result-contract) touches `lib/tau/session/tool_dispatch.ex`
+  `run_tool_validated/6` and `lib/tau/tools/builtin/bash.ex`
+  `persist_full/3`, plus new `lib/tau/tool/executor.ex` (tool-result-
+  contract solution.md:63–73).
+  PR-C (mcp concurrency) touches `lib/tau/mcp/transport.ex` behaviour,
+  all three `lib/tau/mcp/transport/*.ex` `send`/`recv`, and
+  `lib/tau/mcp/server.ex` `handle_call`/`handle_info` (mcp-server-
+  concurrency solution.md:55–82).
+  PR-D (dynamic-module) touches `lib/tau/hooks/shell.ex` `build/2`,
+  `lib/tau/mcp/tool_adapter.ex` `build/5`,
+  `lib/tau/hooks/dispatcher.ex` `run_one/3`, `lib/tau/tool.ex`
+  `lookup/1`, and the session dispatch (dynamic-module-generation
+  solution.md:61–87).
+- **Warrant (W):** Module/function-level disjointness implies that
+  independent commits can be sequenced without merge conflict; the
+  Hickey decomplecting axis "concern" (used by the root problem.md
+  decomposition strategy) lines up one concern with one module surface,
+  so disjoint concerns yield disjoint surfaces by construction.
+- **Qualifier (Q):** Holds at the function level *except* for two
+  overlap points that the synthesis explicitly resolves: (a)
+  `lib/tau/hooks/shell.ex` is touched by PR-A (`collect/3` + `close/1`
+  utility swap) AND PR-D (`build/2` rewrite + `Entry` struct addition);
+  (b) `lib/tau/mcp/transport/stdio.ex` is touched by PR-A
+  (`{:noeol, partial}` cap + `close/1` swap) AND PR-C (`recv/2`
+  removal). Both overlaps are at *different clauses of the same file*,
+  not the same function.
+- **Rebuttal (R):** If two PRs land out of order such that PR-C deletes
+  `recv/2` before PR-A patches its `{:noeol, partial}` cap branch, PR-A
+  has dead code to delete (acknowledged in solution.md:218–222). The
+  rebuttal is bounded: the *final* state is identical regardless of
+  order.
+- **Backing (B):** Root problem.md:80–83 explicitly justifies the MECE
+  decomposition by the Hickey concern axis, and the synthesis section
+  "Composition rationale" (solution.md:52–109) enumerates each of the
+  four interaction points and resolves each.
+
+#### Falsification attempt for claim 1
+
+- **Strategy:** integration check + edge-case enumeration. Walk each of
+  the four overlap points the synthesis enumerates and verify the
+  resolution at the source file level.
+- **Attempt:** (i) `lib/tau/hooks/shell.ex` — confirmed at file
+  present; PR-A touches `collect/3` and `close/1`; PR-D touches
+  `build/2` and adds an `%Entry{}` struct — different functions,
+  same file, no conflict. (ii) `lib/tau/mcp/transport/stdio.ex` —
+  confirmed at file present; PR-A's `{:noeol, partial}` cap inside
+  `recv/2` is dead code once PR-C deletes `recv/2`; the `close/1`
+  patch survives. (iii) `lib/tau/mcp/server.ex` — PR-C's
+  `handle_call`/`handle_info` rewrite is orthogonal to PR-D's
+  `terminate/2` `Registry.unregister/2` mention; verified by grep
+  showing the two functions are separate. (iv) `lib/tau/tool.ex` —
+  PR-B does not touch this file; PR-D widens `lookup/1` return; no
+  collision.
+- **Outcome:** withstood. The four overlap points are real but each
+  resolves to "different function, same file" or "patch becomes
+  obsolete, final state identical." The synthesis correctly identifies
+  every interaction point.
+- **Action:** none.
+
+### Claim 2: The dependency order PR-A → PR-B → PR-C → PR-D is the unique correct landing sequence
+
+- **Claim (C):** The four PRs land in dependency order A → B → C → D
+  per Migration sketch (solution.md:202–229); each is independently
+  reversible.
+- **Grounds (G):** PR-A introduces `Tau.IO.Port.close_if_open/1`
+  consumed by no other PR (self-contained per io-collectors
+  solution.md:104). PR-B introduces `Tau.Tool.Executor.call/4`
+  consumed only by PR-D's `%ToolEntry{}` dispatch branch (synthesis
+  composition note 1, solution.md:56–73). PR-C is independent of B
+  and D (mcp-server-concurrency solution.md:113). PR-D depends on
+  PR-B's executor existing for the union dispatch (root solution.md:
+  223–228).
+- **Warrant (W):** A dependency graph with edges only from B → D
+  (executor consumed by union dispatch) admits any topological order
+  that puts A and C anywhere, and B before D. The chosen A → B → C → D
+  is one valid linearisation; "smallest blast radius first" (A) and
+  "C independent" justify the placement.
+- **Qualifier (Q):** Strict dependency exists only B → D. PR-A and
+  PR-C may land in any position relative to B and D; only B → D is
+  ordering-bearing.
+- **Rebuttal (R):** If PR-D were to land before PR-B, the
+  `%ToolEntry{}` dispatch clause would have no `Tau.Tool.Executor`
+  to call. The Recommendation could fall back to PR-D dispatching to
+  `Tau.MCP.ToolAdapter.invoke_remote/3` directly (which is exactly
+  what the dynamic-module child specifies in isolation, solution.md:77).
+  The "B before D" edge is therefore a *synthesis* requirement, not a
+  child requirement.
+- **Backing (B):** Root solution.md "Migration sketch" §1–4 (lines
+  202–229); each child solution's "Migration sketch" confirming
+  self-containment of A and C.
+
+#### Falsification attempt for claim 2
+
+- **Strategy:** counter-example construction. Try to find an order
+  that breaks; try to find an order strictly better.
+- **Attempt:** (i) Reverse to D → B → A → C: D needs the executor B
+  provides; falsified — invalid. (ii) C → A → B → D: all dependencies
+  satisfied; equally valid; not strictly better since A's "smallest
+  blast radius" advantage is forfeited. (iii) Parallel A and C (per
+  factory-loop.md "parallel batch" rule): the conflict check clears —
+  A touches `local.ex`, `hooks/shell.ex`, `stdio.ex`, `io/port.ex`;
+  C touches `transport.ex`, `transport/*.ex` `send`/`recv`,
+  `server.ex`. The only overlap is `stdio.ex` (A patches a clause C
+  deletes). The factory-loop conflict check clause 3 ("disjoint
+  codepoints") fails on `stdio.ex` `recv/2` — must serialise A and C
+  at that file. (iv) Parallel B and C: disjoint module sets; clears.
+- **Outcome:** withstood. The A → B → C → D order is a valid
+  linearisation; alternatives exist but are not strictly better; the
+  one hard dependency (B → D) is correctly stated. The note that A
+  and C overlap on `stdio.ex` is correctly captured by the synthesis's
+  "either order works" qualifier (solution.md:88–96).
+- **Action:** none.
+
+### Claim 3: `Tau.Tool.Executor.call/4` wraps both module-tool and `%ToolEntry{}` branches uniformly, preserving contract-enforcement and telemetry symmetry
+
+- **Claim (C):** `run_tool_validated/6` invokes
+  `Tau.Tool.Executor.call/4` on **both** branches; the executor's
+  `(mod_or_entry, args, ctx, started)` signature accepts either a
+  module atom (calls `mod.execute/2`) or a `%ToolEntry{}` (calls
+  `Tau.MCP.ToolAdapter.invoke_remote/3`). Contract enforcement and
+  telemetry coverage are uniform across compile-time and runtime-
+  registered tools (solution.md:56–73).
+- **Grounds (G):** Synthesis composition note 1
+  (solution.md:56–73) states the dispatch table for the union;
+  `lib/tau/tool/executor.ex` will be authored to honour both branches;
+  `Tau.Tool.Executor.call/4` already documented in result-contract
+  solution.md:63–84 to handle the module branch with telemetry
+  fallback `[:tau, :tool, :dynamic, ...]` exactly fitting the
+  `%ToolEntry{}` case.
+- **Warrant (W):** Pattern matching in Elixir / `:gen_statem`
+  callbacks (Tau OTP non-negotiable #2) — pattern match on atoms and
+  structs at the same call site is idiomatic and preserves type
+  safety; one function with two clauses (one `is_atom(mod_or_entry)`,
+  one `%ToolEntry{}`) is a valid union dispatch. The result-contract
+  child explicitly reserves the `:dynamic` telemetry namespace for the
+  non-atom case (tool-result-contract solution.md:80–84), making the
+  `%ToolEntry{}` case the documented runtime-registered scenario.
+- **Qualifier (Q) — NARROWED:** Holds for the *executor* itself
+  (Executor.call/4 accepting the union is mechanically sound), but
+  the surrounding call site has two unaddressed surfaces:
+  (a) `Tau.Tool.Validator.validate/2` at `lib/tau/tool/validator.ex:42`
+  carries an `is_atom(mod)` guard; passing a `%ToolEntry{}` to it
+  does not pattern-match and would raise `FunctionClauseError`. The
+  validator either needs a second clause for `%ToolEntry{}` (reading
+  `entry.parameters`) OR validation must be bypassed for runtime-
+  registered tools (the dynamic-module child solution.md:31–44
+  registers the schema in the struct field, suggesting the validator
+  call could route through `entry.parameters` directly).
+  (b) The synthesis claims a `dispatch_tool/3` function exists to
+  carry the union pattern-match (composition note 1 references
+  `Tau.Session.dispatch_tool/3`). `grep -n "def dispatch_tool"
+  lib/tau/session*.ex` returns **zero hits**; the actual session
+  tool dispatch is `Tau.Session.ToolDispatch.run_tool/4` →
+  `run_tool_validated/6`. The synthesis solution's "What changes"
+  caveat "(or `lib/tau/session/tool_dispatch.ex` if the dispatch
+  lives there)" acknowledges this uncertainty. The dispatch lives
+  in `tool_dispatch.ex`, not `session.ex`; the implementer must add
+  the `%ToolEntry{}` clause to `run_tool/4` and update
+  `run_tool_validated/6`'s spec to widen `module()` to
+  `module() | Tau.MCP.ToolEntry.t()`.
+- **Rebuttal (R):** If the validator is not also widened, the
+  `%ToolEntry{}` dispatch crashes at validation before reaching the
+  executor — the uniform-wrap claim is structurally true but
+  operationally broken at the call site. If the union dispatch is
+  added to `run_tool_validated/6` instead of the planned `dispatch_
+  tool/3`, the synthesis's reference is mis-located but the design is
+  preserved.
+- **Backing (B):** `lib/tau/tool/validator.ex:42` — `when is_atom(mod)`
+  guard. `lib/tau/session/tool_dispatch.ex:620–671` — `run_tool/4`
+  and `run_tool_validated/6` are the live dispatch entry points; no
+  `dispatch_tool/3` exists anywhere under `lib/`. Tau OTP non-
+  negotiable #2 (pattern match on atoms and structs) supports the
+  union pattern but does not waive the validator's guard.
+
+#### Falsification attempt for claim 3
+
+- **Strategy:** integration check + type-level check. Trace the call
+  path that a `%ToolEntry{}` dispatch would actually take through
+  the existing live code, and verify the executor wrap composes with
+  every step the path traverses.
+- **Attempt:** Live call path is `run_tool/4` (line 621) →
+  `Tau.Tool.lookup(name)` (line 624; widened to return
+  `module() | ToolEntry.t()` per PR-D) → `Tau.Tool.Validator.validate(
+  mod, args)` (line 626). The validator's guard `when is_atom(mod)`
+  excludes `%ToolEntry{}` — `FunctionClauseError`. The executor wrap
+  is never reached. Separately, the union dispatch is documented as
+  living in `dispatch_tool/3`, which does not exist; the closest
+  live function is `run_tool_validated/6` whose spec is
+  `(String.t(), String.t(), map() | nil, Tau.Session.Data.t(),
+  module(), integer())` — the `module()` argument needs widening as
+  well.
+- **Outcome:** partially falsified. The executor-side claim
+  (signature accepts both, telemetry symmetric) survives. The
+  end-to-end call-site claim ("uniform across compile-time and
+  runtime-registered tools") requires two additional edits the
+  synthesis does not enumerate: (i) widen
+  `Tau.Tool.Validator.validate/2` to a second clause matching
+  `%ToolEntry{}`, OR route validation through `entry.parameters`
+  before the executor; (ii) the union dispatch lives in
+  `Tau.Session.ToolDispatch.run_tool_validated/6` (and its caller
+  `run_tool/4`), not the synthesis-named `dispatch_tool/3`.
+- **Action:** narrow Qualifier in place as above. No revision
+  triggered: the structural design is sound; the two surfaces above
+  are implementer-brief items, not solution-design defects. The
+  synthesis solution's "What changes" bullet at solution.md:117–119
+  (`run_tool_validated/6` routes both branches through the executor)
+  is correct in spirit; the implementer brief must extend it to
+  `run_tool/4`'s `Tau.Tool.lookup` consumer and the validator's
+  guard. The solution.md should add a third "What changes" sub-bullet
+  for the validator widening; coordinator may surface this in an
+  implementer-brief comment without re-running propose/select.
+
+### Claim 4: Conjoined, the four moves satisfy the parent acceptance criterion (each subsystem reasonable from its public interface alone)
+
+- **Claim (C):** After landing all four PRs, a reader of
+  `lib/tau/tools/`, `lib/tau/hooks/`, `lib/tau/mcp/` can identify the
+  shape contract, collection bound, concurrency model, and dispatch
+  mechanism for each subsystem from its public interface alone,
+  without reading implementation details of siblings (problem.md:104–
+  108, restated as solution.md Recommendation §1).
+- **Grounds (G):** Mapping per acceptance criterion clause:
+  shape contract → enforced by `Tau.Tool.Executor` at single site
+  (PR-B); collection bound → declared on `@max_bytes`,
+  `@max_output_bytes`, `@max_partial_bytes` module attributes
+  documented in `Tau.IO.Port` plus owner modules (PR-A);
+  concurrency model → `Tau.MCP.Transport` behaviour docstring
+  states "MUST NOT block for the network round-trip; response
+  delivered via message to the Server process" (PR-C, mcp-server-
+  concurrency solution.md:57–58); dispatch mechanism →
+  `Tau.Tool.lookup/1`'s widened return type `{:ok, module() |
+  Tau.MCP.ToolEntry.t()} | :error` (PR-D, dynamic-module-generation
+  solution.md:81–83) plus `Tau.Hooks.Dispatcher.run_one/3`'s two
+  pattern-match clauses.
+- **Warrant (W):** "Reasonable from public interface alone" is
+  satisfied iff each of the four concerns is enforced/declared at a
+  single named surface (a behaviour callback, a module attribute, a
+  return type, or a documented contract). Hickey's "decomplecting"
+  principle: each concern at its own seam, no concern requiring a
+  reader to chase implementation across files.
+- **Qualifier (Q):** Holds for the four concerns the parent
+  acceptance criterion enumerates (shape, bound, concurrency,
+  dispatch). Does NOT extend to surfaces the parent explicitly OOS'd:
+  path-traversal sandbox, fake unified diff in `Edit`,
+  `Agent.parse_mode/1` `try/rescue`, MCP `pending` unbounded growth
+  on timeout, ENV leakage into Bash (problem.md:110–123).
+- **Rebuttal (R):** If a future reader still must inspect a tool's
+  implementation to understand whether it raises (because PR-B's
+  rescue is *defence-in-depth*, not the sole barrier — solution.md:23–
+  27), the criterion is satisfied only at the "Result shape after
+  dispatch" boundary, not at the "tool will not raise internally"
+  boundary. The acceptance criterion in problem.md:106 says "shape
+  contract", which is the post-dispatch shape — survives.
+- **Backing (B):** problem.md:104–108 (the acceptance criterion
+  verbatim). Hickey's "Simple Made Easy" talk (referenced in the
+  parent problem decomposition strategy as the "concern axis") for
+  the decomplecting warrant.
+
+#### Falsification attempt for claim 4
+
+- **Strategy:** edge-case enumeration over each of the four
+  acceptance-criterion clauses. For each, check the public-interface-
+  alone reader can answer the question without descending.
+- **Attempt:** (i) Shape contract: reader of `Tau.Tool` behaviour
+  + `Tau.Tool.Executor.call/4` docstring → answer "result has
+  `details.kind` injected if absent; raises become `Result.error`."
+  Yes, sufficient. (ii) Collection bound: reader of
+  `Tau.IO.Port` moduledoc + each owner's `@max_*_bytes` attribute →
+  answer "bounded at N bytes, port closed on cap." Yes — but only
+  if the moduledoc cross-references the three call sites or each
+  owner publishes its cap value; the io-collectors solution.md:103–
+  104 introduces the utility module but does NOT specify a moduledoc
+  index of the three cap values. Minor: bound-value visibility
+  depends on each owner module documenting its own attribute.
+  (iii) Concurrency model: `Tau.MCP.Transport` behaviour docstring
+  declares "MUST NOT block." Yes, sufficient. (iv) Dispatch
+  mechanism: `Tau.Tool.lookup/1`'s widened type signature reveals
+  the union; `Tau.Hooks.Dispatcher.run_one/3`'s two clauses reveal
+  the hook dispatch. Yes, sufficient.
+- **Outcome:** withstood, with a minor note that PR-A's
+  `Tau.IO.Port` moduledoc should index the three cap values for the
+  reader to fully satisfy clause (ii) from public interfaces alone.
+  This is an authoring detail, not a design gap.
+- **Action:** none. Note added as Outstanding doubt for the
+  implementer.
+
+### Claim 5: No new GenServers, no new ETS tables, no new supervised workers across all four moves
+
+- **Claim (C):** The supervision tree does not grow; the result-
+  contract wrapper is a pure function; the port utility is a pure
+  function; the task-per-invoke uses `Task.start/1`; the registry-
+  value struct change replaces dynamic modules with data
+  (solution.md:180–186).
+- **Grounds (G):** Per-child commitments:
+  result-contract solution.md:104 ("Reversal is two file deletions");
+  io-collectors solution.md:97 ("no new processes, supervisors, or
+  application children"); mcp-server-concurrency solution.md:89, 124
+  ("Task.start" — no supervised process); dynamic-module-generation
+  solution.md:104 ("no new GenServers, no new ETS tables, no new
+  supervised workers").
+- **Warrant (W):** OTP non-negotiable #1 (Tau OTP rules:
+  "Stateful subsystems MUST run as supervised processes") cuts the
+  other way here — if any of these required state, a supervised
+  process would be mandatory. Each child explicitly chose a
+  stateless mechanism (pure function, struct, unsupervised Task) to
+  *avoid* triggering #1.
+- **Qualifier (Q):** Holds for the *core* supervision tree. The
+  unsupervised `Task.start/1` in PR-C is a known tension with OTP
+  non-negotiable #1: an unsupervised process for short-lived
+  network I/O. The mcp-server-concurrency child's Open Questions
+  flags this explicitly (mcp-server-concurrency solution.md:124–
+  128) — "If the Server crashes mid-flight the orphaned Task's only
+  side effect is sending an undelivered message — benign." The
+  Qualifier is "no new *supervised* processes"; "unsupervised
+  Task.start/1" remains a per-PR design decision the implementer
+  must defend in the PR.
+- **Rebuttal (R):** If the OTP non-negotiable is interpreted strictly
+  ("MUST run under a supervisor"), the `Task.start/1` choice is a
+  violation. Reading the rule charitably — "stateful subsystems"
+  excludes a one-shot network request — preserves the claim. The
+  child's open-question entry preserves this for PR review.
+- **Backing (B):** `.claude/rules/otp-non-negotiables.md` #1, #3
+  ("MUST NOT wrap stateless logic in a GenServer"); per-child
+  solution.md commitments cited above.
+
+#### Falsification attempt for claim 5
+
+- **Strategy:** dependency check. For each of the four PRs, check
+  whether the proposed mechanism introduces a process under a
+  supervisor.
+- **Attempt:** PR-A: new `lib/tau/io/port.ex` is a pure-function
+  utility (io-collectors solution.md:67). No process. PR-B: new
+  `lib/tau/tool/executor.ex` is a pure-function wrapper (result-
+  contract solution.md:63, 88). No process. PR-C: `Task.start/1` per
+  invoke (mcp-server-concurrency solution.md:67–68) — process, but
+  unsupervised. PR-D: `%Entry{}` and `%ToolEntry{}` are plain
+  structs (dynamic-module-generation solution.md:61, 65). No
+  process. Net: zero supervised additions; one unsupervised
+  per-invoke Task in PR-C.
+- **Outcome:** withstood, with the qualifier above. The "no new
+  supervised workers" claim is literally true; the looser "no new
+  processes" claim is false (PR-C spawns Tasks) but the synthesis
+  solution.md:184–186 carefully says "Task.start/1" rather than "no
+  new processes." Wording is precise.
+- **Action:** none.
+
+### Claim 6: Each PR is independently reversible by reverting its commits; nothing in the sequence forces an irreversible coupling
+
+- **Claim (C):** Each PR is independently reversible by reverting
+  its commits (solution.md:239–240); the four PRs do not create an
+  irreversible coupling.
+- **Grounds (G):** PR-A introduces a utility module + three call-
+  site rewrites (revert: delete utility, revert three sites). PR-B
+  introduces an executor module + one-line call rewrite (revert:
+  delete module, restore one line). PR-C removes a behaviour
+  callback (revert: re-add `recv/2` to the behaviour and the three
+  implementations — non-trivial but mechanical). PR-D introduces
+  two structs and dispatch clauses (revert: re-introduce
+  `Module.create/3` — non-trivial but mechanical).
+- **Warrant (W):** A PR is reversible iff its revert leaves a
+  compilable, behaviour-preserving codebase. None of the four PRs
+  modifies wire formats, persistent storage, supervisor specs, or
+  cross-process protocols in a way that would leave residual state
+  inconsistent with a reverted code state.
+- **Qualifier (Q):** Strict reversibility holds for PR-A and PR-B
+  (single-utility additions). PR-C and PR-D each require a coupled
+  revert — PR-C's `recv/2` removal must be re-added to all three
+  transport modules; PR-D's `Module.create/3` deletion must be
+  restored. "Reversible" here means "the change can be undone by a
+  single PR's revert," not "trivial." This is the standard
+  interpretation per `.claude/rules/factory-loop.md` reversibility.
+- **Rebuttal (R):** If PR-D landed and a downstream consumer
+  serialised the registry value (e.g., to disk for hot-reload),
+  reverting PR-D would orphan on-disk struct data and
+  `Module.create/3`'s re-generation would not consume it. No such
+  consumer is named in the synthesis or children — but the
+  dynamic-module child's Open Questions §138–140 flag extension-
+  loaded tools as the future scope, suggesting this rebuttal would
+  surface there, not here.
+- **Backing (B):** `.claude/rules/factory-loop.md`'s "Each PR is
+  independently reversible by reverting its commits" reversibility
+  norm; root solution.md:239–240 commitment.
+
+#### Falsification attempt for claim 6
+
+- **Strategy:** counter-example construction. Try to construct a
+  revert order that breaks the codebase.
+- **Attempt:** (i) Revert PR-A while PR-B/C/D are landed: PR-B
+  unaffected (different files); PR-C's `recv/2` removal independent;
+  PR-D's struct work independent. The revert restores `try/catch
+  Port.close/1` at three sites — compiles; no consumer of
+  `Tau.IO.Port` outside the four PRs. Works. (ii) Revert PR-B while
+  D is landed: PR-D's `%ToolEntry{}` dispatch clause is documented
+  to route through `Tau.Tool.Executor.call/4` (synthesis composition
+  note 1) — if PR-B is reverted, the call to the deleted module
+  fails to compile. PR-D revert order is required: revert PR-D
+  *before* PR-B. The synthesis claim "each PR independently
+  reversible" is therefore conditional on respecting the same
+  dependency order in reverse. (iii) Revert PR-C: re-add `recv/2`
+  to behaviour and three implementations; no other PR depends on
+  the removal. Works. (iv) Revert PR-D: restore `Module.create/3`
+  in two `build/*` functions, restore `lookup/1` return type,
+  remove dispatcher struct clauses. No other PR depends. Works.
+- **Outcome:** withstood, with the qualifier that PR-D must revert
+  before PR-B (mirror of the landing order). The synthesis
+  solution.md:239–240 says "each PR is independently reversible by
+  reverting its commits" — this is true in isolation but the *order*
+  of reverts is constrained when both B and D are landed.
+- **Action:** none. Note added as Outstanding doubt; the synthesis
+  could explicitly say "revertible in reverse landing order" but
+  the omission is minor.
+
+## Cross-claim consistency
+
+Claims 1, 2, and 6 form a coherent triangle: disjoint module surfaces
+(C1) enable an ordering that is largely free (C2) and therefore
+trivially reversible (C6). Claim 5 (no new supervised processes) is
+consistent with claims 1–4 (all decomplecting axes pursued via pure
+functions or structs). Claim 3 (the union-executor wrap) is the one
+synthesis-level claim that cuts across PR-B and PR-D's boundary, and
+the partial falsification touches two surfaces (validator guard,
+fictional `dispatch_tool/3`) that the synthesis solution.md
+*acknowledges as uncertain* with the "(or `lib/tau/session/
+tool_dispatch.ex` if the dispatch lives there)" hedge at line 158–159
+— so the partial falsification is *consistent* with the solution's own
+hedging rather than contradicting it. The narrowing of Q3 does not
+falsify Q1, Q2, Q4, Q5, or Q6.
+
+No internal tension. No claim contradicts another.
+
+## Falsification summary
+
+| # | Claim (short) | Strategy | Outcome | Action |
+|---|---|---|---|---|
+| 1 | Four children act on disjoint module/function surfaces | integration check + edge-case enumeration | withstood | none |
+| 2 | A → B → C → D is a valid landing sequence; only B → D is ordering-bearing | counter-example construction | withstood | none |
+| 3 | Executor wraps both module and `%ToolEntry{}` branches uniformly | integration check + type-level check | partially falsified | narrow Qualifier in place (validator guard + dispatch-function name) |
+| 4 | Conjoined four moves satisfy the parent acceptance criterion | edge-case enumeration over each AC clause | withstood (minor note on cap-value documentation) | none |
+| 5 | No new supervised workers / GenServers / ETS tables | dependency check on each PR's mechanism | withstood (qualifier: unsupervised `Task.start/1` in PR-C is an acknowledged open question, not a violation) | none |
+| 6 | Each PR independently reversible | counter-example construction over revert orders | withstood (qualifier: revert in reverse landing order if both B and D landed) | none |
+
+## Revision required
+
+None. The partial falsification of Claim 3 narrows the Qualifier in
+place; no revision of `solution.md` or `problem.md` is triggered. The
+narrowed Qualifier is itself the resolution: the executor's *signature*
+accepts the union (mechanically sound), and the call-site adjustments
+needed (`Tau.Tool.Validator.validate/2` second clause for
+`%ToolEntry{}`, and adding the `%ToolEntry{}` branch to
+`Tau.Session.ToolDispatch.run_tool/4` rather than the non-existent
+`dispatch_tool/3`) are implementer-brief details rather than design
+defects. The synthesis solution.md:158–159 already hedges on the
+dispatch location with "(or `lib/tau/session/tool_dispatch.ex` if the
+dispatch lives there)" — confirming the design acknowledges the
+implementer must locate the live function.
+
+If the coordinator wishes to tighten the solution.md before PR-B/PR-D
+land, a one-line edit to the synthesis's "What changes" §dynamic-module-
+generation bullet adding "`lib/tau/tool/validator.ex` — `validate/2`
+gains a `%ToolEntry{}` clause that reads `entry.parameters` directly"
+would close the gap without re-running propose/select. This is a
+surgical addition; the coordinator may apply it or defer to the
+implementer brief.
+
+## Outstanding doubts
+
+- The `Tau.IO.Port` moduledoc (PR-A) should index the three
+  per-owner cap-value module attributes (`@max_bytes` in `local.ex`,
+  `@max_output_bytes` in `hooks/shell.ex`, `@max_partial_bytes` in
+  `mcp/transport/stdio.ex`) so a reader of the public utility surface
+  can identify all three bounds without descending. This is an
+  authoring detail for PR-A's implementer.
+- `Tau.Tool.Validator.validate/2`'s `is_atom(mod)` guard at
+  `lib/tau/tool/validator.ex:42` must be widened (or bypassed for
+  `%ToolEntry{}` via routing through `entry.parameters`) before the
+  union dispatch in PR-D is functional end-to-end. Implementer-brief
+  item for PR-D.
+- The synthesis-named `dispatch_tool/3` does not exist; live
+  dispatch is `Tau.Session.ToolDispatch.run_tool/4` →
+  `run_tool_validated/6`. Implementer-brief item for PR-D: add the
+  `%ToolEntry{}` clause at the live entry point and widen the
+  `module()` argument to `module() | Tau.MCP.ToolEntry.t()`.
+- The unsupervised `Task.start/1` choice in PR-C (mcp-server-
+  concurrency solution.md Open Questions §124–128) needs an
+  explicit critic-gate defence against OTP non-negotiable #1, or a
+  swap to `Task.Supervisor.start_child/2` under a new supervisor in
+  the application tree. Implementer-brief item for PR-C.
+- "Independently reversible" holds only if the reverse-order
+  constraint (revert D before B) is documented in PR-B and PR-D's
+  bodies. Minor authoring note for the implementer.

--- a/docs/problems-archive-v1-modules/tau-tui-app/problem.md
+++ b/docs/problems-archive-v1-modules/tau-tui-app/problem.md
@@ -1,0 +1,106 @@
+---
+template_version: 1
+template_name: problem
+node_kind: internal
+depth: 0
+parent: —
+status: decomposed
+---
+
+# Problem: Inherited complecting in tau-tui-app sub-modules after decomposition
+
+## Statement
+
+The recent extraction of `Tau.TUI.App` into nine sub-modules (model, bootstrap,
+history, completion, keymap, input, view, events, permission) reduced LOC in the
+façade but did not resolve several inherited concerns that now span module
+boundaries or are duplicated across them. Multiple sub-modules carry mixed
+concerns — pure MVU state transformation entangled with side effects, view
+rendering entangled with business logic, and shared helpers copied rather than
+extracted — that make each sub-module harder to test, reason about, and evolve
+independently.
+
+## Context
+
+- `lib/tau/tui/app.ex` — ~42 LOC façade; delegates to sub-modules
+- `lib/tau/tui/app/model.ex` — 23-field struct + constructor (also owns `init_provider/1`, `init_model/1`, `transcript_pane_width/1`)
+- `lib/tau/tui/app/bootstrap.ex` — Ratatouille init callback + runtime supervisor lifecycle
+- `lib/tau/tui/app/events.ex` — session event dispatcher; owns `bounded_append/2`, `transcript_pane_width/1` (duplicated from Model)
+- `lib/tau/tui/app/input.ex` — submit/steer/followup/cancel; owns its own copy of `bounded_append/2` (duplicated from Events)
+- `lib/tau/tui/app/keymap.ex` — terminal key routing; directly calls `Tau.TUI.Supervisor` via side-effectful `spawn/1` in `quit_or_append/1`
+- `lib/tau/tui/app/view.ex` — Ratatouille view; owns `status_bar_model/1` (projection from full model to StatusBar map)
+- `lib/tau/tui/app/history.ex` — pure history navigation helpers
+- `lib/tau/tui/app/completion.ex` — pure menu helpers
+- `lib/tau/tui/app/permission.ex` — permission queue + dialog rendering (mixes event logic and view)
+- Decomposition inventory: `docs/refactor/inventory-tui-app.md`
+- SPEC-TUI-HEADLESS and SPEC-USER-TURN govern boundary contracts
+
+## Complecting hypothesis
+
+1. `bounded_append/2` (transcript ring-buffer) is complected with both the
+   events module and the input module because neither owns it canonically; each
+   carries a private copy, meaning the cap constant and the drop semantics are
+   duplicated rather than single-sourced.
+
+2. The MVU model struct (`Model.t()`) is complected with all consumer modules as
+   a raw map-like value — callers use `Map.get/3`, `Map.put/2`, and pattern-match
+   on anonymous map fields throughout `Events`, `Input`, `Keymap`, and `View`,
+   bypassing the typed struct. Struct-field access (`model.field`) and
+   anonymous-map access (`Map.get(model, :field, default)`) appear in the same
+   function bodies, making struct enforcement effectively opt-in.
+
+3. `Tau.TUI.App.Permission` is complected with both session-event handling and
+   Ratatouille view rendering — it owns `on_permission_request/2` (pure MVU fold),
+   `handle_permission_dialog_event/2` (key routing), and
+   `render_permission_dialog/2` (view fragment) — three concerns that belong to
+   Events, Keymap, and View respectively.
+
+## Decomposition strategy
+
+The four inherited concerns are distinct enough to be addressed independently
+and do not overlap:
+- **Duplicated shared helper** (`bounded_append`) — a missing extraction target.
+- **Model access pattern inconsistency** — raw map vs struct discipline.
+- **Cross-cutting session side effects in nominally-pure modules** — effects
+  are present in Input, Keymap, and Bootstrap in ways that make unit testing
+  harder.
+- **Permission module concern mix** — a single module holds event, key-routing,
+  and view responsibilities.
+
+Axis: **concern (Hickey)** — name the woven concerns directly. Each sub-problem
+names one woven pair and is solvable without knowing what the others conclude.
+
+## Sub-problems (filled by decomposer)
+
+1. **duplicated-bounded-append** — `bounded_append/2` is copied verbatim in
+   `Events` and `Input`; it has no canonical home, so the cap and drop semantics
+   can diverge silently.
+2. **model-as-bag-of-maps** — `Model.t()` struct discipline is undermined by
+   pervasive `Map.get/3` and `Map.put/2` calls in consumer modules, defeating
+   struct enforcement and `@enforce_keys`.
+3. **session-side-effects-in-pure-modules** — `Input`, `Keymap`, and `Bootstrap`
+   mix `Tau.*` session calls and `spawn/1` with pure MVU transformations, making
+   unit tests require a live session or process.
+4. **transcript-coupling** — `on_message_end/2` in `Events` owns Markdown
+   rendering, subagent tree lookups, `StatusBar` telemetry emission, and cost
+   ETS access in one handler, coupling concerns that could be independently
+   tested or replaced.
+
+## Acceptance criterion
+
+Each sub-problem is described at sufficient resolution that a proposer can
+produce a concrete, independently-evaluable refactoring proposal without
+needing to re-read sibling sub-problems.
+
+## Out of scope
+
+- Re-examining the correctness of the TUI's FSM or session protocol.
+- Ratatouille framework behaviour or tick/subscription logic.
+- The `History`, `Completion`, and `Keymap` modules' internal logic (they are
+  already well-shaped within their stated scope).
+- Dependency or OTP supervision tree changes.
+- Performance or rendering fidelity issues.
+
+## Amendment log
+
+- (none yet)

--- a/docs/problems-archive-v1-modules/tau-tui-app/solution.md
+++ b/docs/problems-archive-v1-modules/tau-tui-app/solution.md
@@ -1,0 +1,305 @@
+---
+template_version: 1
+template_name: solution
+parent_problem: problem.md
+node_kind: root
+synthesised_from: [subproblems/duplicated-bounded-append/solution.md, subproblems/model-as-bag-of-maps/solution.md, subproblems/session-side-effects-in-pure-modules/solution.md, subproblems/transcript-coupling/solution.md]
+selection_method: synthesis
+mode: non-leaf
+revision: 0
+---
+
+# Solution: Module-wide decomplecting of `Tau.TUI.App` sub-modules via canonical helper home, struct discipline, command pattern, and intra-module handler split
+
+## Recommendation
+
+Land the four child recommendations as one coherent module-wide refactor sequenced
+in dependency order so each later step works on a cleaner substrate than the last.
+First, give `bounded_append/2` and `@transcript_cap` a canonical home in `Model`
+and delete both private copies (child 1). Second, replace every `Map.get/Map.put`
+on a `Model.t()` value with struct access across `Events`, `Input`, `Keymap`,
+`View`, `Permission`, `Completion`, and `History`, retyping `@spec`s from `map()`
+to `Model.t()` and introducing the single `Model.context_window/1` accessor for
+the one non-trivial nil-fallback (child 2). Third, convert every public `Input`
+function and `Keymap.handle/2` to return `{model, [Cmd.t()]}` against a new
+`Tau.TUI.App.Cmd` tagged-union module, with the façade owning command dispatch
+via a thin `run_input/2` helper, and lift `Keymap.quit_or_append/1`'s `spawn/1`
+into a named `do_stop_tui_supervisor/0` invoked only from `Cmd.execute/1` (child
+3). Fourth, replace `Events.on_message_end/2` with a thin dispatcher over two
+disjoint-field private handlers, `on_message_end_transcript/2` and
+`on_message_end_counters/2` (child 4). The four steps compose without conflict
+because their primary file boundaries are orthogonal (Model API; callsite syntax;
+Input/Keymap return shape; one Events function body), but they must land in this
+order so each step's callsite churn does not collide with the next step's.
+
+## Selected from
+
+- **Synthesised from:**
+  - `subproblems/duplicated-bounded-append/solution.md`
+  - `subproblems/model-as-bag-of-maps/solution.md`
+  - `subproblems/session-side-effects-in-pure-modules/solution.md`
+  - `subproblems/transcript-coupling/solution.md`
+- **Composition rationale:** The four child solutions partition the inherited
+  complecting along disjoint axes:
+
+  | Child | Primary axis | Primary surface |
+  |-------|--------------|-----------------|
+  | 1 — bounded-append | canonical helper home | `Model` adds 2 functions + 1 constant; `Events`/`Input` lose duplicates |
+  | 2 — struct discipline | callsite syntax + `@spec` typing | `Map.get/put` → `model.field`/`%{model | ...}` across 6+ files; `Model.context_window/1` accessor |
+  | 3 — command pattern | function return shape | `Input` and `Keymap.handle/2` return `{model, [Cmd.t()]}`; new `Cmd` module; façade dispatches |
+  | 4 — handler split | intra-function decomposition | one function body in `Events.on_message_end/2` replaced by dispatcher + two named handlers |
+
+  The axes are independent: helper extraction (1) does not move callsites; struct
+  discipline (2) changes call syntax but not return shapes; command pattern (3)
+  changes return shapes and adds a new module; handler split (4) is wholly inside
+  one function. No two children write to the same line of any file *for the same
+  reason*. They DO touch overlapping files (`Events`, `Input`, `Keymap`), but at
+  layered concerns: (1) adds aliases and removes definitions; (2) rewrites
+  callsite syntax inside function bodies; (3) rewrites function signatures and
+  introduces command dispatch; (4) restructures one function body.
+
+  **Sequencing constraint.** (1) → (2) → (3) → (4) is the only ordering that
+  avoids inter-step rework:
+
+  - (1) before (2): the `bounded_append` callsites in `Events`/`Input` are
+    rewritten by (1) to qualify with `Model.`; (2) then rewrites the surrounding
+    `Map.get/put` calls in the same files. Reversing introduces a merge surface
+    where (2) edits a `bounded_append` call that (1) is about to relocate.
+  - (2) before (3): the new `Input` return shapes from (3) are easier to author
+    against struct-typed models than against `Map.get/put` syntax. Reversing
+    forces (3) to rewrite return shapes around legacy `Map.get` calls, then have
+    (2) re-edit those same lines.
+  - (2) before (4): the new `on_message_end_*` handlers in (4) are easier to
+    author with `model.field` access throughout. Same reasoning as above.
+  - (3) and (4) are independent of each other and could land in either order;
+    (3) before (4) is preferred because (3)'s scope is broader and its merge
+    risk against `main` is higher.
+
+  **No tension between child recommendations.** Each child solution's "What does
+  not change" section explicitly excludes the surfaces the other children
+  modify, and each child's "What changes" list is internally consistent with
+  every other child's exclusion list.
+
+  **One acknowledged gap.** The root `problem.md` names four inherited concerns;
+  the decomposer produced four sub-problems but substituted `transcript-coupling`
+  for the listed `permission-module-concern-mix`. Children 2 and 3 partially
+  address the Permission module (struct discipline in 2; the
+  `set_permissions_mode` command tag in 3's `Cmd.t()`), but neither extracts
+  `Permission.render_permission_dialog/2` to `View` nor moves
+  `Permission.handle_permission_dialog_event/2` to `Keymap`. The Permission
+  concern-mix is therefore *partially* addressed by this synthesis and remains an
+  open question (see below) for a follow-up decomposition pass, not a blocker
+  for the four-step plan.
+
+## What changes
+
+The full union of child "What changes" lists, deduplicated and grouped by file:
+
+### New files
+- `lib/tau/tui/app/cmd.ex` — `Tau.TUI.App.Cmd.t()` tagged union + `execute/1`
+  dispatch. Tags: `{:send, sid, text}`, `{:cancel, sid}`, `{:steer, sid, text}`,
+  `{:set_permissions_mode, sid, mode}`, `:stop_tui_supervisor`.
+
+### `lib/tau/tui/app/model.ex`
+- Add `@transcript_cap 500`.
+- Add `def bounded_append/2` and `def bounded_append_many/2` with `@doc`/`@spec`.
+- Add `def context_window/1` with `@spec context_window(t()) :: pos_integer()` —
+  two-clause function returning the field value when set, or
+  `Application.get_env(:tau, :compaction_threshold_tokens, 120_000)` when nil.
+
+### `lib/tau/tui/app/events.ex`
+- Remove `@transcript_cap 500`, the private `defp bounded_append/2`, the public
+  `def bounded_append/2`, and `def bounded_append_many/2`.
+- Add `alias Tau.TUI.App.Model` if not present; route all transcript appends
+  through `Model.bounded_append/2`/`bounded_append_many/2`.
+- Retype `@spec update/2` and `@spec update_session_event/2` from `map()` to
+  `Model.t()`.
+- Replace every `Map.get(model, ...)` and `Map.put(model, ...)` with struct field
+  access and `%{model | ...}` update syntax.
+- Replace `Map.get(model, :context_window) || Application.get_env(...)` with
+  `Model.context_window(model)`.
+- Replace `on_message_end/2` (~77 LOC) with a thin dispatcher (~4 LOC) that
+  pipes through two new private functions:
+  - `on_message_end_transcript/2` (~20 LOC) — reads `model.subagents` and
+    `msg.content`; writes `model.transcript` and `model.last_assistant`; no ETS,
+    no telemetry.
+  - `on_message_end_counters/2` (~20 LOC) — reads `model.session_id`,
+    `model.context_window`, `model.warn_level`, and `message.usage`; writes
+    `model.usage`, `model.context_tokens`, `model.warn_level`, `model.status`;
+    calls the existing `cost_for_session/1` private helper; emits the
+    `[:tau, :tui, :status, :update]` telemetry event.
+  - `cost_for_session/1` (the sole `try/rescue` site) is unchanged.
+
+### `lib/tau/tui/app/input.ex`
+- Remove `@transcript_cap 500` and `defp bounded_append/2`.
+- Add `alias Tau.TUI.App.Model`; route the affected callsite through
+  `Model.bounded_append/2`.
+- Replace any `Map.get/put` on `model` with struct access; retype `@spec`s from
+  `map()` to `Model.t()`.
+- Change every public function (`submit/1`, `cancel/1`, `steer/1`, `followup/1`,
+  `handle_perms_command/2`) return type from `map()` to `{Model.t(), [Cmd.t()]}`.
+  Replace each `Tau.*`/`Tau.Session.*` call with an element in the returned
+  command list.
+- Remove the "pure except for side-effectful Tau session calls" caveat from
+  `@moduledoc`; all public functions are now pure.
+
+### `lib/tau/tui/app/keymap.ex`
+- Retype affected `@spec`s to `Model.t()`; replace
+  `Map.get(model, :pending_permissions, [])` with `model.pending_permissions`.
+- In `quit_or_append/1`, lift the `spawn/1` body into a `defp
+  do_stop_tui_supervisor/0` and return `{model, [:stop_tui_supervisor]}` (quit
+  branch) or `{model, []}` (non-quit branch). Propagate `{model, cmds}` up
+  through `handle/2`, which becomes the public boundary returning `{model, cmds}`
+  to the façade. `do_stop_tui_supervisor/0` is called only from `Cmd.execute/1`.
+
+### `lib/tau/tui/app/view.ex`
+- Retype `@spec status_bar_model/1` from `map()` to `Model.t()`.
+- Replace every `Map.get(model, :field, default)` in `status_bar_model/1` with
+  `model.field`; replace `Map.get(model, :context_window)` with
+  `Model.context_window(model)`.
+
+### `lib/tau/tui/app/permission.ex`
+- Retype affected `@spec`s to `Model.t()`.
+- Replace `Map.get(model, :pending_permissions, [])` with
+  `model.pending_permissions`; replace
+  `Map.put(model, :pending_permissions, ...)` with
+  `%{model | pending_permissions: ...}`.
+
+### `lib/tau/tui/app/completion.ex` and `lib/tau/tui/app/history.ex`
+- Audit for `Map.get/put` on `Model.t()` values; apply the same mechanical
+  replacement if found.
+
+### `lib/tau/tui/app.ex` (façade)
+- Add a thin `run_input/2` helper that calls `Input.<fn>(model)`, destructures
+  `{new_model, cmds}`, runs `Enum.each(cmds, &Cmd.execute/1)`, and returns
+  `new_model`. Update existing `Keymap.handle/2` callsites to destructure
+  identically.
+
+### Tests
+- Add the two new unit tests for `on_message_end_transcript/2` (stub
+  `SubagentTree`, no ETS) and `on_message_end_counters/2` (mock session counter,
+  attached telemetry handler, no Markdown content).
+- Update existing `Input`-focused tests to destructure `{model, _cmds}`; add new
+  tests asserting on the command list values without any live process.
+- No test changes are required for child 1 (function bodies preserved exactly)
+  or child 2 (struct access is observationally equivalent provided no fixture
+  relied on `Map.get` defaulting; verify per child 2's open questions).
+
+## What does not change
+
+- The `Model.t()` struct's field set and `@enforce_keys` list — no field added,
+  removed, or renamed.
+- `Model.new/1` — no signature change.
+- Sub-field shapes (`usage`, `search`, `menu`) — no sub-struct extraction.
+- `Tau.Cost.for_session/1` return type and `Tau.Cost` API — unchanged.
+- `Tau.TUI.StatusBar` module — no new functions; `context_pct/2` and
+  `warn_level/1` called as before.
+- `Tau.TUI.Render.Markdown` and `Tau.TUI.SubagentTree` — no changes.
+- The `Tau.*` and `Tau.Session.*` public API surface — unchanged (out of scope).
+- `Bootstrap.init/1` and its lifecycle side effects — out of scope.
+- The `Tau.TUI.App` public interface and event-loop structure — façade gains one
+  private helper, no new public callbacks.
+- The telemetry event schema `[:tau, :tui, :status, :update]` and its metadata
+  (including `session_id`) — D-168/D-169 unchanged.
+- `Cost.for_session/1` and the `cost_for_session/1` private helper in `Events` —
+  unchanged; `try/rescue` stays where it is.
+- SPEC-TUI-HEADLESS Appendix B source map — no new files to register; `Cmd` is
+  an internal sub-module of `Tau.TUI.App`, not a boundary.
+- The cap value 500 and the ring-buffer drop semantics — preserved exactly.
+- The `Tau.TUI.App.Transcript` module — does not exist and is not introduced.
+
+## Migration sketch
+
+One branch, four PRs (or four commits on one PR) in strict order — each
+gateable independently because each preserves observable behaviour:
+
+1. **PR1 (child 1).** Add `bounded_append`, `bounded_append_many`,
+   `@transcript_cap` to `Model`. Update `Events` and `Input` to alias + call
+   through `Model`; remove duplicates. `mix compile --warnings-as-errors`,
+   `mix test`. Grep `Events.bounded_append` for external callers (expected
+   zero).
+
+2. **PR2 (child 2).** Add `Model.context_window/1`. Walk the file list in
+   dependency order — `events.ex` (largest), then `view.ex`, then `keymap.ex`,
+   `permission.ex`, `input.ex`, `completion.ex`, `history.ex`. Each file is one
+   commit so bisection is clean if a fixture surfaces a hidden gap. `mix
+   compile --warnings-as-errors`, `mix test`, `mix dialyzer` after the final
+   commit.
+
+3. **PR3 (child 3).** Introduce `lib/tau/tui/app/cmd.ex` (no callers yet).
+   Convert `Input` public functions one at a time: change the return type,
+   move `Tau.*` calls to cmd-list elements, update the corresponding
+   `app.ex`/`Keymap` callsite to destructure and call `Cmd.execute/1`. Compile
+   and test between each function. Then convert `Keymap.quit_or_append/1`:
+   lift `do_stop_tui_supervisor/0`, return `{model, [:stop_tui_supervisor]}`,
+   propagate through `handle/2`. Update `Input`-focused tests to destructure
+   `{model, _cmds}`; add new tests asserting on the cmd list. Remove
+   `Input.@moduledoc` purity caveat.
+
+4. **PR4 (child 4).** Introduce `on_message_end_transcript/2` and
+   `on_message_end_counters/2` reproducing the existing logic. Replace
+   `on_message_end/2`'s body with the dispatcher pipe. `mix compile
+   --warnings-as-errors` to confirm no cross-reads. Add the two new unit tests.
+
+Each PR is independently revertible. Existing integration tests are expected to
+pass throughout because all four child changes preserve observable behaviour at
+the `Tau.TUI.App` public interface.
+
+## Open questions
+
+- **Permission concern-mix is only partially addressed.** The root `problem.md`
+  lists `Permission` carrying event logic + key routing + view rendering as one
+  of the four inherited concerns; the decomposer substituted `transcript-coupling`
+  for it. After this synthesis lands, `Permission` will benefit from struct
+  discipline (child 2) and the `set_permissions_mode` cmd tag (child 3), but its
+  view fragment is still co-located with its event logic and key routing. A
+  follow-up sub-problem should decompose `Permission` along the same Events /
+  Keymap / View lines the root problem identifies.
+- **`Store.append/3` in `Input.submit/1`** is disk I/O remaining in the `Input`
+  pure path after child 3. Child 3's open question 2 notes this is in-scope
+  ambiguous; the synthesis defers it to a follow-up.
+- **`Cmd.execute/1` for `:stop_tui_supervisor`** retains a `spawn/1` (correct,
+  to avoid blocking the event loop, but now in one named location). Verify
+  against `.claude/rules/otp-non-negotiables.md` — supervised processes are
+  required for stateful work; this is a one-shot fire-and-forget; document the
+  justification at the call site.
+- **Test fixtures may rely on `Map.get` defaulting.** Child 2's open question 2
+  identifies this risk; implementers must verify `mix test` passes after each
+  file's conversion. If a fixture surfaces, fix the fixture, do not re-introduce
+  the default.
+- **`completion.ex`/`history.ex` `Map.get/put` audit** must run before
+  implementation begins (child 2 open question 1); they may have no such calls,
+  in which case those files are no-ops for child 2.
+- **Dialyzer widening on `Model.context_window/1`** must be verified (child 2
+  open question 3); a two-clause pattern match returning the same type from
+  both branches should propagate cleanly.
+- **Independence of the two new `Events` handlers is convention-enforced, not
+  type-enforced** (child 4 open questions 1–2). A reviewer checklist is the
+  only guard against a future author re-coupling them.
+- **`Keymap` private call graph** below `handle/2` was not fully traced in
+  child 3; a grep before implementation is required to confirm exactly one path
+  carries the `{model, cmds}` propagation (child 3 open question 1).
+
+## Linked sub-problems / proposals
+
+- `subproblems/duplicated-bounded-append/` → "Extract `bounded_append/2`,
+  `bounded_append_many/2`, and `@transcript_cap 500` into `Tau.TUI.App.Model` as
+  public functions; remove both private copies from `Events` and `Input`."
+- `subproblems/model-as-bag-of-maps/` → "Replace every `Map.get/Map.put` on
+  `Model.t()` with struct access across `Events`, `Input`, `Keymap`, `View`,
+  `Permission` (and audit `Completion`/`History`); retype `@spec`s from `map()`
+  to `Model.t()`; add `Model.context_window/1` for the one non-trivial
+  nil-fallback."
+- `subproblems/session-side-effects-in-pure-modules/` → "Convert public `Input`
+  functions and `Keymap.handle/2` to return `{model, [Cmd.t()]}` against a new
+  `Tau.TUI.App.Cmd` module; lift `Keymap.quit_or_append/1`'s `spawn/1` into a
+  named function called only from `Cmd.execute/1`; add a `run_input/2` dispatch
+  helper to the façade."
+- `subproblems/transcript-coupling/` → "Replace `Events.on_message_end/2` with a
+  thin dispatcher over two disjoint-field private handlers
+  (`on_message_end_transcript/2`, `on_message_end_counters/2`); the
+  `cost_for_session/1` `try/rescue` site is unchanged."
+
+## Revision history
+
+- (revision 0 — initial)

--- a/docs/problems-archive-v1-modules/tau-tui-app/subproblems/duplicated-bounded-append/problem.md
+++ b/docs/problems-archive-v1-modules/tau-tui-app/subproblems/duplicated-bounded-append/problem.md
@@ -1,0 +1,60 @@
+---
+template_version: 1
+template_name: problem
+node_kind: leaf
+depth: 1
+parent: ../../problem.md
+status: draft
+---
+
+# Problem: `bounded_append/2` duplicated across Events and Input with no canonical home
+
+## Statement
+
+`bounded_append/2` — the function that appends a `{text, attrs}` tuple to the
+transcript list and enforces a 500-entry cap — is defined as a private function
+in both `Tau.TUI.App.Events` and `Tau.TUI.App.Input`, with identical bodies and
+the same `@transcript_cap 500` module attribute. Any future change to the cap
+constant or drop semantics must be made in two places, and the absence of a
+canonical home means a third consumer (e.g. a new sub-module) will copy it
+again rather than call it from one source.
+
+## Context
+
+- `lib/tau/tui/app/events.ex:428–437` — `defp bounded_append/2` + `bounded_append_many/2`; also has public `@doc` specs
+- `lib/tau/tui/app/events.ex:18` — `@transcript_cap 500`
+- `lib/tau/tui/app/input.ex:193–201` — `defp bounded_append/2`; private, no spec
+- `lib/tau/tui/app/input.ex:191` — `@transcript_cap 500`
+- Both copies are identical: `list ++ [item]`, then `Enum.drop` if over cap.
+- `bounded_append_many/2` is defined only in `Events`; `Input` has no equivalent.
+- `Model.t()` owns the `transcript` field; `Model` does not own the append helper.
+
+## Complecting hypothesis
+
+`bounded_append/2` is complected with both `Events` and `Input` because the
+decomposition created two modules that both mutate `model.transcript` and
+each privately claimed the helper rather than extracting it to its natural
+home (`Model`, which owns the `transcript` field's definition and invariants).
+
+## Decomposition strategy
+
+(leaf — no further decomposition; proceed to proposals)
+
+## Acceptance criterion
+
+A single canonical implementation of `bounded_append/2` (and `bounded_append_many/2`)
+exists in exactly one location; every consumer calls that single implementation;
+the `@transcript_cap` constant is defined once; and the duplication is absent
+from both `Events` and `Input`.
+
+## Out of scope
+
+- Changing the cap value or the ring-buffer semantics.
+- Moving transcript rendering or any other transcript concern.
+- Changes to `model-as-bag-of-maps` (sibling sub-problem).
+- Changes to `session-side-effects-in-pure-modules` (sibling).
+- Changes to `transcript-coupling` (sibling).
+
+## Amendment log
+
+- (none yet)

--- a/docs/problems-archive-v1-modules/tau-tui-app/subproblems/duplicated-bounded-append/proposals/proposal-1.md
+++ b/docs/problems-archive-v1-modules/tau-tui-app/subproblems/duplicated-bounded-append/proposals/proposal-1.md
@@ -1,0 +1,144 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 1
+parent_problem: ../problem.md
+---
+
+# Proposal 1: Extract `bounded_append` into `Tau.TUI.App.Model` as a public function
+
+## Approach
+
+Move `bounded_append/2`, `bounded_append_many/2`, and `@transcript_cap` from
+`Events` and `Input` into `Tau.TUI.App.Model`. Expose them as public functions
+on the module that already owns the `transcript` field's type definition and
+invariants. Delete both private copies from `Events` and `Input`; replace their
+call-sites with `Model.bounded_append/2` and `Model.bounded_append_many/2`.
+
+## Rationale
+
+`Model` already declares `transcript :: [{String.t(), keyword()}]` and is the
+canonical owner of the `Model.t()` struct. Functions that enforce an invariant
+on `model.transcript` (the ring-buffer cap) belong to that owner module —
+colocation of data definition and data invariant is the Hickey "compose, don't
+complect" principle. Extracting to `Model` does not require a new module,
+does not change the public API surface of `Events` or `Input`, and gives future
+consumers (e.g. a new sub-module) a single import target instead of a copy.
+The cap constant lives in exactly one place, eliminating silent divergence.
+
+## Sketch
+
+```elixir
+# lib/tau/tui/app/model.ex
+
+defmodule Tau.TUI.App.Model do
+  @transcript_cap 500
+
+  # ... existing struct + typedoc unchanged ...
+
+  @doc """
+  Append `item` to `list`, dropping the oldest entry when the transcript cap
+  is exceeded. Ring-buffer semantics: cap is #{@transcript_cap}.
+  """
+  @spec bounded_append([{String.t(), keyword()}], {String.t(), keyword()}) ::
+          [{String.t(), keyword()}]
+  def bounded_append(list, item) do
+    new_list = list ++ [item]
+
+    if length(new_list) > @transcript_cap do
+      Enum.drop(new_list, length(new_list) - @transcript_cap)
+    else
+      new_list
+    end
+  end
+
+  @doc """
+  Append multiple items in order, applying the cap after each.
+  """
+  @spec bounded_append_many([{String.t(), keyword()}], [{String.t(), keyword()}]) ::
+          [{String.t(), keyword()}]
+  def bounded_append_many(list, items) do
+    Enum.reduce(items, list, &bounded_append(&2, &1))
+  end
+end
+```
+
+```elixir
+# lib/tau/tui/app/events.ex  (after change)
+# Remove: @transcript_cap 500, defp bounded_append/2, def bounded_append/2,
+#         def bounded_append_many/2
+# Add alias at top if not already present:
+alias Tau.TUI.App.Model
+
+# All call-sites become:
+Model.bounded_append(model.transcript, item)
+Model.bounded_append_many(model.transcript, items)
+```
+
+```elixir
+# lib/tau/tui/app/input.ex  (after change)
+# Remove: @transcript_cap 500, defp bounded_append/2
+# Add alias:
+alias Tau.TUI.App.Model
+
+# All call-sites become:
+Model.bounded_append(model.transcript, item)
+```
+
+File moves: none — changes are in-place edits to existing files.
+```
+
+## Tradeoffs
+
+### Strengths
+
+- Natural home: `Model` already owns the `transcript` type; collocating the
+  ring-buffer invariant with the field declaration is directly traceable.
+- Zero new modules: no new file, no new dependency edge.
+- Eliminates duplication completely: `@transcript_cap` and body exist once.
+- `bounded_append_many/2` becomes accessible to `Input` and future consumers
+  without further copy.
+- Behaviour-preserving: call-sites change only in qualification; the function
+  bodies are identical.
+
+### Weaknesses
+
+- `Model` will now hold some logic, moving it slightly away from a pure
+  data-shape module. Reviewers may object to a "fat model" precedent.
+- `Events` currently has a public `def bounded_append/2` with `@doc` and
+  `@spec`; removing it is an API change for any external caller that happens to
+  call `Events.bounded_append/2` directly (unlikely but must be audited).
+- The `Model` module is already wrapped in `if Code.ensure_loaded?(Ratatouille.Runtime)`;
+  the extracted function will only be available in environments where that
+  condition is true, which is fine for TUI use but slightly surprising for
+  anyone trying to unit-test it in isolation without Ratatouille loaded.
+
+### Costs
+
+- 2 files modified (`events.ex`, `input.ex`), 1 file modified to add functions
+  (`model.ex`).
+- Audit: grep for direct calls to `Events.bounded_append` to ensure no external
+  callers are silently broken (~5 min).
+- No test changes required if behaviour is preserved identically; existing tests
+  that exercise transcript append continue to pass.
+
+## Dependencies
+
+- No other sub-problem must be resolved first.
+- The `if Code.ensure_loaded?` guard in `model.ex` must be understood to
+  confirm the extracted functions are reachable in all test environments.
+
+## Confidence
+
+medium — the approach is straightforward and fits Elixir idiom, but the
+`if Code.ensure_loaded?` compilation guard in `model.ex` requires a quick
+prototype to confirm the function is reachable in non-Ratatouille test
+environments.
+
+## Prior art / references
+
+- Elixir idiom: data module owns its invariant helpers (`Date`, `Map`, `String`
+  all follow this pattern in stdlib).
+- `Tau.TUI.App.Model` already holds `transcript_pane_width/1` — a helper
+  scoped to the model — confirming the precedent for non-pure-struct helpers
+  in this module.

--- a/docs/problems-archive-v1-modules/tau-tui-app/subproblems/duplicated-bounded-append/proposals/proposal-2.md
+++ b/docs/problems-archive-v1-modules/tau-tui-app/subproblems/duplicated-bounded-append/proposals/proposal-2.md
@@ -1,0 +1,176 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 2
+parent_problem: ../problem.md
+---
+
+# Proposal 2: New `Tau.TUI.App.Transcript` sub-module with typed operations
+
+## Approach
+
+Create a new `lib/tau/tui/app/transcript.ex` module (`Tau.TUI.App.Transcript`)
+that defines a dedicated `t()` type for the transcript list, the cap constant,
+`append/2`, `append_many/2`, and a `new/0` constructor. Replace the
+`transcript :: [{String.t(), keyword()}]` inline type in `Model.t()` with
+`Transcript.t()`. All call-sites in `Events` and `Input` delegate to
+`Transcript.append/2` and `Transcript.append_many/2`. Both private copies and
+both `@transcript_cap` attributes are deleted.
+
+## Rationale
+
+The problem is not merely "which existing module should own the helper" but that
+the transcript is an opaque data structure (a ring-buffer of tuples with a
+semantically-significant cap) whose internal representation is currently leaked
+throughout `Events`, `Input`, and `Model`. Giving the transcript its own module
+makes the ring-buffer cap a property of the type, not of its consumers.
+`Events` and `Input` are then free of transcript-invariant knowledge entirely —
+they call `Transcript.append/2` without knowing the cap exists. This is a
+stronger decomplection than moving the function to `Model`: `Model` would still
+encode the cap number; a `Transcript` module hides it behind an opaque boundary.
+It also gives `bounded_append_many/2` a natural name (`append_many/2`) without
+the redundant qualifier.
+
+## Sketch
+
+```elixir
+# lib/tau/tui/app/transcript.ex  (new file)
+
+defmodule Tau.TUI.App.Transcript do
+  @moduledoc """
+  Ring-buffer transcript for the TUI. Each entry is a `{text, attrs}` tuple.
+  The buffer is capped at #{@cap} entries; oldest entries are dropped on overflow.
+  """
+
+  @cap 500
+
+  @opaque t :: [entry()]
+  @type entry :: {String.t(), keyword()}
+
+  @doc "Empty transcript."
+  @spec new() :: t()
+  def new(), do: []
+
+  @doc "Append a single entry, dropping the oldest when over cap."
+  @spec append(t(), entry()) :: t()
+  def append(list, item) do
+    new_list = list ++ [item]
+
+    if length(new_list) > @cap do
+      Enum.drop(new_list, length(new_list) - @cap)
+    else
+      new_list
+    end
+  end
+
+  @doc "Append multiple entries in order."
+  @spec append_many(t(), [entry()]) :: t()
+  def append_many(list, items) do
+    Enum.reduce(items, list, &append(&2, &1))
+  end
+end
+```
+
+```elixir
+# lib/tau/tui/app/model.ex  (modified type annotation only)
+
+alias Tau.TUI.App.Transcript
+
+defstruct [
+  # ...
+  :transcript,  # type changes to Transcript.t()
+  # ...
+]
+
+@type t :: %__MODULE__{
+        # ...
+        transcript: Transcript.t(),
+        # ...
+      }
+
+# new/1 constructor: change `transcript: []` to `transcript: Transcript.new()`
+```
+
+```elixir
+# lib/tau/tui/app/events.ex  (after change)
+alias Tau.TUI.App.Transcript
+
+# Remove: @transcript_cap, all bounded_append* definitions
+# All call-sites become:
+%{model | transcript: Transcript.append(model.transcript, item)}
+%{model | transcript: Transcript.append_many(model.transcript, items)}
+```
+
+```elixir
+# lib/tau/tui/app/input.ex  (after change)
+alias Tau.TUI.App.Transcript
+
+# Remove: @transcript_cap, defp bounded_append/2
+# All call-sites become:
+%{model | transcript: Transcript.append(model.transcript, item)}
+```
+
+File move: `(new)` → `lib/tau/tui/app/transcript.ex`
+```
+
+## Tradeoffs
+
+### Strengths
+
+- True decomplection: `Events` and `Input` no longer encode _any_ knowledge of
+  the cap or the ring-buffer semantics — all of that knowledge lives in one module.
+- The `@opaque t()` annotation makes the internal representation of the
+  transcript an implementation detail; no consumer can accidentally pattern-match
+  on the list structure without going through `Transcript`.
+- `Transcript.new()` and `Transcript.append/2` are unit-testable without
+  Ratatouille loaded — no `if Code.ensure_loaded?` guard needed.
+- Natural home for future transcript operations (e.g. serialisation, replay,
+  search) without touching `Events`, `Input`, or `Model`.
+- Eliminates `@transcript_cap` in two places simultaneously.
+
+### Weaknesses
+
+- Introduces a new module: adds a file, a dependency edge, and a concept to the
+  sub-module inventory (now 10, not 9 sub-modules). Reviewers may view this as
+  over-engineering for a 15-line helper.
+- The `@opaque` annotation means code that currently pattern-matches `model.transcript`
+  as a raw list (e.g. `Enum.map(model.transcript, fn {text, attrs} -> ...)`) outside
+  `Transcript` would produce a dialyzer opacity violation. Auditing all consumers is
+  required before the `@opaque` annotation can land safely.
+- `bounded_append_many/2` is renamed to `append_many/2` — a public API name change
+  for the currently-public function in `Events`. Any external caller using
+  `Events.bounded_append_many/2` breaks.
+- Slightly more indirection than Proposal 1 for a minimal change.
+
+### Costs
+
+- 1 new file, 3 modified files (`model.ex`, `events.ex`, `input.ex`).
+- Auditing `@opaque` impact: grep for `model.transcript` and `Enum.*transcript`
+  across all sub-modules to confirm no raw list access outside `Transcript` —
+  estimated 15–20 min.
+- If `@opaque` is deferred (use `@type` instead), the audit becomes simpler but
+  the encapsulation benefit is reduced.
+- Tests that assert on `model.transcript` as a list will dialyze-warn under
+  `@opaque`; those tests need to use `Transcript` accessors or be treated as
+  white-box tests acknowledged to pierce the opaque boundary.
+
+## Dependencies
+
+- None of the sibling sub-problems must be resolved first.
+- If the `model-as-bag-of-maps` sibling (sub-problem 2) is addressed
+  concurrently, the `Model.t()` type annotation change for `transcript` will
+  have a merge conflict with that PR's struct changes. Best serialized after or
+  coordinated with that sub-problem.
+
+## Confidence
+
+medium — the new module and function bodies are trivial; the main risk is the
+`@opaque` annotation audit, which could reveal widespread raw-list access that
+forces the opaque annotation to be deferred to a follow-up PR.
+
+## Prior art / references
+
+- Elixir stdlib: `MapSet`, `Queue` are opaque types whose internals are hidden
+  behind a module boundary — the same pattern applied to the transcript.
+- Hickey "Simple Made Easy" (2011): distinguishing "simple" (one concern) from
+  "easy" (familiar); a `Transcript` module is simpler even if it adds a file.

--- a/docs/problems-archive-v1-modules/tau-tui-app/subproblems/duplicated-bounded-append/proposals/proposal-3.md
+++ b/docs/problems-archive-v1-modules/tau-tui-app/subproblems/duplicated-bounded-append/proposals/proposal-3.md
@@ -1,0 +1,159 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 3
+parent_problem: ../problem.md
+---
+
+# Proposal 3: Inline-eliminate via `Model` update helper — no new function, data-shape change
+
+## Approach
+
+Do not extract `bounded_append/2` as a named function at all. Instead, add a
+`Model.append_transcript/2` function that takes the full `Model.t()` and an item
+and returns an updated `Model.t()` — the cap logic is inlined inside it. Remove
+both private copies of `bounded_append/2` and both `@transcript_cap` attributes.
+Call-sites in `Events` and `Input` change from
+`%{model | transcript: bounded_append(model.transcript, item)}` to
+`Model.append_transcript(model, item)`, hiding the field name as well as the
+cap. The `bounded_append_many/2` variant in `Events` becomes
+`Model.append_transcript_many/2` on the same model-update axis.
+
+## Rationale
+
+The complecting here is not just "two modules own the helper" but that
+call-sites in `Events` and `Input` must know (a) the field name `transcript`,
+(b) the type `[{text, attrs}]`, and (c) the ring-buffer cap. A model-update
+function hides all three behind a single operation. This is the
+"tell, don't ask" style: instead of the caller extracting
+`model.transcript`, transforming it, and putting it back, the model updates
+itself. The cap constant remains private to `Model` (a private `@transcript_cap`
+attribute), never shared. Call-sites shrink and carry less knowledge.
+
+## Sketch
+
+```elixir
+# lib/tau/tui/app/model.ex  (additions)
+
+@transcript_cap 500
+
+@doc """
+Append one `{text, attrs}` entry to the model's transcript, enforcing the
+#{@transcript_cap}-entry ring-buffer cap. Returns the updated model.
+"""
+@spec append_transcript(t(), {String.t(), keyword()}) :: t()
+def append_transcript(%__MODULE__{transcript: list} = model, item) do
+  new_list = list ++ [item]
+
+  trimmed =
+    if length(new_list) > @transcript_cap do
+      Enum.drop(new_list, length(new_list) - @transcript_cap)
+    else
+      new_list
+    end
+
+  %{model | transcript: trimmed}
+end
+
+@doc """
+Append multiple `{text, attrs}` entries in order, applying the cap after each.
+Returns the updated model.
+"""
+@spec append_transcript_many(t(), [{String.t(), keyword()}]) :: t()
+def append_transcript_many(model, items) do
+  Enum.reduce(items, model, &append_transcript(&2, &1))
+end
+```
+
+```elixir
+# lib/tau/tui/app/events.ex  (after change)
+alias Tau.TUI.App.Model
+
+# Remove: @transcript_cap 500, defp/def bounded_append/2, def bounded_append_many/2
+# Before:
+#   %{model | transcript: bounded_append(model.transcript, {text, attrs})}
+# After:
+#   Model.append_transcript(model, {text, attrs})
+
+# Before:
+#   %{model | transcript: bounded_append_many(model.transcript, items)}
+# After:
+#   Model.append_transcript_many(model, items)
+```
+
+```elixir
+# lib/tau/tui/app/input.ex  (after change)
+alias Tau.TUI.App.Model
+
+# Remove: @transcript_cap 500, defp bounded_append/2
+# Before:
+#   %{model | transcript: bounded_append(model.transcript, {text, attrs})}
+# After:
+#   Model.append_transcript(model, {text, attrs})
+```
+
+File moves: none.
+```
+
+## Tradeoffs
+
+### Strengths
+
+- Call-sites in `Events` and `Input` are maximally lean: they neither know the
+  field name `transcript` nor the type nor the cap — strongest information hiding
+  of all proposals.
+- Single definition of `@transcript_cap` and body; no extraction to new module.
+- "Tell, don't ask" style is natural for MVU: callers hand the whole model in,
+  get the whole model back.
+- No module proliferation; `Model` already holds `transcript_pane_width/1` as a
+  precedent for model-scoped helpers.
+- `append_transcript_many/2` becomes available to `Input` at no extra cost.
+
+### Weaknesses
+
+- `Model` gains business logic (the cap rule) more deeply than Proposal 1: it
+  now holds state + invariant + mutation operation, blurring the distinction
+  between a data definition module and a logic module. Future reviewers may
+  escalate this toward a fat-model anti-pattern.
+- The function signature change is more invasive than Proposals 1–2: call-sites
+  must be updated to pass the full model rather than just `model.transcript`.
+  For deeply nested pattern-matched call-sites this may require unfolding a
+  match to get the model in scope.
+- The function body inlines the cap logic rather than delegating to a named
+  `bounded_append` function; this is a minor loss of composability if the cap
+  logic needs to be tested independently.
+- `Events` currently exposes a public `def bounded_append/2` — removing it is
+  a public API change for any external caller.
+
+### Costs
+
+- 3 files modified (`model.ex`, `events.ex`, `input.ex`), 0 new files.
+- Call-site audit: all uses of `bounded_append` in `Events` and `Input` must
+  be updated to pass `model` not `model.transcript`. Where `Events` or `Input`
+  functions receive only the transcript list (not the full model) as a parameter,
+  the parameter type must be widened — this may cascade into callers of those
+  functions.
+- Test changes: any test that calls `Events.bounded_append/2` directly or that
+  passes `model.transcript` to the function must be updated to use the new
+  model-update signature.
+
+## Dependencies
+
+- Same `if Code.ensure_loaded?` guard applies as Proposal 1.
+- If call-sites in `Events` or `Input` use `bounded_append` on a raw list
+  rather than `model.transcript` (verify with grep), the parameter widening
+  cascades are larger than expected.
+
+## Confidence
+
+medium — the model-update idiom is clean and consistent with the rest of the
+MVU style, but the call-site cascade when widening parameters from `list` to
+`model` needs a prototype pass to confirm scope.
+
+## Prior art / references
+
+- MVU / Elm Architecture: update functions operate on the full model, returning
+  the full model — the `append_transcript` shape mirrors this precisely.
+- Elixir idiom: `Map.update/4`, `Keyword.update/4` — operations that take the
+  container and return the container rather than operating on a value extracted
+  from it.

--- a/docs/problems-archive-v1-modules/tau-tui-app/subproblems/duplicated-bounded-append/proposals/proposal-4.md
+++ b/docs/problems-archive-v1-modules/tau-tui-app/subproblems/duplicated-bounded-append/proposals/proposal-4.md
@@ -1,0 +1,123 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 4
+parent_problem: ../problem.md
+---
+
+# Proposal 4: Delete `Events`' public copy; keep one private copy in `Events`, expose via delegation from `Input`
+
+## Approach
+
+Keep a single private `bounded_append/2` in `Events` and promote it to a
+module-private-but-accessible function via a thin public delegating wrapper
+only in `Events`; `Input` delegates its call through `Events`. Delete `Input`'s
+own private copy and `@transcript_cap` entirely. The cap constant and the body
+live in exactly one place (`Events`). `bounded_append_many/2` remains in
+`Events`. No new module; `Model` is not modified.
+
+## Rationale
+
+`Events` already holds the canonical copy — it has the `@doc`, the `@spec`, and
+the public visibility marker that `Input` does not. The minimum-disturbance fix
+is to make `Events` the single source without changing `Model` or introducing
+new modules: `Input` calls `Events.bounded_append/2` instead of its private
+duplicate. This is a behaviour-preserving, API-preserving, incremental
+change: the public surface of `Events` stays identical (the function was already
+public there); only `Input`'s internal structure changes. The acceptance
+criterion is satisfied with the smallest diff possible.
+
+## Sketch
+
+```elixir
+# lib/tau/tui/app/events.ex  (minimal change: no modification needed)
+# bounded_append/2 and bounded_append_many/2 are already public with @doc/@spec.
+# @transcript_cap 500 stays here.
+# No change required in events.ex.
+```
+
+```elixir
+# lib/tau/tui/app/input.ex  (after change)
+
+# Remove these two lines entirely:
+#   @transcript_cap 500
+#   defp bounded_append(list, item) do ... end
+
+# Add alias at top of inner module:
+alias Tau.TUI.App.Events
+
+# All call-sites in input.ex that previously called bounded_append/2 become:
+Events.bounded_append(model.transcript, item)
+
+# Example — before:
+#   %{model | transcript: bounded_append(model.transcript, {text, attrs})}
+# After:
+#   %{model | transcript: Events.bounded_append(model.transcript, {text, attrs})}
+```
+
+File moves: none. Only `input.ex` is changed.
+```
+
+## Tradeoffs
+
+### Strengths
+
+- Smallest possible diff: only `input.ex` changes, `events.ex` requires zero
+  modification.
+- Zero new modules, zero changes to `Model`.
+- Acceptance criterion is fully satisfied: `@transcript_cap` defined once;
+  duplication absent from both `Events` and `Input`.
+- Strictly behaviour-preserving: function bodies are identical; call-sites only
+  change in qualification.
+- Lowest merge-conflict risk with sibling sub-problems; `model.ex` is untouched.
+
+### Weaknesses
+
+- Creates a dependency from `Input` to `Events` — a sibling-sub-module coupling
+  that does not currently exist. Sibling modules in the same decomposed layer
+  should typically not depend on each other; this coupling makes `Input` harder
+  to test or evolve independently of `Events`.
+- `bounded_append/2` remaining in `Events` (not in `Model`) is still
+  architecturally surprising: the function operates on `model.transcript` but
+  lives in the event dispatcher. Any future third consumer that doesn't naturally
+  depend on `Events` will face the same friction again.
+- Does not fix the "natural home" concern from the problem statement — the
+  complecting hypothesis says `Model` is the natural home; this proposal leaves
+  the function in `Events`, which is an event dispatcher, not a data-invariant
+  module.
+- `bounded_append_many/2` is not accessible to `Input` without adding another
+  delegation call — if `Input` ever needs it, this proposal requires a second
+  change.
+
+### Costs
+
+- 1 file modified (`input.ex`), 0 new files, 0 changes to `model.ex` or
+  `events.ex`.
+- Introduces an `alias Tau.TUI.App.Events` in `input.ex` — must verify there
+  is no circular dependency (Events → Input exists for event routing; if
+  `Input` imports `Events`, a cycle forms). **This requires explicit audit.**
+  If Events already depends on Input, this proposal is not viable and collapses
+  to a halt.
+
+## Dependencies
+
+- **Critical dependency:** verify that `events.ex` does NOT `alias` or call
+  into `input.ex`. If it does, a circular module dependency results and this
+  proposal cannot be applied without restructuring. This is the primary
+  feasibility gate for the proposal.
+- No other sub-problem must be resolved first.
+
+## Confidence
+
+low — the circular-dependency risk is a real blocker that has not been verified.
+If `Events` calls into `Input` anywhere (likely, given the decomposition), this
+proposal is invalid. Confidence becomes medium only after a negative grep result
+confirms there is no current `Events → Input` dependency.
+
+## Prior art / references
+
+- This "promote the already-canonical copy" pattern is common in incremental
+  refactors — the principle that the smallest behaviour-preserving diff is
+  preferred for low-risk changes.
+- Anti-pattern: sibling module coupling in decomposed MVU architectures (Elm
+  community guidance on not importing sibling update modules into each other).

--- a/docs/problems-archive-v1-modules/tau-tui-app/subproblems/duplicated-bounded-append/solution.md
+++ b/docs/problems-archive-v1-modules/tau-tui-app/subproblems/duplicated-bounded-append/solution.md
@@ -1,0 +1,137 @@
+---
+template_version: 1
+template_name: solution
+parent_problem: problem.md
+node_kind: leaf
+synthesised_from: [proposals/proposal-1.md]
+selection_method: single
+revision: 0
+---
+
+# Solution: Extract `bounded_append` into `Tau.TUI.App.Model`
+
+## Recommendation
+
+Move `bounded_append/2`, `bounded_append_many/2`, and `@transcript_cap 500`
+into `Tau.TUI.App.Model` as public functions. Delete both private copies from
+`Events` and `Input`. Update all call-sites in those modules to call
+`Model.bounded_append/2` and `Model.bounded_append_many/2`. The cap constant
+and the ring-buffer body then exist in exactly one place — the module that
+already declares the `transcript` field type and is the canonical owner of
+`Model.t()` invariants.
+
+## Selected from
+
+- **Chosen:** `proposals/proposal-1.md`
+- **Why chosen:** Proposal 1 satisfies the acceptance criterion fully — one
+  canonical implementation, one `@transcript_cap`, duplication absent from
+  both `Events` and `Input` — while adding no new module and no new dependency
+  edge. It places the invariant in `Model`, which already owns the `transcript`
+  field type and already hosts `transcript_pane_width/1` as a non-pure-struct
+  helper, so there is clear existing precedent. Migration cost is the lowest of
+  the three viable proposals (2 files modified to remove, 1 to add functions).
+
+  Proposal 2 (`Transcript` sub-module) offers deeper decomplection and better
+  opaque encapsulation but at materially higher cost and risk: an `@opaque`
+  audit across all consumers, a new module, and a merge-conflict surface with
+  the `model-as-bag-of-maps` sibling. These costs are not justified by the
+  problem statement, which asks only for a single canonical home — not for a
+  new abstraction boundary.
+
+  Proposal 3 (model-update helpers) has the cleanest call-sites ("tell, don't
+  ask") but carries a call-site cascade risk: any `Events` or `Input` function
+  that receives only `model.transcript` as a parameter must be widened to
+  accept the full `Model.t()`, which may propagate to their callers. The
+  problem statement does not require hiding the field name or the type — only
+  eliminating the duplication. Proposal 3 solves a broader problem than stated
+  at higher cost.
+
+  Proposal 4 (`Input` delegates to `Events`) is the smallest diff but creates
+  a new sibling-module coupling (`Input → Events`) that does not currently
+  exist, leaves the function architecturally misplaced in an event-dispatcher,
+  and is self-rated low confidence due to the unverified circular-dependency
+  risk. Even after confirming no `Events → Input` cycle exists, the coupling
+  anti-pattern and wrong-home diagnosis make this the weakest choice.
+
+## Scoring table
+
+| # | Fit | Decomplecting depth | Migration cost | Risk | Reversibility |
+|---|-----|---------------------|----------------|------|---------------|
+| 1 | Yes | Substantial | Low | Low | Easy |
+| 2 | Yes | Deep | Medium | Medium | Easy |
+| 3 | Yes | Substantial | Medium | Low-Medium | Easy |
+| 4 | Partially | Surface | Low | Medium | Easy |
+
+Proposal 1 is the only proposal that scores Yes on fit, Substantial on
+decomplecting depth, and Low on both migration cost and risk simultaneously.
+
+## What changes
+
+- `lib/tau/tui/app/model.ex` — add `@transcript_cap 500`, `def bounded_append/2`
+  (with `@doc` and `@spec`), and `def bounded_append_many/2` (with `@doc` and
+  `@spec`).
+- `lib/tau/tui/app/events.ex` — remove `@transcript_cap 500`, remove
+  `defp bounded_append/2`, remove `def bounded_append/2`, remove
+  `def bounded_append_many/2`; add `alias Tau.TUI.App.Model` if not already
+  present; update all call-sites to `Model.bounded_append/2` and
+  `Model.bounded_append_many/2`.
+- `lib/tau/tui/app/input.ex` — remove `@transcript_cap 500`, remove
+  `defp bounded_append/2`; add `alias Tau.TUI.App.Model`; update all
+  call-sites to `Model.bounded_append/2`.
+
+## What does not change
+
+- The function bodies: `list ++ [item]` → `Enum.drop` semantics are preserved
+  exactly.
+- The cap value (500).
+- The public API of `Events` for any caller using `Events.bounded_append/2`
+  directly — this function is removed from `Events` (it was the source of the
+  duplication), so callers must be audited; however, given the function is
+  specific to internal transcript mutation, external callers are expected to be
+  absent.
+- `Model.t()` struct shape and field names — no field is added, renamed, or
+  typed differently.
+- `Tau.TUI.App.Transcript` does not exist and is not introduced.
+- All sibling sub-problems (`model-as-bag-of-maps`, `session-side-effects-in-pure-modules`,
+  `transcript-coupling`) are unaffected.
+
+## Migration sketch
+
+1. Add `@transcript_cap`, `bounded_append/2`, and `bounded_append_many/2` to
+   `model.ex` with `@doc`/`@spec`. Run `mix compile`; confirm clean.
+2. Update `events.ex`: add alias, replace all `bounded_append` calls with
+   `Model.bounded_append`, remove the now-dead private/public definitions and
+   `@transcript_cap`. Run `mix compile --warnings-as-errors`; confirm no unused
+   variable or function warnings.
+3. Update `input.ex` identically: add alias, replace call, remove dead code.
+   Run `mix compile --warnings-as-errors`.
+4. Run `mix test` — no test changes are expected because the function bodies
+   are identical and the rename only changes call qualification.
+5. Grep for `Events.bounded_append` across the repo to confirm no external
+   caller is silently broken. One-time check; expected result: zero hits.
+
+## Open questions
+
+- The `if Code.ensure_loaded?(Ratatouille.Runtime)` compilation guard in
+  `model.ex` wraps the module. The proposal notes this is fine for TUI use, but
+  should be confirmed with `mix test` run without Ratatouille loaded (e.g. in a
+  stripped CI environment) to verify the functions are reachable in all test
+  contexts.
+- `Events` currently exposes `bounded_append/2` as a public function with
+  `@doc`/`@spec`. Removing it is a breaking API change for any external caller.
+  The grep in step 5 of the migration sketch settles this; if an external caller
+  exists, it should be redirected to `Model.bounded_append/2` in the same PR.
+
+## Linked sub-problems / proposals
+
+- `proposals/proposal-1.md` — Extract into `Model` as public functions (chosen)
+- `proposals/proposal-2.md` — New `Tau.TUI.App.Transcript` sub-module with
+  opaque type (deeper decomplection, higher cost; not chosen)
+- `proposals/proposal-3.md` — Model-update helpers (`append_transcript/2`);
+  "tell, don't ask" style; call-site cascade risk (not chosen)
+- `proposals/proposal-4.md` — Keep in `Events`, delegate from `Input`; sibling
+  coupling anti-pattern, wrong architectural home (not chosen)
+
+## Revision history
+
+- (revision 0 — initial)

--- a/docs/problems-archive-v1-modules/tau-tui-app/subproblems/duplicated-bounded-append/validation.md
+++ b/docs/problems-archive-v1-modules/tau-tui-app/subproblems/duplicated-bounded-append/validation.md
@@ -1,0 +1,326 @@
+---
+template_version: 1
+template_name: validation
+parent_solution: solution.md
+parent_problem: problem.md
+toulmin_complete: true
+falsification_attempted: true
+falsification_outcome: partially_falsified — claim/4
+revision_triggered: none
+---
+
+# Validation: Extract `bounded_append` into `Tau.TUI.App.Model`
+
+## Overview
+
+The solution makes four checkable propositions: (1) a single canonical
+implementation of `bounded_append/2` and `bounded_append_many/2` will exist in
+`Model`; (2) a single `@transcript_cap 500` constant will exist in `Model`; (3)
+the duplicate definitions will be absent from `Events` and `Input`; (4) no
+external callers of `Events.bounded_append/2` will be silently broken.
+Six claims total (the acceptance-criterion decomposition produces two additional
+propositions from "What does not change": (5) function bodies are preserved
+exactly; (6) `Model.t()` struct shape is unchanged). Falsification strategies
+are edge-case enumeration and dependency/integration checks. All claims withstood
+or survive with a narrowed qualifier; no revision is triggered.
+
+---
+
+## Toulmin per claim
+
+### Claim 1: A single canonical implementation of `bounded_append/2` and `bounded_append_many/2` exists in `Tau.TUI.App.Model`.
+
+- **Claim (C):** "Move `bounded_append/2`, `bounded_append_many/2`, and
+  `@transcript_cap 500` into `Tau.TUI.App.Model` as public functions."
+- **Grounds (G):** Currently `bounded_append/2` is private in both
+  `lib/tau/tui/app/events.ex:429` and `lib/tau/tui/app/input.ex:193`.
+  `bounded_append_many/2` exists only in `events.ex:445`. `Model` has no
+  `bounded_append` function at all (verified: `grep -n bounded_append
+  lib/tau/tui/app/model.ex` — zero hits). The solution's migration sketch
+  step 1 adds the functions to `model.ex` before removing them elsewhere.
+- **Warrant (W):** A module that declares a type and its invariants is the
+  natural owner of pure helpers that enforce those invariants (OTP
+  non-negotiable §8: pure functions are the default). `Model` already
+  declares `transcript: [{String.t(), keyword()}]` at `model.ex:76` and
+  is the single type-owner.
+- **Qualifier (Q):** Q: holds after all three files are updated atomically in
+  one PR; if the migration is interrupted mid-step (e.g. `events.ex` updated
+  but `input.ex` not), duplication remains until completion.
+- **Rebuttal (R):** If `model.ex` is wrapped in
+  `if Code.ensure_loaded?(Ratatouille.Runtime)` (confirmed at `model.ex:1`)
+  and `bounded_append` is called from a non-TUI code path compiled without
+  Ratatouille, the function will be undefined at that call-site. The solution's
+  Open Questions section acknowledges this.
+- **Backing (B):** OTP non-negotiable §8 (`.claude/rules/otp-non-negotiables.md`);
+  Hickey "Simple Made Easy" — place behaviour with the data it operates on.
+
+#### Falsification attempt for claim 1
+
+- **Strategy:** Dependency check — verify `model.ex` is conditionally compiled
+  and confirm the compilation guard applies.
+- **Attempt:** `grep -n "Code.ensure_loaded\|defmodule" lib/tau/tui/app/model.ex`
+  confirms `if Code.ensure_loaded?(Ratatouille.Runtime) do` at line 1 wrapping
+  the entire module. All three files (`events.ex`, `input.ex`, `model.ex`) share
+  the same guard. Any call-site in `events.ex` or `input.ex` that calls
+  `Model.bounded_append` would also be under the same guard, so the
+  availability context is uniform. No falsifying case found.
+- **Outcome:** withstood
+- **Action:** none
+
+---
+
+### Claim 2: A single `@transcript_cap 500` constant is defined in `Tau.TUI.App.Model`; the copies in `Events` and `Input` are removed.
+
+- **Claim (C):** "`@transcript_cap 500` … the cap constant … then exist in
+  exactly one place."
+- **Grounds (G):** Currently `@transcript_cap 500` exists at
+  `lib/tau/tui/app/events.ex:24` and `lib/tau/tui/app/input.ex:191`
+  (confirmed by grep). `model.ex` has no `@transcript_cap` attribute (verified:
+  zero hits). The solution's "What changes" section removes it from both modules
+  and adds it to `model.ex`.
+- **Warrant (W):** A module attribute used only inside a function body is module-
+  private; placing it alongside the function it governs ensures a single point of
+  truth and eliminates drift risk. This is a standard Elixir constant-colocation
+  pattern.
+- **Qualifier (Q):** Q: holds once migration is complete; intermediate states
+  (during the PR) will transiently have the constant in all three locations
+  before the deletions occur.
+- **Rebuttal (R):** If another module in `lib/tau/tui/` also defines
+  `@transcript_cap` with a different value for a different purpose (e.g. a
+  render cap), that would not be addressed by this solution. Verified: no other
+  `@transcript_cap` in the repo (`grep -rn transcript_cap lib/` returns only
+  `events.ex:24` and `input.ex:191`). Rebuttal does not apply.
+- **Backing (B):** DRY principle; Elixir module attributes as compile-time
+  constants pattern (official Elixir docs §Module attributes).
+
+#### Falsification attempt for claim 2
+
+- **Strategy:** Edge-case enumeration — are there other consumers of
+  `@transcript_cap` besides `bounded_append`?
+- **Attempt:** In `events.ex`, `@transcript_cap` is referenced only inside
+  `bounded_append/2` (lines 432–433) and `bounded_append_many/2` delegates
+  through `bounded_append`. In `input.ex`, referenced only inside `bounded_append/2`
+  (lines 196–197). No other reference found in either file or across the repo.
+  Removing the attribute from `events.ex` and `input.ex` after moving the
+  function is therefore safe.
+- **Outcome:** withstood
+- **Action:** none
+
+---
+
+### Claim 3: The duplication is absent from `Events` and `Input` after the change.
+
+- **Claim (C):** "Delete both private copies from `Events` and `Input`."
+- **Grounds (G):** Current state: `events.ex:429` has `def bounded_append/2`
+  (public) and `events.ex:445` has `def bounded_append_many/2`; `input.ex:193`
+  has `defp bounded_append/2`. These will be removed; all call-sites in both
+  modules replaced with `Model.bounded_append/2`. Call-sites are:
+  `events.ex:69,253,284,296,390` and `input.ex:41,103,145,174`.
+- **Warrant (W):** Removing a local definition after aliasing the canonical
+  module and updating call-sites produces no duplication — the compiler will
+  error on any missed call-site referencing the removed private function,
+  providing complete deletion verification.
+- **Qualifier (Q):** Q: holds after `mix compile --warnings-as-errors` passes
+  on both files post-deletion (any surviving call to the removed `defp` would
+  cause a compile error in Elixir, not a silent failure).
+- **Rebuttal (R):** The public `Events.bounded_append/2` (not just the private
+  copies) must also be removed. The solution's "What changes" section specifies
+  removing "the now-dead private/public definitions". If only the private copy
+  is removed and the public one remains, duplication of definition persists
+  (though in a different form). The migration sketch step 2 covers this
+  explicitly.
+- **Backing (B):** Elixir compiler error on undefined local calls; OTP
+  non-negotiable §2 (no dead code paths).
+
+#### Falsification attempt for claim 3
+
+- **Strategy:** Edge-case enumeration — missed call-sites or compiler
+  non-detection.
+- **Attempt:** Elixir's compiler does not error on calls to `defp` functions of
+  an *aliased* module — it errors on calls to undefined *local* functions. The
+  call-sites in `events.ex` call `bounded_append(...)` unqualified, which
+  resolves to the local `defp`. After removing the local `defp`, an unqualified
+  call would fail to compile. If all unqualified calls are replaced with
+  `Model.bounded_append(...)` and the local `defp` is removed, the compiler
+  confirms completeness. Migration sketch step 2 includes `mix compile
+  --warnings-as-errors` after each file change, which catches unused aliases
+  and dead code as warnings-as-errors. This provides complete post-deletion
+  verification.
+- **Outcome:** withstood (qualifier already in solution; compiler as
+  verification guard confirmed adequate)
+- **Action:** none
+
+---
+
+### Claim 4: No external callers of `Events.bounded_append/2` are silently broken.
+
+- **Claim (C):** "Callers must be audited; however, given the function is
+  specific to internal transcript mutation, external callers are expected to be
+  absent."
+- **Grounds (G):** `grep -rn "Events.bounded_append" lib/ test/` returns zero
+  hits (verified). The function is used only by unqualified calls inside
+  `events.ex` itself. The migration sketch step 5 repeats this grep as a
+  one-time check.
+- **Warrant (W):** A function with no external call-sites cannot have external
+  callers silently broken by its removal. Zero grep hits in `lib/` and `test/`
+  is definitive for a single-repo codebase.
+- **Qualifier (Q):** Q: holds for the current codebase state. External packages
+  or plugins that call `Events.bounded_append/2` as a published API would not
+  be caught by the in-repo grep. The solution itself scopes the "no external
+  callers" claim only to the repo.
+- **Rebuttal (R):** If tau has downstream consumers (plugins, extensions) that
+  `alias Tau.TUI.App.Events` and call `bounded_append/2`, those would be broken
+  without being caught. The solution does not address this but acknowledges the
+  audit requirement.
+- **Backing (B):** In-repo grep coverage; `lib/tau/tui/app/events.ex` is not
+  listed in any `SPEC-*.md` public API surface; `SPEC-TUI-HEADLESS.md` and
+  `SPEC-USER-TURN.md` are the relevant specs and neither lists `bounded_append`
+  as a boundary-contract function.
+
+#### Falsification attempt for claim 4
+
+- **Strategy:** Integration check — could an extension or plugin call this
+  function?
+- **Attempt:** The `SPEC-EXTENSIONS.md` describes extension loading via
+  `Tau.Extension` behaviour and `Tau.Extensions.Loader`. Extensions interact
+  through the `Tau.Extension` behaviour and PubSub, not by aliasing internal TUI
+  App modules. No extension interface documents `Events.bounded_append/2` as a
+  callable surface. However, the `docs/spec/SPEC-EXTENSIONS.md` cannot
+  categorically rule out an extension author calling any Elixir module that
+  happens to be loaded. The claim's qualifier "external callers are **expected**
+  to be absent" is probabilistic, not absolute.
+- **Outcome:** partially falsified — the qualifier should be narrowed: "no
+  external callers **within the tau repo**; out-of-repo extension authors are
+  not audited"
+- **Action:** narrow qualifier in place; no solution revision needed. The
+  narrowed qualifier is already implicit in the solution's phrasing ("expected
+  to be absent") and the migration sketch's in-repo grep.
+
+---
+
+### Claim 5: The function bodies (`list ++ [item]` → `Enum.drop` semantics) are preserved exactly.
+
+- **Claim (C):** "The function bodies … are preserved exactly."
+- **Grounds (G):** Both copies are byte-identical per the problem statement and
+  confirmed by reading `events.ex:429–437` and `input.ex:193–201`. The solution
+  moves, not rewrites, these bodies. Migration sketch steps 4 confirms via `mix
+  test` that no behavioural change occurs.
+- **Warrant (W):** A copy-move operation that makes no substitutions to the
+  function body preserves semantics exactly. The only change is the site of
+  definition; the AST of the body is unchanged.
+- **Qualifier (Q):** Q: holds when the migration is performed by textual move
+  of the exact body, not a re-implementation. Verified by `mix test` (step 4).
+- **Rebuttal (R):** If an implementer introduces a subtle difference (e.g.,
+  `Enum.take(-@transcript_cap, new_list)` vs. `Enum.drop`) while moving, the
+  body would not be "preserved exactly". The solution requires an exact move;
+  `mix test` is the verification gate.
+- **Backing (B):** Elixir AST equivalence is verifiable by inspection; `mix
+  test` as regression gate.
+
+#### Falsification attempt for claim 5
+
+- **Strategy:** Counter-example construction — is there any way the moved body
+  could behave differently than the original?
+- **Attempt:** The body references only `@transcript_cap`, `list`, `item`,
+  `length/1`, `Enum.drop/2`, and `++`. None of these are module-local except
+  `@transcript_cap`, which becomes `@transcript_cap` in `model.ex` with the
+  same value 500. No external state, no process calls, no references to sibling
+  private functions. Counter-example would require the cap value to differ or
+  the body to be mis-transcribed — both excluded by the migration's step 2
+  compile-check and step 4 test run.
+- **Outcome:** withstood
+- **Action:** none
+
+---
+
+### Claim 6: `Model.t()` struct shape and field names are unchanged.
+
+- **Claim (C):** "`Model.t()` struct shape and field names — no field is added,
+  renamed, or typed differently."
+- **Grounds (G):** The solution adds only module-level functions and a module
+  attribute to `model.ex`; it does not modify `@enforce_keys`, `defstruct`, or
+  the `@type t` definition. Confirmed: `model.ex:14–93` defines the struct and
+  type; the proposed changes (adding functions and `@transcript_cap`) are
+  appended after the struct block per Elixir convention.
+- **Warrant (W):** Adding functions and module attributes to an Elixir module
+  does not alter the module's struct definition. Struct fields are declared
+  only in `defstruct`; `@type t` is a documentation type. Adding neither
+  changes the struct.
+- **Qualifier (Q):** Q: none — universal for this specific change type (adding
+  functions to an Elixir module cannot modify its defstruct).
+- **Rebuttal (R):** Rebuttal: none. Elixir's compilation model makes this
+  categorically true — `defstruct` and function definitions are orthogonal
+  constructs. No change to `defstruct` is possible without explicitly editing it.
+- **Backing (B):** Elixir language specification §defstruct; `mix compile
+  --warnings-as-errors` as structural regression gate.
+
+#### Falsification attempt for claim 6
+
+- **Strategy:** Counter-example construction — can adding a function to a
+  module alter struct shape?
+- **Attempt:** In Elixir, `defstruct` is evaluated once at compile time based
+  on the argument list passed to `defstruct`. Function definitions (`def`,
+  `defp`) do not interact with `defstruct` — they compile to distinct entries
+  in the module's BEAM chunk. Adding `def bounded_append/2` cannot add, rename,
+  or retype a struct field. No counter-example is constructable.
+- **Outcome:** withstood
+- **Action:** none
+
+---
+
+## Cross-claim consistency
+
+Claims 1–3 form a coherent whole: move the function (C1), move the constant
+(C2), remove duplicates (C3). No tension among them. C4 (external caller audit)
+is independent and does not conflict with C1–C3. C5 (body preservation) is
+entailed by C1–C3 if migration is a move not a rewrite; no tension. C6 (struct
+stability) is orthogonal to all others; no tension.
+
+One potential tension: C1 makes `bounded_append` **public** in `Model` (the
+solution says "public functions"), whereas both current copies are `defp`. A
+critic could argue that making it public introduces a new external API surface.
+However, `bounded_append` is a pure function whose inputs and outputs are
+entirely determined by the `Model.t()` transcript type — it is appropriate for
+`Model` to expose it publicly for any future sub-modules in the `Tau.TUI.App.*`
+namespace. This is not a tension requiring revision; it is a deliberate scope
+choice recorded in the solution.
+
+---
+
+## Falsification summary
+
+| # | Claim (short) | Strategy | Outcome | Action |
+|---|---|---|---|---|
+| 1 | Single canonical impl in Model | Dependency check (compilation guard) | withstood | none |
+| 2 | Single @transcript_cap in Model | Edge-case enumeration (other users of constant) | withstood | none |
+| 3 | Duplication absent from Events/Input | Edge-case enumeration (missed call-sites) | withstood | none |
+| 4 | No external callers broken | Integration check (extension authors) | partially falsified | narrow qualifier to in-repo only |
+| 5 | Function bodies preserved exactly | Counter-example construction | withstood | none |
+| 6 | Model.t() struct shape unchanged | Counter-example construction | withstood | none |
+
+---
+
+## Revision required
+
+No revision triggered. Claim 4 is partially falsified but the narrowed qualifier
+("no in-repo external callers") is already implicit in the solution's own
+language ("expected to be absent" + in-repo grep in migration step 5). The
+solution text does not overclaim; no solution.md edit is required.
+
+---
+
+## Outstanding doubts
+
+- The `Code.ensure_loaded?(Ratatouille.Runtime)` compilation guard wrapping
+  `model.ex` is acknowledged as an open question in the solution. If CI runs
+  `mix test` without Ratatouille in scope (e.g. stripped-deps mode), the module
+  and its functions including `bounded_append` are undefined, meaning any test
+  exercising the transcript path would fail to compile. The solution flags this
+  as an open question but does not resolve it. Confidence: the compilation guard
+  applies equally to `events.ex` and `input.ex`, so this risk pre-exists the
+  change and is not introduced by it — but it is worth confirming.
+- `transcript_pane_width/1` in `model.ex` is `defp`, not `def`. The solution
+  cites it as "existing precedent" for non-pure-struct helpers in `Model`. It is
+  a valid precedent, but the fact that `transcript_pane_width` is private while
+  `bounded_append` would be public is a minor asymmetry. No action required;
+  noted for the parent-level validator.

--- a/docs/problems-archive-v1-modules/tau-tui-app/subproblems/model-as-bag-of-maps/problem.md
+++ b/docs/problems-archive-v1-modules/tau-tui-app/subproblems/model-as-bag-of-maps/problem.md
@@ -1,0 +1,64 @@
+---
+template_version: 1
+template_name: problem
+node_kind: leaf
+depth: 1
+parent: ../../problem.md
+status: draft
+---
+
+# Problem: `Model.t()` struct discipline is undermined by pervasive `Map.get/3` and `Map.put/2` across consumer modules
+
+## Statement
+
+`Tau.TUI.App.Model` defines a typed struct with `@enforce_keys` to ensure
+mandatory fields are always present, but consumer modules bypass struct field
+access with `Map.get(model, :field, default)` and `Map.put(model, :field, val)`
+throughout `Events`, `Input`, `Keymap`, and `View`. This means the compiler
+cannot enforce field existence at call sites, `@enforce_keys` provides no
+protection once the struct value leaves `Model.new/1`, and the default fallback
+values embedded in `Map.get` calls can silently diverge from the canonical
+defaults in `Model.new/1`.
+
+## Context
+
+- `lib/tau/tui/app/model.ex:14–28` — `@enforce_keys` lists 13 mandatory fields
+- `lib/tau/tui/app/view.ex:118–138` — `status_bar_model/1` uses `Map.get(model, :field, default)` for every field it projects
+- `lib/tau/tui/app/events.ex:234–258` — `on_message_end/2` uses `Map.get(model, :context_window)`, `Map.get(model, :warn_level, :ok)`
+- `lib/tau/tui/app/events.ex:84` — `update_session_event/2` spec typed as `map()` not `Model.t()`
+- `lib/tau/tui/app/keymap.ex:31` — `Map.get(model, :pending_permissions, [])` — field is in `@enforce_keys`
+- `lib/tau/tui/app/permission.ex:40` — `Map.get(model, :pending_permissions, [])` — same enforced field
+- `lib/tau/tui/app/events.ex:32` — `update/2` spec typed as `map()` not `Model.t()`
+- The `@spec` signatures across all sub-modules use `map()` as both input and
+  output type, not `Model.t()`, so Dialyzer cannot catch field-name typos.
+
+## Complecting hypothesis
+
+The MVU model struct is complected with generic-map access patterns because
+the decomposition preserved the original anonymous-map access style of the
+pre-decomposition `app.ex`, even though the struct was introduced as `Model.t()`
+at the same time. The struct's value discipline (enforced keys, typed fields) is
+present at construction but absent at all mutation sites.
+
+## Decomposition strategy
+
+(leaf — no further decomposition; proceed to proposals)
+
+## Acceptance criterion
+
+All consumer modules (`Events`, `Input`, `Keymap`, `View`, `Permission`,
+`Completion`, `History`) access `Model.t()` fields via struct syntax
+(`model.field`), not `Map.get/3`; `@spec` annotations use `Model.t()` not
+`map()`; and no `Map.get` call with a default that re-states a canonical
+default from `Model.new/1` remains.
+
+## Out of scope
+
+- Changing the struct's field set or the `@enforce_keys` list.
+- Changes to `duplicated-bounded-append` (sibling sub-problem).
+- Changes to `session-side-effects-in-pure-modules` (sibling).
+- Changes to `transcript-coupling` (sibling).
+
+## Amendment log
+
+- (none yet)

--- a/docs/problems-archive-v1-modules/tau-tui-app/subproblems/model-as-bag-of-maps/proposals/proposal-1.md
+++ b/docs/problems-archive-v1-modules/tau-tui-app/subproblems/model-as-bag-of-maps/proposals/proposal-1.md
@@ -1,0 +1,170 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 1
+parent_problem: ../problem.md
+---
+
+# Proposal 1: Mechanical callsite replacement — `Map.get/put` → struct field syntax
+
+## Approach
+
+Replace every `Map.get(model, :field, default)` and `Map.put(model, :field, val)`
+call in `Events`, `Input`, `Keymap`, `View`, and `Permission` with direct struct
+field access (`model.field`) and struct update syntax (`%{model | field: val}`).
+Update all `@spec` annotations that use `map()` as input or output to use
+`Model.t()`. Remove any `Map.get` call whose fallback default re-states a value
+already present in `Model.new/1`. No new modules, no new abstractions — pure
+callsite cleanup, one file at a time.
+
+## Rationale
+
+The complecting hypothesis is clear: the anonymous-map access style migrated from
+the pre-decomposition `app.ex` without being updated to use the struct that was
+simultaneously introduced. The complecting is not architectural — it is a uniform
+callsite smell. A mechanical callsite replacement eliminates the smell at its
+source: every consumer module is forced through the compiler's field-access path,
+`@enforce_keys` protection applies at all mutation sites, and Dialyzer can
+typecheck field names. No behaviour changes, no new dependencies.
+
+## Sketch
+
+**Events** — `events.ex:83,84,241,252–257`:
+
+```elixir
+# Before
+@spec update_session_event(map(), term()) :: map()
+# ...
+Map.get(model, :context_window) || Application.get_env(...)
+prior_warn = Map.get(model, :warn_level, :ok)
+model
+|> Map.put(:status, :idle)
+|> Map.put(:transcript, bounded_append_many(model.transcript, transcript_lines))
+|> Map.put(:last_assistant, nil)
+|> Map.put(:usage, session_counters)
+|> Map.put(:context_tokens, new_context_tokens)
+|> Map.put(:warn_level, new_warn)
+
+# After
+@spec update_session_event(Model.t(), term()) :: Model.t()
+# ...
+model.context_window || Application.get_env(...)
+prior_warn = model.warn_level
+%{model | status: :idle,
+          transcript: bounded_append_many(model.transcript, transcript_lines),
+          last_assistant: nil,
+          usage: session_counters,
+          context_tokens: new_context_tokens,
+          warn_level: new_warn}
+```
+
+**View** — `view.ex:117–129`:
+
+```elixir
+# Before
+@spec status_bar_model(map()) :: map()
+def status_bar_model(model) do
+  base = %{
+    session_id: Map.get(model, :session_id),
+    usage: Map.get(model, :usage, %{input_tokens: 0, ...}),
+    context_tokens: Map.get(model, :context_tokens, 0),
+    compaction: Map.get(model, :compaction, :idle),
+    permissions_mode: Map.get(model, :permissions_mode, :default)
+    ...
+  }
+end
+
+# After
+@spec status_bar_model(Model.t()) :: map()
+def status_bar_model(model) do
+  base = %{
+    session_id: model.session_id,
+    usage: model.usage,
+    context_tokens: model.context_tokens,
+    compaction: model.compaction,
+    permissions_mode: model.permissions_mode,
+    ...
+  }
+end
+```
+
+**Keymap** — `keymap.ex:31`:
+
+```elixir
+# Before
+case Map.get(model, :pending_permissions, []) do
+
+# After
+case model.pending_permissions do
+```
+
+**Permission** — `permission.ex:40–41`:
+
+```elixir
+# Before
+queue = Map.get(model, :pending_permissions, [])
+Map.put(model, :pending_permissions, queue ++ [req])
+
+# After
+%{model | pending_permissions: model.pending_permissions ++ [req]}
+```
+
+All `@spec` lines using `map()` for `Model.t()` inputs/outputs updated to
+`Model.t()` via `alias Tau.TUI.App.Model` at the top of each consumer module.
+
+## Tradeoffs
+
+### Strengths
+
+- Directly addresses the acceptance criterion: no `Map.get/3` or `Map.put/2`
+  remains on `Model.t()` values; all specs use `Model.t()`.
+- Zero runtime behaviour change — pure syntax migration; safe to apply
+  incrementally file by file.
+- Enables Dialyzer to catch field-name typos at every callsite immediately
+  after each file is updated.
+- Lowest cognitive overhead for reviewers — each diff is a uniform substitution
+  with obvious before/after.
+- Removes the hidden default re-statement problem: `Map.get(model, :usage, %{...})`
+  can silently differ from `Model.new/1`'s seed; `model.usage` cannot.
+
+### Weaknesses
+
+- Does not add any new abstraction; if a consumer needs to mutate multiple
+  fields together as a logical unit, it still does so via a flat `%{model | ...}`
+  update spread across the call site.
+- No enforcement that future contributors avoid reverting to `Map.get` — the fix
+  is one Credo rule away but that rule is not part of this proposal.
+- The fix to `View.status_bar_model/1` removes defaults that currently paper
+  over missing fields (e.g., `usage: %{input_tokens: 0, ...}`) — after the
+  change, a test that constructs an incomplete `Model.t()` will crash rather
+  than silently returning a zeroed-out default. That is the correct behaviour,
+  but it may surface latent test-setup gaps.
+
+### Costs
+
+- Approximately 30–40 callsite edits across five files; mechanical but tedious.
+- Every file touched requires a new `alias Tau.TUI.App.Model` import and a
+  corresponding `@moduledoc` cross-reference.
+- Test runs after each file change to confirm no test setup was relying on the
+  defaulting behaviour of `Map.get`.
+
+## Dependencies
+
+- None. The struct and `@enforce_keys` already exist in `Model.t()`; no new
+  modules or behaviours required.
+
+## Confidence
+
+Medium. The approach is straightforward and the target callsites are fully
+inventoried in the problem statement. Confidence would be high after one file
+(e.g., `events.ex`) is updated and `mix test` and `mix dialyzer` both pass
+cleanly, confirming no hidden test fixtures rely on the `Map.get` defaults.
+
+## Prior art / references
+
+- Elixir official docs: struct field access vs `Map.get` — struct syntax is the
+  idiomatic path and the compiler enforces it; `Map.get` defeats enforcement.
+- `mix credo --strict` `Credo.Check.Refactor.MapGet` — a community Credo rule
+  that flags this exact pattern.
+- The problem statement's own inventory (`events.ex:84`, `view.ex:118–138`,
+  `keymap.ex:31`, `permission.ex:40`) gives the full callsite list.

--- a/docs/problems-archive-v1-modules/tau-tui-app/subproblems/model-as-bag-of-maps/proposals/proposal-2.md
+++ b/docs/problems-archive-v1-modules/tau-tui-app/subproblems/model-as-bag-of-maps/proposals/proposal-2.md
@@ -1,0 +1,162 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 2
+parent_problem: ../problem.md
+---
+
+# Proposal 2: Typed accessor/updater functions on `Model` — thin façade that owns all field defaults
+
+## Approach
+
+Add a small set of public `get_*` and `put_*` functions (or a general `update/2`
+multi-field updater) directly on `Tau.TUI.App.Model` that centralize field
+defaults and struct mutation. Consumer modules (`Events`, `View`, `Keymap`,
+`Permission`) call `Model.context_window(model)`, `Model.warn_level(model)`,
+`Model.update(model, status: :idle, warn_level: :ok)`, etc., instead of either
+`Map.get/3` or raw struct access. The canonical default for every field lives
+once, in `Model`, co-located with `Model.new/1`.
+
+## Rationale
+
+The root complaint is that default values for fields are scattered across
+`Map.get(model, :field, default)` calls in multiple consumer files, where they
+can silently diverge from `Model.new/1`. This proposal decomplects the
+"canonical default" concern from the "field access" concern by making `Model`
+the single owner of both. Consumers become callers of typed functions rather
+than map-readers; `@spec` annotations on those functions enforce `Model.t()` as
+both input and output; Dialyzer follows the types through the indirection.
+
+## Sketch
+
+**New in `model.ex`** — typed field accessors for fields that have non-nil
+defaults and are currently accessed via `Map.get/3` with fallbacks:
+
+```elixir
+defmodule Tau.TUI.App.Model do
+  # ... existing struct/typedefs unchanged ...
+
+  @doc "Current context window size, or the fallback compaction threshold."
+  @spec context_window(t()) :: pos_integer()
+  def context_window(%__MODULE__{context_window: nil}),
+    do: Application.get_env(:tau, :compaction_threshold_tokens, 120_000)
+  def context_window(%__MODULE__{context_window: w}), do: w
+
+  @doc "Multi-field struct updater. Only listed fields may be set; unknown keys raise at compile time."
+  @spec update(t(), keyword()) :: t()
+  def update(%__MODULE__{} = model, fields) when is_list(fields) do
+    struct!(model, fields)
+  end
+end
+```
+
+**Updated callsite in `events.ex`** (on_message_end/2):
+
+```elixir
+# Before
+pct = StatusBar.context_pct(
+  new_context_tokens,
+  Map.get(model, :context_window) || Application.get_env(...)
+)
+prior_warn = Map.get(model, :warn_level, :ok)
+model
+|> Map.put(:status, :idle)
+|> Map.put(:warn_level, new_warn)
+...
+
+# After
+pct = StatusBar.context_pct(new_context_tokens, Model.context_window(model))
+prior_warn = model.warn_level
+Model.update(model, status: :idle, warn_level: new_warn, ...)
+```
+
+**Updated callsite in `view.ex`** (status_bar_model/1):
+
+```elixir
+@spec status_bar_model(Model.t()) :: map()
+def status_bar_model(model) do
+  %{
+    session_id: model.session_id,
+    usage: model.usage,
+    context_tokens: model.context_tokens,
+    context_window: Model.context_window(model),   # uses the canonical fallback
+    compaction: model.compaction,
+    permissions_mode: model.permissions_mode,
+    ...
+  }
+end
+```
+
+**Updated callsite in `permission.ex`**:
+
+```elixir
+def on_permission_request(%Model{} = model, req) do
+  Model.update(model, pending_permissions: model.pending_permissions ++ [req])
+end
+```
+
+**`struct!/2` enforces field names at runtime** (compile-time for literals);
+Dialyzer enforces `Model.t()` at the function boundary. No need for a per-field
+`get_*` function when the default is simply the struct field value — those sites
+use `model.field` directly.
+
+## Tradeoffs
+
+### Strengths
+
+- Canonical defaults live in exactly one place (`Model`) rather than being
+  copied into each consumer; a future change to the compaction-threshold fallback
+  only updates `Model.context_window/1`.
+- `struct!/2` inside `Model.update/2` raises at the callsite for unknown keys,
+  providing a better error message than a silent struct bypass.
+- `@spec status_bar_model(Model.t())` and all consumer specs are now typed
+  correctly without requiring that every single `map.field` access also be
+  changed — `Model.context_window/1` is the only callsite that needs the
+  fallback logic.
+- Adds a stable internal API surface on `Model` that can be extended (e.g.,
+  derived projections like `Model.status_bar_projection/1`) without touching
+  consumer modules again.
+
+### Weaknesses
+
+- Adds indirection: `Model.context_window(model)` is less familiar at first
+  glance than `model.context_window`; reviewers must know the function exists to
+  understand why it is called instead of direct access.
+- `Model.update/2` with `struct!/2` raises at runtime, not at compile time, for
+  dynamically-constructed keyword lists. If a caller builds the keyword list
+  programmatically, bad keys are not caught until the update executes.
+- Does not prevent future contributors from re-introducing `Map.get` at new
+  callsites — same enforcement gap as Proposal 1, without Proposal 1's
+  simplicity argument.
+- Slightly larger API surface on `Model` than Proposal 1; more functions to
+  test and document.
+
+### Costs
+
+- Write `Model.context_window/1` (and any other accessor needed for non-trivial
+  defaults); write `Model.update/2`.
+- Update all `Map.get/3` and `Map.put/2` callsites to use either `model.field`
+  (trivial) or the new accessors (where defaults are non-trivial).
+- Update `@spec` annotations as in Proposal 1 — identical cost.
+- ~5 new functions in `model.ex`; ~30–40 callsite edits across consumer files.
+
+## Dependencies
+
+- None. The struct already exists. `struct!/2` is a built-in.
+
+## Confidence
+
+Medium. `struct!/2` is a well-established Elixir idiom for typed multi-field
+updates; the accessor pattern is common in larger Elixir codebases. Confidence
+would be raised by confirming that Dialyzer propagates `Model.t()` through
+`Model.update/2` without losing type information (depends on Dialyzer's
+structural inference for `struct!/2`).
+
+## Prior art / references
+
+- Elixir `struct!/2` documentation — raises `KeyError` for unknown keys, unlike
+  `Map.merge`.
+- Pattern used in `Phoenix.Socket` (accessor functions for socket state, not raw
+  map access, to keep defaults centralized).
+- Elixir Forum discussion on "typed struct accessors" — common recommendation to
+  co-locate defaults with the struct constructor.

--- a/docs/problems-archive-v1-modules/tau-tui-app/subproblems/model-as-bag-of-maps/proposals/proposal-3.md
+++ b/docs/problems-archive-v1-modules/tau-tui-app/subproblems/model-as-bag-of-maps/proposals/proposal-3.md
@@ -1,0 +1,183 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 3
+parent_problem: ../problem.md
+---
+
+# Proposal 3: Typed sub-structs replace `map()` fields — decompose `Model.t()` into composable domain structs
+
+## Approach
+
+Several fields of `Model.t()` that are currently typed as `map()` or `nil | map()`
+(`usage`, `search`, `menu`) are accessed by consumers via `Map.get/3` because
+their shapes are not typed. Introduce named structs for each of these field types
+(`Model.Usage.t()`, `Model.Search.t()`, `Model.Menu.t()`), replace the
+corresponding `map()` type annotations in `Model.t()` with the new struct types,
+and update callsites to use struct field access throughout. Consumer `@spec`
+annotations change from `map()` to `Model.t()`. This is an API-breaking data
+shape change, not a callsite-only cleanup.
+
+## Rationale
+
+The `Map.get/3` calls in `View.status_bar_model/1` and `Events.on_message_end/2`
+are not only a callsite discipline failure — they reflect genuinely untyped
+sub-shapes within `Model.t()`. When `usage` is typed as `map()`, consumers have
+no choice but to use `Map.get`; when it is `Model.Usage.t()` with enforced keys,
+the compiler rejects `Map.get`. This proposal attacks the root cause (missing
+type discipline on nested fields) rather than only its surface symptom (consumers
+using `Map.get`). After the change, `Map.get` cannot be reintroduced without
+breaking Dialyzer.
+
+## Sketch
+
+**New modules** (three small structs):
+
+```elixir
+# lib/tau/tui/app/model/usage.ex
+defmodule Tau.TUI.App.Model.Usage do
+  @enforce_keys [:input_tokens, :output_tokens, :cache_read, :cache_write]
+  defstruct [:input_tokens, :output_tokens, :cache_read, :cache_write]
+
+  @type t :: %__MODULE__{
+    input_tokens: non_neg_integer(),
+    output_tokens: non_neg_integer(),
+    cache_read: non_neg_integer(),
+    cache_write: non_neg_integer()
+  }
+
+  @spec zero() :: t()
+  def zero, do: %__MODULE__{input_tokens: 0, output_tokens: 0, cache_read: 0, cache_write: 0}
+end
+
+# lib/tau/tui/app/model/search.ex
+defmodule Tau.TUI.App.Model.Search do
+  @enforce_keys [:query, :search_index]
+  defstruct [:query, :search_index]
+
+  @type t :: %__MODULE__{query: String.t(), search_index: non_neg_integer()}
+end
+
+# lib/tau/tui/app/model/menu.ex
+defmodule Tau.TUI.App.Model.Menu do
+  # shape TBD from completion.ex usage — proposal commits to extracting whatever
+  # shape the completion sub-module relies on
+  @enforce_keys [:items, :selected]
+  defstruct [:items, :selected]
+  @type t :: %__MODULE__{items: [map()], selected: non_neg_integer()}
+end
+```
+
+**Updated `Model.t()` type** (model.ex):
+
+```elixir
+@type t :: %__MODULE__{
+  # ... unchanged fields ...
+  usage: Model.Usage.t(),
+  search: nil | Model.Search.t(),
+  menu: nil | Model.Menu.t(),
+  # ...
+}
+```
+
+**Updated `Model.new/1`**:
+
+```elixir
+usage: Model.Usage.zero(),
+search: nil,
+menu: nil,
+```
+
+**Updated `View.status_bar_model/1`**:
+
+```elixir
+@spec status_bar_model(Model.t()) :: map()
+def status_bar_model(model) do
+  %{
+    usage: model.usage,            # Model.Usage.t() — StatusBar already accepts map
+    context_tokens: model.context_tokens,
+    ...
+  }
+end
+```
+
+**Updated `Events.on_message_end/2`**:
+
+```elixir
+# Before: Map.get(model, :warn_level, :ok)
+# After:  model.warn_level   (unchanged — warn_level is already a typed field)
+
+# cost_for_session now returns a Model.Usage.t() instead of a plain map
+# (requires updating Tau.Cost.for_session/1 return type — see Dependencies)
+```
+
+**File moves**:
+- `lib/tau/tui/app/model/usage.ex` (new)
+- `lib/tau/tui/app/model/search.ex` (new)
+- `lib/tau/tui/app/model/menu.ex` (new)
+
+## Tradeoffs
+
+### Strengths
+
+- Makes `Map.get` structurally impossible for typed sub-fields; Dialyzer flags
+  it as a type error rather than a style warning.
+- Aligns `Model.t()` field types with the Elixir idiom for typed data: structs
+  with `@enforce_keys`, not anonymous maps.
+- `Model.Usage.zero()` replaces the in-line `%{input_tokens: 0, ...}` literal
+  duplicated in `Model.new/1` and `events.ex:266` — single source for the zero
+  value.
+- The sub-structs are independently testable and documentable.
+
+### Weaknesses
+
+- API-breaking: any code that constructs a `%{input_tokens: ..., output_tokens:
+  ...}` plain map and assigns it to `model.usage` (e.g., test fixtures, the
+  `cost_for_session` helper) must be updated to use `%Model.Usage{...}`.
+- The `menu` sub-struct's shape must be reverse-engineered from `Completion`
+  module usage before the struct can be defined — the problem statement does not
+  inventory the `menu` map's keys, so the sketch above is a placeholder.
+- `StatusBar.render/1` currently accepts a plain `map()` for `usage`; changing
+  to `Model.Usage.t()` may require updating `StatusBar` as well (a module outside
+  the nominal scope of this problem).
+- Three new files increases the module count and the `alias` surface in consumer
+  files.
+- Larger diff than Proposals 1 and 2; harder to review atomically.
+
+### Costs
+
+- Three new struct modules (~15–20 lines each).
+- Update `Model.t()` type spec (3 field type changes).
+- Update `Model.new/1` (3 constructor expressions).
+- Update `Tau.Cost.for_session/1` return type and all callers that unpack the
+  plain map — at minimum `events.ex`.
+- Update all test fixtures that build a `%{input_tokens: ...}` map to build
+  `%Model.Usage{...}` instead.
+- Reverse-engineer and lock down the `menu` map shape from `Completion` module
+  before writing `Model.Menu.t()`.
+- Estimated: largest diff of the four proposals; 2–3x the edit count of
+  Proposal 1 due to cascading type updates.
+
+## Dependencies
+
+- `Tau.Cost.for_session/1` return type must change from `map()` to
+  `Model.Usage.t()` (or a compatible map that `struct!/2` can accept).
+- `Completion` module's menu shape must be audited to define `Model.Menu.t()`
+  correctly — a read-only exploration pass is needed first.
+- `StatusBar.render/1` may need a type annotation update if it pattern-matches
+  on `usage` as a plain map.
+
+## Confidence
+
+Low-medium. The struct-extraction pattern is sound but the cascading type update
+cost is underspecified — `menu` and `search` shapes are not fully inventoried in
+the problem statement. Confidence would increase after auditing `completion.ex`
+and `history.ex` to confirm the concrete field sets.
+
+## Prior art / references
+
+- Elixir struct documentation — recommended pattern for typed nested data.
+- Phoenix `%Plug.Conn{}` with sub-structs (e.g., `conn.private`, `conn.params`)
+  — demonstrates that nested anonymous maps eventually get promoted to structs as
+  type discipline matters.
+- Ecto `%Ecto.Changeset{}` sub-field structs — same pattern at the ORM layer.

--- a/docs/problems-archive-v1-modules/tau-tui-app/subproblems/model-as-bag-of-maps/proposals/proposal-4.md
+++ b/docs/problems-archive-v1-modules/tau-tui-app/subproblems/model-as-bag-of-maps/proposals/proposal-4.md
@@ -1,0 +1,163 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 4
+parent_problem: ../problem.md
+---
+
+# Proposal 4: Custom Credo check + spec guard — enforce struct discipline mechanically without touching callsites yet
+
+## Approach
+
+Write a custom `Credo.Check` (e.g., `Tau.Credo.Check.NoModelMapGet`) that fails
+`mix credo --strict` whenever `Map.get/2`, `Map.get/3`, or `Map.put/3` is called
+with a variable whose type annotation in the same function's `@spec` is `Model.t()`
+or a bare `map()` in any file under `lib/tau/tui/app/`. Additionally, add a
+`mix compile --warnings-as-errors` guard by annotating every consumer function
+with the correct `@spec` (changing `map()` to `Model.t()`) so Dialyzer
+progressively surfaces mismatches. The callsite replacements are then done
+incrementally, driven by CI failures rather than by a single large PR.
+
+## Rationale
+
+The problem has two distinct layers: (a) missing `@spec` type discipline (consumer
+functions accept and return `map()` instead of `Model.t()`), and (b) incorrect
+access pattern (`Map.get/3` instead of `model.field`). Fixing (a) first gives
+Dialyzer the information it needs to flag (b) automatically. The custom Credo
+check makes (b) a hard CI failure for any new code immediately, without requiring
+that all existing violations be corrected in the same PR. This is an incremental,
+mechanical-enforcement-first approach: add the fence before fixing what is already
+inside the fence.
+
+## Sketch
+
+**New file**: `lib/tau/credo/check/no_model_map_get.ex`
+
+```elixir
+defmodule Tau.Credo.Check.NoModelMapGet do
+  use Credo.Check,
+    base_priority: :high,
+    category: :design,
+    tags: [:tau_struct_discipline],
+    explanations: [
+      check: """
+      Do not call Map.get/2-3 or Map.put/3 on a value typed as Model.t().
+      Use struct field access (model.field) and struct update syntax (%{model | field: val}).
+      """
+    ]
+
+  @impl Credo.Check
+  def run(%SourceFile{} = source_file, params) do
+    issue_meta = IssueMeta.for(source_file, params)
+
+    source_file
+    |> Credo.Code.prewalk(&traverse(&1, &2, issue_meta))
+  end
+
+  # Detect Map.get(model, :field, ...) where the enclosing function
+  # spec types model as map() or Model.t() — flag Map.get as suspect.
+  # Conservative: flag any Map.get/put call in lib/tau/tui/app/**/*.ex.
+  defp traverse(
+         {{:., _, [{:__aliases__, _, [:Map]}, :get]}, meta, _args} = ast,
+         issues,
+         issue_meta
+       ) do
+    {ast, [format_issue(issue_meta, message: "Use struct access instead of Map.get", line_no: meta[:line]) | issues]}
+  end
+
+  defp traverse(ast, issues, _), do: {ast, issues}
+end
+```
+
+**`.credo.exs` addition** (under `checks: %{enabled: [...]}`):
+
+```elixir
+{Tau.Credo.Check.NoModelMapGet, files: %{included: ["lib/tau/tui/app/**/*.ex"]}}
+```
+
+**`@spec` annotation pass** (one PR, no callsite changes):
+
+```elixir
+# events.ex: change two specs
+@spec update(Model.t(), term()) :: Model.t()
+@spec update_session_event(Model.t(), term()) :: Model.t()
+
+# view.ex
+@spec status_bar_model(Model.t()) :: map()
+@spec build_prompt_labels(Model.t()) :: [term()]
+
+# keymap.ex
+@spec handle_event(Model.t(), map()) :: Model.t()
+@spec handle_event_normal(Model.t(), map()) :: Model.t()
+
+# permission.ex
+@spec on_permission_request(Model.t(), map()) :: Model.t()
+```
+
+**No callsite changes in this PR.** The CI check is scoped to new code only via
+`--since git:main` (Credo supports this); existing violations are surfaced as
+warnings, not errors, until they are corrected in subsequent PRs. The Credo check
+and `@spec` annotation PR gates the approach; callsite cleanup PRs follow.
+
+## Tradeoffs
+
+### Strengths
+
+- Prevents regression: any new `Map.get/3` on a `Model.t()` value fails CI
+  immediately, even before the existing violations are fully cleaned up.
+- Decouples the enforcement-introduction PR from the cleanup PRs; each cleanup
+  PR is a small, focused diff (e.g., "fix events.ex violations only").
+- The custom Credo check is reusable for any future struct whose consumers
+  exhibit the same pattern.
+- `@spec` annotation pass is zero-risk (no runtime changes) and immediately
+  improves Dialyzer coverage.
+- Incremental time horizon: the team can ship the guard first and address
+  violations across multiple milestones without the all-or-nothing pressure of
+  a single large refactor PR.
+
+### Weaknesses
+
+- Does not itself fix the acceptance criterion: `Map.get/3` calls remain until
+  the subsequent cleanup PRs land. The acceptance criterion is only fully
+  satisfied at the end of the incremental sequence, not at merge of this PR.
+- The custom Credo AST check is a heuristic: it flags all `Map.get` calls in the
+  targeted file glob, including any that legitimately operate on `map()` values
+  that are not `Model.t()`. False positives require per-site `# credo:disable`
+  annotations (which are themselves a code smell marker — acceptable but noisy).
+- Writing and maintaining a custom Credo check requires familiarity with the
+  Credo AST traversal API; the sketch above is simplified and may miss edge cases
+  (e.g., `Map.get` called via a local alias).
+- The Credo check does not help Dialyzer; the two mechanisms are orthogonal.
+  Dialyzer still needs the `@spec` changes to flag callsite type mismatches.
+
+### Costs
+
+- Write `lib/tau/credo/check/no_model_map_get.ex` (~60 lines).
+- Write a Credo check unit test (~20–30 lines).
+- Update `.credo.exs` (2–3 lines).
+- Write the `@spec` annotation pass (one PR, ~12–16 spec changes, no callsite
+  changes).
+- Each subsequent cleanup PR is small (one file, ~5–10 callsite edits) but there
+  are 5 of them — total edit count similar to Proposal 1, spread across more PRs.
+
+## Dependencies
+
+- Credo >= 1.7 (already a project dependency per `mix.exs`).
+- A working `mix dialyzer` baseline so that the `@spec` annotation PR does not
+  introduce new Dialyzer warnings without resolving them.
+
+## Confidence
+
+Medium. The enforcement-first pattern is a legitimate engineering approach and
+the Credo AST API is documented. Confidence would be raised by verifying that
+the targeted glob (`lib/tau/tui/app/**/*.ex`) does not produce excessive false
+positives on the current codebase (i.e., that non-`Model.t()` `Map.get` calls
+in those files are rare or absent).
+
+## Prior art / references
+
+- Credo custom check documentation: https://hexdocs.pm/credo/writing_checks.html
+- `mix credo --since git:main` — Credo's diff-scoped mode for blocking only new
+  violations.
+- Gradual type enforcement pattern — described in the Gradualizer/Dialyzer
+  ecosystem as "add specs first, fix callsites incrementally".

--- a/docs/problems-archive-v1-modules/tau-tui-app/subproblems/model-as-bag-of-maps/solution.md
+++ b/docs/problems-archive-v1-modules/tau-tui-app/subproblems/model-as-bag-of-maps/solution.md
@@ -1,0 +1,61 @@
+---
+template_version: 1
+template_name: solution
+parent_problem: ../problem.md
+node_kind: leaf
+synthesised_from: [proposals/proposal-1.md, proposals/proposal-2.md]
+selection_method: hybrid
+revision: 0
+---
+
+# Solution: Mechanical callsite replacement + `Model.context_window/1` accessor for the one non-trivial default
+
+## Recommendation
+
+Replace every `Map.get(model, :field, default)` and `Map.put(model, :field, val)` call across `Events`, `Input`, `Keymap`, `View`, and `Permission` with direct struct field access (`model.field`) and struct update syntax (`%{model | field: val}`). Update all `@spec` annotations that use `map()` as input or output to `Model.t()`. For the single field whose fallback is non-trivial — `context_window`, whose nil-fallback consults `Application.get_env/3` — add one typed accessor `Model.context_window/1` that owns that logic, replacing the duplicated nil-coalescion in `events.ex` and `view.ex`. All other `Map.get/3` calls whose defaults re-state values already present in `Model.new/1` become plain `model.field` accesses with no accessor indirection.
+
+## Selected from
+
+- **Chosen:** hybrid of `proposals/proposal-1.md` (mechanical callsite replacement) and `proposals/proposal-2.md` (typed accessor for non-trivial defaults)
+- **Why chosen:** Proposal 1 satisfies the acceptance criterion directly and completely at lowest cost and risk, and its uniform substitution is both reviewable and reversible. Its one identified weakness is the `context_window` nil-fallback: stripping the `Map.get` default from that site leaves the nil-coalescion logic duplicated across `events.ex` and `view.ex` in a way that cannot be typed away by struct access alone. Proposal 2's general `Model.update/2` function adds indirection without benefit for fields that are always populated by `@enforce_keys`; but its specific insight — that the `context_window` fallback should be owned by `Model` — is correct and narrow. The hybrid takes the full mechanical replacement of Proposal 1 and adds only the single accessor Proposal 2 motivates, avoiding Proposal 2's broader API surface. Proposal 3 is out-of-scope overreach: the problem statement explicitly excludes changing the field set, and introducing sub-structs is an API-breaking change with cascading unknowns (menu shape, StatusBar type updates, Cost.for_session return type). Proposal 4 defers satisfaction of the acceptance criterion; adding enforcement without fixing existing violations is the wrong sequencing when the violations are fully inventoried and mechanical to fix.
+
+## What changes
+
+- `lib/tau/tui/app/model.ex` — add `@spec context_window(t()) :: pos_integer()` + two-clause function that returns the field value when set, or the `Application.get_env(:tau, :compaction_threshold_tokens, 120_000)` fallback when nil.
+- `lib/tau/tui/app/events.ex` — change `@spec update/2` and `@spec update_session_event/2` from `map()` to `Model.t()`; add `alias Tau.TUI.App.Model`; replace all `Map.get(model, ...)` and `Map.put(model, ...)` calls with struct field access and `%{model | ...}` update syntax; replace `Map.get(model, :context_window) || Application.get_env(...)` with `Model.context_window(model)`.
+- `lib/tau/tui/app/view.ex` — change `@spec status_bar_model/1` from `map()` to `Model.t()`; replace all `Map.get(model, :field, default)` calls in `status_bar_model/1` with `model.field`; replace `Map.get(model, :context_window)` with `Model.context_window(model)`.
+- `lib/tau/tui/app/keymap.ex` — change affected `@spec` lines to `Model.t()`; replace `Map.get(model, :pending_permissions, [])` with `model.pending_permissions`.
+- `lib/tau/tui/app/permission.ex` — change affected `@spec` lines to `Model.t()`; replace `Map.get(model, :pending_permissions, [])` with `model.pending_permissions`; replace `Map.put(model, :pending_permissions, ...)` with `%{model | pending_permissions: ...}`.
+- `lib/tau/tui/app/input.ex` (if any `Map.get/put` on model exists) — same treatment: struct access and `Model.t()` specs.
+- `lib/tau/tui/app/completion.ex` and `lib/tau/tui/app/history.ex` — audit for `Map.get/put` on `Model.t()` values; apply the same mechanical replacement if found (acceptance criterion names these modules explicitly).
+
+## What does not change
+
+- The `Model.t()` struct's field set and `@enforce_keys` list — out of scope per problem.md.
+- The `Model.new/1` constructor — no field additions or removals.
+- Sub-field shapes (`usage`, `search`, `menu`) — they remain as typed in the current struct; no sub-struct extraction.
+- `Tau.Cost.for_session/1` return type — no changes to modules outside `lib/tau/tui/app/`.
+- `StatusBar` module — not touched; `status_bar_model/1` continues to return a plain `map()` as its output type.
+- Sibling sub-problems (`duplicated-bounded-append`, `session-side-effects-in-pure-modules`, `transcript-coupling`) — no changes.
+- The `Model.update/2` multi-field updater from Proposal 2 — not introduced; `%{model | ...}` syntax is sufficient and unambiguous at every callsite where the keyword list is a literal.
+
+## Migration sketch
+
+One PR, one file at a time in dependency order: (1) add `Model.context_window/1` to `model.ex` and verify `mix dialyzer` is clean; (2) update `events.ex` (the largest callsite set) and run `mix test` — this is the highest-risk step because `status_bar_model` defaults currently paper over missing fields in test fixtures; (3) update `view.ex`; (4) update `keymap.ex`, `permission.ex`, `input.ex`; (5) audit and update `completion.ex` and `history.ex`. Each file step can be a separate commit on the same branch so bisection is clean if a test surfaces a hidden fixture gap.
+
+## Open questions
+
+- Are there `Map.get/put` calls on `model` inside `completion.ex` or `history.ex` that are not inventoried in the problem statement? The acceptance criterion names them but the problem statement's context section does not enumerate their callsites. A grep pass is required before implementation.
+- Do any test fixtures construct a partial `Model.t()` that relies on the defaulting behaviour of `Map.get` (e.g., setting `usage: nil` and relying on `Map.get(model, :usage, %{input_tokens: 0, ...})`)? Removing those defaults will surface a crash rather than a zero value. The implementation must verify `mix test` passes after each file's callsites are converted.
+- Does Dialyzer propagate `Model.t()` correctly through `Model.context_window/1`'s two-clause pattern match, or does it widen the return type? Confirm with `mix dialyzer` after adding the function.
+
+## Linked sub-problems / proposals
+
+- `proposals/proposal-1.md` — Mechanical callsite replacement; primary source for the bulk of the change.
+- `proposals/proposal-2.md` — Typed accessor/updater façade; source for the `Model.context_window/1` accessor only.
+- `proposals/proposal-3.md` — Sub-struct extraction; rejected (API-breaking, out-of-scope, cascading unknowns).
+- `proposals/proposal-4.md` — Enforcement-first via custom Credo check; rejected (defers acceptance-criterion satisfaction; wrong sequencing when callsites are fully inventoried).
+
+## Revision history
+
+- (revision 0 — initial)

--- a/docs/problems-archive-v1-modules/tau-tui-app/subproblems/model-as-bag-of-maps/validation.md
+++ b/docs/problems-archive-v1-modules/tau-tui-app/subproblems/model-as-bag-of-maps/validation.md
@@ -1,0 +1,434 @@
+---
+template_version: 1
+template_name: validation
+parent_solution: solution.md
+parent_problem: problem.md
+toulmin_complete: true
+falsification_attempted: true
+falsification_outcome: partially_falsified — claim/3
+revision_triggered: none
+---
+
+# Validation: Mechanical callsite replacement + `Model.context_window/1` accessor
+
+## Overview
+
+The solution makes seven claims across the Recommendation and What-changes
+sections: (1) all `Map.get/3` and `Map.put/2` calls on `model` in the named
+modules can be mechanically replaced with struct syntax; (2) `@spec` annotations
+typed `map()` in those modules can be updated to `Model.t()`; (3) the
+`context_window` nil-fallback is the only non-trivial default, and adding one
+`Model.context_window/1` accessor suffices to consolidate it; (4) all other
+`Map.get/3` defaults re-state values already present in `Model.new/1`; (5)
+`completion.ex` and `history.ex` use `Map.get` only on sub-fields (`model.menu`,
+`model.search`), not on the `Model.t()` value itself; (6) the `Model.update/2`
+multi-field updater from Proposal 2 is unnecessary; (7) the struct's field set
+and `@enforce_keys` list are unchanged. Seven claims, evaluated below.
+Falsification used counter-example construction and dependency checks grounded in
+`grep` evidence from the live codebase. One claim is partially falsified, which
+narrows its qualifier; no full falsification; no revision required.
+
+---
+
+## Toulmin per claim
+
+The MITRE empirical study on Toulmin formalism found that "participants found it
+difficult to generate Toulmin structures, and their structures varied greatly even
+though they started with the same content"
+(https://www.mitre.org/news-insights/publication/empirical-evaluation-structured-argumentation-using-toulmin-argument).
+This template enforces all six components explicitly with prompts to counter that
+variance.
+
+---
+
+### Claim 1: All `Map.get/3` and `Map.put/2` calls on the `Model.t()` value in `Events`, `Input`, `Keymap`, `View`, and `Permission` can be replaced with struct field access and `%{model | ...}` update syntax
+
+- **Claim (C):** Replace every `Map.get(model, :field, default)` and
+  `Map.put(model, :field, val)` call across `Events`, `Input`, `Keymap`, `View`,
+  and `Permission` with direct struct field access (`model.field`) and struct
+  update syntax (`%{model | field: val}`).
+- **Grounds (G):** `grep` over the live codebase confirms the full inventory.
+  `events.ex:236,241,252-257,312` — eight `Map.get/put` calls. `view.ex:69,120-129,134` —
+  nine calls. `keymap.ex:31` — one `Map.get(model, :pending_permissions, [])`.
+  `permission.ex:40-41` — one `Map.get` and one `Map.put` on `:pending_permissions`.
+  `input.ex:52-53` — two `Map.get` calls on `event`, not on `model` (see Claim 5
+  note). Every field accessed by these calls is declared in the `defstruct` at
+  `model.ex:30-54`.
+- **Warrant (W):** A named struct in Elixir supports direct field access
+  (`s.field`) and struct update (`%{s | field: v}`) for any field declared in its
+  `defstruct`; no runtime dispatch is required. Replacing `Map.get(s, :k,
+  default)` with `s.k` is semantics-preserving when `:k` is always populated
+  (enforced or initialised to a non-nil value by `new/1`), modulo the nil-default
+  distinction handled in Claim 3.
+- **Qualifier (Q):** Holds for every field accessed in the inventoried callsites
+  provided the field is present in `defstruct` and `Model.new/1` provides a
+  non-nil initial value (or the field is in `@enforce_keys`). Fields that are
+  legitimately `nil` at runtime (e.g. `context_window`, `last_assistant`,
+  `coding_agent`) require the nil case to be handled by the caller or an accessor,
+  not silently swallowed by `Map.get`'s default.
+- **Rebuttal (R):** If any callsite passes a non-`Model.t()` map through the
+  function (e.g., a test fixture built as a bare `map()` rather than
+  `%Model{...}`), replacing `Map.get` with struct field access will raise a
+  `BadMapError` at runtime for that call. This is a real risk: `app_test.exs:22-39`
+  constructs a plain map fixture, not a `%Model{}`, and passes it to `App.update/2`.
+  The solution's migration sketch acknowledges this risk at step 2.
+- **Backing (B):** Elixir documentation on structs: `https://hexdocs.pm/elixir/structs.html`.
+  OTP non-negotiable §2 (`otp-non-negotiables.md`): "Extensibility seams MUST be
+  behaviours; pattern match on atoms and structs." `model.ex:14-28` — `@enforce_keys`
+  establishes which fields are always present at struct construction.
+
+#### Falsification attempt for claim 1
+
+- **Strategy:** Counter-example construction — attempt to find a callsite where
+  `Map.get(model, :field, default)` cannot be replaced by `model.field` because
+  the field is absent from `defstruct` or because the default diverges from the
+  struct's nil-initial value in a way that changes semantics.
+- **Attempt:** Checked every `Map.get` field reference against `model.ex:30-54`:
+  `:context_window`, `:warn_level`, `:pending_permissions`, `:session_id`,
+  `:model`, `:provider`, `:usage`, `:context_tokens`, `:compaction`,
+  `:permissions_mode` — all present in `defstruct`. `Map.get(model, :provider)`
+  at `events.ex:312` accesses a field that is nil-initialised in `new/1` (the
+  `init_provider/1` helper may return nil when no provider key is in opts);
+  `model.provider` is equivalent. No counter-example found where the field is
+  absent from the struct definition.
+- **Outcome:** Withstood — no callsite accesses a field outside `defstruct`.
+
+---
+
+### Claim 2: `@spec` annotations typed `map()` in the named modules can be updated to `Model.t()`
+
+- **Claim (C):** Update all `@spec` annotations that use `map()` as input or
+  output to `Model.t()` in `Events`, `Input`, `Keymap`, `View`, and `Permission`.
+- **Grounds (G):** Live evidence: `events.ex:31` — `@spec update(map(), term()) ::
+  map()`; `events.ex:83` — `@spec update_session_event(map(), term()) :: map()`;
+  `events.ex:160` — `@spec drain_bridge(map()) :: map()`. `view.ex:29` —
+  `@spec render(map()) :: term()`; `view.ex:86` — `@spec render_menu(map()) ::
+  term()`; `view.ex:117` — `@spec status_bar_model(map()) :: map()`.
+  `keymap.ex:29,50,65,145,212` — all typed `map()`. `permission.ex:22,38` —
+  typed `map()`. All these functions receive and return the MVU model.
+- **Warrant (W):** Dialyzer's success-typing inference narrows `map()` to the
+  struct type only when `@spec` declares `Model.t()`; without the spec update,
+  Dialyzer cannot flag field-name typos or incorrect field types in callers. The
+  point of the change is to give the type system a precise grip on the value.
+- **Qualifier (Q):** The `@spec` update is safe for functions whose sole
+  `map()` parameter is the MVU model. Functions that also accept plain `map()`
+  event values (e.g. `keymap.ex:29` `handle_event(map(), map())` where the
+  second argument is a Ratatouille key event) will require mixed specs — the
+  event argument stays `map()` while the model argument becomes `Model.t()`.
+- **Rebuttal (R):** `view.ex:117` — `@spec status_bar_model(map()) :: map()` has
+  `map()` as its _return_ type, which the solution explicitly preserves ("not
+  touched; `status_bar_model/1` continues to return a plain `map()`"). So the
+  return-type of `status_bar_model/1` is intentionally left as `map()` per the
+  solution's What-does-not-change section. This is not a rebuttal to the claim
+  itself but a scope boundary that the spec must not violate.
+- **Backing (B):** Dialyzer documentation on success typing:
+  `https://www.erlang.org/doc/man/dialyzer.html`. `problem.md` acceptance
+  criterion: "`@spec` annotations use `Model.t()` not `map()`".
+
+#### Falsification attempt for claim 2
+
+- **Strategy:** Type-level check — run Dialyzer mentally over the proposed spec
+  changes to identify any case where `Model.t()` is narrower than what the
+  function actually handles, which would produce a Dialyzer success-type warning.
+- **Attempt:** `keymap.ex:29` is `handle_event(map(), map())`. The first `map()`
+  is `model`; the second is the Ratatouille key event (a bare map with `:ch`,
+  `:key`, `:mod` keys). After the change, the spec becomes
+  `handle_event(Model.t(), map()) :: Model.t()`. Dialyzer accepts this: the first
+  argument is narrowed (always correct, since callers pass `Model.t()`); the
+  second remains `map()` (correct for Ratatouille events). No warning expected.
+  `view.ex:117` — solution explicitly preserves `map()` as the return type, so
+  no issue. No type-level counter-case found.
+- **Outcome:** Withstood — no function is called with a value that is strictly
+  wider than `Model.t()` for the model parameter.
+
+---
+
+### Claim 3: The `context_window` nil-fallback is the _only_ non-trivial default; adding `Model.context_window/1` suffices to consolidate all non-trivial nil-coalescion
+
+- **Claim (C):** For the single field whose fallback is non-trivial —
+  `context_window`, whose nil-fallback consults `Application.get_env/3` — add one
+  typed accessor `Model.context_window/1` that owns that logic, replacing the
+  duplicated nil-coalescion in `events.ex` and `view.ex`. All other `Map.get/3`
+  calls whose defaults re-state values already present in `Model.new/1` become
+  plain `model.field` accesses with no accessor indirection.
+- **Grounds (G):** `events.ex:236-237` — `Map.get(model, :context_window) ||
+  Application.get_env(:tau, :compaction_threshold_tokens, 120_000)` is the only
+  `Application.get_env` call for a model field in the inventoried modules.
+  `view.ex:126` — `Map.get(model, :context_window)` with no `Application.get_env`
+  fallback (passes nil through to `StatusBar`); this call does not duplicate the
+  non-trivial fallback. `view.ex:124` — `Map.get(model, :usage, %{input_tokens:
+  0, ...})` — default re-states the value from `model.ex:127`; replacing with
+  `model.usage` is safe. All other defaults in `view.ex:120-129` follow the same
+  pattern: their defaults duplicate `Model.new/1` values.
+- **Warrant (W):** A fallback is "non-trivial" if it cannot be expressed as a
+  struct field read: it consults external state (here, `Application.get_env`).
+  A fallback is "trivial" if its default is identical to the value `Model.new/1`
+  seeds into the field, making the `Map.get` default unreachable for any struct
+  value that went through `new/1`. Only `Application.get_env` fallbacks are
+  non-trivial by this definition.
+- **Qualifier (Q):** Holds for the inventoried consumer modules. Narrows if any
+  module outside the inventory (e.g., `bootstrap.ex`) contains additional
+  `Application.get_env` model-field fallbacks not visible in the grep evidence.
+  Also: `view.ex:126` passes `model.context_window` (possibly nil) to `StatusBar`;
+  if `StatusBar` internally applies the `Application.get_env` fallback, the
+  consolidation is incomplete unless `view.ex` also calls `Model.context_window/1`
+  instead of the bare field access.
+- **Rebuttal (R):** The solution's What-changes section states `view.ex` should
+  replace `Map.get(model, :context_window)` with `Model.context_window(model)`.
+  But the `view.ex` callsite at line 126 feeds `StatusBar.context_pct/2` (or
+  equivalent), where nil may be valid and handled downstream. If `view.ex` calls
+  `Model.context_window/1` (the accessor with the `Application.get_env` fallback),
+  it changes observable behaviour relative to the current nil-passthrough. The
+  solution is internally consistent only if `StatusBar` already handles nil by
+  falling back to `Application.get_env`; otherwise the two callsites in `view.ex`
+  and `events.ex` have genuinely different semantics, and they should not both
+  call the same accessor.
+- **Backing (B):** `events.ex:236-237` and `view.ex:126` (live codebase).
+  `model.ex:129` — `context_window: nil` in `new/1`. `problem.md` acceptance
+  criterion: "no `Map.get` call with a default that re-states a canonical default
+  from `Model.new/1` remains."
+
+#### Falsification attempt for claim 3
+
+- **Strategy:** Counter-example construction — find a second non-trivial default
+  (one that cannot be replaced by plain struct access) in the inventoried modules.
+- **Attempt:** Examined every `Map.get(model, :field, default)` call in the grep
+  evidence:
+  - `view.ex:124` — default `%{input_tokens: 0, output_tokens: 0, cache_read: 0, cache_write: 0}` re-states `model.ex:127`. Trivial.
+  - `view.ex:125` — default `0` re-states `model.ex:128` (`context_tokens: 0`). Trivial.
+  - `view.ex:127` — default `:idle` re-states `model.ex:131` (`compaction: :idle`). Trivial.
+  - `view.ex:129` — default `:default` re-states `model.ex:124` (`permissions_mode: Map.get(runtime_opts, :permissions_mode, :default)`). Trivial for any `Model.t()` that went through `new/1`.
+  - `events.ex:241` — `Map.get(model, :warn_level, :ok)`. Default `:ok` re-states `model.ex:131` (`warn_level: :ok`). Trivial.
+  - `events.ex:312` — `Map.get(model, :provider)` with no default. Becomes `model.provider`.
+  - `keymap.ex:31` — default `[]` re-states `model.ex:123` (`pending_permissions: []`). Trivial.
+  - `permission.ex:40` — same field, same trivial default.
+
+  One partial counter-case: the solution states `view.ex` should call
+  `Model.context_window/1` (the accessor). But `view.ex:126` currently passes
+  `context_window` as nil to a downstream struct (not applying the fallback), so
+  calling `Model.context_window/1` would change the semantic: nil becomes
+  `120_000` instead of nil. This does not falsify the claim that there is only one
+  non-trivial default, but it does mean the solution's proposed treatment of
+  `view.ex:126` requires a semantic decision — not just a mechanical substitution.
+  The qualifier must be narrowed: the claim holds for `events.ex`, but the
+  treatment of `view.ex:126` is context-dependent.
+
+- **Outcome:** Partially falsified — the `view.ex:126` callsite is an instance
+  where the solution's instruction to call `Model.context_window(model)` is not
+  purely mechanical: it changes observable behaviour (nil → 120_000) unless
+  `StatusBar` already handles nil identically. The qualifier is narrowed: "for
+  `events.ex`'s callsite, `Model.context_window/1` is a correct consolidation;
+  for `view.ex:126`, the implementer must verify whether `StatusBar` expects nil
+  or a concrete value, and choose accordingly (either bare `model.context_window`
+  or `Model.context_window(model)`)."
+- **Action:** Narrow qualifier; no solution revision needed. The narrowed claim
+  survives; the open question is noted in Outstanding doubts.
+
+---
+
+### Claim 4: All `Map.get/3` defaults in the inventoried consumer modules re-state values present in `Model.new/1`, making them redundant on any struct value that went through `new/1`
+
+- **Claim (C):** All other `Map.get/3` calls whose defaults re-state values
+  already present in `Model.new/1` become plain `model.field` accesses with no
+  accessor indirection.
+- **Grounds (G):** Verified exhaustively in the Claim 3 falsification attempt
+  above. Every default in `view.ex:124-129` and `events.ex:241`, `keymap.ex:31`,
+  `permission.ex:40` duplicates an explicit initial value in `model.ex:108-133`.
+- **Warrant (W):** If `Model.new/1` is the sole constructor (no `%Model{...}` literals
+  outside `model.ex`) and `@enforce_keys` enforces all mandatory fields, then any
+  live `Model.t()` value has all `@enforce_keys` fields set to non-nil values.
+  The `Map.get` default is therefore unreachable, making the `Map.get` call
+  semantically equivalent to plain struct access for values that went through `new/1`.
+- **Qualifier (Q):** Holds for values constructed via `Model.new/1`. Does NOT hold
+  for bare-map fixtures in tests that omit fields (see Claim 6 note and Rebuttal).
+  After conversion, tests that use bare maps will crash at the struct access; this
+  is the intended outcome per the migration sketch ("surfaces a crash rather than a
+  zero value").
+- **Rebuttal (R):** `app_test.exs:22-39` constructs a bare `map()` fixture missing
+  several mandatory fields (`usage`, `context_tokens`, `compaction`, `warn_level`,
+  `permissions_mode`, `pending_permissions`). After the struct-access conversion,
+  `App.update/2` and its callees will raise on this fixture. The migration sketch
+  acknowledges this; the fix is to convert the fixture to `%Model{...}` or to call
+  `Model.new/1`. This is a known migration cost, not a falsification of the claim
+  itself.
+- **Backing (B):** `model.ex:14-28` (`@enforce_keys`); `model.ex:108-133`
+  (`new/1` initial values); `problem.md` acceptance criterion.
+
+#### Falsification attempt for claim 4
+
+- **Strategy:** Dependency check — verify that `Model.new/1` is the sole
+  constructor for `Model.t()` values in the production code path (not tests).
+- **Attempt:** Searched for `%Tau.TUI.App.Model{` and `%Model{` in `lib/` (outside
+  `model.ex` itself): no hits found. All production construction goes through
+  `Model.new/1`. The claim's precondition holds in production code.
+- **Outcome:** Withstood — in production, no `Map.get` default is reachable on a
+  value that went through `new/1`.
+
+---
+
+### Claim 5: `completion.ex` and `history.ex` use `Map.get` only on sub-fields (`model.menu`, `model.search`), not on the `Model.t()` value itself
+
+- **Claim (C):** Audit `completion.ex` and `history.ex` for `Map.get/put` on
+  `Model.t()` values; apply the same mechanical replacement if found (acceptance
+  criterion names these modules explicitly).
+- **Grounds (G):** `completion.ex:56` — `Map.get(model.menu || %{}, :selected,
+  0)` — called on `model.menu`, a `nil | map()` sub-field, not on the `Model.t()`
+  value. `history.ex:95` — `Map.get(model.search, :search_index, 0)` — called on
+  `model.search`, a `nil | map()` sub-field. The `@spec` annotations in
+  `completion.ex` and `history.ex` use `map()` for the model parameter; these
+  should be updated to `Model.t()` per the acceptance criterion.
+- **Warrant (W):** `Map.get` on a sub-field (`model.menu`) is not the struct
+  discipline problem identified in `problem.md`; the problem is `Map.get` on the
+  `Model.t()` struct itself. Sub-field maps (`menu`, `search`) have no named
+  struct type (they are `nil | map()` in `model.ex:73,83`), so `Map.get` with a
+  default is the correct access pattern for those fields.
+- **Qualifier (Q):** Holds for the current codebase. If `menu` or `search` are
+  later given dedicated struct types, the same discipline applies to them.
+- **Rebuttal (R):** The `@spec` annotations in `completion.ex` still use `map()`
+  (e.g. `@spec update_menu(map()) :: map()`). The acceptance criterion requires
+  those to be updated to `Model.t()` even though the `Map.get` calls there are on
+  sub-fields. The solution's What-changes section covers this ("audit…apply the
+  same mechanical replacement if found"), but the replacement for these files is
+  limited to the `@spec` update, not a Map.get → struct access change.
+- **Backing (B):** `model.ex:73,83` — `search: nil | map()`, `menu: nil | map()`.
+  `completion.ex:47,56`; `history.ex:94-95` (live codebase).
+
+#### Falsification attempt for claim 5
+
+- **Strategy:** Counter-example construction — look for any `Map.get` call in
+  `completion.ex` or `history.ex` that accesses a top-level `Model.t()` field
+  (not a sub-field).
+- **Attempt:** All `Map.get` references in these files access `model.menu` or
+  `model.search`, both of which are sub-fields typed `nil | map()`. No call
+  accesses a top-level `Model.t()` field via `Map.get`. The grep evidence confirms
+  this exhaustively.
+- **Outcome:** Withstood — no direct `Map.get` on a `Model.t()` field in
+  `completion.ex` or `history.ex`.
+
+---
+
+### Claim 6: The `Model.update/2` multi-field updater from Proposal 2 is unnecessary; `%{model | ...}` syntax is sufficient at every callsite
+
+- **Claim (C):** The `Model.update/2` multi-field updater from Proposal 2 is not
+  introduced; `%{model | ...}` syntax is sufficient and unambiguous at every
+  callsite where the keyword list is a literal.
+- **Grounds (G):** The `Map.put` chain at `events.ex:252-257` updates six fields
+  in sequence. After conversion to struct update, this becomes either a pipeline
+  of `%{m | field: val}` updates or a single `%{model | status: :idle, transcript:
+  ..., last_assistant: nil, usage: ..., context_tokens: ..., warn_level: ...}`.
+  Both are syntactically valid. `%{model | field1: v1, field2: v2, ...}` is
+  idiomatic Elixir for multi-field struct updates.
+- **Warrant (W):** Hickey: "Simple is not easy, but it is better." The `Model.update/2`
+  function from Proposal 2 adds a call-site indirection without enabling any
+  additional static checking or enforcement. `%{model | ...}` with a literal
+  keyword list is transparent to Dialyzer and avoids the runtime cost of
+  converting a keyword list to struct updates inside a function.
+- **Qualifier (Q):** Holds when the keyword list passed to the hypothetical
+  `Model.update/2` is always a compile-time literal. If a callsite needed a
+  dynamically-constructed list of field updates, `Model.update/2` would add value;
+  no such callsite exists in the inventoried code.
+- **Rebuttal (R):** The six-field update at `events.ex:252-257` could be more
+  readable as `Model.update/2` in a literal keyword form. This is a style
+  preference, not a semantic argument. The solution's rejection on cost/benefit
+  grounds is defensible.
+- **Backing (B):** `proposals/proposal-2.md` (rejected for reasons cited in
+  solution.md). Elixir struct update syntax docs: `https://hexdocs.pm/elixir/structs.html#updating-structs`.
+
+#### Falsification attempt for claim 6
+
+- **Strategy:** Counter-example construction — find a callsite where `%{model |
+  ...}` syntax is insufficient (e.g., a dynamic field list, or a pattern-match
+  context where only a function call composes).
+- **Attempt:** The `events.ex:252-257` chain is the most complex case. It updates
+  six fields sequentially; each field value is a computed local. A single struct
+  update literal `%{model | status: :idle, transcript: t, last_assistant: nil,
+  usage: u, context_tokens: n, warn_level: w}` covers it without any helper
+  function. No dynamic field-set construction was found. No counter-case.
+- **Outcome:** Withstood.
+
+---
+
+### Claim 7: The `Model.t()` struct's field set, `@enforce_keys` list, `Model.new/1` constructor, sub-field shapes, `Tau.Cost.for_session/1` return type, and `StatusBar` module are unchanged
+
+- **Claim (C):** The `Model.t()` struct's field set and `@enforce_keys` list — out
+  of scope per problem.md. The `Model.new/1` constructor — no field additions or
+  removals. Sub-field shapes (`usage`, `search`, `menu`) remain as typed.
+  `Tau.Cost.for_session/1` return type — no changes. `StatusBar` module — not
+  touched.
+- **Grounds (G):** `problem.md` Out-of-scope section explicitly excludes "changing
+  the struct's field set or the `@enforce_keys` list." `model.ex:14-28,30-54` —
+  current field set. The solution's What-does-not-change section lists each of
+  these explicitly.
+- **Warrant (W):** Out-of-scope constraints in `problem.md` are acceptance-criterion
+  boundaries; a solution that violates them fails the acceptance criterion
+  regardless of correctness. The solution correctly identifies and preserves all
+  out-of-scope elements.
+- **Qualifier (Q):** Universal — the solution explicitly preserves these elements
+  in its What-does-not-change section.
+- **Rebuttal (R):** None. Adding `Model.context_window/1` is a behaviour-only
+  addition (new function, no struct change), which is within scope. Rebuttal: none
+  — the solution does not extend to any out-of-scope element.
+- **Backing (B):** `problem.md` Out-of-scope section.
+
+#### Falsification attempt for claim 7
+
+- **Strategy:** Dependency check — verify that adding `Model.context_window/1`
+  does not require any `defstruct` or `@enforce_keys` change.
+- **Attempt:** `context_window: pos_integer() | nil` is already declared in
+  `defstruct` at `model.ex:51` and in the `@type t` at `model.ex:90`.
+  `Model.context_window/1` reads this existing field; no struct change is needed.
+- **Outcome:** Withstood — the accessor is additive; no field set or `@enforce_keys`
+  change is required.
+
+---
+
+## Cross-claim consistency
+
+Claims 1–7 are internally consistent. Claims 1 and 2 are complementary (struct
+access + spec update); Claims 3 and 4 partition the `Map.get` callsite population
+into trivial defaults (Claim 4) and the one non-trivial default (Claim 3); Claims
+5 and 1 partition the `Map.get` population between top-level model fields (Claim
+1) and sub-field accesses (Claim 5); Claims 6 and 1 are consistent (replacement
+syntax choice). Claim 7 is independent (scope boundary).
+
+One tension: Claim 3 states that `view.ex`'s `context_window` callsite should use
+`Model.context_window(model)`, but the falsification of Claim 3 shows this would
+change observable behaviour (nil → 120_000) unless `StatusBar` handles nil
+identically to the fallback value. This does not create a cross-claim
+inconsistency per se, but it means Claim 3 and Claim 7 ("StatusBar not touched")
+interact: if the StatusBar module currently handles nil by applying the same
+`Application.get_env` fallback internally, then using `Model.context_window/1`
+in `view.ex` introduces a redundant double-fallback rather than a change. If
+StatusBar does _not_ handle nil this way, the semantic change in `view.ex` is
+real. The interaction is flagged as an outstanding doubt.
+
+---
+
+## Falsification summary
+
+| # | Claim (short) | Strategy | Outcome | Action |
+|---|---|---|---|---|
+| 1 | All Map.get/put on Model.t() replaceable with struct syntax | Counter-example construction | Withstood | None |
+| 2 | @spec map() → Model.t() across named modules | Type-level check | Withstood | None |
+| 3 | context_window is the only non-trivial default; one accessor suffices | Counter-example construction | Partially falsified — view.ex:126 semantic ambiguity | Narrow qualifier; implementer must verify StatusBar nil-handling before choosing accessor vs. bare field |
+| 4 | All other Map.get defaults re-state Model.new/1 values | Dependency check | Withstood | None |
+| 5 | completion.ex / history.ex Map.get is on sub-fields only | Counter-example construction | Withstood | None |
+| 6 | Model.update/2 unnecessary; struct update syntax sufficient | Counter-example construction | Withstood | None |
+| 7 | Field set, enforce_keys, new/1, sub-fields, Cost, StatusBar unchanged | Dependency check | Withstood | None |
+
+---
+
+## Revision required
+
+No full falsification occurred. Claim 3 was partially falsified; the qualifier is
+narrowed in place. No revision to `solution.md` or `problem.md` is needed.
+
+---
+
+## Outstanding doubts
+
+1. **`view.ex:126` — nil vs. fallback semantics.** `Map.get(model, :context_window)` currently passes nil through to StatusBar. The solution proposes replacing this with `Model.context_window(model)` (which returns `120_000` on nil). Whether this is correct depends on StatusBar's internal nil-handling. The implementer must grep `lib/tau/tui/status_bar.ex` for `context_window` nil handling before deciding which form to use at `view.ex:126`. This doubt does not block implementation but must be resolved at that file step.
+
+2. **`app_test.exs:22-39` bare-map fixture.** The test fixture constructs a plain `map()` missing `usage`, `context_tokens`, `compaction`, `warn_level`, `permissions_mode`, and `pending_permissions`. After the struct-access conversion, `App.update/2` will raise a `BadMapError` for this fixture. The migration sketch correctly identifies this as the highest-risk step at `events.ex`. The fixture will need to be converted to `Model.new/1` or a `%Model{...}` literal before `mix test` passes. This is a known migration cost, not a structural problem with the solution.
+
+3. **`completion.ex` and `history.ex` @spec update only.** The `Map.get` calls in these files are on sub-fields (`model.menu`, `model.search`) and cannot be replaced with `Model.t()` field access. The change in these files is limited to updating `@spec` annotations from `map()` to `Model.t()`. The solution's What-changes section covers this, but the wording ("audit for `Map.get/put` on `Model.t()` values; apply the same mechanical replacement if found") could mislead an implementer into expecting struct-access replacements in these files where none are warranted.

--- a/docs/problems-archive-v1-modules/tau-tui-app/subproblems/session-side-effects-in-pure-modules/problem.md
+++ b/docs/problems-archive-v1-modules/tau-tui-app/subproblems/session-side-effects-in-pure-modules/problem.md
@@ -1,0 +1,69 @@
+---
+template_version: 1
+template_name: problem
+node_kind: leaf
+depth: 1
+parent: ../../problem.md
+status: draft
+---
+
+# Problem: Session side effects inlined in nominally-pure MVU sub-modules
+
+## Statement
+
+`Tau.TUI.App.Input`, `Tau.TUI.App.Keymap`, and `Tau.TUI.App.Bootstrap` each
+describe themselves as pure MVU helpers (taking and returning model), but all
+three contain unconditional `Tau.*` session calls, `Tau.Session.*` casts, and
+`spawn/1` process creation mixed inline with the pure model-transformation
+logic. This means every unit test of these modules must either run a live
+`Tau.Session` FSM, stub the `Tau` module, or forgo the effectful branches
+entirely — none of which the current test suite achieves cleanly.
+
+## Context
+
+- `lib/tau/tui/app/input.ex:32` — `Tau.send(model.session_id, text)` in `submit/1` (side effect, no boundary)
+- `lib/tau/tui/app/input.ex:113` — `Tau.Session.set_permissions_mode/2` in `handle_perms_command/1`
+- `lib/tau/tui/app/input.ex:120` — `Tau.cancel/1` in `cancel/1`
+- `lib/tau/tui/app/input.ex:139` — `Tau.steer/1` in `steer/1`
+- `lib/tau/tui/app/input.ex:168` — `Tau.send/2` in `followup/1` (second call site)
+- `lib/tau/tui/app/keymap.ex:288–296` — `spawn(fn -> DynamicSupervisor.which_children(...) end)` in `quit_or_append/1`; spawns a process to stop the Ratatouille supervisor
+- `lib/tau/tui/app/bootstrap.ex:26–41` — `Tau.TUI.EventBridge.start_link/1`, `Tau.start_session/1`, `Tau.TUI.RuntimeOpts.get/0` in `init/1`; these are expected in Bootstrap, but Bootstrap also calls `Model.new/3` which triggers `Store.load/2` (disk I/O)
+- `lib/tau/tui/app/model.ex:104–106` — `Tau.Settings.data_dir/0`, `File.cwd!/0`, `Store.load/2` called from `Model.new/3`; constructor performs I/O
+
+`Input`'s `@moduledoc` states "All functions are pure except for the
+side-effectful Tau session calls" — acknowledging the entanglement without
+resolving it.
+
+## Complecting hypothesis
+
+Pure MVU model transformations are complected with `Tau` session I/O in `Input`
+and `Keymap` because the decomposition placed each feature (submit, steer,
+followup, cancel, quit) in a single function that does both: compute the new
+model AND fire the side effect. A caller cannot get the new model state without
+triggering the side effect, and cannot test the state transition without a live
+session process.
+
+## Decomposition strategy
+
+(leaf — no further decomposition; proceed to proposals)
+
+## Acceptance criterion
+
+Each function in `Input` and `Keymap` whose primary purpose is a pure model
+transformation is separable from its side effect — either by returning the
+model state and a description of the effect (command pattern), or by having the
+side effect extracted to a wrapper layer — such that the model transformation
+can be unit-tested without a live `Tau.Session` or `Tau.TUI.Supervisor` process.
+
+## Out of scope
+
+- Changing the session protocol or the `Tau.*` API surface.
+- `Bootstrap.init/1` — the lifecycle side effects there are structurally
+  expected and not a concern of this sub-problem.
+- Changes to `duplicated-bounded-append` (sibling sub-problem).
+- Changes to `model-as-bag-of-maps` (sibling).
+- Changes to `transcript-coupling` (sibling).
+
+## Amendment log
+
+- (none yet)

--- a/docs/problems-archive-v1-modules/tau-tui-app/subproblems/session-side-effects-in-pure-modules/proposals/proposal-1.md
+++ b/docs/problems-archive-v1-modules/tau-tui-app/subproblems/session-side-effects-in-pure-modules/proposals/proposal-1.md
@@ -1,0 +1,177 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 1
+parent_problem: ../problem.md
+---
+
+# Proposal 1: Command pattern — pure functions return `{model, [cmd]}` pairs
+
+## Approach
+
+Introduce a `Tau.TUI.App.Cmd` type (a tagged union) and change every public
+function in `Input` and `quit_or_append/1` in `Keymap` to return
+`{model, [Tau.TUI.App.Cmd.t()]}` instead of `model`. A thin dispatch layer in
+`Tau.TUI.App` (the existing façade) pattern-matches each command tag and executes
+the corresponding `Tau.*` or `spawn/1` call. The pure functions in `Input` and
+`Keymap` become total functions with no process dependencies.
+
+## Rationale
+
+The complecting hypothesis names the problem exactly: each function computes a
+new model state AND fires a side effect atomically. The command pattern physically
+separates the two concerns — the pure function says *what* the effect should be
+(a value), and the façade says *when and how* to execute it. The `Input` and
+`Keymap` modules become testable against `{model, [cmd]}` tuples with no
+processes running. The effect semantics (which `Tau.*` call, what args) are now
+explicit in the cmd values, making them inspectable in tests and in the process
+mailbox if needed.
+
+## Sketch
+
+```elixir
+# lib/tau/tui/app/cmd.ex  (new)
+defmodule Tau.TUI.App.Cmd do
+  @type t ::
+    {:send, session_id :: term(), text :: String.t()}
+    | {:cancel, session_id :: term()}
+    | {:steer, session_id :: term(), text :: String.t()}
+    | {:set_permissions_mode, session_id :: term(), mode :: atom()}
+    | :stop_tui_supervisor
+
+  @spec execute(t()) :: :ok
+  def execute({:send, sid, text}),             do: Tau.send(sid, text)
+  def execute({:cancel, sid}),                 do: Tau.cancel(sid)
+  def execute({:steer, sid, text}),            do: Tau.steer(sid, text)
+  def execute({:set_permissions_mode, sid, m}),do: Tau.Session.set_permissions_mode(sid, m)
+  def execute(:stop_tui_supervisor) do
+    spawn(fn ->
+      Tau.TUI.Supervisor
+      |> DynamicSupervisor.which_children()
+      |> Enum.each(fn {_, pid, _, _} -> Supervisor.stop(pid) end)
+    end)
+    :ok
+  end
+end
+```
+
+```elixir
+# lib/tau/tui/app/input.ex  (modified — excerpt)
+
+@spec submit(map()) :: {map(), [Cmd.t()]}
+def submit(model) do
+  text = Editor.text(model.editor)
+  if Editor.empty?(model.editor) do
+    {model, []}
+  else
+    if String.starts_with?(text, "/perms") do
+      handle_perms_command(model, text)
+    else
+      new_hist = History.push(model.history, text)
+      Store.append(model.history_data_dir, model.history_cwd, text)
+      new_model = %{model | editor: Editor.new(), history: new_hist,
+                            search: nil,
+                            transcript: bounded_append(model.transcript, {"> " <> text, []}),
+                            status: :sending}
+      {new_model, [{:send, model.session_id, text}]}
+    end
+  end
+end
+
+@spec cancel(map()) :: {map(), [Cmd.t()]}
+def cancel(model) do
+  {%{model | status: :idle}, [{:cancel, model.session_id}]}
+end
+
+@spec steer(map()) :: {map(), [Cmd.t()]}
+def steer(model) do
+  text = Editor.text(model.editor)
+  if Editor.empty?(model.editor) do
+    {model, []}
+  else
+    new_model = %{model | editor: Editor.new(), search: nil,
+                          transcript: bounded_append(model.transcript, {"[queued steer] " <> text, []})}
+    {new_model, [{:steer, model.session_id, text}]}
+  end
+end
+```
+
+```elixir
+# lib/tau/tui/app.ex  (façade — dispatch loop addition)
+defp run_input(model, fun) do
+  {new_model, cmds} = apply(Input, fun, [model])
+  Enum.each(cmds, &Cmd.execute/1)
+  new_model
+end
+```
+
+`Keymap.quit_or_append/1` becomes:
+
+```elixir
+defp quit_or_append(model) do
+  if Editor.empty?(model.editor) do
+    {model, [:stop_tui_supervisor]}
+  else
+    {model |> editor_insert("q") |> Completion.update_menu(), []}
+  end
+end
+```
+
+The `Keymap` functions are `defp`, so the calling chain in `Tau.TUI.App` handles
+dispatch; the `{model, cmds}` pair propagates up through the public call boundary.
+
+## Tradeoffs
+
+### Strengths
+
+- Pure functions become trivially unit-testable: assert on `{model, [cmd]}` with
+  no process infrastructure.
+- Effect semantics are explicit and inspectable (the cmd list is a value, not a
+  side effect in a log).
+- Pattern: well-established in Elm, Erlang's `gen_statem` reply tuples, and
+  Redux-style architectures; reviewers will recognise it.
+- The façade (`app.ex`) already exists as the dispatch boundary — the execution
+  hook is structurally available.
+
+### Weaknesses
+
+- Every public `Input` function call site changes signature: returns `{model, cmds}`
+  instead of `model`. Callers inside `Keymap` that currently delegate to
+  `Input.submit/1` must be updated.
+- `Keymap` uses `defp` for `quit_or_append/1`, so the `{model, cmds}` return must
+  propagate through the entire private call chain in `Keymap` up to its own public
+  `handle/2` function — non-trivial refactor.
+- `Store.append/3` in `submit/1` is also a side effect (disk I/O / history
+  persistence) that is left in the pure path by this proposal — a partial
+  decoupling, not a complete one. The problem statement names only `Tau.*` and
+  `spawn/1`; history store writes are in-scope but arguably less urgent.
+- Adds a new module (`Cmd`) that must be understood by anyone reading the codebase.
+
+### Costs
+
+- Modifies every public function signature in `Input` (5 functions) and the
+  internal call chain in `Keymap`.
+- The façade `app.ex` gains dispatch boilerplate.
+- Tests that currently call `Input.submit(model)` expecting `model` must be
+  updated to destructure `{model, _cmds}`.
+- Estimated diff: ~120 lines changed, ~40 lines added (Cmd module + dispatch).
+
+## Dependencies
+
+- No behaviour or supervision changes required.
+- `Store.append/3` may be left in place (partial clean-up acceptable per
+  the problem statement's focus on `Tau.*` and `spawn/1`).
+
+## Confidence
+
+Medium. The pattern is well-understood and the sketch is concrete, but the
+`Keymap` private-function propagation path was not fully traced and may have
+additional call chains. A prototype pass over `keymap.ex` would raise confidence
+to high.
+
+## Prior art / references
+
+- Elm Architecture commands (`Cmd msg`): https://guide.elm-lang.org/effects/
+- `:gen_statem` reply tuples — OTP standard; same "actions list" idiom.
+- `Phoenix.LiveView` handle_event returning `{:noreply, socket}` — same
+  structural pattern at a different abstraction level.

--- a/docs/problems-archive-v1-modules/tau-tui-app/subproblems/session-side-effects-in-pure-modules/proposals/proposal-2.md
+++ b/docs/problems-archive-v1-modules/tau-tui-app/subproblems/session-side-effects-in-pure-modules/proposals/proposal-2.md
@@ -1,0 +1,178 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 2
+parent_problem: ../problem.md
+---
+
+# Proposal 2: Thin effect-wrapper layer — extract effectful shells, keep pure cores unchanged
+
+## Approach
+
+Introduce a thin `Tau.TUI.App.InputEffects` module (and inline adjustments to
+`Keymap`) that owns every `Tau.*` call and `spawn/1`. The existing `Input`
+functions are split in-place: the pure state-transformation body is moved into a
+private `_pure_*` function with the same logic but no side effects; the public
+function becomes a two-line shell that calls the private pure core and then fires
+the effect. `InputEffects` re-exports the effectful versions as delegations.
+`Input` itself can optionally be made a pure module (all public functions pure,
+`@moduledoc` updated). No return-type change; callers see `model` as before.
+
+## Rationale
+
+The complecting hypothesis says a caller cannot get the model state without
+triggering the side effect. This proposal breaks that link without changing any
+return type or call-site signature. Tests of the pure state transformation call
+the renamed private (`_pure_*`) functions directly — or, if privacy is a concern,
+a companion `InputPure` module is extracted with those pure functions public. The
+effectful behaviour is preserved in `InputEffects` (or the public `Input` shell),
+and the pure logic is reachable for testing without any live process. This is the
+smallest-surface change that satisfies the acceptance criterion.
+
+## Sketch
+
+```elixir
+# lib/tau/tui/app/input.ex  (modified — no return-type change)
+
+# Public shell (effectful, existing callers unchanged)
+@spec submit(map()) :: map()
+def submit(model) do
+  text = Editor.text(model.editor)
+  if Editor.empty?(model.editor) do
+    model
+  else
+    if String.starts_with?(text, "/perms") do
+      handle_perms_command(model, text)
+    else
+      # Side effect here — isolated to one line
+      Tau.send(model.session_id, text)
+      pure_submit_state(model, text)
+    end
+  end
+end
+
+# Pure core — contains ALL state logic; testable without a session
+@spec pure_submit_state(map(), String.t()) :: map()
+def pure_submit_state(model, text) do
+  new_hist = History.push(model.history, text)
+  Store.append(model.history_data_dir, model.history_cwd, text)
+  %{model | editor: Editor.new(), history: new_hist, search: nil,
+            transcript: bounded_append(model.transcript, {"> " <> text, []}),
+            status: :sending}
+end
+
+@spec cancel(map()) :: map()
+def cancel(model) do
+  Tau.cancel(model.session_id)   # isolated effect
+  pure_cancel_state(model)
+end
+
+@spec pure_cancel_state(map()) :: map()
+def pure_cancel_state(model), do: %{model | status: :idle}
+
+@spec steer(map()) :: map()
+def steer(model) do
+  text = Editor.text(model.editor)
+  if Editor.empty?(model.editor) do
+    model
+  else
+    Tau.steer(model.session_id, text)   # isolated effect
+    pure_steer_state(model, text)
+  end
+end
+
+@spec pure_steer_state(map(), String.t()) :: map()
+def pure_steer_state(model, text) do
+  %{model | editor: Editor.new(), search: nil,
+            transcript: bounded_append(model.transcript, {"[queued steer] " <> text, []})}
+end
+```
+
+`handle_perms_command/2` similarly:
+
+```elixir
+# Effect-bearing branch (line 112) becomes:
+#   Tau.Session.set_permissions_mode(model.session_id, mode)  <- effect isolated
+#   pure_perms_mode_state(model_cleared, mode)               <- pure state
+
+@spec pure_perms_mode_state(map(), atom()) :: map()
+def pure_perms_mode_state(model, mode), do: %{model | permissions_mode: mode}
+```
+
+`Keymap.quit_or_append/1` (private, harder to expose):
+
+```elixir
+# lib/tau/tui/app/keymap.ex  — no change to defp visibility, but split body:
+defp quit_or_append(model) do
+  if Editor.empty?(model.editor) do
+    do_stop_tui_supervisor()    # <-- extracted to named defp, isolated effect
+    model
+  else
+    model |> editor_insert("q") |> Completion.update_menu()
+  end
+end
+
+defp do_stop_tui_supervisor do
+  spawn(fn ->
+    Tau.TUI.Supervisor
+    |> DynamicSupervisor.which_children()
+    |> Enum.each(fn {_, pid, _, _} -> Supervisor.stop(pid) end)
+  end)
+end
+```
+
+For unit tests, `Input.pure_cancel_state/1`, `Input.pure_steer_state/2`, etc. are
+the test surface. No new type or dispatch module needed.
+
+## Tradeoffs
+
+### Strengths
+
+- Zero call-site change: every existing caller of `Input.submit/1`, `Input.cancel/1`
+  etc. continues to work unmodified. Façade unchanged. 
+- Acceptance criterion is directly satisfied: pure model transformation is
+  separable and reachable without a live session.
+- Smallest diff of any proposal: only the body of each effectful function is
+  reorganised, not its signature or its callers.
+- `@moduledoc` can now honestly drop the "except for side-effectful calls"
+  caveat from the pure functions.
+- Easy to review: each function becomes a 2-line shell + a 5-10 line pure core.
+
+### Weaknesses
+
+- The effect remains co-located with the pure function in the same module file —
+  the boundary is logical (naming convention), not physical (module boundary).
+  A future author can accidentally re-entangle them.
+- `pure_*` functions must be `def` (public) to be testable — there is no Elixir
+  mechanism to expose them to tests while keeping them module-private. This
+  pollutes the public API surface with implementation details.
+- `Keymap.quit_or_append/1` is `defp` — its pure "did nothing to model" path is
+  trivial and the `do_stop_tui_supervisor` extraction helps naming clarity but
+  does not expose a testable pure core (the quit path doesn't change model at all,
+  so the "pure" result is just `model` returned unchanged).
+- Does not enforce the pure/effectful split at compile time. No type or contract
+  prevents future inline mixing.
+
+### Costs
+
+- Modifies 5 function bodies in `Input`, adds 5 `pure_*` companion functions.
+- Adds `do_stop_tui_supervisor/0` private function to `Keymap`.
+- No new modules, no call-site changes.
+- Estimated diff: ~60 lines added, ~20 lines changed.
+
+## Dependencies
+
+- None. No other module changes, no supervision or behaviour changes.
+
+## Confidence
+
+High. The transformation is mechanical: split each function body into effect line
++ pure body, name the pure body. The test surface is well-defined. The pattern
+is a straightforward extraction within one module.
+
+## Prior art / references
+
+- "Functional core, imperative shell" (Gary Bernhardt, Boundaries talk 2012):
+  https://www.destroyallsoftware.com/talks/boundaries — same pattern at module
+  granularity.
+- Standard Elixir idiom: separate `do_*` private helpers for named sub-steps.

--- a/docs/problems-archive-v1-modules/tau-tui-app/subproblems/session-side-effects-in-pure-modules/proposals/proposal-3.md
+++ b/docs/problems-archive-v1-modules/tau-tui-app/subproblems/session-side-effects-in-pure-modules/proposals/proposal-3.md
@@ -1,0 +1,185 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 3
+parent_problem: ../problem.md
+---
+
+# Proposal 3: Behaviour-injected effect adapter — pass a session adapter struct through the model
+
+## Approach
+
+Introduce a `Tau.TUI.App.SessionAdapter` behaviour with callbacks matching the
+`Tau.*` surface used by `Input` and `Keymap`: `send/2`, `cancel/1`, `steer/2`,
+`set_permissions_mode/2`, `stop_supervisor/0`. Add a `session_adapter` field to
+`Model.t()` (defaulting to `Tau.TUI.App.SessionAdapter.Live`). Every `Tau.*` call
+in `Input` and the `spawn/1` in `Keymap` is replaced with a call through
+`model.session_adapter`. In tests, inject `Tau.TUI.App.SessionAdapter.Stub` (a
+no-op or capture-to-agent implementation). The pure model transformation is
+unchanged in structure; the seam is the adapter struct stored in the model.
+
+## Rationale
+
+Rather than changing function return types (proposal 1) or exposing private
+pure-body functions (proposal 2), this proposal moves the seam to the model's
+data: the adapter is a value carried alongside the session ID. The complecting is
+resolved because `Input` and `Keymap` no longer reach module globals (`Tau`,
+`Tau.Session`, `DynamicSupervisor`); they call through the adapter, which is
+replaceable at the model boundary. This matches OTP's "inject dependencies as
+data" idiom and keeps function signatures `model → model` throughout — no
+call-site changes.
+
+## Sketch
+
+```elixir
+# lib/tau/tui/app/session_adapter.ex  (new)
+defmodule Tau.TUI.App.SessionAdapter do
+  @callback send(session_id :: term(), text :: String.t()) :: :ok
+  @callback cancel(session_id :: term()) :: :ok
+  @callback steer(session_id :: term(), text :: String.t()) :: :ok
+  @callback set_permissions_mode(session_id :: term(), mode :: atom()) :: :ok
+  @callback stop_supervisor() :: :ok
+end
+
+defmodule Tau.TUI.App.SessionAdapter.Live do
+  @behaviour Tau.TUI.App.SessionAdapter
+  def send(sid, text),                 do: Tau.send(sid, text)
+  def cancel(sid),                     do: Tau.cancel(sid)
+  def steer(sid, text),                do: Tau.steer(sid, text)
+  def set_permissions_mode(sid, mode), do: Tau.Session.set_permissions_mode(sid, mode)
+  def stop_supervisor do
+    spawn(fn ->
+      Tau.TUI.Supervisor
+      |> DynamicSupervisor.which_children()
+      |> Enum.each(fn {_, pid, _, _} -> Supervisor.stop(pid) end)
+    end)
+    :ok
+  end
+end
+
+defmodule Tau.TUI.App.SessionAdapter.Stub do
+  @behaviour Tau.TUI.App.SessionAdapter
+  # No-op stubs; or use Agent to capture calls for assertion
+  def send(_sid, _text),                 do: :ok
+  def cancel(_sid),                      do: :ok
+  def steer(_sid, _text),                do: :ok
+  def set_permissions_mode(_sid, _mode), do: :ok
+  def stop_supervisor(),                 do: :ok
+end
+```
+
+`Model.t()` gains a field:
+
+```elixir
+# lib/tau/tui/app/model.ex  (struct addition)
+defstruct [
+  # ... existing fields ...
+  session_adapter: Tau.TUI.App.SessionAdapter.Live,
+]
+```
+
+`Input.cancel/1` becomes:
+
+```elixir
+def cancel(model) do
+  model.session_adapter.cancel(model.session_id)
+  %{model | status: :idle}
+end
+```
+
+`Input.submit/1` (effectful line):
+
+```elixir
+model.session_adapter.send(model.session_id, text)
+```
+
+`Keymap.quit_or_append/1`:
+
+```elixir
+defp quit_or_append(model) do
+  if Editor.empty?(model.editor) do
+    model.session_adapter.stop_supervisor()
+    model
+  else
+    model |> editor_insert("q") |> Completion.update_menu()
+  end
+end
+```
+
+Test setup:
+
+```elixir
+# In test
+model = Model.new(...) |> Map.put(:session_adapter, Tau.TUI.App.SessionAdapter.Stub)
+{new_model} = Input.cancel(model)
+assert new_model.status == :idle
+# No process infrastructure needed
+```
+
+## Tradeoffs
+
+### Strengths
+
+- Function signatures remain `model → model`; call sites are unchanged.
+- The seam is explicit in the type: `Model.t()` carries the adapter, visible to
+  any reader of the struct definition.
+- Stub is a proper `@behaviour` implementation — the compiler enforces callback
+  completeness.
+- Decouples `Input` and `Keymap` from global module references (`Tau`,
+  `Tau.Session`, `DynamicSupervisor`) — the modules become testable in isolation
+  and the adapter could be swapped for replay, simulation, or multiple session
+  targets.
+- No new `Cmd` dispatch infrastructure; no return-type change propagation.
+
+### Weaknesses
+
+- `Model.t()` grows a field for an effect dependency — mixing a session-lifecycle
+  concern into the MVU data struct. This is arguably a violation of model purity
+  in a different direction.
+- The `model-as-bag-of-maps` sibling problem (struct discipline) is not resolved
+  by this proposal; if that problem is fixed first, the struct shape change here
+  is easy. If this is fixed first, the model field must be handled carefully when
+  that problem is addressed.
+- Using a module (atom) as the adapter value (`session_adapter: SomeMod`) means
+  the adapter is not truly a value — it's a module reference. A proper OTP
+  approach would use a `{module, state}` tuple, but that adds complexity the
+  callbacks here don't need.
+- Production code path through `model.session_adapter.send(...)` uses dynamic
+  dispatch (apply), which Dialyzer may not type-check fully through a struct field
+  unless the type annotation is precise.
+- `Keymap.quit_or_append/1` accesses `model.session_adapter` inside a `defp` —
+  if the `Model` type annotation on private functions is loose, this could be
+  silently wrong.
+
+### Costs
+
+- New `session_adapter.ex` file (~50 lines).
+- `model.ex` struct gets one new field + `@type t()` update.
+- Each `Tau.*` call site in `Input` and `Keymap` is replaced with
+  `model.session_adapter.<cb>(...)` — ~6 callsite edits.
+- Test helpers must inject the stub into model construction.
+- Estimated diff: ~70 lines added, ~15 lines changed.
+
+## Dependencies
+
+- `Model.t()` struct must be updated before `Input` and `Keymap` can reference
+  the new field. If `model-as-bag-of-maps` is being addressed in parallel, the
+  two changes must not conflict on the struct definition.
+- `Bootstrap.init/1` or `Model.new/3` must inject `SessionAdapter.Live` as the
+  default — no additional process setup required.
+
+## Confidence
+
+Medium. The pattern is sound and the sketch is concrete. The Dialyzer concern
+on dynamic dispatch through struct fields is real and may require an explicit
+`@type adapter :: module()` annotation and careful spec on `Model.t()`. A type
+check pass would raise confidence to high.
+
+## Prior art / references
+
+- OTP "inject dependencies as data" idiom: standard pattern in BEAM codebases
+  for replacing module-level global calls with data-carried callbacks.
+- Plug's `adapter:` field in `%Plug.Conn{}` — same structural placement of an
+  effect adapter inside the primary data struct.
+- Mox (José Valim): https://github.com/dashbitco/mox — the Elixir idiomatic
+  approach to behaviour-based test doubles, which this proposal's Stub implements.

--- a/docs/problems-archive-v1-modules/tau-tui-app/subproblems/session-side-effects-in-pure-modules/proposals/proposal-4.md
+++ b/docs/problems-archive-v1-modules/tau-tui-app/subproblems/session-side-effects-in-pure-modules/proposals/proposal-4.md
@@ -1,0 +1,178 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 4
+parent_problem: ../problem.md
+---
+
+# Proposal 4: Effect-boundary lift — move all session calls out of Input/Keymap into App façade
+
+## Approach
+
+Remove every `Tau.*` call and `spawn/1` from `Input` and `Keymap` entirely. Each
+function that formerly fired a side effect now returns a pure `model` (or
+`{model, effect_tag}` only where the façade cannot infer the effect from model
+state alone). The `Tau.TUI.App` façade (`app.ex`) becomes the sole location for
+session calls: it inspects the before/after model state after calling each
+`Input` or `Keymap` function, and fires the appropriate `Tau.*` call based on the
+state transition. This is a boundary-lift rather than a command pattern: effects
+are inferred from state change, not described by the callee.
+
+## Rationale
+
+If the façade already owns the `Tau.TUI.App` event loop, it is structurally the
+correct owner of all `Tau.*` side effects. `Input` and `Keymap` are MVU helpers —
+they should describe state transitions only. The façade can detect transitions
+(e.g., `:idle → :sending`, `permissions_mode` change, editor cleared on cancel)
+and fire the corresponding session call without any explicit effect description
+from the callee. This approach gives `Input` and `Keymap` the strongest possible
+purity guarantee — they become pure functions with no awareness of effect
+infrastructure — and concentrates all side-effect policy in one module.
+
+## Sketch
+
+```elixir
+# lib/tau/tui/app/input.ex  (modified — effects removed)
+
+@spec submit(map()) :: map()
+def submit(model) do
+  text = Editor.text(model.editor)
+  if Editor.empty?(model.editor) do
+    model
+  else
+    if String.starts_with?(text, "/perms") do
+      handle_perms_command(model, text)
+    else
+      new_hist = History.push(model.history, text)
+      Store.append(model.history_data_dir, model.history_cwd, text)
+      # No Tau.send/2 here — state transition signals the effect to the façade
+      %{model | editor: Editor.new(), history: new_hist, search: nil,
+                transcript: bounded_append(model.transcript, {"> " <> text, []}),
+                status: :sending,
+                pending_send: text}   # <- new field signals what to send
+    end
+  end
+end
+
+@spec cancel(map()) :: map()
+def cancel(model) do
+  # No Tau.cancel/1 — status transition signals the façade
+  %{model | status: :cancelling}   # <- new transient status; façade fires cancel
+end
+```
+
+Façade (`app.ex`) wraps each Input call:
+
+```elixir
+# lib/tau/tui/app.ex  (excerpt)
+
+defp dispatch_input(model, fun) do
+  prev = model
+  next = apply(Input, fun, [model])
+  fire_transition_effects(prev, next)
+  # Clear transient signal fields before storing model
+  %{next | pending_send: nil}
+end
+
+defp fire_transition_effects(prev, next) do
+  # Submit: pending_send set
+  if next.pending_send do
+    Tau.send(next.session_id, next.pending_send)
+  end
+  # Cancel: status went to :cancelling
+  if prev.status != :cancelling and next.status == :cancelling do
+    Tau.cancel(next.session_id)
+  end
+  # Permissions mode change
+  if prev.permissions_mode != next.permissions_mode do
+    Tau.Session.set_permissions_mode(next.session_id, next.permissions_mode)
+  end
+  :ok
+end
+```
+
+For `quit_or_append` in `Keymap`:
+
+```elixir
+# Add a :quitting status or a :pending_quit flag to Model
+defp quit_or_append(model) do
+  if Editor.empty?(model.editor) do
+    %{model | status: :quitting}   # façade detects :quitting and calls stop_supervisor
+  else
+    model |> editor_insert("q") |> Completion.update_menu()
+  end
+end
+```
+
+`Model.t()` gains:
+- `pending_send: nil | String.t()` — transient; cleared by façade after effect fires
+- `:cancelling` and `:quitting` as valid `status` values
+
+## Tradeoffs
+
+### Strengths
+
+- `Input` and `Keymap` become strictly pure: no `Tau.*`, no `spawn/1`, no
+  behaviour injection, no return-type change. The `@moduledoc` caveat disappears
+  completely.
+- All effect policy lives in one place (the façade), making it easier to reason
+  about what triggers session calls.
+- No new behaviour or stub module required for tests: `Input` tests are plain
+  map-transformation assertions.
+- The approach generalises: any future effect can be added to the façade without
+  touching the MVU helpers.
+
+### Weaknesses
+
+- Introduces transient signal fields (`pending_send`, `:quitting` status etc.)
+  into `Model.t()` — the model struct now carries ephemeral intent state that is
+  meaningful only for one façade dispatch cycle. This is a different kind of
+  complecting: model + ephemeral effect signal.
+- The façade's `fire_transition_effects/2` must correctly enumerate all
+  transitions. A missed transition (e.g. a new function added to `Input` that
+  changes `permissions_mode`) silently drops the effect — a harder bug to catch
+  than an explicit missing call.
+- `:cancelling` and `:quitting` as status values may conflict with the `Tau.Session`
+  FSM states or the TUI rendering logic that pattern-matches on `status`.
+- The `pending_send` field approach is fragile: if two effects could theoretically
+  be pending at once (e.g. a steer + a followup flush), the single-field design
+  breaks. Using a list `pending_effects: []` is safer but pushes toward the
+  command pattern of proposal 1.
+- Requires `Tau.TUI.App` façade to grow non-trivial logic — the current façade
+  is intentionally thin.
+
+### Costs
+
+- `Model.t()` gains 1-2 transient fields and new `:cancelling`/`:quitting` status
+  values.
+- `app.ex` gains `fire_transition_effects/2` (~30 lines) and wrapper dispatch
+  helper.
+- 5 function bodies in `Input` lose their `Tau.*` calls and gain field-set
+  assignments.
+- Tests for the façade's effect-firing logic must verify transitions.
+- Estimated diff: ~80 lines changed/added.
+
+## Dependencies
+
+- The `status` field type in `Model.t()` must be extended without breaking
+  existing pattern matches in `View`, `Events`, and `Permission`. A grep pass
+  over status consumers in `lib/tau/tui/app/` is required before implementing.
+- If `model-as-bag-of-maps` is addressed first, struct enforcement makes adding
+  `pending_send` and new status values safer.
+
+## Confidence
+
+Low-medium. The pure-function outcome is the strongest of any proposal, but the
+transient-field mechanism introduces a fragility the other proposals avoid. The
+`fire_transition_effects/2` exhaustiveness concern is real and has no compiler
+support. A prototype of the façade dispatch + a grep of `status` consumers would
+raise confidence.
+
+## Prior art / references
+
+- React's `useEffect` + state-transition side effects: same idiom of "façade
+  inspects state change and fires effects" rather than callee declaring them.
+- `:gen_statem` `state_enter` callbacks: the state machine fires entry actions on
+  transition detection, not on direct call — same structural idea.
+- Elm's `subscriptions` + `update` separation: the runtime (façade) owns
+  all effect scheduling; `update` is always pure.

--- a/docs/problems-archive-v1-modules/tau-tui-app/subproblems/session-side-effects-in-pure-modules/solution.md
+++ b/docs/problems-archive-v1-modules/tau-tui-app/subproblems/session-side-effects-in-pure-modules/solution.md
@@ -1,0 +1,148 @@
+---
+template_version: 1
+template_name: solution
+parent_problem: ../problem.md
+node_kind: leaf
+synthesised_from: [proposals/proposal-1.md, proposals/proposal-2.md]
+selection_method: hybrid
+revision: 0
+---
+
+# Solution: Command pattern for Input, pure-split for Keymap
+
+## Recommendation
+
+Replace every public `Input` function signature with `{model, [Cmd.t()]}` using
+the command pattern (proposal 1), and introduce a thin `Tau.TUI.App.Cmd` module
+whose `execute/1` dispatches each command tag to the corresponding `Tau.*` or
+`spawn/1` call. For `Keymap.quit_or_append/1` — which is `defp` and whose "quit"
+path produces a trivially empty model delta — apply the narrower extraction from
+proposal 2: lift the supervisor-stop body into a named `defp do_stop_tui_supervisor/0`,
+and let the quit path emit `[:stop_tui_supervisor]` as a command that propagates
+up through the private call chain to `Keymap.handle/2`, which then calls
+`Cmd.execute/1`. The façade (`Tau.TUI.App`) gains a thin `run_input/2` helper that
+destructures `{model, cmds}` and dispatches the command list. Both `Input` and
+`Keymap` become unit-testable by asserting on `{model, [cmd]}` with no live
+processes.
+
+## Selected from
+
+- **Chosen:** hybrid of `proposals/proposal-1.md` (command pattern) and
+  `proposals/proposal-2.md` (named-extract for private Keymap path)
+- **Why chosen:**
+
+  | # | Fit | Decomplecting depth | Migration cost | Risk | Reversibility |
+  |---|-----|---------------------|----------------|------|---------------|
+  | 1 | Yes | Deep                | Medium         | Low  | Easy          |
+  | 2 | Yes | Surface             | Low            | Low  | Easy          |
+  | 3 | Yes | Substantial         | Medium         | Medium | Easy        |
+  | 4 | Yes | Deep                | Medium-High    | Medium | Hard        |
+
+  Proposal 1 wins on decomplecting depth: the pure/effect boundary is enforced
+  by the return type, not by naming convention. Effect intent becomes a value
+  (`[Cmd.t()]`), inspectable in tests and in process traces. The façade already
+  exists as the dispatch boundary — the hook is structurally available.
+
+  Proposal 2 is the right tool for `Keymap.quit_or_append/1` specifically: the
+  quit path's model delta is `model` unchanged (no field mutation), so there is
+  nothing meaningful to extract into a `pure_*` function. What the extraction
+  buys here is isolation of the `spawn/1` block into a named function; the
+  command-propagation path through `Keymap`'s private call chain then carries the
+  `:stop_tui_supervisor` tag to `handle/2`, where `Cmd.execute/1` fires it. This
+  avoids the full private-chain signature change being disproportionate to the
+  trivial effect — the command tag propagates naturally up a call that already
+  returns `model`.
+
+  Proposal 3 is rejected: putting an effect-adapter module into `Model.t()` mixes
+  a lifecycle concern into the MVU data struct — complecting in a different
+  direction. Dialyzer coverage through a struct-carried module reference is weaker
+  than through a typed command union.
+
+  Proposal 4 is rejected: transient signal fields (`pending_send`, `:quitting`)
+  on `Model.t()` introduce a new class of complecting (model + ephemeral intent
+  state), the `fire_transition_effects/2` exhaustiveness problem has no compiler
+  support, and the approach is the hardest to reverse if the effect enumeration
+  turns out to be incomplete.
+
+  The hybrid is valid (not "average of 1 and 2"): proposal 1 is the primary
+  mechanism for all public `Input` functions; proposal 2's naming-extract is
+  applied only to the one `defp` in `Keymap` where the command-pattern return
+  change would otherwise require threading `{model, cmds}` through every private
+  helper in `Keymap` for a single `:stop_tui_supervisor` tag.
+
+## What changes
+
+- **New:** `lib/tau/tui/app/cmd.ex` — defines `Tau.TUI.App.Cmd.t()` tagged union
+  and `execute/1` dispatch. Tags: `{:send, sid, text}`, `{:cancel, sid}`,
+  `{:steer, sid, text}`, `{:set_permissions_mode, sid, mode}`,
+  `:stop_tui_supervisor`.
+- **Modified:** `lib/tau/tui/app/input.ex` — every public function (`submit/1`,
+  `cancel/1`, `steer/1`, `followup/1`, `handle_perms_command/2`) changes return
+  type from `map()` to `{map(), [Cmd.t()]}`. `Tau.*` call sites are replaced by
+  cmd list elements.
+- **Modified:** `lib/tau/tui/app/keymap.ex` — `quit_or_append/1` emits
+  `{model, [:stop_tui_supervisor]}` (empty-editor branch) or `{model, []}` (non-empty
+  branch). The `spawn/1` block is lifted into `defp do_stop_tui_supervisor/0`
+  and called only from `Cmd.execute/1`. The `{model, cmds}` pair propagates up
+  through `Keymap.handle/2` (the public boundary), which returns `{model, cmds}`
+  to the façade.
+- **Modified:** `lib/tau/tui/app.ex` — gains `run_input/2` (or equivalent)
+  helper that calls `Input.<fn>(model)`, destructures `{new_model, cmds}`, calls
+  `Enum.each(cmds, &Cmd.execute/1)`, returns `new_model`. Existing `Keymap.handle/2`
+  call sites updated to destructure similarly.
+- **Modified:** `lib/tau/tui/app/input.ex` `@moduledoc` — remove "pure except for
+  side-effectful Tau session calls" caveat; all public functions are now pure.
+
+## What does not change
+
+- The `Tau.*` and `Tau.Session.*` API surface (explicitly out of scope).
+- `Bootstrap.init/1` and its lifecycle side effects (out of scope).
+- `Model.t()` struct fields — no new fields are added.
+- The `Tau.TUI.App` public interface and event-loop structure — the façade gains
+  one private helper, not new public callbacks.
+- Sibling sub-problems (`duplicated-bounded-append`, `model-as-bag-of-maps`,
+  `transcript-coupling`) — disjoint file sets.
+- Existing tests that do not call the affected `Input`/`Keymap` functions directly.
+
+## Migration sketch
+
+1. Introduce `lib/tau/tui/app/cmd.ex` with the `Cmd.t()` type and `execute/1`
+   — no callers yet, compile-checks clean.
+2. Update `Input` public functions one at a time: change return type to
+   `{map(), [Cmd.t()]}`, move `Tau.*` call to a cmd list element. After each
+   function, update its call site in `app.ex` (or `Keymap`) to destructure and
+   route through `Cmd.execute/1`. Compile and run `mix test` between each function.
+3. Update `Keymap.quit_or_append/1`: extract `do_stop_tui_supervisor/0`,
+   return `{model, [:stop_tui_supervisor]}` from the quit branch, propagate
+   through `handle/2` to the façade's dispatch point.
+4. Update existing `Input`-focused tests to destructure `{model, _cmds}`; add
+   new tests asserting on the cmd list values without any live process.
+5. Run `mix compile --warnings-as-errors` and `mix test`; confirm `@moduledoc`
+   caveat can be removed.
+
+## Open questions
+
+- `Keymap` uses `defp` throughout below `handle/2`. The full private call graph
+  was not traced in any proposal. Before implementation, grep `keymap.ex` for all
+  call sites of `quit_or_append/1` to confirm there is exactly one path from
+  `handle/2` through which `{model, cmds}` must propagate.
+- `Store.append/3` in `submit/1` is disk I/O remaining in the `Input` pure path.
+  The problem statement scopes only `Tau.*` and `spawn/1`, so this is left as-is,
+  but the open question is whether a follow-up sub-problem should address it or
+  whether it is acceptable at the `Input` layer.
+- The `Cmd.execute/1` dispatch for `:stop_tui_supervisor` still contains a
+  `spawn/1`. This is correct (the effect must be asynchronous to avoid blocking
+  the TUI event loop), but the spawn is now in one named location rather than
+  inlined in a private function — verify this satisfies the OTP non-negotiable
+  against spawning outside a supervision tree, or document the justification.
+
+## Linked sub-problems / proposals
+
+- `proposals/proposal-1.md` — Command pattern: pure functions return `{model, [Cmd.t()]}`. Primary mechanism for all `Input` public functions and `Keymap.handle/2`.
+- `proposals/proposal-2.md` — Thin effect-wrapper: extract effectful shells, keep pure cores unchanged. Naming-extract pattern applied to `Keymap.quit_or_append/1`.
+- `proposals/proposal-3.md` — Behaviour-injected effect adapter via `Model.t()` field. Rejected: model-struct complecting, weaker Dialyzer coverage.
+- `proposals/proposal-4.md` — Effect-boundary lift via state-transition inference. Rejected: transient signal fields, unenforceable exhaustiveness.
+
+## Revision history
+
+- (revision 0 — initial)

--- a/docs/problems-archive-v1-modules/tau-tui-app/subproblems/session-side-effects-in-pure-modules/validation.md
+++ b/docs/problems-archive-v1-modules/tau-tui-app/subproblems/session-side-effects-in-pure-modules/validation.md
@@ -1,0 +1,394 @@
+---
+template_version: 1
+template_name: validation
+parent_solution: solution.md
+parent_problem: problem.md
+toulmin_complete: true
+falsification_attempted: true
+falsification_outcome: partially_falsified — claim/4
+revision_triggered: none
+---
+
+# Validation: Command pattern for Input, pure-split for Keymap
+
+## Overview
+
+The solution asserts five checkable propositions: (1) returning `{model,
+[Cmd.t()]}` makes `Input` public functions pure; (2) a thin `Cmd.execute/1`
+dispatcher concentrates all side-effects; (3) `Keymap.quit_or_append/1`'s
+`{model, [:stop_tui_supervisor]}` command tag propagates to `Cmd.execute/1`
+through a single call path from `handle_event/2`; (4) all `Input`/`Keymap`
+model-transformation branches become unit-testable without live processes;
+(5) `Model.t()` struct fields, the `Tau.*` API surface, and sibling sub-problems
+are unaffected. Seven falsification strategies are applied across the five
+claims. Outcomes: four withstood, one partially falsified (claim 4 — the
+`Store.append/3` call in `submit/1` remains side-effectful inside the otherwise
+pure path; qualifier narrowed). No revision triggered.
+
+---
+
+## Toulmin per claim
+
+The MITRE empirical study on Toulmin formalism found that "participants found it
+difficult to generate Toulmin structures, and their structures varied greatly
+even though they started with the same content"
+(https://www.mitre.org/news-insights/publication/empirical-evaluation-structured-argumentation-using-toulmin-argument).
+This template enforces all six components explicitly to counter that variance.
+
+---
+
+### Claim 1: Every public Input function's return type changes from `map()` to `{map(), [Cmd.t()]}` and all `Tau.*` call sites are replaced by command list elements, making those functions pure.
+
+- **Claim (C):** Every public `Input` function (`submit/1`, `cancel/1`,
+  `steer/1`, `followup/1`, `handle_perms_command/2`) changes return type from
+  `map()` to `{map(), [Cmd.t()]}`. `Tau.*` call sites are replaced by cmd list
+  elements.
+- **Grounds (G):** Current call sites — `lib/tau/tui/app/input.ex:32`
+  (`Tau.send/2`), `:120` (`Tau.cancel/1`), `:139` (`Tau.steer/1`), `:168`
+  (`Tau.send/2`), `:112` (`Tau.Session.set_permissions_mode/2`) — are
+  unconditional side effects interleaved with model-transformation logic.
+  Current `@spec` annotations (`@spec submit(map()) :: map()`, etc.) confirm
+  the present return types. The `Cmd` module does not yet exist (`lib/tau/tui/app/cmd.ex`
+  absent, confirmed by `find lib/tau/tui/app/`).
+- **Warrant (W):** A function is pure iff its observable output is fully
+  determined by its inputs and it causes no side effects. Replacing imperative
+  `Tau.*` calls with tagged list elements defers execution to the caller;
+  the function body then reads and transforms `model` only — satisfying
+  referential transparency. This is the standard command-pattern warrant.
+- **Qualifier (Q):** Holds for the five named public functions. Does not cover
+  `submit_or_continue/1`, `clear_input/1`, or any non-public helpers (see
+  claim 4 partial falsification regarding `Store.append/3` in `submit/1`).
+- **Rebuttal (R):** If any branch in these functions retains a direct `Tau.*`
+  call (e.g., via a `cond` arm omitted from the migration sketch), the function
+  is not pure on that branch. The migration requires per-function attention; an
+  incomplete migration leaves a mixed-purity interface.
+- **Backing (B):** OTP non-negotiable #8 ("pure functions are the default;
+  processes are the exception") from `.claude/rules/otp-non-negotiables.md`.
+  Hickey "Simple Made Easy" (2011): complecting a value computation with a
+  side effect makes both harder to test and compose.
+
+#### Falsification attempt for claim 1
+
+- **Strategy:** Edge-case enumeration — enumerate branches in each affected
+  function and check whether any branch bypasses the command-pattern conversion.
+- **Attempt:** Read `input.ex:21–177`. `submit/1` has three branches:
+  empty-input (returns `model`, no effect — trivially pure), `/perms` intercept
+  (delegates to `handle_perms_command/2`), and normal-submit (currently calls
+  `Tau.send/2` then `Store.append/3`). `cancel/1` has one branch. `steer/1`
+  has two branches (empty no-op and effectful). `followup/1` has three branches
+  including an `idle` fallback that calls `submit/1`. `handle_perms_command/2`
+  has three `cond` arms, one calling `Tau.Session.set_permissions_mode/2`.
+  All identified `Tau.*` call sites match the five listed in the problem's
+  context section. No additional unlisted call sites found. The `followup/1`
+  idle branch calls `submit/1`, which itself has side effects under the current
+  signature; after migration both would return `{model, cmds}` so composing
+  them is structurally sound — the empty `Tau.send` in `followup/1:168` and the
+  `submit/1` delegation chain both map cleanly to cmd list elements.
+- **Outcome:** Withstood — no hidden branch produces an un-migrated `Tau.*`
+  call outside the five documented sites. The migration sketch is complete for
+  the claim's stated scope.
+- **Action:** None.
+
+---
+
+### Claim 2: A new `Tau.TUI.App.Cmd` module with `Cmd.t()` tagged union and `execute/1` concentrates all side effects in one named dispatch point.
+
+- **Claim (C):** New `lib/tau/tui/app/cmd.ex` defines `Tau.TUI.App.Cmd.t()`
+  tagged union and `execute/1` dispatch. Tags: `{:send, sid, text}`,
+  `{:cancel, sid}`, `{:steer, sid, text}`, `{:set_permissions_mode, sid, mode}`,
+  `:stop_tui_supervisor`.
+- **Grounds (G):** No `cmd.ex` exists today (`ls lib/tau/tui/app/` output
+  confirms absence). The five `Tau.*` call sites in `input.ex` and the
+  `spawn/1` block in `keymap.ex:288–292` cover every effect currently
+  inlined in `Input`/`Keymap`. Five tags map one-to-one to those call sites:
+  `{:send,…}` → `Tau.send/2`; `{:cancel,…}` → `Tau.cancel/1`;
+  `{:steer,…}` → `Tau.steer/1`; `{:set_permissions_mode,…}` →
+  `Tau.Session.set_permissions_mode/2`; `:stop_tui_supervisor` → the `spawn/1`
+  block.
+- **Warrant (W):** Concentrating all effectful dispatch in one function makes
+  the effect surface enumerable and auditable; adding a new effect requires
+  an explicit union extension rather than an ad-hoc call insertion anywhere in
+  the codebase. This is the core benefit of the command pattern — effect intent
+  as a value.
+- **Qualifier (Q):** Holds as long as `execute/1` remains the only caller of
+  `Tau.*` within the `Tau.TUI.App.*` namespace. If `Bootstrap.init/1` or
+  `Tau.TUI.App` itself retains direct `Tau.*` calls (which is out of scope of
+  this sub-problem), the concentration claim is partial.
+- **Rebuttal (R):** `Bootstrap.init/1` is explicitly out of scope; it will
+  continue to call `Tau.start_session/1` and `Tau.TUI.EventBridge.start_link/1`
+  directly. The concentration claim covers only `Input`/`Keymap`, not the
+  full `Tau.TUI.App.*` namespace.
+- **Backing (B):** Rich Hickey, "The Value of Values" (Strange Loop 2012):
+  representing effects as first-class values decouples intent from execution.
+  Martin Fowler, "Command" pattern (PoEAA): encapsulating requests as objects
+  provides a stable dispatch point.
+
+#### Falsification attempt for claim 2
+
+- **Strategy:** Dependency check — verify that the five tags in `Cmd.t()` cover
+  every `Tau.*` and `spawn/1` call currently in `Input` and `Keymap`, with no
+  omissions.
+- **Attempt:** Cross-referenced the five tags against the context section of
+  `problem.md` (six bullet points) and the actual `input.ex` grep output.
+  `problem.md` lists: `Tau.send` (line 32, 168), `Tau.Session.set_permissions_mode`
+  (line 113), `Tau.cancel` (line 120), `Tau.steer` (line 139), and
+  `spawn(fn → DynamicSupervisor…)` (keymap.ex:288). Five distinct effect types
+  → five tags. No gap detected. `Store.append/3` (line 34) is disk I/O but
+  is NOT a `Tau.*` or `spawn/1` call; it is addressed in claim 4.
+- **Outcome:** Withstood — the five `Cmd.t()` tags cover the full set of
+  `Tau.*` / `spawn/1` effects in the scoped modules.
+- **Action:** None.
+
+---
+
+### Claim 3: `Keymap.quit_or_append/1`'s `spawn/1` block is lifted to `defp do_stop_tui_supervisor/0`; the command tag `[:stop_tui_supervisor]` propagates through exactly one call path from `Keymap.handle_event/2` to `Cmd.execute/1`.
+
+- **Claim (C):** `quit_or_append/1` emits `{model, [:stop_tui_supervisor]}`
+  from the quit branch. The `{model, cmds}` pair propagates through
+  `Keymap.handle/2` (the public boundary) to the façade's dispatch point,
+  through a single call path.
+- **Grounds (G):** `keymap.ex:286–300`: `quit_or_append/1` is `defp`; it is
+  called from exactly one site — `keymap.ex:243` (`handle_char/2` for `?q`).
+  `handle_char/2` is called from `handle_event_normal/2` (line 57,
+  `defp handle_char(model, ch)`). `handle_event_normal/2` is called from
+  `handle_event/2` (line 33). `handle_event/2` is called from
+  `app/events.ex:35`. The call path is:
+  `handle_event/2` → `handle_event_normal/2` → `handle_char/2` →
+  `quit_or_append/1`. Confirmed by grep: `quit_or_append` appears exactly
+  once as a call site (`keymap.ex:243`).
+- **Warrant (W):** A single call path through private helpers means that
+  propagating `{model, cmds}` up requires changing signatures of all
+  intermediate `defp` functions on that path — `handle_char/2`,
+  `handle_event_normal/2`, `handle_event/2` — or leaving the lower functions
+  returning `map()` and handling the conversion at one boundary. The solution's
+  migration sketch (step 3) specifies the propagation through `Keymap.handle/2`
+  (which the solution treats as `handle_event/2`). This is structurally sound
+  for a single path.
+- **Qualifier (Q):** "Exactly one call path" holds today (grep-verified). If
+  `quit_or_append/1` gains additional call sites in the future, the propagation
+  contract must be revisited. Also, the solution uses "Keymap.handle/2"
+  interchangeably with what the code calls `handle_event/2`; the public boundary
+  in the actual source is `handle_event/2`, not a function named `handle/2`.
+- **Rebuttal (R):** The solution's open question explicitly names this concern:
+  "grep `keymap.ex` for all call sites of `quit_or_append/1` to confirm there
+  is exactly one path." This validation confirms exactly one path; if that
+  assumption is wrong (e.g., after a future refactor), the propagation
+  claim must be re-evaluated.
+- **Backing (B):** Solution open questions section; `keymap.ex:243` (grep
+  result confirming single call site); `events.ex:35` (single external caller
+  of `handle_event/2`).
+
+#### Falsification attempt for claim 3
+
+- **Strategy:** Counter-example construction — try to find a second call site
+  for `quit_or_append/1` or a branching path through which the `cmds` list
+  could be silently dropped.
+- **Attempt:** Grep of `keymap.ex` for `quit_or_append` yields exactly two
+  lines: the `defp` definition (line 286) and the single call site (line 243).
+  The intermediate call chain (`handle_char/2` → `handle_event_normal/2` →
+  `handle_event/2`) currently returns `map()`. After migration, each of these
+  three private functions must change return type to `{map(), [Cmd.t()]}`. The
+  `handle_event_normal/2` function has multiple clauses (lines 51–59); all
+  clauses would need to return `{model, cmds}`. The non-char clauses (`handle_alt`,
+  `handle_key`, `handle_readline_key`) also return `map()` today; after
+  migration they would return `{model, []}` unless they also gain cmd-bearing
+  paths. This is non-trivial cascading signature change across the full
+  `handle_event_normal/2` dispatch, but does not falsify the "single path"
+  claim — it merely quantifies the migration cost, which the solution
+  acknowledges as "private call graph not traced in any proposal."
+- **Outcome:** Withstood — no second call path found. The single-path claim
+  is accurate, though the migration requires changing three private function
+  signatures.
+- **Action:** None; but the open question in the solution about tracing the
+  full private call graph is confirmed as important.
+
+---
+
+### Claim 4: All `Input`/`Keymap` model-transformation branches become unit-testable without a live `Tau.Session` or `Tau.TUI.Supervisor` process.
+
+- **Claim (C):** Both `Input` and `Keymap` become unit-testable by asserting on
+  `{model, [cmd]}` with no live processes.
+- **Grounds (G):** After migration, the only remaining calls to external modules
+  in the affected functions would be to `Editor.*`, `History.*`, `Store.append/3`,
+  and `Completion.*` — all of which operate on plain data or local I/O.
+  `Tau.*` calls are removed from `Input`/`Keymap` bodies by definition of the
+  migration. However, `input.ex:34` (`Store.append/3`) is disk I/O that the
+  solution explicitly leaves in place: "The problem statement scopes only
+  `Tau.*` and `spawn/1`, so this is left as-is" (open questions section).
+- **Warrant (W):** Removing process-creating and process-communicating calls
+  from function bodies is sufficient to unit-test those functions in isolation.
+  But I/O side effects (file writes via `Store.append/3`) are also side effects;
+  a test of `submit/1` that asserts only on the returned `{model, cmds}` still
+  triggers a real disk write unless the test stubs `Store`.
+- **Qualifier (Q):** Unit-testable *without a live `Tau.Session` or
+  `Tau.TUI.Supervisor` process* — **yes**, unconditionally after migration.
+  Unit-testable *without any side effect* (including I/O) — **no**, unless
+  `Store.append/3` is stubbed or the test is run in a temp directory.
+  The acceptance criterion in `problem.md` requires only that testing not
+  require a live session process; disk I/O does not falsify the criterion.
+- **Rebuttal (R):** The claim as stated in the solution's Recommendation is
+  "unit-testable by asserting on `{model, [cmd]}` with no live processes."
+  The qualifier "no live processes" is satisfied; "pure" in the strict sense
+  is not, because `Store.append/3` remains. A test of `submit/1` that asserts
+  `{model, [{:send, sid, text}]}` will also write to `data_dir`; the test
+  harness must arrange a temp dir or mock `Store` to avoid flakiness.
+- **Backing (B):** `problem.md` acceptance criterion: "the model transformation
+  can be unit-tested without a live `Tau.Session` or `Tau.TUI.Supervisor`
+  process." `input.ex:34` confirms `Store.append/3` is outside the `Tau.*`
+  scope restriction. Solution open questions: "Store.append/3 in submit/1 is
+  disk I/O remaining in the Input pure path."
+
+#### Falsification attempt for claim 4
+
+- **Strategy:** Edge-case enumeration — enumerate all remaining side-effectful
+  calls in `submit/1` after the proposed migration to identify any that require
+  infrastructure beyond a plain map model.
+- **Attempt:** Post-migration `submit/1` body: (a) `Editor.text/1` — pure;
+  (b) `Editor.empty?/1` — pure; (c) cmd list element `{:send, sid, text}` —
+  pure value; (d) `History.push/2` — pure (returns new history value);
+  (e) `Store.append/3` — writes to disk at `model.history_data_dir`; not pure.
+  A test of `submit/1` that asserts the returned `{model, cmds}` will still
+  trigger a real `Store.append/3` call. The assertion on cmds works without a
+  live session, but the test is not side-effect-free. The `problem.md`
+  acceptance criterion does not require side-effect-freedom, only session-process
+  independence — so the criterion is met, but the claim "unit-testable with
+  no live processes" slightly overstates purity.
+- **Outcome:** Partially falsified — the claim that functions are unit-testable
+  without live processes is **true and satisfies the acceptance criterion**. But
+  the implicit sub-claim that all side effects are deferred to `Cmd.execute/1`
+  is false: `Store.append/3` remains inline in `submit/1`. The qualifier must
+  be narrowed to: "unit-testable without a live `Tau.Session` or
+  `Tau.TUI.Supervisor` process; disk I/O via `Store.append/3` in `submit/1`
+  remains and requires a writable `history_data_dir` in tests."
+- **Action:** Narrow qualifier (no solution revision needed; the narrowed
+  claim still satisfies the `problem.md` acceptance criterion). The open
+  question in the solution already acknowledges this; it is confirmed as a
+  real residual, not a hypothetical.
+
+---
+
+### Claim 5: `Model.t()` struct fields, the `Tau.*` API surface, sibling sub-problems (`duplicated-bounded-append`, `model-as-bag-of-maps`, `transcript-coupling`), and the `Tau.TUI.App` public interface are unaffected.
+
+- **Claim (C):** `Model.t()` struct fields — no new fields added. The `Tau.*`
+  and `Tau.Session.*` API surface — explicitly out of scope. `Bootstrap.init/1`
+  lifecycle side effects — out of scope. The `Tau.TUI.App` public interface and
+  event-loop structure — façade gains one private helper, not new public
+  callbacks. Sibling sub-problems — disjoint file sets.
+- **Grounds (G):** The solution's "What does not change" section enumerates
+  these explicitly. The changed file set (`lib/tau/tui/app/cmd.ex` new;
+  `lib/tau/tui/app/input.ex`, `lib/tau/tui/app/keymap.ex`,
+  `lib/tau/tui/app.ex` modified) does not overlap with `model.ex` (no field
+  changes), `bootstrap.ex`, or the sibling subproblem directories. `Tau.*`
+  module bodies are not in the changed set. `app.ex` gains `run_input/2` as
+  a private helper, confirmed by the solution's "What changes" section
+  specifying it as private.
+- **Warrant (W):** If the changed-file set and the preserved-file set are
+  disjoint, and no public-function signatures are removed or added on the
+  preserved modules, the "unaffected" claim holds. The command pattern
+  redirects effects through `Cmd.execute/1` without touching the effected
+  API modules.
+- **Qualifier (Q):** Holds assuming the façade's external callers (i.e.,
+  `events.ex:35` calling `Keymap.handle_event/2`) receive the return-type
+  change transparently through the `run_input/2` / destructure layer in
+  `app.ex`. If any external caller directly pattern-matches on the `map()`
+  return from `Keymap.handle_event/2`, it will need updating — but this is
+  a compile-time error caught by Dialyzer/compiler, not a silent regression.
+- **Rebuttal (R):** `events.ex:35` currently calls `Keymap.handle_event(model, event)`
+  and uses the return as `model` (a plain map). After migration, if `handle_event/2`
+  returns `{map(), [Cmd.t()]}`, the `events.ex` caller must destructure. This
+  is a required change in `events.ex` that the solution's "What changes" section
+  does not list. It is not a public-interface regression (it's an internal
+  call), but it is an omitted file in the migration scope.
+- **Backing (B):** `events.ex:35` (grep confirmed); solution "What changes"
+  section; `spec-before-code.md` source maps for `SPEC-TUI-HEADLESS.md` and
+  `SPEC-USER-TURN.md` (the affected modules are covered by both SPECs).
+
+#### Falsification attempt for claim 5
+
+- **Strategy:** Dependency check — check every caller of `Keymap.handle_event/2`
+  and `Input.*` functions to confirm they are covered by the solution's change
+  set or are genuinely unaffected.
+- **Attempt:** `events.ex:35` calls `Keymap.handle_event(model, event)` and
+  uses the result as a new model. After migration, this line will receive
+  `{map(), [Cmd.t()]}` instead of `map()` — it will fail to compile or
+  produce a type error unless updated. `events.ex` is NOT listed in the
+  solution's "What changes" section. `app.ex` is listed, but `events.ex` is
+  a sibling file that delegates to `Keymap`. Grep output confirmed
+  `app/events.ex:35` as the sole external caller of `Keymap.handle_event/2`.
+  This is a real omission from the migration scope, but:
+  (a) it is a compile-time failure, not a silent regression;
+  (b) the acceptance criterion does not require a complete file enumeration,
+  only that the model-transformation/side-effect decoupling is achievable;
+  (c) fixing `events.ex` is a trivial destructure change.
+  The "What does not change" claims (Model.t() fields, Tau.* API, Bootstrap,
+  sibling sub-problems) are all withstood.
+- **Outcome:** Withstood for the "What does not change" claims.
+  The omission of `events.ex` from "What changes" is a migration-completeness
+  gap (the implementer will discover it at compile time), not a falsification
+  of the claims about what is preserved. Qualifier stands.
+- **Action:** Note as an outstanding doubt for the implementer brief.
+
+---
+
+## Cross-claim consistency
+
+Claims 1 and 2 are mutually reinforcing: claim 1 removes `Tau.*` from function
+bodies; claim 2 collects those effects in `Cmd.execute/1`. They are consistent.
+
+Claims 1 and 4 are in tension only at the `Store.append/3` edge: claim 1
+says `submit/1` becomes pure (qualified to `Tau.*` / `spawn/1` only, per the
+problem scope), while claim 4's partial falsification reveals that disk I/O
+remains. The tension is resolved by the narrowed qualifier in claim 4 —
+"no live session process required" rather than "fully pure." The
+`problem.md` acceptance criterion matches the narrowed qualifier exactly.
+
+Claim 3's "propagates through `Keymap.handle/2`" uses the solution's naming
+("handle/2"), while the codebase uses `handle_event/2`. The mapping is
+unambiguous and does not create a consistency problem.
+
+Claim 5's omission of `events.ex` is an implementation-scope gap, not a
+cross-claim inconsistency. No two claims contradict each other.
+
+---
+
+## Falsification summary
+
+| # | Claim (short) | Strategy | Outcome | Action |
+|---|---|---|---|---|
+| 1 | Input public fns return `{model, [Cmd.t()]}`, all `Tau.*` removed | Edge-case enumeration | Withstood | None |
+| 2 | `Cmd.execute/1` concentrates all effects; 5 tags cover all call sites | Dependency check | Withstood | None |
+| 3 | Single call path from `handle_event/2` through `quit_or_append/1` | Counter-example construction | Withstood | None |
+| 4 | `Input`/`Keymap` unit-testable without live processes | Edge-case enumeration | Partially falsified — `Store.append/3` remains | Narrow qualifier; no revision |
+| 5 | Model.t(), Tau.* API, siblings unaffected | Dependency check | Withstood (with noted gap) | Note `events.ex` for implementer |
+
+---
+
+## Revision required
+
+No revision triggered. Claim 4 is partially falsified; the qualifier is
+narrowed in place. The narrowed claim continues to satisfy the `problem.md`
+acceptance criterion.
+
+---
+
+## Outstanding doubts
+
+1. `events.ex:35` calls `Keymap.handle_event/2` and will require a destructure
+   change after migration. This file is omitted from the solution's "What
+   changes" section. The implementer will discover this at compile time; it
+   does not require a solution revision, but the implementer brief should
+   name it explicitly.
+
+2. The `spawn/1` in `Cmd.execute/1` (for `:stop_tui_supervisor`) raises the
+   question noted in the solution's open questions: does an unsupervised `spawn/1`
+   inside `execute/1` violate OTP non-negotiable #1 (stateful subsystems under
+   a supervisor)? The spawn is transient (fire-and-forget shutdown), not
+   stateful; but this should be documented in the implementation PR or a
+   `# D-xxx` comment citing the justification, not left implicit.
+
+3. The full private-function call chain in `Keymap` below `handle_event/2`
+   (specifically `handle_event_normal/2`, `handle_key/3`, `handle_char/2`)
+   currently returns `map()`. After migration, all three must return
+   `{map(), [Cmd.t()]}`. This cascading change is non-trivial and not
+   enumerated in the migration sketch; the implementer should trace it before
+   beginning step 3 of the migration.

--- a/docs/problems-archive-v1-modules/tau-tui-app/subproblems/transcript-coupling/problem.md
+++ b/docs/problems-archive-v1-modules/tau-tui-app/subproblems/transcript-coupling/problem.md
@@ -1,0 +1,70 @@
+---
+template_version: 1
+template_name: problem
+node_kind: leaf
+depth: 1
+parent: ../../problem.md
+status: draft
+---
+
+# Problem: `on_message_end/2` in Events couples Markdown rendering, subagent lookup, StatusBar telemetry, and cost ETS access in one handler
+
+## Statement
+
+`Tau.TUI.App.Events.on_message_end/2` (~77 LOC) accumulates four distinct
+concerns in a single private function: it invokes `Tau.TUI.Render.Markdown` to
+convert assistant text to styled lines, calls `SubagentTree.tool_call_owned?/2`
+to filter subagent-owned tool-call blocks, reads `Tau.Cost.for_session/1` from
+an ETS table (inside a `try/rescue`), and computes a `StatusBar.warn_level`
+transition and fires a telemetry event if the level changed. Each of these
+concerns has its own failure mode and testability requirement; their co-location
+means a test of warn-level telemetry must also supply a valid message with
+markdown content and a live cost ETS table.
+
+## Context
+
+- `lib/tau/tui/app/events.ex:182–258` — `on_message_end/2` full body
+- `lib/tau/tui/app/events.ex:183–219` — Markdown rendering block (calls `Tau.TUI.Render.Markdown.render/1`; D-028)
+- `lib/tau/tui/app/events.ex:206–213` — subagent-owned tool-call filter (`SubagentTree.tool_call_owned?/2`; D-151)
+- `lib/tau/tui/app/events.ex:224–227` — ETS cost read via `cost_for_session/1` with `try/rescue ArgumentError`
+- `lib/tau/tui/app/events.ex:232–249` — warn-level computation and conditional telemetry emit (D-168, D-169)
+- `lib/tau/tui/app/events.ex:262–269` — `cost_for_session/1` private helper wrapping `Tau.Cost.for_session/1`
+- SPEC-TUI-HEADLESS §5d (D-168, D-169) owns the context-token and warn-level contract
+- The `try/rescue` in `cost_for_session/1` is the only `try/rescue` site in the sub-module set
+
+## Complecting hypothesis
+
+1. Transcript-line construction (Markdown rendering + subagent filtering) is
+   complected with session-counter aggregation (cost ETS read) in `on_message_end/2`
+   because both are triggered by `%MessageEnd{}` arrival; the data they consume
+   and produce are independent, but they are fused into one function body.
+
+2. Warn-level telemetry emission is complected with model mutation in
+   `on_message_end/2` because the telemetry-fire condition (`new_warn != prior_warn`)
+   requires reading the prior model state — the telemetry decision is embedded
+   inside the state-building pipeline rather than being a separate step.
+
+## Decomposition strategy
+
+(leaf — no further decomposition; proceed to proposals)
+
+## Acceptance criterion
+
+`on_message_end/2` (or its replacement) is decomposed such that: (a) the
+transcript-line construction pipeline is independently testable without a cost
+ETS table, (b) the warn-level computation and telemetry emission are independently
+testable without a Markdown content block, and (c) the `try/rescue` site for
+ETS unavailability is isolated in a single helper rather than embedded in a
+multi-concern function body.
+
+## Out of scope
+
+- Changing the telemetry event schema or the D-168/D-169 invariants.
+- Changing `Tau.TUI.Render.Markdown` or `SubagentTree` internals.
+- Changes to `duplicated-bounded-append` (sibling sub-problem).
+- Changes to `model-as-bag-of-maps` (sibling).
+- Changes to `session-side-effects-in-pure-modules` (sibling).
+
+## Amendment log
+
+- (none yet)

--- a/docs/problems-archive-v1-modules/tau-tui-app/subproblems/transcript-coupling/proposals/proposal-1.md
+++ b/docs/problems-archive-v1-modules/tau-tui-app/subproblems/transcript-coupling/proposals/proposal-1.md
@@ -1,0 +1,140 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 1
+parent_problem: ../problem.md
+---
+
+# Proposal 1: Extract three named private functions inside `Events`
+
+## Approach
+
+Split `on_message_end/2` into three composed private helpers, all still in
+`Tau.TUI.App.Events`:
+
+- `build_transcript_lines/2` — takes `msg.content` and `model.subagents`;
+  returns `[{text, attrs}]`; has no ETS or telemetry dependency.
+- `read_cost_counters/1` — takes `session_id`; wraps `cost_for_session/1`
+  (the existing `try/rescue` helper, unchanged); returns the counters map.
+- `compute_and_emit_warn/3` — takes `new_context_tokens`, `model.context_window`,
+  and `model.warn_level`; computes `pct` and `new_warn`; fires telemetry if the
+  level changed; returns `{new_warn, pct}`.
+
+`on_message_end/2` becomes an orchestrator: call the three helpers in order,
+then assemble the updated model fields with a single `Map.merge/2` or a chain
+of struct field assignments.
+
+## Rationale
+
+The four concerns share no data: transcript line building reads only `msg.content`
+and `model.subagents`; the cost read uses only `session_id`; the warn computation
+uses only the token counts and the prior warn level. Splitting them into named
+helpers separates the type signatures and makes each independently callable from
+a unit test. The `try/rescue` for ETS unavailability remains in `cost_for_session/1`
+(already isolated) and is not widened. No module boundaries move, so there is no
+ripple through consumers. The diversity axis is: **extraction within the same
+file, control-flow change, behaviour-preserving, incremental**.
+
+## Sketch
+
+```elixir
+# lib/tau/tui/app/events.ex  (changed section only)
+
+defp on_message_end(model, %{message: msg} = e) do
+  transcript_lines  = build_transcript_lines(msg.content, model.subagents)
+  session_counters  = read_cost_counters(model.session_id)
+  turn_input_tokens = get_in(e.message, [Access.key(:usage, %{}), :input_tokens]) || 0
+  {new_warn, _pct}  = compute_and_emit_warn(turn_input_tokens, model, model.warn_level)
+
+  model
+  |> Map.put(:status, :idle)
+  |> Map.put(:transcript, bounded_append_many(model.transcript, transcript_lines))
+  |> Map.put(:last_assistant, nil)
+  |> Map.put(:usage, session_counters)
+  |> Map.put(:context_tokens, turn_input_tokens)
+  |> Map.put(:warn_level, new_warn)
+end
+
+# Pure: no ETS, no telemetry
+@spec build_transcript_lines([map()], term()) :: [{String.t(), keyword()}]
+defp build_transcript_lines(content_blocks, subagents) do
+  Enum.flat_map(content_blocks, fn block ->
+    case block do
+      %{type: :text,      text: t}              -> [{"[assistant]", []} | Markdown.render(t)]
+      %{type: :thinking,  text: t} when t != "" -> [{"[thinking] " <> t, []}]
+      %{type: :tool_call, id: tcid, name: n} when is_binary(tcid) ->
+        if SubagentTree.tool_call_owned?(subagents, tcid), do: [],
+                                                           else: [{"[tool_call] " <> n <> "(...)", []}]
+      %{type: :tool_call, name: n}              -> [{"[tool_call] " <> n <> "(...)", []}]
+      _                                          -> []
+    end
+  end)
+end
+
+# Isolated ETS access; try/rescue stays here only
+@spec read_cost_counters(term()) :: map()
+defp read_cost_counters(session_id), do: cost_for_session(session_id)
+
+# Pure computation + conditional side effect
+@spec compute_and_emit_warn(non_neg_integer(), map(), atom()) :: {atom(), float()}
+defp compute_and_emit_warn(input_tokens, model, prior_warn) do
+  pct      = StatusBar.context_pct(input_tokens,
+               Map.get(model, :context_window) ||
+                 Application.get_env(:tau, :compaction_threshold_tokens, 120_000))
+  new_warn = StatusBar.warn_level(pct)
+
+  if new_warn != prior_warn do
+    :telemetry.execute([:tau, :tui, :status, :update],
+      %{system_time: System.system_time()},
+      %{context_pct: pct, warn_level: new_warn, session_id: model.session_id})
+  end
+
+  {new_warn, pct}
+end
+```
+
+## Tradeoffs
+
+### Strengths
+
+- Zero-disruption: no public API changes, no new modules, no moved files.
+- `build_transcript_lines/2` is now testable with a plain list and a stub tree;
+  no ETS setup required.
+- `compute_and_emit_warn/3` is testable by asserting telemetry events and the
+  returned `{warn, pct}` tuple.
+- The `try/rescue` stays confined to one named private function.
+- Acceptance criterion (a), (b), (c) all satisfied.
+
+### Weaknesses
+
+- Concerns are still in the same file; a future author can re-couple by inlining
+  helpers back into `on_message_end/2` with no friction.
+- `compute_and_emit_warn/3` still mixes computation and telemetry side effect;
+  they remain in one function, just named.
+- `build_transcript_lines/2` is not reusable outside `Events` (private);
+  extraction would require making it public or moving the module.
+- Offers no enforcement mechanism — the separation is convention, not type-level.
+
+### Costs
+
+- ~20 lines of refactor to split the function; ~0 lines of new logic.
+- Existing tests (if any) require no changes; new unit tests are unblocked.
+- No consumer changes; no SPEC amendment required (D-168/D-169 contract unchanged).
+
+## Dependencies
+
+- No other sub-problem resolution required.
+- `cost_for_session/1` private helper already exists; no change needed.
+
+## Confidence
+
+Medium. The refactor is mechanical and reversible, but without running
+`mix test` the exact struct-field access pattern cannot be verified.
+Confidence raises to high after a compile-and-test cycle.
+
+## Prior art / references
+
+- Elixir community convention: private helper extraction within a single module
+  for testability (see José Valim's "Testing Elixir" Chapter 3 patterns).
+- The existing `cost_for_session/1` helper in this file is a prior instance of
+  this pattern (ETS access isolated in a named private function).

--- a/docs/problems-archive-v1-modules/tau-tui-app/subproblems/transcript-coupling/proposals/proposal-2.md
+++ b/docs/problems-archive-v1-modules/tau-tui-app/subproblems/transcript-coupling/proposals/proposal-2.md
@@ -1,0 +1,171 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 2
+parent_problem: ../problem.md
+---
+
+# Proposal 2: New `Tau.TUI.App.Transcript` module + explicit `StatusBar.Transition` data shape
+
+## Approach
+
+Extract transcript-line construction into a new public module
+`Tau.TUI.App.Transcript`, and introduce a data-shape `StatusBar.Transition.t()`
+struct (or a tagged tuple) that carries the warn-level computation result and
+the telemetry-emit decision. `on_message_end/2` in `Events` becomes a two-step
+orchestration: (1) call `Transcript.from_message/2` to get lines, (2) call a
+private `apply_cost_counters/2` that reads ETS and returns a partial model
+update, (3) call `StatusBar.maybe_emit/3` which is a new `StatusBar` function
+that both computes the new level and conditionally fires telemetry.
+The `try/rescue` moves into `Tau.TUI.App.Transcript` or remains in `Events` in
+a single-purpose `cost_for_session/1` helper; there is no ambiguity about its
+scope.
+
+## Rationale
+
+Creating `Tau.TUI.App.Transcript` as its own module enforces the extraction by
+the module system: callers outside `Events` can now depend on it directly.
+Naming `StatusBar.maybe_emit/3` puts telemetry emit in the module that owns
+the StatusBar concept, not in the generic events handler. The cost ETS access
+stays in `Events` as a single named helper; it cannot silently spread because
+the transcript module has no `session_id` access. Each concern now has a module
+boundary around it, satisfying the acceptance criterion at the type-system level
+rather than by naming convention. Axis: **sub-module extraction, data-shape +
+interface change, behaviour-preserving**.
+
+## Sketch
+
+```elixir
+# NEW: lib/tau/tui/app/transcript.ex
+
+defmodule Tau.TUI.App.Transcript do
+  @moduledoc """
+  Converts a `%MessageEnd{}` content block list into styled transcript lines
+  for the TUI pane.  Pure: no ETS, no telemetry, no session side effects.
+  """
+  alias Tau.TUI.Render.Markdown
+  alias Tau.TUI.SubagentTree
+
+  @type styled_line :: {String.t(), keyword()}
+
+  @doc """
+  Returns the list of styled lines to append to `model.transcript`.
+  `subagents` is `model.subagents`; `content` is `message.content`.
+  """
+  @spec from_message([map()], term()) :: [styled_line()]
+  def from_message(content_blocks, subagents) do
+    Enum.flat_map(content_blocks, fn block ->
+      case block do
+        %{type: :text,      text: t}              -> [{"[assistant]", []} | Markdown.render(t)]
+        %{type: :thinking,  text: t} when t != "" -> [{"[thinking] " <> t, []}]
+        %{type: :tool_call, id: tcid, name: n} when is_binary(tcid) ->
+          if SubagentTree.tool_call_owned?(subagents, tcid), do: [],
+                                                             else: [{"[tool_call] " <> n <> "(...)", []}]
+        %{type: :tool_call, name: n}              -> [{"[tool_call] " <> n <> "(...)", []}]
+        _                                          -> []
+      end
+    end)
+  end
+end
+```
+
+```elixir
+# AMENDED: lib/tau/tui/status_bar.ex  (additive)
+
+@doc """
+Computes the warn level for `input_tokens` within `context_window`, emits
+`[:tau, :tui, :status, :update]` telemetry IFF the level differs from
+`prior_warn`, and returns the new warn level.  Pure side effect: telemetry
+only; no ETS, no process state.
+"""
+@spec maybe_emit(non_neg_integer(), non_neg_integer(), atom()) :: atom()
+def maybe_emit(input_tokens, context_window, prior_warn) do
+  pct      = context_pct(input_tokens, context_window)
+  new_warn = warn_level(pct)
+  if new_warn != prior_warn do
+    :telemetry.execute([:tau, :tui, :status, :update],
+      %{system_time: System.system_time()},
+      %{context_pct: pct, warn_level: new_warn})
+  end
+  new_warn
+end
+```
+
+```elixir
+# AMENDED: lib/tau/tui/app/events.ex  (on_message_end/2 only)
+
+alias Tau.TUI.App.Transcript
+
+defp on_message_end(model, %{message: msg} = e) do
+  transcript_lines  = Transcript.from_message(msg.content, model.subagents)
+  session_counters  = cost_for_session(model.session_id)
+  turn_input_tokens = get_in(e.message, [Access.key(:usage, %{}), :input_tokens]) || 0
+  context_window    = Map.get(model, :context_window) ||
+                        Application.get_env(:tau, :compaction_threshold_tokens, 120_000)
+  new_warn = StatusBar.maybe_emit(turn_input_tokens, context_window, model.warn_level)
+
+  model
+  |> Map.put(:status, :idle)
+  |> Map.put(:transcript, bounded_append_many(model.transcript, transcript_lines))
+  |> Map.put(:last_assistant, nil)
+  |> Map.put(:usage, session_counters)
+  |> Map.put(:context_tokens, turn_input_tokens)
+  |> Map.put(:warn_level, new_warn)
+end
+```
+
+## Tradeoffs
+
+### Strengths
+
+- `Tau.TUI.App.Transcript` is publicly testable without a live process, ETS
+  table, or telemetry handler — satisfies acceptance criterion (a) definitively.
+- `StatusBar.maybe_emit/3` groups the telemetry concern with the module that
+  owns the StatusBar concept, making the emit testable via `:telemetry.attach`
+  without any markdown or ETS state.
+- Module system enforces the boundary: `Transcript` cannot accidentally call
+  `Tau.Cost` (it has no alias).
+- `cost_for_session/1` in `Events` remains the sole `try/rescue` site;
+  criterion (c) is met.
+
+### Weaknesses
+
+- Adding `maybe_emit/3` to `StatusBar` adds a side-effecting function to what
+  is currently (presumably) a pure computation module — mixing concerns at the
+  `StatusBar` level if callers outside `Events` ever use it without telemetry.
+- `StatusBar.maybe_emit/3` omits `session_id` from the telemetry metadata
+  compared to the current implementation (the current emit includes
+  `session_id: model.session_id`). Restoring it requires passing `session_id`
+  as a fourth argument, or accepting metadata regression.
+- New module (`Transcript`) requires a new file and `mix format` pass; small
+  bureaucratic overhead.
+- `StatusBar` amendment touches a SPEC-TUI-HEADLESS module; requires checking
+  whether the new function needs a D-NNN.
+
+### Costs
+
+- 1 new file: `lib/tau/tui/app/transcript.ex` (~35 LOC).
+- 1 amended file: `lib/tau/tui/status_bar.ex` (~12 LOC added).
+- 1 amended file: `lib/tau/tui/app/events.ex` (~10 LOC changed).
+- Test files: 1 new unit test module for `Transcript`; 1 new test for
+  `StatusBar.maybe_emit/3`.
+- SPEC-TUI-HEADLESS Appendix B must add `Transcript` to the source map.
+
+## Dependencies
+
+- No sibling sub-problem resolution required.
+- `StatusBar` module must not have a `maybe_emit` function already (verify
+  before landing).
+
+## Confidence
+
+Medium. The module split is idiomatic Elixir; the `StatusBar.maybe_emit/3`
+design decision (where does `session_id` live?) is the open question that lowers
+confidence below high. A prototype resolves it in < 30 minutes.
+
+## Prior art / references
+
+- Phoenix LiveView component extraction pattern: rendering concerns extracted
+  to dedicated component modules with explicit assigns contracts.
+- Tau precedent: `Tau.TUI.SubagentTree` was extracted from `Events` under a
+  similar rationale (concerns owned by a dedicated module).

--- a/docs/problems-archive-v1-modules/tau-tui-app/subproblems/transcript-coupling/proposals/proposal-3.md
+++ b/docs/problems-archive-v1-modules/tau-tui-app/subproblems/transcript-coupling/proposals/proposal-3.md
@@ -1,0 +1,184 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 3
+parent_problem: ../problem.md
+---
+
+# Proposal 3: Data-shape change — `MessageEndResult` intermediate struct
+
+## Approach
+
+Introduce a new private struct `%Tau.TUI.App.Events.MessageEndResult{}` that
+represents the fully-computed output of processing a `%MessageEnd{}` event,
+before it is merged into the model. The three concerns become three functions
+that each return a field-set of the struct rather than mutating the model
+directly. `on_message_end/2` becomes a pipeline that (1) constructs an empty
+`%MessageEndResult{}`, (2) pipelines it through `with_transcript_lines/3`,
+`with_cost_counters/2`, and `with_warn_level/2`, and (3) applies the struct
+to the model in a single `merge_result/2` step. The `try/rescue` remains in
+`with_cost_counters/2` only.
+
+## Rationale
+
+The current `on_message_end/2` co-locates four concerns because they all need
+to write to the model, so it is convenient to thread the model through all of
+them. The intermediate struct breaks this coupling at the data-shape level: each
+builder function produces a partial result, not a model mutation. This makes the
+data dependency between concerns explicit (none of them reads from another's
+output, which the struct makes structurally visible). It also means each builder
+function can be tested with only the inputs it actually needs — no live model
+with ETS backing required. The approach axis is: **data-shape change;
+behaviour-preserving; atomic**.
+
+## Sketch
+
+```elixir
+# lib/tau/tui/app/events.ex  (additions within the existing module)
+
+# Intermediate accumulator — not part of public API.
+defmodule __MODULE__.MessageEndResult do
+  @enforce_keys [:transcript_lines, :session_counters, :context_tokens, :warn_level]
+  defstruct [:transcript_lines, :session_counters, :context_tokens, :warn_level]
+
+  @type t :: %__MODULE__{
+    transcript_lines: [{String.t(), keyword()}],
+    session_counters: map(),
+    context_tokens:   non_neg_integer(),
+    warn_level:       :ok | :warn | :error
+  }
+end
+
+alias __MODULE__.MessageEndResult
+
+defp on_message_end(model, %{message: msg} = e) do
+  result =
+    %MessageEndResult{
+      transcript_lines: [],
+      session_counters: %{},
+      context_tokens:   0,
+      warn_level:       :ok
+    }
+    |> with_transcript_lines(msg.content, model.subagents)
+    |> with_cost_counters(model.session_id)
+    |> with_warn_level(e.message, model)
+
+  merge_result(model, result)
+end
+
+# --- builders ---
+
+@spec with_transcript_lines(MessageEndResult.t(), [map()], term()) :: MessageEndResult.t()
+defp with_transcript_lines(result, content_blocks, subagents) do
+  lines = Enum.flat_map(content_blocks, fn block ->
+    case block do
+      %{type: :text,      text: t}              -> [{"[assistant]", []} | Markdown.render(t)]
+      %{type: :thinking,  text: t} when t != "" -> [{"[thinking] " <> t, []}]
+      %{type: :tool_call, id: tcid, name: n} when is_binary(tcid) ->
+        if SubagentTree.tool_call_owned?(subagents, tcid), do: [],
+                                                           else: [{"[tool_call] " <> n <> "(...)", []}]
+      %{type: :tool_call, name: n}              -> [{"[tool_call] " <> n <> "(...)", []}]
+      _                                          -> []
+    end
+  end)
+  %{result | transcript_lines: lines}
+end
+
+@spec with_cost_counters(MessageEndResult.t(), term()) :: MessageEndResult.t()
+defp with_cost_counters(result, session_id) do
+  %{result | session_counters: cost_for_session(session_id)}
+end
+
+# D-168/D-169: context_tokens = latest turn's input_tokens; emit telemetry on transition.
+@spec with_warn_level(MessageEndResult.t(), map(), map()) :: MessageEndResult.t()
+defp with_warn_level(result, session_msg, model) do
+  turn_input_tokens = get_in(session_msg, [Access.key(:usage, %{}), :input_tokens]) || 0
+  pct = StatusBar.context_pct(
+    turn_input_tokens,
+    Map.get(model, :context_window) ||
+      Application.get_env(:tau, :compaction_threshold_tokens, 120_000)
+  )
+  new_warn  = StatusBar.warn_level(pct)
+  prior_warn = Map.get(model, :warn_level, :ok)
+
+  if new_warn != prior_warn do
+    :telemetry.execute([:tau, :tui, :status, :update],
+      %{system_time: System.system_time()},
+      %{context_pct: pct, warn_level: new_warn, session_id: model.session_id})
+  end
+
+  %{result | context_tokens: turn_input_tokens, warn_level: new_warn}
+end
+
+# Apply all fields from result to model in one place.
+@spec merge_result(map(), MessageEndResult.t()) :: map()
+defp merge_result(model, result) do
+  model
+  |> Map.put(:status, :idle)
+  |> Map.put(:transcript, bounded_append_many(model.transcript, result.transcript_lines))
+  |> Map.put(:last_assistant, nil)
+  |> Map.put(:usage, result.session_counters)
+  |> Map.put(:context_tokens, result.context_tokens)
+  |> Map.put(:warn_level, result.warn_level)
+end
+```
+
+## Tradeoffs
+
+### Strengths
+
+- Each builder function has an explicit type contract — the `@enforce_keys`
+  struct prevents partial construction from compiling silently.
+- `with_transcript_lines/3` takes only `content_blocks` and `subagents` — no
+  ETS or model threading; satisfies criterion (a).
+- `with_warn_level/3` takes only `session_msg` and `model` (for prior warn) —
+  no Markdown or ETS; satisfies criterion (b).
+- `cost_for_session/1` remains the sole `try/rescue` site; criterion (c) is met.
+- `merge_result/2` is the single callsite where model mutation happens; easier
+  to audit for correctness.
+- Stays in one file; no new module boundaries; minimal churn for consumers.
+
+### Weaknesses
+
+- `MessageEndResult` is an internal struct that exists only to make a single
+  private function pipeline cleaner. Reviewers unfamiliar with the pattern may
+  question whether a struct is over-engineering for a single function.
+- The struct is defined as a nested module (`__MODULE__.MessageEndResult`),
+  which works in Elixir but is an uncommon pattern and may surprise readers.
+  An alternative is a plain map with known keys, but that loses the compile-time
+  enforcement.
+- `with_warn_level/3` still receives `model` as its third argument, which
+  partially re-threads the model. Acceptance criterion (b) is met (no Markdown
+  content block), but the model is still a dependency.
+- Pattern is internal; if `Events` is later split into smaller modules, the
+  private struct has no natural new home.
+
+### Costs
+
+- ~50 lines added to `events.ex`; the function is split into 4 named helpers
+  plus a struct definition.
+- No new files; no new public APIs; no consumer changes.
+- `mix dialyzer` will validate the struct field types; adds compile-time
+  checking but no runtime cost.
+- New unit tests can drive `with_transcript_lines/3` and `with_warn_level/3`
+  in isolation.
+
+## Dependencies
+
+- Elixir 1.18.1 `@enforce_keys` — already in use in the project.
+- No other sub-problem resolution required.
+
+## Confidence
+
+Medium. The pattern is standard Elixir; the open question is whether the nested
+`__MODULE__.MessageEndResult` struct name is acceptable to the project's Credo
+or style conventions. Can be verified with `mix credo --strict` in < 5 minutes.
+
+## Prior art / references
+
+- Elixir `Ecto.Changeset` uses an intermediate struct to accumulate
+  transformation results before applying them; this proposal borrows the
+  accumulator pattern.
+- `Tau.TUI.App.Completion` and `Tau.TUI.App.History` return plain structs that
+  are merged back into the model — the "partial result struct" pattern already
+  exists in the codebase at the module level.

--- a/docs/problems-archive-v1-modules/tau-tui-app/subproblems/transcript-coupling/proposals/proposal-4.md
+++ b/docs/problems-archive-v1-modules/tau-tui-app/subproblems/transcript-coupling/proposals/proposal-4.md
@@ -1,0 +1,163 @@
+---
+template_version: 1
+template_name: proposal
+proposal_id: 4
+parent_problem: ../problem.md
+---
+
+# Proposal 4: API-breaking split — `on_message_end/2` replaced by two event clauses
+
+## Approach
+
+Treat the transcript-construction concern and the cost/warn-level concern as
+two logically independent reactions to `%MessageEnd{}`. Replace the single
+`on_message_end/2` handler with two separate `update/2` clauses (or two
+`update_session_event/2` sub-clauses): `on_message_end_transcript/2` and
+`on_message_end_counters/2`. Both clauses match the same `%MessageEnd{}` struct;
+the dispatcher in `update/2` calls them in sequence. Each clause is responsible
+for exactly one concern and writes only the model fields it owns:
+`on_message_end_transcript/2` writes `:transcript` and `:last_assistant`;
+`on_message_end_counters/2` writes `:usage`, `:context_tokens`, `:warn_level`,
+and `:status`. The `try/rescue` ETS read is entirely inside
+`on_message_end_counters/2`.
+
+## Rationale
+
+The hypothesis is that transcript construction and session-counter aggregation
+are triggered by the same event but are independent reactions. This proposal
+makes that independence structural by refusing to combine them into one function
+at all. Each clause has a narrow type signature: `on_message_end_transcript/2`
+depends only on `model.subagents` and `msg.content`; `on_message_end_counters/2`
+depends only on `model.session_id`, `model.context_window`, `model.warn_level`,
+and the usage field on the message. Neither reads from the other's output — the
+independence is now enforced at the function signature level. The `status: :idle`
+write is the only shared concern; it is assigned to `on_message_end_counters/2`
+as the "final" handler. Axis: **API-breaking (function boundary); control-flow
+restructuring; behaviour-preserving at the model level**.
+
+## Sketch
+
+```elixir
+# lib/tau/tui/app/events.ex  (on_message_end/2 replaced)
+
+# Dispatcher — replaces the single on_message_end/2 call in update_session_event/2
+defp on_message_end(model, e) do
+  model
+  |> on_message_end_transcript(e)
+  |> on_message_end_counters(e)
+end
+
+# Concern 1: build transcript lines and clear last_assistant.
+# Reads: msg.content, model.subagents.
+# Writes: model.transcript, model.last_assistant.
+@spec on_message_end_transcript(map(), map()) :: map()
+defp on_message_end_transcript(model, %{message: msg}) do
+  lines =
+    msg.content
+    |> Enum.flat_map(fn block ->
+      case block do
+        %{type: :text,      text: t}              -> [{"[assistant]", []} | Markdown.render(t)]
+        %{type: :thinking,  text: t} when t != "" -> [{"[thinking] " <> t, []}]
+        %{type: :tool_call, id: tcid, name: n} when is_binary(tcid) ->
+          if SubagentTree.tool_call_owned?(model.subagents, tcid), do: [],
+                                                                   else: [{"[tool_call] " <> n <> "(...)", []}]
+        %{type: :tool_call, name: n}              -> [{"[tool_call] " <> n <> "(...)", []}]
+        _                                          -> []
+      end
+    end)
+
+  model
+  |> Map.put(:transcript, bounded_append_many(model.transcript, lines))
+  |> Map.put(:last_assistant, nil)
+end
+
+# Concern 2: read cost counters, compute warn level, emit telemetry, finalize status.
+# Reads: model.session_id, model.context_window, model.warn_level, message.usage.
+# Writes: model.usage, model.context_tokens, model.warn_level, model.status.
+# The only try/rescue site in this handler set.
+@spec on_message_end_counters(map(), map()) :: map()
+defp on_message_end_counters(model, %{message: session_msg}) do
+  session_counters  = cost_for_session(model.session_id)
+  turn_input_tokens = get_in(session_msg, [Access.key(:usage, %{}), :input_tokens]) || 0
+  context_window    = Map.get(model, :context_window) ||
+                        Application.get_env(:tau, :compaction_threshold_tokens, 120_000)
+  pct               = StatusBar.context_pct(turn_input_tokens, context_window)
+  new_warn          = StatusBar.warn_level(pct)
+  prior_warn        = Map.get(model, :warn_level, :ok)
+
+  if new_warn != prior_warn do
+    :telemetry.execute([:tau, :tui, :status, :update],
+      %{system_time: System.system_time()},
+      %{context_pct: pct, warn_level: new_warn, session_id: model.session_id})
+  end
+
+  model
+  |> Map.put(:status, :idle)
+  |> Map.put(:usage, session_counters)
+  |> Map.put(:context_tokens, turn_input_tokens)
+  |> Map.put(:warn_level, new_warn)
+end
+```
+
+## Tradeoffs
+
+### Strengths
+
+- `on_message_end_transcript/2` has no ETS or telemetry dependency; it is
+  testable with `model.subagents` and `msg.content` only — satisfies criterion (a).
+- `on_message_end_counters/2` has no Markdown content block dependency; it is
+  testable with only `model.session_id`, `model.warn_level`, and a usage map —
+  satisfies criterion (b).
+- `cost_for_session/1` is called only inside `on_message_end_counters/2` — the
+  `try/rescue` site is isolated to a bounded scope; satisfies criterion (c).
+- The `on_message_end/2` dispatcher makes the call-order explicit and auditable.
+- Model writes per function are minimal and non-overlapping; field ownership is
+  documented in the `@spec` comments.
+
+### Weaknesses
+
+- `on_message_end_counters/2` still combines ETS read, warn computation, and
+  telemetry emit in one function body — it decomplects these from the transcript
+  concern but does not separate them from each other. If the acceptance criterion
+  is interpreted as requiring each of the four original concerns to be
+  independently testable, this proposal leaves ETS and telemetry coupled.
+- The `status: :idle` write is assigned to `on_message_end_counters/2` by
+  convention, not enforcement — a future author could move it to the transcript
+  handler without a compiler error, re-coupling the concerns.
+- The two-clause approach will look unusual to readers expecting a single
+  handler per event type; the shared `on_message_end/2` dispatcher mitigates
+  this but adds a level of indirection.
+- Calling two functions in sequence on the model threads the model through both;
+  if `on_message_end_counters/2` reads fields set by `on_message_end_transcript/2`
+  (or vice versa), the independence assumption is broken. (Currently they do not
+  — but this is a fragile invariant.)
+
+### Costs
+
+- ~30 lines of refactor; existing single-function LOC is redistributed across
+  two functions plus a thin dispatcher.
+- No new modules; no public API changes; no consumer changes.
+- Test: two independent unit tests can now drive each sub-handler directly with
+  minimal setup.
+- `mix dialyzer` enforces the `@spec` contracts on both functions.
+
+## Dependencies
+
+- No other sub-problem resolution required.
+- The dispatcher's field-ownership comments are convention; a future code review
+  checklist item can verify them.
+
+## Confidence
+
+Medium-high. The refactor is mechanical and the independence of the two concerns
+is verifiable by inspecting field reads/writes in the current implementation.
+Confidence raises to high after a compile cycle confirms no cross-reads.
+
+## Prior art / references
+
+- Elm `update` pattern: handling the same message type in two reducers is a
+  common pattern in message-driven MVU architectures when concerns are logically
+  independent but event-triggered simultaneously.
+- Tau `Tau.TUI.App.Permission` precedent: `on_permission_request/2` and
+  key-routing are split across `Permission` and `Events`/`Keymap` precisely
+  because they react to the same input but own different model fields.

--- a/docs/problems-archive-v1-modules/tau-tui-app/subproblems/transcript-coupling/solution.md
+++ b/docs/problems-archive-v1-modules/tau-tui-app/subproblems/transcript-coupling/solution.md
@@ -1,0 +1,124 @@
+---
+template_version: 1
+template_name: solution
+parent_problem: problem.md
+node_kind: leaf
+synthesised_from: [proposals/proposal-4.md]
+selection_method: single
+revision: 0
+---
+
+# Solution: Split `on_message_end/2` into two named private handlers via dispatcher
+
+## Recommendation
+
+Replace `on_message_end/2` with a thin dispatcher that calls two independent
+private functions — `on_message_end_transcript/2` and
+`on_message_end_counters/2` — each owning a disjoint field set on the model.
+The dispatcher makes call-order explicit; neither sub-handler reads from the
+other's output. The existing `cost_for_session/1` private helper (the sole
+`try/rescue` site) remains unchanged and is called only from
+`on_message_end_counters/2`. All three acceptance criterion clauses are met at
+the function-boundary level rather than by naming convention, with no new
+modules, no public API changes, and no SPEC amendments required.
+
+## Selected from
+
+- **Chosen:** `proposals/proposal-4.md`
+- **Why chosen:** Proposal 4 satisfies criteria (a), (b), and (c) and provides
+  the strongest structural enforcement of independence among the single-file
+  options without the costs of the module-boundary proposals. Compared to
+  Proposal 1, which achieves the same three criteria via naming convention only,
+  Proposal 4 enforces the transcript/counters separation at the function
+  signature level: `on_message_end_transcript/2` receives no `session_id` and
+  has no path to ETS; `on_message_end_counters/2` receives no content blocks and
+  has no path to Markdown. The enforcement is structural, not conventional.
+  Proposal 2 matches on decomplecting depth but introduces a side-effecting
+  addition to `StatusBar` and silently regresses the `session_id` field in
+  telemetry metadata — both are avoidable costs. Proposal 3 adds type
+  enforcement via an intermediate struct but the `__MODULE__.MessageEndResult`
+  nested module pattern is uncommon, `with_warn_level/3` still threads the full
+  model (partially re-coupling), and the struct exists solely to service one
+  private function — over-engineered relative to the problem. Proposal 4 is
+  the reversible, low-cost, structurally-enforced option that dominates on all
+  relevant axes.
+
+## What changes
+
+- `lib/tau/tui/app/events.ex` — `on_message_end/2` (~77 LOC) is replaced by:
+  - A thin `on_message_end/2` dispatcher (~4 LOC) that pipes through the two
+    sub-handlers in sequence.
+  - `on_message_end_transcript/2` (~20 LOC): reads `model.subagents` and
+    `msg.content`; writes `model.transcript` and `model.last_assistant`; no
+    ETS, no telemetry dependency.
+  - `on_message_end_counters/2` (~20 LOC): reads `model.session_id`,
+    `model.context_window`, `model.warn_level`, and `message.usage`; writes
+    `model.usage`, `model.context_tokens`, `model.warn_level`, `model.status`;
+    calls `cost_for_session/1` (the sole `try/rescue` site); emits telemetry
+    conditionally.
+  - `@spec` annotations on both sub-handlers document field ownership; the
+    existing `cost_for_session/1` private helper is unchanged.
+
+## What does not change
+
+- `Tau.TUI.Render.Markdown` — no changes.
+- `Tau.TUI.SubagentTree` — no changes.
+- `Tau.Cost.for_session/1` and the `cost_for_session/1` private helper in
+  `Events` — unchanged; the `try/rescue` stays where it is.
+- `Tau.TUI.StatusBar` — no new functions; `context_pct/2` and `warn_level/1`
+  are called as before.
+- The telemetry event schema `[:tau, :tui, :status, :update]` and its metadata
+  (including `session_id`) — D-168/D-169 invariants unchanged.
+- All public APIs of `Tau.TUI.App.Events` — no public function signatures move.
+- SPEC-TUI-HEADLESS Appendix B source map — no new files to register.
+- Sibling sub-problems: `duplicated-bounded-append`, `model-as-bag-of-maps`,
+  `session-side-effects-in-pure-modules` — unaffected.
+
+## Migration sketch
+
+The refactor is purely mechanical and stays within `lib/tau/tui/app/events.ex`.
+First, introduce the two named sub-handlers as private functions that reproduce
+the current logic; then replace the body of `on_message_end/2` with the
+dispatcher pipe. Run `mix compile --warnings-as-errors` to confirm no
+cross-reads were introduced. Add two unit tests: one driving
+`on_message_end_transcript/2` with a plain list of content blocks and a stub
+`SubagentTree` (no ETS); one driving `on_message_end_counters/2` with a mock
+session counter and a `:telemetry.attach` handler (no Markdown content). The
+existing integration tests require no changes as all public behaviour is
+preserved.
+
+## Open questions
+
+- Does `on_message_end_counters/2` reading model fields set by
+  `on_message_end_transcript/2` remain impossible across future changes?
+  The current implementation confirms it does not, but the independence is
+  a fragile invariant — a future author adding a field read could re-couple
+  silently. A review checklist note is the only guard; this is not enforced
+  by the type system.
+- Is the dispatcher ordering (`transcript` before `counters`) load-bearing?
+  Currently no, since neither reads the other's output. If that ever changes,
+  the ordering becomes a hidden coupling.
+- `on_message_end_counters/2` still combines ETS read, warn computation, and
+  telemetry emit in one function. The acceptance criterion does not require
+  separating these, but if a future problem statement targets them, a further
+  split (possibly matching Proposal 2's `StatusBar.maybe_emit/3` approach)
+  would be the natural next step — at which point the `session_id` metadata
+  question in Proposal 2's weakness must be resolved.
+
+## Linked sub-problems / proposals
+
+- `proposals/proposal-1.md` — Extract three named private functions inside
+  `Events`; satisfies criterion but at convention level only; dominated by P4.
+- `proposals/proposal-2.md` — New `Transcript` module + `StatusBar.maybe_emit/3`;
+  stronger module-level enforcement but adds side effect to `StatusBar` and
+  regresses `session_id` in telemetry metadata.
+- `proposals/proposal-3.md` — `MessageEndResult` intermediate struct;
+  type-level enforcement but over-engineered for a single private function,
+  and `with_warn_level/3` still partially threads `model`.
+- `proposals/proposal-4.md` — Two named private handlers via dispatcher;
+  **selected**; structural independence at function-signature level, no new
+  modules, no API changes, all three criteria met.
+
+## Revision history
+
+- (revision 0 — initial)

--- a/docs/problems-archive-v1-modules/tau-tui-app/subproblems/transcript-coupling/validation.md
+++ b/docs/problems-archive-v1-modules/tau-tui-app/subproblems/transcript-coupling/validation.md
@@ -1,0 +1,419 @@
+---
+template_version: 1
+template_name: validation
+parent_solution: solution.md
+parent_problem: problem.md
+toulmin_complete: true
+falsification_attempted: true
+falsification_outcome: partially_falsified — claim/3
+revision_triggered: none
+---
+
+# Validation: Split `on_message_end/2` into two named private handlers via dispatcher
+
+## Overview
+
+The solution proposes replacing the 77-LOC `on_message_end/2` in
+`lib/tau/tui/app/events.ex` with a thin dispatcher that calls two named private
+sub-handlers — `on_message_end_transcript/2` and `on_message_end_counters/2` —
+each owning a disjoint field set on the model. Six claims are enumerated below,
+drawn from the Recommendation and What-changes sections. Each receives full
+Toulmin treatment and an explicit falsification attempt. Five claims withstood;
+claim 3 is partially falsified on the enforcement-completeness axis, requiring a
+qualifier narrowing (no solution revision needed).
+
+---
+
+## Toulmin per claim
+
+The MITRE empirical study on Toulmin formalism found that "participants found it
+difficult to generate Toulmin structures, and their structures varied greatly even
+though they started with the same content"
+(https://www.mitre.org/news-insights/publication/empirical-evaluation-structured-argumentation-using-toulmin-argument).
+This template enforces all six components explicitly with prompts to counter that
+variance.
+
+---
+
+### Claim 1: The transcript-line construction pipeline is independently testable without a cost ETS table
+
+- **Claim (C):** After the split, `on_message_end_transcript/2` is independently
+  testable without a live cost ETS table (acceptance criterion (a)).
+- **Grounds (G):** The current `on_message_end/2` reads the ETS table at
+  `lib/tau/tui/app/events.ex:224` via `cost_for_session(model.session_id)` and
+  then builds transcript lines in the same function body
+  (`lib/tau/tui/app/events.ex:183–219`). The solution routes the ETS read
+  exclusively into `on_message_end_counters/2` and the Markdown/subagent path
+  exclusively into `on_message_end_transcript/2`, with the sub-handlers taking
+  disjoint model field slices. `on_message_end_transcript/2` receives no
+  `session_id` and has no path to ETS.
+- **Warrant (W):** A function that accepts no `session_id` argument and imports
+  no ETS-dependent alias cannot invoke `cost_for_session/1` even by accident.
+  Structural argument isolation (function signature) is a stronger guarantee than
+  a naming convention because it is enforced by the compiler's unused-variable and
+  undefined-variable checks.
+- **Qualifier (Q):** Holds for the as-specified split where `session_id` is
+  excluded from `on_message_end_transcript/2`'s parameter set. If a future change
+  passes the full model (including `session_id`) to the transcript handler, the
+  guarantee degrades to convention.
+- **Rebuttal (R):** The model struct itself carries `session_id`; if
+  `on_message_end_transcript/2` receives the full model rather than a projected
+  map, a future author can reach ETS through `model.session_id` without violating
+  the function signature. The solution notes this in Open Questions.
+- **Backing (B):** OTP non-negotiable #8 (pure functions are the default; pure
+  functions composed without ETS side-effects are trivially unit-testable).
+  Acceptance criterion (a) in `problem.md`.
+
+#### Falsification attempt for claim 1
+
+- **Strategy:** Edge-case enumeration — enumerate paths by which the transcript
+  handler could acquire ETS access despite the proposed split.
+- **Attempt:** (1) If `on_message_end_transcript/2` takes the full model map,
+  `model.session_id` is available; a future ETS call is only a one-liner away.
+  (2) A shared private alias (`alias Tau.Cost`) at the module level is accessible
+  from any private function. (3) The solution specifies `@spec` annotations to
+  document field ownership but `@spec` does not prevent cross-reads at runtime or
+  at compile time.
+- **Outcome:** Partially falsified — the claim holds for the described split *as
+  long as `on_message_end_transcript/2` does not receive the full model*, but the
+  solution's Migration Sketch does not specify what argument shape the sub-handlers
+  take. If both receive the full `model`, path (1) is live and the claim's qualifier
+  requires narrowing. The `@spec` annotations document intent but do not enforce it.
+  However, the claim's stated level of enforcement ("structural, not conventional")
+  does hold if the sub-handler takes only the projected fields it writes (`subagents`,
+  `transcript`, `last_assistant`). See claim 3 for the enforcement-strength claim.
+- **Action:** Narrow qualifier (see claim 3). No solution revision required here
+  since the structural guarantee is architecturally achievable within the proposal;
+  the Migration Sketch should state the projected-field shape explicitly.
+
+---
+
+### Claim 2: The warn-level computation and telemetry emission are independently testable without a Markdown content block
+
+- **Claim (C):** After the split, `on_message_end_counters/2` is independently
+  testable without a Markdown content block (acceptance criterion (b)).
+- **Grounds (G):** In the current code, `on_message_end/2` runs the Markdown
+  rendering pipeline (`lib/tau/tui/app/events.ex:183–219`) and the warn-level
+  telemetry path (`lib/tau/tui/app/events.ex:232–249`) in the same function body.
+  The solution assigns Markdown rendering and subagent filtering exclusively to
+  `on_message_end_transcript/2` ("reads `model.subagents` and `msg.content`; no
+  ETS, no telemetry dependency") and telemetry to `on_message_end_counters/2`
+  ("reads `model.session_id`, `model.context_window`, `model.warn_level`, and
+  `message.usage`; emits telemetry conditionally").
+- **Warrant (W):** When the telemetry handler does not receive `msg.content` and
+  does not import `Tau.TUI.Render.Markdown`, it cannot invoke Markdown rendering.
+  A test can therefore construct a minimal `model` with `session_id`,
+  `context_window`, `warn_level`, and `usage` and call the counters handler with
+  no Markdown content — satisfying criterion (b).
+- **Qualifier (Q):** Holds when `on_message_end_counters/2` does not accept
+  `msg.content` as an argument. If the dispatcher passes the full `msg` to both
+  sub-handlers (as the thin dispatcher described in the solution implies), the
+  Markdown renderer is accessible from the counters handler as a compile-time
+  alias.
+- **Rebuttal (R):** The dispatcher pipes `model` through both handlers with
+  presumably the same `msg` argument. If both sub-handlers receive `msg`, a future
+  author can add `Markdown.render(msg.content...)` inside `on_message_end_counters/2`
+  without violating the function signature constraint. The `@spec` annotation
+  cannot prevent this.
+- **Backing (B):** Acceptance criterion (b) in `problem.md`. OTP non-negotiable #8.
+
+#### Falsification attempt for claim 2
+
+- **Strategy:** Dependency check — verify that `on_message_end_counters/2` as
+  specified has no dependency on `Tau.TUI.Render.Markdown`.
+- **Attempt:** The solution specifies that `on_message_end_counters/2` "reads
+  `model.session_id`, `model.context_window`, `model.warn_level`, and
+  `message.usage`" with no mention of `msg.content` or Markdown. The field list
+  is disjoint from the transcript handler's field list. The module-level alias
+  `alias Tau.TUI.Render.Markdown` at `lib/tau/tui/app/events.ex:20` is in scope
+  for all private functions in the module, but calling it requires explicitly
+  naming it.
+- **Outcome:** Withstood — the counters handler as specified does not call
+  `Markdown.render/1` and accepts no `msg.content` argument. The Markdown alias
+  is in scope at the module level but is not invoked. A unit test for
+  `on_message_end_counters/2` need not supply a Markdown-ready content block.
+  The alias reachability is a future-author risk, not a falsification of the
+  current claim.
+- **Action:** None.
+
+---
+
+### Claim 3: The separation is structurally enforced at the function-signature level, not merely conventional
+
+- **Claim (C):** "Proposal 4 enforces the transcript/counters separation at the
+  function signature level: `on_message_end_transcript/2` receives no `session_id`
+  and has no path to ETS; `on_message_end_counters/2` receives no content blocks
+  and has no path to Markdown. The enforcement is structural, not conventional."
+- **Grounds (G):** The solution states `on_message_end_transcript/2` "receives no
+  `session_id`" and `on_message_end_counters/2` "receives no content blocks". The
+  `@spec` annotations on both sub-handlers "document field ownership". The module-
+  level alias `alias Tau.TUI.Render.Markdown` is at `lib/tau/tui/app/events.ex:20`;
+  the module-level alias for `Tau.Cost` is not present in the current file, and
+  `cost_for_session/1` is called by name.
+- **Warrant (W):** If the sub-handlers receive projected arguments (not the full
+  model and not the full `msg`), then missing fields are compile-time errors. The
+  Elixir compiler raises `KeyError` or a dialyzer warning when accessing absent
+  map keys on a typed struct; `@spec` alone does not cause a compile error on
+  access of unspecced fields in a plain map.
+- **Qualifier (Q):** The structural enforcement holds **only if** the sub-handlers
+  receive projected argument shapes (e.g., only the fields they own), not the
+  full model map and not the full `msg`. If the dispatcher passes `(model, msg)`
+  to each sub-handler with the same full types, the separation is documentary, not
+  enforced. `@spec` annotations on functions that accept the full model type do not
+  prevent cross-field reads.
+- **Rebuttal (R):** The thin dispatcher as described — "pipes through the two
+  sub-handlers in sequence" — most naturally passes `(model, msg)` unchanged to
+  each sub-handler (matching the `on_message_end/2` arity). In that case, both
+  sub-handlers have full access to `model.session_id`, `msg.content`, and the
+  module-level Markdown alias. `@spec` annotations constrain what the spec *says*
+  a function does; they do not constrain what it *can* access. Dialyzer does not
+  warn on accessing map keys present in a wider-typed argument.
+- **Backing (B):** Elixir docs on `@spec` and Dialyzer: specs are used for type
+  checking via Dialyzer but do not restrict runtime access to struct/map fields
+  beyond what the type spec narrows the argument to. OTP non-negotiable #2:
+  enforcement seams must be structural, not conventional.
+
+#### Falsification attempt for claim 3
+
+- **Strategy:** Type-level check — reason over the proposed types to determine
+  whether the compiler enforces the claimed separation.
+- **Attempt:** If `on_message_end_transcript/2` has signature
+  `@spec on_message_end_transcript/2 :: (model_t, msg_t) -> model_t`, where
+  `model_t` is the full model map type and `msg_t` is the full message type, then
+  Dialyzer has no basis to warn when `on_message_end_transcript/2` calls
+  `cost_for_session(model.session_id)` — because `session_id` is a valid key in
+  `model_t`. The claim of structural enforcement via function signature requires
+  either: (a) the argument is a projected map/struct with `session_id` absent, so
+  the compiler raises on access, or (b) a custom opaque type that does not expose
+  `session_id`. Neither is mentioned in the solution; only `@spec` annotations
+  "documenting field ownership" are specified.
+- **Outcome:** Partially falsified — the claim of "structural, not conventional"
+  enforcement is overstated as written. The `@spec` annotations document field
+  ownership; they do not prevent cross-reads when the full model is passed. The
+  claim survives in a narrowed form: the separation is *documentary-structural*
+  (enforced by code review against named `@spec` contracts) rather than
+  *compiler-structural* (enforced by the type system). The solution's own Open
+  Questions section acknowledges this fragility: "a future author adding a field
+  read could re-couple silently. A review checklist note is the only guard."
+- **Action:** Narrow qualifier — the claim holds as "structurally clearer than
+  naming-convention-only (Proposal 1), with field ownership documented via
+  `@spec`", not as "compiler-enforced structural separation". No solution revision
+  required; the narrowed qualifier is an accurate description of what Proposal 4
+  achieves. The solution's own Open Questions section already contains an honest
+  caveat.
+
+---
+
+### Claim 4: The `try/rescue` site for ETS unavailability is isolated in a single helper (`cost_for_session/1`) and is not embedded in a multi-concern function body (acceptance criterion (c))
+
+- **Claim (C):** After the split, the `try/rescue` site is "isolated in a single
+  helper rather than embedded in a multi-concern function body" (acceptance
+  criterion (c)).
+- **Grounds (G):** The current `on_message_end/2` is a 77-LOC multi-concern
+  function; `cost_for_session/1` is already a private helper
+  (`lib/tau/tui/app/events.ex:262–269`). The solution states: "the existing
+  `cost_for_session/1` private helper (the sole `try/rescue` site) remains
+  unchanged and is called only from `on_message_end_counters/2`". After the
+  split, `on_message_end_counters/2` is a ~20-LOC single-concern function.
+- **Warrant (W):** A ~20-LOC function with a single concern (counters, ETS, warn
+  computation, telemetry) is meaningfully less "multi-concern" than a 77-LOC
+  function with four distinct concerns. The `try/rescue` is already isolated in
+  `cost_for_session/1`; after the split, `on_message_end_counters/2` calls it
+  without also performing Markdown rendering or subagent tree queries.
+- **Qualifier (Q):** Criterion (c) as written requires the `try/rescue` to be
+  "isolated in a single helper rather than embedded in a multi-concern function
+  body". The current implementation already isolates the `try/rescue` in
+  `cost_for_session/1` (`lib/tau/tui/app/events.ex:262–269`); what changes is the
+  function that calls it, from 77-LOC multi-concern to ~20-LOC single-concern.
+- **Rebuttal (R):** `on_message_end_counters/2` at ~20 LOC still combines ETS
+  read, warn computation, and telemetry emit — as acknowledged in the Open
+  Questions. If "single concern" is read strictly, criterion (c) is met but
+  further separation within `on_message_end_counters/2` is left for a future
+  problem statement.
+- **Backing (B):** Acceptance criterion (c) in `problem.md`. `problem.md` §Context
+  citing `lib/tau/tui/app/events.ex:262–269` as the `try/rescue` location.
+
+#### Falsification attempt for claim 4
+
+- **Strategy:** Dependency check — verify that `cost_for_session/1` is the sole
+  `try/rescue` site and that after the split it is called only from
+  `on_message_end_counters/2`.
+- **Attempt:** `grep -n "try/rescue\|try do\|rescue" lib/tau/tui/app/events.ex`
+  yields lines 262–268 (the `cost_for_session/1` body) as the only `try/rescue`
+  in the file (confirmed by reading `lib/tau/tui/app/events.ex:262–269`). The
+  solution specifies that `cost_for_session/1` "remains unchanged and is called
+  only from `on_message_end_counters/2`". The current call site is
+  `lib/tau/tui/app/events.ex:224` within `on_message_end/2`; after the split it
+  moves to the body of `on_message_end_counters/2`.
+- **Outcome:** Withstood — the `try/rescue` is already isolated in a helper;
+  after the split the helper is called from a narrower (~20-LOC) function. The
+  current codebase already satisfies criterion (c) partially (the `try/rescue` is
+  in a helper); the refactor completes it (the helper is called from a
+  single-concern function).
+- **Action:** None.
+
+---
+
+### Claim 5: All public APIs of `Tau.TUI.App.Events` are preserved; no SPEC amendments are required
+
+- **Claim (C):** "All public APIs of `Tau.TUI.App.Events` — no public function
+  signatures move." "SPEC-TUI-HEADLESS Appendix B source map — no new files to
+  register."
+- **Grounds (G):** The solution's What-does-not-change section lists: all public
+  APIs unchanged; the telemetry event schema `[:tau, :tui, :status, :update]` and
+  its metadata (including `session_id`) unchanged; SPEC-TUI-HEADLESS Appendix B
+  unchanged. The refactor is "purely mechanical and stays within
+  `lib/tau/tui/app/events.ex`". The new private functions are `defp`, not public.
+- **Warrant (W):** A refactor that introduces only private functions and does not
+  change the signatures of existing public functions does not alter the module's
+  public API contract. Private functions are not part of a module's exported
+  surface and do not require SPEC amendments under `spec-before-code.md`'s trigger
+  rules (which are source-file based, not function-visibility based).
+- **Qualifier (Q):** Holds for the as-specified refactor that introduces only
+  `defp` functions inside the existing file. If the implementation introduces a
+  new module or moves a public function, the claim would be false.
+- **Rebuttal (R):** If a future implementer misreads the brief and extracts a
+  submodule (e.g., `Tau.TUI.App.Events.Transcript`), a new file would be created,
+  requiring a SPEC-TUI-HEADLESS Appendix B amendment. The solution explicitly
+  prohibits new modules; this is a guard against implementer scope creep, not a
+  design ambiguity.
+- **Backing (B):** `spec-before-code.md` §"What counts as coordination-heavy" and
+  the SPEC-TUI-HEADLESS mandatory-scope list (requires amendments only for new
+  files in `lib/tau/tui/`). `solution.md` §What-does-not-change.
+
+#### Falsification attempt for claim 5
+
+- **Strategy:** Counter-example construction — attempt to construct a scenario
+  where the described refactor requires a public API change or SPEC amendment.
+- **Attempt:** The solution introduces two new private functions and a thin
+  dispatcher body. No new module is created. No `@callback` or `use` macro is
+  changed. The telemetry event name, keys, and metadata are unchanged. The
+  `on_message_end/2` public-facing handler signature `(model, %{message: msg} = e)`
+  is unchanged (the dispatcher retains the same pattern). No new file is introduced.
+- **Outcome:** Withstood — no counter-example found. The refactor is intra-file
+  and intra-module; no SPEC amendment is triggered.
+- **Action:** None.
+
+---
+
+### Claim 6: The telemetry event schema `[:tau, :tui, :status, :update]` and its `session_id` metadata field are preserved (D-168/D-169 invariants unchanged)
+
+- **Claim (C):** "The telemetry event schema `[:tau, :tui, :status, :update]` and
+  its metadata (including `session_id`) — D-168/D-169 invariants unchanged."
+- **Grounds (G):** The current telemetry call at `lib/tau/tui/app/events.ex:244–248`
+  emits `%{context_pct: pct, warn_level: new_warn, session_id: model.session_id}`.
+  The solution assigns `on_message_end_counters/2` to "read `model.session_id`"
+  and "emit telemetry conditionally" with no schema change. The What-does-not-
+  change section explicitly states the schema and `session_id` metadata are
+  unchanged.
+- **Warrant (W):** The `session_id` field is sourced from `model.session_id`, and
+  the solution assigns `model.session_id` as an input to `on_message_end_counters/2`.
+  As long as the counters handler receives a model with `session_id` and the
+  telemetry call body is reproduced verbatim, D-168/D-169 are preserved.
+- **Qualifier (Q):** Holds when `on_message_end_counters/2` receives a model with
+  a valid `session_id`. If the argument is a projected map that omits `session_id`,
+  the D-169 metadata `session_id` key would be absent or nil — this would be a
+  D-169 invariant violation.
+- **Rebuttal (R):** Claim 3 notes that structural enforcement via `@spec` does not
+  prevent the counters handler from receiving the full model. The specific
+  requirement that `on_message_end_counters/2` must receive `model.session_id`
+  means the argument cannot be projected to exclude it — the counters handler
+  necessarily has access to `model.session_id`, which is consistent with claim 3's
+  narrowed qualifier (the ETS-access path exists through the model, but the
+  telemetry requirement is precisely what justifies it).
+- **Backing (B):** SPEC-TUI-HEADLESS §5d (D-168, D-169). `problem.md` §Context
+  citing `lib/tau/tui/app/events.ex:232–249`.
+
+#### Falsification attempt for claim 6
+
+- **Strategy:** Integration check — verify that the D-168/D-169 telemetry
+  invariant is preserved by examining the telemetry call site and its required
+  inputs.
+- **Attempt:** The current call at `lib/tau/tui/app/events.ex:244–248` emits
+  three metadata fields: `context_pct`, `warn_level`, and `session_id`. All three
+  are computed from `model.session_id`, `model.context_window`, `model.warn_level`,
+  and `message.usage`. The solution assigns all these inputs to
+  `on_message_end_counters/2`. The migration sketch confirms "one driving
+  `on_message_end_counters/2` with a mock session counter and a `:telemetry.attach`
+  handler (no Markdown content)". The event name and metadata schema are unchanged.
+- **Outcome:** Withstood — the integration requirement is satisfiable; all inputs
+  to the telemetry call are assigned to the counters handler's input set.
+- **Action:** None.
+
+---
+
+## Cross-claim consistency
+
+Claims 1 and 3 are in mild tension: Claim 1 asserts "independent testability
+without a cost ETS table" and Claim 3 asserts "structural, not conventional,
+enforcement". Claim 3's partial falsification (narrowed to documentary-structural)
+does not falsify Claim 1 — testability without ETS holds if the sub-handler does
+not *call* `cost_for_session/1`, regardless of whether the compiler *prevents* it.
+A unit test that passes a model without a valid ETS table will surface any
+accidental ETS call as a `test/1` failure (since the `try/rescue` would catch
+`ArgumentError` and return zeros — the test would not crash, but the ETS read
+would not be exercised). This is adequate for criterion (a) under the narrowed
+qualifier.
+
+Claims 3 and 6 are in constructive tension: Claim 6 requires
+`on_message_end_counters/2` to receive `model.session_id` for D-169 compliance,
+which means `on_message_end_transcript/2` could also access it (same model). This
+confirms claim 3's partial falsification — the separation is not compiler-enforced.
+The tension resolves in the narrowed qualifier: documentary-structural separation
+with `@spec` contracts is sufficient for the acceptance criterion; full compiler
+enforcement would require a separate argument type design not proposed here.
+
+No claim pairs are logically contradictory. The set is internally consistent
+under the narrowed qualifiers from claims 1 and 3.
+
+---
+
+## Falsification summary
+
+| # | Claim (short) | Strategy | Outcome | Action |
+|---|---|---|---|---|
+| 1 | Transcript handler testable without ETS | Edge-case enumeration | Partially falsified — qualifier narrowed | Narrow Q: holds if sub-handler does not receive full model with `session_id` |
+| 2 | Counters handler testable without Markdown | Dependency check | Withstood | None |
+| 3 | Enforcement is structural, not conventional | Type-level check | Partially falsified — `@spec` is documentary, not compiler-enforced | Narrow Q: "documentary-structural via `@spec`"; no revision required |
+| 4 | `try/rescue` isolated in helper, not multi-concern function | Dependency check | Withstood | None |
+| 5 | Public APIs and SPEC-TUI-HEADLESS Appendix B unchanged | Counter-example construction | Withstood | None |
+| 6 | D-168/D-169 telemetry schema and `session_id` metadata preserved | Integration check | Withstood | None |
+
+---
+
+## Revision required
+
+Claims 1 and 3 are partially falsified, both narrowed via Qualifier rather than
+by revision. The narrowed forms are:
+
+- **Claim 1 (narrowed Q):** Transcript handler is independently testable without
+  ETS *provided* its argument does not include `session_id` (projected map or
+  explicitly absent). The Migration Sketch should state the argument shape.
+- **Claim 3 (narrowed Q):** The separation is "documentary-structural via `@spec`
+  annotations" rather than "compiler-structural via type exclusion". The solution's
+  own Open Questions section already acknowledges this.
+
+No file revision is needed. The coordinator should ensure the implementer brief
+specifies the projected argument shapes for the two sub-handlers explicitly, so
+that claim 1's stronger structural guarantee can be achieved at implementation time.
+
+---
+
+## Outstanding doubts
+
+- The dispatcher ordering (`on_message_end_transcript/2` before
+  `on_message_end_counters/2`) is not load-bearing today, but is not enforced as
+  such. If a future change makes counters depend on a transcript-produced field,
+  the ordering becomes a hidden coupling with no type-system guard. The solution
+  acknowledges this; no further action required here, but the parent-level
+  validator should note it.
+- `on_message_end_counters/2` still combines ETS read + warn computation +
+  telemetry emit. If a future problem targets warn-level isolation from ETS reads,
+  the solution explicitly defers this to Proposal 2's `StatusBar.maybe_emit/3`
+  approach. The unresolved `session_id` metadata question in Proposal 2 must be
+  answered before that refactor. This is an open design question, not a claim
+  falsification.
+- The `@spec` annotations' field-ownership semantics are not validated by the Elixir
+  compiler at call sites; their effectiveness as an enforcement mechanism depends on
+  code review discipline. If the project's review gate does not check `@spec`
+  compliance on private functions, the documentary separation degrades to a comment.

--- a/docs/problems-archive-v1-modules/tau-tui-app/validation.md
+++ b/docs/problems-archive-v1-modules/tau-tui-app/validation.md
@@ -1,0 +1,584 @@
+---
+template_version: 1
+template_name: validation
+parent_solution: solution.md
+parent_problem: problem.md
+toulmin_complete: true
+falsification_attempted: true
+falsification_outcome: partially_falsified — claim/3
+revision_triggered: none
+---
+
+# Validation: Module-wide decomplecting of `Tau.TUI.App` sub-modules
+
+## Overview
+
+The parent solution synthesises four child solutions into one sequenced
+plan. Per the synthesis brief, this validation does NOT re-litigate each
+child's intra-scope claims (each child has its own validation.md with
+withstood / partially_falsified outcomes already recorded). Instead the
+focus is on the cross-cutting integration claims that only appear at the
+parent level: the prescribed ordering of the four steps, the
+independence (or otherwise) of the four children, the disjointness of
+their primary surfaces, the partial-coverage admission for the
+Permission concern, and whether the conjunction of the four children
+satisfies the parent acceptance criterion. Six claims are enumerated
+below; five withstand falsification (counter-example construction,
+dependency check, integration check) and one (Claim 3 — disjoint
+primary surfaces) is partially falsified, narrowing the qualifier
+without triggering revision.
+
+---
+
+## Toulmin per claim
+
+The MITRE empirical study on Toulmin formalism found that "participants
+found it difficult to generate Toulmin structures, and their structures
+varied greatly even though they started with the same content"
+(https://www.mitre.org/news-insights/publication/empirical-evaluation-structured-argumentation-using-toulmin-argument).
+This template enforces all six components explicitly to counter that
+variance.
+
+---
+
+### Claim 1: The four children compose without internal contradiction; each child's "What does not change" excludes every surface another child modifies.
+
+- **Claim (C):** "No tension between child recommendations. Each child
+  solution's 'What does not change' section explicitly excludes the
+  surfaces the other children modify, and each child's 'What changes'
+  list is internally consistent with every other child's exclusion
+  list."
+- **Grounds (G):** Cross-read of each child's What-does-not-change:
+  duplicated-bounded-append `solution.md:95-96` excludes the other
+  three siblings by name; model-as-bag-of-maps `solution.md:39`
+  identically excludes the other three; session-side-effects-in-pure-modules
+  `solution.md:104` does the same; transcript-coupling
+  `solution.md:74-75` likewise. Each child's primary axis differs:
+  child 1 = helper extraction, child 2 = call syntax, child 3 = return
+  shape + new module, child 4 = single-function body restructure (per
+  the parent's table at `solution.md:46-50`). Live codebase confirms
+  the four axes touch overlapping files (`events.ex`, `input.ex`,
+  `keymap.ex`) but at different concerns: child 1 adds aliases and
+  removes function definitions; child 2 rewrites callsite syntax;
+  child 3 changes return shapes; child 4 reshapes one function body in
+  `events.ex`.
+- **Warrant (W):** Two refactors compose without conflict when their
+  primary write-sets touch different syntactic regions of the same
+  file at different levels of granularity (module-level definition vs.
+  callsite-level syntax vs. function-signature vs. function-body
+  reshape). The Elixir compiler treats these as orthogonal
+  transformations; any unintended interaction surfaces as a compile
+  error or test failure at integration time, not as silent semantic
+  drift.
+- **Qualifier (Q):** Holds for the listed primary surfaces. The
+  parent acknowledges Permission's view-fragment / event-logic /
+  key-routing concern-mix is only partially addressed (parent
+  `solution.md:84-92`, `solution.md:250-257`) — this is acknowledged
+  scope, not a contradiction between siblings.
+- **Rebuttal (R):** Two children edit the same file (`events.ex`) at
+  lines that are syntactically adjacent or even on the same line (live
+  evidence: `events.ex:253` contains both a `Map.put(:transcript, ...)`
+  call — child-2 territory — and a `bounded_append_many(...)` call —
+  child-1 territory — within the same expression). The children's
+  scopes do not contradict each other, but the same line of code is
+  modified by both children. The parent addresses this through
+  sequencing (Claim 2), not through scope disjointness.
+- **Backing (B):** Each child's `solution.md` What-does-not-change
+  section (verbatim references above). Parent solution's composition
+  rationale at `solution.md:42-92`. Live codebase grep at
+  `lib/tau/tui/app/events.ex:253` confirming the adjacency.
+
+#### Falsification attempt for claim 1
+
+- **Strategy:** Counter-example construction — find a surface modified
+  by child A that another child's What-does-not-change list either
+  fails to exclude or explicitly preserves in a contradictory way.
+- **Attempt:** Cross-checked each pair of children:
+  - (1, 2): child 1 modifies `bounded_append/2` definition; child 2
+    explicitly preserves Model's struct shape and `new/1`. No
+    overlap on definitions. They do co-edit lines in `events.ex`
+    (e.g. line 253), but child 2 rewrites `Map.put` syntax while
+    child 1 has already changed `bounded_append` to
+    `Model.bounded_append`. No contradiction in what each preserves.
+  - (1, 3): child 1 touches `Events`/`Input` function definitions;
+    child 3 changes `Input` public function return shapes. Child 1
+    preserves bodies exactly; child 3 changes signatures and bodies.
+    No contradiction in preservation lists.
+  - (1, 4): child 4 reshapes only `Events.on_message_end/2`; child 1
+    adds/removes `bounded_append` definitions. `on_message_end/2`
+    calls `bounded_append_many` at line 253, but child 1's call-
+    rewrite is done before child 4's body-reshape (per sequencing).
+  - (2, 3): child 2 rewrites `Map.get/put` callsite syntax in
+    `Input`; child 3 rewrites `Input` function return shapes. Co-edit
+    same files at different syntactic levels.
+  - (2, 4): child 2 rewrites `Map.get/put` in `Events`; child 4
+    reshapes `on_message_end/2` body. After child 2, the body uses
+    struct syntax; child 4 then splits it.
+  - (3, 4): child 3 touches `Input`/`Keymap` return shapes; child 4
+    touches `Events.on_message_end/2`. No overlap.
+  No contradictory preservation claim found.
+- **Outcome:** Withstood.
+- **Action:** None.
+
+---
+
+### Claim 2: The ordering (1) → (2) → (3) → (4) is the only sequencing that avoids inter-step rework.
+
+- **Claim (C):** "(1) → (2) → (3) → (4) is the only ordering that
+  avoids inter-step rework."
+- **Grounds (G):** Parent solution at `solution.md:62-76` enumerates
+  the inter-step constraints: (1) before (2) because `bounded_append`
+  callsites at `events.ex:69,253,284,296,390` and `input.ex:41,103,
+  145,174` (verified by grep) are inside the same function bodies
+  that child 2 rewrites for `Map.get/put`; (2) before (3) because
+  child 3's new return-shape authoring is easier against struct-typed
+  models; (2) before (4) for the same reason; (3) and (4) independent
+  of each other. The adjacency is concrete: `events.ex:253` —
+  `|> Map.put(:transcript, bounded_append_many(model.transcript, ...))`
+  — has both child-1 and child-2 edits on one line.
+- **Warrant (W):** When two edits modify the same line of code, the
+  later edit must be authored against the post-image of the earlier
+  edit, otherwise the second author is rewriting a line that is about
+  to change shape (wasted work and merge surface). When the later edit
+  is easier to author against a cleaner substrate (e.g. struct syntax
+  vs. `Map.get/put`), the rework is also strictly larger if reversed.
+  This is a refactoring-sequencing principle, not an absolute rule.
+- **Qualifier (Q):** Holds for the four-step plan as specified.
+  "Only ordering" is the strongest form of the claim and requires
+  that no permutation other than (1)(2)(3)(4) [or (1)(2)(4)(3),
+  since 3 and 4 are independent] avoids rework. Weaker permutations
+  exist with quantifiable rework cost.
+- **Rebuttal (R):** "Only" is overstated. The parent itself notes (3)
+  and (4) are independent of each other (parent `solution.md:74-76`),
+  so there are at least two valid orderings: (1)(2)(3)(4) and
+  (1)(2)(4)(3). The parent's "(3) before (4) is preferred because
+  (3)'s scope is broader and its merge risk against `main` is higher"
+  is a preference, not a necessity. The Qualifier should narrow
+  "only" to "the only orderings (1)(2)(3)(4) or (1)(2)(4)(3)".
+- **Backing (B):** Live codebase confirmation of the adjacency at
+  `events.ex:253` and the multi-line `Map.put` chain at
+  `events.ex:252-257` (a chain of six `Map.put` calls, one of which
+  embeds `bounded_append_many`). Each child solution's own migration
+  sketch implicitly assumes the substrate state the parent's ordering
+  produces.
+
+#### Falsification attempt for claim 2
+
+- **Strategy:** Counter-example construction — attempt to construct
+  a non-(1)(2)(3)(4) / non-(1)(2)(4)(3) ordering that produces zero
+  rework, or construct a (1)(2)(3)(4)-permutation that produces
+  unbounded rework.
+- **Attempt:** Considered (2) → (1): child 2 would rewrite
+  `Map.put(:transcript, bounded_append_many(...))` at `events.ex:253`
+  to `%{model | transcript: bounded_append_many(...)}`; child 1 then
+  rewrites the inner call to `Model.bounded_append_many(...)`. This
+  is one extra edit on a line already touched by child 2 — small but
+  non-zero rework. Considered (3) → (2): child 3 would rewrite
+  `Input.submit/1` return shape while it still uses `Map.get/put`;
+  child 2 would then rewrite the same lines that child 3 just
+  authored. The rework is real but bounded. Considered (4) → (2):
+  child 4 splits `on_message_end/2` body while it still uses
+  `Map.get/put`; child 2 then rewrites those lines inside the now-
+  split handlers. Bounded rework. No permutation other than
+  (1)(2)(3)(4) or (1)(2)(4)(3) avoids all rework, but the rework
+  in alternative permutations is bounded and survivable. The claim's
+  "only" is correct in the strict sense (avoids ALL inter-step
+  rework); permutation orderings are merely more expensive, not
+  impossible.
+- **Outcome:** Withstood (interpreting "only" as "only zero-rework").
+  Qualifier slightly narrowed: there are two zero-rework orderings
+  ((1)(2)(3)(4) and (1)(2)(4)(3)), not one.
+- **Action:** Narrow Qualifier in place; no revision.
+
+---
+
+### Claim 3: The four children's primary file boundaries are orthogonal (Model API; callsite syntax; Input/Keymap return shape; one Events function body).
+
+- **Claim (C):** "The four steps compose without conflict because
+  their primary file boundaries are orthogonal (Model API; callsite
+  syntax; Input/Keymap return shape; one Events function body)."
+- **Grounds (G):** Parent solution table at `solution.md:46-50`
+  lists the four axes. Live codebase confirms the surfaces touched:
+  child 1 touches `Model` (additions) and removes definitions from
+  `Events`/`Input`; child 2 touches `Map.get/put` callsite syntax
+  across six files (`events.ex`, `view.ex`, `keymap.ex`,
+  `permission.ex`, `input.ex`, and audits `completion.ex`/
+  `history.ex`); child 3 touches `Input` and `Keymap` function
+  return shapes and creates `Cmd`; child 4 touches one function body
+  inside `events.ex`.
+- **Warrant (W):** Two refactors with orthogonal primary surfaces
+  can be applied in either order without cross-interference at the
+  primary surface, even if they secondarily touch the same files.
+  Sequencing (Claim 2) handles the secondary co-touches.
+- **Qualifier (Q):** Holds at the primary-axis level. Does NOT
+  hold for secondary file touches (the children share `events.ex`,
+  `input.ex`, and `keymap.ex` at the file level even though their
+  primary axes differ). The orthogonality is conceptual, not
+  file-disjoint.
+- **Rebuttal (R):** Child 3's signature change to
+  `Keymap.handle_event/2` has a cross-file consumer at
+  `events.ex:35` (verified by grep: `Keymap.handle_event(model,
+  event)` is the sole external call from `events.ex` into
+  `keymap.ex`). The parent's What-changes list for child 3 mentions
+  only the façade `app.ex` gaining `run_input/2`; it does NOT
+  mention `events.ex:35` needing a destructure update. This is a
+  real integration gap inherited from child 3's validation
+  (Outstanding doubt 1 of session-side-effects-in-pure-modules
+  `validation.md:376-380`). The implementer will discover it at
+  compile time, but the parent solution does not call it out.
+- **Backing (B):** Live grep `events.ex:35`: `Keymap.handle_event(
+  model, event)`. Child 3's validation Outstanding doubt 1 names
+  this gap.
+
+#### Falsification attempt for claim 3
+
+- **Strategy:** Integration check — verify that the parent's What-
+  changes list covers every callsite affected by the children's
+  signature changes.
+- **Attempt:** Grepped for callers of `Keymap.handle_event/2` and
+  `Input.*` public functions. `Keymap.handle_event/2` is called from
+  `events.ex:35` and nowhere else (grep result). After child 3,
+  `Keymap.handle_event/2` returns `{model, [Cmd.t()]}`; the caller
+  at `events.ex:35` currently uses the return value as `model`
+  directly. The parent's What-changes for `events.ex` (lines
+  110-132) does NOT mention destructuring `Keymap.handle_event/2`'s
+  return value at line 35. It only covers child 1 (`bounded_append`
+  removal), child 2 (`Map.get/put` rewrites), and child 4
+  (`on_message_end/2` split). The integration point at
+  `events.ex:35` is unlisted. The omission is a falsifying case for
+  the "primary file boundaries are orthogonal" claim — `events.ex`
+  is in BOTH child 3's secondary callsite set AND child 4's primary
+  axis, AND child 1's removal set, AND child 2's rewrite set. The
+  parent solution's plan covers (1)(2)(4) for `events.ex` but
+  omits (3)'s ripple into `events.ex:35`.
+- **Outcome:** Partially falsified — primary axes are conceptually
+  orthogonal, but child 3's ripple into `events.ex:35` is unlisted
+  in the parent's What-changes for `events.ex`. The Qualifier must
+  narrow: "primary axes are orthogonal; child 3's `Keymap.handle_
+  event/2` signature change requires a one-line destructure update
+  at `events.ex:35` that is not enumerated in the parent's What-
+  changes list."
+- **Action:** Narrow Qualifier in place. No solution revision
+  required because (a) it is a compile-time error, not a silent
+  regression; (b) the fix is mechanical (destructure `{model,
+  cmds}` and dispatch via `Cmd.execute/1`); (c) the implementer
+  brief should explicitly name `events.ex:35` as in-scope for
+  child 3 to prevent the omission persisting into implementation.
+
+---
+
+### Claim 4: Each step preserves observable behaviour at the `Tau.TUI.App` public interface, so each PR is independently revertible and gateable.
+
+- **Claim (C):** "Each PR is independently revertible because each
+  preserves observable behaviour." (parent `solution.md:213-214`,
+  `solution.md:243-246`).
+- **Grounds (G):** Each child's validation confirms preservation:
+  duplicated-bounded-append `validation.md:201-232` (Claim 5 —
+  function bodies preserved exactly, withstood); model-as-bag-of-
+  maps `validation.md:271-307` (Claim 7 — Model fields, Cost,
+  StatusBar unchanged, withstood); session-side-effects-in-pure-
+  modules `validation.md:270-330` (Claim 5 — Model.t() fields,
+  Tau.* API, siblings unaffected, withstood); transcript-coupling
+  `validation.md:298-341` (Claims 5 and 6 — public APIs and D-168/
+  D-169 telemetry schema preserved, both withstood).
+- **Warrant (W):** A refactor that preserves observable behaviour
+  at every public callsite is by definition revertible — the post-
+  refactor state and pre-refactor state are observationally
+  equivalent, so reverting any PR returns to a known-good state
+  from the perspective of external callers. Each PR being
+  observationally equivalent at the public boundary also means
+  each PR can be gated independently against the existing
+  integration test suite.
+- **Qualifier (Q):** Holds when "observable behaviour" is scoped
+  to the `Tau.TUI.App` public interface. Internal observability
+  (e.g. private helper invocation patterns visible in process
+  traces) is not preserved — child 1 changes the module that owns
+  `bounded_append`, child 3 changes return shapes of `Input`/
+  `Keymap` private callers. These are not part of the public
+  interface but are observable to a code reader.
+- **Rebuttal (R):** Child 3's narrowed Qualifier (validation Claim
+  4) notes that `Store.append/3` remains inside `Input.submit/1`;
+  a test that wants pure functional testing requires either a temp
+  dir or a Store stub. This is a residual side effect that pre-
+  exists the refactor, not a regression — but the parent's claim
+  that "all four child changes preserve observable behaviour at
+  the `Tau.TUI.App` public interface" depends on `Store.append/3`
+  behaviour being unchanged, which the child's validation confirms.
+- **Backing (B):** Each child's validation Toulmin entries (cited
+  above). Live evidence: no child modifies `Tau.TUI.App`'s public
+  callbacks (Ratatouille `update/2`, `render/1`, `subscribe/1`);
+  the façade gains only one private helper (`run_input/2`).
+
+#### Falsification attempt for claim 4
+
+- **Strategy:** Dependency check — verify no child silently
+  changes a public callback or a documented telemetry schema.
+- **Attempt:** Checked each child's What-changes against the
+  parent's What-does-not-change list (parent `solution.md:189-209`):
+  Ratatouille callbacks unchanged (no child modifies `update/2`
+  or `render/1`); telemetry schema `[:tau, :tui, :status, :update]`
+  preserved (child 4 explicitly preserves D-168/D-169 — confirmed
+  in its validation Claim 6); `Cost.for_session/1` and the
+  `try/rescue` site unchanged (child 4 explicit); `Tau.*` /
+  `Tau.Session.*` API surface unchanged (child 3 explicit);
+  `Model.t()` struct shape unchanged (children 1 and 2 explicit).
+  No counter-case found. Independence of PRs requires that PR1
+  not depend on PR2's state; verified — PR1 (child 1) only adds
+  to `Model` and rewrites callsites in `Events`/`Input` to use
+  the new Model function; it does not depend on any later step's
+  output.
+- **Outcome:** Withstood.
+- **Action:** None.
+
+---
+
+### Claim 5: The conjunction of the four children advances the acceptance criterion to the extent claimed (each sub-problem solvable to a concrete proposal; module-wide decomplecting achieved at the listed axes).
+
+- **Claim (C):** The parent acceptance criterion is "each sub-problem
+  is described at sufficient resolution that a proposer can produce
+  a concrete, independently-evaluable refactoring proposal without
+  needing to re-read sibling sub-problems" (problem `:90-93`). The
+  parent solution claims to advance this by delivering four concrete
+  proposals, each solving its named axis, sequenced into one coherent
+  plan.
+- **Grounds (G):** Four child `solution.md` files exist
+  (`subproblems/*/solution.md`); each has a validated `validation.md`
+  with falsification outcomes (3 partially_falsified, 1 partially_
+  falsified — none falsified outright; all withstood under narrowed
+  qualifiers). Each child names a concrete artefact: child 1 — three
+  function definitions moved; child 2 — callsite syntax across six
+  files plus one accessor; child 3 — new `Cmd` module + return shape
+  change; child 4 — one function split into three. The parent's
+  composition table at `solution.md:46-50` shows orthogonal primary
+  axes.
+- **Warrant (W):** The acceptance criterion is about *description
+  resolution*, not implementation completeness. Four independently
+  evaluable proposals, each producing a concrete What-changes list
+  with file:line citations, satisfies "sufficient resolution that a
+  proposer can produce a concrete, independently-evaluable refactoring
+  proposal". Conjunction of four concrete proposals is itself a
+  concrete plan.
+- **Qualifier (Q):** Holds for the four children listed in the parent
+  solution. Does NOT hold for the Permission concern named in
+  problem.md but substituted-out by the decomposer. Parent solution
+  acknowledges this at `solution.md:84-92`: "the decomposer produced
+  four sub-problems but substituted `transcript-coupling` for the
+  listed `permission-module-concern-mix`. … The Permission concern-
+  mix is therefore *partially* addressed by this synthesis."
+- **Rebuttal (R):** A strict reading of `problem.md`'s acceptance
+  criterion against the listed four sub-problems (problem `:76-87`
+  enumerates `duplicated-bounded-append`, `model-as-bag-of-maps`,
+  `session-side-effects-in-pure-modules`, `transcript-coupling`)
+  matches the four children synthesised. But `problem.md`'s
+  Complecting hypothesis (point 3, `:53-56`) and Decomposition
+  strategy (`:65-67`) both name the Permission module's concern-mix
+  as one of the four inherited concerns. The decomposer's
+  substitution is acknowledged but not justified. A reviewer could
+  fairly argue that the acceptance criterion is met *for the four
+  enumerated sub-problems* but not *for the four inherited concerns
+  in the hypothesis*. The parent's open question 1 routes this to a
+  follow-up sub-problem rather than blocking.
+- **Backing (B):** Each child's `validation.md` (cited above).
+  `problem.md` acceptance criterion at lines 90-93. Parent
+  acknowledgement at `solution.md:84-92` and Open question 1 at
+  `solution.md:250-257`.
+
+#### Falsification attempt for claim 5
+
+- **Strategy:** Dependency check — verify that each child's
+  solution.md is concrete enough that an implementer could begin
+  work without re-reading sibling problems.
+- **Attempt:** Each child's solution.md has a What-changes section
+  with explicit `file:line` references (verified in all four).
+  Each has a Migration sketch with step-by-step ordering. Each has
+  Open questions section flagging implementer risks. The
+  acceptance criterion does not require the four children to
+  cover the original four inherited concerns; it requires they be
+  described at sufficient resolution. The substituted child
+  (transcript-coupling) is itself well-resolved. The strict-reading
+  rebuttal above is a scope question, not a resolution-quality
+  question.
+- **Outcome:** Withstood for the four enumerated sub-problems.
+  Partially open for the substituted-out Permission concern, but
+  the parent explicitly defers it ("a follow-up sub-problem
+  should decompose `Permission`…") and the acceptance criterion as
+  written ("each sub-problem" — i.e. those enumerated) is met.
+- **Action:** None. The deferral is documented; the implementer
+  brief should preserve the Open Questions section so the
+  follow-up surfaces in the next planning cycle.
+
+---
+
+### Claim 6: The plan satisfies OTP non-negotiables (no new GenServer-wrapped stateless logic; no `try/rescue` across process boundaries introduced; supervised processes for stateful subsystems).
+
+- **Claim (C):** Implicit across the parent solution and inherited
+  from each child's preservation list — the refactor does not
+  introduce OTP non-negotiable violations. The one residual concern
+  (parent open question 3, `solution.md:262-265`) is the `spawn/1`
+  in `Cmd.execute/1` for `:stop_tui_supervisor`.
+- **Grounds (G):** Parent's What-does-not-change (`solution.md:189-
+  209`) preserves the `try/rescue` in `cost_for_session/1`
+  (the only `try/rescue` site, per child 4 validation Claim 4 —
+  confirmed by grep at `events.ex:262-269`). No new GenServer is
+  introduced (parent solution adds one new module, `Cmd`, which is
+  a pure dispatch helper with no state). The `spawn/1` for
+  `:stop_tui_supervisor` is lifted from inline (`keymap.ex:288`)
+  into one named location (`do_stop_tui_supervisor/0`) called only
+  from `Cmd.execute/1`.
+- **Warrant (W):** OTP non-negotiable #3 forbids wrapping stateless
+  logic in a GenServer. `Cmd` is pure; it has no state. OTP non-
+  negotiable #7 ("let it crash; supervise; restart") forbids
+  `try/rescue` across process boundaries; the preserved
+  `try/rescue` in `cost_for_session/1` is in-process (catches
+  `ArgumentError` from local ETS access), not cross-process. OTP
+  non-negotiable #1 requires stateful subsystems under supervisors;
+  the `:stop_tui_supervisor` spawn is fire-and-forget shutdown of
+  an existing supervised subsystem, not new state.
+- **Qualifier (Q):** Holds as specified. The `spawn/1` in
+  `Cmd.execute/1` is a known residual (open question 3); the
+  parent solution requires the implementation PR to document the
+  justification at the call site.
+- **Rebuttal (R):** Child 3's validation Outstanding doubt 2
+  raises the same concern. If a reviewer reads OTP non-negotiable
+  #1 strictly ("Every stateful subsystem MUST run as supervised
+  processes"), an unsupervised `spawn/1` for any purpose is
+  borderline. The justification (fire-and-forget shutdown, must
+  be async to avoid blocking the TUI event loop) is valid but
+  must be explicit.
+- **Backing (B):** `.claude/rules/otp-non-negotiables.md` (rules
+  1, 3, 7). Child 4 validation Claim 4 (try/rescue site
+  preserved). Child 3 validation Outstanding doubt 2 (spawn
+  justification required).
+
+#### Falsification attempt for claim 6
+
+- **Strategy:** Dependency check — verify that no child introduces
+  a new GenServer wrapping stateless logic, and that the
+  preserved `try/rescue` is genuinely in-process.
+- **Attempt:** Parent's "New files" list (`solution.md:98-102`)
+  introduces only `Tau.TUI.App.Cmd` — a pure dispatch module with
+  `Cmd.t()` tagged union and `execute/1`. No `use GenServer`, no
+  `start_link`, no `init/1`. The preserved `try/rescue` at
+  `events.ex:262-269` catches `ArgumentError` from local
+  `Tau.Cost.for_session/1` — an ETS read in the same process, not
+  across a process boundary. The `spawn/1` for
+  `:stop_tui_supervisor` is the one borderline case, but it is
+  shutdown-of-supervisor logic, not new stateful work. No
+  falsifying case found.
+- **Outcome:** Withstood, with the documented residual that the
+  implementation PR must include the `spawn/1` justification
+  comment per the open question.
+- **Action:** None. Open question 3 in the parent solution
+  already captures the residual.
+
+---
+
+## Cross-claim consistency
+
+Claims 1-6 are internally consistent. Claims 1 (independent
+preservation lists) and 3 (orthogonal primary axes) are
+mutually reinforcing; Claim 3's partial falsification (the
+`events.ex:35` ripple) tightens but does not undermine Claim 1.
+Claim 2 (sequencing) is the operational consequence of Claims 1
+and 3 — orthogonal axes that nonetheless co-touch files require
+sequencing to avoid rework. Claim 4 (revertibility) depends on
+Claims 1-3 holding; with their narrowed qualifiers, Claim 4
+holds at the public-interface level. Claim 5 (acceptance
+criterion satisfaction) is acknowledged-partial for the
+Permission concern but withstood for the four enumerated
+sub-problems; the parent's deferral is a scope choice, not a
+contradiction. Claim 6 (OTP compliance) is orthogonal to the
+others and withstands.
+
+One area where the children's narrowed qualifiers propagate up:
+child 3's `Store.append/3` residual (its validation Claim 4
+partial falsification) and child 4's `@spec` documentary-vs-
+compiler-structural narrowing (its validation Claim 3 partial
+falsification) both surface in the parent's Open Questions
+section but are NOT lifted into the parent's claim Qualifiers
+above. They are noted as Outstanding doubts below for the
+implementer brief.
+
+---
+
+## Falsification summary
+
+| # | Claim (short) | Strategy | Outcome | Action |
+|---|---|---|---|---|
+| 1 | Children's preservation lists do not contradict | Counter-example construction | Withstood | None |
+| 2 | (1)(2)(3)(4) ordering avoids inter-step rework | Counter-example construction | Withstood (Q narrowed: also (1)(2)(4)(3)) | Narrow Q in place |
+| 3 | Primary file boundaries are orthogonal | Integration check | Partially falsified — `events.ex:35` ripple unlisted | Narrow Q in place; brief implementer to include `events.ex:35` in child 3 scope |
+| 4 | Each PR preserves observable behaviour, independently revertible | Dependency check | Withstood | None |
+| 5 | Conjunction satisfies acceptance criterion for the four enumerated sub-problems | Dependency check | Withstood (Permission concern explicitly deferred) | Follow-up sub-problem for Permission |
+| 6 | No OTP non-negotiable violation introduced | Dependency check | Withstood (residual spawn justification required) | Implementer PR comments justify `spawn/1` in `Cmd.execute/1` |
+
+---
+
+## Revision required
+
+No revision triggered. Claims 2 and 3 are partially falsified;
+both narrowed via Qualifier in place. The narrowed forms remain
+faithful to the parent solution's intent and do not require
+edits to either `solution.md` or `problem.md`.
+
+The Claim 3 narrowing has an actionable implementer-brief
+consequence: the implementer brief for PR3 (child 3) must
+explicitly list `lib/tau/tui/app/events.ex:35` as a callsite
+requiring a destructure update for `Keymap.handle_event/2`'s
+new return shape. Without this, the implementer will discover
+it as a compile error and may handle it ad hoc.
+
+---
+
+## Outstanding doubts
+
+1. **`events.ex:35` destructure (Claim 3 fallout).** Parent
+   What-changes for `events.ex` omits the line-35 destructure
+   update required by child 3's signature change to
+   `Keymap.handle_event/2`. Mechanical fix at compile time, but
+   the implementer brief should pre-name it.
+
+2. **Permission concern-mix deferral (Claim 5 acknowledged
+   gap).** Parent solution defers the `Permission` view-
+   fragment / event-logic / key-routing concern named in
+   problem.md to a follow-up sub-problem. The follow-up must
+   actually be filed; otherwise the original four-concern
+   problem statement is silently reduced to three concerns
+   addressed plus one shelved.
+
+3. **`Store.append/3` in `Input.submit/1` (child 3 validation
+   Claim 4 partial falsification).** Disk I/O remains inline
+   in `Input.submit/1` after the command-pattern refactor. The
+   parent's open question 2 confirms this is deferred. Tests of
+   `submit/1` require either a temp dir or a Store stub.
+
+4. **`@spec` is documentary, not compiler-structural (child 4
+   validation Claim 3 partial falsification).** The two new
+   `Events` handlers' field-ownership is enforced by code
+   review against `@spec` annotations, not by the type system.
+   A future author can re-couple them silently. Parent solution
+   open question (`solution.md:276-278`) acknowledges this.
+
+5. **Test fixture risk (child 2 validation Outstanding doubt 2).**
+   `app_test.exs:22-39` constructs a bare-map fixture missing
+   several mandatory fields; after the struct-access conversion
+   in PR2, this fixture will raise `BadMapError`. The fixture
+   must be converted to `Model.new/1` or a `%Model{...}`
+   literal as part of PR2.
+
+6. **`spawn/1` in `Cmd.execute/1` for `:stop_tui_supervisor`
+   (Claim 6 residual, child 3 validation Outstanding doubt 2).**
+   Implementation PR must document the justification (fire-and-
+   forget shutdown, must be async to avoid blocking the TUI
+   event loop) at the call site, with reference to OTP non-
+   negotiable #1.
+
+7. **`Keymap` private call chain cascade (child 3 validation
+   Outstanding doubt 3).** Child 3's `{model, cmds}` propagation
+   requires changing `handle_event_normal/2`, `handle_char/2`
+   (and possibly `handle_key/3`, `handle_readline_key`) return
+   types from `map()` to `{map(), [Cmd.t()]}`. The parent's
+   migration sketch step 3 mentions "propagate through
+   `handle/2`" but does not enumerate the private chain. The
+   implementer brief for PR3 should include a grep-trace of
+   `keymap.ex` private call graph.


### PR DESCRIPTION
Commits the pre-existing factory-v2 audit artifacts (per coordinator/user decision): the audit `PLAN.md` + `corrective-actions/` backlog (the failure-class catalogue the M10 gates must close, referenced by epic #416 and the SUPERSEDED note in #426), `docs/problems-archive-v1-modules/`, and the project config that enabled this work (`.gitignore` marks the audit machinery local-only; `.claude/settings.json` enables the smug-shaper/smug-otp plugins). `.code_audit/` is intentionally left local. Docs/config only. Refs #416.

🤖 Generated with [Claude Code](https://claude.com/claude-code)