### PR TITLE
P4b-2: Scheduler admission authority (D-312/D-343) — advances #437

### DIFF
--- a/lib/tau/factory/scheduler.ex
+++ b/lib/tau/factory/scheduler.ex
@@ -1,0 +1,177 @@
+defmodule Tau.Factory.Scheduler do
+  @moduledoc """
+  Admission authority for parallel PR execution (SPEC-FACTORY-CORE §4, D-312, D-343).
+
+  Holds the in-flight set F (`%{unit_id => declared_scope}`) in GenServer state
+  and gates admission through three sequential conditions:
+
+  1. **Conflict check** — `ConflictCheck.clear?(declared_scope, F)`.
+  2. **Capacity check** — `map_size(F) < w_cap`.
+  3. **Budget check** (when `:budget` is configured) — calls
+     `Budget.Owner.budget_precheck/2` for each configured dimension.
+
+  The first failing condition wins (defer reason precedence: conflict →
+  at_capacity → budget). A `{:defer, _}` reply NEVER mutates F (D-343).
+
+  ## Public API
+
+    - `start_link/1` — start and register.
+    - `admit/3` — `call`; returns `:admit` or `{:defer, reason}`.
+    - `release/2` — `call`; removes `unit_id` from F; no-op if absent.
+    - `in_flight/1` — `call`; returns the current F snapshot.
+  """
+
+  use GenServer
+
+  alias Tau.Factory.Budget.Owner, as: BudgetOwner
+  alias Tau.Factory.ConflictCheck
+
+  # ---------------------------------------------------------------------------
+  # Types
+  # ---------------------------------------------------------------------------
+
+  @type unit_id :: String.t()
+  @type declared_scope :: ConflictCheck.scope()
+  @type defer_reason ::
+          {:conflict, ConflictCheck.clause()}
+          | :at_capacity
+          | {:budget, atom()}
+
+  @type state :: %{
+          f: %{unit_id() => declared_scope()},
+          w_cap: pos_integer(),
+          budget: {atom(), [atom()]} | nil
+        }
+
+  # ---------------------------------------------------------------------------
+  # Public API
+  # ---------------------------------------------------------------------------
+
+  @doc """
+  Start the Scheduler and register it under `:name`.
+
+  Required options:
+    - `:name`  — atom; registered name for the GenServer.
+    - `:w_cap` — positive integer; maximum concurrent admitted units (|F| < W_cap).
+
+  Optional options:
+    - `:budget` — `{owner_name :: atom(), dimensions :: [atom()]}`;
+                  if present, `admit/3` gates on `Budget.Owner.budget_precheck/2`
+                  for each listed dimension.
+  """
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(opts) do
+    name = Keyword.fetch!(opts, :name)
+    GenServer.start_link(__MODULE__, opts, name: name)
+  end
+
+  @doc """
+  Attempt to admit `unit_id` with `declared_scope`.
+
+  Returns `:admit` when all conditions clear; `{:defer, reason}` otherwise.
+  On `:admit`, `unit_id => declared_scope` is added to F before the reply.
+  On `{:defer, _}`, F is left unchanged (D-343).
+
+  Defer reason precedence: `{:conflict, clause}` → `:at_capacity` → `{:budget, dim}`.
+  """
+  @spec admit(GenServer.server(), unit_id(), declared_scope()) ::
+          :admit | {:defer, defer_reason()}
+  def admit(server, unit_id, declared_scope) do
+    GenServer.call(server, {:admit, unit_id, declared_scope})
+  end
+
+  @doc """
+  Release `unit_id` from F. No-op if `unit_id` is not currently in F.
+  """
+  @spec release(GenServer.server(), unit_id()) :: :ok
+  def release(server, unit_id) do
+    GenServer.call(server, {:release, unit_id})
+  end
+
+  @doc """
+  Return a snapshot of the current in-flight set F.
+  """
+  @spec in_flight(GenServer.server()) :: %{unit_id() => declared_scope()}
+  def in_flight(server) do
+    GenServer.call(server, :in_flight)
+  end
+
+  # ---------------------------------------------------------------------------
+  # GenServer callbacks
+  # ---------------------------------------------------------------------------
+
+  @impl GenServer
+  def init(opts) do
+    w_cap = Keyword.fetch!(opts, :w_cap)
+    budget = Keyword.get(opts, :budget, nil)
+
+    state = %{
+      f: %{},
+      w_cap: w_cap,
+      budget: budget
+    }
+
+    {:ok, state}
+  end
+
+  @impl GenServer
+  def handle_call({:admit, unit_id, declared_scope}, _from, state) do
+    case evaluate_admission(declared_scope, state) do
+      :admit ->
+        new_f = Map.put(state.f, unit_id, declared_scope)
+        {:reply, :admit, %{state | f: new_f}}
+
+      {:defer, reason} ->
+        # D-343: F MUST NOT be mutated on a defer path.
+        {:reply, {:defer, reason}, state}
+    end
+  end
+
+  def handle_call({:release, unit_id}, _from, state) do
+    new_f = Map.delete(state.f, unit_id)
+    {:reply, :ok, %{state | f: new_f}}
+  end
+
+  def handle_call(:in_flight, _from, state) do
+    {:reply, state.f, state}
+  end
+
+  # ---------------------------------------------------------------------------
+  # Private helpers
+  # ---------------------------------------------------------------------------
+
+  # Evaluate all three admission conditions in precedence order.
+  # Returns :admit or {:defer, reason}. Never mutates state.
+  @spec evaluate_admission(declared_scope(), state()) :: :admit | {:defer, defer_reason()}
+  defp evaluate_admission(declared_scope, %{f: f, w_cap: w_cap, budget: budget}) do
+    with :clear <- ConflictCheck.clear?(declared_scope, f),
+         :ok <- check_capacity(f, w_cap),
+         :ok <- check_budget(budget) do
+      :admit
+    else
+      {:conflict, clause} -> {:defer, {:conflict, clause}}
+      {:defer, reason} -> {:defer, reason}
+    end
+  end
+
+  @spec check_capacity(%{}, pos_integer()) :: :ok | {:defer, :at_capacity}
+  defp check_capacity(f, w_cap) do
+    if map_size(f) < w_cap do
+      :ok
+    else
+      {:defer, :at_capacity}
+    end
+  end
+
+  @spec check_budget({atom(), [atom()]} | nil) :: :ok | {:defer, {:budget, atom()}}
+  defp check_budget(nil), do: :ok
+
+  defp check_budget({owner_name, dimensions}) do
+    Enum.reduce_while(dimensions, :ok, fn dim, :ok ->
+      case BudgetOwner.budget_precheck(owner_name, dim) do
+        :ok -> {:cont, :ok}
+        {:exhausted, dim} -> {:halt, {:defer, {:budget, dim}}}
+      end
+    end)
+  end
+end

