### PR TITLE
fix(test): deterministic RateLimiter 429 telemetry assertion

### DIFF
--- a/test/tau/providers/rate_limiter_429_test.exs
+++ b/test/tau/providers/rate_limiter_429_test.exs
@@ -35,9 +35,9 @@ defmodule Tau.Providers.RateLimiter429Test do
 
     RateLimiter.record_response(provider, %{status: 429})
 
-    # record_response/2 is a GenServer.cast (async). Flush the mailbox by
-    # issuing a subsequent GenServer.call — calls queue behind casts for the
-    # same process, so state/1 returns only after the cast has landed.
+    # record_response/2 is a GenServer.cast (async). Flush by calling
+    # RateLimiter.state/1 — a GenServer.call that queues behind the cast for
+    # the same process, so it returns only after handle_cast/2 has landed.
     halved = RateLimiter.state(provider)
     assert halved.rpm_bucket.size == 300
     assert halved.tpm_bucket.size == 3_000
@@ -71,6 +71,14 @@ defmodule Tau.Providers.RateLimiter429Test do
 
     RateLimiter.record_response(provider, %{status: 429})
 
+    # record_response/2 is a GenServer.cast (async). Flush by calling
+    # RateLimiter.state/1 — a GenServer.call that queues behind the cast for
+    # the same process, so it returns only after handle_cast/2 has emitted
+    # :halved. The telemetry handler send/2s to this test pid from inside
+    # handle_cast, so by the time state/1 returns, {:halved, ...} is already
+    # in our mailbox — assert_receive then matches a delivered message instead
+    # of racing the 500ms budget.
+    _ = RateLimiter.state(provider)
     assert_receive {:halved, %{provider: ^provider, new_size: 100}}, 500
   end
 end

--- a/test/tau/providers/rate_limiter_429_test.exs
+++ b/test/tau/providers/rate_limiter_429_test.exs
@@ -8,48 +8,51 @@ defmodule Tau.Providers.RateLimiter429Test do
 
   alias Tau.Providers.RateLimiter
 
-  defmodule FakeProviderForFiveTwentyNine do
-    @moduledoc false
-  end
-
-  setup do
-    on_exit(fn ->
-      case RateLimiter.state(FakeProviderForFiveTwentyNine) do
-        :no_limiter -> :ok
-        _ -> Tau.Providers.RateLimiter.Supervisor.stop(FakeProviderForFiveTwentyNine)
-      end
-    end)
-
-    :ok
+  # Each test gets a unique provider atom to prevent on_exit cleanup from a
+  # prior test racing against a subsequent test's GenServer. ExUnit runs
+  # on_exit callbacks in a separate cleanup process; under full-suite load
+  # those can overlap with the next test's setup — stop/1 on a shared atom
+  # kills the limiter mid-cast, so the telemetry event never fires.
+  # See same pattern + comment in test/tau/providers/rate_limiter_test.exs.
+  defp unique_provider do
+    String.to_atom("FakeProvider429_#{System.unique_integer([:positive])}")
   end
 
   test "429 record_response halves bucket; next acquire sees the smaller cap" do
+    provider = unique_provider()
+    on_exit(fn -> Tau.Providers.RateLimiter.Supervisor.stop(provider) end)
+
     {:ok, _} =
       Tau.Providers.RateLimiter.Supervisor.ensure_started(
-        FakeProviderForFiveTwentyNine,
+        provider,
         rpm: 600,
         tpm: 6_000
       )
 
-    original = RateLimiter.state(FakeProviderForFiveTwentyNine)
+    original = RateLimiter.state(provider)
     assert original.rpm_bucket.size == 600
     assert original.tpm_bucket.size == 6_000
 
-    RateLimiter.record_response(FakeProviderForFiveTwentyNine, %{status: 429})
-    Process.sleep(20)
+    RateLimiter.record_response(provider, %{status: 429})
 
-    halved = RateLimiter.state(FakeProviderForFiveTwentyNine)
+    # record_response/2 is a GenServer.cast (async). Flush the mailbox by
+    # issuing a subsequent GenServer.call — calls queue behind casts for the
+    # same process, so state/1 returns only after the cast has landed.
+    halved = RateLimiter.state(provider)
     assert halved.rpm_bucket.size == 300
     assert halved.tpm_bucket.size == 3_000
 
     # And acquire still works against the smaller cap.
