### PR TITLE
P2-Ledger: bootstrap durable verdict store (Exqlite, WAL-before-ack) — completes #420

### DIFF
--- a/lib/tau/application.ex
+++ b/lib/tau/application.ex
@@ -19,6 +19,9 @@ defmodule Tau.Application do
        runs schema migrations in `init/1` before reporting `:ok`.
        Must follow Watcher (needs `data_dir/0`) and precede Finch
        (embedding pipeline in PR3 uses Finch). D-045/D-046/D-047.
+    5b. **Factory.Supervisor** — `Tau.Factory.Ledger.Writer` owner process;
+        WAL-committed verdict ledger (D-315 RPO=0). Must follow Watcher
+        (needs `data_dir/0`). D-312/D-315/D-335 / SPEC-FACTORY-CORE.
     6. **Permissions.RuleSet** — subscribes to settings PubSub,
        compiles rules from Settings.Cache.
     7. **Finch** — HTTP client, used by providers.
@@ -74,6 +77,11 @@ defmodule Tau.Application do
         # :rest_for_one a crash cascades forward — intentional; a broken
         # memory store should not allow new sessions to start.
         Tau.Memory.Supervisor,
+        # Factory ledger. Must follow Memory.Supervisor (data_dir/0 depends on
+        # Settings.Watcher, same requirement). Under :rest_for_one a crash
+        # cascades forward — intentional; a broken ledger should not allow the
+        # factory to continue operating. D-315 / SPEC-FACTORY-CORE.
+        Tau.Factory.Supervisor,
         Tau.Permissions.RuleSet,
         {Finch, name: Tau.Providers.Finch},
         Tau.Providers.RateLimiter.Supervisor,

--- a/lib/tau/factory/ledger/migrations.ex
+++ b/lib/tau/factory/ledger/migrations.ex
@@ -1,0 +1,135 @@
+defmodule Tau.Factory.Ledger.Migrations do
+  @moduledoc """
+  Ordered, idempotent schema migrations for the factory ledger.
+
+  Mirrors `Tau.Memory.Migrations`. Each migration is a
+  `{version :: String.t(), sql :: String.t()}` pair. `run/1` checks
+  `ledger_schema_migrations` before applying each entry; already-applied
+  migrations are skipped.
+
+  ## Invariants
+
+  - Idempotent: re-running against a fully-migrated DB is a no-op.
+  - Append-only: never mutate an existing entry's SQL; add a new entry instead.
+
+  ## D-335 partial unique index
+
+  `CREATE UNIQUE INDEX verdicts_original_uidx ON verdicts (hash, run, half)
+  WHERE supersedes_id IS NULL` enforces that only ONE original (non-superseded)
+  verdict row may exist per `(hash, run, half)` coordinate. A revoke inserts a
+  new row with `supersedes_id` set, which is exempt from the index.
+  """
+
+  @migrations [
+    {"20260609_001_ledger_schema_migrations",
+     """
+     CREATE TABLE IF NOT EXISTS ledger_schema_migrations (
+       version    TEXT PRIMARY KEY,
+       applied_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+     )
+     """},
+    {"20260609_002_verdicts",
+     """
+     CREATE TABLE IF NOT EXISTS verdicts (
+       id               INTEGER PRIMARY KEY AUTOINCREMENT,
+       hash             TEXT    NOT NULL,
+       run              TEXT    NOT NULL,
+       half             TEXT    NOT NULL CHECK (half IN ('critic', 'reviewer')),
+       status           TEXT    NOT NULL CHECK (status IN ('pass', 'fail')),
+       idempotency_key  TEXT    NOT NULL,
+       supersedes_id    INTEGER REFERENCES verdicts(id),
+       inserted_at      TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+     )
+     """},
+    {"20260609_003_verdicts_original_uidx",
+     """
+     CREATE UNIQUE INDEX IF NOT EXISTS verdicts_original_uidx
+       ON verdicts (hash, run, half)
+       WHERE supersedes_id IS NULL
+     """}
+  ]
+
+  @doc "Expose the migration list. Used by tests to verify idempotency."
+  @spec migrations() :: [{String.t(), String.t()}]
+  def migrations, do: @migrations
+
+  @doc """
+  Apply pending migrations to `db` (an `Exqlite.Sqlite3` db reference).
+
+  Returns `:ok` or `{:error, reason}`. Idempotent: already-applied migrations
+  are skipped. Failures halt the run immediately.
+  """
+  @spec run(reference()) :: :ok | {:error, term()}
+  def run(db) do
+    # Bootstrap: create ledger_schema_migrations unconditionally (IF NOT EXISTS).
+    # This is the only migration that cannot check ledger_schema_migrations first.
+    {bootstrap_version, bootstrap_sql} = hd(@migrations)
+
+    with :ok <- exec(db, String.trim(bootstrap_sql)),
+         :ok <- record(db, bootstrap_version) do
+      @migrations
+      |> tl()
+      |> Enum.reduce_while(:ok, fn {version, sql}, :ok ->
+        case applied?(db, version) do
+          {:ok, true} ->
+            {:cont, :ok}
+
+          {:ok, false} ->
+            case exec(db, String.trim(sql)) do
+              :ok ->
+                case record(db, version) do
+                  :ok -> {:cont, :ok}
+                  {:error, _} = err -> {:halt, err}
+                end
+
+              {:error, _} = err ->
+                {:halt, err}
+            end
+
+          {:error, _} = err ->
+            {:halt, err}
+        end
+      end)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Private helpers
+  # ---------------------------------------------------------------------------
+
+  defp exec(db, sql) do
+    case Exqlite.Sqlite3.execute(db, sql) do
+      :ok -> :ok
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp applied?(db, version) do
+    sql = "SELECT 1 FROM ledger_schema_migrations WHERE version = ?1 LIMIT 1"
+
+    with {:ok, stmt} <- Exqlite.Sqlite3.prepare(db, sql),
+         :ok <- Exqlite.Sqlite3.bind(stmt, [version]),
+         {:ok, rows} <- Exqlite.Sqlite3.fetch_all(db, stmt),
+         :ok <- Exqlite.Sqlite3.release(db, stmt) do
+      {:ok, rows != []}
+    else
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp record(db, version) do
+    sql = "INSERT OR IGNORE INTO ledger_schema_migrations (version) VALUES (?1)"
+
+    with {:ok, stmt} <- Exqlite.Sqlite3.prepare(db, sql),
+         :ok <- Exqlite.Sqlite3.bind(stmt, [version]),
+         step_result <- Exqlite.Sqlite3.step(db, stmt),
+         :ok <- Exqlite.Sqlite3.release(db, stmt) do
+      case step_result do
+        :done -> :ok
+        {:error, reason} -> {:error, reason}
+      end
+    else
+      {:error, reason} -> {:error, reason}
+    end
+  end
+end

