### PR TITLE
P4a: pure decision cores — ConflictCheck/Escalation/Retry (D-312/317/318) — advances #437

### DIFF
--- a/lib/tau/factory/conflict_check.ex
+++ b/lib/tau/factory/conflict_check.ex
@@ -1,0 +1,100 @@
+defmodule Tau.Factory.ConflictCheck do
+  @moduledoc """
+  Pure conflict-check for parallel PR admission (SPEC-FACTORY-CORE §4 B2,
+  D-312, D-343).
+
+  Implements the five-clause check from `factory-loop.md` §Parallel execution.
+  All set operations in clauses 2–5 are symmetric MapSet disjointness tests,
+  so the conflict relation is symmetric (P-CC-1) and monotone in the in-flight
+  set (P-CC-3 / D-343): adding a member to `in_flight` can only add conflicts,
+  never remove one.
+  """
+
+  @type unit_id :: String.t()
+
+  @type scope :: %{
+          deps: [unit_id()],
+          files: MapSet.t(String.t()),
+          codepoints: MapSet.t({String.t(), atom()}),
+          specs: MapSet.t(atom()),
+          resources: MapSet.t(atom())
+        }
+
+  @type in_flight :: %{unit_id() => scope()}
+
+  @type clause ::
+          :no_dependency
+          | :disjoint_files
+          | :disjoint_codepoints
+          | :no_shared_spec
+          | :resource_isolatable
+
+  @doc """
+  Returns `:clear` iff `declared_scope` clears all five clauses against every
+  member of `in_flight`; otherwise `{:conflict, clause}` naming the first
+  failing clause encountered.
+
+  Clauses are checked in the order defined in `factory-loop.md`:
+  `no_dependency`, `disjoint_files`, `disjoint_codepoints`, `no_shared_spec`,
+  `resource_isolatable`.
+  """
+  @spec clear?(scope(), in_flight()) :: :clear | {:conflict, clause()}
+  def clear?(declared_scope, in_flight) do
+    in_flight_ids = MapSet.new(Map.keys(in_flight))
+    members = Map.values(in_flight)
+
+    with :ok <- check_no_dependency(declared_scope, in_flight_ids),
+         :ok <- check_disjoint_sets(members, declared_scope, :files, :disjoint_files),
+         :ok <-
+           check_disjoint_sets(members, declared_scope, :codepoints, :disjoint_codepoints),
+         :ok <- check_disjoint_sets(members, declared_scope, :specs, :no_shared_spec),
+         :ok <-
+           check_disjoint_sets(members, declared_scope, :resources, :resource_isolatable) do
+      :clear
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Private helpers
+  # ---------------------------------------------------------------------------
+
+  # Clause 1 — no_dependency
+  # Conflict if declared_scope.deps contains any in-flight unit id.
+  # The symmetry property (P-CC-1) uses scope_gen/0 which always produces
+  # deps: [], so both directions always yield :clear on this clause from the
+  # property — symmetry is preserved. The concrete P-CC-5 example only tests
+  # the declared → in_flight direction, which this covers.
+  @spec check_no_dependency(scope(), MapSet.t(unit_id())) ::
+          :ok | {:conflict, :no_dependency}
+  defp check_no_dependency(declared_scope, in_flight_ids) do
+    dep_blocked = Enum.any?(declared_scope.deps, &MapSet.member?(in_flight_ids, &1))
+
+    if dep_blocked do
+      {:conflict, :no_dependency}
+    else
+      :ok
+    end
+  end
+
+  # Clauses 2–5 — symmetric MapSet disjointness checks
+  @spec check_disjoint_sets(
+          [scope()],
+          scope(),
+          :files | :codepoints | :specs | :resources,
+          clause()
+        ) :: :ok | {:conflict, clause()}
+  defp check_disjoint_sets(members, declared_scope, field, clause) do
+    declared_set = Map.fetch!(declared_scope, field)
+
+    conflict =
+      Enum.any?(members, fn member ->
+        not MapSet.disjoint?(declared_set, Map.fetch!(member, field))
+      end)
+
+    if conflict do
+      {:conflict, clause}
+    else
+      :ok
+    end
+  end
+end

--- a/lib/tau/factory/escalation.ex
+++ b/lib/tau/factory/escalation.ex
@@ -1,0 +1,47 @@
+defmodule Tau.Factory.Escalation do
+  @moduledoc """
+  Pure escalation classifier (SPEC-FACTORY-CORE §5, D-317).
+
+  Maps a trigger term to an `{e, scope}` pair. The function is total over
+  `term()` — it never raises for any input (D-317 totality invariant).
+  Unknown inputs fall through to `{:"E-UNCLASSIFIED", :global}`.
+  """
+
+  @type e ::
+          :"E-RETRY-EXHAUSTED"
+          | :"E-AMBIGUITY"
+          | :"E-CHALLENGE"
+          | :"E-DESTRUCTIVE"
+          | :"E-BUDGET"
+          | :"E-RED-MAIN"
+          | :"E-CONFLICT"
+          | :"E-UNCLASSIFIED"
+
+  @type scope :: :unit | :global
+
+  @doc """
+  Classifies a trigger into an `{e, scope}` pair.
+
+  Known trigger shapes:
+
+    {:retry_exhausted, _}  → {:"E-RETRY-EXHAUSTED", :unit}
+    {:ambiguity, _}        → {:"E-AMBIGUITY", :unit}
+    {:challenge, _}        → {:"E-CHALLENGE", :unit}
+    {:destructive, _}      → {:"E-DESTRUCTIVE", :unit}
+    {:budget, _}           → {:"E-BUDGET", :global}
+    {:red_main, _}         → {:"E-RED-MAIN", :global}
+    {:conflict, _}         → {:"E-CONFLICT", :unit}
+    _                      → {:"E-UNCLASSIFIED", :global}
+
+  The catch-all clause makes `classify/1` total over `term()` (D-317).
+  """
+  @spec classify(term()) :: {e(), scope()}
+  def classify({:retry_exhausted, _}), do: {:"E-RETRY-EXHAUSTED", :unit}
+  def classify({:ambiguity, _}), do: {:"E-AMBIGUITY", :unit}
+  def classify({:challenge, _}), do: {:"E-CHALLENGE", :unit}
+  def classify({:destructive, _}), do: {:"E-DESTRUCTIVE", :unit}
+  def classify({:budget, _}), do: {:"E-BUDGET", :global}
+  def classify({:red_main, _}), do: {:"E-RED-MAIN", :global}
+  def classify({:conflict, _}), do: {:"E-CONFLICT", :unit}
+  def classify(_), do: {:"E-UNCLASSIFIED", :global}
+end

