### PR TITLE
P4d-1: Worker.Isolation pure helper (D-309/D-311/D-313) — advances #437

### DIFF
--- a/lib/tau/factory/worker/isolation.ex
+++ b/lib/tau/factory/worker/isolation.ex
@@ -1,0 +1,122 @@
+defmodule Tau.Factory.Worker.Isolation do
+  @moduledoc """
+  Pure helper functions for per-worker isolation in the Factory Worker fleet.
+
+  All functions are stateless path and command computations — no processes,
+  no filesystem side-effects, no shell invocations. The Worker (P4d-2) calls
+  these to derive paths and build command descriptors; execution is the
+  caller's responsibility.
+
+  ## Invariants enforced
+
+    * **D-309** — namespace totality and cross-worker disjointness. Every
+      declared `var` maps to a directory rooted strictly inside the given
+      worktree, so two distinct worktrees yield disjoint directory sets.
+    * **D-311** — position verification. A `pwd` outside the worktree or a
+      mismatched HEAD/branch always returns `{:error, reason}`.
+    * **D-313** — capture-before-destroy command set. All three dirty-state
+      kinds (`:status`, `:patch`, `:untracked`) are always present.
+  """
+
+  alias Tau.Toolchain.ResourceNS
+
+  @typedoc "Absolute path to the worker's worktree root."
+  @type worktree_abs :: String.t()
+
+  @typedoc "Map from environment-variable name to its per-worker directory."
+  @type namespace_map :: %{String.t() => String.t()}
+
+  @typedoc "Observed runtime position of a worker process."
+  @type observed :: %{pwd: String.t(), head: String.t(), branch: String.t()}
+
+  @typedoc "Expected git ref and branch for the worker."
+  @type expected :: %{head: String.t(), branch: String.t()}
+
+  @typedoc "A single command descriptor for the capture-before-destroy sequence."
+  @type command :: %{kind: atom(), argv: [String.t()]}
+
+  # ---------------------------------------------------------------------------
+  # Public API
+  # ---------------------------------------------------------------------------
+
+  @doc """
+  Resolve per-worker namespace directories for a list of resource declarations.
+
+  For each `%ResourceNS{var: var}` in `decls`, maps `var` to the absolute
+  directory `<worktree_abs>/.factory-ns/<var>`. The result map is **total**
+  over `decls`: every declared `var` appears as a key. All resulting dirs are
+  rooted inside `worktree_abs`, guaranteeing cross-worker disjointness when
+  worktrees differ (D-309).
+
+  This function only computes paths — it does NOT create directories.
+  """
+  @spec resolve_namespace(worktree_abs(), [ResourceNS.t()]) :: namespace_map()
+  def resolve_namespace(worktree_abs, decls) do
+    Map.new(decls, fn %ResourceNS{var: var} ->
+      {var, Path.join([worktree_abs, ".factory-ns", var])}
+    end)
+  end
+
+  @doc """
+  Verify that a worker process is positioned inside the expected worktree and
+  at the expected git ref.
+
+  Returns `:ok` iff all three conditions hold:
+    1. `observed.pwd` starts with `worktree_abs` (the worker is inside its worktree).
+    2. `observed.head == expected.head` (correct commit).
+    3. `observed.branch == expected.branch` (correct branch).
+
+  Returns `{:error, reason}` where `reason` is the atom naming the first
+  failing check (D-311, F-6):
+    * `:not_in_worktree` — `pwd` is outside the worktree (e.g. parent root).
+    * `:head_mismatch`   — HEAD does not match the expected commit SHA.
+    * `:branch_mismatch` — the checked-out branch does not match.
+  """
+  @spec verify_position(worktree_abs(), observed(), expected()) ::
+          :ok | {:error, atom() | {atom(), term()}}
+  def verify_position(worktree_abs, observed, expected) do
+    cond do
+      not String.starts_with?(observed.pwd, worktree_abs) ->
+        {:error, :not_in_worktree}
+
+      observed.head != expected.head ->
+        {:error, :head_mismatch}
+
+      observed.branch != expected.branch ->
+        {:error, :branch_mismatch}
+
+      true ->
+        :ok
+    end
+  end
+
+  @doc """
+  Build the list of command descriptors for capturing all dirty state in a
+  worktree before destroying it (D-313, C203/C209).
+
+  Returns exactly three descriptors — one per dirty kind:
+    * `:status`    — `git -C <ws> status --short`
+    * `:patch`     — `git -C <ws> diff HEAD` (staged + unstaged modifications)
+    * `:untracked` — `git -C <ws> ls-files --others --exclude-standard`
+
+  These descriptors are **not** executed here. The caller (WorkspaceJanitor,
+  P4d-3) runs them in order and pipes the untracked list into a tar archive.
+  """
+  @spec capture_commands(worktree_abs()) :: [command()]
+  def capture_commands(worktree_abs) do
+    [
+      %{
+        kind: :status,
+        argv: ["git", "-C", worktree_abs, "status", "--short"]
+      },
+      %{
+        kind: :patch,
+        argv: ["git", "-C", worktree_abs, "diff", "HEAD"]
+      },
+      %{
+        kind: :untracked,
+        argv: ["git", "-C", worktree_abs, "ls-files", "--others", "--exclude-standard"]
+      }
+    ]
+  end
+end

