### PR TITLE
feat(factory): P2 — engine-executed gate (Engine.TestRun + ReportParser) [advances #420]

### DIFF
--- a/lib/tau/factory/engine/test_run.ex
+++ b/lib/tau/factory/engine/test_run.ex
@@ -1,0 +1,98 @@
+defmodule Tau.Factory.Engine.TestRun do
+  @moduledoc """
+  Engine component C6: executes a `%Tau.Toolchain.TestDescriptor{}` as a
+  subprocess, captures the artifact it writes, and parses that artifact via
+  `Tau.Toolchain.ReportParser` — returning an engine-produced
+  `%Tau.Toolchain.TestReport{}`.
+
+  ## HR-3 anti-gaming contract (SPEC-FACTORY-GATE §4 B4/B5, D-354)
+
+  The verdict comes EXCLUSIVELY from parsing the artifact file. Any field the
+  adapter (descriptor) may carry — `__adapter_verdict__`, `__adapter_result__`,
+  or any other key beyond the four canonical ones (`argv`, `env`, `report`,
+  `artifact`) — is IGNORED. The engine reads only:
+
+    1. `descriptor.argv`     — the command to run.
+    2. `descriptor.env`      — environment variables for the subprocess.
+    3. `descriptor.report`   — format tag selecting the trusted parser.
+    4. `descriptor.artifact` — relative path to the output file.
+
+  The `ReportParser` is engine-owned (trusted); the adapter never supplies a
+  parser or a pre-computed result.
+
+  ## Subprocess execution
+
+  Uses `System.cmd/3` for one-shot capture (stdout + stderr captured, not
+  streamed). The subprocess receives an expanded environment containing both
+  the inherited process env and the descriptor's `:env` map. The artifact path
+  is resolved relative to `workspace_dir`; if absent after the recipe exits,
+  `execute/2` returns `{:error, :artifact_missing}`.
+
+  ## Return
+
+    * `{:ok, %TestReport{}}` — artifact read and parsed successfully.
+    * `{:error, reason}`     — recipe failed to start, crashed, or the artifact
+      was absent. Reason is a tagged atom or tuple; never a fabricated pass.
+  """
+
+  alias Tau.Toolchain.ReportParser
+  alias Tau.Toolchain.TestReport
+
+  @doc """
+  Execute `descriptor` in `workspace_dir`, parse the artifact, return a report.
+
+  The second argument is an absolute path to the workspace directory. The
+  descriptor's `:artifact` field is a relative path within that directory.
+  """
+  @spec execute(map(), String.t()) :: {:ok, TestReport.t()} | {:error, term()}
+  def execute(descriptor, workspace_dir) when is_binary(workspace_dir) do
+    [cmd | args] = descriptor.argv
+    env_list = build_env(descriptor.env)
+
+    opts = [
+      env: env_list,
+      cd: workspace_dir,
+      stderr_to_stdout: true
+    ]
+
+    case System.cmd(cmd, args, opts) do
+      {_output, _exit_code} ->
+        # We do not check exit_code — the artifact is the truth (HR-3).
+        # A recipe that writes a correct artifact and exits non-zero is still
+        # valid (e.g. mix test exits 1 when tests fail but the report is written).
+        artifact_path = Path.join(workspace_dir, descriptor.artifact)
+        read_and_parse(artifact_path, descriptor.report)
+    end
+  rescue
+    e in ErlangError ->
+      # System.cmd raises ErlangError when the executable is not found.
+      {:error, {:exec_failed, e.original}}
+
+    _ ->
+      {:error, :exec_failed}
+  catch
+    _, _ ->
+      {:error, :exec_failed}
+  end
+
+  # ---------------------------------------------------------------------------
+  # Private helpers
+  # ---------------------------------------------------------------------------
+
+  defp build_env(env_map) when is_map(env_map) do
+    Enum.map(env_map, fn {k, v} -> {to_string(k), to_string(v)} end)
+  end
+
+  defp build_env(_), do: []
+
+  defp read_and_parse(artifact_path, format_tag) do
+    case File.read(artifact_path) do
+      {:ok, bytes} ->
+        report = ReportParser.parse(bytes, format_tag)
+        {:ok, report}
+
+      {:error, _} ->
+        {:error, :artifact_missing}
+    end
+  end
+end

--- a/lib/tau/factory/gate/mutation.ex
+++ b/lib/tau/factory/gate/mutation.ex
@@ -106,4 +106,38 @@ defmodule Tau.Factory.Gate.Mutation do
       _ -> {:pass, Enum.map(failed, & &1.id)}
     end
   end
+
+  @doc """
+  Strictly-ordered cross-check: assert `killed_ids ⊆ passing_ids(real_report)`.
+
+  Given:
+  - `killed_ids`  — the `:failed` case ids from the reverted-run report (from
+    `judge/1`'s `{:pass, killed_ids}` result).
+  - `real_report` — the engine-parsed report from the real (green) tree.
+
+  Returns `:pass` iff every id in `killed_ids` appears with status `:passed`
+  in `real_report`. Returns `{:fail, :cross_check_failed}` otherwise.
+
+  Empty `killed_ids` vacuously satisfies the subset condition (∅ ⊆ anything).
+
+  Pure function (P-MU4): no I/O, referentially transparent.
+
+  SPEC-FACTORY-GATE §3 [C203-B3], §4 B3, D-306.
+  """
+  @spec cross_check([term()], report()) :: :pass | {:fail, :cross_check_failed}
+  def cross_check(killed_ids, real_report) when is_list(killed_ids) do
+    passing_ids =
+      real_report
+      |> Map.get(:cases, [])
+      |> Enum.filter(&(&1.status == :passed))
+      |> MapSet.new(& &1.id)
+
+    killed_set = MapSet.new(killed_ids)
+
+    if MapSet.subset?(killed_set, passing_ids) do
+      :pass
+    else
+      {:fail, :cross_check_failed}
+    end
+  end
 end

--- a/lib/tau/toolchain/report_parser.ex
+++ b/lib/tau/toolchain/report_parser.ex
@@ -1,0 +1,208 @@
+defmodule Tau.Toolchain.ReportParser do
+  @moduledoc """
+  Engine-owned, trusted, TOTAL parser for test artifact formats.
+
+  `parse/2` accepts raw artifact bytes and a format tag (supplied by the
+  toolchain descriptor's `:report` field) and returns a
+  `%Tau.Toolchain.TestReport{}`. The engine selects the parser by format tag;
+  the adapter never supplies a parser (SPEC-FACTORY-GATE §4 B5, HR-3).
+
+  ## Totality guarantee (D-306)
+
+  `parse/2` is total: any input bytes, including malformed or empty artifacts,
+  yield a defined `%Tau.Toolchain.TestReport{}`. It never raises or crashes.
+  Malformed input produces `%TestReport{cases: []}` rather than an exception,
+  so a forged or corrupt artifact cannot take down the gate process.
+
+  ## Supported format tags
+
+    * `:junit` — JUnit XML (as emitted by `junit_formatter` / `jest-junit`).
+    * `:tap`   — Test Anything Protocol v12/v13.
+
+  Unknown format tags produce `%TestReport{cases: []}` — fail-closed, not a
+  fabricated pass.
+  """
+
+  alias Tau.Toolchain.TestReport
+
+  @doc """
+  Parse `artifact_bytes` according to `format_tag`.
+
+  Returns a `%TestReport{}`. Never raises on any input.
+
+  ## Parameters
+
+    * `artifact_bytes` — binary artifact content (may be empty or malformed).
+    * `format_tag`     — `:junit | :tap | atom()`. Unknown tags yield an empty
+      report.
+  """
+  @spec parse(binary(), atom()) :: TestReport.t()
+  def parse(artifact_bytes, format_tag) when is_binary(artifact_bytes) do
+    cases =
+      case format_tag do
+        :junit -> parse_junit(artifact_bytes)
+        :tap -> parse_tap(artifact_bytes)
+        _ -> []
+      end
+
+    %TestReport{cases: cases}
+  rescue
+    _ -> %TestReport{cases: []}
+  catch
+    _, _ -> %TestReport{cases: []}
+  end
+
+  # ---------------------------------------------------------------------------
+  # JUnit XML parser (uses :xmerl from OTP — no new deps)
+  # ---------------------------------------------------------------------------
+
+  defp parse_junit(""), do: []
+
+  defp parse_junit(bytes) do
+    # :xmerl_scan.string/2 requires a char list and returns {xmlElement, rest}.
+    # We wrap everything defensively — malformed XML must not crash.
+    charlist = :erlang.binary_to_list(bytes)
+
+    case safe_xmerl_scan(charlist) do
+      {:ok, doc} -> extract_junit_cases(doc)
+      :error -> []
+    end
+  rescue
+    _ -> []
+  catch
+    _, _ -> []
+  end
+
+  defp safe_xmerl_scan(charlist) do
+    # {:quiet, true} suppresses xmerl Logger error output on malformed XML.
+    # :xmerl_scan is part of OTP's :xmerl application declared in extra_applications.
+    # credo:disable-for-next-line Credo.Check.Refactor.Apply
+    result = apply(:xmerl_scan, :string, [charlist, [{:quiet, true}]])
+    {doc, _rest} = result
+    {:ok, doc}
+  rescue
+    _ -> :error
+  catch
+    _, _ -> :error
+  end
+
+  defp extract_junit_cases(doc) do
+    # The document root may be <testsuites> (wrapper) or <testsuite> directly.
+    # We find all <testcase> elements recursively.
+    doc
+    |> find_elements(:testcase)
+    |> Enum.map(&testcase_to_map/1)
+  end
+
+  defp find_elements(node, tag) do
+    # :xmerl elements have shape {:xmlElement, name, ...}
+    case node do
+      {:xmlElement, ^tag, _, _, _, _, _, _, _, _, _, _} ->
+        [node]
+
+      {:xmlElement, _, _, _, _, _, _, _, content, _, _, _} when is_list(content) ->
+        Enum.flat_map(content, &find_elements(&1, tag))
+
+      _ ->
+        []
+    end
+  end
+
+  defp testcase_to_map(node) do
+    {:xmlElement, :testcase, _, _, _, _, _, attrs, content, _, _, _} = node
+
+    classname = xml_attr_value(attrs, :classname, "")
+    name = xml_attr_value(attrs, :name, "")
+    id = build_id(classname, name)
+
+    status =
+      cond do
+        has_child_element(content, :failure) -> :failed
+        has_child_element(content, :error) -> :failed
+        has_child_element(content, :skipped) -> :skipped
+        true -> :passed
+      end
+
+    %{id: id, status: status}
+  end
+
+  defp xml_attr_value(attrs, key, default) do
+    case Enum.find(attrs, fn attr -> elem(attr, 1) == key end) do
+      nil -> default
+      {:xmlAttribute, _, _, _, _, _, _, _, value, _} -> to_string(value)
+    end
+  end
+
+  defp has_child_element(content, tag) when is_list(content) do
+    Enum.any?(content, fn
+      {:xmlElement, ^tag, _, _, _, _, _, _, _, _, _, _} -> true
+      _ -> false
+    end)
+  end
+
+  defp has_child_element(_content, _tag), do: false
+
+  defp build_id("", name), do: name
+  defp build_id(classname, ""), do: classname
+  defp build_id(classname, name), do: "#{classname}.#{name}"
+
+  # ---------------------------------------------------------------------------
+  # TAP parser (line-based; no external dep)
+  # ---------------------------------------------------------------------------
+
+  defp parse_tap(""), do: []
+
+  defp parse_tap(bytes) do
+    bytes
+    |> safe_to_string()
+    |> String.split("\n")
+    |> Enum.flat_map(&parse_tap_line/1)
+  rescue
+    _ -> []
+  catch
+    _, _ -> []
+  end
+
+  defp safe_to_string(bytes) do
+    # If the bytes are not valid UTF-8, fall back to Latin-1 interpretation.
+    case String.valid?(bytes) do
+      true -> bytes
+      false -> :unicode.characters_to_binary(bytes, :latin1, :utf8) |> to_string_safe()
+    end
+  end
+
+  defp to_string_safe(result) do
+    case result do
+      bin when is_binary(bin) -> bin
+      _ -> ""
+    end
+  end
+
+  defp parse_tap_line(line) do
+    trimmed = String.trim(line)
+
+    cond do
+      String.starts_with?(trimmed, "ok ") ->
+        id = tap_test_id(trimmed, "ok ")
+        [%{id: id, status: :passed}]
+
+      String.starts_with?(trimmed, "not ok ") ->
+        id = tap_test_id(trimmed, "not ok ")
+        [%{id: id, status: :failed}]
+
+      true ->
+        []
+    end
+  end
+
+  defp tap_test_id(line, prefix) do
+    # "ok N description" or "not ok N description"
+    # Strip the prefix, then optionally strip leading number.
+    rest = String.slice(line, String.length(prefix), String.length(line))
+
+    case Integer.parse(rest) do
+      {_n, remainder} -> String.trim_leading(remainder)
+      :error -> rest
+    end
+  end
+end

--- a/lib/tau/toolchain/test_report.ex
+++ b/lib/tau/toolchain/test_report.ex
@@ -1,0 +1,33 @@
+defmodule Tau.Toolchain.TestReport do
+  @moduledoc """
+  Engine-produced test report parsed from a subprocess artifact (JUnit XML,
+  TAP, or similar).
+
+  This struct is produced exclusively by `Tau.Toolchain.ReportParser.parse/2`
+  and returned by `Tau.Factory.Engine.TestRun.execute/2`. The adapter (toolchain
+  descriptor) never writes or fabricates this struct — HR-3, SPEC-FACTORY-GATE
+  §4 B5.
+
+  ## Fields
+
+    * `cases` — ordered list of `%{id: String.t(), status: :passed | :failed |
+      :skipped}` maps. The `id` is stable across identical artifact inputs and
+      is used by the mutation cross-check to bind reverted-run failures to
+      real-run passes (D-306).
+  """
+
+  @enforce_keys [:cases]
+
+  defstruct [:cases]
+
+  @typedoc "A single test case in a report."
+  @type test_case :: %{
+          required(:id) => String.t(),
+          required(:status) => :passed | :failed | :skipped
+        }
+
+  @typedoc "An engine-produced test report."
+  @type t :: %__MODULE__{
+          cases: [test_case()]
+        }
+end

--- a/mix.exs
+++ b/mix.exs
@@ -36,7 +36,7 @@ defmodule Tau.MixProject do
   def application do
     [
       mod: {Tau.Application, []},
-      extra_applications: [:logger, :crypto, :ssl, :inets],
+      extra_applications: [:logger, :crypto, :ssl, :inets, :xmerl],
       included_applications: [:aws_credentials]
     ]
   end

--- a/test/tau/factory/engine/test_run_test.exs
+++ b/test/tau/factory/engine/test_run_test.exs
@@ -1,0 +1,383 @@
+defmodule Tau.Factory.Engine.TestRunTest do
+  @moduledoc """
+  Gating tests for PR #431 (Closes #420) — `Tau.Factory.Engine.TestRun` (C6).
+
+  Written BEFORE production code exists (oracle-separation phase, D-304).
+  These tests fail with UndefinedFunctionError until the implementer creates:
+    - `lib/tau/factory/engine/test_run.ex`
+    - `lib/tau/toolchain/report_parser.ex`
+    - `lib/tau/toolchain/test_report.ex`
+
+  The central invariant tested is HR-3: the ENGINE runs the subprocess, captures
+  the artifact, selects a trusted parser by format tag, parses it ITSELF, and
+  returns an engine-produced %TestReport{}. The adapter never touches the verdict
+  path. A stubbed adapter that returns a fabricated "passed" descriptor CANNOT
+  fold the mutation half PASS — the engine runs and parses the artifact itself,
+  and a forged adapter claim has no path into the verdict.
+
+  Approach for non-flakiness: every test uses a SYNTHETIC %TestDescriptor{} whose
+  recipe is a tiny shell command that writes a KNOWN, deterministic JUnit-XML
+  artifact to the named artifact path. This avoids invoking a real `mix test`
+  subprocess (which would be slow, environment-dependent, and flaky) while still
+  exercising the real Engine.TestRun.execute/2 code path with a real Port, real
+  file write, and real parser invocation.
+
+  The synthetic recipe:
+    argv: ["sh", "-c", "<write known JUnit XML to $artifact_path>"]
+    env: %{}
+    report: :junit
+    artifact: <relative path under tmp workspace>
+
+  The workspace is a per-test tmp directory (System.tmp_dir!/0).
+
+  AC linkage (SPEC-FACTORY-GATE §7):
+    - AC-5 (D-306/HR-3): engine runs descriptor, parses artifact, returns %TestReport{}.
+    - AC-DZ-1 / D-354: a forged adapter claim cannot make the engine return :passed
+      when the artifact reports :failed.
+
+  All property tests are tagged `:property`.
+  """
+
+  use ExUnit.Case, async: true
+
+  @moduletag :ac_5
+  @moduletag :d_306
+
+  # Module references — runtime, so the file compiles before modules exist.
+  @engine Tau.Factory.Engine.TestRun
+  @test_report_mod Tau.Toolchain.TestReport
+  @test_descriptor_mod Tau.Toolchain.TestDescriptor
+
+  # ---------------------------------------------------------------------------
+  # Helpers
+  # ---------------------------------------------------------------------------
+
+  # A tiny JUnit XML artifact with one FAILING case (the reverted-tree scenario).
+  defp junit_one_failure do
+    """
+    <?xml version="1.0" encoding="UTF-8"?>
+    <testsuites>
+      <testsuite name="GatingTest" tests="2" failures="1">
+        <testcase classname="GatingTest" name="gating test passes on real tree" time="0.001"/>
+        <testcase classname="GatingTest" name="gating test fails on reverted tree" time="0.002">
+          <failure message="Expected implementation, got nothing">UndefinedFunctionError</failure>
+        </testcase>
+      </testsuite>
+    </testsuites>
+    """
+  end
+
+  # A tiny JUnit XML artifact with ALL cases PASSING (vacuous suite / real-tree scenario).
+  defp junit_all_pass do
+    """
+    <?xml version="1.0" encoding="UTF-8"?>
+    <testsuites>
+      <testsuite name="GatingTest" tests="2" failures="0">
+        <testcase classname="GatingTest" name="gating test passes on real tree" time="0.001"/>
+        <testcase classname="GatingTest" name="second passing test" time="0.002"/>
+      </testsuite>
+    </testsuites>
+    """
+  end
+
+  # Build a synthetic TestDescriptor whose recipe writes `content` to the
+  # relative artifact path within the workspace, then exits 0.
+  # Uses `sh -c` so it runs on any POSIX system (same constraint as the engine).
+  defp descriptor_writing_artifact(content, artifact_rel) do
+    # Escape single quotes in content for embedding in a sh -c string.
+    safe = String.replace(content, "'", "'\\''")
+
+    script = "mkdir -p \"$(dirname \"$artifact\")\" && printf '%s' '#{safe}' > \"$artifact\""
+
+    %{
+      __struct__: @test_descriptor_mod,
+      argv: ["sh", "-c", script],
+      env: %{"artifact" => artifact_rel},
+      report: :junit,
+      artifact: artifact_rel
+    }
+  end
+
+  # Create a fresh tmp workspace directory for each test.
+  defp tmp_workspace do
+    base = System.tmp_dir!()
+    dir = Path.join(base, "tau_engine_test_#{System.unique_integer([:positive])}")
+    File.mkdir_p!(dir)
+    dir
+  end
+
+  # ---------------------------------------------------------------------------
+  # AC-5 / HR-3 — Engine executes descriptor and returns engine-parsed report
+  #
+  # This is the core HR-3 test: execute/2 runs the subprocess via Port, reads
+  # the artifact, and returns a %TestReport{} whose content matches the artifact.
+  # The adapter (descriptor) supplied only the recipe + format tag; the engine
+  # parsed the artifact itself.
+  # ---------------------------------------------------------------------------
+
+  describe "AC-5 / D-306 / HR-3: Engine.TestRun.execute/2 — engine runs and parses the artifact" do
+    test "execute/2 with a descriptor that writes a failing JUnit artifact returns {:ok, %TestReport{}} with :failed cases" do
+      ws = tmp_workspace()
+      descriptor = descriptor_writing_artifact(junit_one_failure(), "report.xml")
+
+      result = @engine.execute(descriptor, ws)
+
+      assert {:ok, report} = result,
+             "execute/2 must return {:ok, %TestReport{}}; got #{inspect(result)}"
+
+      assert is_struct(report, @test_report_mod),
+             "The Ok payload must be %#{inspect(@test_report_mod)}{}; got #{inspect(report)}"
+
+      assert is_list(report.cases),
+             "TestReport.cases must be a list"
+
+      failed_cases = Enum.filter(report.cases, &(&1.status == :failed))
+
+      assert failed_cases != [],
+             "Engine-parsed report must contain :failed cases matching the artifact; " <>
+               "cases: #{inspect(report.cases)}"
+
+      File.rm_rf!(ws)
+    end
+
+    test "execute/2 with a descriptor that writes an all-pass JUnit artifact returns {:ok, %TestReport{}} with only :passed cases" do
+      ws = tmp_workspace()
+      descriptor = descriptor_writing_artifact(junit_all_pass(), "report.xml")
+
+      result = @engine.execute(descriptor, ws)
+
+      assert {:ok, report} = result
+      assert is_struct(report, @test_report_mod)
+      assert is_list(report.cases)
+
+      failed_cases = Enum.filter(report.cases, &(&1.status == :failed))
+
+      assert failed_cases == [],
+             "Engine-parsed report must have no :failed cases for an all-pass artifact; " <>
+               "cases: #{inspect(report.cases)}"
+
+      File.rm_rf!(ws)
+    end
+
+    test "execute/2 returns {:error, _} when the recipe crashes (absent executable)" do
+      ws = tmp_workspace()
+
+      # A descriptor whose argv references a non-existent executable.
+      # The engine must fail-closed: a crashing recipe => {:error, _}, not a fake pass.
+      bad_descriptor = %{
+        __struct__: @test_descriptor_mod,
+        argv: ["/nonexistent/binary/that/does/not/exist"],
+        env: %{},
+        report: :junit,
+        artifact: "report.xml"
+      }
+
+      result =
+        try do
+          @engine.execute(bad_descriptor, ws)
+        rescue
+          _e -> :raised
+        catch
+          k, v -> {:caught, k, v}
+        end
+
+      case result do
+        {:error, _} ->
+          # Correct: fail-closed.
+          :ok
+
+        :raised ->
+          # Also acceptable: fail-closed (the engine raises, not returns a fake pass).
+          :ok
+
+        {:caught, _, _} ->
+          # Also acceptable.
+          :ok
+
+        {:ok, report} ->
+          flunk(
+            "execute/2 must fail-closed on a crashing recipe; " <>
+              "but returned {:ok, #{inspect(report)}} — this is a fake pass"
+          )
+      end
+
+      File.rm_rf!(ws)
+    end
+
+    test "execute/2 returns {:error, _} when the artifact is absent after recipe runs" do
+      ws = tmp_workspace()
+
+      # Recipe runs successfully (exits 0) but does NOT write the artifact.
+      no_artifact_descriptor = %{
+        __struct__: @test_descriptor_mod,
+        argv: ["sh", "-c", "true"],
+        # sh -c "true" exits 0 but writes nothing
+        env: %{},
+        report: :junit,
+        artifact: "nonexistent-report.xml"
+      }
+
+      result = @engine.execute(no_artifact_descriptor, ws)
+
+      assert match?({:error, _}, result),
+             "execute/2 must return {:error, _} when artifact is absent; got #{inspect(result)}"
+
+      File.rm_rf!(ws)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # AC-DZ-1 / D-354 — Anti-forge: the engine follows the ARTIFACT, not any
+  # adapter claim.
+  #
+  # This is the load-bearing HR-3 anti-gaming test. The scenario:
+  #   1. A descriptor's recipe writes a JUnit artifact reporting FAILURE.
+  #   2. Some hypothetical adapter claim says "tests passed" — but this claim
+  #      has no path into Engine.TestRun.execute/2; the engine ignores it.
+  #   3. The engine's returned %TestReport{} reflects the ARTIFACT (failure),
+  #      not the adapter claim.
+  #
+  # The "adapter claim" is simulated by verifying that the return value of
+  # execute/2 matches the artifact, regardless of any field we might inject
+  # into the descriptor struct beyond what the engine uses.
+  # ---------------------------------------------------------------------------
+
+  describe "AC-DZ-1 / D-354: Engine follows the artifact, not any adapter-supplied verdict" do
+    @describetag :ac_dz_1
+    @describetag :d_354
+
+    test "descriptor recipe writes FAILING artifact; engine returns :failed cases (adapter claim is irrelevant)" do
+      ws = tmp_workspace()
+
+      # The descriptor's recipe writes a FAILING JUnit artifact.
+      # We add a fabricated field to the descriptor map that an adversarial adapter
+      # might hope the engine reads as a "verdict" — the engine must ignore it.
+      descriptor =
+        descriptor_writing_artifact(junit_one_failure(), "report.xml")
+        |> Map.put(:__adapter_verdict__, :passed)
+        |> Map.put(:__adapter_result__, {:pass, []})
+
+      result = @engine.execute(descriptor, ws)
+
+      assert {:ok, report} = result,
+             "execute/2 must return {:ok, _}; got #{inspect(result)}"
+
+      assert is_struct(report, @test_report_mod)
+
+      # The ARTIFACT says failure — the engine must reflect that.
+      failed_cases = Enum.filter(report.cases, &(&1.status == :failed))
+
+      assert failed_cases != [],
+             "AC-DZ-1 / D-354: engine must follow the ARTIFACT (has failures), " <>
+               "not the fabricated adapter verdict field (:passed). " <>
+               "Returned cases: #{inspect(report.cases)}"
+
+      File.rm_rf!(ws)
+    end
+
+    test "descriptor recipe writes PASSING artifact; engine returns :passed cases (no fabricated failure)" do
+      ws = tmp_workspace()
+
+      # Inverse: adapter might try to inject a :failed verdict, but artifact is all-pass.
+      descriptor =
+        descriptor_writing_artifact(junit_all_pass(), "report.xml")
+        |> Map.put(:__adapter_verdict__, :failed)
+        |> Map.put(:__adapter_result__, {:fail, :some_fabricated_reason})
+
+      result = @engine.execute(descriptor, ws)
+
+      assert {:ok, report} = result
+      assert is_struct(report, @test_report_mod)
+
+      failed_cases = Enum.filter(report.cases, &(&1.status == :failed))
+
+      assert failed_cases == [],
+             "AC-DZ-1 / D-354: engine must follow the all-pass ARTIFACT, " <>
+               "not the fabricated adapter :failed verdict. " <>
+               "Returned cases: #{inspect(report.cases)}"
+
+      File.rm_rf!(ws)
+    end
+
+    test "engine-parsed report case ids from the artifact are stable across two identical runs (both engine-produced)" do
+      # This tests the cross-check binding: killed_ids from the reverted run must
+      # appear in the passing ids from the real run. Both runs are engine-produced.
+      # We verify that the same artifact yields the same case ids on two executions.
+      ws1 = tmp_workspace()
+      ws2 = tmp_workspace()
+      descriptor = descriptor_writing_artifact(junit_one_failure(), "report.xml")
+
+      {:ok, report1} = @engine.execute(descriptor, ws1)
+      {:ok, report2} = @engine.execute(descriptor, ws2)
+
+      ids1 = Enum.map(report1.cases, & &1.id) |> Enum.sort()
+      ids2 = Enum.map(report2.cases, & &1.id) |> Enum.sort()
+
+      assert ids1 == ids2,
+             "AC-DZ-1 / D-354: same artifact must yield same case ids across runs " <>
+               "(cross-check requires stable ids). Got #{inspect(ids1)} vs #{inspect(ids2)}"
+
+      File.rm_rf!(ws1)
+      File.rm_rf!(ws2)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # AC-5 — The engine selects the parser by the descriptor's :report format tag
+  #
+  # The adapter supplies :report => :junit (or :tap). The engine selects the
+  # trusted parser by that tag. The adapter does NOT supply the parser itself.
+  # We verify this indirectly: a descriptor with :report => :junit is parsed as
+  # JUnit; one with :report => :tap is parsed as TAP.
+  # ---------------------------------------------------------------------------
+
+  describe "AC-5: engine selects parser by format tag from the descriptor" do
+    test "format tag :junit → JUnit parser is used (case count matches JUnit fixture)" do
+      ws = tmp_workspace()
+      descriptor = descriptor_writing_artifact(junit_one_failure(), "report.xml")
+
+      {:ok, report} = @engine.execute(descriptor, ws)
+
+      # JUnit fixture has exactly 2 testcases; the JUnit parser should produce 2 cases.
+      assert length(report.cases) == 2,
+             "JUnit parser must produce 2 cases from the 2-testcase JUnit fixture; " <>
+               "got #{length(report.cases)} cases: #{inspect(report.cases)}"
+
+      File.rm_rf!(ws)
+    end
+
+    test "a TAP artifact with TAP format tag is parsed as TAP" do
+      ws = tmp_workspace()
+
+      tap_content = """
+      TAP version 13
+      1..2
+      ok 1 first test
+      not ok 2 second test
+      """
+
+      safe = String.replace(tap_content, "'", "'\\''")
+      script = "mkdir -p \"$(dirname \"$artifact\")\" && printf '%s' '#{safe}' > \"$artifact\""
+
+      tap_descriptor = %{
+        __struct__: @test_descriptor_mod,
+        argv: ["sh", "-c", script],
+        env: %{"artifact" => "tap-report.txt"},
+        report: :tap,
+        artifact: "tap-report.txt"
+      }
+
+      result = @engine.execute(tap_descriptor, ws)
+
+      assert {:ok, report} = result,
+             "execute/2 with :tap format must return {:ok, _}; got #{inspect(result)}"
+
+      assert is_struct(report, @test_report_mod)
+      statuses = Enum.map(report.cases, & &1.status)
+      assert :passed in statuses, "TAP 'ok 1' must parse as :passed"
+      assert :failed in statuses, "TAP 'not ok 2' must parse as :failed"
+
+      File.rm_rf!(ws)
+    end
+  end
+end

--- a/test/tau/factory/gate/mutation_cross_check_test.exs
+++ b/test/tau/factory/gate/mutation_cross_check_test.exs
@@ -1,0 +1,312 @@
+defmodule Tau.Factory.Gate.MutationCrossCheckTest do
+  @moduledoc """
+  Gating tests for PR #431 (Closes #420) — the mutation cross-check contract
+  (AC-4, D-306, SPEC-FACTORY-GATE §3 [C203-B3]).
+
+  Written BEFORE production code exists (oracle-separation phase, D-304).
+  These tests fail until the implementer creates:
+    - `lib/tau/factory/gate/mutation.ex` (specifically the cross-check logic)
+    - `lib/tau/toolchain/test_report.ex`
+
+  The cross-check (SPEC-FACTORY-GATE §3 [C203-B3], §4 B3):
+    Given:
+      - reverted_report: the engine-parsed report from running tests on the
+        REVERTED tree (production removed). Must have ≥1 :failed case.
+      - real_report: the engine-parsed report from running tests on the REAL
+        (green) tree.
+    Assert: `killed_ids ⊆ passing_ids(real_report)`
+      where killed_ids = the :failed case ids from reverted_report.
+
+    The half PASSes iff:
+      1. judge(reverted_report) = {:pass, killed_ids}  (≥1 :failed case), AND
+      2. killed_ids ⊆ passing_ids(real_report)         (cross-check holds).
+
+    The half FAILs if:
+      - judge(reverted_report) = {:fail, :no_test_failed}  (vacuous suite), OR
+      - killed_ids ⊄ passing_ids(real_report)  (cross-check fails — suspicious).
+
+  The function tested is `Tau.Factory.Gate.Mutation.cross_check/2`:
+    @spec cross_check(killed_ids :: [term()], real_report :: TestReport.t()) ::
+            :pass | {:fail, :cross_check_failed}
+
+  This is a PURE function (P-MU4) — no I/O, property-testable in isolation.
+
+  AC linkage (SPEC-FACTORY-GATE §7):
+    AC-4 (D-306/D-354): the strictly-ordered mutation cross-check.
+
+  All property tests are tagged `:property`.
+  """
+
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  alias Tau.Factory.Gate.Mutation
+
+  @moduletag :ac_4
+  @moduletag :d_306
+
+  # ---------------------------------------------------------------------------
+  # Generators
+  # ---------------------------------------------------------------------------
+
+  defp test_id_gen do
+    StreamData.bind(
+      StreamData.string(:alphanumeric, min_length: 3, max_length: 20),
+      fn s -> StreamData.constant("test_" <> s) end
+    )
+  end
+
+  defp unique_ids_gen(min, max) do
+    StreamData.bind(
+      StreamData.list_of(test_id_gen(), min_length: min, max_length: max),
+      fn ids -> StreamData.constant(Enum.uniq(ids)) end
+    )
+  end
+
+  # A report containing the given ids all as :passed.
+  defp passing_report(ids) do
+    %{cases: Enum.map(ids, &%{id: &1, status: :passed})}
+  end
+
+  # A report containing the given ids all as :failed.
+  defp failing_report(ids) do
+    %{cases: Enum.map(ids, &%{id: &1, status: :failed})}
+  end
+
+  # A report mixing some passed (passed_ids) and some failed (failed_ids).
+  defp mixed_report(passed_ids, failed_ids) do
+    passed = Enum.map(passed_ids, &%{id: &1, status: :passed})
+    failed = Enum.map(failed_ids, &%{id: &1, status: :failed})
+    %{cases: passed ++ failed}
+  end
+
+  # ---------------------------------------------------------------------------
+  # AC-4 / D-306 — Cross-check: killed_ids ⊆ passing_ids(real_report)
+  #
+  # SPEC-FACTORY-GATE §4 B3: "the engine asserts killed_ids ⊆ passing_ids(real_report)"
+  # ---------------------------------------------------------------------------
+
+  describe "AC-4 / D-306: cross_check/2 — killed_ids ⊆ passing_ids(real_report)" do
+    @tag :ac_4
+    @tag :d_306
+    test "cross_check passes when all killed_ids appear :passed in the real report" do
+      killed_ids = ["test_gating_1", "test_gating_2"]
+      # Real run: ALL the killed ids now pass (production is present).
+      real_report = passing_report(killed_ids ++ ["test_extra_passing"])
+
+      result = Mutation.cross_check(killed_ids, real_report)
+
+      assert result == :pass,
+             "cross_check/2 must return :pass when killed_ids ⊆ passing_ids(real); " <>
+               "got #{inspect(result)}"
+    end
+
+    @tag :ac_4
+    @tag :d_306
+    test "cross_check fails when a killed_id is NOT passing in the real report" do
+      killed_ids = ["test_gating_1", "test_gating_2"]
+      # Real run: only one of the killed ids is passing.
+      real_report = passing_report(["test_gating_1"])
+
+      result = Mutation.cross_check(killed_ids, real_report)
+
+      assert match?({:fail, _}, result),
+             "cross_check/2 must return {:fail, _} when killed_ids ⊄ passing_ids(real); " <>
+               "got #{inspect(result)}"
+    end
+
+    @tag :ac_4
+    @tag :d_306
+    test "cross_check fails when a killed_id appears :failed in the real report (suspicious — should be fixed)" do
+      killed_ids = ["test_gating_1"]
+      # Real run: the killed id is STILL failing on the real tree — suspicious.
+      real_report = failing_report(["test_gating_1"])
+
+      result = Mutation.cross_check(killed_ids, real_report)
+
+      assert match?({:fail, _}, result),
+             "cross_check/2 must return {:fail, _} when killed_id is :failed on real tree; " <>
+               "got #{inspect(result)}"
+    end
+
+    @tag :ac_4
+    @tag :d_306
+    test "cross_check passes with empty killed_ids (vacuous cross-check — though judge would have failed)" do
+      # If killed_ids is empty, the cross-check vacuously holds (∅ ⊆ anything).
+      # In practice judge/1 would have returned {:fail, :no_test_failed} before
+      # cross_check is invoked, so this is an edge-case boundary test.
+      real_report = passing_report(["some_other_test"])
+
+      result = Mutation.cross_check([], real_report)
+
+      # ∅ ⊆ anything = true → cross_check should pass.
+      assert result == :pass,
+             "cross_check/2 with empty killed_ids should return :pass (vacuous ⊆); " <>
+               "got #{inspect(result)}"
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # AC-4 / D-306 — Vacuous suite detection: judge/1 rejects all-pass reverted run
+  #
+  # This is the non-vacuity gate. A gating test that passes even when production
+  # is removed is worthless — it does not depend on the production code.
+  # SPEC-FACTORY-GATE §3 [C203-B3] step 5: judge/1 yields {:fail, :no_test_failed}
+  # for a vacuous suite; the half FAILs.
+  # ---------------------------------------------------------------------------
+
+  describe "AC-4 / D-306: vacuous suite → half FAIL (non-vacuity gate)" do
+    @tag :ac_4
+    @tag :d_306
+    test "judge/1 on all-pass reverted report returns {:fail, :no_test_failed}" do
+      # ALL tests pass on the reverted (production-absent) tree — the test suite
+      # does not depend on production code. This is the vacuous test hole.
+      vacuous_report = passing_report(["test_a", "test_b"])
+
+      result = Mutation.judge(vacuous_report)
+
+      assert {:fail, :no_test_failed} = result,
+             "AC-4 / D-306: judge/1 must return {:fail, :no_test_failed} for a vacuous suite; " <>
+               "got #{inspect(result)}"
+    end
+
+    @tag :ac_4
+    @tag :d_306
+    test "judge/1 on partially-failing reverted report returns {:pass, killed_ids}" do
+      # Some tests FAIL on the reverted tree — those tests DO depend on production.
+      # The mutation gate passes; killed_ids names the ids to cross-check.
+      report = mixed_report(["test_passing_anyway"], ["test_gating_1", "test_gating_2"])
+
+      result = Mutation.judge(report)
+
+      assert {:pass, killed} = result,
+             "AC-4 / D-306: judge/1 must return {:pass, killed_ids} when ≥1 test fails; " <>
+               "got #{inspect(result)}"
+
+      assert MapSet.subset?(
+               MapSet.new(killed),
+               MapSet.new(["test_gating_1", "test_gating_2"])
+             ),
+             "killed_ids must be a subset of the :failed case ids; " <>
+               "killed=#{inspect(killed)}"
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # AC-4 / D-306 — Full mutation half sequence (pure logic, no I/O)
+  #
+  # The ordered sequence from SPEC-FACTORY-GATE §3 [C203-B3]:
+  # Step 5: judge(reverted_report) → {:pass, killed_ids}
+  # Step 7: cross_check(killed_ids, real_report) → :pass
+  # Step 8: half PASS iff 5 ∧ 7
+  #
+  # We test the combined logic: given two engine-produced reports, compute
+  # whether the mutation half passes.
+  # ---------------------------------------------------------------------------
+
+  describe "AC-4 / D-306: full mutation half — judge + cross_check combined" do
+    @tag :ac_4
+    @tag :d_306
+    test "half PASSES: reverted has failures, real has those ids passing" do
+      reverted_report = mixed_report(["test_irrelevant"], ["test_gating_1"])
+      real_report = mixed_report(["test_gating_1", "test_irrelevant"], [])
+
+      {:pass, killed} = Mutation.judge(reverted_report)
+      cross = Mutation.cross_check(killed, real_report)
+
+      assert cross == :pass,
+             "AC-4 / D-306: cross_check must pass when killed_ids all appear :passed in real report; " <>
+               "killed=#{inspect(killed)}"
+    end
+
+    @tag :ac_4
+    @tag :d_306
+    test "half FAILS (vacuous): reverted all-pass → judge fails, cross_check never reached" do
+      vacuous_reverted = passing_report(["test_gating_1"])
+
+      result = Mutation.judge(vacuous_reverted)
+
+      assert {:fail, :no_test_failed} = result,
+             "AC-4 / D-306: vacuous reverted suite must fail judge/1; got #{inspect(result)}"
+    end
+
+    @tag :ac_4
+    @tag :d_306
+    test "half FAILS (cross-check): reverted has failures, but real does NOT have them passing" do
+      reverted_report = failing_report(["test_gating_1", "test_gating_2"])
+      real_report = passing_report(["test_gating_1"])
+
+      # Only gating_1 passes in real — gating_2 is missing. Cross-check fails.
+      {:pass, killed} = Mutation.judge(reverted_report)
+      cross = Mutation.cross_check(killed, real_report)
+
+      assert match?({:fail, _}, cross),
+             "AC-4 / D-306: cross_check must fail when not all killed_ids pass in real; " <>
+               "killed=#{inspect(killed)}, cross=#{inspect(cross)}"
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # AC-4 / D-306 — Properties (referential transparency of pure functions)
+  # ---------------------------------------------------------------------------
+
+  @tag :property
+  @tag :ac_4
+  @tag :d_306
+  property "AC-4 (property): cross_check/2 is pure (same inputs → same output)" do
+    check all(
+            killed_ids <- unique_ids_gen(0, 5),
+            passing_ids <- unique_ids_gen(0, 8)
+          ) do
+      real_report = passing_report(passing_ids)
+
+      result1 = Mutation.cross_check(killed_ids, real_report)
+      result2 = Mutation.cross_check(killed_ids, real_report)
+
+      assert result1 == result2,
+             "cross_check/2 must be pure (same inputs → same output); " <>
+               "got #{inspect(result1)} then #{inspect(result2)}"
+    end
+  end
+
+  @tag :property
+  @tag :ac_4
+  @tag :d_306
+  property "AC-4 (property): cross_check passes iff killed_ids ⊆ passing_ids(real_report)" do
+    check all(
+            killed_ids <- unique_ids_gen(0, 4),
+            extra_passing <- unique_ids_gen(0, 4)
+          ) do
+      # Build a real_report that has ALL killed_ids as :passed.
+      all_passing = (killed_ids ++ extra_passing) |> Enum.uniq()
+      real_report = passing_report(all_passing)
+
+      result = Mutation.cross_check(killed_ids, real_report)
+
+      assert result == :pass,
+             "AC-4 (property): cross_check must pass when killed_ids ⊆ passing_ids; " <>
+               "killed=#{inspect(killed_ids)}, passing=#{inspect(all_passing)}, got #{inspect(result)}"
+    end
+  end
+
+  @tag :property
+  @tag :ac_4
+  @tag :d_306
+  property "AC-4 (property): cross_check fails when a killed_id is absent from real_report" do
+    check all(
+            present_ids <- unique_ids_gen(1, 4),
+            absent_id <- test_id_gen(),
+            not Enum.member?(present_ids, absent_id)
+          ) do
+      killed_ids = [absent_id | present_ids]
+      # Real report only has present_ids passing — absent_id is missing.
+      real_report = passing_report(present_ids)
+
+      result = Mutation.cross_check(killed_ids, real_report)
+
+      assert match?({:fail, _}, result),
+             "AC-4 (property): cross_check must fail when killed_id #{inspect(absent_id)} " <>
+               "is absent from real_report passing ids; got #{inspect(result)}"
+    end
+  end
+end

--- a/test/tau/toolchain/report_parser_test.exs
+++ b/test/tau/toolchain/report_parser_test.exs
@@ -1,0 +1,394 @@
+defmodule Tau.Toolchain.ReportParserTest do
+  @moduledoc """
+  Gating tests for PR #431 (Closes #420) — `Tau.Toolchain.ReportParser` (C9).
+
+  Written BEFORE production code exists (oracle-separation phase, D-304).
+  These tests fail with UndefinedFunctionError until the implementer creates:
+    - `lib/tau/toolchain/report_parser.ex`
+    - `lib/tau/toolchain/test_report.ex`
+
+  Pins SPEC-FACTORY-GATE §4 B5:
+    `ReportParser.parse/2 :: (artifact_bytes, format_tag) -> %TestReport{}` —
+    total, engine-owned. `format_tag ∈ {:junit, :tap, …}` is the adapter's
+    `report` field; the engine selects the parser, the adapter does NOT supply one.
+
+  Invariants tested:
+    - The parser is TOTAL: any artifact bytes (including malformed) yield a
+      defined `%TestReport{}`, never a crash.
+    - A valid JUnit-XML artifact with one passing and one failing case produces
+      the expected `%TestReport{cases: [%{id, status}]}`.
+    - A valid TAP artifact with one passing and one failing case is parsed.
+    - Unknown format tags produce a defined result (empty report or error tuple),
+      never a crash.
+    - Properties: totality across random byte inputs (property-before-examples,
+      OTP non-negotiable #6).
+
+  AC linkage (SPEC-FACTORY-GATE §7):
+    - AC-5 (D-306/HR-3): engine parses artifact itself via trusted ReportParser.
+    - D-306: the parser is total; no crash on malformed input.
+
+  All property tests are tagged `:property`.
+  """
+
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  @moduletag :ac_5
+  @moduletag :d_306
+
+  # Module references are runtime so the file compiles when modules do not exist;
+  # each test fails independently with UndefinedFunctionError at call-time.
+  @parser Tau.Toolchain.ReportParser
+  @test_report_mod Tau.Toolchain.TestReport
+
+  # ---------------------------------------------------------------------------
+  # JUnit-XML fixtures
+  #
+  # Small self-contained XML strings the engine would receive as artifact_bytes.
+  # Modelled on the JUnit-XML format JUnitFormatter / jest-junit emits.
+  # ---------------------------------------------------------------------------
+
+  @junit_one_pass_one_fail """
+  <?xml version="1.0" encoding="UTF-8"?>
+  <testsuites>
+    <testsuite name="MyApp.SomeTest" tests="2" failures="1">
+      <testcase classname="MyApp.SomeTest" name="passing test" time="0.001"/>
+      <testcase classname="MyApp.SomeTest" name="failing test" time="0.002">
+        <failure message="Expected true, got false">assertion failed</failure>
+      </testcase>
+    </testsuite>
+  </testsuites>
+  """
+
+  @junit_all_pass """
+  <?xml version="1.0" encoding="UTF-8"?>
+  <testsuites>
+    <testsuite name="MyApp.SomeTest" tests="2" failures="0">
+      <testcase classname="MyApp.SomeTest" name="first passing test" time="0.001"/>
+      <testcase classname="MyApp.SomeTest" name="second passing test" time="0.002"/>
+    </testsuite>
+  </testsuites>
+  """
+
+  @junit_all_fail """
+  <?xml version="1.0" encoding="UTF-8"?>
+  <testsuites>
+    <testsuite name="MyApp.SomeTest" tests="2" failures="2">
+      <testcase classname="MyApp.SomeTest" name="first failing test" time="0.001">
+        <failure message="Assertion error">boom</failure>
+      </testcase>
+      <testcase classname="MyApp.SomeTest" name="second failing test" time="0.002">
+        <failure message="Another error">bang</failure>
+      </testcase>
+    </testsuite>
+  </testsuites>
+  """
+
+  # ---------------------------------------------------------------------------
+  # TAP fixtures
+  #
+  # Test Anything Protocol — a line-based format. "ok N name" = pass,
+  # "not ok N name" = fail.
+  # ---------------------------------------------------------------------------
+
+  @tap_one_pass_one_fail """
+  TAP version 13
+  1..2
+  ok 1 passing test
+  not ok 2 failing test
+  """
+
+  @tap_all_pass """
+  TAP version 13
+  1..2
+  ok 1 first passing test
+  ok 2 second passing test
+  """
+
+  # ---------------------------------------------------------------------------
+  # AC-5 / D-306 — JUnit parse: fixture assertions
+  #
+  # The parser is total and produces %TestReport{cases: [%{id, status}]}.
+  # ---------------------------------------------------------------------------
+
+  describe "AC-5 / D-306: parse/2 with :junit format tag" do
+    test "one passing + one failing case → TestReport with :passed and :failed cases" do
+      result = @parser.parse(@junit_one_pass_one_fail, :junit)
+
+      # Must return a %TestReport{}, not crash or {:error, _}.
+      assert is_struct(result, @test_report_mod),
+             "parse/2 must return %#{inspect(@test_report_mod)}{}; got #{inspect(result)}"
+
+      assert is_list(result.cases),
+             "TestReport.cases must be a list; got #{inspect(result.cases)}"
+
+      assert length(result.cases) == 2,
+             "Expected 2 cases in the report; got #{inspect(result.cases)}"
+
+      statuses = Enum.map(result.cases, & &1.status)
+      assert :passed in statuses, "Expected at least one :passed case; got #{inspect(statuses)}"
+      assert :failed in statuses, "Expected at least one :failed case; got #{inspect(statuses)}"
+
+      # Every case must have an :id (the AC-to-test cross-check uses these).
+      Enum.each(result.cases, fn tc ->
+        assert Map.has_key?(tc, :id) and tc.id != nil and tc.id != "",
+               "Each case must have a non-empty :id; got #{inspect(tc)}"
+      end)
+    end
+
+    test "all-pass JUnit → TestReport with only :passed cases (vacuous suite scenario)" do
+      result = @parser.parse(@junit_all_pass, :junit)
+
+      assert is_struct(result, @test_report_mod)
+      assert is_list(result.cases)
+
+      assert Enum.all?(result.cases, &(&1.status == :passed)),
+             "All cases must be :passed; got #{inspect(result.cases)}"
+    end
+
+    test "all-fail JUnit → TestReport with only :failed cases" do
+      result = @parser.parse(@junit_all_fail, :junit)
+
+      assert is_struct(result, @test_report_mod)
+      assert is_list(result.cases)
+
+      assert Enum.all?(result.cases, &(&1.status == :failed)),
+             "All cases must be :failed; got #{inspect(result.cases)}"
+    end
+
+    test "parsed :failed case ids from JUnit are non-empty strings" do
+      result = @parser.parse(@junit_one_pass_one_fail, :junit)
+
+      failed_cases = Enum.filter(result.cases, &(&1.status == :failed))
+      assert failed_cases != [], "Expected at least one :failed case"
+
+      Enum.each(failed_cases, fn tc ->
+        assert is_binary(tc.id) and tc.id != "",
+               "Failed case id must be a non-empty string; got #{inspect(tc.id)}"
+      end)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # AC-5 / D-306 — TAP parse: fixture assertions
+  # ---------------------------------------------------------------------------
+
+  describe "AC-5 / D-306: parse/2 with :tap format tag" do
+    test "one passing + one failing TAP → TestReport with :passed and :failed cases" do
+      result = @parser.parse(@tap_one_pass_one_fail, :tap)
+
+      assert is_struct(result, @test_report_mod),
+             "parse/2 with :tap must return %#{inspect(@test_report_mod)}{}; got #{inspect(result)}"
+
+      assert is_list(result.cases)
+      statuses = Enum.map(result.cases, & &1.status)
+      assert :passed in statuses
+      assert :failed in statuses
+    end
+
+    test "all-pass TAP → TestReport with only :passed cases" do
+      result = @parser.parse(@tap_all_pass, :tap)
+
+      assert is_struct(result, @test_report_mod)
+      assert Enum.all?(result.cases, &(&1.status == :passed))
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # D-306 — Totality: malformed input must never crash (always returns %TestReport{})
+  #
+  # SPEC-FACTORY-GATE §4 B5: "total, engine-owned" — a malformed artifact yields
+  # a defined result (e.g. %TestReport{cases: []} or an :error), never a crash.
+  # A crash here means a forged artifact could take down the gate process.
+  # ---------------------------------------------------------------------------
+
+  describe "AC-5 / D-306: parse/2 totality — malformed input never crashes" do
+    test "malformed JUnit (truncated XML) → defined result, no crash" do
+      malformed = "<testsuites><testsuite name=\"broken\""
+
+      result =
+        try do
+          {:ok, @parser.parse(malformed, :junit)}
+        rescue
+          e -> {:crashed, e}
+        catch
+          kind, val -> {:caught, kind, val}
+        end
+
+      case result do
+        {:ok, report} ->
+          # Either an empty-cases report or a map/struct indicating parse failure.
+          # What it must NOT be is a crash.
+          assert is_struct(report, @test_report_mod) or is_map(report) or
+                   match?({:error, _}, report),
+                 "Malformed input must yield a defined result; got #{inspect(report)}"
+
+        {:crashed, e} ->
+          flunk(
+            "parse/2 with malformed JUnit must not crash; " <>
+              "got exception #{inspect(e.__struct__)}: #{Exception.message(e)}"
+          )
+
+        {:caught, kind, val} ->
+          flunk(
+            "parse/2 with malformed JUnit must not raise; " <>
+              "caught #{kind}: #{inspect(val)}"
+          )
+      end
+    end
+
+    test "empty byte string → defined result, no crash" do
+      result =
+        try do
+          {:ok, @parser.parse("", :junit)}
+        rescue
+          e -> {:crashed, e}
+        catch
+          kind, val -> {:caught, kind, val}
+        end
+
+      case result do
+        {:ok, _} -> :ok
+        {:crashed, e} -> flunk("parse/2 with empty input crashed: #{Exception.message(e)}")
+        {:caught, k, v} -> flunk("parse/2 with empty input threw #{k}: #{inspect(v)}")
+      end
+    end
+
+    test "binary garbage bytes → defined result, no crash" do
+      garbage = <<0x00, 0xFF, 0x80, 0x01, 0x7F, 0xAB, 0xCD>>
+
+      result =
+        try do
+          {:ok, @parser.parse(garbage, :junit)}
+        rescue
+          e -> {:crashed, e}
+        catch
+          kind, val -> {:caught, kind, val}
+        end
+
+      case result do
+        {:ok, _} -> :ok
+        {:crashed, e} -> flunk("parse/2 with garbage bytes crashed: #{Exception.message(e)}")
+        {:caught, k, v} -> flunk("parse/2 with garbage bytes threw #{k}: #{inspect(v)}")
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # D-306 — Unknown format tag: defined result, never crash
+  # SPEC-FACTORY-GATE §4 B5: format_tag ∈ {:junit, :tap, …}.
+  # An unknown tag must produce a defined result, not crash or silently
+  # emit a forged pass.
+  # ---------------------------------------------------------------------------
+
+  @tag :ac_5
+  @tag :d_306
+  test "AC-5 / D-306: unknown format tag → defined result, no crash or fabricated pass" do
+    result =
+      try do
+        {:ok, @parser.parse("<some>data</some>", :unknown_format)}
+      rescue
+        e -> {:crashed, e}
+      catch
+        kind, val -> {:caught, kind, val}
+      end
+
+    case result do
+      {:ok, report} ->
+        # A well-defined output — either empty cases or {:error, _} wrapped in a struct.
+        # It must NOT be a struct with :passed cases that look legitimate.
+        refute match?(%{cases: [%{status: :passed} | _]}, report),
+               "Unknown format must not fabricate a passing report; got #{inspect(report)}"
+
+      {:crashed, _e} ->
+        # A crash on unknown format is also acceptable (fail-closed).
+        # But it must NOT be a silent pass — which we already tested above.
+        :ok
+
+      {:caught, _k, _v} ->
+        :ok
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # AC-5 — Property: totality across random byte inputs + known format tags
+  #
+  # For all binary inputs (including malformed), parse/2 with a known format
+  # tag must never crash — it must return a defined value.
+  # Properties before examples (OTP non-negotiable #6; SPEC-FACTORY-GATE §6 D-306).
+  # ---------------------------------------------------------------------------
+
+  @tag :ac_5
+  @tag :d_306
+  @tag :property
+  property "AC-5 / D-306 (property): parse/2 with :junit is total — never crashes on arbitrary bytes" do
+    check all(artifact_bytes <- StreamData.binary()) do
+      result =
+        try do
+          {:ok, @parser.parse(artifact_bytes, :junit)}
+        rescue
+          _ -> :crashed
+        catch
+          _, _ -> :crashed
+        end
+
+      refute result == :crashed,
+             "parse/2 with :junit must be total — must not crash on any binary input"
+    end
+  end
+
+  @tag :ac_5
+  @tag :d_306
+  @tag :property
+  property "AC-5 / D-306 (property): parse/2 with :tap is total — never crashes on arbitrary bytes" do
+    check all(artifact_bytes <- StreamData.binary()) do
+      result =
+        try do
+          {:ok, @parser.parse(artifact_bytes, :tap)}
+        rescue
+          _ -> :crashed
+        catch
+          _, _ -> :crashed
+        end
+
+      refute result == :crashed,
+             "parse/2 with :tap must be total — must not crash on any binary input"
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # AC-5 — %TestReport{} shape invariant
+  #
+  # Whatever parse/2 returns, if it is a %TestReport{}, every case must have
+  # :id and :status fields (the cross-check in Engine.TestRun uses these).
+  # ---------------------------------------------------------------------------
+
+  @tag :ac_5
+  @tag :d_306
+  @tag :property
+  property "AC-5 (property): every case in a TestReport has :id and :status fields" do
+    check all(artifact_bytes <- StreamData.binary()) do
+      result =
+        try do
+          @parser.parse(artifact_bytes, :junit)
+        rescue
+          _ -> nil
+        catch
+          _, _ -> nil
+        end
+
+      if is_struct(result, @test_report_mod) and is_list(result.cases) do
+        Enum.each(result.cases, fn tc ->
+          assert Map.has_key?(tc, :id),
+                 "Every TestReport case must have an :id field; got #{inspect(tc)}"
+
+          assert Map.has_key?(tc, :status),
+                 "Every TestReport case must have a :status field; got #{inspect(tc)}"
+
+          assert tc.status in [:passed, :failed, :skipped],
+                 "Case :status must be :passed | :failed | :skipped; got #{inspect(tc.status)}"
+        end)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Advances
**Advances #420** — P2, the *engine-executed gate* half (M10, migration.md §6; SPEC-FACTORY-GATE C6/C9, AC-4/AC-5). #420 also covers the bootstrap Ledger (durable verdict persistence, SPEC-FACTORY-CORE); that lands in a **tightly-following PR** when a durable consumer exists (Coordinator/Unit). #420 stays open until both halves merge — this PR does NOT close it. Split for gateability (engine + ReportParser + cross-check is already a full one-pass review; bundling the Exqlite Ledger would exceed the gateability ceiling).

## Scope & order
Make HR-3 real: the **engine** (not the adapter) executes the toolchain descriptors and judges the result. Build on P1's `Tau.Factory.Toolchain.Elixir` (data-only descriptors).
1. `lib/tau/toolchain/test_report.ex` — `%TestReport{cases: [%{id, status}]}` (engine-produced).
2. `lib/tau/toolchain/report_parser.ex` — `Tau.Toolchain.ReportParser.parse(artifact_bytes, format_tag) :: %TestReport{}` — **engine-owned, trusted, total**, format-keyed (`:junit | :tap`), NOT by language; the adapter cannot inject a parser (SPEC C9 / B5).
3. `lib/tau/factory/engine/test_run.ex` — `Tau.Factory.Engine.TestRun`: given a `TestDescriptor` (+ for the mutation half, the declared gating paths + merge-base), run the recipe as a subprocess (`System.cmd`/`Port`) in a workspace, capture the artifact, select the parser **by the descriptor's format tag**, parse it itself, return the engine-produced `%TestReport{}`. The adapter never touches the verdict path (SPEC C6 / B4 — HR-3).
4. **The mutation cross-check (the anti-gaming heart, [C203-B3]/D-306):** strictly ordered `revert → run-reverted → judge → run-real → cross-check` — the reverted-run failing ids MUST be a subset of the real-run passing ids; `Gate.Mutation.judge/1` is applied to the **engine-parsed** report. A malicious/buggy adapter cannot fake a pass or forge the cross-check ids (the engine parses the real artifact).
5. Wire `Tau.Factory.Toolchain.for(:elixir)` → the adapter's `test_descriptor`/`mutation_descriptor` recipes into the engine.

The engine **returns** verdicts (no durable persistence in this PR — that is the Ledger half).

## SPECs
`SPEC-FACTORY-GATE` — advances **C6** (Engine.TestRun), **C9** (ReportParser), boundaries **B4/B5/B3** (HR-3 trust boundary + cross-check), **D-306** (non-vacuous mutation, engine-executed) and **D-354** (game-resistance: a forged adapter result cannot pass).

## Acceptance criteria
- **AC-5 (D-306/HR-3):** `engine_test_run_test.exs` — the engine runs a (synthetic) subprocess, selects the parser by format tag, parses the artifact ITSELF, returns a `%TestReport{}`; the adapter's claimed result is never trusted.
- **AC-4 (D-306):** `mutation_property_test.exs` (engine-executed) — a vacuous gating suite (passes against the reverted tree) is caught; the cross-check binds reverted-run failing ids ⊆ real-run passing ids.
- **AC-DZ-1 (D-354 / HR-3 anti-forge):** a malicious adapter that returns a forged "tests passed" descriptor/result cannot defeat the gate — the engine parses the real artifact, so a forged claim is ignored (`game_resistance_test.exs`).
- **AC-meta:** `mix compile --warnings-as-errors`, `credo --strict`, `dialyzer` clean; existing gate path (`lib/mix/gate/*`) unchanged. *(meta — CI.)*

## Gating-test paths
`test/tau/toolchain/report_parser_test.exs`, `test/tau/factory/engine/test_run_test.exs`, `test/tau/factory/gate/mutation_cross_check_test.exs` (FROZEN — implementer MUST NOT edit; challenge via coordinator if a test contradicts a SPEC §4 contract).

## Dependencies
Built on P0 (#418, pure `Gate.*`) + P1 (#419, `Toolchain.Elixir` adapter), both merged. The bootstrap-Ledger half of #420 follows.

## Gate verdicts
_(filled at gate time — Opus critic + reviewer; recorded as PR comments per attempt)_