### PR TITLE
P3a: MergeAuthority gen_statem + verdict-gated CAS (B=1, D-300/301/302) — advances #421

### DIFF
--- a/lib/tau/factory/merge/cas.ex
+++ b/lib/tau/factory/merge/cas.ex
@@ -1,0 +1,108 @@
+defmodule Tau.Factory.Merge.Cas do
+  @moduledoc """
+  The COMMIT critical section as pure data + effects for the Merge Authority.
+
+  Two functions:
+
+    - `assert_all_verdicts_live/3` — re-reads the **latest** verdict status for
+      every (unit, half) pair at the merge instant (HR-2, D-300). Returns
+      `:all_pass` only if every required half's latest status is `{:ok, :pass}`.
+      Returns `{:revoked, unit}` on the first revoked or missing half.
+
+    - `cas_push/3` — runs `git push --force-with-lease=refs/heads/main:<oid>`
+      (HR-1, D-301). Returns `:ok` on success or `{:error, :stale_ref}` on a
+      lease rejection. Never raises on rejection.
+
+  See `docs/spec/SPEC-FACTORY-MERGE.md` §4 B3/B4, D-300, D-301.
+  """
+
+  alias Tau.Factory.Ledger.Writer
+
+  @doc """
+  Re-read the latest verdict status for every `(unit, half)` pair in `units ×
+  required_halves`.
+
+  Returns `:all_pass` if and only if every query returns `{:ok, :pass}`.
+  Returns `{:revoked, unit}` on the first unit whose any required half yields
+  `{:ok, :fail}` or `:none`.
+  """
+  @spec assert_all_verdicts_live(GenServer.server(), [map()], [:critic | :reviewer]) ::
+          :all_pass | {:revoked, map()}
+  def assert_all_verdicts_live(ledger, units, required_halves) do
+    Enum.reduce_while(units, :all_pass, fn unit, :all_pass ->
+      case check_unit(ledger, unit, required_halves) do
+        :all_pass -> {:cont, :all_pass}
+        {:revoked, ^unit} = revoked -> {:halt, revoked}
+      end
+    end)
+  end
+
+  @doc """
+  Push `tip` onto `origin/main` using `--force-with-lease` anchored at
+  `expected_old_oid`.
+
+  Runs `git push --force-with-lease=refs/heads/main:<expected_old_oid> origin
+  <tip>:refs/heads/main` inside `repo_dir`.
+
+  Returns:
+    - `:ok` on exit 0.
+    - `{:error, :stale_ref}` when the remote rejects the push due to a stale
+      lease (output contains "stale", "rejected", or "force-with-lease").
+    - `{:error, {:git_error, output}}` for other git failures.
+  """
+  @spec cas_push(String.t(), String.t(), String.t()) ::
+          :ok | {:error, :stale_ref} | {:error, term()}
+  def cas_push(repo_dir, tip, expected_old_oid) do
+    # Fetch first so the local remote-tracking ref is current. Without this,
+    # --force-with-lease compares against a stale local tracking ref and
+    # would not detect a concurrent push that advanced origin/main (HR-1, D-301).
+    System.cmd("git", ["fetch", "origin"], cd: repo_dir, stderr_to_stdout: true)
+
+    lease_arg = "refs/heads/main:#{expected_old_oid}"
+    refspec = "#{tip}:refs/heads/main"
+
+    {output, exit_code} =
+      System.cmd(
+        "git",
+        ["push", "--force-with-lease=#{lease_arg}", "origin", refspec],
+        cd: repo_dir,
+        stderr_to_stdout: true
+      )
+
+    cond do
+      exit_code == 0 ->
+        :ok
+
+      stale_ref_output?(output) ->
+        {:error, :stale_ref}
+
+      true ->
+        {:error, {:git_error, output}}
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Private helpers
+  # ---------------------------------------------------------------------------
+
+  defp check_unit(ledger, unit, required_halves) do
+    Enum.reduce_while(required_halves, :all_pass, fn half, :all_pass ->
+      coord = %{hash: unit.hash, run: unit.run, half: half}
+
+      case Writer.latest_verdict_status(ledger, coord) do
+        {:ok, :pass} -> {:cont, :all_pass}
+        {:ok, :fail} -> {:halt, {:revoked, unit}}
+        :none -> {:halt, {:revoked, unit}}
+      end
+    end)
+  end
+
+  defp stale_ref_output?(output) do
+    lower = String.downcase(output)
+
+    String.contains?(lower, "stale info") or
+      String.contains?(lower, "stale") or
+      String.contains?(lower, "rejected") or
+      String.contains?(lower, "force-with-lease")
+  end
+end