--- a/lib/tau/factory/worker/isolation.ex
+++ b/lib/tau/factory/worker/isolation.ex
@@ -76,7 +76,8 @@ defmodule Tau.Factory.Worker.Isolation do
           :ok | {:error, atom() | {atom(), term()}}
   def verify_position(worktree_abs, observed, expected) do
     cond do
-      not String.starts_with?(observed.pwd, worktree_abs) ->
+      not (observed.pwd == worktree_abs or
+               String.starts_with?(observed.pwd, worktree_abs <> "/")) ->
         {:error, :not_in_worktree}
 
       observed.head != expected.head ->

--- a/test/tau/factory/worker_isolation_property_test.exs
+++ b/test/tau/factory/worker_isolation_property_test.exs
@@ -74,17 +74,36 @@ defmodule Tau.Factory.WorkerIsolationPropertyTest do
     end)
   end
 
+  # Generates pairs of distinct worktree paths that include prefix-colliding
+  # cases such as ("/tmp/ws_1", "/tmp/ws_12") and ("/tmp/ws_1", "/tmp/ws_1x").
+  # This ensures the cross-worker disjointness property is proven against the
+  # exact segment-boundary collision that the D-311/F-6 bug exploits.
   defp two_distinct_worktrees_gen do
-    StreamData.bind(
-      StreamData.tuple({StreamData.positive_integer(), StreamData.positive_integer()}),
-      fn {a, b} ->
-        if a == b do
-          StreamData.constant({"/tmp/ws_#{a}", "/tmp/ws_#{b + 1}"})
-        else
-          StreamData.constant({"/tmp/ws_#{a}", "/tmp/ws_#{b}"})
+    # Pool includes well-separated pairs AND adjacent-integer / shared-prefix
+    # pairs that share a string prefix but are at distinct path segments.
+    prefix_colliding_pairs = [
+      {"/tmp/ws_1", "/tmp/ws_12"},
+      {"/tmp/ws_1", "/tmp/ws_1x"},
+      {"/tmp/ws_10", "/tmp/ws_100"},
+      {"/tmp/ws_2", "/tmp/ws_20"},
+      {"/tmp/ws_9", "/tmp/ws_99"}
+    ]
+
+    StreamData.one_of([
+      # Well-separated integer pairs
+      StreamData.bind(
+        StreamData.tuple({StreamData.positive_integer(), StreamData.positive_integer()}),
+        fn {a, b} ->
+          if a == b do
+            StreamData.constant({"/tmp/ws_#{a}", "/tmp/ws_#{b + 1}"})
+          else
+            StreamData.constant({"/tmp/ws_#{a}", "/tmp/ws_#{b}"})
+          end
         end
-      end
-    )
+      ),
+      # Prefix-colliding pairs
+      StreamData.member_of(prefix_colliding_pairs)
+    ])
   end
 
   # Generates a non-empty list of ResourceNS structs with distinct vars.
