### PR TITLE
P4b-1: Budget — Ledger debit extension + Budget.Owner (D-320/D-332) — advances #437

### DIFF
--- a/lib/tau/factory/budget/owner.ex
+++ b/lib/tau/factory/budget/owner.ex
@@ -1,0 +1,171 @@
+defmodule Tau.Factory.Budget.Owner do
+  @moduledoc """
+  Supervised `GenServer` that owns the per-dimension budget snapshot.
+
+  ## Responsibilities
+
+  - Tracks remaining budget per dimension (`%{atom => non_neg_integer()}`).
+  - Maintains a named ETS table (`:named_table`, `read_concurrency: true`)
+    keyed by `dimension` atom, holding `{dimension, remaining}` tuples.
+  - The ETS table name equals the `:name` atom supplied at `start_link/1`,
+    so `budget_precheck/2` can read it directly by atom without looking up
+    the GenServer pid (B4 — mailbox bypass for the hot admission path).
+
+  ## Invariants
+
+  - **Truth lives in the Ledger.** `Ledger.Writer.debit_budget/4` is called
+    BEFORE the ETS snapshot is updated (D-315 / D-320 WAL-before-ack).
+  - **ETS is a derived projection.** On `init/1` the snapshot is rebuilt from
+    `Ledger.Writer.budget_debited/1`, so a restarted Owner reflects all
+    persisted debits.
+  - **ETS table owned by this process.** Created in `init/1`; dies with the
+    process; rebuilt on restart. No ETS outside an owner process (OTP-1).
+  - **Writer → ETS table mapping** stored in `:persistent_term` so `debit/4`
+    can locate the ETS table given only the writer name. The mapping is
+    registered in `init/1` and erased in `terminate/2`.
+
+  ## Public API
+
+    - `start_link/1` — start and register the process.
+    - `budget_precheck/2` — direct ETS read; returns `:ok` or
+      `{:exhausted, dimension}` (B4).
+    - `debit/4` — plain function: writes to Ledger first, then updates the
+      ETS snapshot directly (D-320 truth-before-projection; no mailbox
+      routing for this call).
+  """
+
+  use GenServer
+
+  alias Tau.Factory.Ledger.Writer
+
+  require Logger
+
+  # `:persistent_term` key prefix for the ledger → ETS table mapping.
+  @pt_prefix {__MODULE__, :ledger_ets_map}
+
+  # ---------------------------------------------------------------------------
+  # Public API
+  # ---------------------------------------------------------------------------
+
+  @doc """
+  Start the `Budget.Owner` and register it under `:name`.
+
+  Required options:
+    - `:ledger`  — `GenServer.server()` reference to a `Ledger.Writer`.
+    - `:totals`  — `%{atom() => non_neg_integer()}` per-dimension limits.
+    - `:name`    — atom; registered name for the GenServer AND the ETS table.
+  """
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(opts) do
+    name = Keyword.fetch!(opts, :name)
+    GenServer.start_link(__MODULE__, opts, name: name)
+  end
+
+  @doc """
+  Check whether the budget for `dimension` has any remaining headroom.
+
+  Reads the ETS table DIRECTLY by the registered name atom — does NOT issue a
+  `GenServer.call`. Returns `:ok` if remaining > 0; `{:exhausted, dimension}`
+  if remaining is 0 or the dimension is absent (B4 / D-320).
+  """
+  @spec budget_precheck(atom(), atom()) :: :ok | {:exhausted, atom()}
+  def budget_precheck(name, dimension) do
+    case :ets.lookup(name, dimension) do
+      [{^dimension, remaining}] when remaining > 0 -> :ok
+      _ -> {:exhausted, dimension}
+    end
+  end
+
+  @doc """
+  Debit `cost` units from `dimension` for `unit_id`.
+
+  `writer` is the `Ledger.Writer` server reference (atom or pid). This
+  function:
+
+  1. Calls `Ledger.Writer.debit_budget/4` first (WAL-before-ack; Ledger is
+     truth). Only after the durable WAL commit does this function proceed.
+  2. Looks up the ETS table associated with `writer` via `:persistent_term`
+     and decrements the snapshot: `remaining' = max(0, remaining - cost)`.
+
+  Returns `:ok`.
+  """
+  @spec debit(GenServer.server(), String.t(), atom(), non_neg_integer()) :: :ok
+  def debit(writer, unit_id, dimension, cost) do
+    # Step 1: persist to Ledger (truth, WAL-before-ack; D-315 / D-320).
+    {:ok, _ref} = Writer.debit_budget(writer, unit_id, dimension, cost)
+
+    # Step 2: update ETS snapshot (projection follows truth).
+    # Look up the ETS table name registered by this writer's Budget.Owner.
+    case :persistent_term.get({@pt_prefix, writer}, nil) do
+      nil ->
+        # No owner registered for this writer — nothing to update.
+        :ok
+
+      ets_table ->
+        update_ets_remaining(ets_table, dimension, cost)
+        :ok
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # GenServer callbacks
+  # ---------------------------------------------------------------------------
+
+  @impl GenServer
+  def init(opts) do
+    ledger = Keyword.fetch!(opts, :ledger)
+    totals = Keyword.fetch!(opts, :totals)
+    name = Keyword.fetch!(opts, :name)
+
+    # Rebuild projection from Ledger truth (D-315).
+    debited = Writer.budget_debited(ledger)
+
+    # Create the named ETS table owned by this process.
+    # Table name == the registered GenServer name (B4).
+    table =
+      :ets.new(name, [
+        :set,
+        :named_table,
+        :public,
+        read_concurrency: true
+      ])
+
+    # Populate with remaining = max(0, total - debited) per dimension.
+    Enum.each(totals, fn {dim, limit} ->
+      spent = Map.get(debited, dim, 0)
+      remaining = max(0, limit - spent)
+      :ets.insert(table, {dim, remaining})
+    end)
+
+    # Register the writer → ETS table mapping so debit/4 can find the table.
+    :persistent_term.put({@pt_prefix, ledger}, name)
+
+    {:ok, %{ledger: ledger, totals: totals, name: name}}
+  end
+
+  @impl GenServer
+  def terminate(_reason, %{ledger: ledger}) do
+    # Clean up the persistent_term entry so a restarted owner can re-register.
+    :persistent_term.erase({@pt_prefix, ledger})
+    :ok
+  end
+
+  def terminate(_reason, _state), do: :ok
+
+  # ---------------------------------------------------------------------------
+  # Private helpers
+  # ---------------------------------------------------------------------------
+
+  # Decrement the ETS remaining counter by `cost`, flooring at 0.
+  defp update_ets_remaining(table, dimension, cost) do
+    case :ets.lookup(table, dimension) do
+      [{^dimension, remaining}] ->
+        new_remaining = max(0, remaining - cost)
+        :ets.insert(table, {dimension, new_remaining})
+
+      [] ->
+        # Dimension not in totals — no ETS entry; nothing to update.
+        :ok
+    end
+  end
+end