--- a/lib/tau/factory/merge_authority.ex
+++ b/lib/tau/factory/merge_authority.ex
@@ -1,0 +1,374 @@
+defmodule Tau.Factory.MergeAuthority do
+  @moduledoc """
+  Serialized Merge Authority (M) — the sole writer of `origin/main`.
+
+  A single `gen_statem` with three states:
+
+    - `:idle` — accepts submissions; assembles and launches the next train.
+    - `:integrating` — monitored `Task` runs the build off the mailbox;
+      M still accepts submissions for the *next* train (INV-3: no second build).
+    - `:committing` — short critical section: re-read latest verdicts (HR-2)
+      then `cas_push` (`--force-with-lease`, HR-1). Milliseconds only.
+
+  The build task runs via `Task.Supervisor.async_nolink/2` so M's mailbox stays
+  free during `T_int` (minutes). `request_merge/2` is non-blocking (D-302).
+
+  See `docs/spec/SPEC-FACTORY-MERGE.md` §4–§5, D-300, D-301, D-302.
+  """
+
+  @behaviour :gen_statem
+
+  alias Tau.Factory.Merge.Cas
+
+  require Logger
+
+  # How long to wait for a build task before treating it as wedged (C207).
+  @build_timeout_ms :timer.minutes(30)
+
+  # ---------------------------------------------------------------------------
+  # Public API
+  # ---------------------------------------------------------------------------
+
+  @doc """
+  Start and register the MergeAuthority.
+
+  Options (all required unless noted):
+    - `:name` — registered name for this process.
+    - `:ledger` — pid/name of the `Tau.Factory.Ledger.Writer`.
+    - `:repo_dir` — filesystem path of the git working directory.
+    - `:tasks_name` — registered name of the `Task.Supervisor` for builds.
+    - `:required_halves` — list of verdict halves required (default `[:critic, :reviewer]`).
+    - `:build_fun` — `(units, base) -> {:built, units, base, tip} | {:build_failed, reason}`
+      (default: the real rebase+push implementation; injectable for tests).
+    - `:cas` — the CAS module to use (default `Tau.Factory.Merge.Cas`; injectable for tests).
+  """
+  @spec child_spec(keyword()) :: Supervisor.child_spec()
+  def child_spec(opts) do
+    %{
+      id: Keyword.get(opts, :name, __MODULE__),
+      start: {__MODULE__, :start_link, [opts]},
+      type: :worker,
+      restart: :permanent,
+      shutdown: 5000
+    }
+  end
+
+  @spec start_link(keyword()) :: :gen_statem.start_ret()
+  def start_link(opts) do
+    name = Keyword.fetch!(opts, :name)
+    :gen_statem.start_link({:local, name}, __MODULE__, opts, [])
+  end
+
+  @doc """
+  Submit a unit for merging. Non-blocking: returns `:queued` immediately.
+
+  The merge outcome is broadcast via telemetry when the commit lands or is
+  rejected.
+
+  `unit` must have keys: `:id`, `:hash`, `:run`, `:branch`.
+  """
+  @spec request_merge(:gen_statem.server_ref(), map()) :: :queued
+  def request_merge(server, unit) do
+    :gen_statem.call(server, {:request_merge, unit})
+  end
+
+  # ---------------------------------------------------------------------------
+  # gen_statem callbacks
+  # ---------------------------------------------------------------------------
+
+  @impl :gen_statem
+  def callback_mode, do: :state_functions
+
+  @impl :gen_statem
+  def init(opts) do
+    ledger = Keyword.fetch!(opts, :ledger)
+    repo_dir = Keyword.fetch!(opts, :repo_dir)
+    tasks_name = Keyword.fetch!(opts, :tasks_name)
+    required_halves = Keyword.get(opts, :required_halves, [:critic, :reviewer])
+    cas = Keyword.get(opts, :cas, Cas)
+
+    # Start the Task.Supervisor for builds if it is not already running.
+    # Linking it to this process ensures it is cleaned up when MA stops.
+    case Process.whereis(tasks_name) do
+      nil ->
+        {:ok, _} = Task.Supervisor.start_link(name: tasks_name)
+
+      _pid ->
+        :already_running
+    end
+
+    build_fun =
+      Keyword.get(opts, :build_fun, fn units, base ->
+        default_build(repo_dir, units, base)
+      end)
+
+    data = %{
+      ledger: ledger,
+      repo_dir: repo_dir,
+      tasks_name: tasks_name,
+      required_halves: required_halves,
+      cas: cas,
+      build_fun: build_fun,
+      # wait queue: list of units waiting to be built
+      queue: [],
+      # task ref for current build (nil when :idle)
+      task_ref: nil,
+      # task pid for forwarding barrier messages (nil when :idle)
+      task_pid: nil,
+      # units currently in the integrating train
+      train: []
+    }
+
+    {:ok, :idle, data}
+  end
+
+  # ---------------------------------------------------------------------------
+  # State: :idle
+  # ---------------------------------------------------------------------------
+
+  def idle({:call, from}, {:request_merge, unit}, data) do
+    data = enqueue(data, unit)
+
+    case start_build(data) do
+      {:integrating, next_data, actions} ->
+        {:next_state, :integrating, next_data, [{:reply, from, :queued} | actions]}
+
+      {:idle, next_data} ->
+        {:keep_state, next_data, [{:reply, from, :queued}]}
+    end
+  end
+
+  # Ignore stray barrier messages in idle state.
+  def idle(:info, {:proceed, _ref}, data) do
+    {:keep_state, data}
+  end
+
+  def idle(:info, msg, data) do
+    Logger.debug("[MergeAuthority] idle received unexpected message: #{inspect(msg)}")
+    {:keep_state, data}
+  end
+
+  # ---------------------------------------------------------------------------
+  # State: :integrating
+  # ---------------------------------------------------------------------------
+
+  def integrating({:call, from}, {:request_merge, unit}, data) do
+    # Enqueue for the NEXT train; do NOT start a second build (INV-3 / D-302).
+    data = enqueue(data, unit)
+    {:keep_state, data, [{:reply, from, :queued}]}
+  end
+
+  # Forward :proceed messages from the test barrier to the blocked task process.
+  def integrating(:info, {:proceed, _ref} = msg, %{task_pid: task_pid} = data)
+      when is_pid(task_pid) do
+    send(task_pid, msg)
+    {:keep_state, data}
+  end
+
+  def integrating(:info, {:proceed, _ref}, data) do
+    {:keep_state, data}
+  end
+
+  # Task result: build succeeded.
+  def integrating(:info, {ref, {:built, units, base, tip}}, %{task_ref: ref} = data) do
+    # Demonitor; flush the :DOWN that async_nolink sends when the task exits.
+    Process.demonitor(ref, [:flush])
+
+    telemetry(:committing, %{hash: hd_hash(units)}, %{units: units, tip: tip})
+
+    next_data = %{data | task_ref: nil, task_pid: nil, train: []}
+    commit_action = {:next_event, :internal, {:commit, units, base, tip}}
+    {:next_state, :committing, next_data, [commit_action]}
+  end
+
+  # Task result: build failed (expected failure path, not a crash).
+  def integrating(:info, {ref, {:build_failed, reason}}, %{task_ref: ref} = data) do
+    Process.demonitor(ref, [:flush])
+    Logger.warning("[MergeAuthority] build failed: #{inspect(reason)}")
+
+    train = data.train
+    telemetry(:reject, %{hash: hd_hash(train)}, %{reason: :build_failed, units: train})
+
+    next_data = requeue_train(data)
+    transition_from_idle(next_data)
+  end
+
+  # Task crashed (:DOWN without a prior result message).
+  def integrating(:info, {:DOWN, ref, :process, _pid, reason}, %{task_ref: ref} = data) do
+    Logger.warning("[MergeAuthority] build task crashed: #{inspect(reason)}")
+
+    train = data.train
+    telemetry(:reject, %{hash: hd_hash(train)}, %{reason: :task_down, units: train})
+
+    next_data = requeue_train(data)
+    transition_from_idle(next_data)
+  end
+
+  # Wedged build guard: state_timeout fires if the build takes too long.
+  def integrating(:state_timeout, :build_timeout, data) do
+    Logger.warning("[MergeAuthority] build task wedged; requeuing train")
+
+    if data.task_pid, do: Process.exit(data.task_pid, :kill)
+    if data.task_ref, do: Process.demonitor(data.task_ref, [:flush])
+
+    train = data.train
+    telemetry(:reject, %{hash: hd_hash(train)}, %{reason: :build_timeout, units: train})
+
+    next_data = requeue_train(data)
+    transition_from_idle(next_data)
+  end
+
+  def integrating(:info, msg, data) do
+    Logger.debug("[MergeAuthority] integrating received unexpected message: #{inspect(msg)}")
+    {:keep_state, data}
+  end
+
+  # ---------------------------------------------------------------------------
+  # State: :committing
+  # ---------------------------------------------------------------------------
+
+  def committing(:internal, {:commit, units, base, tip}, data) do
+    %{ledger: ledger, required_halves: required_halves, cas: cas, repo_dir: repo_dir} = data
+
+    case cas.assert_all_verdicts_live(ledger, units, required_halves) do
+      {:revoked, revoked_unit} ->
+        Logger.info(
+          "[MergeAuthority] verdict revoked for unit #{inspect(revoked_unit.id)}; no push"
+        )
+
+        telemetry(:reject, %{hash: revoked_unit.hash}, %{
+          reason: :verdict_revoked,
+          unit: revoked_unit
+        })
+
+        # Eject the revoked unit; requeue the rest (no push).
+        rest = Enum.reject(units, &(&1.id == revoked_unit.id))
+        next_data = requeue_units(data, rest)
+        transition_from_idle(next_data)
+
+      :all_pass ->
+        case cas.cas_push(repo_dir, tip, base) do
+          :ok ->
+            Logger.info("[MergeAuthority] merged tip #{tip}")
+            telemetry(:merged, %{hash: hd_hash(units)}, %{tip: tip, units: units})
+            transition_from_idle(data)
+
+          {:error, :stale_ref} ->
+            Logger.info("[MergeAuthority] stale ref; requeuing train for rebase + re-gate")
+            telemetry(:reject, %{hash: hd_hash(units)}, %{reason: :stale_ref, units: units})
+            next_data = requeue_units(data, units)
+            transition_from_idle(next_data)
+
+          {:error, reason} ->
+            Logger.warning("[MergeAuthority] cas_push failed: #{inspect(reason)}")
+            telemetry(:reject, %{hash: hd_hash(units)}, %{reason: reason, units: units})
+            next_data = requeue_units(data, units)
+            transition_from_idle(next_data)
+        end
+    end
+  end
+
+  def committing({:call, from}, {:request_merge, unit}, data) do
+    data = enqueue(data, unit)
+    {:keep_state, data, [{:reply, from, :queued}]}
+  end
+
+  def committing(:info, msg, data) do
+    Logger.debug("[MergeAuthority] committing received unexpected message: #{inspect(msg)}")
+    {:keep_state, data}
+  end
+
+  # ---------------------------------------------------------------------------
+  # Private helpers
+  # ---------------------------------------------------------------------------
+
+  defp enqueue(%{queue: queue} = data, unit) do
+    %{data | queue: queue ++ [unit]}
+  end
+
+  # Attempt to start a new build from the queue. Returns a gen_statem reply tuple.
+  # Used from `:idle` to avoid duplicating the transition logic.
+  defp start_build(%{queue: []} = data), do: {:idle, data}
+
+  defp start_build(%{queue: [unit | rest]} = data) do
+    train = [unit]
+    base = fetch_main_oid(data.repo_dir)
+
+    build_fun = data.build_fun
+    tasks_name = data.tasks_name
+
+    task = Task.Supervisor.async_nolink(tasks_name, fn -> build_fun.(train, base) end)
+
+    telemetry(:integrating, %{hash: hd_hash(train)}, %{units: train, base: base})
+
+    next_data = %{
+      data
+      | queue: rest,
+        train: train,
+        task_ref: task.ref,
+        task_pid: task.pid
+    }
+
+    timeout_action = {:state_timeout, @build_timeout_ms, :build_timeout}
+    {:integrating, next_data, [timeout_action]}
+  end
+
+  # Transition back from a terminal state (after a commit/reject completes).
+  # Either returns to :idle or kicks off the next build.
+  defp transition_from_idle(data) do
+    case start_build(data) do
+      {:integrating, next_data, actions} ->
+        {:next_state, :integrating, next_data, actions}
+
+      {:idle, next_data} ->
+        {:next_state, :idle, next_data}
+    end
+  end
+
+  defp requeue_train(%{train: train} = data) do
+    requeue_units(%{data | train: []}, train)
+  end
+
+  defp requeue_units(%{queue: queue} = data, units) do
+    %{data | queue: units ++ queue, task_ref: nil, task_pid: nil, train: []}
+  end
+
+  # Fetch current origin/main oid after a fetch; returns a string or raises.
+  defp fetch_main_oid(repo_dir) do
+    case System.cmd("git", ["fetch", "origin"], cd: repo_dir, stderr_to_stdout: true) do
+      {_, 0} ->
+        :ok
+
+      {output, code} ->
+        Logger.warning("[MergeAuthority] git fetch failed (#{code}): #{output}")
+    end
+
+    {oid, 0} = System.cmd("git", ["rev-parse", "origin/main"], cd: repo_dir)
+    String.trim(oid)
+  end
+
+  # Default build_fun: fetch + rebase unit branch onto base, return tip.
+  defp default_build(repo_dir, [unit | _] = units, base) do
+    git = fn args ->
+      System.cmd("git", args, cd: repo_dir, stderr_to_stdout: true)
+    end
+
+    with {_, 0} <- git.(["fetch", "origin"]),
+         {_, 0} <- git.(["checkout", unit.branch]),
+         {_, 0} <- git.(["rebase", base]),
+         {tip_raw, 0} <- git.(["rev-parse", "HEAD"]) do
+      tip = String.trim(tip_raw)
+      {:built, units, base, tip}
+    else
+      {output, code} ->
+        {:build_failed, {:git_error, code, output}}
+    end
+  end
+
+  defp hd_hash([%{hash: hash} | _]), do: hash
+  defp hd_hash([]), do: nil
+
+  defp telemetry(event, measurements, metadata) do
+    :telemetry.execute([:tau, :factory, :merge, event], measurements, metadata)
+  end
+end