--- a/lib/tau/factory/ledger/writer.ex
+++ b/lib/tau/factory/ledger/writer.ex
@@ -1,0 +1,324 @@
+defmodule Tau.Factory.Ledger.Writer do
+  @moduledoc """
+  Single-writer `GenServer` owning one `Exqlite.Sqlite3` connection for the
+  factory verdict ledger.
+
+  The connection never escapes this process's heap (D-045 pattern). All writes
+  are serialised through the mailbox, satisfying SQLite's single-writer
+  constraint without external locking.
+
+  On init: opens the DB at `:db_path`, sets `PRAGMA journal_mode=WAL` and
+  `PRAGMA synchronous=FULL`, runs schema migrations. A DB-open or migration
+  failure causes `init/1` to return `{:stop, reason}`, hard-failing boot.
+
+  ## WAL-before-ack (D-315, RPO=0)
+
+  `PRAGMA synchronous=FULL` causes SQLite to fsync the WAL to disk before
+  returning from the write call. The `GenServer.call/2` reply is sent only
+  after the `Exqlite.Sqlite3.step/2` call (the SQLite write) returns, so the
+  caller's `{:ok, ref}` is guaranteed to arrive after the WAL commit is durable.
+
+  ## Append-only invariant (D-335)
+
+  There are NO `UPDATE` statements in this module. Revocations insert a NEW row
+  with `supersedes_id` pointing at the latest existing row for the coordinate.
+  The partial unique index on `verdicts (hash, run, half) WHERE supersedes_id IS
+  NULL` enforces that only one original row per coordinate exists; the
+  uniqueness constraint does not apply to superseding rows.
+
+  ## Public API
+
+    - `start_link/1` — start and register the process.
+    - `append_verdict/2` — insert an original verdict; returns `{:ok, ref}` or
+      `{:error, reason}` on a duplicate-original constraint violation.
+    - `revoke_verdict/2` — insert a superseding verdict row; returns `{:ok, ref}`.
+    - `latest_verdict_status/2` — return `{:ok, :pass | :fail}` or `:none`.
+  """
+
+  use GenServer
+
+  alias Tau.Factory.Ledger.Migrations
+
+  require Logger
+
+  @type verdict_attrs :: %{
+          hash: String.t(),
+          run: String.t(),
+          half: :critic | :reviewer,
+          status: :pass | :fail,
+          idempotency_key: String.t()
+        }
+
+  @type coord :: %{
+          hash: String.t(),
+          run: String.t(),
+          half: :critic | :reviewer
+        }
+
+  @type ref :: integer()
+
+  # ---------------------------------------------------------------------------
+  # Public API
+  # ---------------------------------------------------------------------------
+
+  @doc """
+  Start the writer (typically supervised by `Tau.Factory.Supervisor`).
+
+  Options:
+    - `:db_path` (required) — path to the SQLite database file.
+    - `:name` — registered name for the process (defaults to `__MODULE__`).
+  """
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(opts) do
+    name = Keyword.get(opts, :name, __MODULE__)
+    GenServer.start_link(__MODULE__, opts, name: name)
+  end
+
+  @doc """
+  Insert an original verdict row.
+
+  Returns `{:ok, ref}` (the inserted row id) on success, or `{:error, reason}`
+  if a duplicate original already exists at the `(hash, run, half)` coordinate
+  (the partial unique index fires). NEVER raises on constraint violations.
+  """
+  @spec append_verdict(GenServer.server(), verdict_attrs()) :: {:ok, ref()} | {:error, term()}
+  def append_verdict(server, attrs) do
+    GenServer.call(server, {:append_verdict, attrs})
+  end
+
+  @doc """
+  Insert a superseding verdict row.
+
+  Finds the current latest row for the coordinate and inserts a new row with
+  `supersedes_id` set to that row's id. Returns `{:ok, ref}` (the new row id).
+  Never issues an UPDATE — append-only (D-335).
+  """
+  @spec revoke_verdict(GenServer.server(), verdict_attrs()) :: {:ok, ref()} | {:error, term()}
+  def revoke_verdict(server, attrs) do
+    GenServer.call(server, {:revoke_verdict, attrs})
+  end
+
+  @doc """
+  Return the status of the latest row in the supersede chain for the given
+  coordinate, or `:none` if no row exists.
+  """
+  @spec latest_verdict_status(GenServer.server(), coord()) ::
+          {:ok, :pass | :fail} | :none
+  def latest_verdict_status(server, coord) do
+    GenServer.call(server, {:latest_verdict_status, coord})
+  end
+
+  # ---------------------------------------------------------------------------
+  # GenServer callbacks
+  # ---------------------------------------------------------------------------
+
+  @impl GenServer
+  def init(opts) do
+    db_path = Keyword.fetch!(opts, :db_path)
+
+    case File.mkdir_p(Path.dirname(db_path)) do
+      {:error, reason} ->
+        {:stop, {:db_open_failed, reason}}
+
+      :ok ->
+        with {:ok, db} <- open_db(db_path),
+             :ok <- run_migrations(db) do
+          {:ok, %{db: db}}
+        end
+    end
+  end
+
+  @impl GenServer
+  def handle_call({:append_verdict, attrs}, _from, %{db: db} = state) do
+    result = do_append_verdict(db, attrs)
+    {:reply, result, state}
+  end
+
+  def handle_call({:revoke_verdict, attrs}, _from, %{db: db} = state) do
+    result = do_revoke_verdict(db, attrs)
+    {:reply, result, state}
+  end
+
+  def handle_call({:latest_verdict_status, coord}, _from, %{db: db} = state) do
+    result = do_latest_verdict_status(db, coord)
+    {:reply, result, state}
+  end
+
+  @impl GenServer
+  def terminate(_reason, %{db: db}) do
+    Exqlite.Sqlite3.close(db)
+    :ok
+  end
+
+  def terminate(_reason, _state), do: :ok
+
+  # ---------------------------------------------------------------------------
+  # Private helpers
+  # ---------------------------------------------------------------------------
+
+  defp open_db(db_path) do
+    with {:ok, db} <- Exqlite.Sqlite3.open(db_path),
+         :ok <- Exqlite.Sqlite3.execute(db, "PRAGMA journal_mode=WAL"),
+         :ok <- Exqlite.Sqlite3.execute(db, "PRAGMA synchronous=FULL") do
+      {:ok, db}
+    else
+      {:error, reason} -> {:stop, {:db_open_failed, reason}}
+    end
+  end
+
+  defp run_migrations(db) do
+    case Migrations.run(db) do
+      :ok -> :ok
+      {:error, reason} -> {:stop, {:migration_failed, reason}}
+    end
+  end
+
+  # Insert an original verdict (supersedes_id IS NULL).
+  # The partial unique index rejects a second original at the same coordinate.
+  # Constraint errors are translated to tagged tuples — never raised.
+  defp do_append_verdict(db, %{
+         hash: hash,
+         run: run,
+         half: half,
+         status: status,
+         idempotency_key: idempotency_key
+       }) do
+    sql = """
+    INSERT INTO verdicts (hash, run, half, status, idempotency_key)
+    VALUES (?1, ?2, ?3, ?4, ?5)
+    """
+
+    half_text = atom_to_half(half)
+    status_text = atom_to_status(status)
+
+    with {:ok, stmt} <- Exqlite.Sqlite3.prepare(db, String.trim(sql)),
+         :ok <- Exqlite.Sqlite3.bind(stmt, [hash, run, half_text, status_text, idempotency_key]),
+         step_result <- Exqlite.Sqlite3.step(db, stmt),
+         :ok <- Exqlite.Sqlite3.release(db, stmt) do
+      case step_result do
+        :done -> {:ok, last_insert_rowid(db)}
+        {:error, reason} -> {:error, reason}
+      end
+    end
+  end
+
+  # Insert a superseding verdict row. Finds the current latest row id for the
+  # coordinate and sets supersedes_id. Never issues an UPDATE (D-335).
+  defp do_revoke_verdict(db, %{
+         hash: hash,
+         run: run,
+         half: half,
+         status: status,
+         idempotency_key: idempotency_key
+       }) do
+    half_text = atom_to_half(half)
+    status_text = atom_to_status(status)
+
+    case fetch_latest_id(db, hash, run, half_text) do
+      {:ok, latest_id} ->
+        sql = """
+        INSERT INTO verdicts (hash, run, half, status, idempotency_key, supersedes_id)
+        VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+        """
+
+        with {:ok, stmt} <- Exqlite.Sqlite3.prepare(db, String.trim(sql)),
+             :ok <-
+               Exqlite.Sqlite3.bind(stmt, [
+                 hash,
+                 run,
+                 half_text,
+                 status_text,
+                 idempotency_key,
+                 latest_id
+               ]),
+             step_result <- Exqlite.Sqlite3.step(db, stmt),
+             :ok <- Exqlite.Sqlite3.release(db, stmt) do
+          case step_result do
+            :done -> {:ok, last_insert_rowid(db)}
+            {:error, reason} -> {:error, reason}
+          end
+        end
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  # Return the status of the row with the highest id for this coordinate.
+  # This is the latest row regardless of supersedes_id depth.
+  defp do_latest_verdict_status(db, %{hash: hash, run: run, half: half}) do
+    half_text = atom_to_half(half)
+
+    sql = """
+    SELECT status FROM verdicts
+    WHERE hash = ?1 AND run = ?2 AND half = ?3
+    ORDER BY id DESC
+    LIMIT 1
+    """
+
+    with {:ok, stmt} <- Exqlite.Sqlite3.prepare(db, String.trim(sql)),
+         :ok <- Exqlite.Sqlite3.bind(stmt, [hash, run, half_text]),
+         {:ok, rows} <- Exqlite.Sqlite3.fetch_all(db, stmt),
+         :ok <- Exqlite.Sqlite3.release(db, stmt) do
+      case rows do
+        [[status_text]] -> {:ok, text_to_status(status_text)}
+        [] -> :none
+      end
+    end
+  end
+
+  # Fetch the id of the latest (highest id) row for a coordinate.
+  defp fetch_latest_id(db, hash, run, half_text) do
+    sql = """
+    SELECT id FROM verdicts
+    WHERE hash = ?1 AND run = ?2 AND half = ?3
+    ORDER BY id DESC
+    LIMIT 1
+    """
+
+    with {:ok, stmt} <- Exqlite.Sqlite3.prepare(db, sql),
+         :ok <- Exqlite.Sqlite3.bind(stmt, [hash, run, half_text]),
+         {:ok, rows} <- Exqlite.Sqlite3.fetch_all(db, stmt),
+         :ok <- Exqlite.Sqlite3.release(db, stmt) do
+      case rows do
+        [[id]] -> {:ok, id}
+        [] -> {:error, :not_found}
+      end
+    end
+  end
+
+  defp last_insert_rowid(db) do
+    case Exqlite.Sqlite3.execute(db, "SELECT last_insert_rowid()") do
+      :ok ->
+        # execute/2 doesn't return rows; use prepare+step pattern
+        fetch_last_rowid(db)
+
+      _ ->
+        fetch_last_rowid(db)
+    end
+  end
+
+  defp fetch_last_rowid(db) do
+    sql = "SELECT last_insert_rowid()"
+
+    with {:ok, stmt} <- Exqlite.Sqlite3.prepare(db, sql),
+         {:ok, rows} <- Exqlite.Sqlite3.fetch_all(db, stmt),
+         :ok <- Exqlite.Sqlite3.release(db, stmt) do
+      case rows do
+        [[id]] -> id
+        _ -> nil
+      end
+    else
+      _ -> nil
+    end
+  end
+
+  defp atom_to_half(:critic), do: "critic"
+  defp atom_to_half(:reviewer), do: "reviewer"
+
+  defp atom_to_status(:pass), do: "pass"
+  defp atom_to_status(:fail), do: "fail"
+
+  defp text_to_status("pass"), do: :pass
+  defp text_to_status("fail"), do: :fail
+end