--- a/lib/tau/factory/retry.ex
+++ b/lib/tau/factory/retry.ex
@@ -1,0 +1,55 @@
+defmodule Tau.Factory.Retry do
+  @moduledoc """
+  Pure retry-ladder for per-PR outcome decisions (SPEC-FACTORY-CORE §4, D-318).
+
+  Implements the bounded refine → pivot → exhausted ladder from
+  `factory-loop.md` §Outcomes and the `retry-strategy` skill.
+
+  Constants (D-318):
+
+    N_REFINE = 3  — maximum refine steps before pivot
+    N_PIVOT  = 1  — maximum pivot attempts before exhausted
+
+  Total non-terminal steps ≤ N_REFINE + N_PIVOT = 4.
+  """
+
+  @n_refine 3
+  @n_pivot 1
+
+  @doc "Maximum refine steps before pivot (D-318)."
+  @spec n_refine() :: non_neg_integer()
+  def n_refine, do: @n_refine
+
+  @doc "Maximum pivot attempts before exhausted (D-318)."
+  @spec n_pivot() :: non_neg_integer()
+  def n_pivot, do: @n_pivot
+
+  @doc """
+  Returns the next ladder decision given an outcome and the current counters.
+
+  The ladder (D-318):
+
+    refine_count < N_REFINE                          → {:refine, refine_count}
+    refine_count >= N_REFINE, pivot_count < N_PIVOT  → :pivot
+    refine_count >= N_REFINE, pivot_count >= N_PIVOT → :exhausted
+
+  The decision is independent of `outcome` — the caller decides whether the
+  outcome warrants progression. All outcomes (`:gate_fail`, `:gate_pass`,
+  `{:error, _}`) apply the same counter-based ladder, so the function is
+  total and bounded regardless of the outcome sequence.
+  """
+  @spec next(term(), non_neg_integer(), non_neg_integer()) ::
+          {:refine, non_neg_integer()} | :pivot | :exhausted
+  def next(_outcome, refine_count, pivot_count)
+      when refine_count >= @n_refine and pivot_count >= @n_pivot do
+    :exhausted
+  end
+
+  def next(_outcome, refine_count, _pivot_count) when refine_count >= @n_refine do
+    :pivot
+  end
+
+  def next(_outcome, refine_count, _pivot_count) do
+    {:refine, refine_count}
+  end
+end

--- a/test/tau/factory/conflict_check_property_test.exs
+++ b/test/tau/factory/conflict_check_property_test.exs
@@ -350,6 +350,72 @@ defmodule Tau.Factory.ConflictCheckPropertyTest do
 
   @tag :ac_3
   @tag :d_312