--- a/lib/tau/factory/supervisor.ex
+++ b/lib/tau/factory/supervisor.ex
@@ -40,6 +40,7 @@ defmodule Tau.Factory.Supervisor do
     required_halves = Keyword.get(opts, :required_halves, [:critic, :reviewer])
     merge_authority_opts = Keyword.get(opts, :merge_authority_opts, [])
     budget_opts = Keyword.get(opts, :budget_opts)
+    scheduler_opts = Keyword.get(opts, :scheduler_opts)
 
     # Derive a per-supervisor writer name so concurrent supervisor instances
     # (e.g. isolated test instances) do not conflict on the writer's name.
@@ -72,6 +73,7 @@ defmodule Tau.Factory.Supervisor do
     children =
       base_children
       |> maybe_add_budget_owner(budget_opts, writer_name)
+      |> maybe_add_scheduler(scheduler_opts, budget_opts)
       |> maybe_add_merge_authority(
         repo_dir,
         ma_name,
@@ -98,6 +100,31 @@ defmodule Tau.Factory.Supervisor do
       |> Keyword.put(:ledger, writer_name)
 
     children ++ [{Tau.Factory.Budget.Owner, owner_opts}]
+  end
+
+  # Add Scheduler as a child only when scheduler_opts are provided.
+  # The budget tuple is wired from budget_opts (owner name) when both are present.
+  defp maybe_add_scheduler(children, nil, _budget_opts), do: children
+
+  defp maybe_add_scheduler(children, scheduler_opts, budget_opts) do
+    # If budget_opts provide a Budget.Owner name, wire it into the Scheduler.
+    scheduler_opts =
+      case budget_opts do
+        nil ->
+          scheduler_opts
+
+        budget_opts ->
+          owner_name = Keyword.fetch!(budget_opts, :name)
+          dims = Keyword.get(scheduler_opts, :budget_dimensions, [])
+
+          if dims == [] do
+            scheduler_opts
+          else
+            Keyword.put(scheduler_opts, :budget, {owner_name, dims})
+          end
+      end
+
+    children ++ [{Tau.Factory.Scheduler, scheduler_opts}]
   end
 
   # Add MergeAuthority as a child only when repo_dir is provided.

--- a/test/tau/factory/scheduler_test.exs
+++ b/test/tau/factory/scheduler_test.exs
@@ -1,0 +1,295 @@
+defmodule Tau.Factory.SchedulerTest do
+  @moduledoc """
+  Gating tests for PR #440 (P4b2-Scheduler) — D-312 / D-343.
+
+  Verifies:
+    - D-312: conflict-gated admission is sound (admit only when ConflictCheck
+      clears, budget headroom holds, and |F| < W_cap; defer otherwise with the
+      right reason; the in-flight set F is only mutated on :admit or release).
+    - D-343: admission is monotone — a {:defer, _} never mutates F; the only
+      writes to F are an :admit (adds one entry) and release (removes one entry);
+      no admit→withdraw→re-admit cycle is possible.
+
+  Written BEFORE production code exists (oracle-separation phase, factory-loop §4b).
+  Tests fail at runtime (UndefinedFunctionError on Tau.Factory.Scheduler) until
+  the implementer creates `lib/tau/factory/scheduler.ex`.
+
+  ## Pinned API contract (implementer must conform exactly)
+
+  ### Tau.Factory.Scheduler (GenServer; wholly absent before this PR)
+
+    - `start_link(opts) :: GenServer.on_start()`
+        Required options:
+          `:name`    — atom; registered name for the GenServer.
+          `:w_cap`   — positive integer; maximum concurrent admitted units (|F| < W_cap).
+        Optional options:
+          `:budget`  — `{budget_owner_name :: atom(), dimensions :: [atom()]}`;
+                       if present, `admit/3` calls `Budget.Owner.budget_precheck/2`
+                       for each listed dimension and defers with `{:defer, {:budget, dim}}`
+                       if any dimension is exhausted.
+                       If absent (or `:budget` not in opts), the budget gate is skipped.
+
+    - `admit(server, unit_id, declared_scope) :: :admit | {:defer, reason}`
+        `call`. Checks three admission conditions in this order:
+          1. Conflict: `ConflictCheck.clear?(declared_scope, F)` — if `{:conflict, clause}`,
+             returns `{:defer, {:conflict, clause}}`.
+          2. Capacity: `map_size(F) < W_cap` — if at or over cap, returns
+             `{:defer, :at_capacity}`.
+          3. Budget (if configured): `Budget.Owner.budget_precheck(owner, dim)` for
+             each gated dimension — if any returns `{:exhausted, dim}`, returns
+             `{:defer, {:budget, dim}}`.
+        On `:admit`: adds `{unit_id => declared_scope}` to F BEFORE the reply.
+
+    - `release(server, unit_id) :: :ok`
+        `call`. Removes `unit_id` from F. No-op if unit_id is not in F.
+
+    - `in_flight(server) :: %{unit_id => declared_scope}`
+        `call`. Returns the current F map (a snapshot at the time of the call).
+
+  Precedence of defer reasons (first failing condition wins):
+    conflict → at_capacity → budget
+
+  AC linkage: D-312 / D-343.
+  """
+
+  use ExUnit.Case, async: true
+
+  @moduletag :d_312
+  @moduletag :d_343
+  @moduletag :capture_log
+
+  # Runtime module references — the file compiles even while Scheduler is absent.
+  # Using @mod attributes avoids alias-time resolution and compile-time crashes
+  # (Credo strict forbids apply/2,3 — use @mod.fun(args) form instead).
+  @scheduler Tau.Factory.Scheduler
+  @writer Tau.Factory.Ledger.Writer
+  @owner Tau.Factory.Budget.Owner
+
+  # ---------------------------------------------------------------------------
+  # Helpers
+  # ---------------------------------------------------------------------------
+
+  # Build a minimal non-conflicting scope (empty MapSets — clears all five
+  # ConflictCheck clauses against any other empty-MapSet scope).
+  defp empty_scope do
+    %{
+      deps: [],
+      files: MapSet.new(),
+      codepoints: MapSet.new(),
+      specs: MapSet.new(),
+      resources: MapSet.new()
+    }
+  end
+
+  # Build a scope that overlaps `other_scope` on the :files clause.
+  defp scope_with_file(filename) do
+    %{
+      deps: [],
+      files: MapSet.new([filename]),
+      codepoints: MapSet.new(),
+      specs: MapSet.new(),
+      resources: MapSet.new()
+    }
+  end
+
+  # Start an isolated Ledger.Writer + Budget.Owner pair backed by a tmp DB.
+  # Returns {writer_name, owner_name}.
+  defp start_isolated_budget(totals) do
+    db_path = Briefly.create!(extname: ".db")
+    uid = System.unique_integer([:positive])
+    writer_name = :"test_sched_writer_#{uid}"
+    owner_name = :"test_sched_owner_#{uid}"
+
+    start_supervised!(
+      {@writer, db_path: db_path, name: writer_name},
+      id: :"sched_writer_#{uid}"
+    )
+
+    start_supervised!(
+      {@owner, ledger: writer_name, totals: totals, name: owner_name},
+      id: :"sched_owner_#{uid}"
+    )
+
+    {writer_name, owner_name}
+  end
+
+  # Start a Scheduler with no budget gate.
+  defp start_scheduler(w_cap) do
+    uid = System.unique_integer([:positive])
+    name = :"test_scheduler_#{uid}"
+
+    start_supervised!(
+      {@scheduler, name: name, w_cap: w_cap},
+      id: :"scheduler_#{uid}"
+    )
+
+    name
+  end
+
+  # Start a Scheduler with a budget gate.
+  defp start_scheduler_with_budget(w_cap, owner_name, dimensions) do
+    uid = System.unique_integer([:positive])
+    name = :"test_scheduler_budgeted_#{uid}"
+
+    start_supervised!(
+      {@scheduler, name: name, w_cap: w_cap, budget: {owner_name, dimensions}},
+      id: :"scheduler_budgeted_#{uid}"
+    )
+
+    name
+  end
+
+  # ---------------------------------------------------------------------------
+  # D-312 — sound admission: :admit when all conditions clear
+  # ---------------------------------------------------------------------------
+
+  describe "D-312 — sound admission" do
+    @tag :d_312
+    test "D-312: a unit with clear scope, budget headroom, and |F| < W_cap is admitted; in_flight gains that unit" do
+      sched = start_scheduler(3)
+      scope = empty_scope()
+
+      result = @scheduler.admit(sched, "unit-alpha", scope)
+      assert result == :admit
+
+      f = @scheduler.in_flight(sched)
+      assert map_size(f) == 1
+      assert Map.has_key?(f, "unit-alpha")
+      assert Map.fetch!(f, "unit-alpha") == scope
+    end
+
+    @tag :d_312
+    test "D-312: defer on conflict — overlapping file scope; F is unchanged (still just unit A)" do
+      sched = start_scheduler(5)
+      scope_a = scope_with_file("lib/foo.ex")
+      scope_b = scope_with_file("lib/foo.ex")
+
+      # Admit unit A — must succeed.
+      assert :admit = @scheduler.admit(sched, "unit-a", scope_a)
+
+      # Admit unit B with the same file — must conflict.
+      result = @scheduler.admit(sched, "unit-b", scope_b)
+      assert {:defer, {:conflict, :disjoint_files}} = result
+
+      # F must still contain only unit A — the defer did not add unit B.
+      f = @scheduler.in_flight(sched)
+      assert map_size(f) == 1
+      assert Map.has_key?(f, "unit-a")
+      refute Map.has_key?(f, "unit-b")
+    end
+
+    @tag :d_312
+    test "D-312: defer on budget exhausted; F is unchanged after the defer" do
+      totals = %{tokens: 10}
+      {writer_name, owner_name} = start_isolated_budget(totals)
+      sched = start_scheduler_with_budget(5, owner_name, [:tokens])
+
+      # Drain the budget via the Owner debit path.
+      :ok = @owner.debit(writer_name, "pre-unit", :tokens, 10)
+      assert {:exhausted, :tokens} = @owner.budget_precheck(owner_name, :tokens)
+
+      # Now attempt to admit a unit with a clear (non-conflicting) scope.
+      result = @scheduler.admit(sched, "unit-budget-denied", empty_scope())
+      assert {:defer, {:budget, :tokens}} = result
+
+      # F must still be empty — the defer did not add the unit.
+      f = @scheduler.in_flight(sched)
+      assert map_size(f) == 0
+    end
+
+    @tag :d_312
+    test "D-312: defer at capacity — second non-conflicting unit deferred when |F| == W_cap; F unchanged" do
+      sched = start_scheduler(1)
+
+      # Admit first unit — must succeed (|F| = 0 < W_cap = 1).
+      assert :admit = @scheduler.admit(sched, "unit-cap-1", empty_scope())
+
+      # A second non-conflicting, no-budget unit — must be deferred because |F| = 1 = W_cap.
+      result = @scheduler.admit(sched, "unit-cap-2", empty_scope())
+      assert {:defer, :at_capacity} = result
+
+      # F must still contain only the first unit.
+      f = @scheduler.in_flight(sched)
+      assert map_size(f) == 1
+      assert Map.has_key?(f, "unit-cap-1")
+      refute Map.has_key?(f, "unit-cap-2")
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # D-343 — monotone / release: F only ever grows via :admit, shrinks via release
+  # ---------------------------------------------------------------------------
+
+  describe "D-343 — monotone admission and release" do
+    @tag :d_343
+    test "D-343: release shrinks F; the previously-deferred unit can then be admitted cleanly" do
+      sched = start_scheduler(1)
+      scope_a = empty_scope()
+      scope_b = empty_scope()
+
+      # Admit unit A (fills capacity).
+      assert :admit = @scheduler.admit(sched, "unit-mono-a", scope_a)
+
+      # Unit B deferred (at capacity).
+      assert {:defer, :at_capacity} = @scheduler.admit(sched, "unit-mono-b", scope_b)
+
+      # F contains only unit A.
+      f_before = @scheduler.in_flight(sched)
+      assert map_size(f_before) == 1
+      assert Map.has_key?(f_before, "unit-mono-a")
+
+      # Release unit A.
+      :ok = @scheduler.release(sched, "unit-mono-a")
+
+      # F is now empty.
+      f_after_release = @scheduler.in_flight(sched)
+      assert map_size(f_after_release) == 0
+
+      # Now admit unit B — fresh decision; must succeed.
+      assert :admit = @scheduler.admit(sched, "unit-mono-b", scope_b)
+
+      # F contains only unit B.
+      f_final = @scheduler.in_flight(sched)
+      assert map_size(f_final) == 1
+      assert Map.has_key?(f_final, "unit-mono-b")
+    end
+
+    @tag :d_343
+    test "D-343: a sequence of defers never mutates F — F changes only on :admit and release" do
+      sched = start_scheduler(1)
+
+      # Pre-condition: F is empty.
+      assert map_size(@scheduler.in_flight(sched)) == 0
+
+      # Attempt to admit a unit with conflicting scope against nothing (will succeed —
+      # but we want to produce defers next).
+      scope_first = scope_with_file("lib/shared.ex")
+      assert :admit = @scheduler.admit(sched, "unit-first", scope_first)
+
+      f_after_admit = @scheduler.in_flight(sched)
+      assert map_size(f_after_admit) == 1
+
+      # Three separate defers in succession — conflict, at_capacity, conflict.
+      # None of these should mutate F.
+      scope_conflict = scope_with_file("lib/shared.ex")
+      assert {:defer, _} = @scheduler.admit(sched, "unit-defer-1", scope_conflict)
+      assert map_size(@scheduler.in_flight(sched)) == 1
+
+      # at_capacity for a non-conflicting unit
+      assert {:defer, _} = @scheduler.admit(sched, "unit-defer-2", empty_scope())
+      assert map_size(@scheduler.in_flight(sched)) == 1
+
+      # conflict again
+      assert {:defer, _} = @scheduler.admit(sched, "unit-defer-3", scope_conflict)
+      assert map_size(@scheduler.in_flight(sched)) == 1
+
+      # F still contains only the first unit — no defer added or removed anything.
+      f_final = @scheduler.in_flight(sched)
+      assert Map.keys(f_final) == ["unit-first"]
+
+      # Release restores empty F (normal shrink path).
+      :ok = @scheduler.release(sched, "unit-first")
+      assert map_size(@scheduler.in_flight(sched)) == 0
+    end
+  end
+end


### PR DESCRIPTION
## P4b-2 — Scheduler admission authority (D-312, D-343)

Advances #437 (P4 control plane). Completes P4b: the `Scheduler` GenServer that
composes the cores just landed — `ConflictCheck` (P4a, #438) + `Budget.Owner`
(P4b-1, #439) — into the single admission authority `S`. The Coordinator (P5)
will call `admit/2`; the Unit FSM (P4c) calls `release/1` on terminal.

### Scope (SPEC-FACTORY-CORE §2 C4, §4 B1/B2/B4, §6 D-312/D-343; [C102-B1])
1. `lib/tau/factory/scheduler.ex` (NEW) — `Tau.Factory.Scheduler`, a `GenServer`
   admission authority. Holds the in-flight set `F` (`unit_id => declared_scope`)
   and `W_cap` (max concurrent). The **sole writer of F** ([C102-B1]).
   - `admit(server, unit_id, declared_scope) :: :admit | {:defer, reason}`
     (`call`). `:admit` ⟺ `ConflictCheck.clear?(declared_scope, F) == :clear`
     ∧ `Budget.Owner.budget_precheck` clears every required dimension
     ∧ `|F| < W_cap`. On `:admit`, `unit_id` is added to F. On any failure,
     `{:defer, reason}` where `reason ∈ {{:conflict, clause}, {:budget, dim},
     :at_capacity}` (the test-author pins the check order / reason precedence).
   - `release(server, unit_id) :: :ok` (`call`/`cast`) — removes `unit_id` from F
     on terminal (merged/escalated/rejected), freeing headroom. F shrinks.
   - `in_flight(server) :: %{unit_id => declared_scope}` (introspection for tests
     + the Coordinator).
   - **D-343 monotone / no-livelock:** a `{:defer, _}` NEVER mutates F (it does
     not demote, withdraw, or reorder any admitted unit); an admitted unit stays
     in F until `release`; re-admission after a release is a fresh, independent
     monotone decision. No reachable admit→withdraw→re-admit cycle within the
     Scheduler.
2. `lib/tau/factory/supervisor.ex` (EDIT) — add `Scheduler` under
   `Tau.Factory.Supervisor` (after `Budget.Owner`, since `admit` calls
   `budget_precheck`), name/`:budget`/`:w_cap`-scoped for test isolation.

### Dependencies
Depends on P4a (`ConflictCheck`, `5698b67`-era) + P4b-1 (`Budget.Owner`,
`4f8e356`). Blocks P4c (Unit FSM `release`s on terminal) and P5 (Coordinator
`admit`s). Advances #437.

### SPECs
In scope: **SPEC-FACTORY-CORE** (Appendix B: `scheduler.ex`,
`factory/supervisor.ex`). Conforms to §4 B1/B2/B4, §6 D-312/D-343, [C102-B1].
The pure properties of D-312/D-343 (symmetry, monotone-in-F) are already
discharged by `conflict_check_property_test.exs` (P4a); this PR adds the
Scheduler's enforcement (admit integrates the predicate + budget + cap + F).
No SPEC amendment expected. (Scope-amendment re-admission, the other D-343 leg,
is deferred to P4c when units can amend declared scope.)

### Acceptance criteria
- **AC (D-312 — sound admission):** `scheduler_test.exs` — `admit` returns
  `:admit` iff the conflict check clears AND budget headroom exists AND
  `|F| < W_cap`; F grows by exactly the admitted unit. A conflicting scope, an
  exhausted budget dimension, and a full F each yield the correct
  `{:defer, reason}` and leave F unchanged.
- **AC (D-343 — monotone / no-livelock):** a `{:defer, _}` does not mutate F (no
  admitted unit is demoted/withdrawn); `release` is the only shrink path; a
  released unit can be re-admitted as a fresh decision. No admit→withdraw cycle.

### Gating-test paths (frozen at 6bfba83 — implementer MUST NOT edit)
- `test/tau/factory/scheduler_test.exs` (D-312 / D-343)

Pinned (oracle): `Scheduler.start_link(name:, w_cap:, budget: {owner_name, [dims]} | absent)`;
`admit(server, unit_id, declared_scope) :: :admit | {:defer, reason}` with defer precedence
**conflict → at_capacity → budget** (`{:conflict, clause}` | `:at_capacity` | `{:budget, dim}`),
F gains the unit on `:admit`; `release(server, unit_id) :: :ok`; `in_flight(server) :: %{unit_id => scope}`.

### Gate verdicts
_(filled at gate time — critic, reviewer)_