@@ -249,6 +268,41 @@ defmodule Tau.Factory.WorkerIsolationPropertyTest do
     observed = %{pwd: ws <> "/work", head: head, branch: "feat-actual"}
     expected = %{head: head, branch: "feat-expected"}
     assert {:error, _} = @mod.verify_position(ws, observed, expected)
+  end
+
+  # D-311/F-6: Segment-exact boundary — the prefix-sibling collision.
+  #
+  # "/tmp/ws_12/work" starts with "/tmp/ws_1" as a STRING, but "/tmp/ws_12"
+  # is a DIFFERENT worktree (a sibling sharing a string prefix, not a child).
+  # A String.starts_with?-based implementation returns :ok here — wrong.
+  # The correct segment-aware implementation must return {:error, :not_in_worktree}.
+  #
+  # This test FAILS against the current String.starts_with? production code
+  # (it gets :ok where {:error, :not_in_worktree} is required) and passes only
+  # after a segment-exact fix.
+  @tag :property
+  test "D-311 F-6 prefix-sibling: verify_position rejects pwd in a sibling worktree that shares a string prefix" do
+    # worktree is "/tmp/ws_1"; sibling is "/tmp/ws_12" — shares prefix "/tmp/ws_1"
+    ws = "/tmp/ws_1"
+    head = String.duplicate("d", 40)
+    branch = "feat-sibling"
+    # pwd is INSIDE the sibling "/tmp/ws_12", not inside "/tmp/ws_1"
+    observed = %{pwd: "/tmp/ws_12/work", head: head, branch: branch}
+    expected = %{head: head, branch: branch}
+
+    # Must be {:error, :not_in_worktree} — NOT :ok
+    assert {:error, :not_in_worktree} = @mod.verify_position(ws, observed, expected)
+  end
+
+  # Complement: the legitimate case — pwd inside ws itself (exact segment) → :ok
+  @tag :property
+  test "D-311 F-6 prefix-sibling complement: verify_position accepts pwd directly inside worktree" do
+    ws = "/tmp/ws_1"
+    head = String.duplicate("e", 40)
+    branch = "feat-inws"
+    observed = %{pwd: "/tmp/ws_1/work", head: head, branch: branch}
+    expected = %{head: head, branch: branch}
+    assert :ok == @mod.verify_position(ws, observed, expected)
   end
 
   # ---------------------------------------------------------------------------

