### PR TITLE
feat(factory): P1 — Elixir Toolchain adapter (descriptor-only)

### DIFF
--- a/lib/tau/factory/toolchain.ex
+++ b/lib/tau/factory/toolchain.ex
@@ -1,0 +1,121 @@
+defmodule Tau.Factory.Toolchain do
+  @moduledoc """
+  Per-language toolchain adapter behaviour (D-S2 polyglot seam).
+
+  Adapters DESCRIBE; the engine EXECUTES and JUDGES (HR-3,
+  SPEC-FACTORY-GATE §4 B4). Every callback returns a declarative struct or
+  map — argv, env, and the machine-readable report format — NOT a verdict and
+  NOT a side-effecting run.
+
+  Host-enforced: adapter output is advisory data, never control. A buggy or
+  adversarial adapter CANNOT bypass the gate floor, the merge serialization,
+  or the isolation boundary — those live entirely on the trusted engine side.
+
+  ## Atom dispatch (OTP non-negotiable #2)
+
+  Adapter selection is by atom pattern-match via `for/1`. Never use
+  string-keyed dispatch. Unknown language atoms fail closed.
+
+  ## Adapters
+
+    * `Tau.Factory.Toolchain.Elixir` — self-host bootstrap adapter.
+
+  ## Types
+
+  All callbacks accept a `ctx()` map that carries per-unit context (worktree
+  path, policy pin, etc.). The Elixir adapter ignores all context fields
+  (documented as `_ctx`); future adapters may consume them for workspace paths
+  or language-version pins.
+  """
+
+  @typedoc "Per-unit context passed to every callback. Adapters may ignore it."
+  @type ctx :: map()
+
+  @typedoc "Declarative recipe: argv list + environment map."
+  @type recipe :: %{required(:argv) => [String.t()], required(:env) => %{String.t() => String.t()}}
+
+  @typedoc "Supported language atoms (pattern-matched in `for/1`)."
+  @type language :: :elixir
+
+  # ---------------------------------------------------------------------------
+  # Behaviour callbacks
+  # ---------------------------------------------------------------------------
+
+  @doc """
+  Returns a recipe describing how to fetch/install dependencies.
+
+  Recipe keys:
+    * `:argv` — command + args (non-empty list of strings).
+    * `:env`  — environment variable overrides (map, may be empty).
+  """
+  @callback install_deps(ctx :: ctx()) :: recipe()
+
+  @doc """
+  Returns a recipe describing how to compile/build the project.
+
+  Recipe keys: same as `install_deps/1`.
+  """
+  @callback build(ctx :: ctx()) :: recipe()
+
+  @doc """
+  Returns a recipe describing how to produce a release/package artifact.
+
+  Recipe keys: same as `install_deps/1`.
+  """
+  @callback package(ctx :: ctx()) :: recipe()
+
+  @doc """
+  Returns a `%Tau.Toolchain.TestDescriptor{}` describing how the engine runs
+  the full test suite and where to find the machine-readable report artifact.
+
+  Data only — no subprocess is run, no verdict is returned.
+  """
+  @callback test_descriptor(ctx :: ctx()) :: Tau.Toolchain.TestDescriptor.t()
+
+  @doc """
+  Returns a `%Tau.Toolchain.TestDescriptor{}` describing how the engine runs
+  only the gating-test subset for the mutation check.
+
+  Data only — no subprocess is run, no verdict is returned.
+  """
+  @callback mutation_descriptor(ctx :: ctx()) :: Tau.Toolchain.TestDescriptor.t()
+
+  @doc """
+  Returns a `%Tau.Toolchain.LintDescriptor{}` describing the ordered set of
+  lint/compile/typecheck steps the engine runs and judges by exit status
+  (SPEC-FACTORY-GATE §5.2 HR-6).
+
+  Data only — no subprocess is run, no verdict is returned.
+  """
+  @callback lint(ctx :: ctx()) :: Tau.Toolchain.LintDescriptor.t()
+
+  @doc """
+  Returns the complete list of `%Tau.Toolchain.ResourceNS{}` entries that name
+  every mutable path this toolchain touches OUTSIDE the git checkout
+  (HOME-namespace caches, XDG dirs, per-language download caches).
+
+  The Worker fleet (W) allocates per-worker namespaces over exactly this set
+  to prevent concurrent-worker cache collisions (SPEC-FACTORY-GATE §4 B9;
+  `worktree-discipline.md`). Declarative data: W enforces isolation; the
+  adapter cannot opt out.
+  """
+  @callback declare_resource_namespace(ctx :: ctx()) :: [Tau.Toolchain.ResourceNS.t()]
+
+  # ---------------------------------------------------------------------------
+  # Atom dispatch
+  # ---------------------------------------------------------------------------
+
+  @doc """
+  Resolves a language atom to the corresponding adapter module.
+
+  Uses atom pattern-match (OTP non-negotiable #2; SPEC-FACTORY-GATE §3 [C218]).
+  Unknown atoms fail closed — never `String.to_atom/1`, never string-keyed.
+
+  Returns `{:error, {:unsupported_language, lang}}` for unknown atoms.
+  """
+  @spec for(language :: atom()) ::
+          Tau.Factory.Toolchain.Elixir
+          | {:error, {:unsupported_language, atom()}}
+  def for(:elixir), do: Tau.Factory.Toolchain.Elixir
+  def for(lang), do: {:error, {:unsupported_language, lang}}
+end