--- a/lib/tau/factory/supervisor.ex
+++ b/lib/tau/factory/supervisor.ex
@@ -36,6 +36,9 @@ defmodule Tau.Factory.Supervisor do
   def init(opts) do
     db_path = Keyword.get(opts, :db_path, default_db_path())
     sup_name = Keyword.get(opts, :name, __MODULE__)
+    repo_dir = Keyword.get(opts, :repo_dir)
+    required_halves = Keyword.get(opts, :required_halves, [:critic, :reviewer])
+    merge_authority_opts = Keyword.get(opts, :merge_authority_opts, [])
 
     # Derive a per-supervisor writer name so concurrent supervisor instances
     # (e.g. isolated test instances) do not conflict on the writer's name.
@@ -46,9 +49,40 @@ defmodule Tau.Factory.Supervisor do
         :"#{sup_name}_writer"
       end
 
-    children = [
-      {Tau.Factory.Ledger.Writer, db_path: db_path, name: writer_name}
+    tasks_name =
+      if sup_name == __MODULE__ do
+        Tau.Factory.MergeTasks
+      else
+        :"#{sup_name}_tasks"
+      end
+
+    ma_name =
+      if sup_name == __MODULE__ do
+        Tau.Factory.MergeAuthority
+      else
+        :"#{sup_name}_merge_authority"
+      end
+
+    base_children = [
+      {Tau.Factory.Ledger.Writer, db_path: db_path, name: writer_name},
+      {Task.Supervisor, name: tasks_name}
     ]
+
+    children =
+      if repo_dir do
+        ma_opts =
+          [
+            name: ma_name,
+            ledger: writer_name,
+            repo_dir: repo_dir,
+            tasks_name: tasks_name,
+            required_halves: required_halves
+          ] ++ merge_authority_opts
+
+        base_children ++ [{Tau.Factory.MergeAuthority, ma_opts}]
+      else
+        base_children
+      end
 
     Supervisor.init(children, strategy: :one_for_one)
   end

--- a/test/tau/factory/merge_force_with_lease_test.exs
+++ b/test/tau/factory/merge_force_with_lease_test.exs
@@ -1,0 +1,377 @@
+defmodule Tau.Factory.MergeForceWithLeaseTest do
+  @moduledoc """
+  Gating tests for PR #434 (P3a — MergeAuthority gen_statem + verdict-gated CAS).
+
+  Tests AC-4 (D-301): origin/main advancing between gate and CAS must cause the
+  --force-with-lease push to be rejected; no merge must land; the unit requeues.
+
+  This pins the HR-1 / FC-3 freshness-via-VCS-primitive contract: the CAS
+  applies as `git push --force-with-lease=refs/heads/main:<expected_old_oid>`,
+  so if origin/main advances after M captured `base` but before cas_push runs,
+  the remote rejects the push atomically. M MUST NOT retry or force past the
+  lease rejection.
+
+  Written BEFORE production code exists (oracle-separation phase).
+  These tests fail with UndefinedFunctionError until the implementer creates:
+    - lib/tau/factory/merge_authority.ex
+    - lib/tau/factory/merge/cas.ex
+
+  AC linkage: AC-4 / D-301.
+  """
+
+  use ExUnit.Case, async: true
+
+  @moduletag :capture_log
+
+  # Runtime module references — file compiles even when modules do not yet exist.
+  @merge_authority Tau.Factory.MergeAuthority
+  @writer Tau.Factory.Ledger.Writer
+
+  # ---------------------------------------------------------------------------
+  # Helpers
+  # ---------------------------------------------------------------------------
+
+  defp seed_pass_verdicts(writer, %{hash: hash, run: run}) do
+    for half <- [:critic, :reviewer] do
+      {:ok, _} =
+        @writer.append_verdict(writer, %{
+          hash: hash,
+          run: run,
+          half: half,
+          status: :pass,
+          idempotency_key: "ikey-#{half}-#{System.unique_integer([:positive])}"
+        })
+    end
+  end
+
+  defp setup_git_repo(tmp_dir, unit) do
+    origin_path = Path.join(tmp_dir, "origin.git")
+    work_path = Path.join(tmp_dir, "work")
+
+    {_, 0} = System.cmd("git", ["init", "-b", "main", work_path])
+
+    git_work = fn args -> System.cmd("git", args, cd: work_path) end
+    git_work.(["config", "user.email", "test@tau.test"])
+    git_work.(["config", "user.name", "Tau Test"])
+
+    File.write!(Path.join(work_path, "README"), "initial")
+    git_work.(["add", "README"])
+    {_, 0} = git_work.(["commit", "-m", "initial commit"])
+
+    {_, 0} = System.cmd("git", ["init", "--bare", origin_path])
+    {_, 0} = git_work.(["remote", "add", "origin", origin_path])
+    {_, 0} = git_work.(["push", "-u", "origin", "main"])
+
+    {main_oid, 0} = git_work.(["rev-parse", "HEAD"])
+    main_oid = String.trim(main_oid)
+
+    {_, 0} = git_work.(["checkout", "-b", unit.branch])
+    File.write!(Path.join(work_path, "feature_#{unit.id}"), "feature")
+    {_, 0} = git_work.(["add", "."])
+    {_, 0} = git_work.(["commit", "-m", "feature for #{unit.branch}"])
+    {tip, 0} = git_work.(["rev-parse", "HEAD"])
+    tip = String.trim(tip)
+    {_, 0} = git_work.(["push", "origin", unit.branch])
+    {_, 0} = git_work.(["checkout", "main"])
+
+    {origin_path, work_path, main_oid, tip}
+  end
+
+  # Advance origin/main directly by pushing a new commit to the bare repo.
+  # This simulates origin/main moving AFTER M captured `base` — the staleness scenario.
+  # Done by cloning the bare repo into a separate tmp dir, committing, and pushing.
+  defp advance_origin_main(origin_path) do
+    advance_dir = Path.join(System.tmp_dir!(), "advance_#{System.unique_integer([:positive])}")
+    File.mkdir_p!(advance_dir)
+
+    {_, 0} = System.cmd("git", ["clone", origin_path, advance_dir])
+
+    git_adv = fn args -> System.cmd("git", args, cd: advance_dir) end
+    git_adv.(["config", "user.email", "test@tau.test"])
+    git_adv.(["config", "user.name", "Tau Test"])
+
+    File.write!(Path.join(advance_dir, "advance_#{System.unique_integer([:positive])}"), "advance")
+    git_adv.(["add", "."])
+    git_adv.(["commit", "-m", "advance origin/main to make base stale"])
+    git_adv.(["push", "origin", "main"])
+
+    {new_oid, 0} = git_adv.(["rev-parse", "HEAD"])
+    new_oid = String.trim(new_oid)
+
+    File.rm_rf!(advance_dir)
+    new_oid
+  end
+
+  defp origin_main_oid(origin_path) do
+    {oid, 0} =
+      System.cmd("git", ["rev-parse", "refs/heads/main"], cd: origin_path)
+
+    String.trim(oid)
+  end
+
+  # ---------------------------------------------------------------------------
+  # AC-4 / D-301: force-with-lease rejected when origin/main advances mid-gate
+  # ---------------------------------------------------------------------------
+
+  describe "AC-4 / D-301 — --force-with-lease rejected when origin/main advances mid-gate" do
+    @tag :ac_4
+    @tag :d_301
+    test "AC-4 / D-301: advancing origin/main at the barrier causes CAS push rejection; no merge lands" do
+      tmp_dir = Briefly.create!(type: :directory)
+      test_pid = self()
+
+      unit = %{
+        id: "u-stale",
+        hash: "hash-stale-#{System.unique_integer([:positive])}",
+        run: "run-stale-001",
+        branch: "feat/stale-test"
+      }
+
+      db_path = Briefly.create!(extname: ".db")
+      writer_name = :"test_ma_writer_stale_#{System.unique_integer([:positive])}"
+
+      writer =
+        start_supervised!(
+          {@writer, db_path: db_path, name: writer_name},
+          id: writer_name
+        )
+
+      seed_pass_verdicts(writer, unit)
+
+      {origin_path, work_path, initial_main_oid, tip} = setup_git_repo(tmp_dir, unit)
+
+      # Barrier build_fun: signals test_pid at the barrier point with the tip oid.
+      # Blocks until :proceed. Returns the ORIGINAL base (which will become stale).
+      barrier_build_fun = fn _units, base ->
+        ref = make_ref()
+        send(test_pid, {:at_barrier, ref, base, tip})
+
+        receive do
+          {:proceed, ^ref} -> :ok
+        after
+          10_000 -> raise "barrier timeout in force_with_lease test"
+        end
+
+        # Return the original base — M will use this as expected_old_oid in cas_push.
+        # By the time M calls cas_push, origin/main will have advanced past this oid.
+        {:built, [unit], base, tip}
+      end
+
+      ma_name = :"test_ma_stale_#{System.unique_integer([:positive])}"
+      tasks_name = :"test_ma_tasks_stale_#{System.unique_integer([:positive])}"
+
+      ma_pid =
+        start_supervised!(
+          {@merge_authority,
+           name: ma_name,
+           ledger: writer,
+           repo_dir: work_path,
+           required_halves: [:critic, :reviewer],
+           tasks_name: tasks_name,
+           build_fun: barrier_build_fun},
+          id: ma_name
+        )
+
+      assert :queued = @merge_authority.request_merge(ma_pid, unit)
+
+      # Wait for M to enter :integrating and reach the barrier
+      assert_receive {:at_barrier, ref, base, ^tip},
+                     5_000,
+                     "AC-4 / D-301: expected M to enter :integrating and hit the barrier"
+
+      # VERIFY: base matches initial_main_oid (M captured the correct base)
+      assert base == initial_main_oid,
+             "AC-4 / D-301: M must capture initial main oid as base; " <>
+               "expected #{initial_main_oid}, got #{base}"
+
+      # AT THE BARRIER: advance origin/main directly (bypassing M — test-only).
+      # This makes M's captured `base` stale.
+      advancing_oid = advance_origin_main(origin_path)
+
+      # Verify origin/main has advanced
+      assert origin_main_oid(origin_path) == advancing_oid,
+             "AC-4 / D-301: test setup error — origin/main did not advance"
+
+      refute advancing_oid == initial_main_oid,
+             "AC-4 / D-301: test setup error — advancing oid must differ from initial"
+
+      # Release the barrier — M proceeds to :committing with stale `base`.
+      # cas_push must issue `git push --force-with-lease=refs/heads/main:<initial_main_oid>`
+      # which the remote will REJECT because origin/main is now at advancing_oid.
+      send(ma_pid, {:proceed, ref})
+
+      # Allow M time to attempt and fail the push
+      :timer.sleep(800)
+
+      # ASSERTION 1: origin/main must equal the test's advancing commit, NOT the unit's tip.
+      # The rejected push must not have overwritten advancing_oid.
+      current_oid = origin_main_oid(origin_path)
+
+      assert current_oid == advancing_oid,
+             "AC-4 / D-301 (D-301, HR-1, FC-3): --force-with-lease push must be rejected " <>
+               "when origin/main advanced; origin/main must remain at the advancing commit.\n" <>
+               "Expected: #{advancing_oid}\n" <>
+               "Got:      #{current_oid}\n" <>
+               "This means M pushed past a stale lease — VIOLATION of D-301 (freshness via VCS primitive)"
+
+      # ASSERTION 2: origin/main must NOT equal the unit tip (no merge landed).
+      refute current_oid == tip,
+             "AC-4 / D-301: the unit tip must NOT be on origin/main after a stale-ref rejection; " <>
+               "tip #{tip} is now on origin/main — merge occurred despite stale lease"
+    end
+
+    @tag :ac_4
+    @tag :d_301
+    test "AC-4 / D-301: Merge.Cas.cas_push returns {:error, :stale_ref} when origin/main advanced" do
+      # Directly exercises Tau.Factory.Merge.Cas.cas_push/3 in isolation:
+      # set up a repo where origin/main has advanced past expected_old_oid,
+      # call cas_push, assert {:error, :stale_ref}.
+      tmp_dir = Briefly.create!(type: :directory)
+      origin_path = Path.join(tmp_dir, "origin_cas.git")
+      work_path = Path.join(tmp_dir, "work_cas")
+
+      {_, 0} = System.cmd("git", ["init", "-b", "main", work_path])
+
+      git_work = fn args -> System.cmd("git", args, cd: work_path) end
+      git_work.(["config", "user.email", "test@tau.test"])
+      git_work.(["config", "user.name", "Tau Test"])
+
+      File.write!(Path.join(work_path, "README"), "initial")
+      git_work.(["add", "README"])
+      {_, 0} = git_work.(["commit", "-m", "initial"])
+      {_, 0} = System.cmd("git", ["init", "--bare", origin_path])
+      {_, 0} = git_work.(["remote", "add", "origin", origin_path])
+      {_, 0} = git_work.(["push", "-u", "origin", "main"])
+
+      {old_oid, 0} = git_work.(["rev-parse", "HEAD"])
+      old_oid = String.trim(old_oid)
+
+      # Create a feature branch tip
+      {_, 0} = git_work.(["checkout", "-b", "feat/cas-test"])
+      File.write!(Path.join(work_path, "feat"), "feat")
+      {_, 0} = git_work.(["add", "."])
+      {_, 0} = git_work.(["commit", "-m", "feat commit"])
+      {tip, 0} = git_work.(["rev-parse", "HEAD"])
+      tip = String.trim(tip)
+      {_, 0} = git_work.(["push", "origin", "feat/cas-test"])
+      {_, 0} = git_work.(["checkout", "main"])
+
+      # Advance origin/main AFTER capturing old_oid
+      _advancing_oid = advance_origin_main(origin_path)
+
+      # Now old_oid is stale. Call cas_push with the stale expected_old_oid.
+      # This must return {:error, :stale_ref}.
+      result =
+        apply(Tau.Factory.Merge.Cas, :cas_push, [work_path, tip, old_oid])
+
+      assert match?({:error, :stale_ref}, result),
+             "AC-4 / D-301: Merge.Cas.cas_push/3 must return {:error, :stale_ref} " <>
+               "when origin/main has advanced past expected_old_oid; got #{inspect(result)}"
+    end
+
+    @tag :ac_4
+    @tag :d_301
+    test "AC-4 / D-301: Merge.Cas.assert_all_verdicts_live returns :all_pass when both halves are :pass" do
+      # Directly exercises assert_all_verdicts_live/3.
+      # When all required halves have latest status :pass, must return :all_pass.
+      unit = %{
+        id: "u-live",
+        hash: "hash-live-#{System.unique_integer([:positive])}",
+        run: "run-live-001",
+        branch: "feat/live-test"
+      }
+
+      db_path = Briefly.create!(extname: ".db")
+      writer_name = :"test_ma_writer_live_#{System.unique_integer([:positive])}"
+
+      writer =
+        start_supervised!(
+          {@writer, db_path: db_path, name: writer_name},
+          id: writer_name
+        )
+
+      for half <- [:critic, :reviewer] do
+        {:ok, _} =
+          @writer.append_verdict(writer, %{
+            hash: unit.hash,
+            run: unit.run,
+            half: half,
+            status: :pass,
+            idempotency_key: "ikey-#{half}-#{System.unique_integer([:positive])}"
+          })
+      end
+
+      result =
+        apply(Tau.Factory.Merge.Cas, :assert_all_verdicts_live, [
+          writer,
+          [unit],
+          [:critic, :reviewer]
+        ])
+
+      assert result == :all_pass,
+             "AC-4 / D-301: assert_all_verdicts_live must return :all_pass when all halves are :pass; " <>
+               "got #{inspect(result)}"
+    end
+
+    @tag :ac_4
+    @tag :d_301
+    test "AC-4 / D-301: Merge.Cas.assert_all_verdicts_live returns {:revoked, unit} when a half is :fail" do
+      # When any required half has latest status :fail, must return {:revoked, unit}.
+      unit = %{
+        id: "u-revoked",
+        hash: "hash-revoked-#{System.unique_integer([:positive])}",
+        run: "run-revoked-001",
+        branch: "feat/revoked-test"
+      }
+
+      db_path = Briefly.create!(extname: ".db")
+      writer_name = :"test_ma_writer_revoked_#{System.unique_integer([:positive])}"
+
+      writer =
+        start_supervised!(
+          {@writer, db_path: db_path, name: writer_name},
+          id: writer_name
+        )
+
+      # Append :pass for reviewer
+      {:ok, _} =
+        @writer.append_verdict(writer, %{
+          hash: unit.hash,
+          run: unit.run,
+          half: :reviewer,
+          status: :pass,
+          idempotency_key: "ikey-reviewer-#{System.unique_integer([:positive])}"
+        })
+
+      # Append :pass for critic, then revoke to :fail
+      {:ok, _} =
+        @writer.append_verdict(writer, %{
+          hash: unit.hash,
+          run: unit.run,
+          half: :critic,
+          status: :pass,
+          idempotency_key: "ikey-critic-orig-#{System.unique_integer([:positive])}"
+        })
+
+      {:ok, _} =
+        @writer.revoke_verdict(writer, %{
+          hash: unit.hash,
+          run: unit.run,
+          half: :critic,
+          status: :fail,
+          idempotency_key: "ikey-critic-revoke-#{System.unique_integer([:positive])}"
+        })
+
+      result =
+        apply(Tau.Factory.Merge.Cas, :assert_all_verdicts_live, [
+          writer,
+          [unit],
+          [:critic, :reviewer]
+        ])
+
+      assert match?({:revoked, _}, result),
+             "AC-4 / D-301: assert_all_verdicts_live must return {:revoked, unit} " <>
+               "when a required half has been revoked to :fail; got #{inspect(result)}"
+    end
+  end
+end

--- a/test/tau/factory/merge_force_with_lease_test.exs
+++ b/test/tau/factory/merge_force_with_lease_test.exs
@@ -59,6 +59,7 @@ defmodule Tau.Factory.MergeForceWithLeaseTest do
     {_, 0} = git_work.(["commit", "-m", "initial commit"])
 
     {_, 0} = System.cmd("git", ["init", "--bare", origin_path])
+    {_, 0} = System.cmd("git", ["symbolic-ref", "HEAD", "refs/heads/main"], cd: origin_path)
     {_, 0} = git_work.(["remote", "add", "origin", origin_path])
     {_, 0} = git_work.(["push", "-u", "origin", "main"])
 
@@ -240,6 +241,7 @@ defmodule Tau.Factory.MergeForceWithLeaseTest do
       git_work.(["add", "README"])
       {_, 0} = git_work.(["commit", "-m", "initial"])
       {_, 0} = System.cmd("git", ["init", "--bare", origin_path])
+      {_, 0} = System.cmd("git", ["symbolic-ref", "HEAD", "refs/heads/main"], cd: origin_path)
       {_, 0} = git_work.(["remote", "add", "origin", origin_path])
       {_, 0} = git_work.(["push", "-u", "origin", "main"])
 

--- a/test/tau/factory/merge_force_with_lease_test.exs
+++ b/test/tau/factory/merge_force_with_lease_test.exs
@@ -26,6 +26,7 @@ defmodule Tau.Factory.MergeForceWithLeaseTest do
   # Runtime module references — file compiles even when modules do not yet exist.
   @merge_authority Tau.Factory.MergeAuthority
   @writer Tau.Factory.Ledger.Writer
+  @cas Tau.Factory.Merge.Cas
 
   # ---------------------------------------------------------------------------
   # Helpers
@@ -264,7 +265,7 @@ defmodule Tau.Factory.MergeForceWithLeaseTest do
       # Now old_oid is stale. Call cas_push with the stale expected_old_oid.
       # This must return {:error, :stale_ref}.
       result =
-        apply(Tau.Factory.Merge.Cas, :cas_push, [work_path, tip, old_oid])
+        @cas.cas_push(work_path, tip, old_oid)
 
       assert match?({:error, :stale_ref}, result),
              "AC-4 / D-301: Merge.Cas.cas_push/3 must return {:error, :stale_ref} " <>
@@ -304,11 +305,7 @@ defmodule Tau.Factory.MergeForceWithLeaseTest do
       end
 
       result =
-        apply(Tau.Factory.Merge.Cas, :assert_all_verdicts_live, [
-          writer,
-          [unit],
-          [:critic, :reviewer]
-        ])
+        @cas.assert_all_verdicts_live(writer, [unit], [:critic, :reviewer])
 
       assert result == :all_pass,
              "AC-4 / D-301: assert_all_verdicts_live must return :all_pass when all halves are :pass; " <>
@@ -365,11 +362,7 @@ defmodule Tau.Factory.MergeForceWithLeaseTest do
         })
 
       result =