--- a/lib/tau/factory/budget/owner.ex
+++ b/lib/tau/factory/budget/owner.ex
@@ -157,15 +157,20 @@ defmodule Tau.Factory.Budget.Owner do
   # ---------------------------------------------------------------------------
 
   # Decrement the ETS remaining counter by `cost`, flooring at 0.
+  #
+  # Uses `:ets.update_counter/3` with a threshold guard so the decrement is
+  # atomic — no read-modify-write window. Tuple layout: {dimension, remaining},
+  # so remaining is at position 2. The op `{2, -cost, 0, 0}` means:
+  # decrement position 2 by `cost`; if the result would go below 0, set to 0.
+  #
+  # Guards with `:ets.member/2` first so that a debit on an unconfigured
+  # dimension (no ETS row) is a silent no-op rather than a raised error — the
+  # same graceful behaviour as the previous `[]` branch.
   defp update_ets_remaining(table, dimension, cost) do
-    case :ets.lookup(table, dimension) do
-      [{^dimension, remaining}] ->
-        new_remaining = max(0, remaining - cost)
-        :ets.insert(table, {dimension, new_remaining})
-
-      [] ->
-        # Dimension not in totals — no ETS entry; nothing to update.
-        :ok
+    if :ets.member(table, dimension) do
+      :ets.update_counter(table, dimension, {2, -cost, 0, 0})
     end
+
+    :ok
   end
 end

--- a/lib/tau/factory/ledger/migrations.ex
+++ b/lib/tau/factory/ledger/migrations.ex
@@ -46,6 +46,16 @@ defmodule Tau.Factory.Ledger.Migrations do
      CREATE UNIQUE INDEX IF NOT EXISTS verdicts_original_uidx
        ON verdicts (hash, run, half)
        WHERE supersedes_id IS NULL