--- a/test/tau/factory/worker_isolation_property_test.exs
+++ b/test/tau/factory/worker_isolation_property_test.exs
@@ -1,0 +1,323 @@
+defmodule Tau.Factory.WorkerIsolationPropertyTest do
+  @moduledoc """
+  StreamData property oracle for `Tau.Factory.Worker.Isolation` (C5).
+
+  Pins SPEC-FACTORY-FLEET §4 B2/B3/B5 + §6 D-309/D-311/D-313.
+
+  ## Pinned interface (oracle-declared; implementer MUST conform)
+
+  ### `resolve_namespace/2`
+
+      resolve_namespace(worktree_abs :: String.t(), decls :: [%Tau.Toolchain.ResourceNS{}])
+        :: %{String.t() => String.t()}
+
+  Maps each declaration's `var` to an absolute directory **inside** `worktree_abs`.
+  Pinned dir layout: `<worktree_abs>/.factory-ns/<var>`.
+
+  Post-conditions (D-309):
+    - Total: every declared `var` appears as a key in the result map.
+    - No escape: every resulting dir starts with `worktree_abs`.
+    - Distinct within a worktree: dir values are pairwise distinct.
+    - Cross-worker disjoint: for `ws1 ≠ ws2`, `dirs(ws1) ∩ dirs(ws2) = ∅`.
+
+  ### `verify_position/3`
+
+      verify_position(
+        worktree_abs :: String.t(),
+        observed :: %{pwd: String.t(), head: String.t(), branch: String.t()},
+        expected :: %{head: String.t(), branch: String.t()}
+      ) :: :ok | {:error, reason :: atom() | {atom(), term()}}
+
+  Returns `:ok` iff:
+    - `observed.pwd` starts with `worktree_abs` (NOT the parent root / outside), AND
+    - `observed.head == expected.head`, AND
+    - `observed.branch == expected.branch`.
+
+  Returns `{:error, reason}` when any condition fails (D-311, F-6).
+
+  ### `capture_commands/1`
+
+      capture_commands(worktree_abs :: String.t()) :: [%{kind: atom(), argv: [String.t()]}]
+
+  Returns a list of command descriptors covering all three dirty kinds (D-313):
+    - `:status` — `git -C <ws> status --short`
+    - `:patch`  — `git -C <ws> diff HEAD` (staged + unstaged)
+    - `:untracked` — `git -C <ws> ls-files --others --exclude-standard` → tar pipeline
+
+  The set of kinds returned MUST equal `{:status, :patch, :untracked}`.
+
+  ## Referenced invariants
+
+  - **D-309** — namespace totality + cross-worker disjointness (C215-B3)
+  - **D-311** — verified position; abort on parent-root or wrong ref (C204-B2, C214-B2)
+  - **D-313** — capture-before-destroy, all three dirty kinds (C203-B5)
+  """
+
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  alias Tau.Toolchain.ResourceNS
+
+  # Runtime reference to the absent module — avoids a CompileError while
+  # guaranteeing UndefinedFunctionError at test execution time.
+  @mod Tau.Factory.Worker.Isolation
+
+  @moduletag :property
+
+  # ---------------------------------------------------------------------------
+  # Generators
+  # ---------------------------------------------------------------------------
+
+  defp worktree_gen do
+    StreamData.bind(StreamData.positive_integer(), fn n ->
+      StreamData.constant("/tmp/ws_#{n}")
+    end)
+  end
+
+  defp two_distinct_worktrees_gen do
+    StreamData.bind(
+      StreamData.tuple({StreamData.positive_integer(), StreamData.positive_integer()}),
+      fn {a, b} ->
+        if a == b do
+          StreamData.constant({"/tmp/ws_#{a}", "/tmp/ws_#{b + 1}"})
+        else
+          StreamData.constant({"/tmp/ws_#{a}", "/tmp/ws_#{b}"})
+        end
+      end
+    )
+  end
+
+  # Generates a non-empty list of ResourceNS structs with distinct vars.
+  defp decls_gen do
+    StreamData.bind(
+      StreamData.list_of(
+        StreamData.tuple({
+          StreamData.member_of([:env, :xdg_data, :dir]),
+          # var names: uppercase letters to keep them realistic
+          StreamData.string(?A..?Z, min_length: 3, max_length: 12)
+        }),
+        min_length: 1,
+        max_length: 8
+      ),
+      fn pairs ->
+        # Deduplicate on var to satisfy distinct-within-worktree precondition.
+        unique_pairs = pairs |> Enum.uniq_by(fn {_, var} -> var end)
+
+        decls =
+          Enum.map(unique_pairs, fn
+            {:dir, var} ->
+              %ResourceNS{kind: :dir, var: var, path: "/tmp/fake/#{String.downcase(var)}"}
+
+            {kind, var} ->
+              %ResourceNS{kind: kind, var: var}
+          end)
+
+        StreamData.constant(decls)
+      end
+    )
+  end
+
+  # Generates a sha-like string for HEAD.
+  defp sha_gen do
+    StreamData.string(?a..?f, length: 40)
+  end
+
+  defp branch_gen do
+    StreamData.string(:alphanumeric, min_length: 4, max_length: 20)
+  end
+
+  # ---------------------------------------------------------------------------
+  # D-309: namespace totality + disjointness
+  # ---------------------------------------------------------------------------
+
+  @tag :property
+  property "D-309 total: every declared var appears as a key in resolve_namespace result" do
+    check all(
+            ws <- worktree_gen(),
+            decls <- decls_gen()
+          ) do
+      result = @mod.resolve_namespace(ws, decls)
+
+      for %ResourceNS{var: var} <- decls do
+        assert Map.has_key?(result, var),
+               "var #{inspect(var)} missing from namespace map; decls=#{inspect(decls)}"
+      end
+    end
+  end
+
+  @tag :property
+  property "D-309 no-escape: every resolved dir starts with worktree_abs" do
+    check all(
+            ws <- worktree_gen(),
+            decls <- decls_gen()
+          ) do
+      result = @mod.resolve_namespace(ws, decls)
+
+      for {var, dir} <- result do
+        assert String.starts_with?(dir, ws),
+               "var #{inspect(var)} dir #{inspect(dir)} escapes worktree #{inspect(ws)}"
+      end
+    end
+  end
+
+  @tag :property
+  property "D-309 distinct-within-worktree: dir values are pairwise distinct for unique vars" do
+    check all(
+            ws <- worktree_gen(),
+            decls <- decls_gen()
+          ) do
+      result = @mod.resolve_namespace(ws, decls)
+      dirs = Map.values(result)
+
+      assert length(dirs) == length(Enum.uniq(dirs)),
+             "two vars resolved to the same dir in #{inspect(ws)}: #{inspect(result)}"
+    end
+  end
+
+  @tag :property
+  property "D-309 cross-worker disjoint: dir sets for distinct worktrees are disjoint" do
+    check all(
+            {ws1, ws2} <- two_distinct_worktrees_gen(),
+            decls <- decls_gen()
+          ) do
+      dirs1 = @mod.resolve_namespace(ws1, decls) |> Map.values() |> MapSet.new()
+      dirs2 = @mod.resolve_namespace(ws2, decls) |> Map.values() |> MapSet.new()
+      intersection = MapSet.intersection(dirs1, dirs2)
+
+      assert MapSet.size(intersection) == 0,
+             "worktrees #{inspect(ws1)} and #{inspect(ws2)} share dirs: #{inspect(intersection)}"
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # D-311: verified position — property
+  # ---------------------------------------------------------------------------
+
+  @tag :property
+  property "D-311 ok: verify_position returns :ok when pwd inside ws and head+branch match" do
+    check all(
+            ws <- worktree_gen(),
+            head <- sha_gen(),
+            branch <- branch_gen()
+          ) do
+      observed = %{pwd: ws <> "/some/subdir", head: head, branch: branch}
+      expected = %{head: head, branch: branch}
+      assert :ok == @mod.verify_position(ws, observed, expected)
+    end
+  end
+
+  @tag :property
+  property "D-311 error on parent root: verify_position returns {:error,_} when pwd == ws or outside ws" do
+    check all(
+            ws <- worktree_gen(),
+            # Use a completely unrelated path (the parent root scenario, F-6)
+            parent_path <- StreamData.member_of(["/home/user/src/tau", "/tmp/other"]),
+            head <- sha_gen(),
+            branch <- branch_gen()
+          ) do
+      observed = %{pwd: parent_path, head: head, branch: branch}
+      expected = %{head: head, branch: branch}
+      assert {:error, _} = @mod.verify_position(ws, observed, expected)
+    end
+  end
+
+  # Directed example: pwd matches worktree root exactly — still valid (inside ws)
+  @tag :property
+  test "D-311 ok: verify_position accepts pwd == worktree_abs itself" do
+    ws = "/tmp/ws_exact"
+    head = String.duplicate("a", 40)
+    branch = "feat-x"
+    observed = %{pwd: ws, head: head, branch: branch}
+    expected = %{head: head, branch: branch}
+    assert :ok == @mod.verify_position(ws, observed, expected)
+  end
+
+  # Directed example: head mismatch
+  @tag :property
+  test "D-311 error on head mismatch: verify_position returns {:error,_}" do
+    ws = "/tmp/ws_head_mismatch"
+    observed = %{pwd: ws <> "/work", head: String.duplicate("a", 40), branch: "main"}
+    expected = %{head: String.duplicate("b", 40), branch: "main"}
+    assert {:error, _} = @mod.verify_position(ws, observed, expected)
+  end
+
+  # Directed example: branch mismatch
+  @tag :property
+  test "D-311 error on branch mismatch: verify_position returns {:error,_}" do
+    ws = "/tmp/ws_branch_mismatch"
+    head = String.duplicate("c", 40)
+    observed = %{pwd: ws <> "/work", head: head, branch: "feat-actual"}
+    expected = %{head: head, branch: "feat-expected"}
+    assert {:error, _} = @mod.verify_position(ws, observed, expected)
+  end
+
+  # ---------------------------------------------------------------------------
+  # D-313: capture_commands — all three dirty kinds
+  # ---------------------------------------------------------------------------
+
+  @tag :property
+  property "D-313 three-kinds: capture_commands returns commands for all three dirty kinds" do
+    check all(ws <- worktree_gen()) do
+      cmds = @mod.capture_commands(ws)
+
+      kinds =
+        cmds
+        |> Enum.map(fn %{kind: k} -> k end)
+        |> MapSet.new()
+
+      assert MapSet.member?(kinds, :status),
+             "capture_commands missing :status kind; got: #{inspect(kinds)}"
+
+      assert MapSet.member?(kinds, :patch),
+             "capture_commands missing :patch kind; got: #{inspect(kinds)}"
+
+      assert MapSet.member?(kinds, :untracked),
+             "capture_commands missing :untracked kind; got: #{inspect(kinds)}"
+    end
+  end
+
+  @tag :property
+  property "D-313 patch argv: the :patch command includes 'diff' and 'HEAD'" do
+    check all(ws <- worktree_gen()) do
+      cmds = @mod.capture_commands(ws)
+      patch_cmd = Enum.find(cmds, fn %{kind: k} -> k == :patch end)
+
+      assert patch_cmd != nil, "no :patch command in #{inspect(cmds)}"
+      assert "diff" in patch_cmd.argv, ":patch argv missing 'diff': #{inspect(patch_cmd.argv)}"
+      assert "HEAD" in patch_cmd.argv, ":patch argv missing 'HEAD': #{inspect(patch_cmd.argv)}"
+    end
+  end
+
+  @tag :property
+  property "D-313 untracked argv: the :untracked command references ls-files --others" do
+    check all(ws <- worktree_gen()) do
+      cmds = @mod.capture_commands(ws)
+      untracked_cmd = Enum.find(cmds, fn %{kind: k} -> k == :untracked end)
+
+      assert untracked_cmd != nil, "no :untracked command in #{inspect(cmds)}"
+
+      argv_str = Enum.join(untracked_cmd.argv, " ")
+
+      assert String.contains?(argv_str, "ls-files") or
+               String.contains?(argv_str, "--others"),
+             ":untracked argv does not reference ls-files/--others: #{inspect(untracked_cmd.argv)}"
+    end
+  end
+
+  @tag :property
+  property "D-313 exact three kinds: set of kinds equals {:status, :patch, :untracked}" do
+    check all(ws <- worktree_gen()) do
+      cmds = @mod.capture_commands(ws)
+
+      kinds =
+        cmds
+        |> Enum.map(fn %{kind: k} -> k end)
+        |> MapSet.new()
+
+      expected_kinds = MapSet.new([:status, :patch, :untracked])
+
+      assert MapSet.subset?(expected_kinds, kinds),
+             "capture_commands missing required kinds; got #{inspect(kinds)}, want superset of #{inspect(expected_kinds)}"
+    end
+  end
+end