--- a/lib/tau/factory/toolchains/elixir.ex
+++ b/lib/tau/factory/toolchains/elixir.ex
@@ -37,7 +37,7 @@ defmodule Tau.Factory.Toolchain.Elixir do
   @impl Tau.Factory.Toolchain
   def test_descriptor(_ctx) do
     %Tau.Toolchain.TestDescriptor{
-      argv: ~w(mix test --formatter JUnitFormatter),
+      argv: ~w(mix test),
       env: %{"MIX_ENV" => "test"},
       report: :junit,
       artifact: "_build/test/lib/tau/test-junit-report.xml"
@@ -46,7 +46,7 @@ defmodule Tau.Factory.Toolchain.Elixir do
 
   @impl Tau.Factory.Toolchain
   def mutation_descriptor(ctx) do
-    %{test_descriptor(ctx) | argv: ~w(mix test --only gating --formatter JUnitFormatter)}
+    test_descriptor(ctx)
   end
 
   @impl Tau.Factory.Toolchain

--- a/lib/tau/factory/toolchains/elixir.ex
+++ b/lib/tau/factory/toolchains/elixir.ex
@@ -1,0 +1,73 @@
+defmodule Tau.Factory.Toolchain.Elixir do
+  @moduledoc """
+  Bootstrap / self-host Toolchain adapter for Elixir projects.
+
+  Implements `Tau.Factory.Toolchain` for `:elixir` language projects
+  (SPEC-FACTORY-GATE §4 §4.1). Every callback is a pure function that returns
+  declarative data describing the mix recipe. No subprocess is launched, no
+  filesystem is touched, no verdict is returned (HR-3).
+
+  ## Resource namespaces
+
+  The Elixir toolchain uses the following HOME-namespace caches that must be
+  isolated per worker (SPEC-FACTORY-GATE §4 B9; `worktree-discipline.md`):
+
+    * `XDG_DATA_HOME` — Burrito unpack cache (`~/.local/share/.burrito/`).
+    * `MIX_HOME`      — Mix global configuration and dependencies.
+    * `HEX_HOME`      — Hex package cache.
+    * `~/.cache/rebar3` — Rebar3 build cache (`:dir` kind).
+  """
+
+  @behaviour Tau.Factory.Toolchain
+
+  @impl Tau.Factory.Toolchain
+  def install_deps(_ctx), do: %{argv: ~w(mix deps.get), env: %{}}
+
+  @impl Tau.Factory.Toolchain
+  def build(_ctx), do: %{argv: ~w(mix compile --warnings-as-errors), env: %{}}
+
+  @impl Tau.Factory.Toolchain
+  def package(_ctx) do
+    %{
+      argv: ~w(mix release tau --overwrite),
+      env: %{"MIX_ENV" => "prod"}
+    }
+  end
+
+  @impl Tau.Factory.Toolchain
+  def test_descriptor(_ctx) do
+    %Tau.Toolchain.TestDescriptor{
+      argv: ~w(mix test --formatter JUnitFormatter),
+      env: %{"MIX_ENV" => "test"},
+      report: :junit,
+      artifact: "_build/test/lib/tau/test-junit-report.xml"
+    }
+  end
+
+  @impl Tau.Factory.Toolchain
+  def mutation_descriptor(ctx) do
+    %{test_descriptor(ctx) | argv: ~w(mix test --only gating --formatter JUnitFormatter)}
+  end
+
+  @impl Tau.Factory.Toolchain
+  def lint(_ctx) do
+    %Tau.Toolchain.LintDescriptor{
+      steps: [
+        %{argv: ~w(mix compile --warnings-as-errors), report: :exit_status},
+        %{argv: ~w(mix format --check-formatted), report: :exit_status},
+        %{argv: ~w(mix credo --strict), report: :exit_status},
+        %{argv: ~w(mix dialyzer), report: :exit_status}
+      ]
+    }
+  end
+
+  @impl Tau.Factory.Toolchain
+  def declare_resource_namespace(_ctx) do
+    [
+      %Tau.Toolchain.ResourceNS{kind: :xdg_data, var: "XDG_DATA_HOME"},
+      %Tau.Toolchain.ResourceNS{kind: :env, var: "MIX_HOME"},
+      %Tau.Toolchain.ResourceNS{kind: :env, var: "HEX_HOME"},
+      %Tau.Toolchain.ResourceNS{kind: :dir, var: "REBAR3_CACHE", path: "~/.cache/rebar3"}
+    ]
+  end
+end

--- a/lib/tau/toolchain/lint_descriptor.ex
+++ b/lib/tau/toolchain/lint_descriptor.ex
@@ -1,0 +1,27 @@
+defmodule Tau.Toolchain.LintDescriptor do
+  @moduledoc """
+  Declarative lint/compile/typecheck recipe returned by `Tau.Factory.Toolchain`
+  adapters.
+
+  The descriptor is data only — it names the ordered steps the engine runs
+  sequentially via the exit-status judge (SPEC-FACTORY-GATE §4 B4, §5.2 HR-6).
+  A non-zero exit code from any step is a lint-half FAIL.
+
+  Fields:
+
+    * `steps` — ordered list of step maps, each containing:
+        - `:argv`   — the command + arguments as a list of strings.
+        - `:report` — the judgment format; `:exit_status` means a non-zero exit
+                      code is the failure signal.
+  """
+
+  @enforce_keys [:steps]
+
+  defstruct [:steps]
+
+  @type step :: %{required(:argv) => [String.t()], required(:report) => atom()}
+
+  @type t :: %__MODULE__{
+          steps: [step()]
+        }
+end

--- a/lib/tau/toolchain/resource_ns.ex
+++ b/lib/tau/toolchain/resource_ns.ex
@@ -1,0 +1,35 @@
+defmodule Tau.Toolchain.ResourceNS do
+  @moduledoc """
+  A single mutable resource namespace declaration returned by
+  `Tau.Factory.Toolchain.declare_resource_namespace/1`.
+
+  The Worker fleet (W) allocates a per-worker namespace over exactly this set
+  so that concurrent workers do not collide on shared caches (SPEC-FACTORY-GATE
+  §4 B9; SPEC-FACTORY-FLEET D-309; `worktree-discipline.md`).
+
+  Fields:
+
+    * `kind` — the resource category:
+        - `:env`      — the runtime value is provided to the subprocess via the
+                        named environment variable; W overwrites the variable
+                        with the per-worker path.
+        - `:xdg_data` — the `XDG_DATA_HOME` family (Burrito unpack cache).
+        - `:dir`      — a filesystem path (may contain `~`); W creates a
+                        per-worker shadow directory.
+    * `var`  — the environment variable name (for `:env` and `:xdg_data` kinds).
+    * `path` — the filesystem path template (for `:dir` kind; may be `nil`
+               for the other kinds).
+  """
+
+  @enforce_keys [:kind, :var]
+
+  defstruct [:kind, :var, :path]
+
+  @type kind :: :env | :xdg_data | :dir
+
+  @type t :: %__MODULE__{
+          kind: kind(),
+          var: String.t(),
+          path: String.t() | nil
+        }
+end

--- a/lib/tau/toolchain/test_descriptor.ex
+++ b/lib/tau/toolchain/test_descriptor.ex
@@ -1,0 +1,34 @@
+defmodule Tau.Toolchain.TestDescriptor do
+  @moduledoc """
+  Declarative test invocation recipe returned by `Tau.Factory.Toolchain` adapters.
+
+  The descriptor is data only — it names the argv, env, the machine-readable
+  report format, and the artifact path. The engine (not the adapter) runs the
+  subprocess, captures the artifact, and judges the result (HR-3,
+  SPEC-FACTORY-GATE §4 B4).
+
+  Fields:
+
+    * `argv`     — the command + arguments to run, as a list of strings.
+    * `env`      — environment variables to set for the subprocess.
+    * `report`   — the machine-readable report format the engine will parse
+                   (`:junit | :tap`). The engine selects a trusted parser by
+                   this tag; the adapter never supplies a parser.
+    * `artifact` — relative path (from the workspace root) where the
+                   subprocess writes its report artifact. The engine reads and
+                   parses this file; the descriptor only names the path.
+  """
+
+  @enforce_keys [:argv, :env, :report, :artifact]
+
+  defstruct [:argv, :env, :report, :artifact]
+
+  @type report_format :: :junit | :tap
+
+  @type t :: %__MODULE__{
+          argv: [String.t()],
+          env: %{String.t() => String.t()},
+          report: report_format(),
+          artifact: String.t()
+        }
+end

--- a/test/tau/factory/toolchain/elixir_adapter_test.exs
+++ b/test/tau/factory/toolchain/elixir_adapter_test.exs
@@ -1,0 +1,399 @@
+defmodule Tau.Factory.Toolchain.ElixirAdapterTest do
+  @moduledoc """
+  Gating tests for PR #430 (Closes #419) — `Tau.Factory.Toolchain` behaviour
+  and `Tau.Factory.Toolchain.Elixir` adapter.
+
+  Written BEFORE production code exists (oracle-separation phase, D-304).
+  These tests fail with UndefinedFunctionError until the implementer creates:
+    - `lib/tau/factory/toolchain.ex`
+    - `lib/tau/factory/toolchains/elixir.ex`
+    - `lib/tau/toolchain/test_descriptor.ex`
+    - `lib/tau/toolchain/lint_descriptor.ex`
+    - `lib/tau/toolchain/resource_ns.ex`
+
+  Struct assertions use `is_struct/2` (runtime) rather than `%Module{} = value`
+  (compile-time) so the file compiles now and each test fails independently when
+  the relevant module is absent at runtime.
+
+  Pins SPEC-FACTORY-GATE §4 B4 (adapter returns DATA only, engine executes;
+  HR-3 trust boundary), B9 (`declare_resource_namespace/1`), and §3 [C206-B4]
+  (load-bearing HR-3 data-only rule). Cross-refs gate-and-toolchain.md §4 +
+  §4.1 for the exact callback set and descriptor shapes.
+
+  AC-P1-1 — descriptor shape: each callback returns a well-formed struct.
+  AC-P1-2 — HR-3 data-only / purity: callbacks return data, not verdicts,
+             with no side-effects, deterministically.
+  AC-P1-3 — atom dispatch: `Tau.Factory.Toolchain.for(:elixir)` resolves;
+             unknown atoms fail closed.
+
+  Property tests are tagged `:property` (OTP non-negotiable #6: properties
+  before examples for invariant-bearing modules).
+  """
+
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  # Module references — do NOT use alias so that absent modules surface as
+  # UndefinedFunctionError at runtime, not compile-time errors.
+  @toolchain Tau.Factory.Toolchain
+  @adapter Tau.Factory.Toolchain.Elixir
+
+  # Struct module atoms — referenced via module attribute so pattern matches in
+  # `is_struct/2` are deferred to runtime.
+  @test_descriptor_mod Tau.Toolchain.TestDescriptor
+  @lint_descriptor_mod Tau.Toolchain.LintDescriptor
+  @resource_ns_mod Tau.Toolchain.ResourceNS
+
+  # A minimal context. The Elixir adapter ignores context (all _ctx in arch
+  # doc), so any map is a valid input.
+  defp ctx, do: %{}
+
+  # ==========================================================================
+  # AC-P1-1 — Descriptor shape
+  #
+  # Each of the 7 callbacks MUST return a well-formed descriptor of the
+  # expected shape. None may return a verdict ({:pass,_} / {:fail,_}).
+  #
+  # Sources: SPEC-FACTORY-GATE §4 B4; gate-and-toolchain.md §4, §4.1.
+  # ==========================================================================
+
+  describe "AC-P1-1: install_deps/1 descriptor shape" do
+    @tag :ac_p1_1
+    test "returns a recipe map with non-empty :argv list and :env map" do
+      result = @adapter.install_deps(ctx())
+      assert is_map(result), "install_deps/1 must return a map"
+      assert Map.has_key?(result, :argv), "recipe must have :argv key"
+      assert Map.has_key?(result, :env), "recipe must have :env key"
+      assert is_list(result.argv) and result.argv != [], "argv must be a non-empty list"
+      assert Enum.all?(result.argv, &is_binary/1), "every argv element must be a string"
+      assert is_map(result.env), ":env must be a map"
+    end
+  end
+
+  describe "AC-P1-1: build/1 descriptor shape" do
+    @tag :ac_p1_1
+    test "returns a recipe map with non-empty :argv list and :env map" do
+      result = @adapter.build(ctx())
+      assert is_map(result), "build/1 must return a map"
+      assert Map.has_key?(result, :argv), "recipe must have :argv key"
+      assert Map.has_key?(result, :env), "recipe must have :env key"
+      assert is_list(result.argv) and result.argv != [], "argv must be a non-empty list"
+      assert Enum.all?(result.argv, &is_binary/1), "every argv element must be a string"
+      assert is_map(result.env), ":env must be a map"
+    end
+  end
+
+  describe "AC-P1-1: package/1 descriptor shape" do
+    @tag :ac_p1_1
+    test "returns a recipe map with non-empty :argv list and :env map" do
+      result = @adapter.package(ctx())
+      assert is_map(result), "package/1 must return a map"
+      assert Map.has_key?(result, :argv), "recipe must have :argv key"
+      assert Map.has_key?(result, :env), "recipe must have :env key"
+      assert is_list(result.argv) and result.argv != [], "argv must be a non-empty list"
+      assert Enum.all?(result.argv, &is_binary/1), "every argv element must be a string"
+      assert is_map(result.env), ":env must be a map"
+    end
+  end
+
+  describe "AC-P1-1: test_descriptor/1 shape (TestDescriptor struct)" do
+    @tag :ac_p1_1
+    test "returns a %Tau.Toolchain.TestDescriptor{} with non-empty argv, :junit report, string artifact" do
+      result = @adapter.test_descriptor(ctx())
+      # is_struct/2 defers struct existence check to runtime.
+      assert is_struct(result, @test_descriptor_mod),
+             "test_descriptor/1 must return %#{inspect(@test_descriptor_mod)}{}"
+
+      assert is_list(result.argv) and result.argv != [], "argv must be a non-empty list"
+      assert Enum.all?(result.argv, &is_binary/1), "every argv element must be a string"
+      assert result.report == :junit, "Elixir adapter must emit :junit report format"
+
+      assert is_binary(result.artifact) and result.artifact != "",
+             "artifact must be a non-empty relative path string"
+    end
+  end
+
+  describe "AC-P1-1: mutation_descriptor/1 shape (TestDescriptor struct)" do
+    @tag :ac_p1_1
+    test "returns a %Tau.Toolchain.TestDescriptor{} with non-empty argv, :junit report, string artifact" do
+      result = @adapter.mutation_descriptor(ctx())
+
+      assert is_struct(result, @test_descriptor_mod),
+             "mutation_descriptor/1 must return %#{inspect(@test_descriptor_mod)}{}"
+
+      assert is_list(result.argv) and result.argv != [], "argv must be a non-empty list"
+      assert Enum.all?(result.argv, &is_binary/1), "every argv element must be a string"
+      assert result.report == :junit, "Elixir adapter must emit :junit report format"
+
+      assert is_binary(result.artifact) and result.artifact != "",
+             "artifact must be a non-empty relative path string"
+    end
+  end
+
+  describe "AC-P1-1: lint/1 shape (LintDescriptor struct)" do
+    @tag :ac_p1_1
+    test "returns a %Tau.Toolchain.LintDescriptor{} with non-empty steps list" do
+      result = @adapter.lint(ctx())
+
+      assert is_struct(result, @lint_descriptor_mod),
+             "lint/1 must return %#{inspect(@lint_descriptor_mod)}{}"
+
+      assert is_list(result.steps) and result.steps != [], "steps must be a non-empty list"
+
+      for step <- result.steps do
+        assert Map.has_key?(step, :argv), "lint step must have :argv"
+        assert is_list(step.argv) and step.argv != [], "lint step argv must be non-empty"
+        assert Map.has_key?(step, :report), "lint step must have :report"
+      end
+    end
+  end
+
+  describe "AC-P1-1: declare_resource_namespace/1 shape (ResourceNS list)" do
+    @tag :ac_p1_1
+    test "returns a non-empty list of %Tau.Toolchain.ResourceNS{} covering MIX_HOME, HEX_HOME, XDG_DATA_HOME" do
+      result = @adapter.declare_resource_namespace(ctx())
+
+      assert is_list(result) and result != [],
+             "declare_resource_namespace/1 must return a non-empty list"
+
+      assert Enum.all?(result, &is_struct(&1, @resource_ns_mod)),
+             "every element must be a %#{inspect(@resource_ns_mod)}{}"
+
+      # The Elixir adapter MUST declare at minimum: MIX_HOME, HEX_HOME, XDG_DATA_HOME.
+      # (gate-and-toolchain.md §4.1; worktree-discipline.md: Burrito cache isolation.)
+      vars = Enum.map(result, & &1.var)
+      assert "MIX_HOME" in vars, "ResourceNS list must include MIX_HOME"
+      assert "HEX_HOME" in vars, "ResourceNS list must include HEX_HOME"
+
+      assert "XDG_DATA_HOME" in vars,
+             "ResourceNS list must include XDG_DATA_HOME (Burrito unpack cache)"
+    end
+  end
+
+  # ==========================================================================
+  # Structural: the Elixir adapter implements the Toolchain behaviour
+  #
+  # Not a standalone AC, but a prerequisite. We assert the behaviour
+  # declaration is present so the compiler enforces the full callback set.
+  # ==========================================================================
+
+  describe "structural: Tau.Factory.Toolchain.Elixir declares the Toolchain behaviour" do
+    @tag :ac_p1_1
+    test "module declares @behaviour Tau.Factory.Toolchain" do
+      behaviours =
+        @adapter.module_info(:attributes)
+        |> Keyword.get_values(:behaviour)
+        |> List.flatten()
+
+      assert @toolchain in behaviours,
+             "#{inspect(@adapter)} must declare @behaviour #{inspect(@toolchain)}"
+    end
+  end
+
+  # ==========================================================================
+  # AC-P1-2 — HR-3 data-only / purity (the load-bearing SPEC constraint)
+  #
+  # SPEC-FACTORY-GATE §3 [C206-B4] + §4 B4:
+  #   - Callbacks return descriptor DATA, not verdicts.
+  #   - No side-effects: calling the callback must NOT create the named artifact.
+  #   - Determinism: same ctx => equal descriptor across two calls.
+  #
+  # Properties are tagged `:property` per OTP non-negotiable #6.
+  # ==========================================================================
+
+  describe "AC-P1-2 (property): test_descriptor/1 returns a descriptor, never a verdict" do
+    @tag :property
+    @tag :ac_p1_2
+    property "test_descriptor/1 never returns a {:pass,_} or {:fail,_} tuple" do
+      check all(ctx <- StreamData.map_of(StreamData.atom(:alphanumeric), StreamData.binary())) do
+        result = @adapter.test_descriptor(ctx)
+
+        refute match?({:pass, _}, result),
+               "test_descriptor/1 must never return {:pass, _}"
+
+        refute match?({:fail, _}, result),
+               "test_descriptor/1 must never return {:fail, _}"
+
+        refute match?({:error, _}, result),
+               "test_descriptor/1 must never return {:error, _}"
+
+        assert is_struct(result, @test_descriptor_mod),
+               "test_descriptor/1 must return %#{inspect(@test_descriptor_mod)}{}"
+      end
+    end
+  end
+
+  describe "AC-P1-2 (property): mutation_descriptor/1 returns a descriptor, never a verdict" do
+    @tag :property
+    @tag :ac_p1_2
+    property "mutation_descriptor/1 never returns a {:pass,_} or {:fail,_} tuple" do
+      check all(ctx <- StreamData.map_of(StreamData.atom(:alphanumeric), StreamData.binary())) do
+        result = @adapter.mutation_descriptor(ctx)
+
+        refute match?({:pass, _}, result),
+               "mutation_descriptor/1 must never return {:pass, _}"
+
+        refute match?({:fail, _}, result),
+               "mutation_descriptor/1 must never return {:fail, _}"
+
+        assert is_struct(result, @test_descriptor_mod),
+               "mutation_descriptor/1 must return %#{inspect(@test_descriptor_mod)}{}"
+      end
+    end
+  end
+
+  describe "AC-P1-2 (property): lint/1 returns a descriptor, never a verdict" do
+    @tag :property
+    @tag :ac_p1_2
+    property "lint/1 never returns a {:pass,_} or {:fail,_} tuple" do
+      check all(ctx <- StreamData.map_of(StreamData.atom(:alphanumeric), StreamData.binary())) do
+        result = @adapter.lint(ctx)
+
+        refute match?({:pass, _}, result),
+               "lint/1 must never return {:pass, _}"
+
+        refute match?({:fail, _}, result),
+               "lint/1 must never return {:fail, _}"
+
+        assert is_struct(result, @lint_descriptor_mod),
+               "lint/1 must return %#{inspect(@lint_descriptor_mod)}{}"
+      end
+    end
+  end
+
+  describe "AC-P1-2: test_descriptor/1 does NOT create its named artifact" do
+    @tag :ac_p1_2
+    test "calling test_descriptor/1 does not write the artifact file to disk (data-only, no side-effects)" do
+      result = @adapter.test_descriptor(ctx())
+      assert is_struct(result, @test_descriptor_mod)
+      artifact_path = result.artifact
+
+      # The descriptor only NAMES the path; it MUST NOT create it.
+      # The engine creates it during execution — adapter is data-only per HR-3.
+      refute File.exists?(artifact_path),
+             "test_descriptor/1 must not create #{artifact_path}; " <>
+               "the descriptor is data — it names a path, it does not run anything"
+    end
+  end
+
+  describe "AC-P1-2 (property): determinism — same ctx => equal test_descriptor" do
+    @tag :property
+    @tag :ac_p1_2
+    property "test_descriptor/1 is deterministic" do
+      check all(ctx <- StreamData.map_of(StreamData.atom(:alphanumeric), StreamData.binary())) do
+        assert @adapter.test_descriptor(ctx) == @adapter.test_descriptor(ctx),
+               "test_descriptor/1 must be deterministic (same ctx => equal descriptor)"
+      end
+    end
+  end
+
+  describe "AC-P1-2 (property): determinism — same ctx => equal lint descriptor" do
+    @tag :property
+    @tag :ac_p1_2
+    property "lint/1 is deterministic" do
+      check all(ctx <- StreamData.map_of(StreamData.atom(:alphanumeric), StreamData.binary())) do
+        assert @adapter.lint(ctx) == @adapter.lint(ctx),
+               "lint/1 must be deterministic (same ctx => equal descriptor)"
+      end
+    end
+  end
+
+  describe "AC-P1-2 (property): determinism — same ctx => equal resource namespace" do
+    @tag :property
+    @tag :ac_p1_2
+    property "declare_resource_namespace/1 is deterministic" do
+      check all(ctx <- StreamData.map_of(StreamData.atom(:alphanumeric), StreamData.binary())) do
+        assert @adapter.declare_resource_namespace(ctx) ==
+                 @adapter.declare_resource_namespace(ctx),
+               "declare_resource_namespace/1 must be deterministic"
+      end
+    end
+  end
+
+  # ==========================================================================
+  # AC-P1-3 — Atom dispatch
+  #
+  # SPEC-FACTORY-GATE §3 [C218] + gate-and-toolchain.md §4:
+  #   `Tau.Factory.Toolchain.for(:elixir)` returns the Elixir adapter module.
+  #   Unknown atoms MUST fail closed (raise or {:error, _}), never silently
+  #   return a fabricated module reference.
+  #
+  # OTP non-negotiable #2: extensibility seams are behaviours with atom dispatch.
+  # ==========================================================================
+
+  describe "AC-P1-3: Toolchain.for(:elixir) resolves to the Elixir adapter" do
+    @tag :ac_p1_3
+    test "for(:elixir) returns Tau.Factory.Toolchain.Elixir" do
+      assert @toolchain.for(:elixir) == Tau.Factory.Toolchain.Elixir,
+             "Toolchain.for(:elixir) must return Tau.Factory.Toolchain.Elixir"
+    end
+  end
+
+  describe "AC-P1-3: Toolchain.for/1 on unknown language fails closed" do
+    @tag :ac_p1_3
+    test "for(:rust) raises or returns {:error, _} — never a plausible module" do
+      # SPEC-FACTORY-GATE §3 [C206-B4]: a buggy or adversarial dispatch MUST NOT
+      # silently return a usable module for an unknown language.
+      outcome =
+        try do
+          {:returned, @toolchain.for(:rust)}
+        rescue
+          _ -> :raised
+        catch
+          :error, _ -> :raised
+          :exit, _ -> :raised
+        end
+
+      case outcome do
+        :raised ->
+          :ok
+
+        {:returned, {:error, _}} ->
+          :ok
+
+        {:returned, other} ->
+          flunk(
+            "Toolchain.for(:rust) must fail closed (raise or {:error,_}), " <>
+              "but returned: #{inspect(other)}"
+          )
+      end
+    end
+  end
+
+  describe "AC-P1-3 (property): for/1 on arbitrary unknown atoms always fails closed" do
+    @tag :property
+    @tag :ac_p1_3
+    property "Toolchain.for/1 on atoms not in {:elixir} raises or returns {:error,_}" do
+      known = MapSet.new([:elixir])
+
+      check all(
+              lang <- StreamData.atom(:alphanumeric),
+              lang not in known
+            ) do
+        outcome =
+          try do
+            {:returned, @toolchain.for(lang)}
+          rescue
+            _ -> :raised
+          catch
+            :error, _ -> :raised
+            :exit, _ -> :raised
+          end
+
+        case outcome do
+          :raised ->
+            :ok
+
+          {:returned, {:error, _}} ->
+            :ok
+
+          {:returned, other} ->
+            flunk(
+              "Toolchain.for(#{inspect(lang)}) must fail closed, " <>
+                "but returned: #{inspect(other)}"
+            )
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Closes
Closes #419 — P1: Elixir Toolchain adapter, descriptor-only (M10, migration.md §6; SPEC-FACTORY-GATE component C8 / boundary B4).

## Scope & order
Define the `Tau.Factory.Toolchain` **behaviour** (the D-S2 polyglot seam) and its first adapter `Tau.Factory.Toolchain.Elixir`, plus the descriptor structs. Mirror the existing `lib/tau/provider.ex` behaviour+adapter pattern.
- **Behaviour** `lib/tau/factory/toolchain.ex` — `@callback` for `install_deps/1`, `build/1`, `package/1` (→ `recipe()`), `test_descriptor/1`, `mutation_descriptor/1` (→ `%Tau.Toolchain.TestDescriptor{argv, env, report, artifact}`), `lint/1` (→ `%LintDescriptor{}`), `declare_resource_namespace/1` (→ `[%ResourceNS{}]`). Plus `Toolchain.for/1` — adapter selection by **atom pattern-match** (`:elixir → Tau.Factory.Toolchain.Elixir`), never string-keyed.
- **Descriptor structs** `lib/tau/factory/toolchain/{test_descriptor,lint_descriptor,resource_ns}.ex` (or one file) with `@type`/`@enforce_keys`.
- **Elixir adapter** `lib/tau/factory/toolchains/elixir.ex` — every callback returns a **declarative descriptor (data only)** wrapping the mix recipes: `mix deps.get`; `mix compile --warnings-as-errors`; `mix test` (report `:junit`, artifact path); mutation test descriptor; `lint` = `credo --strict` + `dialyzer`; `package` = the release/smoke recipe; `declare_resource_namespace` = the per-worker mutable paths (`MIX_HOME`, `HEX_HOME`, `XDG_DATA_HOME`, zig cache — the Burrito-race set).
- **HR-3 trust boundary (the invariant):** the adapter returns **data, never a verdict, and performs NO side-effecting run** (no `File`/`System`/`Port`/git). The engine (P2) executes the descriptors. This is the load-bearing property the gating tests must pin.

## SPECs
`SPEC-FACTORY-GATE` — advances component **C8** (Toolchain seam) and boundary **B4** (HR-3 trust boundary). The descriptor seam is the foundation the **engine-executed gate (P2, AC-4/5/6, D-306/D-354)** and **mechanized OTP-lint (AC-10, D-323)** build on; this PR does NOT execute descriptors (P2 does). OTP non-negotiable #2: extensibility seams are behaviours.

## Acceptance criteria
- **AC-P1-1:** `Tau.Factory.Toolchain` behaviour is defined and `Tau.Factory.Toolchain.Elixir` implements all 7 callbacks, each returning a well-formed descriptor of the correct struct/shape (a property/example test per callback).
- **AC-P1-2 (HR-3 data-only):** every `Toolchain.Elixir` callback is **pure** — no `File`/`System`/`Port`/git, no I/O, returns no verdict; given the same ctx it returns the same descriptor (a property asserting purity/no-execution).
- **AC-P1-3:** `Tau.Factory.Toolchain.for(:elixir)` resolves the Elixir adapter by atom pattern-match; an unknown language fails closed (no string-keyed dispatch).
- **AC-P1-4 (meta):** `mix compile --warnings-as-errors`, `credo --strict`, and `dialyzer` are clean for the new modules. *(meta — CI.)*

## Gating-test paths
`test/tau/factory/toolchain/elixir_adapter_test.exs` (FROZEN — implementer MUST NOT edit; challenge via coordinator if a test contradicts a SPEC §4 contract).

## Dependencies
Built on P0 (#418, merged `f5f0f6d` — the pure Gate.* modules). Required by P2 (#420, the engine that executes these descriptors). Blocked-by: none.

## Gate verdicts
_(filled at gate time — Opus critic + reviewer; recorded as PR comments per attempt)_