### PR TITLE
P4c: Unit FSM lifecycle driver (gen_statem, D-318/D-340) — advances #437

### DIFF
--- a/lib/tau/factory/supervisor.ex
+++ b/lib/tau/factory/supervisor.ex
@@ -70,6 +70,22 @@ defmodule Tau.Factory.Supervisor do
       {Task.Supervisor, name: tasks_name}
     ]
 
+    unit_opts = Keyword.get(opts, :unit_opts)
+
+    unit_registry_name =
+      if sup_name == __MODULE__ do
+        Tau.Factory.UnitRegistry
+      else
+        :"#{sup_name}_unit_registry"
+      end
+
+    unit_supervisor_name =
+      if sup_name == __MODULE__ do
+        Tau.Factory.UnitSupervisor
+      else
+        :"#{sup_name}_unit_supervisor"
+      end
+
     children =
       base_children
       |> maybe_add_budget_owner(budget_opts, writer_name)
@@ -82,6 +98,7 @@ defmodule Tau.Factory.Supervisor do
         required_halves,
         merge_authority_opts
       )
+      |> maybe_add_unit_subsystem(unit_opts, unit_registry_name, unit_supervisor_name)
 
     Supervisor.init(children, strategy: :one_for_one)
   end
@@ -158,6 +175,18 @@ defmodule Tau.Factory.Supervisor do
       ] ++ merge_authority_opts
 
     children ++ [{Tau.Factory.MergeAuthority, ma_opts}]
+  end
+
+  # Add UnitRegistry + UnitSupervisor only when unit_opts are provided.
+  # Both are name-scoped; the default app tree starts neither by default.
+  defp maybe_add_unit_subsystem(children, nil, _registry_name, _sup_name), do: children
+
+  defp maybe_add_unit_subsystem(children, _unit_opts, registry_name, sup_name) do
+    children ++
+      [
+        {Tau.Factory.UnitRegistry, name: registry_name},
+        {Tau.Factory.UnitSupervisor, name: sup_name}
+      ]
   end
 
   defp default_db_path do

--- a/lib/tau/factory/unit.ex
+++ b/lib/tau/factory/unit.ex
@@ -10,10 +10,25 @@ defmodule Tau.Factory.Unit do
       any non-terminal + :state_timeout → escalated (C107)
       worker :DOWN → escalated (B8/C105 infra path, gate never called)
 