+     """},
+    {"20260611_004_budget_debits",
+     """
+     CREATE TABLE IF NOT EXISTS budget_debits (
+       id          INTEGER PRIMARY KEY AUTOINCREMENT,
+       unit_id     TEXT    NOT NULL,
+       dimension   TEXT    NOT NULL,
+       cost        INTEGER NOT NULL,
+       inserted_at TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+     )
      """}
   ]
 

--- a/lib/tau/factory/ledger/writer.ex
+++ b/lib/tau/factory/ledger/writer.ex
@@ -108,6 +108,32 @@ defmodule Tau.Factory.Ledger.Writer do
     GenServer.call(server, {:latest_verdict_status, coord})
   end
 
+  @doc """
+  Append a budget-debit row for the given `unit_id`, `dimension`, and `cost`.
+
+  This is append-only — no UPDATE or upsert. Multiple calls with the same
+  `(unit_id, dimension)` each produce a separate row. WAL-before-ack: the
+  `{:ok, ref}` reply arrives only after the SQLite WAL commit is durable (D-315,
+  D-320).
+
+  Returns `{:ok, ref}` where `ref` is the inserted row id.
+  """
+  @spec debit_budget(GenServer.server(), String.t(), atom(), non_neg_integer()) ::
+          {:ok, ref()}
+  def debit_budget(server, unit_id, dimension, cost) do
+    GenServer.call(server, {:debit_budget, unit_id, dimension, cost})
+  end
+
+  @doc """
+  Return a map of `%{dimension_atom => total_cost}` by summing all recorded
+  debit rows per dimension. Used by `Tau.Factory.Budget.Owner.init/1` to
+  rebuild the ETS snapshot from Ledger truth.
+  """
+  @spec budget_debited(GenServer.server()) :: %{atom() => non_neg_integer()}
+  def budget_debited(server) do
+    GenServer.call(server, :budget_debited)
+  end
+
   # ---------------------------------------------------------------------------
   # GenServer callbacks
   # ---------------------------------------------------------------------------
@@ -141,6 +167,16 @@ defmodule Tau.Factory.Ledger.Writer do
 
   def handle_call({:latest_verdict_status, coord}, _from, %{db: db} = state) do
     result = do_latest_verdict_status(db, coord)
+    {:reply, result, state}
+  end
+
+  def handle_call({:debit_budget, unit_id, dimension, cost}, _from, %{db: db} = state) do
+    result = do_debit_budget(db, unit_id, dimension, cost)
+    {:reply, result, state}
+  end
+
+  def handle_call(:budget_debited, _from, %{db: db} = state) do
+    result = do_budget_debited(db)
     {:reply, result, state}
   end
 
@@ -311,6 +347,56 @@ defmodule Tau.Factory.Ledger.Writer do
     else
       _ -> nil
     end
+  end
+
+  # Insert an append-only budget-debit row. No UPDATE/upsert path.
+  # WAL-before-ack: reply sent only after step/2 (commit) returns.
+  defp do_debit_budget(db, unit_id, dimension, cost) do
+    dimension_text = Atom.to_string(dimension)
+
+    sql = """
+    INSERT INTO budget_debits (unit_id, dimension, cost)
+    VALUES (?1, ?2, ?3)
+    """
+
+    with {:ok, stmt} <- Exqlite.Sqlite3.prepare(db, String.trim(sql)),
+         :ok <- Exqlite.Sqlite3.bind(stmt, [unit_id, dimension_text, cost]),
+         step_result <- Exqlite.Sqlite3.step(db, stmt),
+         :ok <- Exqlite.Sqlite3.release(db, stmt) do
+      case step_result do
+        :done -> {:ok, fetch_last_rowid(db)}
+        {:error, reason} -> {:error, reason}
+      end
+    end
+  end
+
+  # SELECT dimension, SUM(cost) GROUP BY dimension; return as %{atom => integer}.
+  # Converts stored text back to atom via String.to_existing_atom/1.
+  # Unknown atoms (not pre-existing in the atom table) are skipped gracefully.
+  defp do_budget_debited(db) do
+    sql = """
+    SELECT dimension, SUM(cost) FROM budget_debits GROUP BY dimension
+    """
+
+    with {:ok, stmt} <- Exqlite.Sqlite3.prepare(db, String.trim(sql)),
+         {:ok, rows} <- Exqlite.Sqlite3.fetch_all(db, stmt),
+         :ok <- Exqlite.Sqlite3.release(db, stmt) do
+      Enum.reduce(rows, %{}, fn [dim_text, sum], acc ->
+        case safe_to_existing_atom(dim_text) do
+          {:ok, dim_atom} -> Map.put(acc, dim_atom, sum)
+          :error -> acc
+        end
+      end)
+    else
+      _ -> %{}
+    end
+  end
+
+  # Safely convert a string to an existing atom; return :error if unknown.
+  defp safe_to_existing_atom(text) do
+    {:ok, String.to_existing_atom(text)}
+  rescue
+    ArgumentError -> :error
   end
 
   defp atom_to_half(:critic), do: "critic"

--- a/lib/tau/factory/supervisor.ex
+++ b/lib/tau/factory/supervisor.ex
@@ -39,6 +39,7 @@ defmodule Tau.Factory.Supervisor do
     repo_dir = Keyword.get(opts, :repo_dir)
     required_halves = Keyword.get(opts, :required_halves, [:critic, :reviewer])
     merge_authority_opts = Keyword.get(opts, :merge_authority_opts, [])
+    budget_opts = Keyword.get(opts, :budget_opts)
 
     # Derive a per-supervisor writer name so concurrent supervisor instances
     # (e.g. isolated test instances) do not conflict on the writer's name.
@@ -69,20 +70,16 @@ defmodule Tau.Factory.Supervisor do
     ]
 
     children =
-      if repo_dir do
-        ma_opts =
-          [
-            name: ma_name,
-            ledger: writer_name,
-            repo_dir: repo_dir,
-            tasks_name: tasks_name,
-            required_halves: required_halves
-          ] ++ merge_authority_opts
-
-        base_children ++ [{Tau.Factory.MergeAuthority, ma_opts}]
-      else
-        base_children
-      end
+      base_children
+      |> maybe_add_budget_owner(budget_opts, writer_name)
+      |> maybe_add_merge_authority(
+        repo_dir,
+        ma_name,
+        writer_name,
+        tasks_name,
+        required_halves,
+        merge_authority_opts
+      )
 
     Supervisor.init(children, strategy: :one_for_one)
   end
@@ -90,6 +87,51 @@ defmodule Tau.Factory.Supervisor do
   # ---------------------------------------------------------------------------
   # Private helpers
   # ---------------------------------------------------------------------------
+
+  # Add Budget.Owner as a child only when budget_opts are provided.
+  # Requires :totals and :name in budget_opts; threads :ledger from writer_name.
+  defp maybe_add_budget_owner(children, nil, _writer_name), do: children
+
+  defp maybe_add_budget_owner(children, budget_opts, writer_name) do
+    owner_opts =
+      budget_opts
+      |> Keyword.put(:ledger, writer_name)
+
+    children ++ [{Tau.Factory.Budget.Owner, owner_opts}]
+  end
+
+  # Add MergeAuthority as a child only when repo_dir is provided.
+  defp maybe_add_merge_authority(
+         children,
+         nil,
+         _ma_name,
+         _writer_name,
+         _tasks_name,
+         _halves,
+         _ma_opts
+       ),
+       do: children
+
+  defp maybe_add_merge_authority(
+         children,
+         repo_dir,
+         ma_name,
+         writer_name,
+         tasks_name,
+         required_halves,
+         merge_authority_opts
+       ) do
+    ma_opts =
+      [
+        name: ma_name,
+        ledger: writer_name,
+        repo_dir: repo_dir,
+        tasks_name: tasks_name,
+        required_halves: required_halves
+      ] ++ merge_authority_opts
+
+    children ++ [{Tau.Factory.MergeAuthority, ma_opts}]
+  end
 
   defp default_db_path do
     Path.join(Tau.Settings.data_dir(), "factory_ledger.db")

--- a/test/tau/factory/budget_admission_test.exs
+++ b/test/tau/factory/budget_admission_test.exs
@@ -1,0 +1,349 @@
+defmodule Tau.Factory.BudgetAdmissionTest do
+  @moduledoc """
+  Gating tests for PR #439 (P4b1-Budget) — AC-4 / D-320 / D-332 / D-315.
+
+  Verifies:
+    - D-320: hard pre-admission ceiling (budget_precheck denies at/after ceiling).
+    - D-332: budget conservation (Σ debits == total − remaining at all points;
+             debits are append-only; duplicate (unit_id, dimension) pairs both persist).
+    - D-315: durability / rebuild from L (Budget.Owner restart rebuilds snapshot
+             from Ledger truth; persisted debits survive projection loss).
+
+  Written BEFORE production code exists (oracle-separation phase, factory-loop §4b).
+  Tests fail at runtime (UndefinedFunctionError / FunctionClauseError) until the
+  implementer creates:
+    - `lib/tau/factory/budget/owner.ex` (Tau.Factory.Budget.Owner — wholly absent)
+    - `lib/tau/factory/ledger/writer.ex` extended with `debit_budget/4` and
+      `budget_debited/1` (Tau.Factory.Ledger.Writer already exists; new functions
+      will raise UndefinedFunctionError until added)
+
+  ## Pinned API contract (implementer must conform exactly)
+
+  ### Tau.Factory.Ledger.Writer extensions (new functions on existing GenServer)
+
+    - `debit_budget(writer, unit_id, dimension, cost) :: {:ok, ref}`
+        Appends a budget-debit row (append-only; no UPDATE/DELETE).
+        WAL-before-ack: ack arrives only after the durable SQLite WAL commit.
+        `unit_id` is a string; `dimension` is an atom (e.g. `:tokens`);
+        `cost` is a non-negative integer.
+        Multiple calls with the same `(unit_id, dimension)` each append a separate
+        row — there is no upsert/merge; every call is independently durable.
+
+    - `budget_debited(writer) :: %{atom() => non_neg_integer()}`
+        Returns a map of `%{dimension => total_cost}` by summing all recorded
+        debit rows per dimension. Used by Budget.Owner.init/1 to rebuild the
+        ETS snapshot from Ledger truth.
+
+  ### Tau.Factory.Budget.Owner (new GenServer; wholly absent before this PR)
+
+    - `start_link(opts) :: GenServer.on_start()`
+        Required options:
+          `:ledger`  — writer ref (pid or registered name).
+          `:totals`  — `%{atom() => non_neg_integer()}` — per-dimension budget limits.
+          `:name`    — registered name for the GenServer process.
+        `init/1` reads `totals` + calls `Ledger.Writer.budget_debited/1` to obtain
+        the current Σ spend per dimension, then creates a `read_concurrency: true`
+        ETS table named after the process's registered name. The ETS table stores
+        `{dimension, remaining}` tuples where `remaining = limit - spent`.
+
+    - `budget_precheck(server_name, dimension) :: :ok | {:exhausted, dimension}`
+        Reads the ETS table DIRECTLY by the registered name (the table is named
+        by the atom given as `:name` at start_link time). Does NOT issue a
+        GenServer.call — bypasses the owner's mailbox. Returns `:ok` if remaining
+        > 0 for the dimension, `{:exhausted, dimension}` otherwise.
+        NOTE: the ETS table name IS the `:name` option passed to start_link.
+
+    - `debit(server, unit_id, dimension, cost) :: :ok`
+        1. Calls `Ledger.Writer.debit_budget(ledger, unit_id, dimension, cost)`
+           first (WAL-before-ack; Ledger is truth).
+        2. Then decrements the ETS snapshot: `remaining' = max(0, remaining - cost)`.
+
+  AC linkage: AC-4 / D-320 / D-332 / D-315.
+  """
+
+  use ExUnit.Case, async: true
+
+  @moduletag :ac_4
+  @moduletag :d_320
+  @moduletag :d_332
+  @moduletag :d_315
+  @moduletag :capture_log
+
+  # Runtime module references — file compiles even when modules do not yet exist.
+  # Using @mod attributes avoids alias-time resolution and compile-time crashes.
+  @writer Tau.Factory.Ledger.Writer
+  @owner Tau.Factory.Budget.Owner
+
+  # ---------------------------------------------------------------------------
+  # Helpers
+  # ---------------------------------------------------------------------------
+
+  # Start an isolated Ledger.Writer and Budget.Owner pair backed by a tmp DB.
+  # Returns {writer_name, owner_name} so tests can reference them.
+  defp start_isolated_pair(totals) do
+    db_path = Briefly.create!(extname: ".db")
+    uid = System.unique_integer([:positive])
+    writer_name = :"test_budget_writer_#{uid}"
+    owner_name = :"test_budget_owner_#{uid}"
+
+    start_supervised!(
+      {@writer, db_path: db_path, name: writer_name},
+      id: :"writer_#{uid}"
+    )
+
+    start_supervised!(
+      {@owner, ledger: writer_name, totals: totals, name: owner_name},
+      id: :"owner_#{uid}"
+    )
+
+    {writer_name, owner_name}
+  end
+
+  # ---------------------------------------------------------------------------
+  # D-320 — hard pre-admission ceiling
+  # ---------------------------------------------------------------------------
+
+  describe "AC-4 / D-320 — budget_precheck denies admission at the ceiling" do
+    @tag :d_320
+    test "AC-4 / D-320: precheck returns :ok while headroom remains, {:exhausted, dim} at ceiling" do
+      totals = %{tokens: 100}
+      {writer_name, owner_name} = start_isolated_pair(totals)
+
+      # Headroom intact initially.
+      assert :ok = @owner.budget_precheck(owner_name, :tokens)
+
+      # Debit up to 99 — still headroom.
+      :ok = @owner.debit(writer_name, "unit-1", :tokens, 50)
+      :ok = @owner.debit(writer_name, "unit-2", :tokens, 49)
+
+      assert :ok = @owner.budget_precheck(owner_name, :tokens)
+
+      # Debit the final token — exactly at ceiling (remaining becomes 0).
+      :ok = @owner.debit(writer_name, "unit-3", :tokens, 1)
+
+      # At or past the ceiling: admission must be denied.
+      assert {:exhausted, :tokens} = @owner.budget_precheck(owner_name, :tokens)
+    end
+
+    @tag :d_320
+    test "AC-4 / D-320: overrun is bounded — recorded spend does not exceed ceiling by more than one in-flight action" do
+      totals = %{tokens: 10}
+      {writer_name, owner_name} = start_isolated_pair(totals)
+
+      # Drain to exactly the limit.
+      :ok = @owner.debit(writer_name, "unit-a", :tokens, 10)
+
+      assert {:exhausted, :tokens} = @owner.budget_precheck(owner_name, :tokens)
+
+      # Total recorded spend via Ledger must not exceed the ceiling.
+      debited = @writer.budget_debited(writer_name)
+      assert Map.get(debited, :tokens, 0) <= totals.tokens
+    end
+
+    @tag :d_320
+    test "AC-4 / D-320: a fresh owner with no prior debits allows any dimension with headroom" do
+      totals = %{tokens: 500, cost_usd_micros: 1_000_000}
+      {_writer_name, owner_name} = start_isolated_pair(totals)
+
+      assert :ok = @owner.budget_precheck(owner_name, :tokens)
+      assert :ok = @owner.budget_precheck(owner_name, :cost_usd_micros)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # D-332 — budget conservation
+  # ---------------------------------------------------------------------------
+
+  describe "AC-4 / D-332 — Σ recorded debits == total − remaining at all observation points" do
+    @tag :d_332
+    test "AC-4 / D-332: conservation holds after each debit" do
+      totals = %{tokens: 200}
+      {writer_name, owner_name} = start_isolated_pair(totals)
+
+      # Observation 1: no debits yet.
+      debited = @writer.budget_debited(writer_name)
+      spent = Map.get(debited, :tokens, 0)
+      # Derive remaining from ETS via budget_precheck and a successive-debit probe
+      # is indirect — instead confirm the conservation law structurally:
+      # spent == 0, so remaining must equal total.
+      assert spent == 0
+
+      # Debit 60.
+      :ok = @owner.debit(writer_name, "unit-1", :tokens, 60)
+
+      # Observation 2: after 60 debit.
+      debited = @writer.budget_debited(writer_name)
+      spent2 = Map.get(debited, :tokens, 0)
+      assert spent2 == 60
+
+      # Debit 40 more.
+      :ok = @owner.debit(writer_name, "unit-2", :tokens, 40)
+
+      # Observation 3: after 100 total.
+      debited = @writer.budget_debited(writer_name)
+      spent3 = Map.get(debited, :tokens, 0)
+      assert spent3 == 100
+
+      # Conservation: spent + remaining == total.
+      # We know total = 200 and spent = 100, so remaining must be 100.
+      # Confirm by checking that precheck still passes (remaining > 0).
+      assert :ok = @owner.budget_precheck(owner_name, :tokens)
+
+      # Drain the remainder.
+      :ok = @owner.debit(writer_name, "unit-3", :tokens, 100)
+
+      debited = @writer.budget_debited(writer_name)
+      spent4 = Map.get(debited, :tokens, 0)
+      assert spent4 == 200
+
+      # Conservation: spent(200) + remaining(0) == total(200).
+      assert {:exhausted, :tokens} = @owner.budget_precheck(owner_name, :tokens)
+    end
+
+    @tag :d_332
+    test "AC-4 / D-332: debits are append-only — two debits at same (unit_id, dimension) both persist" do
+      totals = %{tokens: 1_000}
+      {writer_name, _owner_name} = start_isolated_pair(totals)
+
+      :ok = @owner.debit(writer_name, "unit-dup", :tokens, 30)
+      :ok = @owner.debit(writer_name, "unit-dup", :tokens, 20)
+
+      # Both rows must persist — total must reflect the SUM, not the latest.
+      debited = @writer.budget_debited(writer_name)
+      assert Map.get(debited, :tokens, 0) == 50
+    end
+
+    @tag :d_332
+    test "AC-4 / D-332: budget_debited returns separate Σ per dimension" do
+      totals = %{tokens: 500, cost_usd_micros: 1_000_000}
+      {writer_name, _owner_name} = start_isolated_pair(totals)
+
+      :ok = @owner.debit(writer_name, "unit-x", :tokens, 100)
+      :ok = @owner.debit(writer_name, "unit-x", :cost_usd_micros, 200)
+      :ok = @owner.debit(writer_name, "unit-y", :tokens, 50)
+
+      debited = @writer.budget_debited(writer_name)
+      assert Map.get(debited, :tokens, 0) == 150
+      assert Map.get(debited, :cost_usd_micros, 0) == 200
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # D-315 — durability / rebuild from L after Budget.Owner restart
+  # ---------------------------------------------------------------------------
+
+  describe "AC-4 / D-315 — Budget.Owner restart rebuilds snapshot from Ledger truth" do
+    @tag :d_315
+    test "AC-4 / D-315: debits survive Budget.Owner process loss — fresh owner reflects persisted spend" do
+      db_path = Briefly.create!(extname: ".db")
+      uid = System.unique_integer([:positive])
+      writer_name = :"test_durability_writer_#{uid}"
+      owner_name = :"test_durability_owner_#{uid}"
+
+      start_supervised!(
+        {@writer, db_path: db_path, name: writer_name},
+        id: :"dur_writer_#{uid}"
+      )
+
+      owner_spec_id = :"dur_owner_#{uid}"
+
+      start_supervised!(
+        {@owner, ledger: writer_name, totals: %{tokens: 300}, name: owner_name},
+        id: owner_spec_id
+      )
+
+      # Debit 250 tokens while the owner is alive.
+      :ok = @owner.debit(writer_name, "unit-persist-1", :tokens, 150)
+      :ok = @owner.debit(writer_name, "unit-persist-2", :tokens, 100)
+
+      # Verify ceiling not yet hit (50 tokens remain).
+      assert :ok = @owner.budget_precheck(owner_name, :tokens)
+
+      # STOP the Budget.Owner — simulates a process crash/restart.
+      stop_supervised!(owner_spec_id)
+
+      # START a FRESH Budget.Owner against the SAME Ledger.Writer (same DB truth).
+      start_supervised!(
+        {@owner, ledger: writer_name, totals: %{tokens: 300}, name: owner_name},
+        id: owner_spec_id
+      )
+
+      # The fresh owner must have rebuilt its snapshot from L truth:
+      # 250 tokens already spent → 50 remaining.
+      # Debit 51 tokens — must exhaust the budget.
+      :ok = @owner.debit(writer_name, "unit-post-restart", :tokens, 50)
+      # Now exactly at ceiling (300 spent).
+      assert {:exhausted, :tokens} = @owner.budget_precheck(owner_name, :tokens)
+
+      # Conservation: Ledger must record all 300 tokens.
+      debited = @writer.budget_debited(writer_name)
+      assert Map.get(debited, :tokens, 0) == 300
+    end
+
+    @tag :d_315
+    test "AC-4 / D-315: a Budget.Owner started with a populated Ledger immediately reflects prior spend" do
+      db_path = Briefly.create!(extname: ".db")
+      uid = System.unique_integer([:positive])
+      writer_name = :"test_prepop_writer_#{uid}"
+      owner_name = :"test_prepop_owner_#{uid}"
+
+      start_supervised!(
+        {@writer, db_path: db_path, name: writer_name},
+        id: :"prepop_writer_#{uid}"
+      )
+
+      # Insert debits directly via the Writer (no Owner started yet).
+      assert {:ok, _} = @writer.debit_budget(writer_name, "pre-1", :tokens, 80)
+      assert {:ok, _} = @writer.debit_budget(writer_name, "pre-2", :tokens, 70)
+
+      # Now start an Owner that must rebuild from those 150 tokens.
+      start_supervised!(
+        {@owner, ledger: writer_name, totals: %{tokens: 200}, name: owner_name},
+        id: :"prepop_owner_#{uid}"
+      )
+
+      # 50 tokens remain (200 - 150). Debit 50 more to hit ceiling exactly.
+      :ok = @owner.debit(writer_name, "post-start", :tokens, 50)
+
+      assert {:exhausted, :tokens} = @owner.budget_precheck(owner_name, :tokens)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # B4 — budget_precheck bypasses the GenServer mailbox (direct ETS read)
+  # ---------------------------------------------------------------------------
+
+  describe "AC-4 / B4 — budget_precheck is a direct ETS read that bypasses the owner mailbox" do
+    @tag :d_320
+    test "AC-4 / B4: budget_precheck can be called with only the registered name (no pid required)" do
+      # B4 contract: `budget_precheck(name, dimension)` resolves the ETS table
+      # by the registered name atom, NOT by the GenServer pid. This means the
+      # caller never needs to look up the owner pid — it reads ETS directly.
+      # If the implementation incorrectly routes through the mailbox
+      # (e.g. GenServer.call), this test still passes in isolation but the
+      # mailbox-bypass contract is violated; the critic's gate covers that.
+      # What we can assert deterministically: the call works with just the name.
+      totals = %{tokens: 1_000}
+      {_writer_name, owner_name} = start_isolated_pair(totals)
+
+      # Call using only the atom name (no pid lookup).
+      result = @owner.budget_precheck(owner_name, :tokens)
+      assert result == :ok
+    end
+
+    @tag :d_320
+    test "AC-4 / B4: budget_precheck reflects the ETS snapshot, not a fresh DB read" do
+      # After a debit the ETS snapshot must be updated synchronously.
+      # budget_precheck must see the updated value immediately — no async lag.
+      totals = %{tokens: 5}
+      {writer_name, owner_name} = start_isolated_pair(totals)
+
+      assert :ok = @owner.budget_precheck(owner_name, :tokens)
+
+      :ok = @owner.debit(writer_name, "unit-snap", :tokens, 5)
+
+      # ETS snapshot was updated by debit/4 after the WAL commit.
+      assert {:exhausted, :tokens} = @owner.budget_precheck(owner_name, :tokens)
+    end
+  end
+end


### PR DESCRIPTION
## P4b-1 — Budget: Ledger debit extension + Budget.Owner (D-320, D-332)

Advances #437 (P4 control plane). First half of P4b (the admission authority);
P4b-2 adds the `Scheduler` that calls `budget_precheck`. Splits P4b so the
Ledger durable-spine change (budget truth, WAL-before-ack) gets focused review
separate from the Scheduler admission logic.

### Scope (SPEC-FACTORY-CORE §2 C1/C2, §4 B3/B4, §6 D-320/D-332; [C101-B4])
1. `lib/tau/factory/ledger/migrations.ex` (EXTEND) — add an **append-only**
   `budget_debits` table (`id`, `unit_id`, `dimension` TEXT, `cost` INTEGER,
   `inserted_at`). No UPDATE/DELETE path — debits accumulate; conservation is a
   query (D-332). The per-dimension **total** (ceiling) is configuration, not a
   row.
2. `lib/tau/factory/ledger/writer.ex` (EXTEND) — `debit_budget(writer, unit_id,
   dimension, cost) :: {:ok, ref}` (append a debit row, **WAL-before-ack** per
   D-315, same discipline as `append_verdict`) + `budget_debited(writer) ::
   %{dimension => integer}` (Σ cost per dimension — the rebuild source). Budget
   **truth is written only here** ([C101-B4]); no other writer.
3. `lib/tau/factory/budget/owner.ex` (NEW) — `Tau.Factory.Budget.Owner`, a
   `GenServer` (**L hot-read, C2**). `init/1`: read the configured totals + the
   Ledger's `budget_debited` Σ → build a `read_concurrency` ETS table of
   **remaining per dimension** (a derived projection rebuilt from L truth).
   - `budget_precheck(dimension_or_unit) :: :ok | {:exhausted, dimension}` —
     reads the ETS snapshot **directly** (bypasses the owner mailbox; reads are
     not serialized, B4). `:ok` iff remaining headroom exists for the dimension;
     else `{:exhausted, dimension}`.
   - `debit(owner, unit_id, dimension, cost)` — writes truth via
     `Ledger.Writer.debit_budget` FIRST, then updates the ETS snapshot. **D-320:**
     admission is denied at the ceiling **before** the unit becomes billable;
     recorded spend overruns the ceiling by ≤ one in-flight action.
   - Crash/restart: the ETS snapshot is rebuilt from L in `init/1` (RPO=0 — the
     truth survives; the projection is reconstructed).
4. `lib/tau/factory/supervisor.ex` (EDIT) — add `Budget.Owner` under
   `Tau.Factory.Supervisor` (after `Ledger.Writer`, since it reads L in init),
   name/`:ledger`/`:totals`-scoped for test isolation.

### Dependencies
Depends on P2-Ledger (`Ledger.Writer`, `5698b67`-era). Blocks P4b-2 (Scheduler's
`budget_precheck`). Advances #437.

### SPECs
In scope: **SPEC-FACTORY-CORE** (Appendix B: `ledger/writer.ex`,
`ledger/migrations.ex`, `budget/owner.ex`, `factory/supervisor.ex`). Conforms to
§4 B3/B4, §6 D-320/D-332, [C101-B4]. No SPEC amendment expected.

### Acceptance criteria
- **AC-4 (D-320):** `budget_admission_test.exs` — `budget_precheck` returns
  `{:exhausted, dimension}` at the ceiling, and admission is denied **before**
  the unit becomes billable (overrun ≤ one in-flight action). The ETS read does
  not go through the owner mailbox.
- **AC-4 (D-332):** budget **conservation** — `Σ recorded debit cost = total −
  remaining` for every dimension at every observation point; debits are
  append-only (no UPDATE/DELETE path exists).
- **AC-4 (D-315 durability):** `Budget.Owner` rebuilds the correct `remaining`
  snapshot from the Ledger after a restart (the debits survive; the projection
  is reconstructed in `init/1`).

### Gating-test paths (frozen at 74d737c — implementer MUST NOT edit)
- `test/tau/factory/budget_admission_test.exs` (AC-4 / D-320 / D-332 / D-315 / B4)

Pinned (oracle): `Ledger.Writer.debit_budget(w, unit_id, dimension, cost) :: {:ok, ref}` (append-only, WAL-before-ack)
+ `budget_debited(w) :: %{dim => Σcost}`; `Budget.Owner.start_link(ledger:, totals: %{dim => limit}, name:)`,
`budget_precheck(name, dimension) :: :ok | {:exhausted, dim}` (direct read of a `read_concurrency` ETS table
named = the `:name` atom — bypasses the mailbox), `debit(server, unit_id, dim, cost)` (Ledger first, then ETS).

### Gate verdicts
_(filled at gate time — critic, reviewer)_