### PR DESCRIPTION
## P4d-1 — Worker.Isolation pure helper (D-309, D-311, D-313)

Advances #437 (P4 control plane). First of the P4d worker-fleet split (along
SPEC-FACTORY-FLEET's components): the **pure** isolation helper `C5` that the
Worker (P4d-2), WorkspaceJanitor (P4d-3), and Watchdog (P4d-4) build on. No
process — properties-before-examples, the lowest-risk fleet foundation.

### Scope (SPEC-FACTORY-FLEET §2a/§2b, §4 B2/B3/B5, §6 D-309/D-311/D-313; [C204-B3]/[C215-B3])
1. `lib/tau/factory/worker/isolation.ex` — `Tau.Factory.Worker.Isolation`, pure:
   - `resolve_namespace(worktree_abs, [%Tau.Toolchain.ResourceNS{}]) :: %{var => abs_dir}`
     — for EVERY declared `ResourceNS` (kinds `:env` / `:xdg_data` / `:dir`),
     produce a per-worker absolute dir **INSIDE** `worktree_abs` (e.g.
     `<ws>/.factory-ns/<var>`), keyed by the decl's `var`. **D-309 totality
     ([C215-B3]):** every decl maps to a dir; no declared path escapes the
     worktree; the map is total over the decls (a missing decl ⇒ a build that
     leaks `$HOME` — forbidden). **Cross-worker disjointness:** because the dirs
     are under `worktree_abs`, `w₁ ≠ w₂ ⟹ workspace(w₁) ⫫ workspace(w₂)`.
   - `verify_position(worktree_abs, observed) :: :ok | {:error, reason}` where
     `observed = %{pwd, head, branch}` (the values the Worker reads via
     `File.cwd`/`git rev-parse`). **D-311:** `:ok` iff `pwd` is within
     `worktree_abs` (NOT the parent repo root) and `head`/`branch` match the
     expected base — else `{:error, reason}` naming the mismatch (a worker in
     the parent root MUST get an error so it aborts before any work; [C214-B2]).
   - `capture_commands(worktree_abs) :: [%{kind, argv}]` — construct (NOT execute)
     the **all-three-dirty-kinds** capture commands ([C203-B5]/[C209-B5], D-313):
     `:status` (`git status --short`), `:patch` (`git diff HEAD` — staged AND
     unstaged), `:untracked` (`git ls-files --others --exclude-standard` piped to
     `tar` — the kind a naïve `git diff` SILENTLY drops, F-4). Pure: the janitor
     (P4d-3) executes these; this module only builds them, so the three-kinds
     coverage is unit-assertable.