--- a/lib/tau/factory/supervisor.ex
+++ b/lib/tau/factory/supervisor.ex
@@ -1,0 +1,63 @@
+defmodule Tau.Factory.Supervisor do
+  @moduledoc """
+  Supervision subtree for the factory control components.
+
+  Hosts `Tau.Factory.Ledger.Writer` under a `one_for_one` strategy. Sits in
+  `Tau.Application`'s `:rest_for_one` child list after `Tau.Memory.Supervisor`
+  (which resolves `data_dir/0` — required before the ledger can open its DB).
+
+  Supports `start_link/1` with `db_path:` and `name:` options for test
+  isolation — each test can spin up an isolated supervisor against a tmp-dir DB
+  without touching the application-started instance.
+
+  See `docs/spec/SPEC-FACTORY-CORE.md`.
+  """
+
+  use Supervisor
+
+  @doc """
+  Start the factory supervisor (called by `Tau.Application` or tests).
+
+  Options:
+    - `:db_path` — path to the SQLite ledger DB file (required when not using
+      the application default).
+    - `:name` — registered name for this supervisor process (defaults to
+      `__MODULE__`). The `Ledger.Writer` child is registered under a derived
+      name (`{:via, name}` convention: `:"<name>_writer"`) so multiple isolated
+      supervisor instances can coexist (e.g. in tests).
+  """
+  @spec start_link(keyword()) :: Supervisor.on_start()
+  def start_link(opts \\ []) do
+    sup_name = Keyword.get(opts, :name, __MODULE__)
+    Supervisor.start_link(__MODULE__, opts, name: sup_name)
+  end
+
+  @impl true
+  def init(opts) do
+    db_path = Keyword.get(opts, :db_path, default_db_path())
+    sup_name = Keyword.get(opts, :name, __MODULE__)
+
+    # Derive a per-supervisor writer name so concurrent supervisor instances
+    # (e.g. isolated test instances) do not conflict on the writer's name.
+    writer_name =
+      if sup_name == __MODULE__ do
+        Tau.Factory.Ledger.Writer
+      else
+        :"#{sup_name}_writer"
+      end
+
+    children = [
+      {Tau.Factory.Ledger.Writer, db_path: db_path, name: writer_name}
+    ]
+
+    Supervisor.init(children, strategy: :one_for_one)
+  end
+
+  # ---------------------------------------------------------------------------
+  # Private helpers
+  # ---------------------------------------------------------------------------
+
+  defp default_db_path do
+    Path.join(Tau.Settings.data_dir(), "factory_ledger.db")
+  end
+end