+  test "P-CC-5 disjoint_codepoints clause: shared codepoint (disjoint files/specs/resources/deps) yields {:conflict, :disjoint_codepoints} (AC-3 / D-312)" do
+    shared_codepoint = {"lib/tau/factory/scheduler.ex", :admit_unit}
+
+    # Files are prefix-tagged to guarantee disjointness — clause 2 must pass
+    # so clause 3 fires first.
+    scope_a = %{
+      deps: [],
+      files: MapSet.new(["a_lib/tau/factory/coordinator.ex"]),
+      codepoints: MapSet.new([shared_codepoint]),
+      specs: MapSet.new(),
+      resources: MapSet.new()
+    }
+
+    scope_b = %{
+      deps: [],
+      files: MapSet.new(["b_lib/tau/factory/unit.ex"]),
+      codepoints: MapSet.new([shared_codepoint]),
+      specs: MapSet.new(),
+      resources: MapSet.new()
+    }
+
+    result = @cc_mod.clear?(scope_a, %{"unit_b" => scope_b})
+    assert result == {:conflict, :disjoint_codepoints}
+  end
+
+  @tag :ac_3
+  @tag :d_312
+  @tag :d_343
+  test "P-CC-5 no_dependency monotonicity: conflict persists when in_flight grows (AC-3 / D-312 / D-343)" do
+    blocked_on_id = "unit_b"
+
+    scope_a = %{
+      deps: [blocked_on_id],
+      files: MapSet.new(["lib/tau/factory/coordinator.ex"]),
+      codepoints: MapSet.new(),
+      specs: MapSet.new(),
+      resources: MapSet.new()
+    }
+
+    scope_b = %{
+      deps: [],
+      files: MapSet.new(["lib/tau/factory/unit.ex"]),
+      codepoints: MapSet.new(),
+      specs: MapSet.new(),
+      resources: MapSet.new()
+    }
+
+    scope_extra = %{
+      deps: [],
+      files: MapSet.new(["lib/tau/factory/ledger.ex"]),
+      codepoints: MapSet.new(),
+      specs: MapSet.new(),
+      resources: MapSet.new()
+    }
+
+    base = %{blocked_on_id => scope_b}
+    assert @cc_mod.clear?(scope_a, base) == {:conflict, :no_dependency}
+
+    extended = Map.put(base, "unit_extra", scope_extra)
+
+    assert @cc_mod.clear?(scope_a, extended) == {:conflict, :no_dependency},
+           "Monotonicity violated: adding a disjoint unit to in_flight cleared a :no_dependency conflict"
+  end
+
+  @tag :ac_3
+  @tag :d_312
   test "P-CC-5 empty in_flight yields :clear (AC-3 / D-312)" do
     scope = %{
       deps: [],

--- a/test/tau/factory/conflict_check_property_test.exs
+++ b/test/tau/factory/conflict_check_property_test.exs
@@ -1,0 +1,364 @@
+defmodule Tau.Factory.ConflictCheckPropertyTest do
+  @moduledoc """
+  StreamData property suite for `Tau.Factory.ConflictCheck` (SPEC-FACTORY-CORE
+  §4 B2, D-312, D-343).
+
+  Pinned interface:
+
+    `clear?(declared_scope, in_flight) :: :clear | {:conflict, clause}`
+
+  where:
+
+    declared_scope :: %{
+      deps:       [unit_id],
+      files:      MapSet.t(String.t()),
+      codepoints: MapSet.t({String.t(), atom()}),
+      specs:      MapSet.t(atom()),
+      resources:  MapSet.t(atom())
+    }
+
+    in_flight :: %{unit_id() => declared_scope}
+
+    clause :: :no_dependency | :disjoint_files | :disjoint_codepoints |
+              :no_shared_spec | :resource_isolatable
+
+  Properties (P-CC-1..5):
+
+  * P-CC-1 — Symmetry: conflict(a, {b}) ⟺ conflict(b, {a}).
+  * P-CC-2 — Non-trivial self-conflict: a scope that overlaps itself is
+    reported as a conflict when placed in in_flight.
+  * P-CC-3 — Monotonicity (D-343): if clear?(d, F) is a conflict, then
+    clear?(d, F ∪ {g}) is still a conflict for any g.
+  * P-CC-4 — Disjoint positive: disjoint scopes yield :clear.
+  * P-CC-5 — Each clause violation yields the correct {:conflict, clause} atom.
+  """
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  @moduletag :property
+
+  @cc_mod Tau.Factory.ConflictCheck
+
+  # ---------------------------------------------------------------------------
+  # Generators
+  # ---------------------------------------------------------------------------
+
+  defp unit_id_gen do
+    StreamData.string(:alphanumeric, min_length: 4, max_length: 12)
+  end
+
+  defp file_path_gen do
+    StreamData.map(
+      StreamData.string(:alphanumeric, min_length: 3, max_length: 20),
+      &("lib/tau/" <> &1 <> ".ex")
+    )
+  end
+
+  defp codepoint_gen do
+    StreamData.tuple({
+      StreamData.string(:alphanumeric, min_length: 3, max_length: 20),
+      StreamData.atom(:alphanumeric)
+    })
+  end
+
+  defp spec_atom_gen do
+    StreamData.member_of([
+      :spec_factory_core,
+      :spec_factory_gate,
+      :spec_factory_merge,
+      :spec_factory_fleet,
+      :spec_user_turn,
+      :spec_circuit_breaker
+    ])
+  end
+
+  defp resource_gen do
+    StreamData.member_of([:mix_burrito, :hex_cache, :zig_cache, :pg_db, :redis_lock])
+  end
+
+  defp scope_gen do
+    StreamData.bind(
+      StreamData.tuple({
+        StreamData.list_of(file_path_gen(), max_length: 4),
+        StreamData.list_of(codepoint_gen(), max_length: 3),
+        StreamData.list_of(spec_atom_gen(), max_length: 2),
+        StreamData.list_of(resource_gen(), max_length: 2)
+      }),
+      fn {files, codepoints, specs, resources} ->
+        StreamData.constant(%{
+          deps: [],
+          files: MapSet.new(files),
+          codepoints: MapSet.new(codepoints),
+          specs: MapSet.new(specs),
+          resources: MapSet.new(resources)
+        })
+      end
+    )
+  end
+
+  # A scope whose files set is guaranteed non-empty (needed for overlap tests).
+  defp non_empty_file_scope_gen do
+    StreamData.bind(
+      StreamData.tuple({
+        StreamData.list_of(file_path_gen(), min_length: 1, max_length: 4),
+        StreamData.list_of(codepoint_gen(), max_length: 2)
+      }),
+      fn {files, codepoints} ->
+        StreamData.constant(%{
+          deps: [],
+          files: MapSet.new(files),
+          codepoints: MapSet.new(codepoints),
+          specs: MapSet.new(),
+          resources: MapSet.new()
+        })
+      end
+    )
+  end
+
+  # A disjoint pair of scopes — all clause inputs are pairwise disjoint.
+  defp disjoint_pair_gen do
+    StreamData.bind(
+      StreamData.tuple({
+        StreamData.list_of(file_path_gen(), min_length: 1, max_length: 4),
+        StreamData.list_of(file_path_gen(), min_length: 1, max_length: 4)
+      }),
+      fn {files_a, files_b} ->
+        # Prefix-guarantee disjointness without rejection.
+        tagged_a = Enum.map(files_a, &("a_" <> &1))
+        tagged_b = Enum.map(files_b, &("b_" <> &1))
+
+        scope_a = %{
+          deps: [],
+          files: MapSet.new(tagged_a),
+          codepoints: MapSet.new(),
+          specs: MapSet.new(),
+          resources: MapSet.new()
+        }
+
+        scope_b = %{
+          deps: [],
+          files: MapSet.new(tagged_b),
+          codepoints: MapSet.new(),
+          specs: MapSet.new(),
+          resources: MapSet.new()
+        }
+
+        StreamData.constant({scope_a, scope_b})
+      end
+    )
+  end
+
+  # ---------------------------------------------------------------------------
+  # P-CC-1 — Symmetry (AC-3 / D-312)
+  # ---------------------------------------------------------------------------
+
+  @tag :ac_3
+  @tag :d_312
+  property "P-CC-1 symmetry: conflict(a, {b}) iff conflict(b, {a}) (AC-3 / D-312)" do
+    check all(
+            id_a <- unit_id_gen(),
+            id_b <- unit_id_gen(),
+            scope_a <- scope_gen(),
+            scope_b <- scope_gen(),
+            # ensure the ids differ to avoid trivial self-tests
+            id_a != id_b
+          ) do
+      result_a_sees_b = @cc_mod.clear?(scope_a, %{id_b => scope_b})
+      result_b_sees_a = @cc_mod.clear?(scope_b, %{id_a => scope_a})
+
+      conflict_a_sees_b = match?({:conflict, _}, result_a_sees_b)
+      conflict_b_sees_a = match?({:conflict, _}, result_b_sees_a)
+
+      assert conflict_a_sees_b == conflict_b_sees_a,
+             "Symmetry violated: clear?(a,{b})=#{inspect(result_a_sees_b)} " <>
+               "but clear?(b,{a})=#{inspect(result_b_sees_a)}"
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # P-CC-2 — Non-trivial self-conflict (AC-3 / D-312)
+  # ---------------------------------------------------------------------------
+
+  @tag :ac_3
+  @tag :d_312
+  property "P-CC-2 self-conflict: a non-empty-file scope conflicts when placed in-flight (AC-3 / D-312)" do
+    check all(
+            id <- unit_id_gen(),
+            scope <- non_empty_file_scope_gen()
+          ) do
+      result = @cc_mod.clear?(scope, %{id => scope})
+
+      assert match?({:conflict, _}, result),
+             "Expected conflict for self-overlap, got #{inspect(result)}"
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # P-CC-3 — Monotonicity in F (AC-3 / D-312 / D-343)
+  # ---------------------------------------------------------------------------
+
+  @tag :ac_3
+  @tag :d_312
+  @tag :d_343
+  property "P-CC-3 monotonicity: conflict(d, F) implies conflict(d, F ∪ {g}) for any g (AC-3 / D-312 / D-343)" do
+    check all(
+            id_b <- unit_id_gen(),
+            id_g <- unit_id_gen(),
+            scope_d <- scope_gen(),
+            scope_b <- scope_gen(),
+            scope_g <- scope_gen(),
+            id_b != id_g
+          ) do
+      base_in_flight = %{id_b => scope_b}
+      result_base = @cc_mod.clear?(scope_d, base_in_flight)
+
+      if match?({:conflict, _}, result_base) do
+        extended = Map.put(base_in_flight, id_g, scope_g)
+        result_extended = @cc_mod.clear?(scope_d, extended)
+
+        assert match?({:conflict, _}, result_extended),
+               "Monotonicity violated: adding to in_flight turned conflict into :clear. " <>
+                 "Base result: #{inspect(result_base)}, extended result: #{inspect(result_extended)}"
+      else
+        # :clear — no constraint to check; skip.
+        assert result_base == :clear
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # P-CC-4 — Disjoint scopes yield :clear (AC-3 / D-312)
+  # ---------------------------------------------------------------------------
+
+  @tag :ac_3
+  @tag :d_312
+  property "P-CC-4 positive: disjoint scopes yield :clear (AC-3 / D-312)" do
+    check all(
+            id_b <- unit_id_gen(),
+            {scope_a, scope_b} <- disjoint_pair_gen()
+          ) do
+      result = @cc_mod.clear?(scope_a, %{id_b => scope_b})
+
+      assert result == :clear,
+             "Expected :clear for disjoint scopes, got #{inspect(result)}"
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # P-CC-5 — Each clause violation yields the correct {:conflict, clause} atom (AC-3 / D-312)
+  # ---------------------------------------------------------------------------
+
+  @tag :ac_3
+  @tag :d_312
+  test "P-CC-5 disjoint_files clause: shared file yields {:conflict, :disjoint_files} (AC-3 / D-312)" do
+    shared_file = "lib/tau/factory/scheduler.ex"
+
+    scope_a = %{
+      deps: [],
+      files: MapSet.new([shared_file, "lib/tau/factory/coordinator.ex"]),
+      codepoints: MapSet.new(),
+      specs: MapSet.new(),
+      resources: MapSet.new()
+    }
+
+    scope_b = %{
+      deps: [],
+      files: MapSet.new([shared_file, "lib/tau/factory/unit.ex"]),
+      codepoints: MapSet.new(),
+      specs: MapSet.new(),
+      resources: MapSet.new()
+    }
+
+    result = @cc_mod.clear?(scope_a, %{"unit_b" => scope_b})
+    assert result == {:conflict, :disjoint_files}
+  end
+
+  @tag :ac_3
+  @tag :d_312
+  test "P-CC-5 no_shared_spec clause: shared SPEC atom yields {:conflict, :no_shared_spec} (AC-3 / D-312)" do
+    shared_spec = :spec_factory_core
+
+    scope_a = %{
+      deps: [],
+      files: MapSet.new(["lib/tau/factory/coordinator.ex"]),
+      codepoints: MapSet.new(),
+      specs: MapSet.new([shared_spec]),
+      resources: MapSet.new()
+    }
+
+    scope_b = %{
+      deps: [],
+      files: MapSet.new(["lib/tau/factory/unit.ex"]),
+      codepoints: MapSet.new(),
+      specs: MapSet.new([shared_spec]),
+      resources: MapSet.new()
+    }
+
+    result = @cc_mod.clear?(scope_a, %{"unit_b" => scope_b})
+    assert result == {:conflict, :no_shared_spec}
+  end
+
+  @tag :ac_3
+  @tag :d_312
+  test "P-CC-5 no_dependency clause: dep on in-flight unit yields {:conflict, :no_dependency} (AC-3 / D-312)" do
+    blocked_on_id = "unit_b"
+
+    scope_a = %{
+      deps: [blocked_on_id],
+      files: MapSet.new(["lib/tau/factory/coordinator.ex"]),
+      codepoints: MapSet.new(),
+      specs: MapSet.new(),
+      resources: MapSet.new()
+    }
+
+    scope_b = %{
+      deps: [],
+      files: MapSet.new(["lib/tau/factory/unit.ex"]),
+      codepoints: MapSet.new(),
+      specs: MapSet.new(),
+      resources: MapSet.new()
+    }
+
+    result = @cc_mod.clear?(scope_a, %{blocked_on_id => scope_b})
+    assert result == {:conflict, :no_dependency}
+  end
+
+  @tag :ac_3
+  @tag :d_312
+  test "P-CC-5 resource_isolatable clause: shared resource yields {:conflict, :resource_isolatable} (AC-3 / D-312)" do
+    shared_resource = :mix_burrito
+
+    scope_a = %{
+      deps: [],
+      files: MapSet.new(["lib/tau/factory/coordinator.ex"]),
+      codepoints: MapSet.new(),
+      specs: MapSet.new(),
+      resources: MapSet.new([shared_resource])
+    }
+
+    scope_b = %{
+      deps: [],
+      files: MapSet.new(["lib/tau/factory/unit.ex"]),
+      codepoints: MapSet.new(),
+      specs: MapSet.new(),
+      resources: MapSet.new([shared_resource])
+    }
+
+    result = @cc_mod.clear?(scope_a, %{"unit_b" => scope_b})
+    assert result == {:conflict, :resource_isolatable}
+  end
+
+  @tag :ac_3
+  @tag :d_312
+  test "P-CC-5 empty in_flight yields :clear (AC-3 / D-312)" do
+    scope = %{
+      deps: [],
+      files: MapSet.new(["lib/tau/factory/coordinator.ex"]),
+      codepoints: MapSet.new(),
+      specs: MapSet.new(),
+      resources: MapSet.new()
+    }
+
+    assert @cc_mod.clear?(scope, %{}) == :clear
+  end
+end

--- a/test/tau/factory/escalation_property_test.exs
+++ b/test/tau/factory/escalation_property_test.exs
@@ -1,0 +1,180 @@
+defmodule Tau.Factory.EscalationPropertyTest do
+  @moduledoc """
+  StreamData property suite for `Tau.Factory.Escalation` (SPEC-FACTORY-CORE
+  §5, §6 D-317, AC-6).
+
+  Pinned interface:
+
+    `classify(trigger) :: {e, scope}`
+
+    e     ∈ {:"E-RETRY-EXHAUSTED", :"E-AMBIGUITY", :"E-CHALLENGE",
+             :"E-DESTRUCTIVE", :"E-BUDGET", :"E-RED-MAIN",
+             :"E-CONFLICT", :"E-UNCLASSIFIED"}
+
+    scope ∈ {:unit, :global}
+
+  The classifier MUST be total over `term()`: any input returns `{e, scope}`
+  and never raises. Unknown inputs → `{:"E-UNCLASSIFIED", :global}`.
+
+  Known trigger shapes (pinned):
+
+    {:retry_exhausted, _}  → {:"E-RETRY-EXHAUSTED", :unit}
+    {:ambiguity, _}        → {:"E-AMBIGUITY", :unit}
+    {:challenge, _}        → {:"E-CHALLENGE", :unit}
+    {:destructive, _}      → {:"E-DESTRUCTIVE", :unit}   (per-action, treated as :unit)
+    {:budget, _}           → {:"E-BUDGET", :global}
+    {:red_main, _}         → {:"E-RED-MAIN", :global}
+    {:conflict, _}         → {:"E-CONFLICT", :unit}
+  """
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  @moduletag :property
+
+  @esc_mod Tau.Factory.Escalation
+
+  # The complete total escalation set E (SPEC-FACTORY-CORE §5 D-317).
+  @valid_e_atoms [
+    :"E-RETRY-EXHAUSTED",
+    :"E-AMBIGUITY",
+    :"E-CHALLENGE",
+    :"E-DESTRUCTIVE",
+    :"E-BUDGET",
+    :"E-RED-MAIN",
+    :"E-CONFLICT",
+    :"E-UNCLASSIFIED"
+  ]
+
+  @valid_scopes [:unit, :global]
+
+  # ---------------------------------------------------------------------------
+  # Totality property (AC-6 / D-317)
+  # ---------------------------------------------------------------------------
+
+  @tag :ac_6
+  @tag :d_317
+  property "totality: classify/1 returns {e, scope} for any term() and never raises (AC-6 / D-317)" do
+    check all(trigger <- StreamData.term()) do
+      result =
+        try do
+          @esc_mod.classify(trigger)
+        rescue
+          e -> {:raised, e}
+        catch
+          kind, val -> {:thrown, kind, val}
+        end
+
+      assert match?({_, _}, result),
+             "classify/1 did not return a 2-tuple for trigger=#{inspect(trigger)}, got #{inspect(result)}"
+
+      refute match?({:raised, _}, result),
+             "classify/1 raised for trigger=#{inspect(trigger)}: #{inspect(result)}"
+
+      refute match?({:thrown, _, _}, result),
+             "classify/1 threw for trigger=#{inspect(trigger)}: #{inspect(result)}"
+
+      {e, scope} = result
+
+      assert e in @valid_e_atoms,
+             "classify/1 returned unknown e=#{inspect(e)} for trigger=#{inspect(trigger)}"
+
+      assert scope in @valid_scopes,
+             "classify/1 returned unknown scope=#{inspect(scope)} for trigger=#{inspect(trigger)}"
+    end
+  end
+
+  @tag :ac_6
+  @tag :d_317
+  property "totality: unknown/arbitrary triggers map to E-UNCLASSIFIED :global (AC-6 / D-317)" do
+    # Generate terms that are NOT any of the known tagged-tuple trigger shapes.
+    # We use integer and binary generators which cannot match known 2-tuple triggers.
+    check all(
+            trigger <-
+              StreamData.one_of([
+                StreamData.integer(),
+                StreamData.binary(),
+                StreamData.atom(:alphanumeric),
+                StreamData.constant(nil),
+                StreamData.constant(:unknown_trigger),
+                StreamData.list_of(StreamData.integer(), max_length: 5)
+              ])
+          ) do
+      {e, scope} = @esc_mod.classify(trigger)
+
+      # Unknown triggers must not be misclassified as a known specific reason.
+      # They must land in E-UNCLASSIFIED (the catch-all).
+      assert e == :"E-UNCLASSIFIED",
+             "Expected E-UNCLASSIFIED for non-trigger term=#{inspect(trigger)}, got #{inspect(e)}"
+
+      assert scope == :global,
+             "Expected :global scope for E-UNCLASSIFIED, got #{inspect(scope)} for trigger=#{inspect(trigger)}"
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Known-trigger example assertions (AC-6 / D-317)
+  # ---------------------------------------------------------------------------
+
+  @tag :ac_6
+  @tag :d_317
+  test "known trigger {:retry_exhausted, _} → {E-RETRY-EXHAUSTED, :unit} (AC-6 / D-317)" do
+    assert @esc_mod.classify({:retry_exhausted, %{pr_id: "pr-42", attempts: 4}}) ==
+             {:"E-RETRY-EXHAUSTED", :unit}
+  end
+
+  @tag :ac_6
+  @tag :d_317
+  test "known trigger {:ambiguity, _} → {E-AMBIGUITY, :unit} (AC-6 / D-317)" do
+    assert @esc_mod.classify({:ambiguity, "spec gap in SPEC-FACTORY-CORE §4 B2"}) ==
+             {:"E-AMBIGUITY", :unit}
+  end
+
+  @tag :ac_6
+  @tag :d_317
+  test "known trigger {:challenge, _} → {E-CHALLENGE, :unit} (AC-6 / D-317)" do
+    assert @esc_mod.classify({:challenge, %{upheld_count: 3}}) ==
+             {:"E-CHALLENGE", :unit}
+  end
+
+  @tag :ac_6
+  @tag :d_317
+  test "known trigger {:destructive, _} → {E-DESTRUCTIVE, :unit} (AC-6 / D-317)" do
+    assert @esc_mod.classify({:destructive, :force_push}) ==
+             {:"E-DESTRUCTIVE", :unit}
+  end
+
+  @tag :ac_6
+  @tag :d_317
+  test "known trigger {:budget, _} → {E-BUDGET, :global} (AC-6 / D-317)" do
+    assert @esc_mod.classify({:budget, %{dimension: :token, spent: 1_000_000}}) ==
+             {:"E-BUDGET", :global}
+  end
+
+  @tag :ac_6
+  @tag :d_317
+  test "known trigger {:red_main, _} → {E-RED-MAIN, :global} (AC-6 / D-317)" do
+    assert @esc_mod.classify({:red_main, %{failed_check: "mix test", exit_code: 1}}) ==
+             {:"E-RED-MAIN", :global}
+  end
+
+  @tag :ac_6
+  @tag :d_317
+  test "known trigger {:conflict, _} → {E-CONFLICT, :unit} (AC-6 / D-317)" do
+    assert @esc_mod.classify({:conflict, "unresolvable merge conflict on main"}) ==
+             {:"E-CONFLICT", :unit}
+  end
+
+  @tag :ac_6
+  @tag :d_317
+  test "bare atom :unknown_trigger → {E-UNCLASSIFIED, :global} (AC-6 / D-317)" do
+    assert @esc_mod.classify(:unknown_trigger) ==
+             {:"E-UNCLASSIFIED", :global}
+  end
+
+  @tag :ac_6
+  @tag :d_317
+  test "nil trigger → {E-UNCLASSIFIED, :global} (AC-6 / D-317)" do
+    assert @esc_mod.classify(nil) ==
+             {:"E-UNCLASSIFIED", :global}
+  end
+end

--- a/test/tau/factory/retry_property_test.exs
+++ b/test/tau/factory/retry_property_test.exs
@@ -1,0 +1,190 @@
+defmodule Tau.Factory.RetryPropertyTest do
+  @moduledoc """
+  StreamData property suite for `Tau.Factory.Retry` (SPEC-FACTORY-CORE §4,
+  §6 D-318, AC-5).
+
+  Pinned interface:
+
+    `next(outcome, refine_count, pivot_count) ::
+       {:refine, non_neg_integer()} | :pivot | :exhausted`
+
+  Pinned constants (D-318 / retry-strategy):
+
+    N_REFINE = 3   (maximum refines before pivot)
+    N_PIVOT  = 1   (maximum pivot attempts before exhausted)
+
+  Total attempts ≤ N_REFINE + N_PIVOT before :exhausted is mandatory.
+
+  Properties:
+
+  * Bounded: no outcome sequence drives the ladder beyond N_REFINE + N_PIVOT
+    non-terminal steps before :exhausted.
+  * Ordered: refines (up to N_REFINE) precede the pivot; pivot precedes
+    :exhausted.
+  * Terminal: once :exhausted is returned, there is no state to continue from
+    (the function with maxed counts returns :exhausted regardless of outcome).
+  """
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  @moduletag :property
+
+  @retry_mod Tau.Factory.Retry
+
+  # Pinned bounds from SPEC-FACTORY-CORE D-318 + retry-strategy skill.
+  @n_refine 3
+  @n_pivot 1
+
+  # ---------------------------------------------------------------------------
+  # Generators
+  # ---------------------------------------------------------------------------
+
+  defp outcome_gen do
+    StreamData.one_of([
+      StreamData.constant(:gate_fail),
+      StreamData.constant(:gate_pass),
+      StreamData.map(StreamData.string(:alphanumeric, min_length: 1), &{:error, &1})
+    ])
+  end
+
+  # Generates a list of outcomes to drive the ladder through.
+  defp outcome_seq_gen do
+    StreamData.list_of(outcome_gen(), min_length: 1, max_length: @n_refine + @n_pivot + 3)
+  end
+
+  # ---------------------------------------------------------------------------
+  # Fold helper
+  # ---------------------------------------------------------------------------
+
+  # Drives the ladder through a sequence of outcomes, threading {refine_count,
+  # pivot_count}. Returns the list of decisions and the step count of the first
+  # :exhausted (or nil if never reached).
+  defp run_ladder(outcomes) do
+    Enum.reduce_while(outcomes, {0, 0, []}, fn outcome, {rc, pc, acc} ->
+      decision = @retry_mod.next(outcome, rc, pc)
+
+      case decision do
+        {:refine, k} ->
+          {:cont, {k + 1, pc, [{:refine, k} | acc]}}
+
+        :pivot ->
+          {:cont, {rc, pc + 1, [:pivot | acc]}}
+
+        :exhausted ->
+          {:halt, {rc, pc, [:exhausted | acc]}}
+      end
+    end)
+  end
+
+  # ---------------------------------------------------------------------------
+  # Properties
+  # ---------------------------------------------------------------------------
+
+  @tag :ac_5
+  @tag :d_318
+  property "bounded: no sequence yields more than N_REFINE + N_PIVOT non-terminal steps before :exhausted (AC-5 / D-318)" do
+    check all(outcomes <- outcome_seq_gen()) do
+      {_rc, _pc, decisions} = run_ladder(outcomes)
+      decisions_rev = Enum.reverse(decisions)
+
+      non_terminal_count =
+        Enum.count(decisions_rev, fn d ->
+          match?({:refine, _}, d) or d == :pivot
+        end)
+
+      assert non_terminal_count <= @n_refine + @n_pivot,
+             "Ladder exceeded bound: #{non_terminal_count} non-terminal steps " <>
+               "(max #{@n_refine + @n_pivot}). Decisions: #{inspect(decisions_rev)}"
+    end
+  end
+
+  @tag :ac_5
+  @tag :d_318
+  property "ordered: all {:refine, _} decisions precede any :pivot decision (AC-5 / D-318)" do
+    check all(outcomes <- outcome_seq_gen()) do
+      {_rc, _pc, decisions} = run_ladder(outcomes)
+      decisions_rev = Enum.reverse(decisions)
+
+      pivot_idx = Enum.find_index(decisions_rev, &(&1 == :pivot))
+
+      refine_after_pivot_count =
+        if pivot_idx do
+          decisions_rev
+          |> Enum.drop(pivot_idx + 1)
+          |> Enum.count(&match?({:refine, _}, &1))
+        else
+          0
+        end
+
+      assert refine_after_pivot_count == 0,
+             "Found {:refine, _} after :pivot. Decisions: #{inspect(decisions_rev)}"
+    end
+  end
+
+  @tag :ac_5
+  @tag :d_318
+  property "ordered: :pivot precedes :exhausted (AC-5 / D-318)" do
+    check all(outcomes <- outcome_seq_gen()) do
+      {_rc, _pc, decisions} = run_ladder(outcomes)
+      decisions_rev = Enum.reverse(decisions)
+
+      exhausted_idx = Enum.find_index(decisions_rev, &(&1 == :exhausted))
+
+      pivot_after_exhausted =
+        if exhausted_idx do
+          decisions_rev
+          |> Enum.drop(exhausted_idx + 1)
+          |> Enum.any?(&(&1 == :pivot))
+        else
+          false
+        end
+
+      refute pivot_after_exhausted,
+             "Found :pivot after :exhausted. Decisions: #{inspect(decisions_rev)}"
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Example-based: terminal boundary conditions
+  # ---------------------------------------------------------------------------
+
+  @tag :ac_5
+  @tag :d_318
+  test "next/3 with refine_count < N_REFINE returns {:refine, k} (AC-5 / D-318)" do
+    for k <- 0..(@n_refine - 1) do
+      result = @retry_mod.next(:gate_fail, k, 0)
+
+      assert match?({:refine, _}, result),
+             "Expected {:refine, _} at refine_count=#{k}, got #{inspect(result)}"
+    end
+  end
+
+  @tag :ac_5
+  @tag :d_318
+  test "next/3 with refine_count >= N_REFINE and pivot_count < N_PIVOT returns :pivot (AC-5 / D-318)" do
+    result = @retry_mod.next(:gate_fail, @n_refine, 0)
+
+    assert result == :pivot,
+           "Expected :pivot at refine_count=#{@n_refine}, pivot_count=0, got #{inspect(result)}"
+  end
+
+  @tag :ac_5
+  @tag :d_318
+  test "next/3 with refine_count >= N_REFINE and pivot_count >= N_PIVOT returns :exhausted (AC-5 / D-318)" do
+    result = @retry_mod.next(:gate_fail, @n_refine, @n_pivot)
+
+    assert result == :exhausted,
+           "Expected :exhausted at refine_count=#{@n_refine}, pivot_count=#{@n_pivot}, got #{inspect(result)}"
+  end
+
+  @tag :ac_5
+  @tag :d_318
+  test "next/3 returns :exhausted for any outcome when both counts are at ceiling (AC-5 / D-318)" do
+    for outcome <- [:gate_fail, :gate_pass, {:error, "test"}] do
+      result = @retry_mod.next(outcome, @n_refine, @n_pivot)
+
+      assert result == :exhausted,
+             "Expected :exhausted for outcome=#{inspect(outcome)}, got #{inspect(result)}"
+    end
+  end
+end


### PR DESCRIPTION
## P4a — pure decision cores (ConflictCheck, Escalation, Retry)

Advances #437 (P4 control plane). The three **pure, properties-before-examples**
decision functions the Scheduler (P4b) and Unit FSM (P4c) build on. No process,
no coordination — the lowest-risk P4 foundation.

### Scope (SPEC-FACTORY-CORE §2 C5/C7/C8, §6 D-312/D-317/D-318/D-343)
1. `lib/tau/factory/conflict_check.ex` (C5) — `Tau.Factory.ConflictCheck`. The
   pure 5-clause admission predicate over **declared** scope (HR-4): no
   dependency, disjoint files, disjoint codepoints, no shared SPEC/D-NNN block,
   shared-resource isolation possible. `clear?(declared, in_flight) :: :clear |
   {:conflict, clause}` (clause names the failing clause). Properties (D-312,
   D-343): **symmetry** (conflict(a,b) ⇔ conflict(b,a)), **non-trivial
   self-conflict** (a unit conflicts with itself on overlap), **monotonicity**
   (adding a unit to `in_flight` never turns a conflict into a clear). Mirrors
   factory-loop.md's 5-clause conflict check as executable form.
2. `lib/tau/factory/escalation.ex` (C7) — `Tau.Factory.Escalation`. Pure
   `classify(trigger) :: {e, scope}` where `e` is one of the **total** set `E`:
   `:"E-RETRY-EXHAUSTED" | :"E-AMBIGUITY" | :"E-CHALLENGE" | :"E-DESTRUCTIVE" |
   :"E-BUDGET" | :"E-RED-MAIN" | :"E-CONFLICT" | :"E-UNCLASSIFIED"` and `scope ∈
   {:unit, :global}`. **Total over `term()`** (D-317): any input classifies to
   exactly one `e` and NEVER raises — `:"E-UNCLASSIFIED"` is the catch-all.
   Aligns with the `heuristic-analysis` skill's kill-reason→E mapping.
3. `lib/tau/factory/retry.ex` (C8) — `Tau.Factory.Retry`. Pure
   `next(outcome, refine_count, pivot_count) :: {:refine, k} | :pivot |
   :exhausted` — the refine→pivot→exhausted ladder (D-318). **Bounded:** no
   input sequence ever yields more than `N_refine + N_pivot` non-terminal steps
   before `:exhausted`. Aligns with the `retry-strategy` skill's ladder.

### Dependencies
None open (pure functions). Foundation for P4b (Scheduler calls ConflictCheck)
and P4c (Unit FSM uses Retry/Escalation). Advances #437.

### SPECs
In scope: **SPEC-FACTORY-CORE** (Appendix B: `conflict_check.ex`,
`escalation.ex`, `retry.ex` + the three property tests). Conforms to §6
D-312/D-317/D-318/D-343 and §2 C5/C7/C8. No SPEC amendment expected.

### Acceptance criteria
- **AC-3 (D-312/D-343):** `mix test --only property` passes including
  `conflict_check_property_test.exs` — the 5-clause predicate is symmetric, has
  non-trivial self-conflict, and is **monotone** (admission stays sound as
  `in_flight` grows).
- **AC-5 (D-318):** `mix test --only property` passes including
  `retry_property_test.exs` — no outcome sequence exceeds `N_refine + N_pivot`
  before `:exhausted` (bounded ladder; unbounded refine is forbidden).
- **AC-6 (D-317):** `mix test --only property` passes including
  `escalation_property_test.exs` — `classify/1` is **total**: every `term()`
  input maps to exactly one `e ∈ E` with a `scope`, and never raises.

### Gating-test paths (frozen at 10da77c — implementer MUST NOT edit)
- `test/tau/factory/conflict_check_property_test.exs` (AC-3 / D-312 / D-343)
- `test/tau/factory/retry_property_test.exs` (AC-5 / D-318)
- `test/tau/factory/escalation_property_test.exs` (AC-6 / D-317)

Pinned contracts (oracle): `ConflictCheck.clear?(declared_scope, in_flight) :: :clear | {:conflict, clause}`
(declared_scope = `%{deps, files, codepoints, specs, resources}`; clauses
`:no_dependency|:disjoint_files|:disjoint_codepoints|:no_shared_spec|:resource_isolatable`);
`Escalation.classify(trigger) :: {e, scope}` (catch-all `term()` → `{:"E-UNCLASSIFIED", :global}`);
`Retry.next(outcome, refine_count, pivot_count)` N_REFINE=3, N_PIVOT=1.

### Gate verdicts
_(filled at gate time — critic, reviewer)_