-    assert :ok = RateLimiter.acquire(FakeProviderForFiveTwentyNine, 100, 1_000)
+    assert :ok = RateLimiter.acquire(provider, 100, 1_000)
   end
 
   test "telemetry :halved fires on 429" do
+    provider = unique_provider()
+    on_exit(fn -> Tau.Providers.RateLimiter.Supervisor.stop(provider) end)
+
     {:ok, _} =
       Tau.Providers.RateLimiter.Supervisor.ensure_started(
-        FakeProviderForFiveTwentyNine,
+        provider,
         rpm: 200,
         tpm: 2_000
       )
@@ -66,8 +69,8 @@ defmodule Tau.Providers.RateLimiter429Test do
 
     on_exit(fn -> :telemetry.detach(handler_id) end)
 
-    RateLimiter.record_response(FakeProviderForFiveTwentyNine, %{status: 429})
+    RateLimiter.record_response(provider, %{status: 429})
 
-    assert_receive {:halved, %{provider: FakeProviderForFiveTwentyNine, new_size: 100}}, 500
+    assert_receive {:halved, %{provider: ^provider, new_size: 100}}, 500
   end
 end


### PR DESCRIPTION
## Root cause

`test/tau/providers/rate_limiter_429_test.exs` used a single static module atom `FakeProviderForFiveTwentyNine` shared between both tests and their `on_exit` cleanup callbacks.

ExUnit runs `on_exit` callbacks in a **separate cleanup process**. Under full-suite load (`mix test` / `mix tau.qa`), the on_exit from test 1 can be scheduled concurrently with test 2's execution. Concretely:

1. Test 1 body completes.
2. Test 2 starts, calls `ensure_started(FakeProviderForFiveTwentyNine, ...)` — finds the existing pid (already running from test 1, same atom), returns `{:ok, existing_pid}`.
3. Test 2 calls `record_response` → `GenServer.cast` queued.
4. Test 1's on_exit fires (`Supervisor.stop(FakeProviderForFiveTwentyNine)`) → **kills the GenServer** while test 2's cast is still in the mailbox or being processed.
5. The telemetry event (`:halved`) never fires → `assert_receive {:halved, ...}, 500` times out.

This is the same race that `test/tau/providers/rate_limiter_test.exs` already identified and fixed (see its comment at line 83–86: "Use a unique provider atom so on_exit cleanup from a sibling test cannot race-stop this limiter"). The 429 test was written without applying the same discipline.

The symptom is isolation-dependent: in isolation (`mix test test/tau/providers/rate_limiter_429_test.exs`) there is no prior test with a competing on_exit, so the race never manifests.

## Fix

Two changes to `test/tau/providers/rate_limiter_429_test.exs`, production code untouched:

1. **Per-test unique provider atoms** via `unique_provider/0` (using `System.unique_integer([:positive])`), matching the pattern in `rate_limiter_test.exs`. Each test now owns its own GenServer; on_exit cleanup cannot affect a sibling test's GenServer.

2. **Remove `Process.sleep(20)`** in test 1 (the bucket-state-check test). Replace with a subsequent `RateLimiter.state/1` call, which is a `GenServer.call` and acts as a mailbox flush: calls queue behind casts for the same process, so `state/1` only returns after the prior cast has landed. This is the canonical deterministic synchronization for this pattern.

The telemetry assertion itself (`assert_receive {:halved, %{provider: ^provider, new_size: 100}}, 500`) is preserved unchanged and still genuinely verifies the `:halved` event fires on a 429.

## Verification

Isolation run:
```
mix test test/tau/providers/rate_limiter_429_test.exs
# 2 tests, 0 failures
```

Multi-seed providers directory:
```
seed=0: 14 properties, 169 tests, 0 failures
seed=1: 14 properties, 169 tests, 0 failures
seed=7: 14 properties, 169 tests, 0 failures
seed=42: 14 properties, 169 tests, 0 failures
seed=137: 14 properties, 169 tests, 0 failures
```

Full suite:
```
mix test --seed 42
198 properties, 1505 tests, 0 failures, 8 excluded, 2 skipped
```

Lint clean: `mix compile --warnings-as-errors`, `mix format --check-formatted`, `mix credo diff --strict --from-git-merge-base origin/main` — all exit 0, no new issues.

---

Closes #429

No AC-N/D-NNN — test-quality fix, oracle-separation phase N/A.