--- a/test/tau/factory/ledger_durability_test.exs
+++ b/test/tau/factory/ledger_durability_test.exs
@@ -1,0 +1,90 @@
+defmodule Tau.Factory.LedgerDurabilityTest do
+  @moduledoc """
+  Gating tests for PR #433 (P2-Ledger) — AC-2 / D-315 (RPO=0, WAL-before-ack).
+
+  Verifies that a verdict acked by `append_verdict/2` survives a Writer process
+  restart against the same DB file, proving WAL was committed before the ack.
+
+  Written BEFORE production code exists (oracle-separation phase).
+  These tests fail with UndefinedFunctionError until the implementer creates:
+    - `lib/tau/factory/ledger/writer.ex`
+    - `lib/tau/factory/ledger/migrations.ex`
+
+  AC linkage: AC-2 / D-315.
+  """
+
+  use ExUnit.Case, async: true
+
+  @moduletag :ac_2
+  @moduletag :d_315
+  @moduletag :capture_log
+
+  # Runtime module references — file compiles even when modules do not yet exist.
+  @writer Tau.Factory.Ledger.Writer
+
+  # ---------------------------------------------------------------------------
+  # AC-2 / D-315: WAL-before-ack — acked writes survive process restart
+  # ---------------------------------------------------------------------------
+
+  describe "AC-2 / D-315 — WAL-before-ack: acked verdict survives Writer restart" do
+    test "AC-2 / D-315: append_verdict returns {:ok, ref} only after WAL commit; verdict readable after restart" do
+      db_path = Briefly.create!(extname: ".db")
+      writer_name = :"test_ledger_writer_#{System.unique_integer([:positive])}"
+
+      # Start writer against isolated tmp DB.
+      writer_pid =
+        start_supervised!(
+          {@writer, db_path: db_path, name: writer_name},
+          id: writer_name
+        )
+
+      verdict = %{
+        hash: "abc123",
+        run: "run-001",
+        half: :critic,
+        status: :pass,
+        idempotency_key: "ikey-#{System.unique_integer([:positive])}"
+      }
+
+      # Append a verdict — ack must come ONLY after WAL commit (D-315 RPO=0).
+      assert {:ok, _ref} = @writer.append_verdict(writer_pid, verdict)
+
+      # Stop the writer cleanly — simulates a process restart.
+      stop_supervised!(writer_name)
+
+      # Start a FRESH writer process against the SAME DB file.
+      writer_pid2 =
+        start_supervised!(
+          {@writer, db_path: db_path, name: writer_name},
+          id: writer_name
+        )
+
+      # The acked verdict must be readable from the fresh process —
+      # it was WAL-committed before the ack, so it survives restart.
+      assert {:ok, :pass} =
+               @writer.latest_verdict_status(writer_pid2, %{
+                 hash: "abc123",
+                 run: "run-001",
+                 half: :critic
+               })
+    end
+
+    test "AC-2 / D-315: latest_verdict_status returns :none for an unknown coordinate" do
+      db_path = Briefly.create!(extname: ".db")
+      writer_name = :"test_ledger_writer_none_#{System.unique_integer([:positive])}"
+
+      writer_pid =
+        start_supervised!(
+          {@writer, db_path: db_path, name: writer_name},
+          id: writer_name
+        )
+
+      assert :none =
+               @writer.latest_verdict_status(writer_pid, %{
+                 hash: "no-such-hash",
+                 run: "no-such-run",
+                 half: :reviewer
+               })
+    end
+  end
+end

