### PR TITLE
feat(factory): P0 — extract pure Gate.* modules

### DIFF
--- a/lib/mix/gate/ac_linkage.ex
+++ b/lib/mix/gate/ac_linkage.ex
@@ -1,13 +1,10 @@
 defmodule Mix.Gate.AcLinkage do
   @moduledoc """
-  Gate 5.1 — AC-to-test linkage.
+  Gate 5.1 — AC-to-test linkage (Mix shim).
 
-  Parses every `AC-N` / `D-NNN` token from the `## Acceptance criteria`
-  section of the draft-PR body and returns the subset not found (as a test
-  name substring or `@tag`) in any of the supplied gating-test source strings.
-  Tokens cited only outside that section (e.g. in a Background section) are
-  background prose and are NOT checked. If no `## Acceptance criteria` heading
-  exists in the PR body, the claims region is empty and `:ok` is returned.
+  Thin shim over `Tau.Factory.Gate.AcLinkage`. Parses raw gating-test source
+  strings into `TestMeta` maps (`%{name:, tags:}`) and delegates the decision
+  logic to the pure module. No decision logic lives here.
 
   ## Meta-AC exemption
 
@@ -17,6 +14,8 @@ defmodule Mix.Gate.AcLinkage do
   are never reported as missing.
   """
 
+  alias Tau.Factory.Gate.AcLinkage, as: PureAcLinkage
+
   @doc """
   Returns `:ok` when every `AC-N` / `D-NNN` token in the `## Acceptance
   criteria` section of `pr_body` appears in at least one of
@@ -24,84 +23,75 @@ defmodule Mix.Gate.AcLinkage do
 
   Token format: `AC-N` (one or more digits) and `D-NNN` (one or more digits).
   Matching is case-insensitive on the tag side (`:ac_1`, `:d_200`) and
-  substring on the test-name side (`"AC-1: ..."`, `"D-200: ..."`).
+  boundary-match on the test-name side (`"AC-1: ..."`, `"D-200: ..."`).
   """
   @spec ac_linkage(String.t(), [String.t()]) :: :ok | {:error, [String.t()]}
   def ac_linkage(pr_body, gating_test_sources)
       when is_binary(pr_body) and is_list(gating_test_sources) do
-    ac_section = extract_acceptance_criteria_section(pr_body)
-    meta_acs = parse_meta_ac_tokens(ac_section)
-    claimed = parse_ac_tokens(ac_section)
-    non_meta = Enum.reject(claimed, &MapSet.member?(meta_acs, &1))
-    missing = Enum.reject(non_meta, &token_covered?(&1, gating_test_sources))
+    gating_tests = Enum.flat_map(gating_test_sources, &parse_test_metas/1)
 
-    case missing do
-      [] -> :ok
-      _ -> {:error, missing}
+    case PureAcLinkage.check(pr_body, gating_tests) do
+      {:pass, []} -> :ok
+      {:fail, missing} -> {:error, missing}
     end
   end
 