-        apply(Tau.Factory.Merge.Cas, :assert_all_verdicts_live, [
-          writer,
-          [unit],
-          [:critic, :reviewer]
-        ])
+        @cas.assert_all_verdicts_live(writer, [unit], [:critic, :reviewer])
 
       assert match?({:revoked, _}, result),
              "AC-4 / D-301: assert_all_verdicts_live must return {:revoked, unit} " <>

--- a/test/tau/factory/merge_serialized_test.exs
+++ b/test/tau/factory/merge_serialized_test.exs
@@ -79,6 +79,7 @@ defmodule Tau.Factory.MergeSerializedTest do
 
     # Create bare origin and push main
     {_, 0} = System.cmd("git", ["init", "--bare", origin_path])
+    {_, 0} = System.cmd("git", ["symbolic-ref", "HEAD", "refs/heads/main"], cd: origin_path)
     {_, 0} = git_work.(["remote", "add", "origin", origin_path])
     {_, 0} = git_work.(["push", "-u", "origin", "main"])
 

--- a/test/tau/factory/merge_serialized_test.exs
+++ b/test/tau/factory/merge_serialized_test.exs
@@ -1,0 +1,306 @@
+defmodule Tau.Factory.MergeSerializedTest do
+  @moduledoc """
+  Gating tests for PR #434 (P3a — MergeAuthority gen_statem + verdict-gated CAS).
+
+  Tests AC-1 (D-302) and AC-2 (D-302): serialized merge via a single gen_statem,
+  non-blocking request_merge, and at most one :integrating train at a time.
+
+  Written BEFORE production code exists (oracle-separation phase).
+  These tests fail with UndefinedFunctionError until the implementer creates:
+    - lib/tau/factory/merge_authority.ex
+    - lib/tau/factory/merge/cas.ex
+    - lib/tau/factory/supervisor.ex (extended with MergeAuthority + MergeTasks)
+
+  AC linkage: AC-1 / D-302, AC-2 / D-302.
+  """
+
+  use ExUnit.Case, async: true
+
+  @moduletag :capture_log
+
+  # Runtime module references — file compiles even when modules do not yet exist.
+  @merge_authority Tau.Factory.MergeAuthority
+  @writer Tau.Factory.Ledger.Writer
+
+  # ---------------------------------------------------------------------------
+  # Helpers
+  # ---------------------------------------------------------------------------
+
+  # Start an isolated Ledger.Writer against a tmp DB and seed PASS verdicts for
+  # both :critic and :reviewer for the given unit.
+  defp start_writer_with_pass_verdicts(unit) do
+    db_path = Briefly.create!(extname: ".db")
+    writer_name = :"test_ma_writer_#{System.unique_integer([:positive])}"
+
+    writer =
+      start_supervised!(
+        {@writer, db_path: db_path, name: writer_name},
+        id: writer_name
+      )
+
+    seed_pass_verdicts(writer, unit)
+    writer
+  end
+
+  defp seed_pass_verdicts(writer, %{hash: hash, run: run}) do
+    for half <- [:critic, :reviewer] do
+      {:ok, _} =
+        @writer.append_verdict(writer, %{
+          hash: hash,
+          run: run,
+          half: half,
+          status: :pass,
+          idempotency_key: "ikey-#{half}-#{System.unique_integer([:positive])}"
+        })
+    end
+  end
+
+  # Set up a real git topology in tmp_dir:
+  #   - origin.git: bare repo with an initial commit on main
+  #   - work/: clone; unit's branch created off main with its own commit
+  # Returns {origin_path, work_path, initial_main_oid, tip}
+  defp setup_git_repo(tmp_dir, unit) do
+    origin_path = Path.join(tmp_dir, "origin.git")
+    work_path = Path.join(tmp_dir, "work")
+
+    # Init a non-bare work repo first, commit on main, then push to bare origin.
+    # This avoids the git-version-dependent --initial-branch flag on bare repos.
+    {_, 0} = System.cmd("git", ["init", "-b", "main", work_path])
+
+    git_work = fn args -> System.cmd("git", args, cd: work_path) end
+
+    git_work.(["config", "user.email", "test@tau.test"])
+    git_work.(["config", "user.name", "Tau Test"])
+
+    # Initial commit on main
+    File.write!(Path.join(work_path, "README"), "initial")
+    git_work.(["add", "README"])
+    {_, 0} = git_work.(["commit", "-m", "initial commit"])
+
+    # Create bare origin and push main
+    {_, 0} = System.cmd("git", ["init", "--bare", origin_path])
+    {_, 0} = git_work.(["remote", "add", "origin", origin_path])
+    {_, 0} = git_work.(["push", "-u", "origin", "main"])
+
+    {main_oid, 0} = git_work.(["rev-parse", "HEAD"])
+    main_oid = String.trim(main_oid)
+
+    # Create the unit's feature branch; sanitize branch name for filename use
+    feature_name = String.replace(unit.branch, "/", "_")
+    {_, 0} = git_work.(["checkout", "-b", unit.branch])
+    File.write!(Path.join(work_path, "feature_#{feature_name}"), "feature work")
+    {_, 0} = git_work.(["add", "."])
+    {_, 0} = git_work.(["commit", "-m", "feature commit for #{unit.branch}"])
+    {tip, 0} = git_work.(["rev-parse", "HEAD"])
+    tip = String.trim(tip)
+    {_, 0} = git_work.(["push", "origin", unit.branch])
+
+    # Return to main
+    {_, 0} = git_work.(["checkout", "main"])
+
+    {origin_path, work_path, main_oid, tip}
+  end
+
+  # ---------------------------------------------------------------------------
+  # AC-1 / D-302: Supervised start; initial state is :idle
+  # ---------------------------------------------------------------------------
+
+  describe "AC-1 / D-302 — MergeAuthority starts supervised in :idle state" do
+    @tag :ac_1
+    @tag :d_302
+    test "AC-1 / D-302: after start_link, :sys.get_state returns {:idle, _} and process is alive" do
+      tmp_dir = Briefly.create!(type: :directory)
+
+      unit = %{
+        id: "u1",
+        hash: "abc-#{System.unique_integer([:positive])}",
+        run: "run-001",
+        branch: "feat/ac1-test"
+      }
+
+      writer = start_writer_with_pass_verdicts(unit)
+
+      {_origin_path, work_path, _main_oid, _tip} = setup_git_repo(tmp_dir, unit)
+
+      ma_name = :"test_ma_ac1_#{System.unique_integer([:positive])}"
+      tasks_name = :"test_ma_tasks_ac1_#{System.unique_integer([:positive])}"
+
+      # This is the runtime call that will fail until production code exists.
+      # The call exercises the real start_link entry point.
+      result =
+        start_supervised!(
+          {@merge_authority,
+           name: ma_name,
+           ledger: writer,
+           repo_dir: work_path,
+           required_halves: [:critic, :reviewer],
+           tasks_name: tasks_name,
+           build_fun: fn _units, _base -> {:built, [], "base", "tip"} end},
+          id: ma_name
+        )
+
+      assert is_pid(result), "start_link must return a pid; got #{inspect(result)}"
+      assert Process.alive?(result), "MergeAuthority process must be alive after start"
+
+      # :sys.get_state on a gen_statem returns {state_name, data}
+      {state_name, _data} = :sys.get_state(result)
+
+      assert state_name == :idle,
+             "AC-1 / D-302: initial state must be :idle; got #{inspect(state_name)}"
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # AC-2 / D-302: request_merge is non-blocking; at most one :integrating train
+  # ---------------------------------------------------------------------------
+
+  describe "AC-2 / D-302 — request_merge is non-blocking; at most one :integrating train" do
+    @tag :ac_2
+    @tag :d_302
+    test "AC-2 / D-302: concurrent request_merge calls return :queued immediately; only one :at_barrier arrives within window" do
+      tmp_dir = Briefly.create!(type: :directory)
+      test_pid = self()
+      n_units = 4
+
+      units =
+        for i <- 1..n_units do
+          %{
+            id: "u#{i}",
+            hash: "hash-#{i}-#{System.unique_integer([:positive])}",
+            run: "run-#{i}",
+            branch: "feat/unit-#{i}"
+          }
+        end
+
+      # Set up a single git repo with all unit branches.
+      # setup_git_repo already creates the branch for hd(units); remaining
+      # branches are created below. The tip from setup is discarded here —
+      # we rebuild all tips uniformly in the loop below.
+      {_origin_path, work_path, _main_oid, _first_tip} =
+        setup_git_repo(tmp_dir, hd(units))
+
+      # Create remaining branches
+      git_work = fn args -> System.cmd("git", args, cd: work_path) end
+      git_work.(["config", "user.email", "test@tau.test"])
+      git_work.(["config", "user.name", "Tau Test"])
+
+      tips =
+        for unit <- units do
+          {_, 0} = git_work.(["checkout", "main"])
+          # Branch for hd(units) already exists; checkout existing or create new.
+          case git_work.(["checkout", unit.branch]) do
+            {_, 0} -> :ok
+            _ -> {_, 0} = git_work.(["checkout", "-b", unit.branch])
+          end
+
+          feature_name = String.replace(unit.branch, "/", "_")
+          File.write!(Path.join(work_path, "feature_#{feature_name}"), "feature for #{unit.branch}")
+          {_, 0} = git_work.(["add", "."])
+          {_, 0} = git_work.(["commit", "-m", "feature #{unit.branch}"])
+          {tip, 0} = git_work.(["rev-parse", "HEAD"])
+          tip = String.trim(tip)
+          {_, 0} = git_work.(["push", "origin", unit.branch])
+          {_, 0} = git_work.(["checkout", "main"])
+          tip
+        end
+
+      # Start a writer and seed pass verdicts for all units
+      db_path = Briefly.create!(extname: ".db")
+      writer_name = :"test_ma_writer_ac2_#{System.unique_integer([:positive])}"
+
+      writer =
+        start_supervised!(
+          {@writer, db_path: db_path, name: writer_name},
+          id: writer_name
+        )
+
+      for unit <- units, do: seed_pass_verdicts(writer, unit)
+
+      # Barrier build_fun using the first tip — blocks until test sends :proceed
+      # This lets us observe how many :at_barrier messages arrive (= integrating trains)
+      first_tip_oid = hd(tips)
+
+      blocking_build_fun = fn _units, _base ->
+        ref = make_ref()
+        send(test_pid, {:at_barrier, ref, first_tip_oid})
+
+        receive do
+          {:proceed, ^ref} -> :ok
+        after
+          10_000 -> raise "barrier timeout"
+        end
+
+        {:built, [], "base", first_tip_oid}
+      end
+
+      ma_name = :"test_ma_ac2_#{System.unique_integer([:positive])}"
+      tasks_name = :"test_ma_tasks_ac2_#{System.unique_integer([:positive])}"
+
+      ma_pid =
+        start_supervised!(
+          {@merge_authority,
+           name: ma_name,
+           ledger: writer,
+           repo_dir: work_path,
+           required_halves: [:critic, :reviewer],
+           tasks_name: tasks_name,
+           build_fun: blocking_build_fun},
+          id: ma_name
+        )
+
+      # Fire N concurrent request_merge calls — ALL must return :queued immediately
+      # (non-blocking per [C206] / B1).
+      t0 = System.monotonic_time(:millisecond)
+
+      results =
+        units
+        |> Enum.map(fn unit ->
+          Task.async(fn ->
+            @merge_authority.request_merge(ma_pid, unit)
+          end)
+        end)
+        |> Enum.map(&Task.await(&1, 5_000))
+
+      t1 = System.monotonic_time(:millisecond)
+      elapsed = t1 - t0
+
+      # All must return :queued
+      for result <- results do
+        assert result == :queued,
+               "AC-2 / D-302: request_merge must return :queued immediately; got #{inspect(result)}"
+      end
+
+      # Non-blocking: all N calls must return well within T_int.
+      # We allow 3000 ms as a generous upper bound (real T_int is minutes).
+      assert elapsed < 3000,
+             "AC-2 / D-302: request_merge must be non-blocking; #{n_units} calls took #{elapsed}ms"
+
+      # Allow M to start one :integrating train
+      # Exactly ONE :at_barrier must arrive within a reasonable window.
+      assert_receive {:at_barrier, ref, _tip},
+                     5_000,
+                     "AC-2 / D-302: expected M to enter :integrating and trigger at_barrier"
+
+      # Drain inbox briefly — no second :at_barrier should arrive while the first barrier holds.
+      # (Only one :integrating train at a time — INV-3)
+      :timer.sleep(200)
+
+      barrier_count =
+        Enum.reduce(1..100, 0, fn _i, acc ->
+          receive do
+            {:at_barrier, _ref2, _tip2} -> acc + 1
+          after
+            0 -> acc
+          end
+        end)
+
+      assert barrier_count == 0,
+             "AC-2 / D-302: only ONE :integrating train must exist at a time (INV-3); " <>
+               "got #{barrier_count} extra :at_barrier messages while first barrier was held"
+
+      # Release the first barrier and let M settle
+      send(ma_pid, {:proceed, ref})
+      :timer.sleep(200)
+    end
+  end
+end