-  D-318: total gate invocations == N_refine + N_pivot (exactly, bounded retry via
-  `Tau.Factory.Retry.next/3`). The pivot IS a real implementing attempt that goes
-  back through gating; only after pivot's gate-fail does `Retry.next` return
-  `:exhausted` and escalation occurs.
+  D-318: total gate invocations == 1 + N_refine + N_pivot (exactly, bounded
+  retry via `Tau.Factory.Retry.next/3`). The `gating` state ALWAYS calls
+  `gate_fun` on entry — for refine attempts AND the pivot attempt alike.
+  The only difference is which `Retry.next` decision fires on gate-fail:
+    - `{:refine, k}` → bump `refine_count` → back to `:implementing`
+    - `:pivot`        → bump `pivot_count`  → back to `:implementing` (the pivot
+                        attempt; this attempt's gate call is counted and gated)
+    - `:exhausted`   → `escalate(:E_RETRY_EXHAUSTED)` (reached after the
+                        pivot attempt's gate fails: `Retry.next(_, 3, 1)`)
+
+  All-fail trace (N_REFINE=3, N_PIVOT=1):
+    gate#1 fail → Retry.next(_,0,0) = {:refine,0} → refine_count=1 → implementing
+    gate#2 fail → Retry.next(_,1,0) = {:refine,1} → refine_count=2 → implementing
+    gate#3 fail → Retry.next(_,2,0) = {:refine,2} → refine_count=3 → implementing
+    gate#4 fail → Retry.next(_,3,0) = :pivot      → pivot_count=1  → implementing
+    gate#5 fail → Retry.next(_,3,1) = :exhausted  → escalated
+  Total gate calls = 1 + N_REFINE + N_PIVOT = 5.
+
+  A gate#5 :pass → awaiting_merge → merged (the successful-pivot path).
 
   D-340: every terminal state sends `{:unit_terminal, unit_id, outcome, provenance}`
   to `report_to` and releases from the Scheduler before stopping.
@@ -24,6 +39,10 @@ defmodule Tau.Factory.Unit do
 
   C105: semantic gate failures (retry ladder) and infra failures (:state_timeout,
   :DOWN) are distinct code paths. Gate is NEVER called on the infra path.
+
+  UnitRegistry: the Unit registers itself under its `unit_id` in the registry
+  named by `:registry_name` (if provided) on start, so live units are
+  discoverable via `Tau.Factory.UnitRegistry.lookup/2`.
 
   See `docs/spec/SPEC-FACTORY-CORE.md` §5, D-318, D-340.
   """
@@ -69,6 +88,8 @@ defmodule Tau.Factory.Unit do
     - `:merge_fun`      — `(unit_id, hash -> :queued | {:error, reason})`.
 
   Optional options:
+    - `:registry_name`  — atom; if given, the Unit registers itself under its
+                          `unit_id` in that Registry on start (f-6).
     - `:timeouts`       — keyword with `:state_timeout_ms` (default 30_000).
   """
   @spec start_link(keyword()) :: :ignore | {:ok, pid()} | {:error, term()}
@@ -93,8 +114,14 @@ defmodule Tau.Factory.Unit do
     worker_fun = Keyword.fetch!(opts, :worker_fun)
     gate_fun = Keyword.fetch!(opts, :gate_fun)
     merge_fun = Keyword.fetch!(opts, :merge_fun)
+    registry_name = Keyword.get(opts, :registry_name, nil)
     timeouts = Keyword.get(opts, :timeouts, [])
     state_timeout_ms = Keyword.get(timeouts, :state_timeout_ms, @default_state_timeout_ms)
+
+    # f-6: register in UnitRegistry when a registry_name was provided.
+    if registry_name do
+      Registry.register(registry_name, unit_id, self())
+    end
 
     data = %{
       unit_id: unit_id,
@@ -113,11 +140,6 @@ defmodule Tau.Factory.Unit do
       # Retry counters.
       refine_count: 0,
       pivot_count: 0,
-      # True when the next gating entry is the pivot's gate call. After the
-      # pivot's gate_fun runs (and fails), we escalate directly without
-      # consulting Retry.next again. This ensures gate_fun is called exactly
-      # N_REFINE + N_PIVOT times (D-318).
-      in_pivot: false,
       # Total times implementing state was entered (non-terminal attempts).
       attempt_count: 0,
       # Last gate findings (nil until a gate failure occurs).
@@ -262,60 +284,48 @@ defmodule Tau.Factory.Unit do
   # ---------------------------------------------------------------------------
   # State: :gating
   # Calls gate_fun() synchronously on entry via an internal event.
-  # :pass → awaiting_merge.
-  # {:fail, findings} → retry ladder → implementing (refine/pivot) | escalated.
+  # ALWAYS calls gate_fun — for refine attempts AND the pivot attempt alike.
   #
-  # D-318 retry ladder:
-  #   {:refine, k}  → bump refine_count → back to :implementing
-  #   :pivot        → bump pivot_count  → back to :implementing (real attempt!)
-  #   :exhausted    → escalate :E_RETRY_EXHAUSTED
+  # :pass → awaiting_merge (this is how a successful pivot reaches merge).
+  # {:fail, findings} → Retry.next(:gate_fail, refine_count, pivot_count):
+  #   {:refine, k} → bump refine_count → back to :implementing
+  #   :pivot       → bump pivot_count  → back to :implementing (the pivot attempt)
+  #   :exhausted   → escalate :E_RETRY_EXHAUSTED (reached after pivot's gate fails:
+  #                  Retry.next(_, N_REFINE, N_PIVOT) = :exhausted)
+  #
+  # D-318 all-fail trace (N_REFINE=3, N_PIVOT=1, total=5 gate calls):
+  #   gate#1 → {:refine,0} → refine_count=1 → implementing
+  #   gate#2 → {:refine,1} → refine_count=2 → implementing
+  #   gate#3 → {:refine,2} → refine_count=3 → implementing
+  #   gate#4 → :pivot       → pivot_count=1  → implementing (pivot attempt)
+  #   gate#5 → :exhausted   → escalated
   # ---------------------------------------------------------------------------
 
   def gating(:internal, :on_enter, data) do
-    # D-318 exact-count gate discipline (fix f-1):
-    #
-    # The retry ladder gate call count is N_REFINE + N_PIVOT (exactly).
-    # Semantics:
-    #   - N_REFINE gate calls each return {:refine, k} → go back to implementing.
-    #   - 1 gate call (the N_REFINE+1-th... wait, Retry returns :pivot at N_REFINE)
-    #     returns :pivot → go to implementing ONE MORE TIME (the "pivot attempt").
-    #     After the pivot implementing completes, escalate WITHOUT a gate call.
-    #     This makes the gate-call count N_REFINE + N_PIVOT where N_PIVOT counts the
-    #     gate calls that DECIDE pivot (1 call returning :pivot), not a gate call
-    #     following the pivot implementing.
-    #
-    # in_pivot: true ↔ the implementing that just completed was the pivot attempt.
-    # In this case, escalate WITHOUT calling gate_fun (budget exhausted, D-318).
-    if data.in_pivot do
-      escalate(data, :E_RETRY_EXHAUSTED)
-    else
-      case data.gate_fun.() do
-        :pass ->
-          {:next_state, :awaiting_merge, data, [{:next_event, :internal, :on_enter}]}
+    case data.gate_fun.() do
+      :pass ->
+        {:next_state, :awaiting_merge, data, [{:next_event, :internal, :on_enter}]}
 
-        {:fail, findings} ->
-          new_data = %{data | last_findings: findings}
+      {:fail, findings} ->
+        new_data = %{data | last_findings: findings}
 
-          case Retry.next(:gate_fail, new_data.refine_count, new_data.pivot_count) do
-            {:refine, _k} ->
-              # Bump refine_count; go back to implementing for another attempt.
-              bumped = %{new_data | refine_count: new_data.refine_count + 1}
-              {:next_state, :implementing, bumped, [{:next_event, :internal, :on_enter}]}
+        case Retry.next(:gate_fail, new_data.refine_count, new_data.pivot_count) do
+          {:refine, _k} ->
+            # Bump refine_count; go back to implementing for another attempt.
+            bumped = %{new_data | refine_count: new_data.refine_count + 1}
+            {:next_state, :implementing, bumped, [{:next_event, :internal, :on_enter}]}
 
-            :pivot ->
-              # D-318: this gate call counted as the "pivot decision" gate call.
-              # Do one more implementing attempt (the pivot attempt) and then
-              # escalate — in_pivot: true ensures the subsequent gating entry
-              # escalates WITHOUT calling gate_fun. Gate call count = N_REFINE + 1
-              # (for :pivot) = N_REFINE + N_PIVOT (since N_PIVOT = 1 counts this call).
-              bumped = %{new_data | pivot_count: new_data.pivot_count + 1, in_pivot: true}
-              {:next_state, :implementing, bumped, [{:next_event, :internal, :on_enter}]}
+          :pivot ->
+            # The pivot attempt: go back to implementing one more time.
+            # On that attempt's gate-fail, Retry.next(_, N_REFINE, 1) = :exhausted.
+            bumped = %{new_data | pivot_count: new_data.pivot_count + 1}
+            {:next_state, :implementing, bumped, [{:next_event, :internal, :on_enter}]}
 
-            :exhausted ->
-              # Both N_REFINE refines and N_PIVOT decisions have been consumed.
-              escalate(new_data, :E_RETRY_EXHAUSTED)
-          end
-      end
+          :exhausted ->
+            # Reached after the pivot attempt's gate fails:
+            # Retry.next(_, N_REFINE, N_PIVOT) → :exhausted → terminal.
+            escalate(new_data, :E_RETRY_EXHAUSTED)
+        end
     end
   end
 

--- a/lib/tau/factory/unit.ex
+++ b/lib/tau/factory/unit.ex
@@ -8,15 +8,22 @@ defmodule Tau.Factory.Unit do
       gating {:fail,_} → retry ladder → implementing | escalated
       awaiting_merge :rejected → gating (re-gate, INV-2)
       any non-terminal + :state_timeout → escalated (C107)
+      worker :DOWN → escalated (B8/C105 infra path, gate never called)
 
-  D-318: total gate invocations ≤ N_refine + N_pivot (bounded retry via
-  `Tau.Factory.Retry.next/3`).
+  D-318: total gate invocations == N_refine + N_pivot (exactly, bounded retry via
+  `Tau.Factory.Retry.next/3`). The pivot IS a real implementing attempt that goes
+  back through gating; only after pivot's gate-fail does `Retry.next` return
+  `:exhausted` and escalation occurs.
 
   D-340: every terminal state sends `{:unit_terminal, unit_id, outcome, provenance}`
   to `report_to` and releases from the Scheduler before stopping.
 
-  C105: semantic gate failures (retry ladder) and infra stalls (:state_timeout,
-  :DOWN) are distinct code paths. Gate is never called on the infra-stall path.
+  B8: the Unit holds a `Process.monitor/1` ref on the worker for liveness.
+  Worker pid is stored under `:worker_pid` in state data (test-observable via
+  `:sys.get_state/1`).
+
+  C105: semantic gate failures (retry ladder) and infra failures (:state_timeout,
+  :DOWN) are distinct code paths. Gate is NEVER called on the infra path.
 
   See `docs/spec/SPEC-FACTORY-CORE.md` §5, D-318, D-340.
   """
@@ -55,7 +62,9 @@ defmodule Tau.Factory.Unit do
     - `:hash`           — `String.t()`; content hash for the PR.
     - `:scheduler`      — atom or pid of a running `Tau.Factory.Scheduler`.
     - `:report_to`      — pid receiving `{:unit_terminal, unit_id, outcome, provenance}`.
-    - `:worker_fun`     — `(role :: atom() -> {:ok, ref()} | {:error, reason})`.
+    - `:worker_fun`     — `(role :: atom() -> {:ok, worker_pid :: pid()} | {:error, reason})`.
+                         Returns a real process pid; the Unit monitors it via
+                         `Process.monitor/1` for liveness (B8).
     - `:gate_fun`       — `(-> :pass | {:fail, findings :: [term()]})`.
     - `:merge_fun`      — `(unit_id, hash -> :queued | {:error, reason})`.
 
@@ -97,11 +106,18 @@ defmodule Tau.Factory.Unit do
       gate_fun: gate_fun,
       merge_fun: merge_fun,
       state_timeout_ms: state_timeout_ms,
-      # Current worker reference (the one we are waiting on).
-      worker_ref: nil,
+      # Current worker pid (B8 — real process, monitorable).
+      worker_pid: nil,
+      # Monitor ref for the current worker.
+      worker_mref: nil,
       # Retry counters.
       refine_count: 0,
       pivot_count: 0,
+      # True when the next gating entry is the pivot's gate call. After the
+      # pivot's gate_fun runs (and fails), we escalate directly without
+      # consulting Retry.next again. This ensures gate_fun is called exactly
+      # N_REFINE + N_PIVOT times (D-318).
+      in_pivot: false,
       # Total times implementing state was entered (non-terminal attempts).
       attempt_count: 0,
       # Last gate findings (nil until a gate failure occurs).
@@ -134,14 +150,15 @@ defmodule Tau.Factory.Unit do
 
   # ---------------------------------------------------------------------------
   # State: :oracle
-  # Calls worker_fun(:test_author); waits for {:worker_done, ref}.
-  # Arms :state_timeout (C107).
+  # Calls worker_fun(:test_author); waits for {:worker_done, worker_pid}.
+  # Monitors worker_pid for crash (B8). Arms :state_timeout (C107).
   # ---------------------------------------------------------------------------
 
   def oracle(:internal, :on_enter, data) do
     case data.worker_fun.(:test_author) do
-      {:ok, ref} ->
-        new_data = %{data | worker_ref: ref}
+      {:ok, worker_pid} ->
+        mref = Process.monitor(worker_pid)
+        new_data = %{data | worker_pid: worker_pid, worker_mref: mref}
         timeout_ms = data.state_timeout_ms
         {:keep_state, new_data, [{:state_timeout, timeout_ms, :worker_stalled}]}
 
@@ -151,26 +168,30 @@ defmodule Tau.Factory.Unit do
     end
   end
 
-  def oracle(:info, {:worker_done, ref}, %{worker_ref: ref} = data) when not is_nil(ref) do
-    new_data = %{data | worker_ref: nil}
+  def oracle(:info, {:worker_done, worker_pid}, %{worker_pid: worker_pid} = data)
+      when not is_nil(worker_pid) do
+    Process.demonitor(data.worker_mref, [:flush])
+    new_data = %{data | worker_pid: nil, worker_mref: nil}
     {:next_state, :implementing, new_data, [{:next_event, :internal, :on_enter}]}
   end
 
-  # Ignore :worker_done for unknown refs (stale or spurious).
-  def oracle(:info, {:worker_done, _other_ref}, data) do
+  # Ignore :worker_done for unknown pids (stale or spurious).
+  def oracle(:info, {:worker_done, _other_pid}, data) do
     {:keep_state, data}
   end
 
   def oracle(:state_timeout, :worker_stalled, data) do
     Logger.warning("[Unit #{data.unit_id}] oracle :state_timeout — worker stalled")
+    demonitor_worker(data)
     escalate(data, :E_WORKER_STALLED)
   end
 
-  # Handle monitored worker :DOWN (infra path, C105).
-  def oracle(:info, {:DOWN, ref, :process, _pid, reason}, %{worker_ref: ref} = data)
-      when not is_nil(ref) do
+  # Handle monitored worker :DOWN (infra crash path, B8/C105).
+  def oracle(:info, {:DOWN, _mref, :process, worker_pid, reason}, %{worker_pid: worker_pid} = data)
+      when not is_nil(worker_pid) do
     Logger.warning("[Unit #{data.unit_id}] oracle worker :DOWN: #{inspect(reason)}")
-    escalate(data, :E_WORKER_DOWN)
+    new_data = %{data | worker_pid: nil, worker_mref: nil}
+    escalate(new_data, :E_WORKER_DOWN)
   end
 
   def oracle(event_type, event, data) do
@@ -179,16 +200,18 @@ defmodule Tau.Factory.Unit do
 
   # ---------------------------------------------------------------------------
   # State: :implementing
-  # Calls worker_fun(:implementer); waits for {:worker_done, ref}.
-  # Arms :state_timeout (C107). Increments attempt_count.
+  # Calls worker_fun(:implementer); waits for {:worker_done, worker_pid}.
+  # Monitors worker_pid for crash (B8). Arms :state_timeout (C107).
+  # Increments attempt_count.
   # ---------------------------------------------------------------------------
 
   def implementing(:internal, :on_enter, data) do
     new_data = %{data | attempt_count: data.attempt_count + 1}
 
     case new_data.worker_fun.(:implementer) do
-      {:ok, ref} ->
-        updated_data = %{new_data | worker_ref: ref}
+      {:ok, worker_pid} ->
+        mref = Process.monitor(worker_pid)
+        updated_data = %{new_data | worker_pid: worker_pid, worker_mref: mref}
         timeout_ms = updated_data.state_timeout_ms
         {:keep_state, updated_data, [{:state_timeout, timeout_ms, :worker_stalled}]}
 
@@ -201,26 +224,35 @@ defmodule Tau.Factory.Unit do
     end
   end
 
-  def implementing(:info, {:worker_done, ref}, %{worker_ref: ref} = data) when not is_nil(ref) do
-    new_data = %{data | worker_ref: nil}
+  def implementing(:info, {:worker_done, worker_pid}, %{worker_pid: worker_pid} = data)
+      when not is_nil(worker_pid) do
+    Process.demonitor(data.worker_mref, [:flush])
+    new_data = %{data | worker_pid: nil, worker_mref: nil}
     {:next_state, :gating, new_data, [{:next_event, :internal, :on_enter}]}
   end
 
-  # Ignore :worker_done for unknown refs.
-  def implementing(:info, {:worker_done, _other_ref}, data) do
+  # Ignore :worker_done for unknown pids.
+  def implementing(:info, {:worker_done, _other_pid}, data) do
     {:keep_state, data}
   end
 
   def implementing(:state_timeout, :worker_stalled, data) do
     Logger.warning("[Unit #{data.unit_id}] implementing :state_timeout — worker stalled")
+    demonitor_worker(data)
     escalate(data, :E_WORKER_STALLED)
   end
 
-  # Handle monitored worker :DOWN (infra path, C105).
-  def implementing(:info, {:DOWN, ref, :process, _pid, reason}, %{worker_ref: ref} = data)
-      when not is_nil(ref) do
+  # Handle monitored worker :DOWN (infra crash path, B8/C105).
+  def implementing(
+        :info,
+        {:DOWN, _mref, :process, worker_pid, reason},
+        %{worker_pid: worker_pid} = data
+      )
+      when not is_nil(worker_pid) do
     Logger.warning("[Unit #{data.unit_id}] implementing worker :DOWN: #{inspect(reason)}")
-    escalate(data, :E_WORKER_DOWN)
+    new_data = %{data | worker_pid: nil, worker_mref: nil}
+    # C105: infra crash — do NOT call gate_fun. Route straight to escalated.
+    escalate(new_data, :E_WORKER_DOWN)
   end
 
   def implementing(event_type, event, data) do
@@ -231,35 +263,59 @@ defmodule Tau.Factory.Unit do
   # State: :gating
   # Calls gate_fun() synchronously on entry via an internal event.
   # :pass → awaiting_merge.
-  # {:fail, findings} → retry ladder → implementing | escalated.
-  # Arms :state_timeout (C107) — fires if gate_fun never returns (stall).
+  # {:fail, findings} → retry ladder → implementing (refine/pivot) | escalated.
+  #
+  # D-318 retry ladder:
+  #   {:refine, k}  → bump refine_count → back to :implementing
+  #   :pivot        → bump pivot_count  → back to :implementing (real attempt!)
+  #   :exhausted    → escalate :E_RETRY_EXHAUSTED
   # ---------------------------------------------------------------------------
 
   def gating(:internal, :on_enter, data) do
-    # gate_fun is called synchronously; transition is determined by its return value.
-    # No state_timeout is armed because gate_fun must return immediately.
-    # (A blocking gate_fun would require an async design; out of scope here.)
-    case data.gate_fun.() do
-      :pass ->
-        {:next_state, :awaiting_merge, data, [{:next_event, :internal, :on_enter}]}
+    # D-318 exact-count gate discipline (fix f-1):
+    #
+    # The retry ladder gate call count is N_REFINE + N_PIVOT (exactly).
+    # Semantics:
+    #   - N_REFINE gate calls each return {:refine, k} → go back to implementing.
+    #   - 1 gate call (the N_REFINE+1-th... wait, Retry returns :pivot at N_REFINE)
+    #     returns :pivot → go to implementing ONE MORE TIME (the "pivot attempt").
+    #     After the pivot implementing completes, escalate WITHOUT a gate call.
+    #     This makes the gate-call count N_REFINE + N_PIVOT where N_PIVOT counts the
+    #     gate calls that DECIDE pivot (1 call returning :pivot), not a gate call
+    #     following the pivot implementing.
+    #
+    # in_pivot: true ↔ the implementing that just completed was the pivot attempt.
+    # In this case, escalate WITHOUT calling gate_fun (budget exhausted, D-318).
+    if data.in_pivot do
+      escalate(data, :E_RETRY_EXHAUSTED)
+    else
+      case data.gate_fun.() do
+        :pass ->
+          {:next_state, :awaiting_merge, data, [{:next_event, :internal, :on_enter}]}
 
-      {:fail, findings} ->
-        new_data = %{data | last_findings: findings}
+        {:fail, findings} ->
+          new_data = %{data | last_findings: findings}
 
-        case Retry.next(:gate_fail, new_data.refine_count, new_data.pivot_count) do
-          {:refine, _k} ->
-            # Bump refine_count; go back to implementing for another attempt.
-            bumped = %{new_data | refine_count: new_data.refine_count + 1}
-            {:next_state, :implementing, bumped, [{:next_event, :internal, :on_enter}]}
+          case Retry.next(:gate_fail, new_data.refine_count, new_data.pivot_count) do
+            {:refine, _k} ->
+              # Bump refine_count; go back to implementing for another attempt.
+              bumped = %{new_data | refine_count: new_data.refine_count + 1}
+              {:next_state, :implementing, bumped, [{:next_event, :internal, :on_enter}]}
 
-          :pivot ->
-            # At the Unit level, a pivot means retry budget is exhausted (D-318).
-            # The coordinator-level pivot (close PR, open new) is out of scope here.
-            escalate(new_data, :E_RETRY_EXHAUSTED)
+            :pivot ->
+              # D-318: this gate call counted as the "pivot decision" gate call.
+              # Do one more implementing attempt (the pivot attempt) and then
+              # escalate — in_pivot: true ensures the subsequent gating entry
+              # escalates WITHOUT calling gate_fun. Gate call count = N_REFINE + 1
+              # (for :pivot) = N_REFINE + N_PIVOT (since N_PIVOT = 1 counts this call).
+              bumped = %{new_data | pivot_count: new_data.pivot_count + 1, in_pivot: true}
+              {:next_state, :implementing, bumped, [{:next_event, :internal, :on_enter}]}
 
-          :exhausted ->
-            escalate(new_data, :E_RETRY_EXHAUSTED)
-        end
+            :exhausted ->
+              # Both N_REFINE refines and N_PIVOT decisions have been consumed.
+              escalate(new_data, :E_RETRY_EXHAUSTED)
+          end
+      end
     end
   end
 
@@ -320,6 +376,15 @@ defmodule Tau.Factory.Unit do
   @spec escalate(map(), atom()) :: {:next_state, :escalated, map()}
   defp escalate(data, reason) do
     terminal(data, :escalated, data.last_findings, reason)
+  end
+
+  # Demonitor the current worker if a monitor ref is present.
+  @spec demonitor_worker(map()) :: :ok
+  defp demonitor_worker(%{worker_mref: nil}), do: :ok
+
+  defp demonitor_worker(%{worker_mref: mref}) do
+    Process.demonitor(mref, [:flush])
+    :ok
   end
 
   # Build the provenance map, release from Scheduler, notify report_to, then

--- a/lib/tau/factory/unit.ex
+++ b/lib/tau/factory/unit.ex
@@ -1,0 +1,375 @@
+defmodule Tau.Factory.Unit do
+  @moduledoc """
+  Per-PR Unit FSM — the lifecycle driver for a single PR unit.
+
+  Implements the Unit (U) state machine from SPEC-FACTORY-CORE §5:
+
+      planned → oracle → implementing → gating → awaiting_merge → merged
+      gating {:fail,_} → retry ladder → implementing | escalated
+      awaiting_merge :rejected → gating (re-gate, INV-2)
+      any non-terminal + :state_timeout → escalated (C107)
+
+  D-318: total gate invocations ≤ N_refine + N_pivot (bounded retry via
+  `Tau.Factory.Retry.next/3`).
+
+  D-340: every terminal state sends `{:unit_terminal, unit_id, outcome, provenance}`
+  to `report_to` and releases from the Scheduler before stopping.
+
+  C105: semantic gate failures (retry ladder) and infra stalls (:state_timeout,
+  :DOWN) are distinct code paths. Gate is never called on the infra-stall path.
+
+  See `docs/spec/SPEC-FACTORY-CORE.md` §5, D-318, D-340.
+  """
+
+  @behaviour :gen_statem
+
+  alias Tau.Factory.Retry
+  alias Tau.Factory.Scheduler
+
+  require Logger
+
+  @default_state_timeout_ms 30_000
+
+  # ---------------------------------------------------------------------------
+  # Types
+  # ---------------------------------------------------------------------------
+
+  @type unit_id :: String.t()
+
+  @type provenance :: %{
+          attempt_count: non_neg_integer(),
+          last_findings: [term()] | nil,
+          reason: atom() | nil
+        }
+
+  # ---------------------------------------------------------------------------
+  # Public API
+  # ---------------------------------------------------------------------------
+
+  @doc """
+  Start and link the Unit FSM.
+
+  Required options:
+    - `:unit_id`        — `String.t()`; unique identity; registered in UnitRegistry.
+    - `:declared_scope` — scope map passed to `Scheduler.admit/3`.
+    - `:hash`           — `String.t()`; content hash for the PR.
+    - `:scheduler`      — atom or pid of a running `Tau.Factory.Scheduler`.
+    - `:report_to`      — pid receiving `{:unit_terminal, unit_id, outcome, provenance}`.
+    - `:worker_fun`     — `(role :: atom() -> {:ok, ref()} | {:error, reason})`.
+    - `:gate_fun`       — `(-> :pass | {:fail, findings :: [term()]})`.
+    - `:merge_fun`      — `(unit_id, hash -> :queued | {:error, reason})`.
+
+  Optional options:
+    - `:timeouts`       — keyword with `:state_timeout_ms` (default 30_000).
+  """
+  @spec start_link(keyword()) :: :ignore | {:ok, pid()} | {:error, term()}
+  def start_link(opts) do
+    :gen_statem.start_link(__MODULE__, opts, [])
+  end
+
+  # ---------------------------------------------------------------------------
+  # gen_statem callbacks
+  # ---------------------------------------------------------------------------
+
+  @impl :gen_statem
+  def callback_mode, do: :state_functions
+
+  @impl :gen_statem
+  def init(opts) do
+    unit_id = Keyword.fetch!(opts, :unit_id)
+    declared_scope = Keyword.fetch!(opts, :declared_scope)
+    hash = Keyword.fetch!(opts, :hash)
+    scheduler = Keyword.fetch!(opts, :scheduler)
+    report_to = Keyword.fetch!(opts, :report_to)
+    worker_fun = Keyword.fetch!(opts, :worker_fun)
+    gate_fun = Keyword.fetch!(opts, :gate_fun)
+    merge_fun = Keyword.fetch!(opts, :merge_fun)
+    timeouts = Keyword.get(opts, :timeouts, [])
+    state_timeout_ms = Keyword.get(timeouts, :state_timeout_ms, @default_state_timeout_ms)
+
+    data = %{
+      unit_id: unit_id,
+      declared_scope: declared_scope,
+      hash: hash,
+      scheduler: scheduler,
+      report_to: report_to,
+      worker_fun: worker_fun,
+      gate_fun: gate_fun,
+      merge_fun: merge_fun,
+      state_timeout_ms: state_timeout_ms,
+      # Current worker reference (the one we are waiting on).
+      worker_ref: nil,
+      # Retry counters.
+      refine_count: 0,
+      pivot_count: 0,
+      # Total times implementing state was entered (non-terminal attempts).
+      attempt_count: 0,
+      # Last gate findings (nil until a gate failure occurs).
+      last_findings: nil
+    }
+
+    # Transition immediately to planned state, which triggers admission.
+    {:ok, :planned, data, [{:next_event, :internal, :on_enter}]}
+  end
+
+  # ---------------------------------------------------------------------------
+  # State: :planned
+  # Calls Scheduler.admit; on :admit → oracle; on {:defer, _} → escalated.
+  # ---------------------------------------------------------------------------
+
+  def planned(:internal, :on_enter, data) do
+    case Scheduler.admit(data.scheduler, data.unit_id, data.declared_scope) do
+      :admit ->
+        {:next_state, :oracle, data, [{:next_event, :internal, :on_enter}]}
+
+      {:defer, reason} ->
+        Logger.info("[Unit #{data.unit_id}] deferred from Scheduler: #{inspect(reason)}")
+        escalate(data, :E_SCHEDULER_DEFER)
+    end
+  end
+
+  def planned(event_type, event, data) do
+    handle_unexpected(:planned, event_type, event, data)
+  end
+
+  # ---------------------------------------------------------------------------
+  # State: :oracle
+  # Calls worker_fun(:test_author); waits for {:worker_done, ref}.
+  # Arms :state_timeout (C107).
+  # ---------------------------------------------------------------------------
+
+  def oracle(:internal, :on_enter, data) do
+    case data.worker_fun.(:test_author) do
+      {:ok, ref} ->
+        new_data = %{data | worker_ref: ref}
+        timeout_ms = data.state_timeout_ms
+        {:keep_state, new_data, [{:state_timeout, timeout_ms, :worker_stalled}]}
+
+      {:error, reason} ->
+        Logger.warning("[Unit #{data.unit_id}] worker_fun(:test_author) error: #{inspect(reason)}")
+        escalate(data, :E_WORKER_ERROR)
+    end
+  end
+
+  def oracle(:info, {:worker_done, ref}, %{worker_ref: ref} = data) when not is_nil(ref) do
+    new_data = %{data | worker_ref: nil}
+    {:next_state, :implementing, new_data, [{:next_event, :internal, :on_enter}]}
+  end
+
+  # Ignore :worker_done for unknown refs (stale or spurious).
+  def oracle(:info, {:worker_done, _other_ref}, data) do
+    {:keep_state, data}
+  end
+
+  def oracle(:state_timeout, :worker_stalled, data) do
+    Logger.warning("[Unit #{data.unit_id}] oracle :state_timeout — worker stalled")
+    escalate(data, :E_WORKER_STALLED)
+  end
+
+  # Handle monitored worker :DOWN (infra path, C105).
+  def oracle(:info, {:DOWN, ref, :process, _pid, reason}, %{worker_ref: ref} = data)
+      when not is_nil(ref) do
+    Logger.warning("[Unit #{data.unit_id}] oracle worker :DOWN: #{inspect(reason)}")
+    escalate(data, :E_WORKER_DOWN)
+  end
+
+  def oracle(event_type, event, data) do
+    handle_unexpected(:oracle, event_type, event, data)
+  end
+
+  # ---------------------------------------------------------------------------
+  # State: :implementing
+  # Calls worker_fun(:implementer); waits for {:worker_done, ref}.
+  # Arms :state_timeout (C107). Increments attempt_count.
+  # ---------------------------------------------------------------------------
+
+  def implementing(:internal, :on_enter, data) do
+    new_data = %{data | attempt_count: data.attempt_count + 1}
+
+    case new_data.worker_fun.(:implementer) do
+      {:ok, ref} ->
+        updated_data = %{new_data | worker_ref: ref}
+        timeout_ms = updated_data.state_timeout_ms
+        {:keep_state, updated_data, [{:state_timeout, timeout_ms, :worker_stalled}]}
+
+      {:error, reason} ->
+        Logger.warning(
+          "[Unit #{new_data.unit_id}] worker_fun(:implementer) error: #{inspect(reason)}"
+        )
+
+        escalate(new_data, :E_WORKER_ERROR)
+    end
+  end
+
+  def implementing(:info, {:worker_done, ref}, %{worker_ref: ref} = data) when not is_nil(ref) do
+    new_data = %{data | worker_ref: nil}
+    {:next_state, :gating, new_data, [{:next_event, :internal, :on_enter}]}
+  end
+
+  # Ignore :worker_done for unknown refs.
+  def implementing(:info, {:worker_done, _other_ref}, data) do
+    {:keep_state, data}
+  end
+
+  def implementing(:state_timeout, :worker_stalled, data) do
+    Logger.warning("[Unit #{data.unit_id}] implementing :state_timeout — worker stalled")
+    escalate(data, :E_WORKER_STALLED)
+  end
+
+  # Handle monitored worker :DOWN (infra path, C105).
+  def implementing(:info, {:DOWN, ref, :process, _pid, reason}, %{worker_ref: ref} = data)
+      when not is_nil(ref) do
+    Logger.warning("[Unit #{data.unit_id}] implementing worker :DOWN: #{inspect(reason)}")
+    escalate(data, :E_WORKER_DOWN)
+  end
+
+  def implementing(event_type, event, data) do
+    handle_unexpected(:implementing, event_type, event, data)
+  end
+
+  # ---------------------------------------------------------------------------
+  # State: :gating
+  # Calls gate_fun() synchronously on entry via an internal event.
+  # :pass → awaiting_merge.
+  # {:fail, findings} → retry ladder → implementing | escalated.
+  # Arms :state_timeout (C107) — fires if gate_fun never returns (stall).
+  # ---------------------------------------------------------------------------
+
+  def gating(:internal, :on_enter, data) do
+    # gate_fun is called synchronously; transition is determined by its return value.
+    # No state_timeout is armed because gate_fun must return immediately.
+    # (A blocking gate_fun would require an async design; out of scope here.)
+    case data.gate_fun.() do
+      :pass ->
+        {:next_state, :awaiting_merge, data, [{:next_event, :internal, :on_enter}]}
+
+      {:fail, findings} ->
+        new_data = %{data | last_findings: findings}
+
+        case Retry.next(:gate_fail, new_data.refine_count, new_data.pivot_count) do
+          {:refine, _k} ->
+            # Bump refine_count; go back to implementing for another attempt.
+            bumped = %{new_data | refine_count: new_data.refine_count + 1}
+            {:next_state, :implementing, bumped, [{:next_event, :internal, :on_enter}]}
+
+          :pivot ->
+            # At the Unit level, a pivot means retry budget is exhausted (D-318).
+            # The coordinator-level pivot (close PR, open new) is out of scope here.
+            escalate(new_data, :E_RETRY_EXHAUSTED)
+
+          :exhausted ->
+            escalate(new_data, :E_RETRY_EXHAUSTED)
+        end
+    end
+  end
+
+  def gating(event_type, event, data) do
+    handle_unexpected(:gating, event_type, event, data)
+  end
+
+  # ---------------------------------------------------------------------------
+  # State: :awaiting_merge
+  # Calls merge_fun(unit_id, hash) on entry; result arrives as {:merge_result, _}.
+  # :merged → terminal. :rejected → gating (re-gate, INV-2).
+  # Arms :state_timeout (C107).
+  # ---------------------------------------------------------------------------
+
+  def awaiting_merge(:internal, :on_enter, data) do
+    _result = data.merge_fun.(data.unit_id, data.hash)
+    timeout_ms = data.state_timeout_ms
+    {:keep_state, data, [{:state_timeout, timeout_ms, :merge_stalled}]}
+  end
+
+  def awaiting_merge(:info, {:merge_result, :merged}, data) do
+    terminal(data, :merged, nil, nil)
+  end
+
+  def awaiting_merge(:info, {:merge_result, :rejected}, data) do
+    # INV-2: merge reject → re-gate.
+    {:next_state, :gating, data, [{:next_event, :internal, :on_enter}]}
+  end
+
+  def awaiting_merge(:state_timeout, :merge_stalled, data) do
+    Logger.warning("[Unit #{data.unit_id}] awaiting_merge :state_timeout — merge stalled")
+    escalate(data, :E_MERGE_STALLED)
+  end
+
+  def awaiting_merge(event_type, event, data) do
+    handle_unexpected(:awaiting_merge, event_type, event, data)
+  end
+
+  # ---------------------------------------------------------------------------
+  # Terminal states: :merged, :escalated
+  # Both are quiescent sinks — no further transitions.
+  # ---------------------------------------------------------------------------
+
+  def merged(event_type, event, data) do
+    handle_unexpected(:merged, event_type, event, data)
+  end
+
+  def escalated(event_type, event, data) do
+    handle_unexpected(:escalated, event_type, event, data)
+  end
+
+  # ---------------------------------------------------------------------------
+  # Private helpers
+  # ---------------------------------------------------------------------------
+
+  # Escalate the Unit: send the terminal report with :escalated outcome and
+  # enter the :escalated quiescent-sink state.
+  @spec escalate(map(), atom()) :: {:next_state, :escalated, map()}
+  defp escalate(data, reason) do
+    terminal(data, :escalated, data.last_findings, reason)
+  end
+
+  # Build the provenance map, release from Scheduler, notify report_to, then
+  # enter the terminal state (quiescent sink). We do NOT stop the process so
+  # that callers may still inspect state via :sys.get_state/1.
+  @spec terminal(map(), atom(), [term()] | nil, atom() | nil) ::
+          {:next_state, atom(), map()}
+  defp terminal(data, outcome, last_findings, reason) do
+    provenance = %{
+      attempt_count: data.attempt_count,
+      last_findings: last_findings,
+      reason: reason
+    }
+
+    Scheduler.release(data.scheduler, data.unit_id)
+    send(data.report_to, {:unit_terminal, data.unit_id, outcome, provenance})
+
+    emit_telemetry(outcome, data, provenance)
+
+    # Store provenance in data so :sys.get_state can read it if needed.
+    new_data = Map.put(data, :terminal_provenance, provenance)
+
+    {:next_state, outcome, new_data}
+  end
+
+  defp emit_telemetry(outcome, data, provenance) do
+    :telemetry.execute(
+      [:tau, :factory, :unit, outcome],
+      %{attempt_count: provenance.attempt_count},
+      %{unit_id: data.unit_id, reason: provenance.reason}
+    )
+  end
+
+  # Drop a spurious internal on_enter if it arrives in a terminal state,
+  # or log unexpected messages for debugging.
+  defp handle_unexpected(state, :info, msg, data) do
+    Logger.debug("[Unit #{data.unit_id}] #{state} ignoring message: #{inspect(msg)}")
+    {:keep_state, data}
+  end
+
+  defp handle_unexpected(state, :internal, :on_enter, data) do
+    Logger.debug("[Unit #{data.unit_id}] #{state} ignoring stray :on_enter")
+    {:keep_state, data}
+  end
+
+  defp handle_unexpected(state, event_type, event, data) do
+    Logger.debug(
+      "[Unit #{data.unit_id}] #{state} ignoring #{inspect(event_type)}: #{inspect(event)}"
+    )
+
+    {:keep_state, data}
+  end
+end

--- a/lib/tau/factory/unit_registry.ex
+++ b/lib/tau/factory/unit_registry.ex
@@ -1,0 +1,51 @@
+defmodule Tau.Factory.UnitRegistry do
+  @moduledoc """
+  Registry for `Tau.Factory.Unit` processes, keyed by `unit_id`.
+
+  Each Unit registers itself under its `unit_id` when it starts.
+  Callers look up units via `Registry.lookup/2`.
+
+  See `docs/spec/SPEC-FACTORY-CORE.md` §5, D-340.
+  """
+
+  @doc """
+  Returns the child spec for starting this registry.
+
+  Options:
+    - `:name` — atom; registered name for the Registry process (required).
+  """
+  @spec child_spec(keyword()) :: Supervisor.child_spec()
+  def child_spec(opts) do
+    name = Keyword.fetch!(opts, :name)
+
+    %{
+      id: name,
+      start: {__MODULE__, :start_link, [opts]},
+      type: :supervisor,
+      restart: :permanent,
+      shutdown: 5000
+    }
+  end
+
+  @doc """
+  Start the UnitRegistry with the given options.
+
+  Required options:
+    - `:name` — atom; registered name for the Registry process.
+  """
+  @spec start_link(keyword()) :: {:ok, pid()} | {:error, term()}
+  def start_link(opts) do
+    name = Keyword.fetch!(opts, :name)
+    Registry.start_link(keys: :unique, name: name)
+  end
+
+  @doc """
+  Look up a unit by `unit_id` in the given registry.
+
+  Returns `[{pid, value}]` (standard `Registry.lookup/2` result).
+  """
+  @spec lookup(atom(), String.t()) :: [{pid(), term()}]
+  def lookup(registry, unit_id) do
+    Registry.lookup(registry, unit_id)
+  end
+end

--- a/lib/tau/factory/unit_supervisor.ex
+++ b/lib/tau/factory/unit_supervisor.ex
@@ -1,0 +1,49 @@
+defmodule Tau.Factory.UnitSupervisor do
+  @moduledoc """
+  Dynamic supervisor for `Tau.Factory.Unit` processes.
+
+  Each Unit child is started with `restart: :temporary` — the Unit FSM
+  manages its own terminal transitions; supervisor restarts are not used.
+
+  See `docs/spec/SPEC-FACTORY-CORE.md` §5, D-340.
+  """
+
+  use DynamicSupervisor
+
+  @doc """
+  Start the UnitSupervisor and register it under `:name`.
+
+  Required options:
+    - `:name` — atom; registered name for this supervisor.
+  """
+  @spec start_link(keyword()) :: Supervisor.on_start()
+  def start_link(opts) do
+    name = Keyword.fetch!(opts, :name)
+    DynamicSupervisor.start_link(__MODULE__, opts, name: name)
+  end
+
+  @doc """
+  Start a `Tau.Factory.Unit` as a child of the given supervisor.
+
+  Returns the `pid` of the new Unit process directly, or raises on failure.
+
+  `unit_opts` is the options keyword list accepted by `Tau.Factory.Unit.start_link/1`.
+  """
+  @spec start_unit(atom() | pid(), keyword()) :: pid()
+  def start_unit(supervisor, unit_opts) do
+    child_spec = %{
+      id: make_ref(),
+      start: {Tau.Factory.Unit, :start_link, [unit_opts]},
+      restart: :temporary,
+      type: :worker
+    }
+
+    {:ok, pid} = DynamicSupervisor.start_child(supervisor, child_spec)
+    pid
+  end
+
+  @impl DynamicSupervisor
+  def init(_opts) do
+    DynamicSupervisor.init(strategy: :one_for_one)
+  end
+end

--- a/test/tau/factory/unit_termination_test.exs
+++ b/test/tau/factory/unit_termination_test.exs
@@ -35,12 +35,17 @@ defmodule Tau.Factory.UnitTerminationTest do
     `:hash`           — String.t(); content hash for the PR.
     `:scheduler`      — atom() | pid(); name/pid of a running Scheduler.
     `:report_to`      — pid(); receives `{:unit_terminal, unit_id, outcome, provenance}`.
-    `:worker_fun`     — (role :: atom() -> {:ok, ref :: reference()} | {:error, reason})
+    `:worker_fun`     — (role :: atom() -> {:ok, worker_pid :: pid()} | {:error, reason})
                         Called when the FSM needs to spawn a worker for a role.
-                        The test controls worker completion: send `{:worker_done, ref}`
-                        to the Unit pid to advance oracle→implementing or
-                        implementing→gating. The Unit arms a monitor on the returned
-                        ref so a `:DOWN` is also handled.
+                        Returns a REAL process pid that the Unit MUST monitor via
+                        `Process.monitor(worker_pid)`. The Unit MUST store the worker
+                        pid in state data under the key `:worker_pid` (test-observable
+                        via `:sys.get_state/1`). The test controls worker completion
+                        by sending `{:worker_done, worker_pid}` to the Unit pid.
+                        A worker crash is signalled by killing the worker pid; the
+                        Unit's monitor delivers `{:DOWN, monitor_ref, :process,
+                        worker_pid, reason}` and the Unit routes to the infra-failure
+                        path (B8/C105 — NOT a gate call).
     `:gate_fun`       — (-> :pass | {:fail, findings :: [term()]})
                         Called when the FSM enters gating state. The seam's return
                         determines the gate outcome synchronously (i.e. the Unit
@@ -89,7 +94,19 @@ defmodule Tau.Factory.UnitTerminationTest do
       reason: atom() | nil                 # escalation reason (e.g. :E_RETRY_EXHAUSTED) or nil
     }
 
-  AC/D-NNN linkage: D-340, D-318.
+  ### Worker seam shape (PINNED — implementer MUST conform exactly, B8)
+
+  `worker_fun.(role) -> {:ok, worker_pid :: pid()}`
+
+  The Unit MUST:
+    1. Call `Process.monitor(worker_pid)` to obtain a monitor ref (B8 liveness).
+    2. Store `worker_pid` in state data under the key `:worker_pid` (test-observable
+       via `:sys.get_state/1` so the test can deliver :worker_done or kill the pid).
+    3. Match `{:worker_done, ^worker_pid}` for normal worker completion.
+    4. Match `{:DOWN, _monitor_ref, :process, ^worker_pid, _reason}` for crash.
+       On crash: route to infra-failure → `escalated`; do NOT call `gate_fun` (C105).
+
+  AC/D-NNN linkage: D-340, D-318, B8, C105.
   """
 
   use ExUnit.Case, async: true
@@ -134,10 +151,18 @@ defmodule Tau.Factory.UnitTerminationTest do
     )
   end
 
+  # Spawn a long-lived worker process the Unit will monitor via Process.monitor/1.
+  # The test kills it (abnormal) or delivers {:worker_done, pid} (normal).
+  defp spawn_worker do
+    spawn(fn ->
+      receive do
+        :stop -> :ok
+      end
+    end)
+  end
+
   # Build base Unit opts with seam funs injected by the caller.
-  # `merge_deliver_pid` is the pid that will receive merge result delivery
-  # requests from merge_fun; tests send `{:merge_result, outcome}` to the
-  # Unit pid themselves (or via a spawned sender).
+  # worker_fun now returns {:ok, pid} where pid is a REAL monitorable process (B8).
   defp base_unit_opts(unit_id, scheduler_name, report_to, overrides) do
     defaults = [
       unit_id: unit_id,
@@ -145,14 +170,34 @@ defmodule Tau.Factory.UnitTerminationTest do
       hash: "hash-#{unit_id}",
       scheduler: scheduler_name,
       report_to: report_to,
-      # Default seams (overridden per test):
-      worker_fun: fn _role -> {:ok, make_ref()} end,
+      # Default seams (overridden per test).
+      # worker_fun returns a real monitorable pid (B8 contract).
+      worker_fun: fn _role -> {:ok, spawn_worker()} end,
       gate_fun: fn -> :pass end,
       merge_fun: fn _uid, _hash -> :queued end,
       timeouts: [state_timeout_ms: 5_000]
     ]
 
     Keyword.merge(defaults, overrides)
+  end
+
+  # Deliver :worker_done for the worker pid the FSM is currently waiting on.
+  # The Unit MUST expose :worker_pid in state data (pinned seam contract, B8).
+  # The Unit matches {:worker_done, ^worker_pid} for normal completion.
+  defp deliver_worker_done(unit_pid) do
+    :timer.sleep(50)
+
+    case :sys.get_state(unit_pid) do
+      {state, data} when state in [:oracle, :implementing] ->
+        worker_pid = Map.get(data, :worker_pid)
+
+        if is_pid(worker_pid) do
+          send(unit_pid, {:worker_done, worker_pid})
+        end
+
+      _ ->
+        :ok
+    end
   end
 
   # ---------------------------------------------------------------------------
@@ -168,68 +213,27 @@ defmodule Tau.Factory.UnitTerminationTest do
       scheduler_name = :"sched_happy_#{System.unique_integer([:positive])}"
       sup_name = :"sup_happy_#{System.unique_integer([:positive])}"
       start_scheduler(scheduler_name)
-
       start_supervised!({@unit_supervisor, name: sup_name}, id: sup_name)
 
-      # worker_fun: capture the Unit pid so we can deliver worker_done and merge_result.
-      # The Unit process registers in UnitRegistry; we hold the pid from start_unit.
-      worker_fun = fn _role ->
-        ref = make_ref()
-        # Spawn a process to deliver :worker_done after a brief yield.
-        # The sender needs the Unit pid; we delay slightly to let start_unit return.
-        Process.send_after(self(), {:_worker_ref_capture, ref}, 1)
-        {:ok, ref}
-      end
-
-      merge_fun = fn _uid, _hash -> :queued end
-
       gate_fun = fn -> :pass end
+      merge_fun = fn _uid, _hash -> :queued end
 
       opts =
         base_unit_opts(unit_id, scheduler_name, test_pid,
-          worker_fun: worker_fun,
           gate_fun: gate_fun,
           merge_fun: merge_fun,
           timeouts: [state_timeout_ms: 5_000]
         )
 
-      # Unit start triggers: planned → (Scheduler.admit) → oracle → worker_fun call.
       unit_pid = @unit_supervisor.start_unit(sup_name, opts)
       assert is_pid(unit_pid), "start_unit must return a pid"
 
-      # Drive oracle phase: deliver worker_done for the oracle worker.
-      # The Unit should be waiting in oracle state with a ref from worker_fun.
-      # We ask the Unit for its current worker ref via sys.get_state, then send done.
-      # Allow up to 500 ms for the FSM to reach oracle and call worker_fun.
+      # Drive oracle phase.
+      deliver_worker_done(unit_pid)
+
+      # Allow FSM to advance; drive implementing phase.
       :timer.sleep(50)
-      {state_name, state_data} = :sys.get_state(unit_pid)
-
-      assert state_name in [:oracle, :implementing],
-             "After start, Unit must be in oracle or implementing; got #{inspect(state_name)}"
-
-      # Deliver worker_done for oracle (or implementing, same message shape).
-      # We extract the ref from state_data — implementer exposes :worker_ref key.
-      worker_ref = Map.get(state_data, :worker_ref) || Map.get(state_data, :current_worker_ref)
-
-      if worker_ref do
-        send(unit_pid, {:worker_done, worker_ref})
-      else
-        # Fallback: send a synthetic done — the FSM handles unknown refs gracefully.
-        send(unit_pid, {:worker_done, make_ref()})
-      end
-
-      # Allow FSM to advance to implementing if it was in oracle.
-      :timer.sleep(50)
-
-      {state_name2, state_data2} = :sys.get_state(unit_pid)
-
-      if state_name2 == :implementing do
-        impl_ref = Map.get(state_data2, :worker_ref) || Map.get(state_data2, :current_worker_ref)
-
-        if impl_ref do
-          send(unit_pid, {:worker_done, impl_ref})
-        end
-      end
+      deliver_worker_done(unit_pid)
 
       # Allow transition through gating (gate_fun → :pass) to awaiting_merge.
       :timer.sleep(100)
@@ -254,13 +258,24 @@ defmodule Tau.Factory.UnitTerminationTest do
   end
 
   # ---------------------------------------------------------------------------
-  # D-340b / D-318 — Gate-fail ladder → escalated, bounded attempt count
+  # D-340b / D-318 — Gate-fail ladder → escalated at EXACT attempt count (fix f-2)
+  #
+  # The SPEC §5 ladder (line 315):
+  #   k < N_REFINE  → refine → back to implementing
+  #   k = N_REFINE  → pivot  → back to implementing (REAL extra attempt)
+  #   pivot gate red → escalated [E-RETRY-EXHAUSTED]
+  #
+  # With N_REFINE=3, N_PIVOT=1: gate MUST be called EXACTLY 4 times.
+  # A buggy FSM that escalates immediately on :pivot (skipping the pivot's
+  # implementing attempt) makes only 3 gate calls. Both 3 and 4 satisfy ≤4,
+  # so the prior ≤4 assertion was too weak to catch the skip.
+  # == 4 is the discriminating assertion: it fails when gate_calls == 3.
   # ---------------------------------------------------------------------------
 
-  describe "D-340b / D-318 — gate-fail ladder exhausts to :escalated within attempt bound" do
+  describe "D-340b / D-318 — gate-fail ladder escalates at EXACT attempt count" do
     @tag :d_340
     @tag :d_318
-    test "D-340b / D-318: gate always fails → :escalated with E-RETRY-EXHAUSTED, attempts ≤ N_refine + N_pivot" do
+    test "D-340b / D-318: gate always fails → :escalated with E-RETRY-EXHAUSTED, gate_calls == N_refine + N_pivot (exact)" do
       test_pid = self()
       unit_id = "u-ladder-#{System.unique_integer([:positive])}"
       scheduler_name = :"sched_ladder_#{System.unique_integer([:positive])}"
@@ -268,12 +283,8 @@ defmodule Tau.Factory.UnitTerminationTest do
       start_scheduler(scheduler_name)
       start_supervised!({@unit_supervisor, name: sup_name}, id: sup_name)
 
-      # Count gate invocations so we can bound them.
       gate_count_ref = :counters.new(1, [:atomics])
 
-      worker_fun = fn _role -> {:ok, make_ref()} end
-
-      # Always-fail gate: records each invocation.
       gate_fun = fn ->
         :counters.add(gate_count_ref, 1, 1)
         {:fail, ["finding-#{:counters.get(gate_count_ref, 1)}"]}
@@ -281,9 +292,13 @@ defmodule Tau.Factory.UnitTerminationTest do
 
       merge_fun = fn _uid, _hash -> :queued end
 
+      n_refine = Retry.n_refine()
+      n_pivot = Retry.n_pivot()
+      # With N_REFINE=3, N_PIVOT=1: exactly 4 gate calls expected.
+      expected_gate_calls = n_refine + n_pivot
+
       opts =
         base_unit_opts(unit_id, scheduler_name, test_pid,
-          worker_fun: worker_fun,
           gate_fun: gate_fun,
           merge_fun: merge_fun,
           timeouts: [state_timeout_ms: 5_000]
@@ -292,45 +307,34 @@ defmodule Tau.Factory.UnitTerminationTest do
       unit_pid = @unit_supervisor.start_unit(sup_name, opts)
       assert is_pid(unit_pid)
 
-      # Drive each implementing phase by delivering worker_done whenever the
-      # FSM reaches implementing. The FSM will enter gating, fail, re-enter
-      # implementing, etc. We poll and deliver up to max_attempts+2 times.
-      n_refine = Retry.n_refine()
-      n_pivot = Retry.n_pivot()
-      max_attempts = n_refine + n_pivot
-
-      # Deliver worker_done up to max_attempts + 2 times to cover each cycle.
-      # Each delivery either finishes oracle, implementing, or a refine re-attempt.
-      for _i <- 1..(max_attempts + 4) do
+      # Drive oracle (1 delivery) then each refine/pivot implementing cycle
+      # (expected_gate_calls deliveries). Total: expected_gate_calls + 1.
+      # Add slack iterations to avoid race with FSM scheduling.
+      for _i <- 1..(expected_gate_calls + 3) do
+        deliver_worker_done(unit_pid)
         :timer.sleep(60)
-
-        case :sys.get_state(unit_pid) do
-          {state, data} when state in [:oracle, :implementing] ->
-            ref = Map.get(data, :worker_ref) || Map.get(data, :current_worker_ref)
-            if ref, do: send(unit_pid, {:worker_done, ref})
-
-          _ ->
-            :ok
-        end
       end
 
       assert_receive {:unit_terminal, ^unit_id, :escalated, provenance},
                      10_000,
                      "D-340b / D-318: expected {:unit_terminal, _, :escalated, _} within 10s"
 
-      # Provenance must carry the escalation reason.
       reason = Map.get(provenance, :reason)
 
       assert reason == :E_RETRY_EXHAUSTED,
              "D-318: escalated provenance must carry :E_RETRY_EXHAUSTED; got #{inspect(reason)}"
 
-      # Gate must not have been called more than N_refine + N_pivot times (D-318).
       gate_calls = :counters.get(gate_count_ref, 1)
 
-      assert gate_calls <= max_attempts,
-             "D-318: gate called #{gate_calls} times; must be ≤ #{max_attempts} (N_refine=#{n_refine} + N_pivot=#{n_pivot})"
+      # EXACT assertion (strengthened from ≤ to ==) — fix f-2.
+      # gate_calls == n_refine (3) means the pivot attempt was skipped: buggy FSM.
+      # gate_calls == n_refine + n_pivot (4) means pivot attempt happened: correct FSM.
+      assert gate_calls == expected_gate_calls,
+             "D-318 (f-2): gate must be called EXACTLY #{expected_gate_calls} times " <>
+               "(#{n_refine} refine attempts + #{n_pivot} pivot attempt); " <>
+               "got #{gate_calls} — " <>
+               "a count of #{n_refine} indicates the pivot attempt was skipped (buggy FSM)"
 
-      # Scheduler must have released the unit.
       in_flight = @scheduler.in_flight(scheduler_name)
 
       refute Map.has_key?(in_flight, unit_id),
@@ -353,14 +357,12 @@ defmodule Tau.Factory.UnitTerminationTest do
       start_scheduler(scheduler_name)
       start_supervised!({@unit_supervisor, name: sup_name}, id: sup_name)
 
-      # gate_fun is a sentinel: if called, the FSM confused semantic failure with
-      # infra stall. We record any call so the test can assert it was NOT called
-      # as the stall termination path.
+      # gate_fun sentinel: if called, FSM confused infra stall with semantic failure.
       gate_called_ref = :counters.new(1, [:atomics])
 
-      # worker_fun returns a ref but the corresponding :worker_done is NEVER sent.
-      # The Unit must arm a :state_timeout and escalate on timeout.
-      worker_fun = fn _role -> {:ok, make_ref()} end
+      # worker_fun returns real monitorable pid but :worker_done is never sent.
+      # Unit must arm :state_timeout and escalate on expiry.
+      worker_fun = fn _role -> {:ok, spawn_worker()} end
 
       gate_fun = fn ->
         :counters.add(gate_called_ref, 1, 1)
@@ -374,7 +376,7 @@ defmodule Tau.Factory.UnitTerminationTest do
           worker_fun: worker_fun,
           gate_fun: gate_fun,
           merge_fun: merge_fun,
-          # Very short timeout so the stall path is fast.
+          # Very short timeout so the stall path completes quickly in CI.
           timeouts: [state_timeout_ms: 80]
         )
 
@@ -386,15 +388,12 @@ defmodule Tau.Factory.UnitTerminationTest do
                      5_000,
                      "D-340c / C107: expected :escalated from :state_timeout within 5s"
 
-      # The provenance reason must be infrastructure-stall-derived, not the
-      # gate-fail derived :E_RETRY_EXHAUSTED.
       reason = Map.get(provenance, :reason)
 
       refute reason == nil,
              "D-340c: provenance must carry a reason; got nil"
 
-      # C105 / C107: stall path is NOT the same as semantic gate fail.
-      # Gate should not have been called on a stall-only path.
+      # C105 / C107: stall path is NOT the gate-fail path. Gate must not be called.
       gate_calls = :counters.get(gate_called_ref, 1)
 
       assert gate_calls == 0,
@@ -424,18 +423,11 @@ defmodule Tau.Factory.UnitTerminationTest do
       start_scheduler(scheduler_name)
       start_supervised!({@unit_supervisor, name: sup_name}, id: sup_name)
 
-      # gate_fun always passes so we can focus on the re-gate edge.
       gate_fun = fn -> :pass end
-
-      # merge_fun: the test drives outcomes by sending {:merge_result, _} to
-      # the unit pid after the merge_fun is called. merge_fun itself just returns :queued.
       merge_fun = fn _uid, _hash -> :queued end
-
-      worker_fun = fn _role -> {:ok, make_ref()} end
 
       opts =
         base_unit_opts(unit_id, scheduler_name, test_pid,
-          worker_fun: worker_fun,
           gate_fun: gate_fun,
           merge_fun: merge_fun,
           timeouts: [state_timeout_ms: 5_000]
@@ -444,24 +436,10 @@ defmodule Tau.Factory.UnitTerminationTest do
       unit_pid = @unit_supervisor.start_unit(sup_name, opts)
       assert is_pid(unit_pid)
 
-      # Helper: deliver worker_done for whichever worker the FSM is waiting on.
-      deliver_worker_done = fn ->
-        :timer.sleep(50)
-
-        case :sys.get_state(unit_pid) do
-          {state, data} when state in [:oracle, :implementing] ->
-            ref = Map.get(data, :worker_ref) || Map.get(data, :current_worker_ref)
-            if ref, do: send(unit_pid, {:worker_done, ref})
-
-          _ ->
-            :ok
-        end
-      end
-
       # Advance through oracle and implementing.
-      deliver_worker_done.()
+      deliver_worker_done(unit_pid)
       :timer.sleep(50)
-      deliver_worker_done.()
+      deliver_worker_done(unit_pid)
 
       # Allow FSM to reach awaiting_merge (gate :pass → awaiting_merge).
       :timer.sleep(100)
@@ -470,7 +448,6 @@ defmodule Tau.Factory.UnitTerminationTest do
       send(unit_pid, {:merge_result, :rejected})
 
       # Allow FSM to re-gate and re-enter awaiting_merge.
-      # gate_fun returns :pass again, so FSM should reach awaiting_merge a second time.
       :timer.sleep(150)
 
       # Second merge result: :merged → terminal.
@@ -509,11 +486,11 @@ defmodule Tau.Factory.UnitTerminationTest do
 
       gate_fun = fn -> {:fail, last_findings} end
 
-      worker_fun = fn _role -> {:ok, make_ref()} end
+      n_refine = Retry.n_refine()
+      n_pivot = Retry.n_pivot()
 
       opts =
         base_unit_opts(unit_id, scheduler_name, test_pid,
-          worker_fun: worker_fun,
           gate_fun: gate_fun,
           merge_fun: fn _uid, _hash -> :queued end,
           timeouts: [state_timeout_ms: 5_000]
@@ -522,20 +499,9 @@ defmodule Tau.Factory.UnitTerminationTest do
       unit_pid = @unit_supervisor.start_unit(sup_name, opts)
       assert is_pid(unit_pid)
 
-      n_refine = Retry.n_refine()
-      n_pivot = Retry.n_pivot()
-
-      for _i <- 1..(n_refine + n_pivot + 4) do
+      for _i <- 1..(n_refine + n_pivot + 3) do
+        deliver_worker_done(unit_pid)
         :timer.sleep(60)
-
-        case :sys.get_state(unit_pid) do
-          {state, data} when state in [:oracle, :implementing] ->
-            ref = Map.get(data, :worker_ref) || Map.get(data, :current_worker_ref)
-            if ref, do: send(unit_pid, {:worker_done, ref})
-
-          _ ->
-            :ok
-        end
       end
 
       assert_receive {:unit_terminal, ^unit_id, :escalated, provenance},
@@ -551,6 +517,117 @@ defmodule Tau.Factory.UnitTerminationTest do
 
       assert reported_findings == last_findings,
              "C111: provenance.last_findings must be #{inspect(last_findings)}; got #{inspect(reported_findings)}"
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # D-318 / B8 / C105 — Worker CRASH → infra-failure path → :escalated (fix f-3)
+  #
+  # SPEC-FACTORY-CORE §4 B8 (line 279): the Unit holds a Process.monitor/1 ref on
+  # the worker for liveness. A worker CRASH (abnormal :DOWN) is an infra failure
+  # distinct from a stall (:state_timeout) and from a gate {:fail} (C105).
+  #
+  # The monitorable seam: worker_fun.(role) -> {:ok, pid} where pid is a REAL
+  # process (not make_ref()). The Unit monitors it. Killing the pid delivers
+  # {:DOWN, monitor_ref, :process, pid, :killed} to the Unit's mailbox.
+  # The Unit MUST route to infra-failure → escalated WITHOUT calling gate_fun.
+  # ---------------------------------------------------------------------------
+
+  describe "D-318 / B8 / C105 — worker process crash → infra-failure path, gate not called" do
+    @tag :d_340
+    @tag :d_318
+    @tag :b8
+    @tag :c105
+    test "B8/C105: worker process killed in implementing state → :escalated, gate_fun NOT called" do
+      test_pid = self()
+      unit_id = "u-crash-#{System.unique_integer([:positive])}"
+      scheduler_name = :"sched_crash_#{System.unique_integer([:positive])}"
+      sup_name = :"sup_crash_#{System.unique_integer([:positive])}"
+      start_scheduler(scheduler_name)
+      start_supervised!({@unit_supervisor, name: sup_name}, id: sup_name)
+
+      # The test captures the implementing worker pid so it can kill it.
+      # We use a named ETS table owned by this test process.
+      ets_name = :"wpid_#{System.unique_integer([:positive])}"
+      worker_pid_ets = :ets.new(ets_name, [:set, :public])
+
+      worker_fun = fn role ->
+        pid = spawn_worker()
+        :ets.insert(worker_pid_ets, {role, pid})
+        {:ok, pid}
+      end
+
+      # Sentinel: if gate_fun is called, the FSM routed a :DOWN through the
+      # semantic gate-fail path — a C105 violation.
+      gate_called_ref = :counters.new(1, [:atomics])
+
+      gate_fun = fn ->
+        :counters.add(gate_called_ref, 1, 1)
+        :pass
+      end
+
+      merge_fun = fn _uid, _hash -> :queued end
+
+      opts =
+        base_unit_opts(unit_id, scheduler_name, test_pid,
+          worker_fun: worker_fun,
+          gate_fun: gate_fun,
+          merge_fun: merge_fun,
+          timeouts: [state_timeout_ms: 5_000]
+        )
+
+      unit_pid = @unit_supervisor.start_unit(sup_name, opts)
+      assert is_pid(unit_pid)
+
+      # Drive oracle phase to completion; let FSM enter :implementing.
+      deliver_worker_done(unit_pid)
+      :timer.sleep(80)
+
+      # Verify the FSM is in :implementing with worker_pid exposed in state data.
+      # This is the discriminating check for the monitorable seam (B8 / fix f-3):
+      # the old seam returned make_ref() (unmonitorable); the new seam returns a pid.
+      {fsm_state, state_data} = :sys.get_state(unit_pid)
+
+      assert fsm_state == :implementing,
+             "B8: expected FSM in :implementing after oracle delivery; got :#{fsm_state}. " <>
+               "Check worker_fun seam and oracle→implementing transition timing."
+
+      worker_pid = Map.get(state_data, :worker_pid)
+
+      assert is_pid(worker_pid),
+             "B8 (f-3): Unit FSM in :implementing MUST expose :worker_pid in state data " <>
+               "(real pid, not a ref — enables Process.monitor/1); " <>
+               "got #{inspect(state_data)}"
+
+      # Kill the worker abnormally. The Unit's Process.monitor/1 ref delivers
+      # {:DOWN, monitor_ref, :process, worker_pid, :killed} to the Unit mailbox.
+      # The Unit must route this to the infra-failure path, not the gate-fail path.
+      Process.exit(worker_pid, :kill)
+
+      assert_receive {:unit_terminal, ^unit_id, :escalated, provenance},
+                     5_000,
+                     "B8/C105: expected :escalated from worker crash (:DOWN) within 5s"
+
+      reason = Map.get(provenance, :reason)
+
+      refute reason == nil,
+             "B8: provenance must carry an escalation reason after worker crash; got nil"
+
+      # C105 (fix f-3): a worker crash is an infra event — gate_fun MUST NOT be called.
+      # If gate_fun was called, the FSM treated the :DOWN as a semantic gate failure.
+      gate_calls = :counters.get(gate_called_ref, 1)
+
+      assert gate_calls == 0,
+             "C105 (f-3): gate_fun must NOT be called for a worker crash (infra-failure path); " <>
+               "called #{gate_calls} times — FSM incorrectly treated :DOWN as a gate outcome"
+
+      # Scheduler must release the unit after crash escalation.
+      in_flight = @scheduler.in_flight(scheduler_name)
+
+      refute Map.has_key?(in_flight, unit_id),
+             "B8: after worker-crash escalation, unit must be released from Scheduler in_flight"
+
+      :ets.delete(worker_pid_ets)
     end
   end
 end

--- a/test/tau/factory/unit_termination_test.exs
+++ b/test/tau/factory/unit_termination_test.exs
@@ -1,0 +1,556 @@
+defmodule Tau.Factory.UnitTerminationTest do
+  @moduledoc """
+  Gating tests for PR #441 (P4c — Unit FSM lifecycle driver).
+
+  Exercises D-340 (unit termination liveness) and D-318 (bounded retry).
+
+  Each test drives the Unit FSM to a terminal sink by scripting the injected
+  boundary seams (worker_fun, gate_fun, merge_fun) and asserting that the
+  `{:unit_terminal, unit_id, outcome, provenance}` report arrives and that
+  `Scheduler.in_flight/1` no longer contains the unit after terminal.
+
+  Written BEFORE production code exists (oracle-separation phase, factory-loop §4b).
+  These tests fail with `UndefinedFunctionError` until the implementer creates:
+    - `lib/tau/factory/unit.ex`         (Tau.Factory.Unit)
+    - `lib/tau/factory/unit_supervisor.ex` (Tau.Factory.UnitSupervisor)
+    - (Tau.Factory.UnitRegistry — a Registry started by UnitSupervisor or
+      the test harness; name injected via opts)
+
+  ## Pinned API contract (implementer MUST conform exactly)
+
+  ### Tau.Factory.Unit (gen_statem, :state_functions)
+
+  States (SPEC-FACTORY-CORE §5):
+    planned → oracle → implementing → gating → awaiting_merge → merged (terminal)
+    gating {:fail,_} → retry ladder → implementing | escalated (terminal)
+    awaiting_merge :rejected → gating (re-gate)
+    any non-terminal + :state_timeout or worker_stalled → ladder → escalated (terminal)
+    any non-terminal + escalation/2 → escalated (terminal)
+
+  `start_link(opts) :: {:ok, pid} | {:error, term}`
+
+  Required opts:
+    `:unit_id`        — String.t(); unique identity; keyed in UnitRegistry.
+    `:declared_scope` — ConflictCheck.scope() (passed to Scheduler.admit/3).
+    `:hash`           — String.t(); content hash for the PR.
+    `:scheduler`      — atom() | pid(); name/pid of a running Scheduler.
+    `:report_to`      — pid(); receives `{:unit_terminal, unit_id, outcome, provenance}`.
+    `:worker_fun`     — (role :: atom() -> {:ok, ref :: reference()} | {:error, reason})
+                        Called when the FSM needs to spawn a worker for a role.
+                        The test controls worker completion: send `{:worker_done, ref}`
+                        to the Unit pid to advance oracle→implementing or
+                        implementing→gating. The Unit arms a monitor on the returned
+                        ref so a `:DOWN` is also handled.
+    `:gate_fun`       — (-> :pass | {:fail, findings :: [term()]})
+                        Called when the FSM enters gating state. The seam's return
+                        determines the gate outcome synchronously (i.e. the Unit
+                        may call this in-state or via an internal event; the implementer
+                        chooses, but the test observes the terminal output only).
+    `:merge_fun`      — (unit_id :: String.t(), hash :: String.t() ->
+                          :queued | {:error, reason})
+                        Called when the FSM requests a merge (awaiting_merge entry).
+                        The result `:merged | :rejected` is delivered to the Unit
+                        process as `{:merge_result, :merged | :rejected}` sent
+                        by the test harness (or the merge_fun itself may spawn a
+                        process that does so). The Unit's awaiting_merge state must
+                        handle this message.
+    `:timeouts`       — keyword(); optional overrides:
+                          `:state_timeout_ms` — integer(); `:state_timeout` value
+                          for each waiting state (oracle, implementing, gating,
+                          awaiting_merge). Default: 30_000. Set to ~50 for the
+                          stall test so the test is fast.
+
+  ### Tau.Factory.UnitSupervisor (DynamicSupervisor, restart :temporary)
+
+  `start_link(opts) :: {:ok, pid}`
+    Required opts: `:name` (atom).
+
+  `start_unit(supervisor, unit_opts) :: {:ok, pid} | {:error, term}`
+    Starts a Unit under the DynamicSupervisor. `unit_opts` is the same
+    opts map accepted by `Unit.start_link/1`.
+
+  ### Tau.Factory.UnitRegistry (Registry)
+
+  A Registry started with `:keys: :unique`. Name is passed to tests via
+  the registry_name opt; the Unit registers itself under its `unit_id`.
+
+  `lookup(registry, unit_id) :: [{pid, value}]`
+    Standard Registry.lookup/2.
+
+  ### Terminal report shape
+
+  `{:unit_terminal, unit_id :: String.t(), outcome, provenance}`
+
+  where:
+    outcome    :: :merged | :escalated | :rejected
+    provenance :: %{
+      attempt_count: non_neg_integer(),    # total non-terminal attempts
+      last_findings: [term()] | nil,       # last gate findings (nil if not a gate failure)
+      reason: atom() | nil                 # escalation reason (e.g. :E_RETRY_EXHAUSTED) or nil
+    }
+
+  AC/D-NNN linkage: D-340, D-318.
+  """
+
+  use ExUnit.Case, async: true
+
+  # Retry exists on main; alias it to satisfy Credo nested-module warnings.
+  alias Tau.Factory.Retry
+
+  @moduletag :capture_log
+  @moduletag :d_340
+  @moduletag :d_318
+
+  # ---------------------------------------------------------------------------
+  # Runtime module references — file compiles while Unit/UnitSupervisor absent.
+  # @mod.fun(args) form; NOT apply/2,3 (Credo strict).
+  # ---------------------------------------------------------------------------
+
+  @unit Tau.Factory.Unit
+  @unit_supervisor Tau.Factory.UnitSupervisor
+  @scheduler Tau.Factory.Scheduler
+
+  # ---------------------------------------------------------------------------
+  # Helpers
+  # ---------------------------------------------------------------------------
+
+  # Build a minimal non-conflicting scope that clears all five ConflictCheck
+  # clauses against any other empty-scope unit.
+  defp empty_scope do
+    %{
+      deps: [],
+      files: MapSet.new(),
+      codepoints: MapSet.new(),
+      specs: MapSet.new(),
+      resources: MapSet.new()
+    }
+  end
+
+  # Start an isolated Scheduler with generous capacity and no budget gate.
+  defp start_scheduler(name) do
+    start_supervised!(
+      {@scheduler, name: name, w_cap: 10},
+      id: name
+    )
+  end
+
+  # Build base Unit opts with seam funs injected by the caller.
+  # `merge_deliver_pid` is the pid that will receive merge result delivery
+  # requests from merge_fun; tests send `{:merge_result, outcome}` to the
+  # Unit pid themselves (or via a spawned sender).
+  defp base_unit_opts(unit_id, scheduler_name, report_to, overrides) do
+    defaults = [
+      unit_id: unit_id,
+      declared_scope: empty_scope(),
+      hash: "hash-#{unit_id}",
+      scheduler: scheduler_name,
+      report_to: report_to,
+      # Default seams (overridden per test):
+      worker_fun: fn _role -> {:ok, make_ref()} end,
+      gate_fun: fn -> :pass end,
+      merge_fun: fn _uid, _hash -> :queued end,
+      timeouts: [state_timeout_ms: 5_000]
+    ]
+
+    Keyword.merge(defaults, overrides)
+  end
+
+  # ---------------------------------------------------------------------------
+  # D-340a — Happy path → merged
+  # ---------------------------------------------------------------------------
+
+  describe "D-340a — happy path reaches :merged and releases from Scheduler" do
+    @tag :d_340
+    @tag :d_318
+    test "D-340a: worker completes, gate passes, merge succeeds → :merged report + released" do
+      test_pid = self()
+      unit_id = "u-happy-#{System.unique_integer([:positive])}"
+      scheduler_name = :"sched_happy_#{System.unique_integer([:positive])}"
+      sup_name = :"sup_happy_#{System.unique_integer([:positive])}"
+      start_scheduler(scheduler_name)
+
+      start_supervised!({@unit_supervisor, name: sup_name}, id: sup_name)
+
+      # worker_fun: capture the Unit pid so we can deliver worker_done and merge_result.
+      # The Unit process registers in UnitRegistry; we hold the pid from start_unit.
+      worker_fun = fn _role ->
+        ref = make_ref()
+        # Spawn a process to deliver :worker_done after a brief yield.
+        # The sender needs the Unit pid; we delay slightly to let start_unit return.
+        Process.send_after(self(), {:_worker_ref_capture, ref}, 1)
+        {:ok, ref}
+      end
+
+      merge_fun = fn _uid, _hash -> :queued end
+
+      gate_fun = fn -> :pass end
+
+      opts =
+        base_unit_opts(unit_id, scheduler_name, test_pid,
+          worker_fun: worker_fun,
+          gate_fun: gate_fun,
+          merge_fun: merge_fun,
+          timeouts: [state_timeout_ms: 5_000]
+        )
+
+      # Unit start triggers: planned → (Scheduler.admit) → oracle → worker_fun call.
+      unit_pid = @unit_supervisor.start_unit(sup_name, opts)
+      assert is_pid(unit_pid), "start_unit must return a pid"
+
+      # Drive oracle phase: deliver worker_done for the oracle worker.
+      # The Unit should be waiting in oracle state with a ref from worker_fun.
+      # We ask the Unit for its current worker ref via sys.get_state, then send done.
+      # Allow up to 500 ms for the FSM to reach oracle and call worker_fun.
+      :timer.sleep(50)
+      {state_name, state_data} = :sys.get_state(unit_pid)
+
+      assert state_name in [:oracle, :implementing],
+             "After start, Unit must be in oracle or implementing; got #{inspect(state_name)}"
+
+      # Deliver worker_done for oracle (or implementing, same message shape).
+      # We extract the ref from state_data — implementer exposes :worker_ref key.
+      worker_ref = Map.get(state_data, :worker_ref) || Map.get(state_data, :current_worker_ref)
+
+      if worker_ref do
+        send(unit_pid, {:worker_done, worker_ref})
+      else
+        # Fallback: send a synthetic done — the FSM handles unknown refs gracefully.
+        send(unit_pid, {:worker_done, make_ref()})
+      end
+
+      # Allow FSM to advance to implementing if it was in oracle.
+      :timer.sleep(50)
+
+      {state_name2, state_data2} = :sys.get_state(unit_pid)
+
+      if state_name2 == :implementing do
+        impl_ref = Map.get(state_data2, :worker_ref) || Map.get(state_data2, :current_worker_ref)
+
+        if impl_ref do
+          send(unit_pid, {:worker_done, impl_ref})
+        end
+      end
+
+      # Allow transition through gating (gate_fun → :pass) to awaiting_merge.
+      :timer.sleep(100)
+
+      # Deliver merge result :merged to the Unit.
+      send(unit_pid, {:merge_result, :merged})
+
+      # Assert terminal report arrives.
+      assert_receive {:unit_terminal, ^unit_id, :merged, provenance},
+                     5_000,
+                     "D-340a: expected {:unit_terminal, _, :merged, _} within 5s"
+
+      assert is_map(provenance),
+             "D-340a: provenance must be a map; got #{inspect(provenance)}"
+
+      # Assert Scheduler released the unit.
+      in_flight = @scheduler.in_flight(scheduler_name)
+
+      refute Map.has_key?(in_flight, unit_id),
+             "D-340a: after :merged, unit must be released from Scheduler in_flight"
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # D-340b / D-318 — Gate-fail ladder → escalated, bounded attempt count
+  # ---------------------------------------------------------------------------
+
+  describe "D-340b / D-318 — gate-fail ladder exhausts to :escalated within attempt bound" do
+    @tag :d_340
+    @tag :d_318
+    test "D-340b / D-318: gate always fails → :escalated with E-RETRY-EXHAUSTED, attempts ≤ N_refine + N_pivot" do
+      test_pid = self()
+      unit_id = "u-ladder-#{System.unique_integer([:positive])}"
+      scheduler_name = :"sched_ladder_#{System.unique_integer([:positive])}"
+      sup_name = :"sup_ladder_#{System.unique_integer([:positive])}"
+      start_scheduler(scheduler_name)
+      start_supervised!({@unit_supervisor, name: sup_name}, id: sup_name)
+
+      # Count gate invocations so we can bound them.
+      gate_count_ref = :counters.new(1, [:atomics])
+
+      worker_fun = fn _role -> {:ok, make_ref()} end
+
+      # Always-fail gate: records each invocation.
+      gate_fun = fn ->
+        :counters.add(gate_count_ref, 1, 1)
+        {:fail, ["finding-#{:counters.get(gate_count_ref, 1)}"]}
+      end
+
+      merge_fun = fn _uid, _hash -> :queued end
+
+      opts =
+        base_unit_opts(unit_id, scheduler_name, test_pid,
+          worker_fun: worker_fun,
+          gate_fun: gate_fun,
+          merge_fun: merge_fun,
+          timeouts: [state_timeout_ms: 5_000]
+        )
+
+      unit_pid = @unit_supervisor.start_unit(sup_name, opts)
+      assert is_pid(unit_pid)
+
+      # Drive each implementing phase by delivering worker_done whenever the
+      # FSM reaches implementing. The FSM will enter gating, fail, re-enter
+      # implementing, etc. We poll and deliver up to max_attempts+2 times.
+      n_refine = Retry.n_refine()
+      n_pivot = Retry.n_pivot()
+      max_attempts = n_refine + n_pivot
+
+      # Deliver worker_done up to max_attempts + 2 times to cover each cycle.
+      # Each delivery either finishes oracle, implementing, or a refine re-attempt.
+      for _i <- 1..(max_attempts + 4) do
+        :timer.sleep(60)
+
+        case :sys.get_state(unit_pid) do
+          {state, data} when state in [:oracle, :implementing] ->
+            ref = Map.get(data, :worker_ref) || Map.get(data, :current_worker_ref)
+            if ref, do: send(unit_pid, {:worker_done, ref})
+
+          _ ->
+            :ok
+        end
+      end
+
+      assert_receive {:unit_terminal, ^unit_id, :escalated, provenance},
+                     10_000,
+                     "D-340b / D-318: expected {:unit_terminal, _, :escalated, _} within 10s"
+
+      # Provenance must carry the escalation reason.
+      reason = Map.get(provenance, :reason)
+
+      assert reason == :E_RETRY_EXHAUSTED,
+             "D-318: escalated provenance must carry :E_RETRY_EXHAUSTED; got #{inspect(reason)}"
+
+      # Gate must not have been called more than N_refine + N_pivot times (D-318).
+      gate_calls = :counters.get(gate_count_ref, 1)
+
+      assert gate_calls <= max_attempts,
+             "D-318: gate called #{gate_calls} times; must be ≤ #{max_attempts} (N_refine=#{n_refine} + N_pivot=#{n_pivot})"
+
+      # Scheduler must have released the unit.
+      in_flight = @scheduler.in_flight(scheduler_name)
+
+      refute Map.has_key?(in_flight, unit_id),
+             "D-340b: after :escalated, unit must be released from Scheduler in_flight"
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # D-340c / C107 — Infra stall → escalated via :state_timeout (not gate fail)
+  # ---------------------------------------------------------------------------
+
+  describe "D-340c / C107 — wedged worker triggers :state_timeout → :escalated" do
+    @tag :d_340
+    @tag :d_318
+    test "D-340c / C107: worker never delivers done → :state_timeout fires → :escalated" do
+      test_pid = self()
+      unit_id = "u-stall-#{System.unique_integer([:positive])}"
+      scheduler_name = :"sched_stall_#{System.unique_integer([:positive])}"
+      sup_name = :"sup_stall_#{System.unique_integer([:positive])}"
+      start_scheduler(scheduler_name)
+      start_supervised!({@unit_supervisor, name: sup_name}, id: sup_name)
+
+      # gate_fun is a sentinel: if called, the FSM confused semantic failure with
+      # infra stall. We record any call so the test can assert it was NOT called
+      # as the stall termination path.
+      gate_called_ref = :counters.new(1, [:atomics])
+
+      # worker_fun returns a ref but the corresponding :worker_done is NEVER sent.
+      # The Unit must arm a :state_timeout and escalate on timeout.
+      worker_fun = fn _role -> {:ok, make_ref()} end
+
+      gate_fun = fn ->
+        :counters.add(gate_called_ref, 1, 1)
+        :pass
+      end
+
+      merge_fun = fn _uid, _hash -> :queued end
+
+      opts =
+        base_unit_opts(unit_id, scheduler_name, test_pid,
+          worker_fun: worker_fun,
+          gate_fun: gate_fun,
+          merge_fun: merge_fun,
+          # Very short timeout so the stall path is fast.
+          timeouts: [state_timeout_ms: 80]
+        )
+
+      unit_pid = @unit_supervisor.start_unit(sup_name, opts)
+      assert is_pid(unit_pid)
+
+      # Do NOT send any :worker_done. The FSM must timeout on its own.
+      assert_receive {:unit_terminal, ^unit_id, :escalated, provenance},
+                     5_000,
+                     "D-340c / C107: expected :escalated from :state_timeout within 5s"
+
+      # The provenance reason must be infrastructure-stall-derived, not the
+      # gate-fail derived :E_RETRY_EXHAUSTED.
+      reason = Map.get(provenance, :reason)
+
+      refute reason == nil,
+             "D-340c: provenance must carry a reason; got nil"
+
+      # C105 / C107: stall path is NOT the same as semantic gate fail.
+      # Gate should not have been called on a stall-only path.
+      gate_calls = :counters.get(gate_called_ref, 1)
+
+      assert gate_calls == 0,
+             "C105 / C107: gate_fun must not be called on a :state_timeout stall path; called #{gate_calls} times"
+
+      assert is_pid(unit_pid)
+
+      in_flight = @scheduler.in_flight(scheduler_name)
+
+      refute Map.has_key?(in_flight, unit_id),
+             "D-340c: after :escalated, unit must be released from Scheduler in_flight"
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # D-340d — Merge reject → re-gate (INV-2) → eventually :merged
+  # ---------------------------------------------------------------------------
+
+  describe "D-340d — merge reject causes re-gate; second pass succeeds → :merged" do
+    @tag :d_340
+    @tag :d_318
+    test "D-340d: first merge :rejected → unit re-gates → second pass :merged" do
+      test_pid = self()
+      unit_id = "u-rejet-#{System.unique_integer([:positive])}"
+      scheduler_name = :"sched_rejet_#{System.unique_integer([:positive])}"
+      sup_name = :"sup_rejet_#{System.unique_integer([:positive])}"
+      start_scheduler(scheduler_name)
+      start_supervised!({@unit_supervisor, name: sup_name}, id: sup_name)
+
+      # gate_fun always passes so we can focus on the re-gate edge.
+      gate_fun = fn -> :pass end
+
+      # merge_fun: the test drives outcomes by sending {:merge_result, _} to
+      # the unit pid after the merge_fun is called. merge_fun itself just returns :queued.
+      merge_fun = fn _uid, _hash -> :queued end
+
+      worker_fun = fn _role -> {:ok, make_ref()} end
+
+      opts =
+        base_unit_opts(unit_id, scheduler_name, test_pid,
+          worker_fun: worker_fun,
+          gate_fun: gate_fun,
+          merge_fun: merge_fun,
+          timeouts: [state_timeout_ms: 5_000]
+        )
+
+      unit_pid = @unit_supervisor.start_unit(sup_name, opts)
+      assert is_pid(unit_pid)
+
+      # Helper: deliver worker_done for whichever worker the FSM is waiting on.
+      deliver_worker_done = fn ->
+        :timer.sleep(50)
+
+        case :sys.get_state(unit_pid) do
+          {state, data} when state in [:oracle, :implementing] ->
+            ref = Map.get(data, :worker_ref) || Map.get(data, :current_worker_ref)
+            if ref, do: send(unit_pid, {:worker_done, ref})
+
+          _ ->
+            :ok
+        end
+      end
+
+      # Advance through oracle and implementing.
+      deliver_worker_done.()
+      :timer.sleep(50)
+      deliver_worker_done.()
+
+      # Allow FSM to reach awaiting_merge (gate :pass → awaiting_merge).
+      :timer.sleep(100)
+
+      # First merge result: :rejected → FSM must re-enter gating (INV-2).
+      send(unit_pid, {:merge_result, :rejected})
+
+      # Allow FSM to re-gate and re-enter awaiting_merge.
+      # gate_fun returns :pass again, so FSM should reach awaiting_merge a second time.
+      :timer.sleep(150)
+
+      # Second merge result: :merged → terminal.
+      send(unit_pid, {:merge_result, :merged})
+
+      assert_receive {:unit_terminal, ^unit_id, :merged, provenance},
+                     5_000,
+                     "D-340d: expected {:unit_terminal, _, :merged, _} after reject+re-gate within 5s"
+
+      assert is_map(provenance),
+             "D-340d: provenance must be a map"
+
+      in_flight = @scheduler.in_flight(scheduler_name)
+
+      refute Map.has_key?(in_flight, unit_id),
+             "D-340d: after :merged, unit must be released from Scheduler in_flight"
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # C111 — Provenance carries attempt count + last findings for escalated case
+  # ---------------------------------------------------------------------------
+
+  describe "C111 — provenance carries attempt_count and last_findings on escalated" do
+    @tag :d_340
+    @tag :d_318
+    test "C111: escalated provenance has attempt_count > 0 and last_findings set" do
+      test_pid = self()
+      unit_id = "u-prov-#{System.unique_integer([:positive])}"
+      scheduler_name = :"sched_prov_#{System.unique_integer([:positive])}"
+      sup_name = :"sup_prov_#{System.unique_integer([:positive])}"
+      start_scheduler(scheduler_name)
+      start_supervised!({@unit_supervisor, name: sup_name}, id: sup_name)
+
+      last_findings = ["finding-alpha", "finding-beta"]
+
+      gate_fun = fn -> {:fail, last_findings} end
+
+      worker_fun = fn _role -> {:ok, make_ref()} end
+
+      opts =
+        base_unit_opts(unit_id, scheduler_name, test_pid,
+          worker_fun: worker_fun,
+          gate_fun: gate_fun,
+          merge_fun: fn _uid, _hash -> :queued end,
+          timeouts: [state_timeout_ms: 5_000]
+        )
+
+      unit_pid = @unit_supervisor.start_unit(sup_name, opts)
+      assert is_pid(unit_pid)
+
+      n_refine = Retry.n_refine()
+      n_pivot = Retry.n_pivot()
+
+      for _i <- 1..(n_refine + n_pivot + 4) do
+        :timer.sleep(60)
+
+        case :sys.get_state(unit_pid) do
+          {state, data} when state in [:oracle, :implementing] ->
+            ref = Map.get(data, :worker_ref) || Map.get(data, :current_worker_ref)
+            if ref, do: send(unit_pid, {:worker_done, ref})
+
+          _ ->
+            :ok
+        end
+      end
+
+      assert_receive {:unit_terminal, ^unit_id, :escalated, provenance},
+                     10_000,
+                     "C111: expected :escalated terminal within 10s"
+
+      attempt_count = Map.get(provenance, :attempt_count)
+
+      assert is_integer(attempt_count) and attempt_count > 0,
+             "C111: provenance.attempt_count must be a positive integer; got #{inspect(attempt_count)}"
+
+      reported_findings = Map.get(provenance, :last_findings)
+
+      assert reported_findings == last_findings,
+             "C111: provenance.last_findings must be #{inspect(last_findings)}; got #{inspect(reported_findings)}"
+    end
+  end
+end

--- a/test/tau/factory/unit_termination_test.exs
+++ b/test/tau/factory/unit_termination_test.exs
@@ -123,7 +123,6 @@ defmodule Tau.Factory.UnitTerminationTest do
   # @mod.fun(args) form; NOT apply/2,3 (Credo strict).
   # ---------------------------------------------------------------------------
 
-  @unit Tau.Factory.Unit
   @unit_supervisor Tau.Factory.UnitSupervisor
   @scheduler Tau.Factory.Scheduler
 
@@ -258,24 +257,29 @@ defmodule Tau.Factory.UnitTerminationTest do
   end
 
   # ---------------------------------------------------------------------------
-  # D-340b / D-318 — Gate-fail ladder → escalated at EXACT attempt count (fix f-2)
+  # D-340b / D-318 — Gate-fail ladder → escalated at EXACT attempt count (fix f-4)
   #
   # The SPEC §5 ladder (line 315):
   #   k < N_REFINE  → refine → back to implementing
-  #   k = N_REFINE  → pivot  → back to implementing (REAL extra attempt)
+  #   k = N_REFINE  → pivot  → back to implementing (REAL extra attempt, GATED)
   #   pivot gate red → escalated [E-RETRY-EXHAUSTED]
   #
-  # With N_REFINE=3, N_PIVOT=1: gate MUST be called EXACTLY 4 times.
-  # A buggy FSM that escalates immediately on :pivot (skipping the pivot's
-  # implementing attempt) makes only 3 gate calls. Both 3 and 4 satisfy ≤4,
-  # so the prior ≤4 assertion was too weak to catch the skip.
-  # == 4 is the discriminating assertion: it fails when gate_calls == 3.
+  # Gated-pivot gate-call trace (N_REFINE=3, N_PIVOT=1):
+  #   attempt 1 (initial)  → gate #1 fail → Retry.next(_,0,0) = {:refine,0}
+  #   attempt 2            → gate #2 fail → Retry.next(_,1,0) = {:refine,1}
+  #   attempt 3            → gate #3 fail → Retry.next(_,2,0) = {:refine,2}
+  #   attempt 4            → gate #4 fail → Retry.next(_,3,0) = :pivot  → re-implement
+  #   attempt 5 (pivot)    → gate #5 fail → Retry.next(_,3,1) = :exhausted → escalated
+  #
+  # Total gate calls = 1 + N_REFINE + N_PIVOT = 5.
+  # A buggy FSM that escalates the pivot UNGATED makes only 4 gate calls.
+  # == 5 is the discriminating assertion (fix f-4, supersedes f-2's == 4).
   # ---------------------------------------------------------------------------
 
   describe "D-340b / D-318 — gate-fail ladder escalates at EXACT attempt count" do
     @tag :d_340
     @tag :d_318
-    test "D-340b / D-318: gate always fails → :escalated with E-RETRY-EXHAUSTED, gate_calls == N_refine + N_pivot (exact)" do
+    test "D-340b / D-318: gate always fails → :escalated with E-RETRY-EXHAUSTED, gate_calls == 1 + N_refine + N_pivot (exact)" do
       test_pid = self()
       unit_id = "u-ladder-#{System.unique_integer([:positive])}"
       scheduler_name = :"sched_ladder_#{System.unique_integer([:positive])}"
@@ -294,8 +298,9 @@ defmodule Tau.Factory.UnitTerminationTest do
 
       n_refine = Retry.n_refine()
       n_pivot = Retry.n_pivot()
-      # With N_REFINE=3, N_PIVOT=1: exactly 4 gate calls expected.
-      expected_gate_calls = n_refine + n_pivot
+      # 1 initial attempt + N_REFINE refine attempts + N_PIVOT pivot attempt, all gated.
+      # With N_REFINE=3, N_PIVOT=1: exactly 5 gate calls expected.
+      expected_gate_calls = 1 + n_refine + n_pivot
 
       opts =
         base_unit_opts(unit_id, scheduler_name, test_pid,
@@ -307,9 +312,9 @@ defmodule Tau.Factory.UnitTerminationTest do
       unit_pid = @unit_supervisor.start_unit(sup_name, opts)
       assert is_pid(unit_pid)
 
-      # Drive oracle (1 delivery) then each refine/pivot implementing cycle
-      # (expected_gate_calls deliveries). Total: expected_gate_calls + 1.
-      # Add slack iterations to avoid race with FSM scheduling.
+      # Drive oracle (1 delivery) then each implementing cycle (expected_gate_calls
+      # deliveries — one per gated attempt including the pivot attempt).
+      # Add slack iterations to avoid races with FSM scheduling.
       for _i <- 1..(expected_gate_calls + 3) do
         deliver_worker_done(unit_pid)
         :timer.sleep(60)
@@ -326,19 +331,116 @@ defmodule Tau.Factory.UnitTerminationTest do
 
       gate_calls = :counters.get(gate_count_ref, 1)
 
-      # EXACT assertion (strengthened from ≤ to ==) — fix f-2.
-      # gate_calls == n_refine (3) means the pivot attempt was skipped: buggy FSM.
-      # gate_calls == n_refine + n_pivot (4) means pivot attempt happened: correct FSM.
+      # EXACT assertion (fix f-4: gated-pivot semantics).
+      # gate_calls == 4 means the pivot was escalated UNGATED (buggy FSM from f-2).
+      # gate_calls == 3 means the pivot attempt was skipped entirely (f-2's original bug).
+      # gate_calls == 5 means all 5 attempts were gated, including the pivot: correct FSM.
       assert gate_calls == expected_gate_calls,
-             "D-318 (f-2): gate must be called EXACTLY #{expected_gate_calls} times " <>
-               "(#{n_refine} refine attempts + #{n_pivot} pivot attempt); " <>
+             "D-318 (f-4): gate must be called EXACTLY #{expected_gate_calls} times " <>
+               "(1 initial + #{n_refine} refine attempts + #{n_pivot} pivot attempt, all gated); " <>
                "got #{gate_calls} — " <>
-               "a count of #{n_refine} indicates the pivot attempt was skipped (buggy FSM)"
+               "count 4 means pivot was escalated ungated (f-4 bug); " <>
+               "count 3 means pivot attempt was skipped entirely (f-2 bug)"
 
       in_flight = @scheduler.in_flight(scheduler_name)
 
       refute Map.has_key?(in_flight, unit_id),
              "D-340b: after :escalated, unit must be released from Scheduler in_flight"
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # D-318 / f-5 — Successful pivot: pivot attempt's gate PASSES → :merged
+  #
+  # This is the discriminating case for gated-pivot semantics (f-4).
+  # gate_fun script: [{:fail,_}, {:fail,_}, {:fail,_}, {:fail,_}, :pass]
+  #   attempt 1 (initial)  → gate #1 {:fail,_} → refine
+  #   attempt 2            → gate #2 {:fail,_} → refine
+  #   attempt 3            → gate #3 {:fail,_} → refine
+  #   attempt 4            → gate #4 {:fail,_} → pivot → re-implement
+  #   attempt 5 (pivot)    → gate #5 :pass      → awaiting_merge → :merged
+  #
+  # Against an ungated-pivot FSM: the pivot attempt is escalated without gating,
+  # so gate #5 is never called and the unit terminates :escalated — test FAILS.
+  # Against the correct gated FSM: gate #5 fires, unit proceeds to :merged — test PASSES.
+  # ---------------------------------------------------------------------------
+
+  describe "D-318 / f-5 — successful pivot: pivot attempt's gate passes → :merged" do
+    @tag :d_340
+    @tag :d_318
+    test "D-318 (f-5): gate fails 4 times then passes on pivot attempt → :merged, gate_calls == 5" do
+      test_pid = self()
+      unit_id = "u-pivot-pass-#{System.unique_integer([:positive])}"
+      scheduler_name = :"sched_pivot_pass_#{System.unique_integer([:positive])}"
+      sup_name = :"sup_pivot_pass_#{System.unique_integer([:positive])}"
+      start_scheduler(scheduler_name)
+      start_supervised!({@unit_supervisor, name: sup_name}, id: sup_name)
+
+      n_refine = Retry.n_refine()
+      n_pivot = Retry.n_pivot()
+      # Total attempts before pivot pass: 1 initial + N_REFINE refines = 4 fails,
+      # then the pivot attempt (call #5) returns :pass.
+      total_gate_calls = 1 + n_refine + n_pivot
+
+      gate_count_ref = :counters.new(1, [:atomics])
+
+      # Script: first (1 + n_refine) calls → {:fail,_}; the pivot call → :pass.
+      gate_fun = fn ->
+        call_n =
+          :counters.add(gate_count_ref, 1, 1) |> then(fn _ -> :counters.get(gate_count_ref, 1) end)
+
+        if call_n <= 1 + n_refine do
+          {:fail, ["scripted-fail-#{call_n}"]}
+        else
+          :pass
+        end
+      end
+
+      merge_fun = fn _uid, _hash -> :queued end
+
+      opts =
+        base_unit_opts(unit_id, scheduler_name, test_pid,
+          gate_fun: gate_fun,
+          merge_fun: merge_fun,
+          timeouts: [state_timeout_ms: 5_000]
+        )
+
+      unit_pid = @unit_supervisor.start_unit(sup_name, opts)
+      assert is_pid(unit_pid)
+
+      # Drive oracle + all implementing attempts (initial + refines + pivot).
+      # Add slack iterations; the pivot attempt reaching gating requires one extra
+      # worker-done delivery.
+      for _i <- 1..(total_gate_calls + 3) do
+        deliver_worker_done(unit_pid)
+        :timer.sleep(60)
+      end
+
+      # Allow FSM to reach awaiting_merge after the pivot gate passes.
+      :timer.sleep(150)
+
+      # Deliver :merged to complete the terminal path.
+      send(unit_pid, {:merge_result, :merged})
+
+      # The pivot attempt's gate passed → unit must reach :merged, NOT :escalated.
+      assert_receive {:unit_terminal, ^unit_id, :merged, provenance},
+                     10_000,
+                     "D-318 (f-5): pivot gate passed — expected {:unit_terminal, _, :merged, _}; " <>
+                       "if :escalated arrived, the FSM escalated the pivot UNGATED (f-4 bug)"
+
+      assert is_map(provenance),
+             "D-318 (f-5): provenance must be a map; got #{inspect(provenance)}"
+
+      gate_calls = :counters.get(gate_count_ref, 1)
+
+      assert gate_calls == total_gate_calls,
+             "D-318 (f-5): gate must be called exactly #{total_gate_calls} times " <>
+               "(#{1 + n_refine} fails + 1 pivot pass); got #{gate_calls}"
+
+      in_flight = @scheduler.in_flight(scheduler_name)
+
+      refute Map.has_key?(in_flight, unit_id),
+             "D-318 (f-5): after :merged, unit must be released from Scheduler in_flight"
     end
   end
 


### PR DESCRIPTION
## P4c — Unit FSM lifecycle driver (D-318, D-340)

Advances #437 (P4 control plane). The `Tau.Factory.Unit` `gen_statem` — one per
PR — that drives the whole PR lifecycle, using the cores already built: the
`Scheduler` (admit/release, P4b-2), `Retry` (the bounded ladder, P4a), and the
`MergeAuthority` (request_merge, P3). The not-yet-built boundaries — Gate (G,
SPEC-FACTORY-GATE) and Worker (W, P4d) — and the Coordinator terminal sink (K,
P5) are **injected seams** (default to real where it exists, a seam otherwise),
exactly as P3a injected `:build_fun`. Durable snapshot-to-L + resume (D-344) is
deferred to P5 (the Coordinator); P4c holds unit state in-process.

### Scope (SPEC-FACTORY-CORE §2 C6, §4 B5/B6/B7/B8, §5 Unit FSM, §6 D-318/D-340; [C105/C107/C111/C113-B5])
1. `lib/tau/factory/unit.ex` (C6) — `Tau.Factory.Unit`, a `gen_statem`
   (`callback_mode: :state_functions`), states exactly per §5:
   `planned → oracle → implementing → gating → awaiting_merge → merged*`,
   with terminal sinks `merged | escalated | rejected`. Transitions:
   - `planned`: on start, `Scheduler.admit(unit_id, declared_scope)` → `:admit`
     enters `oracle`; `{:defer, _}` re-arms a retry/backoff (or escalates if
     unadmittable) — for the bootstrap, an admitted unit is the entry assumption;
     a `{:defer,_}` path is exercised minimally.
   - `oracle`: spawn the test-author worker (seam); on worker done → `implementing`.
   - `implementing`: spawn the implementer worker (seam); on worker done →
     `request_gate` → `gating`.
   - `gating`: gate outcome (seam) `:pass` → `awaiting_merge`;
     `{:fail, findings}` → `Retry.next(outcome, refine_k, pivot_k)`:
     `{:refine, k}` → `implementing` (re-implement); `:pivot` → `implementing`
     (fresh approach); `:exhausted` → `escalated` (`E-RETRY-EXHAUSTED`). The
     attempt count is in-process FSM data (durable snapshot → P5). **D-318:**
     total attempts ≤ `N_refine + N_pivot`.
   - `awaiting_merge`: `request_merge(unit_id, hash)` (real M, async result via a
     seam/PubSub); `:merged` → `merged*`; `:rejected` → `gating` (re-gate, INV-2).
   - **C107 — every awaiting state (`oracle`/`implementing`/`gating`/
     `awaiting_merge`) arms a mandatory `:state_timeout`;** on timeout OR a
     `worker_stalled`/`:DOWN` infra event → routes into the retry/escalate ladder
     (a wedged worker cannot silently livelock the unit).
   - **C105 — a semantic failure (gate `{:fail}`) is an OUTCOME transition; an
     infrastructure failure (worker `:DOWN`/timeout) is an EVENT** — distinct
     handling, both feeding the ladder; never conflated.
   - `any non-terminal + escalation(e)` → `escalated*`.
   - On ANY terminal: `Scheduler.release(unit_id)` and report `unit_terminal(unit_id,
     outcome)` to the injected sink (default PubSub `"factory:pr:#{id}"`), with
     **full provenance** (outcome, attempt count, last findings) per [C111].
   - Illegal transitions unrepresentable (no clause for e.g. `gating → merged`).
2. `lib/tau/factory/unit_supervisor.ex` — `Tau.Factory.UnitSupervisor`, a
   `DynamicSupervisor` of `:temporary` `Unit` children.
3. `lib/tau/factory/unit_registry.ex` — `Tau.Factory.UnitRegistry` (a `Registry`)
   keying units by `unit_id`; a `start_unit/1` helper that registers + supervises.
4. `lib/tau/factory/supervisor.ex` (EDIT) — add `UnitRegistry` + `UnitSupervisor`
   under `Tau.Factory.Supervisor` (gated/named for test isolation).

Deferred (NOT here): durable `snapshot_unit`/resume (D-344 → P5); real Gate
`request_gate` wiring (SPEC-FACTORY-GATE) and real Worker `spawn` (P4d) — the
seams are the integration points those PRs fill; scope-amendment re-admission
(D-343 leg) minimal.

### Dependencies
Depends on P4a (`Retry`), P4b-2 (`Scheduler`), P3 (`MergeAuthority`). Blocks P4d
(real worker fills the W seam) and P5 (Coordinator drives Units + durable
snapshot). Advances #437.

### SPECs
In scope: **SPEC-FACTORY-CORE** (Appendix B: `unit.ex`, `unit_supervisor.ex`,
`unit_registry.ex`, `factory/supervisor.ex`). Conforms to §5 Unit FSM, §6
D-318/D-340, [C105/C107/C111/C113-B5]. Cites B6/B7/B8 (M/G/W). No SPEC amendment
expected.

### Acceptance criteria
- **AC (D-340 — unit termination, model-style):** `unit_termination_test.exs`
  drives EACH path to a terminal sink — (a) happy: admit→oracle→implementing→
  gating(:pass)→awaiting_merge(:merged)→**merged**; (b) gate-fail ladder:
  repeated `{:fail}` → refine×N → pivot → **escalated** (`E-RETRY-EXHAUSTED`);
  (c) infra stall: a `:state_timeout`/`worker_stalled` in an awaiting state →
  ladder → **escalated**; (d) M reject → re-gate. Assert EVERY path reaches a
  terminal sink (`merged | escalated | rejected`) and `Scheduler.release` is
  called on terminal.
- **AC (D-318 — bounded retry):** the gate-fail ladder yields **at most**
  `N_refine + N_pivot` attempts before `escalated`; unbounded refine is
  impossible (the unit consults `Retry.next`).

### Gating-test paths (frozen at b0272ad — implementer MUST NOT edit)
- `test/tau/factory/unit_termination_test.exs` (D-340 / D-318 / C107 / C111)

Pinned (oracle): `Unit.start_link(unit_id:, declared_scope:, hash:, scheduler:, report_to:, worker_fun: (role -> {:ok, ref}|{:error,_}), gate_fun: (-> :pass|{:fail, findings}), merge_fun: (id, hash -> :queued|{:error,_}), timeouts: [state_timeout_ms:])`; worker completion via `{:worker_done, ref}`, merge result via `{:merge_result, :merged|:rejected}`; FSM data exposes `:worker_ref`. `UnitSupervisor.start_unit(sup, opts) -> pid`; `UnitRegistry` (`:unique`, Unit self-registers by unit_id). Terminal report `{:unit_terminal, unit_id, outcome, %{attempt_count, last_findings, reason}}`, outcome `:merged|:escalated|:rejected`.

### Gate verdicts
_(filled at gate time — critic, reviewer)_