--- a/test/tau/factory/ledger_supervision_test.exs
+++ b/test/tau/factory/ledger_supervision_test.exs
@@ -1,0 +1,94 @@
+defmodule Tau.Factory.LedgerSupervisionTest do
+  @moduledoc """
+  Gating tests for PR #433 (P2-Ledger) — AC-1 / D-312.
+
+  Verifies that `Tau.Factory.Supervisor` starts `Tau.Factory.Ledger.Writer`
+  as a live supervised child and restarts it after a crash.
+
+  Written BEFORE production code exists (oracle-separation phase).
+  These tests fail with UndefinedFunctionError until the implementer creates:
+    - `lib/tau/factory/supervisor.ex`
+    - `lib/tau/factory/ledger/writer.ex`
+    - `lib/tau/factory/ledger/migrations.ex`
+
+  AC linkage: AC-1 / D-312.
+  """
+
+  use ExUnit.Case, async: false
+
+  @moduletag :ac_1
+  @moduletag :d_312
+  @moduletag :capture_log
+
+  # Runtime module references — file compiles even when modules do not yet exist.
+  # Each test fails with UndefinedFunctionError at call-time (not CompileError).
+  @supervisor Tau.Factory.Supervisor
+  @writer Tau.Factory.Ledger.Writer
+
+  # ---------------------------------------------------------------------------
+  # AC-1 / D-312: Tau.Factory.Supervisor supervises Tau.Factory.Ledger.Writer
+  # ---------------------------------------------------------------------------
+
+  describe "AC-1 / D-312 — Tau.Factory.Supervisor supervises Tau.Factory.Ledger.Writer" do
+    setup do
+      db_path = Briefly.create!(extname: ".db")
+
+      # Start the full supervisor tree against an isolated tmp-dir DB.
+      # Uses a unique name to avoid clashing with any application-started instance.
+      sup_name = :"test_factory_sup_#{System.unique_integer([:positive])}"
+
+      sup_pid =
+        start_supervised!(
+          {
+            @supervisor,
+            db_path: db_path, name: sup_name
+          },
+          id: sup_name
+        )
+
+      %{sup_pid: sup_pid, db_path: db_path, sup_name: sup_name}
+    end
+
+    test "AC-1 / D-312: Tau.Factory.Ledger.Writer is alive after supervisor start",
+         %{sup_pid: sup_pid} do
+      # The Writer must be a child of the supervisor.
+      children = Supervisor.which_children(sup_pid)
+      writer_child = Enum.find(children, fn {id, _, _, _} -> id == @writer end)
+
+      assert writer_child != nil,
+             "Expected Tau.Factory.Ledger.Writer to be a child of Tau.Factory.Supervisor"
+
+      {_id, writer_pid, :worker, _} = writer_child
+      assert is_pid(writer_pid), "Expected writer pid to be a pid"
+      assert Process.alive?(writer_pid), "Expected writer process to be alive"
+    end
+
+    test "AC-1 / D-312: Tau.Factory.Ledger.Writer restarts after abnormal exit",
+         %{sup_pid: sup_pid} do
+      # Capture the original writer pid.
+      children_before = Supervisor.which_children(sup_pid)
+
+      {_, writer_pid_before, :worker, _} =
+        Enum.find(children_before, fn {id, _, _, _} -> id == @writer end)
+
+      assert Process.alive?(writer_pid_before)
+
+      # Kill the writer abnormally — the supervisor must restart it.
+      Process.exit(writer_pid_before, :kill)
+
+      # Give the supervisor a moment to restart the child.
+      Process.sleep(100)
+
+      children_after = Supervisor.which_children(sup_pid)
+
+      {_, writer_pid_after, :worker, _} =
+        Enum.find(children_after, fn {id, _, _, _} -> id == @writer end)
+
+      assert Process.alive?(writer_pid_after),
+             "Tau.Factory.Ledger.Writer was not restarted by the supervisor after kill"
+
+      assert writer_pid_after != writer_pid_before,
+             "Expected a new pid after restart (supervisor created a fresh process)"
+    end
+  end
+end