--- a/test/tau/factory/merge_verdict_revoke_test.exs
+++ b/test/tau/factory/merge_verdict_revoke_test.exs
@@ -1,0 +1,263 @@
+defmodule Tau.Factory.MergeVerdictRevokeTest do
+  @moduledoc """
+  Gating tests for PR #434 (P3a — MergeAuthority gen_statem + verdict-gated CAS).
+
+  Tests AC-3 (D-300): a verdict revoked AFTER the build starts is re-read in
+  :committing; the push must NOT occur and origin/main must remain unchanged.
+
+  This pins the HR-2 value-staleness contract: `assert_all_verdicts_live/3`
+  re-reads the LATEST verdict status at the merge instant, not at gate time.
+
+  Written BEFORE production code exists (oracle-separation phase).
+  These tests fail with UndefinedFunctionError until the implementer creates:
+    - lib/tau/factory/merge_authority.ex
+    - lib/tau/factory/merge/cas.ex
+
+  AC linkage: AC-3 / D-300.
+  """
+
+  use ExUnit.Case, async: true
+
+  @moduletag :capture_log
+
+  # Runtime module references — file compiles even when modules do not yet exist.
+  @merge_authority Tau.Factory.MergeAuthority
+  @writer Tau.Factory.Ledger.Writer
+
+  # ---------------------------------------------------------------------------
+  # Helpers
+  # ---------------------------------------------------------------------------
+
+  defp seed_pass_verdicts(writer, %{hash: hash, run: run}) do
+    for half <- [:critic, :reviewer] do
+      {:ok, _} =
+        @writer.append_verdict(writer, %{
+          hash: hash,
+          run: run,
+          half: half,
+          status: :pass,
+          idempotency_key: "ikey-#{half}-#{System.unique_integer([:positive])}"
+        })
+    end
+  end
+
+  defp setup_git_repo(tmp_dir, unit) do
+    origin_path = Path.join(tmp_dir, "origin.git")
+    work_path = Path.join(tmp_dir, "work")
+
+    {_, 0} = System.cmd("git", ["init", "-b", "main", work_path])
+
+    git_work = fn args -> System.cmd("git", args, cd: work_path) end
+    git_work.(["config", "user.email", "test@tau.test"])
+    git_work.(["config", "user.name", "Tau Test"])
+
+    File.write!(Path.join(work_path, "README"), "initial")
+    git_work.(["add", "README"])
+    {_, 0} = git_work.(["commit", "-m", "initial commit"])
+
+    {_, 0} = System.cmd("git", ["init", "--bare", origin_path])
+    {_, 0} = git_work.(["remote", "add", "origin", origin_path])
+    {_, 0} = git_work.(["push", "-u", "origin", "main"])
+
+    {main_oid, 0} = git_work.(["rev-parse", "HEAD"])
+    main_oid = String.trim(main_oid)
+
+    {_, 0} = git_work.(["checkout", "-b", unit.branch])
+    File.write!(Path.join(work_path, "feature_#{unit.id}"), "feature")
+    {_, 0} = git_work.(["add", "."])
+    {_, 0} = git_work.(["commit", "-m", "feature for #{unit.branch}"])
+    {tip, 0} = git_work.(["rev-parse", "HEAD"])
+    tip = String.trim(tip)
+    {_, 0} = git_work.(["push", "origin", unit.branch])
+    {_, 0} = git_work.(["checkout", "main"])
+
+    {origin_path, work_path, main_oid, tip}
+  end
+
+  defp origin_main_oid(origin_path) do
+    {oid, 0} =
+      System.cmd("git", ["rev-parse", "refs/heads/main"], cd: origin_path)
+
+    String.trim(oid)
+  end
+
+  # ---------------------------------------------------------------------------
+  # AC-3 / D-300: verdict revoked mid-build => no push, origin/main unchanged
+  # ---------------------------------------------------------------------------
+
+  describe "AC-3 / D-300 — verdict revoked after build starts; no push occurs" do
+    @tag :ac_3
+    @tag :d_300
+    test "AC-3 / D-300: revoke a required half after :integrating starts; assert no push and origin/main unchanged" do
+      tmp_dir = Briefly.create!(type: :directory)
+      test_pid = self()
+
+      unit = %{
+        id: "u-revoke",
+        hash: "hash-revoke-#{System.unique_integer([:positive])}",
+        run: "run-revoke-001",
+        branch: "feat/revoke-test"
+      }
+
+      db_path = Briefly.create!(extname: ".db")
+      writer_name = :"test_ma_writer_revoke_#{System.unique_integer([:positive])}"
+
+      writer =
+        start_supervised!(
+          {@writer, db_path: db_path, name: writer_name},
+          id: writer_name
+        )
+
+      seed_pass_verdicts(writer, unit)
+
+      {origin_path, work_path, initial_main_oid, tip} = setup_git_repo(tmp_dir, unit)
+
+      # Barrier build_fun: signals test_pid and blocks until :proceed.
+      # This lets the test revoke a verdict AFTER :integrating is entered
+      # but BEFORE :committing can run.
+      barrier_build_fun = fn _units, _base ->
+        ref = make_ref()
+        send(test_pid, {:at_barrier, ref, tip})
+
+        receive do
+          {:proceed, ^ref} -> :ok
+        after
+          10_000 -> raise "barrier timeout in verdict_revoke test"
+        end
+
+        {:built, [unit], initial_main_oid, tip}
+      end
+
+      ma_name = :"test_ma_revoke_#{System.unique_integer([:positive])}"
+      tasks_name = :"test_ma_tasks_revoke_#{System.unique_integer([:positive])}"
+
+      ma_pid =
+        start_supervised!(
+          {@merge_authority,
+           name: ma_name,
+           ledger: writer,
+           repo_dir: work_path,
+           required_halves: [:critic, :reviewer],
+           tasks_name: tasks_name,
+           build_fun: barrier_build_fun},
+          id: ma_name
+        )
+
+      # Submit unit — returns :queued immediately (non-blocking, [C206])
+      assert :queued = @merge_authority.request_merge(ma_pid, unit)
+
+      # Wait for M to enter :integrating and reach the barrier
+      assert_receive {:at_barrier, ref, ^tip},
+                     5_000,
+                     "AC-3 / D-300: expected M to enter :integrating"
+
+      # AT THE BARRIER: revoke one required half (flip :pass -> :fail)
+      # This simulates a late challenge or incomplete-fix finding.
+      {:ok, _} =
+        @writer.revoke_verdict(writer, %{
+          hash: unit.hash,
+          run: unit.run,
+          half: :critic,
+          status: :fail,
+          idempotency_key: "revoke-ikey-#{System.unique_integer([:positive])}"
+        })
+
+      # Verify the revocation is visible to the writer immediately
+      assert {:ok, :fail} =
+               @writer.latest_verdict_status(writer, %{
+                 hash: unit.hash,
+                 run: unit.run,
+                 half: :critic
+               }),
+             "AC-3 / D-300: revocation must be readable from the writer before proceeding"
+
+      # Release the barrier — M will proceed to :committing, re-read the verdict,
+      # find :fail, and must NOT push.
+      send(ma_pid, {:proceed, ref})
+
+      # Allow M time to complete :committing
+      :timer.sleep(500)
+
+      # ASSERTION: origin/main must be unchanged — no merge occurred
+      current_oid = origin_main_oid(origin_path)
+
+      assert current_oid == initial_main_oid,
+             "AC-3 / D-300 (D-300, HR-2): a revoked verdict must prevent the push; " <>
+               "origin/main advanced from #{initial_main_oid} to #{current_oid} — MERGE OCCURRED (VIOLATION)"
+    end
+
+    @tag :ac_3
+    @tag :d_300
+    test "AC-3 / D-300: when both halves remain :pass, merge lands (baseline for the revoke test)" do
+      # This baseline ensures the barrier seam and git topology actually work:
+      # without revocation, a push with valid CAS should land.
+      tmp_dir = Briefly.create!(type: :directory)
+      test_pid = self()
+
+      unit = %{
+        id: "u-baseline",
+        hash: "hash-baseline-#{System.unique_integer([:positive])}",
+        run: "run-baseline-001",
+        branch: "feat/baseline-test"
+      }
+
+      db_path = Briefly.create!(extname: ".db")
+      writer_name = :"test_ma_writer_baseline_#{System.unique_integer([:positive])}"
+
+      writer =
+        start_supervised!(
+          {@writer, db_path: db_path, name: writer_name},
+          id: writer_name
+        )
+
+      seed_pass_verdicts(writer, unit)
+
+      {origin_path, work_path, initial_main_oid, tip} = setup_git_repo(tmp_dir, unit)
+
+      barrier_build_fun = fn _units, _base ->
+        ref = make_ref()
+        send(test_pid, {:at_barrier, ref, tip})
+
+        receive do
+          {:proceed, ^ref} -> :ok
+        after
+          10_000 -> raise "barrier timeout in baseline test"
+        end
+
+        {:built, [unit], initial_main_oid, tip}
+      end
+
+      ma_name = :"test_ma_baseline_#{System.unique_integer([:positive])}"
+      tasks_name = :"test_ma_tasks_baseline_#{System.unique_integer([:positive])}"
+
+      ma_pid =
+        start_supervised!(
+          {@merge_authority,
+           name: ma_name,
+           ledger: writer,
+           repo_dir: work_path,
+           required_halves: [:critic, :reviewer],
+           tasks_name: tasks_name,
+           build_fun: barrier_build_fun},
+          id: ma_name
+        )
+
+      assert :queued = @merge_authority.request_merge(ma_pid, unit)
+      assert_receive {:at_barrier, ref, ^tip}, 5_000
+
+      # Do NOT revoke — both verdicts remain :pass
+      send(ma_pid, {:proceed, ref})
+
+      # Allow M time to complete the push
+      :timer.sleep(800)
+
+      # With valid verdicts and a fresh lease, the push should have landed.
+      # origin/main should now equal tip.
+      current_oid = origin_main_oid(origin_path)
+
+      assert current_oid == tip,
+             "AC-3 baseline: with PASS verdicts and no stale ref, origin/main must advance to tip; " <>
+               "expected #{tip}, got #{current_oid}"
+    end
+  end
+end