### Dependencies
Depends on P1 (`Tau.Toolchain.ResourceNS` + `declare_resource_namespace`).
Foundation for P4d-2 (Worker `init/1` calls `resolve_namespace` + `verify_position`)
and P4d-3 (Janitor runs `capture_commands`). Advances #437.

### SPECs
In scope: **SPEC-FACTORY-FLEET** (Appendix B: `worker/isolation.ex`). Conforms to
§4 B2/B3/B5, §6 D-309/D-311/D-313, [C203/C204/C209/C214/C215]. No SPEC amendment
expected.

### Acceptance criteria
- **AC (D-309 — namespace totality + disjointness):** a property test —
  `resolve_namespace` is TOTAL over any generated `[ResourceNS]` (every decl's
  `var` appears in the map), every resulting dir is a prefix-child of
  `worktree_abs` (no escape), the dirs are pairwise distinct within a worktree,
  and two distinct worktrees yield disjoint dir sets.
- **AC (D-311 — verified position):** `verify_position` returns `:ok` only when
  `pwd` is inside `worktree_abs` and head/branch match; a parent-root `pwd` or a
  head/branch mismatch ⇒ `{:error, reason}`.
- **AC (D-313 — three-kinds capture):** `capture_commands` includes all three
  dirty kinds (`:status`, `:patch` via `git diff HEAD`, `:untracked` via
  `ls-files --others | tar`); a missing kind is an assertable failure.

### Gating-test paths (frozen at 830f404 — implementer MUST NOT edit)
- `test/tau/factory/worker_isolation_property_test.exs` (D-309 / D-311 / D-313)

Pinned (oracle): `resolve_namespace(ws, decls) :: %{var => dir}` dir layout `<ws>/.factory-ns/<var>`;
`verify_position(ws, observed%{pwd,head,branch}, expected%{head,branch}) :: :ok | {:error, reason}`
(`:ok` iff `pwd` starts_with `ws` AND head/branch match expected); `capture_commands(ws) :: [%{kind, argv}]`
with kinds `{:status, :patch, :untracked}` (`:patch` argv has `diff`+`HEAD`; `:untracked` has `ls-files`/`--others`).

### Gate verdicts
_(filled at gate time — critic, reviewer)_