--- a/test/tau/factory/verdict_append_only_test.exs
+++ b/test/tau/factory/verdict_append_only_test.exs
@@ -1,0 +1,234 @@
+defmodule Tau.Factory.VerdictAppendOnlyTest do
+  @moduledoc """
+  Gating tests for PR #433 (P2-Ledger) — AC-9 / D-335 (append-only).
+
+  Three assertions against the real Writer process:
+    (a) Duplicate original inserts at the same (hash, run, half) coordinate
+        are rejected (partial unique index on rows WHERE supersedes_id IS NULL).
+    (b) revoke_verdict/2 inserts a NEW row (with supersedes_id set) rather than
+        updating the existing row; latest_verdict_status returns the superseding
+        row's status; the original row is still present (nothing was UPDATEd).
+    (c) latest_verdict_status always returns the status of the superseding
+        (latest) row in the chain — the most recent revocation wins.
+
+  Written BEFORE production code exists (oracle-separation phase).
+  These tests fail with UndefinedFunctionError until the implementer creates:
+    - `lib/tau/factory/ledger/writer.ex`
+    - `lib/tau/factory/ledger/migrations.ex`
+
+  AC linkage: AC-9 / D-335.
+  """
+
+  use ExUnit.Case, async: true
+
+  @moduletag :ac_9
+  @moduletag :d_335
+  @moduletag :capture_log
+
+  # Runtime module references — file compiles even when modules do not yet exist.
+  @writer Tau.Factory.Ledger.Writer
+
+  # ---------------------------------------------------------------------------
+  # Setup: one isolated Writer per test
+  # ---------------------------------------------------------------------------
+
+  setup do
+    db_path = Briefly.create!(extname: ".db")
+    writer_name = :"test_ledger_ao_#{System.unique_integer([:positive])}"
+
+    writer_pid =
+      start_supervised!(
+        {@writer, db_path: db_path, name: writer_name},
+        id: writer_name
+      )
+
+    %{writer: writer_pid, db_path: db_path}
+  end
+
+  # ---------------------------------------------------------------------------
+  # AC-9 / D-335 (a): duplicate original insert is rejected
+  # ---------------------------------------------------------------------------
+
+  describe "AC-9 / D-335 (a) — partial unique index rejects duplicate original rows" do
+    test "AC-9 / D-335: second append at same (hash, run, half) coordinate returns an error tuple",
+         %{writer: writer} do
+      coord = %{
+        hash: "sha-dup",
+        run: "run-dup",
+        half: :critic,
+        status: :pass,
+        idempotency_key: "ikey-a-#{System.unique_integer([:positive])}"
+      }
+
+      # First append must succeed.
+      assert {:ok, _ref} = @writer.append_verdict(writer, coord)
+
+      # Second append at the same coordinate (same hash/run/half, different ikey)
+      # must be rejected — the partial unique index fires for rows WHERE supersedes_id IS NULL.
+      second = %{
+        coord
+        | status: :fail,
+          idempotency_key: "ikey-b-#{System.unique_integer([:positive])}"
+      }
+
+      result = @writer.append_verdict(writer, second)
+
+      assert match?({:error, _}, result),
+             "Expected {:error, _} for duplicate original at same (hash, run, half) coordinate, got: #{inspect(result)}"
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # AC-9 / D-335 (b): revoke_verdict inserts a new row; original row survives
+  # ---------------------------------------------------------------------------
+
+  describe "AC-9 / D-335 (b) — revoke_verdict inserts new row with supersedes_id; nothing is UPDATEd" do
+    test "AC-9 / D-335: after revoke_verdict, latest_verdict_status returns the revocation's status",
+         %{writer: writer} do
+      coord = %{
+        hash: "sha-rev",
+        run: "run-rev",
+        half: :reviewer,
+        status: :fail,
+        idempotency_key: "ikey-rev-#{System.unique_integer([:positive])}"
+      }
+
+      # Append an original :fail verdict.
+      assert {:ok, _ref} = @writer.append_verdict(writer, coord)
+
+      assert {:ok, :fail} =
+               @writer.latest_verdict_status(writer, %{
+                 hash: "sha-rev",
+                 run: "run-rev",
+                 half: :reviewer
+               })
+
+      # Revoke — this must INSERT a new row with supersedes_id pointing at the original.
+      # The revocation flips the effective status to :pass.
+      assert {:ok, _ref2} =
+               @writer.revoke_verdict(writer, %{
+                 hash: "sha-rev",
+                 run: "run-rev",
+                 half: :reviewer,
+                 status: :pass,
+                 idempotency_key: "ikey-rev2-#{System.unique_integer([:positive])}"
+               })
+
+      # latest_verdict_status must now return the superseding row's status.
+      assert {:ok, :pass} =
+               @writer.latest_verdict_status(writer, %{
+                 hash: "sha-rev",
+                 run: "run-rev",
+                 half: :reviewer
+               })
+    end
+
+    test "AC-9 / D-335: revoke_verdict preserves the original row (append-only; no UPDATEs)",
+         %{writer: writer} do
+      coord = %{
+        hash: "sha-ao",
+        run: "run-ao",
+        half: :critic,
+        status: :pass,
+        idempotency_key: "ikey-ao-#{System.unique_integer([:positive])}"
+      }
+
+      assert {:ok, _ref} = @writer.append_verdict(writer, coord)
+
+      # Now revoke with a different status.
+      assert {:ok, _} =
+               @writer.revoke_verdict(writer, %{
+                 hash: "sha-ao",
+                 run: "run-ao",
+                 half: :critic,
+                 status: :fail,
+                 idempotency_key: "ikey-ao2-#{System.unique_integer([:positive])}"
+               })
+
+      # Both rows must exist in the store — the table is append-only.
+      # We verify this by asserting there are 2 rows for this coordinate,
+      # using a direct GenServer call that exposes a row-count query.
+      # The Writer must expose `all_verdicts_for/2` or we verify via the
+      # superseding row's presence by attempting another revoke of the revoked
+      # row and confirming it succeeds (i.e. the supersedes chain exists).
+      #
+      # Primary assertion: latest status reflects the revocation.
+      assert {:ok, :fail} =
+               @writer.latest_verdict_status(writer, %{
+                 hash: "sha-ao",
+                 run: "run-ao",
+                 half: :critic
+               })
+
+      # Confirming append-only by re-revoking back to :pass — the new row
+      # must supersede the prior revocation row (chain: original → rev1 → rev2).
+      assert {:ok, _} =
+               @writer.revoke_verdict(writer, %{
+                 hash: "sha-ao",
+                 run: "run-ao",
+                 half: :critic,
+                 status: :pass,
+                 idempotency_key: "ikey-ao3-#{System.unique_integer([:positive])}"
+               })
+
+      assert {:ok, :pass} =
+               @writer.latest_verdict_status(writer, %{
+                 hash: "sha-ao",
+                 run: "run-ao",
+                 half: :critic
+               })
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # AC-9 / D-335 (c): latest-wins — superseding chain determines status
+  # ---------------------------------------------------------------------------
+
+  describe "AC-9 / D-335 (c) — latest_verdict_status reflects the most-recent row in the supersedes chain" do
+    test "AC-9 / D-335: latest_verdict_status returns the final status after multiple revocations",
+         %{writer: writer} do
+      base = %{
+        hash: "sha-chain",
+        run: "run-chain",
+        half: :critic
+      }
+
+      # Row 1: original :pass
+      assert {:ok, _} =
+               @writer.append_verdict(
+                 writer,
+                 Map.merge(base, %{
+                   status: :pass,
+                   idempotency_key: "chain-1-#{System.unique_integer([:positive])}"
+                 })
+               )
+
+      assert {:ok, :pass} = @writer.latest_verdict_status(writer, base)
+
+      # Row 2: revocation → :fail
+      assert {:ok, _} =
+               @writer.revoke_verdict(
+                 writer,
+                 Map.merge(base, %{
+                   status: :fail,
+                   idempotency_key: "chain-2-#{System.unique_integer([:positive])}"
+                 })
+               )
+
+      assert {:ok, :fail} = @writer.latest_verdict_status(writer, base)
+
+      # Row 3: revocation → :pass again
+      assert {:ok, _} =
+               @writer.revoke_verdict(
+                 writer,
+                 Map.merge(base, %{
+                   status: :pass,
+                   idempotency_key: "chain-3-#{System.unique_integer([:positive])}"
+                 })
+               )
+
+      # The latest row in the chain wins.
+      assert {:ok, :pass} = @writer.latest_verdict_status(writer, base)
+    end
+  end
+end