--- a/test/tau/factory/merge_verdict_revoke_test.exs
+++ b/test/tau/factory/merge_verdict_revoke_test.exs
@@ -56,6 +56,7 @@ defmodule Tau.Factory.MergeVerdictRevokeTest do
     {_, 0} = git_work.(["commit", "-m", "initial commit"])
 
     {_, 0} = System.cmd("git", ["init", "--bare", origin_path])
+    {_, 0} = System.cmd("git", ["symbolic-ref", "HEAD", "refs/heads/main"], cd: origin_path)
     {_, 0} = git_work.(["remote", "add", "origin", origin_path])
     {_, 0} = git_work.(["push", "-u", "origin", "main"])
 


### PR DESCRIPTION
## P3a — MergeAuthority gen_statem + verdict-gated CAS (B=1)

Advances #421 (P3, B=1 MergeAuthority). This is the first of three P3 PRs split
along SPEC-FACTORY-MERGE's own PR-MERGE boundaries to stay within the gateability
ceiling:
- **P3a (this PR):** the `gen_statem` + `Merge.Cas` — the verdict-gated CAS.
  D-300 (gate-before-merge), D-301 (`--force-with-lease` freshness), D-302
  (serialized via the single `gen_statem`). AC-1..4.
- **P3b (next):** post-merge health on the batch tip (D-303, AC-5).
- **P3c:** fair-queue/aging + sole-writer for B>1 (PR-MERGE-4, D-341, AC-6/7).