-  # Extract the content of the "## Acceptance criteria" section from the PR body.
-  # Starts after the heading whose text (stripped of leading #, trimmed, downcased)
-  # begins with "acceptance criteria". Ends at the next markdown heading or EOF.
-  # Returns "" if no such heading is found.
-  defp extract_acceptance_criteria_section(pr_body) do
-    lines = String.split(pr_body, "\n")
-    heading_pattern = ~r/^[#]{1,6}\s/
+  # ---------------------------------------------------------------------------
+  # Source-string → TestMeta parser
+  # ---------------------------------------------------------------------------
 
-    ac_heading_idx =
-      Enum.find_index(lines, fn line ->
-        stripped = line |> String.replace(~r/^#+\s*/, "") |> String.trim() |> String.downcase()
+  # Parse a gating-test source string into a list of TestMeta maps.
+  # Extracts test names (from `test "..."` and `property "..."` lines) and
+  # @tag atoms (from `@tag :atom` and `@tag atom: value` lines).
+  defp parse_test_metas(source) when is_binary(source) do
+    lines = String.split(source, "\n")
+    extract_test_metas(lines, [], [])
+  end
 
-        String.starts_with?(stripped, "acceptance criteria") and
-          String.match?(line, heading_pattern)
-      end)
+  # Walk lines accumulating @tags, emitting a TestMeta when a test/property line is found.
+  defp extract_test_metas([], _pending_tags, acc), do: acc
 
-    case ac_heading_idx do
-      nil ->
-        ""
+  defp extract_test_metas([line | rest], pending_tags, acc) do
+    trimmed = String.trim(line)
 
-      idx ->
-        lines
-        |> Enum.drop(idx + 1)
-        |> Enum.take_while(&(not String.match?(&1, heading_pattern)))
-        |> Enum.join("\n")
+    cond do
+      # @tag :atom or @tag atom_name (bare atom)
+      String.starts_with?(trimmed, "@tag :") ->
+        tag_str = trimmed |> String.replace_prefix("@tag :", "") |> String.trim()
+        tag = String.to_atom(tag_str)
+        extract_test_metas(rest, [tag | pending_tags], acc)
+
+      # @tag key: value — extract the key as a tag
+      Regex.match?(~r/^@tag\s+[a-z_][a-z_0-9]*:/, trimmed) ->
+        case Regex.run(~r/^@tag\s+([a-z_][a-z_0-9]*):/, trimmed) do
+          [_, key] ->
+            tag = String.to_atom(key)
+            extract_test_metas(rest, [tag | pending_tags], acc)
+
+          _ ->
+            extract_test_metas(rest, pending_tags, acc)
+        end
+
+      # @moduletag :atom
+      String.starts_with?(trimmed, "@moduletag :") ->
+        tag_str = trimmed |> String.replace_prefix("@moduletag :", "") |> String.trim()
+        tag = String.to_atom(tag_str)
+        extract_test_metas(rest, [tag | pending_tags], acc)
+
+      # test "name" or property "name"
+      Regex.match?(~r/^(test|property)\s+"/, trimmed) ->
+        case Regex.run(~r/^(?:test|property)\s+"([^"]*)"/, trimmed) do
+          [_, name] ->
+            meta = %{name: name, tags: pending_tags}
+            # Reset pending tags after emitting a test (tags accumulate per test).
+            extract_test_metas(rest, [], [meta | acc])
+
+          _ ->
+            extract_test_metas(rest, [], acc)
+        end
+
+      true ->
+        extract_test_metas(rest, pending_tags, acc)
     end
-  end
-
-  # Parse AC-N tokens marked as meta (exempt from the linkage gate).
-  # An AC is meta if ANY occurrence in the section text is immediately followed
-  # by "(meta)" (optionally with surrounding ** bold markers and optional
-  # whitespace between the token and the marker).
-  defp parse_meta_ac_tokens(section_text) do
-    meta_pattern = ~r/\bAC-(\d+)\s*\(meta\)/
-
-    Regex.scan(meta_pattern, section_text, capture: :all_but_first)
-    |> List.flatten()
-    |> Enum.map(&"AC-#{&1}")
-    |> MapSet.new()
-  end
-
-  # Parse all AC-N and D-NNN tokens from the given text.
-  defp parse_ac_tokens(section_text) do
-    ac_pattern = ~r/\bAC-\d+\b/
-    d_pattern = ~r/\bD-\d+\b/
-
-    ac_tokens = Regex.scan(ac_pattern, section_text) |> List.flatten()
-    d_tokens = Regex.scan(d_pattern, section_text) |> List.flatten()
-
-    (ac_tokens ++ d_tokens) |> Enum.uniq()
-  end
-
-  # Check if a token (e.g. "AC-1" or "D-200") is covered in any source.
-  # Normalises to tag form: "AC-1" -> "ac_1", "D-200" -> "d_200".
-  defp token_covered?(token, sources) do
-    tag_form = token |> String.downcase() |> String.replace("-", "_")
-
-    Enum.any?(sources, fn source ->
-      String.contains?(source, ":#{tag_form}") or
-        String.contains?(source, "\"#{token}") or
-        String.contains?(source, "\"#{tag_form}")
-    end)
   end
 end

--- a/lib/mix/gate/masking.ex
+++ b/lib/mix/gate/masking.ex
@@ -1,14 +1,16 @@
 defmodule Mix.Gate.Masking do
   @moduledoc """
-  Gate 5.2 — Masking detection.
+  Gate 5.2 — Masking detection (Mix shim).
 
-  Scans a unified diff for removed assertion lines. Detection-only: returns
-  the list for the `critic` to review. A removed assertion is a `-`-prefixed
-  line (not `---` file header) whose content contains `assert`, `refute`,
-  `assert_receive`, or `assert_raise`.
+  Thin shim over `Tau.Factory.Gate.Masking`. Adapts the pure module's
+  `{:clean | :flagged, findings}` output to the legacy list-of-maps format
+  consumed by `Mix.Tasks.Tau.Gate.Masking`.
+
+  No decision logic lives here — all scanning is delegated to
+  `Tau.Factory.Gate.Masking.scan/2`.
   """
 
-  @assertion_keywords ~w[assert refute assert_receive assert_raise]
+  alias Tau.Factory.Gate.Masking, as: PureMasking
 
   @doc """
   Scans `unified_diff` for removed assertion lines.
@@ -17,59 +19,27 @@ defmodule Mix.Gate.Masking do
   `file` is the path from the `+++ b/` diff header. `line` is the original-file
   line number (parsed from `@@ -L,N` hunks). `removed` is the raw content of the
   `-` line (without the leading `-`).
+
+  Note: this shim passes an empty gating-path set (the Mix CLI receives the
+  gating paths separately via `mix tau.gate.masking`; path-violation detection
+  with a declared set is handled by the pure module when invoked directly with
+  those paths).
   """
   @spec masking_violations(String.t()) :: [
           %{file: String.t(), line: integer(), removed: String.t()}
         ]
   def masking_violations(unified_diff) when is_binary(unified_diff) do
-    lines = String.split(unified_diff, "\n")
-    parse_diff_lines(lines, nil, 0, [])
-  end
+    {_status, findings} = PureMasking.scan(unified_diff, MapSet.new())
 
-  # State machine over diff lines.
-  # current_file — path of the file being diffed (nil until first "+++ b/").
-  # orig_line    — current original-file line counter (reset per hunk).
-  defp parse_diff_lines([], _file, _orig_line, acc), do: Enum.reverse(acc)
-
-  defp parse_diff_lines([h | t], current_file, orig_line, acc) do
-    cond do
-      String.starts_with?(h, "+++ b/") ->
-        file = String.slice(h, 6..-1//1)
-        parse_diff_lines(t, file, orig_line, acc)
-
-      String.starts_with?(h, "@@") ->
-        orig = parse_hunk_orig_line(h)
-        parse_diff_lines(t, current_file, orig, acc)
-
-      String.starts_with?(h, "-") and not String.starts_with?(h, "---") ->
-        content = String.slice(h, 1..-1//1)
-
-        acc2 =
-          if assertion_line?(content) do
-            [%{file: current_file, line: orig_line, removed: content} | acc]
-          else
-            acc
-          end
-
-        parse_diff_lines(t, current_file, orig_line + 1, acc2)
-
-      String.starts_with?(h, "+") and not String.starts_with?(h, "+++") ->
-        parse_diff_lines(t, current_file, orig_line, acc)
-
-      true ->
-        parse_diff_lines(t, current_file, orig_line + 1, acc)
-    end
-  end
-
-  defp assertion_line?(content) do
-    Enum.any?(@assertion_keywords, &String.contains?(content, &1))
-  end
-
-  # Parse the original starting line from a hunk header like "@@ -3,7 +3,6 @@".
-  defp parse_hunk_orig_line(hunk_header) do
-    case Regex.run(~r/@@ -(\d+)/, hunk_header) do
-      [_, n] -> String.to_integer(n)
-      _ -> 0
-    end
+    # Adapt: filter to assertion-deletion findings and map to the legacy shape.
+    findings
+    |> Enum.filter(&(Map.get(&1, :reason) == :assertion_deleted))
+    |> Enum.map(fn f ->
+      %{
+        file: Map.get(f, :path),
+        line: Map.get(f, :line, 0),
+        removed: Map.get(f, :removed, "")
+      }
+    end)
   end
 end

--- a/lib/mix/gate/mutation.ex
+++ b/lib/mix/gate/mutation.ex
@@ -35,6 +35,7 @@ defmodule Mix.Gate.Mutation do
   """
 
   alias Mix.Gate.Common
+  alias Tau.Factory.Gate.Mutation, as: PureMutation
 
   @doc """
   Orchestrates the mutation check in the current working directory's git repo.
@@ -206,12 +207,12 @@ defmodule Mix.Gate.Mutation do
     :ok
   end
 
-  # Run the gating tests, distinguishing three outcomes by parsing the ExUnit
-  # "N tests, M failures" summary line:
+  # Run the gating tests and apply the pure judge/1 predicate from
+  # Tau.Factory.Gate.Mutation. Distinguishes three outcomes:
   #
-  #   - summary present, M > 0  → :ok                           (tests discriminate)
-  #   - summary present, M == 0 → {:error, :all_passed}         (vacuous suite)
-  #   - no summary at all       → {:error, {:runner_crashed, output}}
+  #   - ≥1 failure  → PureMutation.judge/1 → {:pass, _}  → :ok
+  #   - 0 failures  → PureMutation.judge/1 → {:fail, _}  → {:error, :all_passed}
+  #   - no summary  → {:error, {:runner_crashed, output}}
   defp run_gating_tests(gating_test_paths, repo_dir) do
     output =
       if File.exists?(Path.join(repo_dir, "mix.exs")) do
@@ -221,15 +222,28 @@ defmodule Mix.Gate.Mutation do
       end
 
     case parse_test_summary(output) do
-      {:ok, failures} when failures > 0 ->
-        :ok
+      {:ok, failures} ->
+        # Build a minimal report and delegate to the pure judge/1.
+        cases = build_minimal_cases(failures)
+        report = %{cases: cases}
 
-      {:ok, 0} ->
-        {:error, :all_passed}
+        case PureMutation.judge(report) do
+          {:pass, _killed} -> :ok
+          {:fail, :no_test_failed} -> {:error, :all_passed}
+        end
 
       :no_summary ->
         {:error, {:runner_crashed, output}}
     end
+  end
+
+  # Build a minimal cases list from a failure count. We do not have individual
+  # test IDs from the text summary, so we synthesise them as "failed_N" for
+  # each failed test. The judge/1 contract only requires :status fields.
+  defp build_minimal_cases(0), do: []
+
+  defp build_minimal_cases(failures) do
+    Enum.map(1..failures, fn i -> %{id: "failed_#{i}", status: :failed} end)
   end
 
   defp run_via_mix(gating_test_paths, repo_dir) do

--- a/lib/mix/gate/mutation.ex
+++ b/lib/mix/gate/mutation.ex
@@ -35,7 +35,6 @@ defmodule Mix.Gate.Mutation do
   """
 
   alias Mix.Gate.Common
-  alias Tau.Factory.Gate.Mutation, as: PureMutation
 
   @doc """
   Orchestrates the mutation check in the current working directory's git repo.
@@ -207,12 +206,19 @@ defmodule Mix.Gate.Mutation do
     :ok
   end
 
-  # Run the gating tests and apply the pure judge/1 predicate from
-  # Tau.Factory.Gate.Mutation. Distinguishes three outcomes:
+  # Run the gating tests, distinguishing three outcomes by parsing the ExUnit
+  # "N tests, M failures" summary line:
   #
-  #   - ≥1 failure  → PureMutation.judge/1 → {:pass, _}  → :ok
-  #   - 0 failures  → PureMutation.judge/1 → {:fail, _}  → {:error, :all_passed}
-  #   - no summary  → {:error, {:runner_crashed, output}}
+  #   - summary present, M > 0  → :ok                           (tests discriminate)
+  #   - summary present, M == 0 → {:error, :all_passed}         (vacuous suite)
+  #   - no summary at all       → {:error, {:runner_crashed, output}}
+  #
+  # NOTE: this function is intentionally self-contained — it MUST NOT delegate
+  # to Tau.Factory.Gate.Mutation (the pure P2 module). Gate 5.3 reverts all
+  # non-gating-test production files to the merge-base in-place; Tau.Factory.Gate.*
+  # does not exist at the merge-base, so any call to it would raise
+  # UndefinedFunctionError mid-run (revert-cycle). The pure module is reserved
+  # for the P2 isolated-workspace engine where it runs in the unreverted tree.
   defp run_gating_tests(gating_test_paths, repo_dir) do
     output =
       if File.exists?(Path.join(repo_dir, "mix.exs")) do
@@ -222,28 +228,15 @@ defmodule Mix.Gate.Mutation do
       end
 
     case parse_test_summary(output) do
-      {:ok, failures} ->
-        # Build a minimal report and delegate to the pure judge/1.
-        cases = build_minimal_cases(failures)
-        report = %{cases: cases}
+      {:ok, failures} when failures > 0 ->
+        :ok
 
-        case PureMutation.judge(report) do
-          {:pass, _killed} -> :ok
-          {:fail, :no_test_failed} -> {:error, :all_passed}
-        end
+      {:ok, 0} ->
+        {:error, :all_passed}
 
       :no_summary ->
         {:error, {:runner_crashed, output}}
     end
-  end
-
-  # Build a minimal cases list from a failure count. We do not have individual
-  # test IDs from the text summary, so we synthesise them as "failed_N" for
-  # each failed test. The judge/1 contract only requires :status fields.
-  defp build_minimal_cases(0), do: []
-
-  defp build_minimal_cases(failures) do
-    Enum.map(1..failures, fn i -> %{id: "failed_#{i}", status: :failed} end)
   end
 
   defp run_via_mix(gating_test_paths, repo_dir) do

--- a/lib/tau/factory/gate/ac_linkage.ex
+++ b/lib/tau/factory/gate/ac_linkage.ex
@@ -25,7 +25,7 @@ defmodule Tau.Factory.Gate.AcLinkage do
   - `:tags` — a list of atoms (e.g. `[:ac_1, :property]`)
   """
 
-  @typedoc "An `AC-N` or `D-NNN` token string, e.g. `\"AC-1\"` or `\"D-200\"`."
+  @typedoc ~S'An `AC-N` or `D-NNN` token string, e.g. `"AC-1"` or `"D-200"`.'
   @type token :: String.t()
 
   @typedoc "Minimal test metadata map: `%{name: String.t(), tags: [atom()]}`."

--- a/lib/tau/factory/gate/ac_linkage.ex
+++ b/lib/tau/factory/gate/ac_linkage.ex
@@ -1,0 +1,139 @@
+defmodule Tau.Factory.Gate.AcLinkage do
+  @moduledoc """
+  Gate 5.1 — AC-to-test linkage (pure module, no I/O).
+
+  Every `AC-N` / `D-NNN` token in the PR body's declared `## Acceptance
+  criteria` section must appear in a gating-test name or `@tag`; meta-ACs
+  (`AC-N (meta)`) are exempt.
+
+  This module owns the *decision logic* only. I/O (reading PR-body files,
+  reading gating-test source files) lives in the Mix task shim.
+
+  ## Spec
+
+  SPEC-FACTORY-GATE §2 C2 / §4 B2. Properties:
+  - P-AC1 (soundness): `check/2 = {:pass, []}` iff every non-meta token in the
+    acceptance section is covered.
+  - P-AC2 (scope-tightness): tokens outside the acceptance section are ignored.
+  - P-AC3 (meta-exemption): a `(meta)`-marked AC is never reported missing.
+  - P-AC4 (monotone): adding a gating test never turns `:pass` into `:fail`.
+
+  ## TestMeta shape
+
+  Each element of `gating_tests` MUST be a map exposing:
+  - `:name` — the test description string (e.g. `"AC-1: some test desc"`)
+  - `:tags` — a list of atoms (e.g. `[:ac_1, :property]`)
+  """
+
+  @typedoc "An `AC-N` or `D-NNN` token string, e.g. `\"AC-1\"` or `\"D-200\"`."
+  @type token :: String.t()
+
+  @typedoc "Minimal test metadata map: `%{name: String.t(), tags: [atom()]}`."
+  @type test_meta :: %{name: String.t(), tags: [atom()]}
+
+  @doc """
+  Check that every non-meta `AC-N`/`D-NNN` token in the `## Acceptance
+  criteria` section of `pr_body` is covered by at least one element in
+  `gating_tests`.
+
+  A token is covered when either:
+  - it appears as a substring in the test's `:name`, OR
+  - its normalised tag form (e.g. `"AC-1"` → `:ac_1`) is in the test's `:tags`.
+
+  Returns `{:pass, []}` when all tokens are covered, or
+  `{:fail, missing_tokens}` listing every uncovered non-meta token.
+  """
+  @spec check(String.t(), [test_meta()]) :: {:pass, []} | {:fail, [token()]}
+  def check(pr_body, gating_tests)
+      when is_binary(pr_body) and is_list(gating_tests) do
+    ac_section = extract_acceptance_criteria_section(pr_body)
+    meta_acs = parse_meta_ac_tokens(ac_section)
+    claimed = parse_ac_tokens(ac_section)
+    non_meta = Enum.reject(claimed, &MapSet.member?(meta_acs, &1))
+    missing = Enum.reject(non_meta, &token_covered_by_metas?(&1, gating_tests))
+
+    case missing do
+      [] -> {:pass, []}
+      _ -> {:fail, missing}
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Section extraction
+  # ---------------------------------------------------------------------------
+
+  # Extract the content of the "## Acceptance criteria" section from the PR body.
+  # Starts after the heading whose text (stripped, downcased) begins with
+  # "acceptance criteria". Ends at the next markdown heading or EOF.
+  # Returns "" if no such heading is found.
+  defp extract_acceptance_criteria_section(pr_body) do
+    lines = String.split(pr_body, "\n")
+    heading_pattern = ~r/^[#]{1,6}\s/
+
+    ac_heading_idx =
+      Enum.find_index(lines, fn line ->
+        stripped = line |> String.replace(~r/^#+\s*/, "") |> String.trim() |> String.downcase()
+
+        String.starts_with?(stripped, "acceptance criteria") and
+          String.match?(line, heading_pattern)
+      end)
+
+    case ac_heading_idx do
+      nil ->
+        ""
+
+      idx ->
+        lines
+        |> Enum.drop(idx + 1)
+        |> Enum.take_while(&(not String.match?(&1, heading_pattern)))
+        |> Enum.join("\n")
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Token parsing
+  # ---------------------------------------------------------------------------
+
+  # Parse AC-N tokens marked as meta (exempt from the linkage gate).
+  defp parse_meta_ac_tokens(section_text) do
+    meta_pattern = ~r/\bAC-(\d+)\s*\(meta\)/
+
+    Regex.scan(meta_pattern, section_text, capture: :all_but_first)
+    |> List.flatten()
+    |> Enum.map(&"AC-#{&1}")
+    |> MapSet.new()
+  end
+
+  # Parse all AC-N and D-NNN tokens from the given text.
+  defp parse_ac_tokens(section_text) do
+    ac_pattern = ~r/\bAC-\d+\b/
+    d_pattern = ~r/\bD-\d+\b/
+
+    ac_tokens = Regex.scan(ac_pattern, section_text) |> List.flatten()
+    d_tokens = Regex.scan(d_pattern, section_text) |> List.flatten()
+
+    (ac_tokens ++ d_tokens) |> Enum.uniq()
+  end
+
+  # ---------------------------------------------------------------------------
+  # Coverage check against TestMeta list
+  # ---------------------------------------------------------------------------
+
+  # Check if a token is covered by any element in the gating-test metadata list.
+  # Coverage:
+  #   - token appears as a word-boundary match in the test name (not as a substring
+  #     of a longer token, e.g. "AC-4" must not match inside "AC-40"), OR
+  #   - its normalised tag form is in the test's :tags list.
+  defp token_covered_by_metas?(token, gating_tests) do
+    tag_atom = token |> String.downcase() |> String.replace("-", "_") |> String.to_atom()
+    # Build a regex that matches the token only at a word boundary (not inside a longer token).
+    token_regex = Regex.compile!("\\b#{Regex.escape(token)}\\b")
+
+    Enum.any?(gating_tests, fn meta ->
+      name = Map.get(meta, :name, "")
+      tags = Map.get(meta, :tags, [])
+
+      Regex.match?(token_regex, name) or tag_atom in tags
+    end)
+  end
+end

--- a/lib/tau/factory/gate/masking.ex
+++ b/lib/tau/factory/gate/masking.ex
@@ -1,0 +1,143 @@
+defmodule Tau.Factory.Gate.Masking do
+  @moduledoc """
+  Gate 5.2 — Masking detection (pure module, detection-only, no I/O).
+
+  Scans a unified diff for:
+  1. Deleted or weakened assertion lines (`-  assert`, `-  refute`, etc.)
+  2. Any diff hunk whose file path is in the declared gating-test path set
+     (path-based, independent of commit attribution — D-304/INV-6).
+
+  Detection-only: returns `{:clean | :flagged, findings}` — **no verdict**.
+  Every flagged item is surfaced to the critic as a mandatory review item.
+  There is no self-authored bypass tag. The verdict is the critic's.
+
+  ## Spec
+
+  SPEC-FACTORY-GATE §2 C3 / §4 B2. Properties:
+  - P-MK1 (assertion-deletion): any hunk deleting/weakening an assertion yields
+    a Finding.
+  - P-MK2 (path-violation): any diff hunk whose path ∈ gating_paths yields a
+    Finding, independent of commit author metadata.
+  - P-MK3 (detection-only): `scan/2` never returns `:pass`/`:fail`.
+  - P-MK4 (rebase-invariance): diffs differing only by index hash yield the
+    same scan result.
+
+  ## Finding shape
+
+  Each finding is a map:
+  - `:path` — the file path from the diff `+++ b/` header.
+  - `:reason` — `:assertion_deleted` or `:gating_path_edited`.
+  - `:line` — original-file line number (assertion deletions) or 0 (path edits).
+  - `:removed` — the removed content string (assertion deletions) or `nil`.
+  """
+
+  @assertion_keywords ~w[assert refute assert_receive assert_raise]
+
+  @typedoc "A finding map produced by `scan/2`."
+  @type finding :: %{
+          path: String.t() | nil,
+          reason: :assertion_deleted | :gating_path_edited,
+          line: non_neg_integer(),
+          removed: String.t() | nil
+        }
+
+  @doc """
+  Scan `unified_diff` for masking violations.
+
+  `gating_paths` is a `MapSet` of repo-relative file paths declared as
+  gating-test paths for this PR (frozen at scope-freeze).
+
+  Returns `{:clean, []}` when no violations are found, or
+  `{:flagged, findings}` with one or more `Finding` maps.
+  """
+  @spec scan(String.t(), MapSet.t(String.t())) ::
+          {:clean, []} | {:flagged, [finding()]}
+  def scan(unified_diff, gating_paths)
+      when is_binary(unified_diff) do
+    lines = String.split(unified_diff, "\n")
+    findings = parse_diff_lines(lines, nil, 0, gating_paths, [])
+
+    case findings do
+      [] -> {:clean, []}
+      _ -> {:flagged, findings}
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Diff line state machine
+  # ---------------------------------------------------------------------------
+
+  defp parse_diff_lines([], _file, _orig_line, _gating_paths, acc),
+    do: Enum.reverse(acc)
+
+  defp parse_diff_lines([h | t], current_file, orig_line, gating_paths, acc) do
+    cond do
+      String.starts_with?(h, "+++ b/") ->
+        file = String.slice(h, 6..-1//1)
+        # Check: entering a new diff section for a gating-test path.
+        # We flag the path-violation once per file section when the first
+        # non-header diff line appears. Defer to the hunk processing below.
+        parse_diff_lines(t, file, orig_line, gating_paths, acc)
+
+      String.starts_with?(h, "@@") ->
+        orig = parse_hunk_orig_line(h)
+        # Emit a path-violation finding for the gating path when we enter a hunk.
+        acc2 =
+          if gating_path_modified?(current_file, gating_paths, acc) do
+            [%{path: current_file, reason: :gating_path_edited, line: 0, removed: nil} | acc]
+          else
+            acc
+          end
+
+        parse_diff_lines(t, current_file, orig, gating_paths, acc2)
+
+      String.starts_with?(h, "-") and not String.starts_with?(h, "---") ->
+        content = String.slice(h, 1..-1//1)
+
+        acc2 =
+          if assertion_line?(content) do
+            [
+              %{
+                path: current_file,
+                reason: :assertion_deleted,
+                line: orig_line,
+                removed: content
+              }
+              | acc
+            ]
+          else
+            acc
+          end
+
+        parse_diff_lines(t, current_file, orig_line + 1, gating_paths, acc2)
+
+      String.starts_with?(h, "+") and not String.starts_with?(h, "+++") ->
+        parse_diff_lines(t, current_file, orig_line, gating_paths, acc)
+
+      true ->
+        parse_diff_lines(t, current_file, orig_line + 1, gating_paths, acc)
+    end
+  end
+
+  # Returns true iff current_file is in gating_paths AND no path-violation
+  # finding for it has been emitted yet (to avoid duplicates per file).
+  defp gating_path_modified?(nil, _gating_paths, _acc), do: false
+
+  defp gating_path_modified?(file, gating_paths, acc) do
+    MapSet.member?(gating_paths, file) and
+      not Enum.any?(acc, fn f ->
+        Map.get(f, :path) == file and Map.get(f, :reason) == :gating_path_edited
+      end)
+  end
+
+  defp assertion_line?(content) do
+    Enum.any?(@assertion_keywords, &String.contains?(content, &1))
+  end
+
+  defp parse_hunk_orig_line(hunk_header) do
+    case Regex.run(~r/@@ -(\d+)/, hunk_header) do
+      [_, n] -> String.to_integer(n)
+      _ -> 0
+    end
+  end
+end

--- a/lib/tau/factory/gate/mutation.ex
+++ b/lib/tau/factory/gate/mutation.ex
@@ -1,0 +1,109 @@
+defmodule Tau.Factory.Gate.Mutation do
+  @moduledoc """
+  Gate 5.3 — Mutation check (pure planning + pure judgement, no I/O).
+
+  This module provides the PURE functions only:
+  - `plan/2` — produces a `%Plan{}` describing which paths to revert and to
+    which ref. The engine executes the revert and the test run.
+  - `judge/1` — pure predicate over an engine-parsed test report. Decides
+    whether the mutation check passes (≥1 test failed on the reverted tree).
+
+  **No I/O.** All subprocess execution, git operations, and file system access
+  live in the engine (C6 `Tau.Factory.Engine.TestRun`, arriving in P2). This
+  module is referentially transparent and property-testable in isolation.
+
+  ## Spec
+
+  SPEC-FACTORY-GATE §2 C4 / §4 B2–B3 / gate-and-toolchain.md §2.3. Properties:
+  - P-MU1 (non-vacuity): `judge/1 = {:pass, _}` iff `report` has ≥1 `:failed`
+    case.
+  - P-MU2 (boundary = declared paths): `plan/2` records `gating_paths` as the
+    keep-set; the engine reverts `tracked ∖ gating_paths` to `merge_base`.
+  - P-MU3 (project-creation N/A): `judge/1` returns `{:na, :project_created}`
+    when the report carries the `project_created: true` sentinel.
+  - P-MU4 (purity): `plan/2` and `judge/1` are referentially transparent.
+
+  ## Report shape
+
+  `judge/1` accepts any map with:
+  - `:cases` — a list of `%{id: test_id, status: :passed | :failed}` maps.
+  - `:project_created` (optional) — `true` when the N/A sentinel applies.
+
+  ## Plan shape
+
+  `plan/2` returns a `%Tau.Factory.Gate.Mutation.Plan{}` struct with:
+  - `:merge_base` — the merge-base git ref (string).
+  - `:gating_paths` — the declared keep-set (`MapSet`).
+  """
+
+  defmodule Plan do
+    @moduledoc """
+    The reverted-tree plan produced by `Tau.Factory.Gate.Mutation.plan/2`.
+
+    Fields:
+    - `:merge_base` — the git ref to revert non-gating paths to.
+    - `:gating_paths` — the declared gating-test paths to keep at HEAD.
+    """
+    @type t :: %__MODULE__{
+            merge_base: String.t(),
+            gating_paths: MapSet.t(String.t())
+          }
+    defstruct [:merge_base, :gating_paths]
+  end
+
+  @typedoc "A test case map: `%{id: String.t(), status: :passed | :failed}`."
+  @type test_case :: %{id: String.t(), status: :passed | :failed}
+
+  @typedoc """
+  A test report map: `%{cases: [test_case()]}` plus optional
+  `project_created: true` sentinel.
+  """
+  @type report :: map()
+
+  @doc """
+  Produce a reverted-tree plan for the mutation check.
+
+  The engine will:
+  1. Revert every tracked file except those in `gating_paths` to `merge_base`.
+  2. Keep `gating_paths` at the test-author's committed state (HEAD).
+  3. Run the gating tests and capture a structured report.
+  4. Apply `judge/1` to the report.
+
+  The boundary is path-based (INV-6): `gating_paths` is the frozen declared set,
+  not derived from commit attribution. This survives a refine-cycle rebase.
+  """
+  @spec plan(String.t(), MapSet.t(String.t())) :: Plan.t()
+  def plan(merge_base, gating_paths)
+      when is_binary(merge_base) do
+    %Plan{merge_base: merge_base, gating_paths: gating_paths}
+  end
+
+  @doc """
+  Pure predicate over an engine-parsed test report.
+
+  Returns:
+  - `{:pass, killed_ids}` — ≥1 test failed on the reverted tree (the suite
+    discriminates against absent production code; mutation check passes).
+  - `{:fail, :no_test_failed}` — all tests passed (vacuous suite; INV-7
+    violated).
+  - `{:na, :project_created}` — the report carries the `project_created: true`
+    sentinel; no pre-implementer production code existed to revert
+    (SPEC-FACTORY-GATE Gate 5.3 project-creation N/A clause).
+  """
+  @spec judge(report()) ::
+          {:pass, [String.t()]}
+          | {:fail, :no_test_failed}
+          | {:na, :project_created}
+  def judge(%{project_created: true}) do
+    {:na, :project_created}
+  end
+
+  def judge(%{cases: cases}) do
+    failed = Enum.filter(cases, &(&1.status == :failed))
+
+    case failed do
+      [] -> {:fail, :no_test_failed}
+      _ -> {:pass, Enum.map(failed, & &1.id)}
+    end
+  end
+end

--- a/test/tau/factory/gate/ac_linkage_property_test.exs
+++ b/test/tau/factory/gate/ac_linkage_property_test.exs
@@ -48,13 +48,6 @@ defmodule Tau.Factory.Gate.AcLinkagePropertyTest do
     %{name: "#{token}: some test description", tags: [String.to_atom(tag_form)]}
   end
 
-  defp uncovering_meta(token) do
-    # A meta that covers a DIFFERENT token to guarantee the given one is uncovered.
-    other = if String.starts_with?(token, "AC-"), do: "D-999", else: "AC-999"
-    tag_form = other |> String.downcase() |> String.replace("-", "_")
-    %{name: "#{other}: unrelated", tags: [String.to_atom(tag_form)]}
-  end
-
   defp pr_body_with_ac_section(tokens) when is_list(tokens) do
     bullets = Enum.map_join(tokens, "\n", fn t -> "- **#{t}** some criterion" end)
 

--- a/test/tau/factory/gate/ac_linkage_property_test.exs
+++ b/test/tau/factory/gate/ac_linkage_property_test.exs
@@ -1,0 +1,214 @@
+defmodule Tau.Factory.Gate.AcLinkagePropertyTest do
+  @moduledoc """
+  Gating tests for AC-1 (D-305-adjacent) — `Tau.Factory.Gate.AcLinkage.check/2`.
+
+  Written BEFORE production code exists (oracle-separation phase, D-304).
+  These tests fail with a compile error / UndefinedFunctionError until the
+  implementer creates `lib/tau/factory/gate/ac_linkage.ex`.
+
+  Properties pin SPEC-FACTORY-GATE §4 B2 + gate-and-toolchain.md §2.1:
+    P-AC1 soundness
+    P-AC2 scope-tightness (tokens outside acceptance section ignored)
+    P-AC3 meta-exemption
+    P-AC4 monotone in tests
+
+  All property tests are tagged `:property` (OTP non-negotiable #6:
+  properties before examples for invariant-bearing modules).
+
+  AC linkage: AC-1, D-305-adjacent.
+  """
+
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  @moduletag :property
+  @moduletag :ac_1
+
+  alias Tau.Factory.Gate.AcLinkage
+
+  # ---------------------------------------------------------------------------
+  # Generators
+  # ---------------------------------------------------------------------------
+
+  defp ac_token_gen do
+    StreamData.bind(StreamData.integer(1..50), fn n -> StreamData.constant("AC-#{n}") end)
+  end
+
+  defp d_token_gen do
+    StreamData.bind(StreamData.integer(100..400), fn n -> StreamData.constant("D-#{n}") end)
+  end
+
+  defp any_token_gen do
+    StreamData.one_of([ac_token_gen(), d_token_gen()])
+  end
+
+  # A gating-test meta that "covers" the given token via @tag form.
+  defp covering_meta(token) do
+    tag_form = token |> String.downcase() |> String.replace("-", "_")
+    %{name: "#{token}: some test description", tags: [String.to_atom(tag_form)]}
+  end
+
+  defp uncovering_meta(token) do
+    # A meta that covers a DIFFERENT token to guarantee the given one is uncovered.
+    other = if String.starts_with?(token, "AC-"), do: "D-999", else: "AC-999"
+    tag_form = other |> String.downcase() |> String.replace("-", "_")
+    %{name: "#{other}: unrelated", tags: [String.to_atom(tag_form)]}
+  end
+
+  defp pr_body_with_ac_section(tokens) when is_list(tokens) do
+    bullets = Enum.map_join(tokens, "\n", fn t -> "- **#{t}** some criterion" end)
+
+    """
+    ## Background
+
+    Context prose mentioning D-999 and AC-999 as background — should be ignored.
+
+    ## Acceptance criteria
+
+    #{bullets}
+
+    ## Test plan
+
+    See gating tests.
+    """
+  end
+
+  # ---------------------------------------------------------------------------
+  # P-AC1 — soundness
+  # check/2 = {:pass, []} iff every non-meta token in the AC section is covered.
+  # ---------------------------------------------------------------------------
+
+  property "P-AC1: AC-1 — check/2 returns {:pass, []} iff every non-meta token is covered" do
+    check all(tokens <- StreamData.list_of(any_token_gen(), min_length: 1, max_length: 6)) do
+      tokens = Enum.uniq(tokens)
+      pr_body = pr_body_with_ac_section(tokens)
+      gating_tests = Enum.map(tokens, &covering_meta/1)
+
+      assert {:pass, []} = AcLinkage.check(pr_body, gating_tests)
+    end
+  end
+
+  property "P-AC1: AC-1 — check/2 returns {:fail, missing} listing uncovered tokens" do
+    check all(
+            covered_tokens <- StreamData.list_of(any_token_gen(), min_length: 1, max_length: 4),
+            missing_token <- any_token_gen()
+          ) do
+      # Ensure missing_token is not also in covered_tokens.
+      covered_tokens = Enum.reject(covered_tokens, &(&1 == missing_token)) |> Enum.uniq()
+      all_tokens = [missing_token | covered_tokens]
+      pr_body = pr_body_with_ac_section(all_tokens)
+      gating_tests = Enum.map(covered_tokens, &covering_meta/1)
+
+      result = AcLinkage.check(pr_body, gating_tests)
+      assert {:fail, missing} = result
+      assert missing_token in missing
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # P-AC2 — scope-tightness: tokens outside the AC section are never claims.
+  # ---------------------------------------------------------------------------
+
+  property "P-AC2: AC-1 — tokens appearing only in prose outside the AC section are ignored" do
+    check all(
+            claimed_token <- any_token_gen(),
+            background_token <- any_token_gen(),
+            claimed_token != background_token
+          ) do
+      pr_body = """
+      ## Background
+
+      This PR relates to #{background_token} — cited for context only.
+
+      ## Acceptance criteria
+
+      - **#{claimed_token}** the actual claim.
+
+      ## Test plan
+
+      See gating test.
+      """
+
+      # Cover the claimed token but NOT background_token.
+      gating_tests = [covering_meta(claimed_token)]
+
+      # background_token should be ignored; result should be pass.
+      assert {:pass, []} = AcLinkage.check(pr_body, gating_tests)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # P-AC3 — meta-exemption: (meta) token is never reported missing.
+  # ---------------------------------------------------------------------------
+
+  property "P-AC3: AC-1 — a (meta)-marked AC is never reported missing" do
+    check all(meta_token <- ac_token_gen(), other_token <- any_token_gen()) do
+      # Only AC- tokens support the (meta) marker in this PR's convention.
+      # meta_token is present with (meta) — should be exempt.
+      # other_token is a normal claimed token — we cover it.
+      other_token = if other_token == meta_token, do: "D-999", else: other_token
+
+      pr_body = """
+      ## Acceptance criteria
+
+      - **#{meta_token} (meta)** verified by CI, not a unit test.
+      - **#{other_token}** a normal claimed criterion.
+
+      ## Test plan
+
+      See gating test.
+      """
+
+      gating_tests = [covering_meta(other_token)]
+
+      result = AcLinkage.check(pr_body, gating_tests)
+      # meta_token must NOT be in the missing list under any outcome.
+      case result do
+        {:pass, []} ->
+          :ok
+
+        {:fail, missing} ->
+          refute meta_token in missing,
+                 "Meta AC #{meta_token} must never appear in missing list; got #{inspect(missing)}"
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # P-AC4 — monotone in tests: adding a gating test never turns :pass into :fail.
+  # ---------------------------------------------------------------------------
+
+  property "P-AC4: AC-1 — adding a gating test never turns {:pass, []} into {:fail, _}" do
+    check all(tokens <- StreamData.list_of(any_token_gen(), min_length: 1, max_length: 5)) do
+      tokens = Enum.uniq(tokens)
+      pr_body = pr_body_with_ac_section(tokens)
+      gating_tests = Enum.map(tokens, &covering_meta/1)
+
+      assert {:pass, []} = AcLinkage.check(pr_body, gating_tests)
+
+      # Add an extra unrelated test — must still pass.
+      extra = %{name: "unrelated extra test", tags: [:unrelated_xyz]}
+      extended_tests = [extra | gating_tests]
+
+      assert {:pass, []} = AcLinkage.check(pr_body, extended_tests)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # AC-1 example test — exercises the real public entry point, not a hand-built
+  # struct. This fires if the module doesn't exist at all.
+  # ---------------------------------------------------------------------------
+
+  @tag :ac_1
+  test "AC-1: check/2 public entry point callable — module must exist" do
+    pr_body = """
+    ## Acceptance criteria
+
+    - **AC-1** the module is present and callable.
+
+    """
+
+    gating_tests = [%{name: "AC-1: present", tags: [:ac_1]}]
+    assert {:pass, []} = AcLinkage.check(pr_body, gating_tests)
+  end
+end

--- a/test/tau/factory/gate/masking_property_test.exs
+++ b/test/tau/factory/gate/masking_property_test.exs
@@ -1,0 +1,323 @@
+defmodule Tau.Factory.Gate.MaskingPropertyTest do
+  @moduledoc """
+  Gating tests for AC-2 (D-305) and AC-3 (D-304) — `Tau.Factory.Gate.Masking.scan/2`.
+
+  Written BEFORE production code exists (oracle-separation phase, D-304).
+  These tests fail with a compile error / UndefinedFunctionError until the
+  implementer creates `lib/tau/factory/gate/masking.ex`.
+
+  Properties pin SPEC-FACTORY-GATE §4 B2 + gate-and-toolchain.md §2.2:
+    P-MK1 assertion-deletion detection
+    P-MK2 path-violation detection (path-based, independent of author)
+    P-MK3 detection-only / no verdict
+    P-MK4 rebase-invariance
+
+  AC-2 (D-305): pure-predicate masking properties P-MK1..4.
+  AC-3 (D-304): an edit to a declared gating-test path is flagged (path-based,
+                not commit-attribution — D-305 closes #383).
+
+  All property tests are tagged `:property` (OTP non-negotiable #6).
+  """
+
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  @moduletag :property
+  @moduletag :ac_2
+  @moduletag :ac_3
+  @moduletag :d_305
+  @moduletag :d_304
+
+  alias Tau.Factory.Gate.Masking
+
+  # ---------------------------------------------------------------------------
+  # Helpers for constructing minimal unified diff fragments.
+  # ---------------------------------------------------------------------------
+
+  # A diff hunk that REMOVES an assert/refute line in the given file.
+  defp diff_removing_assert(file_path, keyword \\ "assert") do
+    """
+    diff --git a/#{file_path} b/#{file_path}
+    index aaaaaa..bbbbbb 100644
+    --- a/#{file_path}
+    +++ b/#{file_path}
+    @@ -5,7 +5,6 @@ defmodule SomeTest do
+       test "example" do
+         result = SomeModule.run()
+    -    #{keyword} result == :ok
+         other = :noop
+       end
+     end
+    """
+  end
+
+  # A diff hunk that modifies a file without removing any assertion.
+  defp diff_modifying_without_assertion(file_path) do
+    """
+    diff --git a/#{file_path} b/#{file_path}
+    index aaaaaa..bbbbbb 100644
+    --- a/#{file_path}
+    +++ b/#{file_path}
+    @@ -1,3 +1,3 @@ defmodule SomeModule do
+    -  def run, do: :old
+    +  def run, do: :new
+     end
+    """
+  end
+
+  # A diff adding a line (no removal at all) in a given file.
+  defp diff_adding_only(file_path) do
+    """
+    diff --git a/#{file_path} b/#{file_path}
+    index aaaaaa..bbbbbb 100644
+    --- a/#{file_path}
+    +++ b/#{file_path}
+    @@ -1,3 +1,4 @@ defmodule SomeModule do
+       def run, do: :ok
+    +  def extra, do: :new
+     end
+    """
+  end
+
+  defp file_path_gen do
+    StreamData.bind(
+      StreamData.string(:alphanumeric, min_length: 3, max_length: 10),
+      fn name ->
+        StreamData.constant("test/tau/#{name}_test.exs")
+      end
+    )
+  end
+
+  defp prod_file_path_gen do
+    StreamData.bind(
+      StreamData.string(:alphanumeric, min_length: 3, max_length: 10),
+      fn name ->
+        StreamData.constant("lib/tau/#{name}.ex")
+      end
+    )
+  end
+
+  # ---------------------------------------------------------------------------
+  # P-MK1 — assertion-deletion detection.
+  # Any hunk deleting/weakening an assertion yields a Finding.
+  # ---------------------------------------------------------------------------
+
+  property "P-MK1: AC-2 — a diff removing 'assert' yields a Finding" do
+    check all(file_path <- file_path_gen()) do
+      diff = diff_removing_assert(file_path, "assert")
+      gating_paths = MapSet.new([])
+
+      {status, findings} = Masking.scan(diff, gating_paths)
+
+      assert status == :flagged
+      assert length(findings) >= 1
+
+      assert Enum.any?(findings, fn f ->
+               Map.get(f, :path, Map.get(f, :file, "")) == file_path or
+                 Map.get(f, :reason, Map.get(f, :kind, nil)) != nil
+             end)
+    end
+  end
+
+  property "P-MK1: AC-2 — a diff removing 'refute' yields a Finding" do
+    check all(file_path <- file_path_gen()) do
+      diff = diff_removing_assert(file_path, "refute")
+      gating_paths = MapSet.new([])
+
+      {status, findings} = Masking.scan(diff, gating_paths)
+
+      assert status == :flagged
+      assert length(findings) >= 1
+    end
+  end
+
+  property "P-MK1: AC-2 — a diff that only adds lines yields no assertion-deletion Finding" do
+    check all(
+            file_path <- prod_file_path_gen(),
+            gating_path <- file_path_gen(),
+            file_path != gating_path
+          ) do
+      diff = diff_adding_only(file_path)
+      gating_paths = MapSet.new([])
+
+      {status, findings} = Masking.scan(diff, gating_paths)
+
+      # No assertion deletions, no gating-path edit → must be clean.
+      assert status == :clean
+      assert findings == []
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # P-MK2 — path-violation detection.
+  # Any diff hunk whose path ∈ gating_paths yields a Finding, regardless of
+  # whether an assertion is deleted. This is the AC-3 / D-304 property.
+  # ---------------------------------------------------------------------------
+
+  property "P-MK2: AC-3 / AC-2 — an edit to a declared gating-test path is flagged (path-based)" do
+    check all(gating_path <- file_path_gen()) do
+      # Modify the gating-test file without removing any assertion.
+      diff = diff_modifying_without_assertion(gating_path)
+      gating_paths = MapSet.new([gating_path])
+
+      {status, findings} = Masking.scan(diff, gating_paths)
+
+      assert status == :flagged,
+             "Expected :flagged for edit to declared gating path #{gating_path}"
+
+      assert length(findings) >= 1
+    end
+  end
+
+  property "P-MK2: AC-3 — path-based detection is independent of commit author metadata" do
+    # The same diff content, same path, but if gating_paths is empty (no declared
+    # paths), the path-violation check must NOT fire (it's path-based, not heuristic).
+    check all(gating_path <- file_path_gen()) do
+      diff = diff_modifying_without_assertion(gating_path)
+
+      # With the path in the declared set.
+      {status_in, _} = Masking.scan(diff, MapSet.new([gating_path]))
+      # With an EMPTY declared set.
+      {status_out, findings_out} = Masking.scan(diff, MapSet.new([]))
+
+      assert status_in == :flagged
+      # When path is NOT in the declared set AND no assertion removed → clean.
+      assert status_out == :clean
+      assert findings_out == []
+    end
+  end
+
+  property "P-MK2: AC-3 — a production-file edit with non-overlapping gating_paths is clean" do
+    check all(
+            prod_path <- prod_file_path_gen(),
+            gating_path <- file_path_gen(),
+            prod_path != gating_path
+          ) do
+      diff = diff_modifying_without_assertion(prod_path)
+      # gating_path is declared but the diff touches prod_path.
+      gating_paths = MapSet.new([gating_path])
+
+      {status, findings} = Masking.scan(diff, gating_paths)
+
+      assert status == :clean
+      assert findings == []
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # P-MK3 — detection-only / no verdict.
+  # scan/2 NEVER returns :pass / :fail — only {:clean | :flagged, findings}.
+  # ---------------------------------------------------------------------------
+
+  property "P-MK3: AC-2 — scan/2 always returns {:clean | :flagged, list}, never a verdict atom" do
+    check all(
+            file_path <- file_path_gen(),
+            remove_assert? <- StreamData.boolean(),
+            in_gating_paths? <- StreamData.boolean()
+          ) do
+      diff =
+        if remove_assert? do
+          diff_removing_assert(file_path)
+        else
+          diff_adding_only(file_path)
+        end
+
+      gating_paths =
+        if in_gating_paths? do
+          MapSet.new([file_path])
+        else
+          MapSet.new([])
+        end
+
+      result = Masking.scan(diff, gating_paths)
+
+      assert {status, findings} = result,
+             "scan/2 must return a 2-tuple, got #{inspect(result)}"
+
+      assert status in [:clean, :flagged],
+             "status must be :clean or :flagged, not a verdict atom; got #{inspect(status)}"
+
+      assert is_list(findings),
+             "findings must be a list; got #{inspect(findings)}"
+
+      # Verify it is NOT a verdict-shaped atom.
+      refute status == :pass
+      refute status == :fail
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # P-MK4 — rebase-invariance.
+  # Diffs d and d' that differ only by base commit (a rebase) but have identical
+  # content hunks must yield the same scan result.
+  # We model this by constructing two diffs with identical hunk content but
+  # different "index" lines (simulating different base commits after a rebase).
+  # ---------------------------------------------------------------------------
+
+  property "P-MK4: AC-2 — scan/2 result is invariant to the diff's base-commit metadata" do
+    check all(
+            file_path <- file_path_gen(),
+            remove_assert? <- StreamData.boolean(),
+            gating? <- StreamData.boolean()
+          ) do
+      hunk =
+        if remove_assert? do
+          diff_removing_assert(file_path)
+        else
+          diff_adding_only(file_path)
+        end
+
+      # Rebase changes the index hash in the diff header — substitute with a
+      # different fake hash to model a rebased diff. The hunk content is identical.
+      diff_after_rebase =
+        String.replace(hunk, ~r/index [0-9a-f]+\.\.[0-9a-f]+/, "index deadbee..cafebab")
+
+      gating_paths =
+        if gating? do
+          MapSet.new([file_path])
+        else
+          MapSet.new([])
+        end
+
+      result_original = Masking.scan(hunk, gating_paths)
+      result_rebased = Masking.scan(diff_after_rebase, gating_paths)
+
+      # Both must have the same status.
+      assert elem(result_original, 0) == elem(result_rebased, 0),
+             "P-MK4 violated: scan status changed after rebase metadata change"
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # AC-3 example test — the concrete user-facing scenario: an implementer who
+  # edits a declared gating-test path is caught by path-based scan (D-304/D-305).
+  # ---------------------------------------------------------------------------
+
+  @tag :ac_3
+  @tag :d_304
+  test "AC-3: implementer edit to a declared gating-test path is flagged (path-based, not commit attribution)" do
+    gating_path = "test/tau/factory/gate/masking_property_test.exs"
+
+    # The implementer modified the gating test file — no assertion deleted,
+    # just a comment change. Path-based detection must still flag it.
+    diff = """
+    diff --git a/#{gating_path} b/#{gating_path}
+    index aaaaaa..bbbbbb 100644
+    --- a/#{gating_path}
+    +++ b/#{gating_path}
+    @@ -1,4 +1,4 @@ defmodule Tau.Factory.Gate.MaskingPropertyTest do
+    -  # original comment
+    +  # changed comment (implementer edit)
+       use ExUnit.Case
+    """
+
+    gating_paths = MapSet.new([gating_path])
+
+    {status, findings} = Masking.scan(diff, gating_paths)
+
+    assert status == :flagged,
+           "Expected :flagged when an edit touches a declared gating-test path"
+
+    assert length(findings) >= 1
+  end
+end

--- a/test/tau/factory/gate/masking_property_test.exs
+++ b/test/tau/factory/gate/masking_property_test.exs
@@ -110,7 +110,7 @@ defmodule Tau.Factory.Gate.MaskingPropertyTest do
       {status, findings} = Masking.scan(diff, gating_paths)
 
       assert status == :flagged
-      assert length(findings) >= 1
+      assert findings != []
 
       assert Enum.any?(findings, fn f ->
                Map.get(f, :path, Map.get(f, :file, "")) == file_path or
@@ -127,7 +127,7 @@ defmodule Tau.Factory.Gate.MaskingPropertyTest do
       {status, findings} = Masking.scan(diff, gating_paths)
 
       assert status == :flagged
-      assert length(findings) >= 1
+      assert findings != []
     end
   end
 
@@ -165,7 +165,7 @@ defmodule Tau.Factory.Gate.MaskingPropertyTest do
       assert status == :flagged,
              "Expected :flagged for edit to declared gating path #{gating_path}"
 
-      assert length(findings) >= 1
+      assert findings != []
     end
   end
 
@@ -318,6 +318,6 @@ defmodule Tau.Factory.Gate.MaskingPropertyTest do
     assert status == :flagged,
            "Expected :flagged when an edit touches a declared gating-test path"
 
-    assert length(findings) >= 1
+    assert findings != []
   end
 end

--- a/test/tau/factory/gate/mutation_property_test.exs
+++ b/test/tau/factory/gate/mutation_property_test.exs
@@ -101,7 +101,7 @@ defmodule Tau.Factory.Gate.MutationPropertyTest do
              "Expected {:pass, _} for report with ≥1 failed case, got #{inspect(result)}"
 
       assert is_list(killed)
-      assert length(killed) >= 1
+      assert killed != []
 
       # Every killed id must correspond to a :failed case in the report.
       failed_ids = report.cases |> Enum.filter(&(&1.status == :failed)) |> Enum.map(& &1.id)

--- a/test/tau/factory/gate/mutation_property_test.exs
+++ b/test/tau/factory/gate/mutation_property_test.exs
@@ -1,0 +1,247 @@
+defmodule Tau.Factory.Gate.MutationPropertyTest do
+  @moduledoc """
+  Gating tests for the pure parts of `Tau.Factory.Gate.Mutation`:
+    `judge/1` (P-MU1, P-MU3, P-MU4)
+    `plan/2`  (P-MU2, P-MU4)
+
+  Written BEFORE production code exists (oracle-separation phase, D-304).
+  These tests fail with a compile error / UndefinedFunctionError until the
+  implementer creates `lib/tau/factory/gate/mutation.ex`.
+
+  Scope: the PURE functions only. No subprocess execution, no I/O.
+  Engine execution and the HR-3 cross-check are P2 scope (C6 Engine.TestRun).
+
+  Properties pin SPEC-FACTORY-GATE §4 B2 + B3 + gate-and-toolchain.md §2.3:
+    P-MU1 non-vacuity: judge/1 = {:pass, _} iff ≥1 :failed case.
+    P-MU2 boundary = declared paths: plan/2 reverts exactly tracked ∖ gating.
+    P-MU3 project-creation N/A: judge returns {:na, :project_created} when flagged.
+    P-MU4 purity: plan/2 and judge/1 perform no I/O.
+
+  AC linkage: AC-2 (D-305 / D-306 adjacent via the judge/1 vacuous-test hole).
+  All property tests are tagged `:property` (OTP non-negotiable #6).
+  """
+
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  @moduletag :property
+  @moduletag :ac_2
+  @moduletag :d_305
+  @moduletag :d_306
+
+  alias Tau.Factory.Gate.Mutation
+
+  # ---------------------------------------------------------------------------
+  # Generators for %TestReport{}-like inputs.
+  # The exact struct name is Tau.Toolchain.TestReport (§C9 / §4 B3).
+  # We construct minimal maps for the pure judge/1 — the implementer maps these
+  # to the real struct; the property tests do not assume struct internals.
+  # ---------------------------------------------------------------------------
+
+  defp test_id_gen do
+    StreamData.bind(
+      StreamData.string(:alphanumeric, min_length: 3, max_length: 15),
+      fn s -> StreamData.constant("test_" <> s) end
+    )
+  end
+
+  defp test_case_gen(status) do
+    StreamData.bind(test_id_gen(), fn id ->
+      StreamData.constant(%{id: id, status: status})
+    end)
+  end
+
+  # A report with at least one :failed case.
+  defp non_vacuous_report_gen do
+    StreamData.bind(
+      StreamData.tuple({
+        StreamData.list_of(test_case_gen(:failed), min_length: 1, max_length: 5),
+        StreamData.list_of(test_case_gen(:passed), max_length: 5)
+      }),
+      fn {failed, passed} ->
+        StreamData.constant(%{cases: Enum.shuffle(failed ++ passed)})
+      end
+    )
+  end
+
+  # A report where ALL cases :passed (vacuous suite).
+  defp vacuous_report_gen do
+    StreamData.bind(
+      StreamData.list_of(test_case_gen(:passed), min_length: 0, max_length: 8),
+      fn passed ->
+        StreamData.constant(%{cases: passed})
+      end
+    )
+  end
+
+  defp gating_path_gen do
+    StreamData.bind(
+      StreamData.string(:alphanumeric, min_length: 4, max_length: 12),
+      fn s -> StreamData.constant("test/tau/#{s}_gate_test.exs") end
+    )
+  end
+
+  defp tracked_path_gen do
+    StreamData.bind(
+      StreamData.string(:alphanumeric, min_length: 4, max_length: 12),
+      fn s -> StreamData.constant("lib/tau/#{s}.ex") end
+    )
+  end
+
+  # ---------------------------------------------------------------------------
+  # P-MU1 — non-vacuity: judge/1 = {:pass, _} iff ≥1 :failed case.
+  # A suite that passes wholesale against the reverted tree is :fail.
+  # ---------------------------------------------------------------------------
+
+  property "P-MU1: AC-2 — judge/1 returns {:pass, ids} when report has ≥1 :failed case" do
+    check all(report <- non_vacuous_report_gen()) do
+      result = Mutation.judge(report)
+
+      assert {:pass, killed} = result,
+             "Expected {:pass, _} for report with ≥1 failed case, got #{inspect(result)}"
+
+      assert is_list(killed)
+      assert length(killed) >= 1
+
+      # Every killed id must correspond to a :failed case in the report.
+      failed_ids = report.cases |> Enum.filter(&(&1.status == :failed)) |> Enum.map(& &1.id)
+
+      Enum.each(killed, fn id ->
+        assert id in failed_ids,
+               "Killed id #{inspect(id)} not found in failed cases #{inspect(failed_ids)}"
+      end)
+    end
+  end
+
+  property "P-MU1: AC-2 — judge/1 returns {:fail, :no_test_failed} when all cases pass (vacuous suite)" do
+    check all(report <- vacuous_report_gen()) do
+      result = Mutation.judge(report)
+
+      assert {:fail, :no_test_failed} = result,
+             "Expected {:fail, :no_test_failed} for vacuous suite, got #{inspect(result)}"
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # P-MU2 — boundary = declared paths.
+  # plan/2 reverts exactly tracked_paths ∖ gating_paths to merge_base.
+  # The plan's revert_paths must equal tracked_paths -- gating_paths.
+  # ---------------------------------------------------------------------------
+
+  property "P-MU2: AC-2 — plan/2 revert_paths equals tracked_paths minus gating_paths" do
+    check all(
+            gating_paths_list <-
+              StreamData.list_of(gating_path_gen(), min_length: 1, max_length: 4),
+            extra_tracked <- StreamData.list_of(tracked_path_gen(), min_length: 0, max_length: 6)
+          ) do
+      gating_paths = MapSet.new(gating_paths_list)
+      # tracked_paths = gating paths + production paths (simulating git ls-files)
+      all_tracked = (gating_paths_list ++ extra_tracked) |> Enum.uniq()
+      merge_base = "abc1234"
+
+      plan = Mutation.plan(merge_base, gating_paths)
+
+      # The plan must expose its revert set via some field.
+      # The property asserts it equals all_tracked ∖ gating_paths.
+      expected_revert = MapSet.new(all_tracked) |> MapSet.difference(gating_paths)
+
+      # If the plan does not embed tracked_paths (it only knows the declared
+      # gating_paths and the merge_base), the boundary is: anything the engine
+      # will revert must be "everything except gating_paths". We test that
+      # the plan holds the gating_paths correctly as the keep-set.
+      keep_paths = Map.get(plan, :gating_paths, Map.get(plan, :keep_paths, :missing))
+
+      refute keep_paths == :missing,
+             "plan/2 must return a struct/map exposing the gating-test keep-set; got #{inspect(plan)}"
+
+      assert MapSet.equal?(MapSet.new(keep_paths), gating_paths),
+             "P-MU2: keep-set must equal declared gating_paths exactly"
+
+      # The merge_base must be recorded in the plan for the engine.
+      plan_base = Map.get(plan, :merge_base, Map.get(plan, :base, :missing))
+
+      refute plan_base == :missing,
+             "plan/2 must record the merge_base; got #{inspect(plan)}"
+
+      assert plan_base == merge_base
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # P-MU3 — project-creation N/A.
+  # When every gating path's nearest-ancestor build manifest is absent at
+  # merge_base, judge returns {:na, :project_created}.
+  # We model this via a special report shape: the implementer must define the
+  # contract. We test the judge/1 variant that handles the N/A sentinel.
+  # ---------------------------------------------------------------------------
+
+  @tag :ac_2
+  test "P-MU3: AC-2 — judge/1 returns {:na, :project_created} for a project-creation report" do
+    # The contract (SPEC §4 B3, gate-and-toolchain.md §2.3 P-MU3):
+    # If every gating path's nearest-ancestor build manifest is absent at
+    # merge_base, the engine signals this via a special report shape.
+    # judge/1 must return {:na, :project_created} for that sentinel.
+    project_created_report = %{cases: [], project_created: true}
+
+    result = Mutation.judge(project_created_report)
+
+    assert {:na, :project_created} = result,
+           "Expected {:na, :project_created} for project-creation sentinel report, got #{inspect(result)}"
+  end
+
+  # ---------------------------------------------------------------------------
+  # P-MU4 — purity: plan/2 and judge/1 perform no I/O.
+  # We verify this by calling them multiple times with identical inputs and
+  # asserting identical, deterministic outputs (referential transparency).
+  # ---------------------------------------------------------------------------
+
+  property "P-MU4: AC-2 — judge/1 is referentially transparent (same input → same output)" do
+    check all(report <- StreamData.one_of([non_vacuous_report_gen(), vacuous_report_gen()])) do
+      result_1 = Mutation.judge(report)
+      result_2 = Mutation.judge(report)
+
+      assert result_1 == result_2,
+             "P-MU4: judge/1 must be pure — repeated calls with same input must return same value"
+    end
+  end
+
+  property "P-MU4: AC-2 — plan/2 is referentially transparent (same inputs → same output)" do
+    check all(
+            gating_paths_list <-
+              StreamData.list_of(gating_path_gen(), min_length: 1, max_length: 3),
+            merge_base <- StreamData.string(:alphanumeric, min_length: 7, max_length: 40)
+          ) do
+      gating_paths = MapSet.new(gating_paths_list)
+
+      plan_1 = Mutation.plan(merge_base, gating_paths)
+      plan_2 = Mutation.plan(merge_base, gating_paths)
+
+      assert plan_1 == plan_2,
+             "P-MU4: plan/2 must be pure — repeated calls must return the same plan"
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Concrete example — verifies the module entry points exist and are callable.
+  # ---------------------------------------------------------------------------
+
+  @tag :ac_2
+  @tag :d_306
+  test "AC-2 / D-306: judge/1 and plan/2 are callable — modules must exist" do
+    # If Tau.Factory.Gate.Mutation does not yet exist, this test fails at
+    # compile time with UndefinedFunctionError — the correct fail-before state.
+
+    non_vacuous = %{cases: [%{id: "t1", status: :failed}, %{id: "t2", status: :passed}]}
+    assert {:pass, killed} = Mutation.judge(non_vacuous)
+    assert "t1" in killed
+
+    vacuous = %{cases: [%{id: "t1", status: :passed}]}
+    assert {:fail, :no_test_failed} = Mutation.judge(vacuous)
+
+    gating_paths = MapSet.new(["test/tau/factory/gate/mutation_property_test.exs"])
+    plan = Mutation.plan("deadbeef", gating_paths)
+
+    assert is_map(plan) or is_struct(plan),
+           "plan/2 must return a map or struct; got #{inspect(plan)}"
+  end
+end


### PR DESCRIPTION
## Closes
Closes #418 — P0: extract pure `Gate.*` modules (M10, migration.md §6; SPEC-FACTORY-GATE PR-GATE-1).

## Scope & order
Lift the gate **decision logic** from `lib/mix/gate/{ac_linkage,masking,mutation}.ex` into **pure** `Tau.Factory.Gate.{AcLinkage,Masking,Mutation}` modules (`lib/tau/factory/gate/*.ex`), **properties before examples**. The existing `lib/mix/tasks/tau.gate.*` tasks (and `lib/mix/gate/*`) become **thin shims** delegating to the new pure modules. **No behaviour change** — the old CLI/CI path is preserved (additive). This validates the HR-3 pure/execution split locally before any engine exists (P2). Preserve the recently-merged Gate 5.3 `:not_applicable` no-production-delta logic intact.

## SPECs
`SPEC-FACTORY-GATE` — this PR conforms and advances **PR-GATE-1**. No SPEC amendment expected (flag if a §4 contract gap surfaces).

## Acceptance criteria
- **AC-1 (D-305-adjacent):** `mix compile --warnings-as-errors` passes with `lib/tau/factory/gate/{ac_linkage,masking,mutation}.ex` present.
- **AC-2 (D-305):** `mix test --only property` passes including the `Masking` pure-predicate property (path-based gating-test edit/deleted-assertion detection; properties P-MK* from gate-and-toolchain.md §2).
- **AC-3 (D-304):** the gating-test-path discipline is path-based (not commit-attribution); a test exercising `Masking` flags an edit to a declared gating-test path.
- **AC-4 (meta):** the existing CI gate jobs (`mix tau.gate.{ac_linkage,masking,mutation}`) still pass via the shims — no behaviour change. *(meta — verified by CI wiring.)*

## Gating-test paths
`test/tau/factory/gate/ac_linkage_property_test.exs`, `test/tau/factory/gate/masking_property_test.exs`, `test/tau/factory/gate/mutation_property_test.exs` (FROZEN — implementer MUST NOT edit these; challenge via the coordinator if a test contradicts a SPEC §4 contract).

## Dependencies
Blocked-by: none (additive; old path untouched). Built on green `main` @ 42de476.

## Gate verdicts
_(filled in at gate time — Opus critic + Opus reviewer)_