### PR DESCRIPTION
## P2-Ledger — bootstrap durable verdict store (completes #420)

Closes #420 (the engine half landed in #431 `2921dc2`; this is the Ledger half).
The full Ledger (units, attempts, budget, reconcile — PR-CORE-2..5) is **P5**;
this PR lands only the **minimal durable verdict store** the gate persists to and
P3's MergeAuthority reads from.

### Scope & order
Mirror the existing raw-Exqlite memory-store pattern
(`lib/tau/memory/{store/sqlite,migrations,supervisor}.ex`) — **not** Ecto.

1. `lib/tau/factory/ledger/migrations.ex` — create the `verdicts` table; **D-335
   partial unique index** `(hash, run, half) WHERE supersedes_id IS NULL` (one
   original verdict per coordinate; a revoke is a *new* row).
2. `lib/tau/factory/ledger/writer.ex` — single-writer `GenServer` owning one
   Exqlite connection. **WAL-before-ack** (`PRAGMA journal_mode=WAL`,
   `synchronous=FULL`): commit before replying `{:ok, ref}` (D-315). API:
   **Pinned by the test-author oracle (99414b1), conform exactly:**
   - `append_verdict(server, %{hash, run, half, status, idempotency_key})` →
     `{:ok, ref} | {:error, reason}` (ref only after WAL commit).
   - `revoke_verdict(server, %{hash, run, half, status, idempotency_key})` →
     `{:ok, ref}`: a NEW row with `supersedes_id` pointing at the prior latest;
     NEVER an UPDATE.
   - `latest_verdict_status(server, %{hash, run, half})` →
     `{:ok, :pass | :fail} | :none` (status of the superseding/latest row).
   - `start_link(db_path: path, name: name)` (mirror `Tau.Memory` naming).
   No `UPDATE` statement against `verdicts` exists anywhere in the module.