#421 stays open until P3a+P3b land (B=1 end-to-end).

### Scope & order (SPEC-FACTORY-MERGE §5 is the contract)
1. `lib/tau/factory/merge/cas.ex` (C3):
   - `assert_all_verdicts_live(ledger, units, required_halves) :: :all_pass | {:revoked, unit}`
     — for each unit, re-read `Tau.Factory.Ledger.Writer.latest_verdict_status`
     for **each required half** (`[:critic, :reviewer]`); `:all_pass` only if every
     required half is `{:ok, :pass}`; first non-pass → `{:revoked, unit}` (HR-2).
   - `cas_push(repo_dir, tip, expected_old_oid) :: :ok | {:error, :stale_ref}` —
     `git push --force-with-lease=refs/heads/main:<expected_old_oid> origin <tip>:refs/heads/main`;
     a lease rejection (main moved off `expected_old_oid`) → `{:error, :stale_ref}`,
     **no merge**, `origin/main` unchanged (HR-1, D-301).
2. `lib/tau/factory/merge_authority.ex` (C1) — `gen_statem`, `state_functions`,
   states `:idle`/`:integrating`/`:committing` exactly per §5:
   - `request_merge(m, unit)` — **non-blocking**, returns `:queued` immediately
     (`unit = %{hash, run, branch}`; B=1).
   - `:idle → :integrating`: capture `base = head(origin/main)`, launch the build
     **off-mailbox** via `Task.Supervisor.async_nolink(MergeTasks, build_fun)`
     (default build = rebase the unit branch onto `base` → `tip`; B=1 train of one).
     Arm a `:state_timeout` so a wedged build cannot hang M.
   - `:integrating → :committing` on `{:built, units, base, tip}`.
   - `:committing` (SHORT): `assert_all_verdicts_live` (re-read latest, HR-2) →
     `{:revoked, u}` → `:idle` (eject, no merge); `:all_pass` → `cas_push(tip, base)`
     → `:ok` → `:idle` (broadcast `:merged`); `{:error, :stale_ref}` → `:idle`
     (requeue). No gate/health/rebase runs in `:committing`.
   - Illegal transitions unrepresentable (no clause for `:idle → :committing`).
   - **Testability seam:** `start_link` accepts `:build_fun` (and `:cas` module)
     opts defaulting to the real implementations, so a test can inject a build
     that reaches a barrier and lets the test deterministically advance
     `origin/main` (stale-ref) or revoke a verdict (HR-2) before `:committing`.