3. `lib/tau/factory/supervisor.ex` — supervises `Ledger.Writer`; DB path under
   the app data dir (test path isolated per the memory-store convention).
4. `lib/tau/application.ex` — add `Tau.Factory.Supervisor` to the children
   (`:rest_for_one`, after `Memory.Supervisor`).

### Dependencies
Blocks P3 (#421, MergeAuthority — reads the latest PASS verdict per hash, HR-2).
Depends on nothing open. `:exqlite ~> 0.27` already a dep.

### SPECs
In scope: **SPEC-FACTORY-CORE** (Appendix B: `ledger/writer.ex`,
`ledger/migrations.ex`, `factory/supervisor.ex`, `application.ex`). This PR
*conforms to and partially advances* PR-CORE-1 (durable spine) + the verdict
slice of PR-CORE-5. No SPEC amendment expected; if a constraint surfaces it
lands in §3 here.

### Acceptance criteria
- **AC-1 (D-312):** `Tau.Factory.Supervisor` starts and supervises
  `Tau.Factory.Ledger.Writer`; the Writer is alive after supervisor start and
  restarts under its child spec.
- **AC-2 (D-315):** durability / RPO=0 — a verdict appended and acked by the
  Writer survives a Writer process restart against the same DB file
  (`latest_verdict_status` returns it after restart). WAL-before-ack.
- **AC-9 (D-335):** verdict append-only — appending a second original at an
  existing `(hash, run, half)` coordinate is rejected by the partial unique
  index; a `revoke_verdict` inserts a NEW row with `supersedes_id` (no UPDATE
  path exists); `latest_verdict_status` returns the superseding row.

### Gating-test paths (frozen at 99414b1 — implementer MUST NOT edit these)
- `test/tau/factory/ledger_supervision_test.exs` (AC-1 / D-312)
- `test/tau/factory/ledger_durability_test.exs` (AC-2 / D-315)
- `test/tau/factory/verdict_append_only_test.exs` (AC-9 / D-335)

### Gate verdicts
_(filled at gate time — critic, reviewer)_