3. `lib/tau/factory/supervisor.ex` (EDIT) — add `MergeAuthority` and the
   `MergeTasks` `Task.Supervisor` as children alongside `Ledger.Writer`; thread
   the `:name`/`:ledger`/`:repo_dir` opts for test isolation (mirror the existing
   `Ledger.Writer` name-scoping).

Deferred to P3b/P3c (NOT here): `merge/health.ex` (D-303), `merge/train.ex`
bisect (B>1), `merge/queue.ex` aging (D-341). For B=1 the train is a list of one,
assembled inline.

### Dependencies
Depends on P2-Ledger (`Tau.Factory.Ledger.Writer`, merged `bdac337`) — reads
verdicts via `latest_verdict_status`. Blocks P3b/P3c. Tests seed verdicts via the
public `Ledger.Writer.append_verdict` (no dependency on the unbuilt gate→ledger
orchestration).

### SPECs
In scope: **SPEC-FACTORY-MERGE** (Appendix B: `merge_authority.ex`, `merge/cas.ex`,
`factory/supervisor.ex`). Cites D-335 (verdict immutability, SPEC-FACTORY-CORE —
M only *reads* the latest). Conforms to §4 contracts B1/B3/B4 and §5 state table.
No SPEC amendment expected.

### Acceptance criteria
- **AC-1 (D-302):** `Tau.Factory.Supervisor` starts `MergeAuthority` + the
  `MergeTasks` `Task.Supervisor`; M boots `:idle` and is supervised.
- **AC-2 (D-302):** N concurrent `request_merge` submissions ⇒ at most one
  `:integrating` train exists at any instant (the rest queue); the `:integrating`
  overlap count is ≤ 1.
- **AC-3 (D-300):** a verdict revoked **after** the build starts is re-read in
  `:committing`; the revoked unit is ejected and **no merge** lands (HR-2
  value-staleness).
- **AC-4 (D-301):** `origin/main` advancing off the captured base mid-integration
  ⇒ the `--force-with-lease` push is **rejected** (`{:error, :stale_ref}`),
  `origin/main` is unchanged by the rejected push, and the unit requeues.

### Gating-test paths (frozen at dc25404 — implementer MUST NOT edit)
- `test/tau/factory/merge_serialized_test.exs` (AC-1, AC-2 / D-302)
- `test/tau/factory/merge_verdict_revoke_test.exs` (AC-3 / D-300)
- `test/tau/factory/merge_force_with_lease_test.exs` (AC-4 / D-301)

Pinned contract additions from the oracle: `unit = %{id, hash, run, branch}`;
`start_link` opts add `:tasks_name`; `build_fun.(units, base) -> {:built, units, base, tip}`.

### Gate verdicts
_(filled at gate time — critic, reviewer)_
