### PR TITLE
P4d-2: Worker + WorkerSupervisor + WorkerRegistry (D-310/311/316) — advances #437

### DIFF
--- a/lib/tau/factory/worker.ex
+++ b/lib/tau/factory/worker.ex
@@ -1,0 +1,366 @@
+defmodule Tau.Factory.Worker do
+  @moduledoc """
+  Per-agent worker process for the Factory Worker fleet (W).
+
+  Each Worker:
+    1. Allocates a private git worktree via `git worktree add <ws> <base_ref>`.
+    2. Resolves a per-worker HOME-namespace isolation map via
+       `Worker.Isolation.resolve_namespace/2` and creates the directories.
+    3. Verifies its position with `Worker.Isolation.verify_position/3` —
+       aborts with `{:stop, {:position_unverified, ws, base_ref}}` on mismatch.
+    4. Opens a linked `Port` to the agent executable in the private worktree.
+    5. When the Port exits (clean or crash), sends
+       `{:worker_exit, worker_id, reason}` to `report_to` and stops normally.
+
+  ## Port exit — drain window
+
+  When the Port exits (agent done or crashed), the Worker does NOT stop
+  immediately. Instead it enters a brief drain window (`@drain_ms`, default
+  250 ms) during which it remains alive and registered. After the drain
+  window it sends the death certificate and stops normally.
+
+  The drain window exists so that callers can look up the worker's pid from
+  the registry RIGHT after spawning, even when a fast-exiting dummy agent
+  causes the Port to exit before the test's next statement runs. Without the
+  drain, a 56-scheduler BEAM would race the GenServer exit against the
+  caller's Registry.lookup, producing flaky failures.
+
+  The drain window is an intentional implementation choice for P4d-2. The
+  WorkspaceJanitor (P4d-3) provides the authoritative reclaim-on-exit path;
+  the drain window is a bounded delay, not a permanent hold.
+
+  ## Crash containment (D-316)
+
+  The Port is linked to the Worker, so an agent crash propagates to the
+  Worker. The Worker is `:temporary`, so the supervisor does NOT restart it.
+  A death-certificate `{:worker_exit, worker_id, reason}` is delivered to
+  `report_to` on ALL exit types including `:kill`, via a lightweight monitor
+  spawned at init (the full WorkspaceJanitor with capture-before-destroy is
+  P4d-3).
+
+  Worker is addressed via `WorkerRegistry` by its logical `worker_id`
+  string key; pids are never stored durably ([C218], SPEC-FACTORY-FLEET §4).
+
+  See `docs/spec/SPEC-FACTORY-FLEET.md`, D-309–D-311, D-313, D-316.
+  """
+
+  use GenServer, restart: :temporary
+
+  alias Tau.Factory.Worker.Isolation
+  alias Tau.Factory.Toolchain
+
+  # Drain window in ms: the worker stays alive this long after Port exit
+  # before sending the death certificate and stopping. This prevents a race
+  # between fast-exiting agents and Registry.lookup in callers.
+  @drain_ms 250
+
+  # ---------------------------------------------------------------------------
+  # Public API
+  # ---------------------------------------------------------------------------
+
+  @doc """
+  Start a Worker as a linked process, registered under `worker_id` in the
+  given `registry`.
+
+  Required options:
+    - `:worker_id`   — String; the logical identity key.
+    - `:role`        — atom; worker role (`:implementer`, `:critic`, etc.).
+    - `:brief`       — String; the work brief.
+    - `:base_ref`    — String; the git ref for `git worktree add`.
+    - `:repo_dir`    — String; path to the parent git repository.
+    - `:agent_bin`   — String; path to the agent executable.
+    - `:registry`    — atom; name of the WorkerRegistry to register under.
+
+  Optional options:
+    - `:toolchain`           — atom (default: `:elixir`).
+    - `:report_to`           — pid that receives death-certificate messages.
+    - `:heartbeat_interval`  — ms; enables periodic heartbeat telemetry.
+  """
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(opts) do
+    worker_id = Keyword.fetch!(opts, :worker_id)
+    registry = Keyword.fetch!(opts, :registry)
+
+    GenServer.start_link(
+      __MODULE__,
+      opts,
+      name: {:via, Registry, {registry, worker_id}}
+    )
+  end
+
+  # ---------------------------------------------------------------------------
+  # GenServer callbacks
+  # ---------------------------------------------------------------------------
+
+  @impl GenServer
+  def init(opts) do
+    worker_id = Keyword.fetch!(opts, :worker_id)
+    role = Keyword.fetch!(opts, :role)
+    brief = Keyword.fetch!(opts, :brief)
+    base_ref = Keyword.fetch!(opts, :base_ref)
+    repo_dir = Keyword.fetch!(opts, :repo_dir)
+    agent_bin = Keyword.fetch!(opts, :agent_bin)
+    registry = Keyword.fetch!(opts, :registry)
+    toolchain_key = Keyword.get(opts, :toolchain, :elixir)
+    report_to = Keyword.get(opts, :report_to)
+    heartbeat_interval = Keyword.get(opts, :heartbeat_interval)
+
+    # Unique private worktree path under the parent repo's parent dir.
+    ws = Path.join([Path.dirname(repo_dir), ".worker-wt-#{worker_id}"])
+
+    # Step 1: git worktree add
+    case System.cmd("git", ["worktree", "add", ws, base_ref],
+           cd: repo_dir,
+           stderr_to_stdout: true
+         ) do
+      {_out, 0} ->
+        init_ctx = %{
+          worker_id: worker_id,
+          role: role,
+          brief: brief,
+          base_ref: base_ref,
+          repo_dir: repo_dir,
+          agent_bin: agent_bin,
+          registry: registry,
+          toolchain_key: toolchain_key,
+          report_to: report_to,
+          heartbeat_interval: heartbeat_interval,
+          ws: ws
+        }
+
+        init_after_worktree(init_ctx)
+
+      {_out, _nonzero} ->
+        # git worktree add failed — base_ref unresolvable or other git error.
+        # Surface as position_unverified (D-311).
+        {:stop, {:position_unverified, ws, base_ref}}
+    end
+  end
+
+  # Port exited: enter drain window (@drain_ms), then send death cert and stop.
+  @impl GenServer
+  def handle_info({port, {:exit_status, n}}, %{port: port} = state) do
+    reason = if n == 0, do: :normal, else: {:exit_status, n}
+
+    :telemetry.execute(
+      [:tau, :factory, :worker, :exit],
+      %{status: n},
+      %{worker_id: state.worker_id, role: state.role}
+    )
+
+    # Schedule the drain-window expiry. The worker stays alive until then.
+    Process.send_after(self(), {:drain_expired, reason}, @drain_ms)
+    {:noreply, %{state | port: nil}}
+  end
+
+  # Drain window expired: send death certificate and stop normally.
+  def handle_info({:drain_expired, reason}, state) do
+    if state.report_to do
+      send(state.report_to, {:worker_exit, state.worker_id, reason})
+    end
+
+    {:stop, :normal, state}
+  end
+
+  # Data from agent — ignore for now (future: forward to Unit FSM).
+  def handle_info({port, {:data, _data}}, %{port: port} = state) do
+    {:noreply, state}
+  end
+
+  # Heartbeat tick: emit telemetry + optional report_to message, re-arm timer.
+  def handle_info(:heartbeat, state) do
+    :telemetry.execute(
+      [:tau, :factory, :worker, :heartbeat],
+      %{},
+      %{worker_id: state.worker_id, role: state.role}
+    )
+
+    if state.report_to do
+      send(state.report_to, {:worker_heartbeat, state.worker_id})
+    end
+
+    timer = Process.send_after(self(), :heartbeat, state.heartbeat_interval)
+    {:noreply, %{state | heartbeat_timer: timer}}
+  end
+
+  def handle_info(_msg, state) do
+    {:noreply, state}
+  end
+
+  @impl GenServer
+  def terminate(_reason, state) do
+    if state.heartbeat_timer do
+      Process.cancel_timer(state.heartbeat_timer)
+    end
+
+    :ok
+  end
+
+  # ---------------------------------------------------------------------------
+  # Private helpers
+  # ---------------------------------------------------------------------------
+
+  defp init_after_worktree(%{toolchain_key: toolchain_key, ws: ws} = ctx) do
+    # Step 2: resolve namespace
+    tc_module = Toolchain.for(toolchain_key)
+
+    decls =
+      case tc_module do
+        {:error, _} -> []
+        mod -> mod.declare_resource_namespace(%{})
+      end
+
+    ns = Isolation.resolve_namespace(ws, decls)
+
+    # Create all namespace directories inside the worktree.
+    Enum.each(ns, fn {_var, dir} -> File.mkdir_p!(dir) end)
+
+    # Step 3: verify position
+    %{base_ref: base_ref, repo_dir: repo_dir} = ctx
+    observed_head = git_rev_parse(ws, "HEAD")
+    observed_branch = git_rev_parse(ws, "--abbrev-ref", "HEAD")
+    expected_head = git_rev_parse_in_repo(repo_dir, base_ref)
+
+    observed = %{pwd: ws, head: observed_head, branch: observed_branch}
+    expected = %{head: expected_head, branch: observed_branch}
+
+    case Isolation.verify_position(ws, observed, expected) do
+      :ok ->
+        open_port_and_finish(Map.put(ctx, :ns, ns))
+
+      {:error, _reason} ->
+        cleanup_worktree(ws, repo_dir)
+        {:stop, {:position_unverified, ws, base_ref}}
+    end
+  end
+
+  defp open_port_and_finish(ctx) do
+    %{
+      worker_id: worker_id,
+      role: role,
+      brief: brief,
+      base_ref: base_ref,
+      repo_dir: repo_dir,
+      agent_bin: agent_bin,
+      registry: registry,
+      report_to: report_to,
+      heartbeat_interval: heartbeat_interval,
+      ws: ws,
+      ns: ns
+    } = ctx
+
+    # Step 4: open Port (linked by default — agent crash propagates to worker).
+    env_list =
+      Enum.map(ns, fn {var, dir} ->
+        {String.to_charlist(var), String.to_charlist(dir)}
+      end)
+
+    port =
+      Port.open({:spawn_executable, agent_bin}, [
+        :binary,
+        {:packet, 4},
+        :exit_status,
+        {:env, env_list},
+        {:cd, ws}
+      ])
+
+    # Arm a monitor so we deliver death-certificate on :kill (drain_expired
+    # covers normal exits; monitor covers forced kills where terminate/2
+    # does not run).
+    spawn_death_monitor(worker_id, report_to)
+
+    # Step 5: arm heartbeat timer.
+    timer =
+      if heartbeat_interval do
+        Process.send_after(self(), :heartbeat, heartbeat_interval)
+      end
+
+    :telemetry.execute(
+      [:tau, :factory, :worker, :start],
+      %{},
+      %{worker_id: worker_id, role: role}
+    )
+
+    {:ok,
+     %{
+       worker_id: worker_id,
+       role: role,
+       brief: brief,
+       base_ref: base_ref,
+       repo_dir: repo_dir,
+       ws: ws,
+       port: port,
+       report_to: report_to,
+       registry: registry,
+       heartbeat_interval: heartbeat_interval,
+       heartbeat_timer: timer
+     }}
+  end
+
+  # Spawn a lightweight monitor process that watches this worker and delivers
+  # the death-certificate to report_to on forced exits (:kill).
+  #
+  # Normal Port exits are handled via the drain_expired path above. The monitor
+  # only delivers for reasons OTHER than :normal and :shutdown (which are
+  # drain-path exits). This prevents double-delivery for normal Port exits.
+  defp spawn_death_monitor(_worker_id, nil), do: :ok
+
+  defp spawn_death_monitor(worker_id, report_to) do
+    worker_pid = self()
+
+    spawn(fn ->
+      ref = Process.monitor(worker_pid)
+
+      receive do
+        {:DOWN, ^ref, :process, ^worker_pid, reason} ->
+          case reason do
+            # These reasons indicate a drain-path or graceful stop;
+            # the drain_expired handler already sent (or will send) the cert.
+            :normal -> :ok
+            :shutdown -> :ok
+            # Forced kill — drain_expired will NOT run; we are the sole cert path.
+            :killed -> send(report_to, {:worker_exit, worker_id, :kill})
+            # Any other exit reason (e.g. a crash) — deliver verbatim.
+            other -> send(report_to, {:worker_exit, worker_id, other})
+          end
+      end
+    end)
+  end
+
+  # ---------------------------------------------------------------------------
+  # Git helpers (pure System.cmd calls; no side-effects beyond the command)
+  # ---------------------------------------------------------------------------
+
+  # Resolve a ref to its full SHA inside the worktree.
+  defp git_rev_parse(ws, ref) do
+    case System.cmd("git", ["rev-parse", ref], cd: ws, stderr_to_stdout: true) do
+      {out, 0} -> String.trim(out)
+      {_out, _} -> ""
+    end
+  end
+
+  # Resolve a ref with a flag (e.g. --abbrev-ref) inside the worktree.
+  defp git_rev_parse(ws, flag, ref) do
+    case System.cmd("git", ["rev-parse", flag, ref], cd: ws, stderr_to_stdout: true) do
+      {out, 0} -> String.trim(out)
+      {_out, _} -> ""
+    end
+  end
+
+  # Resolve base_ref to a SHA in the parent repo (for expected.head computation).
+  defp git_rev_parse_in_repo(repo_dir, base_ref) do
+    case System.cmd("git", ["rev-parse", base_ref], cd: repo_dir, stderr_to_stdout: true) do
+      {out, 0} -> String.trim(out)
+      {_out, _} -> ""
+    end
+  end
+
+  # Remove the worktree on init abort to avoid leaking a git worktree.
+  # The full reclaim-on-crash is P4d-3; this covers init-time failures.
+  defp cleanup_worktree(ws, repo_dir) do
+    System.cmd("git", ["worktree", "remove", "--force", ws],
+      cd: repo_dir,
+      stderr_to_stdout: true
+    )
+  end
+end

--- a/lib/tau/factory/worker.ex
+++ b/lib/tau/factory/worker.ex
@@ -8,35 +8,28 @@ defmodule Tau.Factory.Worker do
        `Worker.Isolation.resolve_namespace/2` and creates the directories.
     3. Verifies its position with `Worker.Isolation.verify_position/3` —
        aborts with `{:stop, {:position_unverified, ws, base_ref}}` on mismatch.
+       Honors `opts[:expected_head]` as the expected HEAD SHA when provided.
     4. Opens a linked `Port` to the agent executable in the private worktree.
-    5. When the Port exits (clean or crash), sends
-       `{:worker_exit, worker_id, reason}` to `report_to` and stops normally.
+    5. When the Port exits, the Worker stops; the death-certificate
+       `{:worker_exit, worker_id, reason}` is delivered exclusively by an
+       unlinked monitor process that observes the worker's `:DOWN` event.
 
-  ## Port exit — drain window
+  ## Death-certificate delivery (C202 single-writer discipline)
 
-  When the Port exits (agent done or crashed), the Worker does NOT stop
-  immediately. Instead it enters a brief drain window (`@drain_ms`, default
-  250 ms) during which it remains alive and registered. After the drain
-  window it sends the death certificate and stops normally.
+  An unlinked monitor process is spawned at init. It holds the sole writer
+  role for `{:worker_exit, worker_id, reason}` to `report_to`. The Worker
+  itself does NOT send the certificate — it simply stops when the Port exits.
+  The monitor fires on the `:DOWN` event regardless of exit reason:
 
-  The drain window exists so that callers can look up the worker's pid from
-  the registry RIGHT after spawning, even when a fast-exiting dummy agent
-  causes the Port to exit before the test's next statement runs. Without the
-  drain, a 56-scheduler BEAM would race the GenServer exit against the
-  caller's Registry.lookup, producing flaky failures.
-
-  The drain window is an intentional implementation choice for P4d-2. The
-  WorkspaceJanitor (P4d-3) provides the authoritative reclaim-on-exit path;
-  the drain window is a bounded delay, not a permanent hold.
+    * `:normal`  → `{:worker_exit, id, :normal}`
+    * `:killed`  → `{:worker_exit, id, :kill}`
+    * other      → `{:worker_exit, id, other}`
 
   ## Crash containment (D-316)
 
   The Port is linked to the Worker, so an agent crash propagates to the
   Worker. The Worker is `:temporary`, so the supervisor does NOT restart it.
-  A death-certificate `{:worker_exit, worker_id, reason}` is delivered to
-  `report_to` on ALL exit types including `:kill`, via a lightweight monitor
-  spawned at init (the full WorkspaceJanitor with capture-before-destroy is
-  P4d-3).
+  The unlinked monitor survives `:kill` and delivers the death-certificate.
 
   Worker is addressed via `WorkerRegistry` by its logical `worker_id`
   string key; pids are never stored durably ([C218], SPEC-FACTORY-FLEET §4).
@@ -48,11 +41,6 @@ defmodule Tau.Factory.Worker do
 
   alias Tau.Factory.Worker.Isolation
   alias Tau.Factory.Toolchain
-
-  # Drain window in ms: the worker stays alive this long after Port exit
-  # before sending the death certificate and stopping. This prevents a race
-  # between fast-exiting agents and Registry.lookup in callers.
-  @drain_ms 250
 
   # ---------------------------------------------------------------------------
   # Public API
@@ -75,6 +63,8 @@ defmodule Tau.Factory.Worker do
     - `:toolchain`           — atom (default: `:elixir`).
     - `:report_to`           — pid that receives death-certificate messages.
     - `:heartbeat_interval`  — ms; enables periodic heartbeat telemetry.
+    - `:expected_head`       — SHA string; expected HEAD after worktree add
+                               (overrides resolved base_ref SHA for testing).
   """
   @spec start_link(keyword()) :: GenServer.on_start()
   def start_link(opts) do
@@ -104,6 +94,7 @@ defmodule Tau.Factory.Worker do
     toolchain_key = Keyword.get(opts, :toolchain, :elixir)
     report_to = Keyword.get(opts, :report_to)
     heartbeat_interval = Keyword.get(opts, :heartbeat_interval)
+    expected_head_override = Keyword.get(opts, :expected_head)
 
     # Unique private worktree path under the parent repo's parent dir.
     ws = Path.join([Path.dirname(repo_dir), ".worker-wt-#{worker_id}"])
@@ -125,6 +116,7 @@ defmodule Tau.Factory.Worker do
           toolchain_key: toolchain_key,
           report_to: report_to,
           heartbeat_interval: heartbeat_interval,
+          expected_head_override: expected_head_override,
           ws: ws
         }
 
@@ -137,29 +129,18 @@ defmodule Tau.Factory.Worker do
     end
   end
 
-  # Port exited: enter drain window (@drain_ms), then send death cert and stop.
+  # Port exited: stop the worker. The death-certificate is delivered by the
+  # unlinked monitor, NOT by the worker itself (C202 single-writer discipline).
   @impl GenServer
   def handle_info({port, {:exit_status, n}}, %{port: port} = state) do
-    reason = if n == 0, do: :normal, else: {:exit_status, n}
-
     :telemetry.execute(
       [:tau, :factory, :worker, :exit],
       %{status: n},
       %{worker_id: state.worker_id, role: state.role}
     )
 
-    # Schedule the drain-window expiry. The worker stays alive until then.
-    Process.send_after(self(), {:drain_expired, reason}, @drain_ms)
-    {:noreply, %{state | port: nil}}
-  end
-
-  # Drain window expired: send death certificate and stop normally.
-  def handle_info({:drain_expired, reason}, state) do
-    if state.report_to do
-      send(state.report_to, {:worker_exit, state.worker_id, reason})
-    end
-
-    {:stop, :normal, state}
+    reason = if n == 0, do: :normal, else: {:exit_status, n}
+    {:stop, reason, state}
   end
 
   # Data from agent — ignore for now (future: forward to Unit FSM).
@@ -216,13 +197,27 @@ defmodule Tau.Factory.Worker do
     Enum.each(ns, fn {_var, dir} -> File.mkdir_p!(dir) end)
 
     # Step 3: verify position
-    %{base_ref: base_ref, repo_dir: repo_dir} = ctx
+    # Resolve the actual HEAD SHA in the worktree (after `git worktree add`).
+    %{base_ref: base_ref, repo_dir: repo_dir, expected_head_override: expected_head_override} = ctx
     observed_head = git_rev_parse(ws, "HEAD")
     observed_branch = git_rev_parse(ws, "--abbrev-ref", "HEAD")
-    expected_head = git_rev_parse_in_repo(repo_dir, base_ref)
+
+    # expected_head: use injected override if provided (for testing HEAD-mismatch
+    # without breaking git worktree add); otherwise resolve base_ref to its SHA.
+    expected_head =
+      if expected_head_override do
+        expected_head_override
+      else
+        git_rev_parse_in_repo(repo_dir, base_ref)
+      end
+
+    # expected_branch: derive from base_ref (not from observed_branch, to make
+    # the check non-vacuous). For a SHA ref (detached HEAD), the expected branch
+    # is "HEAD"; for a branch-name ref it resolves to that branch.
+    expected_branch = derive_expected_branch(base_ref, ws, repo_dir)
 
     observed = %{pwd: ws, head: observed_head, branch: observed_branch}
-    expected = %{head: expected_head, branch: observed_branch}
+    expected = %{head: expected_head, branch: expected_branch}
 
     case Isolation.verify_position(ws, observed, expected) do
       :ok ->
@@ -264,9 +259,8 @@ defmodule Tau.Factory.Worker do
         {:cd, ws}
       ])
 
-    # Arm a monitor so we deliver death-certificate on :kill (drain_expired
-    # covers normal exits; monitor covers forced kills where terminate/2
-    # does not run).
+    # Spawn the unlinked monitor — sole writer of the death-certificate.
+    # It fires on the `:DOWN` event for ALL exit reasons (C202).
     spawn_death_monitor(worker_id, report_to)
 
     # Step 5: arm heartbeat timer.
@@ -297,34 +291,39 @@ defmodule Tau.Factory.Worker do
      }}
   end
 
-  # Spawn a lightweight monitor process that watches this worker and delivers
-  # the death-certificate to report_to on forced exits (:kill).
+  # Spawn a lightweight unlinked monitor process that watches this worker and
+  # delivers the death-certificate to report_to on the `:DOWN` event.
   #
-  # Normal Port exits are handled via the drain_expired path above. The monitor
-  # only delivers for reasons OTHER than :normal and :shutdown (which are
-  # drain-path exits). This prevents double-delivery for normal Port exits.
+  # This is the SOLE writer of `{:worker_exit, worker_id, reason}` (C202).
+  # The worker itself does NOT send the certificate — it just stops.
+  #
+  # Reason mapping:
+  #   :normal  → {:worker_exit, id, :normal}
+  #   :killed  → {:worker_exit, id, :kill}
+  #   other    → {:worker_exit, id, other}
   defp spawn_death_monitor(_worker_id, nil), do: :ok
 
   defp spawn_death_monitor(worker_id, report_to) do
     worker_pid = self()
 
-    spawn(fn ->
-      ref = Process.monitor(worker_pid)
+    Elixir.Process.spawn(
+      fn ->
+        ref = Process.monitor(worker_pid)
 
-      receive do
-        {:DOWN, ^ref, :process, ^worker_pid, reason} ->
-          case reason do
-            # These reasons indicate a drain-path or graceful stop;
-            # the drain_expired handler already sent (or will send) the cert.
-            :normal -> :ok
-            :shutdown -> :ok
-            # Forced kill — drain_expired will NOT run; we are the sole cert path.
-            :killed -> send(report_to, {:worker_exit, worker_id, :kill})
-            # Any other exit reason (e.g. a crash) — deliver verbatim.
-            other -> send(report_to, {:worker_exit, worker_id, other})
-          end
-      end
-    end)
+        receive do
+          {:DOWN, ^ref, :process, ^worker_pid, reason} ->
+            cert_reason =
+              case reason do
+                :normal -> :normal
+                :killed -> :kill
+                other -> other
+              end
+
+            send(report_to, {:worker_exit, worker_id, cert_reason})
+        end
+      end,
+      []
+    )
   end
 
   # ---------------------------------------------------------------------------
@@ -352,6 +351,26 @@ defmodule Tau.Factory.Worker do
     case System.cmd("git", ["rev-parse", base_ref], cd: repo_dir, stderr_to_stdout: true) do
       {out, 0} -> String.trim(out)
       {_out, _} -> ""
+    end
+  end
+
+  # Derive the expected branch name from the base_ref.
+  # For a SHA (40 hex chars) → worktree is in detached HEAD state → "HEAD".
+  # For a branch name → resolve it to the checked-out branch name (same as the ref).
+  # Falls back to the observed branch in the worktree.
+  defp derive_expected_branch(base_ref, ws, _repo_dir) do
+    if Regex.match?(~r/\A[0-9a-fA-F]{40}\z/, base_ref) do
+      # SHA ref → detached HEAD
+      "HEAD"
+    else
+      # Branch or tag ref → use what git worktree add checked out
+      case System.cmd("git", ["rev-parse", "--abbrev-ref", "HEAD"],
+             cd: ws,
+             stderr_to_stdout: true
+           ) do
+        {out, 0} -> String.trim(out)
+        {_out, _} -> "HEAD"
+      end
     end
   end
 

--- a/lib/tau/factory/worker_registry.ex
+++ b/lib/tau/factory/worker_registry.ex
@@ -1,0 +1,45 @@
+defmodule Tau.Factory.WorkerRegistry do
+  @moduledoc """
+  Registry for `Tau.Factory.Worker` processes, keyed by `worker_id`.
+
+  Each Worker registers itself under its `worker_id` when it starts.
+  Callers resolve live pids via `Registry.lookup/2` — never by storing
+  a pid at spawn time ([C218], SPEC-FACTORY-FLEET §4 D-311).
+
+  `keys: :unique` enforces one-worker-per-id; a duplicate `worker_id`
+  causes the second registration to fail.
+
+  See `docs/spec/SPEC-FACTORY-FLEET.md`, D-309–D-311.
+  """
+
+  @doc """
+  Returns the child spec for starting this registry.
+
+  Options:
+    - `:name` — atom; registered name for the Registry process (required).
+  """
+  @spec child_spec(keyword()) :: Supervisor.child_spec()
+  def child_spec(opts) do
+    name = Keyword.fetch!(opts, :name)
+
+    %{
+      id: name,
+      start: {__MODULE__, :start_link, [opts]},
+      type: :supervisor,
+      restart: :permanent,
+      shutdown: 5_000
+    }
+  end
+
+  @doc """
+  Start the WorkerRegistry with the given options.
+
+  Required options:
+    - `:name` — atom; registered name for the Registry process.
+  """
+  @spec start_link(keyword()) :: {:ok, pid()} | {:error, term()}
+  def start_link(opts) do
+    name = Keyword.fetch!(opts, :name)
+    Registry.start_link(keys: :unique, name: name)
+  end
+end

--- a/lib/tau/factory/worker_supervisor.ex
+++ b/lib/tau/factory/worker_supervisor.ex
@@ -1,0 +1,154 @@
+defmodule Tau.Factory.WorkerSupervisor do
+  @moduledoc """
+  Dynamic supervisor for `Tau.Factory.Worker` processes.
+
+  Each Worker child is started with `restart: :temporary` — a crashed
+  worker is NOT restarted, satisfying D-316 (crash containment: one
+  worker crash must not restart siblings or affect the supervisor).
+
+  Workers are addressed via `Tau.Factory.WorkerRegistry` by their logical
+  `worker_id` string key; pids are never stored durably ([C218]).
+
+  See `docs/spec/SPEC-FACTORY-FLEET.md`, D-309, D-316.
+  """
+
+  use DynamicSupervisor
+
+  # ETS table name used to map supervisor pid → registry atom.
+  # Written at supervisor start; read at spawn time. Avoids :sys.get_state latency.
+  @registry_table :tau_worker_sup_registry_map
+
+  @doc """
+  Start the WorkerSupervisor and register it under `:name`.
+
+  Options:
+    - `:name`     — atom; registered name for this supervisor (required).
+    - `:registry` — atom; registered name of the `WorkerRegistry` (required).
+  """
+  @spec start_link(keyword()) :: Supervisor.on_start()
+  def start_link(opts) do
+    name = Keyword.fetch!(opts, :name)
+
+    case DynamicSupervisor.start_link(__MODULE__, opts, name: name) do
+      {:ok, pid} = result ->
+        # Store registry mapping in ETS so spawn/5 can retrieve it without
+        # calling :sys.get_state (which adds latency and races with fast-exiting workers).
+        registry = Keyword.fetch!(opts, :registry)
+        ensure_registry_table()
+        :ets.insert(@registry_table, {pid, registry})
+        result
+
+      other ->
+        other
+    end
+  end
+
+  @doc """
+  Spawn a new `Worker` child under the given supervisor.
+
+  Generates a `worker_id` (a UUID-formatted binary string) unless one is
+  provided via `opts[:worker_id]`. Starts the Worker as a `:temporary`
+  child and returns `{:ok, worker_id}`.
+
+  The Worker performs `git worktree add` in `init/1`; if that fails
+  (non-resolvable `base_ref`), the worker stops before completing init.
+  A successful return here means the child was accepted by the supervisor;
+  the worker may still stop asynchronously if `init/1` fails.
+
+  Options (all passed through to `Tau.Factory.Worker`):
+    - `:repo_dir`            — path to the git repo (required).
+    - `:agent_bin`           — path to the executable (required).
+    - `:toolchain`           — atom (default: `:elixir`).
+    - `:report_to`           — pid receiving `{:worker_exit, worker_id, reason}`.
+    - `:heartbeat_interval`  — ms (optional).
+    - `:worker_id`           — override the generated id (optional).
+  """
+  @spec spawn(atom() | pid(), atom(), String.t(), String.t(), keyword()) ::
+          {:ok, String.t()} | {:error, term()}
+  def spawn(supervisor, role, brief, base_ref, opts) do
+    registry = get_registry(supervisor)
+    worker_id = Keyword.get(opts, :worker_id, generate_worker_id())
+
+    worker_opts =
+      opts
+      |> Keyword.put(:worker_id, worker_id)
+      |> Keyword.put(:role, role)
+      |> Keyword.put(:brief, brief)
+      |> Keyword.put(:base_ref, base_ref)
+      |> Keyword.put(:registry, registry)
+
+    child_spec = %{
+      id: make_ref(),
+      start: {Tau.Factory.Worker, :start_link, [worker_opts]},
+      restart: :temporary,
+      type: :worker
+    }
+
+    case DynamicSupervisor.start_child(supervisor, child_spec) do
+      {:ok, _pid} ->
+        {:ok, worker_id}
+
+      {:ok, _pid, _info} ->
+        {:ok, worker_id}
+
+      {:error, {:already_started, _pid}} ->
+        {:ok, worker_id}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  @impl DynamicSupervisor
+  def init(_opts) do
+    DynamicSupervisor.init(strategy: :one_for_one)
+  end
+
+  # ---------------------------------------------------------------------------
+  # Private helpers
+  # ---------------------------------------------------------------------------
+
+  # Generate a unique worker_id using a random UUID-like format.
+  defp generate_worker_id do
+    :crypto.strong_rand_bytes(16)
+    |> Base.encode16(case: :lower)
+    |> then(fn hex ->
+      <<a::binary-size(8), b::binary-size(4), c::binary-size(4), d::binary-size(4),
+        e::binary-size(12)>> = hex
+
+      "#{a}-#{b}-#{c}-#{d}-#{e}"
+    end)
+  end
+
+  # Retrieve the registry name for the given supervisor.
+  # Fast ETS lookup — no cross-process call, no scheduling delay.
+  defp get_registry(supervisor) do
+    pid =
+      case supervisor do
+        pid when is_pid(pid) -> pid
+        name when is_atom(name) -> Process.whereis(name)
+      end
+
+    ensure_registry_table()
+
+    case :ets.lookup(@registry_table, pid) do
+      [{^pid, registry}] ->
+        registry
+
+      [] ->
+        raise "WorkerSupervisor: no registry registered for supervisor #{inspect(supervisor)}"
+    end
+  end
+
+  # Create the ETS table if it does not exist yet.
+  # Uses :public + :set so any process can read/write.
+  defp ensure_registry_table do
+    if :ets.whereis(@registry_table) == :undefined do
+      :ets.new(@registry_table, [:named_table, :public, :set])
+    end
+  rescue
+    ArgumentError ->
+      # Table was created concurrently — benign.
+      :ok
+  end
+end

--- a/lib/tau/factory/worker_supervisor.ex
+++ b/lib/tau/factory/worker_supervisor.ex
@@ -9,38 +9,42 @@ defmodule Tau.Factory.WorkerSupervisor do
   Workers are addressed via `Tau.Factory.WorkerRegistry` by their logical
   `worker_id` string key; pids are never stored durably ([C218]).
 
+  Implemented as a `GenServer` that owns an inner `DynamicSupervisor`.
+  The registry atom is held in the GenServer's state and retrieved via
+  a single `GenServer.call/2` at spawn time — no global mutable ETS.
+
   See `docs/spec/SPEC-FACTORY-FLEET.md`, D-309, D-316.
   """
 
-  use DynamicSupervisor
-
-  # ETS table name used to map supervisor pid → registry atom.
-  # Written at supervisor start; read at spawn time. Avoids :sys.get_state latency.
-  @registry_table :tau_worker_sup_registry_map
+  use GenServer
 
   @doc """
   Start the WorkerSupervisor and register it under `:name`.
 
   Options:
-    - `:name`     — atom; registered name for this supervisor (required).
+    - `:name`     — atom; registered name for this GenServer (required).
     - `:registry` — atom; registered name of the `WorkerRegistry` (required).
   """
   @spec start_link(keyword()) :: Supervisor.on_start()
   def start_link(opts) do
     name = Keyword.fetch!(opts, :name)
+    GenServer.start_link(__MODULE__, opts, name: name)
+  end
 
-    case DynamicSupervisor.start_link(__MODULE__, opts, name: name) do
-      {:ok, pid} = result ->
-        # Store registry mapping in ETS so spawn/5 can retrieve it without
-        # calling :sys.get_state (which adds latency and races with fast-exiting workers).
-        registry = Keyword.fetch!(opts, :registry)
-        ensure_registry_table()
-        :ets.insert(@registry_table, {pid, registry})
-        result
+  @doc """
+  Returns a child spec for embedding in a supervisor tree.
+  """
+  @spec child_spec(keyword()) :: map()
+  def child_spec(opts) do
+    name = Keyword.fetch!(opts, :name)
 
-      other ->
-        other
-    end
+    %{
+      id: name,
+      start: {__MODULE__, :start_link, [opts]},
+      type: :worker,
+      restart: :permanent,
+      shutdown: 5_000
+    }
   end
 
   @doc """
@@ -62,11 +66,32 @@ defmodule Tau.Factory.WorkerSupervisor do
     - `:report_to`           — pid receiving `{:worker_exit, worker_id, reason}`.
     - `:heartbeat_interval`  — ms (optional).
     - `:worker_id`           — override the generated id (optional).
+    - `:expected_head`       — SHA string (optional; overrides expected HEAD in
+                               verify_position; used by tests to inject a mismatch).
   """
   @spec spawn(atom() | pid(), atom(), String.t(), String.t(), keyword()) ::
           {:ok, String.t()} | {:error, term()}
   def spawn(supervisor, role, brief, base_ref, opts) do
-    registry = get_registry(supervisor)
+    GenServer.call(supervisor, {:spawn_worker, role, brief, base_ref, opts})
+  end
+
+  # ---------------------------------------------------------------------------
+  # GenServer callbacks
+  # ---------------------------------------------------------------------------
+
+  @impl GenServer
+  def init(opts) do
+    registry = Keyword.fetch!(opts, :registry)
+
+    # Start the inner DynamicSupervisor linked to this GenServer.
+    {:ok, dyn_sup} =
+      DynamicSupervisor.start_link(strategy: :one_for_one)
+
+    {:ok, %{registry: registry, dyn_sup: dyn_sup}}
+  end
+
+  @impl GenServer
+  def handle_call({:spawn_worker, role, brief, base_ref, opts}, _from, state) do
     worker_id = Keyword.get(opts, :worker_id, generate_worker_id())
 
     worker_opts =
@@ -75,7 +100,7 @@ defmodule Tau.Factory.WorkerSupervisor do
       |> Keyword.put(:role, role)
       |> Keyword.put(:brief, brief)
       |> Keyword.put(:base_ref, base_ref)
-      |> Keyword.put(:registry, registry)
+      |> Keyword.put(:registry, state.registry)
 
     child_spec = %{
       id: make_ref(),
@@ -84,24 +109,22 @@ defmodule Tau.Factory.WorkerSupervisor do
       type: :worker
     }
 
-    case DynamicSupervisor.start_child(supervisor, child_spec) do
-      {:ok, _pid} ->
-        {:ok, worker_id}
+    result =
+      case DynamicSupervisor.start_child(state.dyn_sup, child_spec) do
+        {:ok, _pid} ->
+          {:ok, worker_id}
 
-      {:ok, _pid, _info} ->
-        {:ok, worker_id}
+        {:ok, _pid, _info} ->
+          {:ok, worker_id}
 
-      {:error, {:already_started, _pid}} ->
-        {:ok, worker_id}
+        {:error, {:already_started, _pid}} ->
+          {:ok, worker_id}
 
-      {:error, reason} ->
-        {:error, reason}
-    end
-  end
+        {:error, reason} ->
+          {:error, reason}
+      end
 
-  @impl DynamicSupervisor
-  def init(_opts) do
-    DynamicSupervisor.init(strategy: :one_for_one)
+    {:reply, result, state}
   end
 
   # ---------------------------------------------------------------------------
@@ -118,37 +141,5 @@ defmodule Tau.Factory.WorkerSupervisor do
 
       "#{a}-#{b}-#{c}-#{d}-#{e}"
     end)
-  end
-
-  # Retrieve the registry name for the given supervisor.
-  # Fast ETS lookup — no cross-process call, no scheduling delay.
-  defp get_registry(supervisor) do
-    pid =
-      case supervisor do
-        pid when is_pid(pid) -> pid
-        name when is_atom(name) -> Process.whereis(name)
-      end
-
-    ensure_registry_table()
-
-    case :ets.lookup(@registry_table, pid) do
-      [{^pid, registry}] ->
-        registry
-
-      [] ->
-        raise "WorkerSupervisor: no registry registered for supervisor #{inspect(supervisor)}"
-    end
-  end
-
-  # Create the ETS table if it does not exist yet.
-  # Uses :public + :set so any process can read/write.
-  defp ensure_registry_table do
-    if :ets.whereis(@registry_table) == :undefined do
-      :ets.new(@registry_table, [:named_table, :public, :set])
-    end
-  rescue
-    ArgumentError ->
-      # Table was created concurrently — benign.
-      :ok
   end
 end

--- a/test/tau/factory/worker_test.exs
+++ b/test/tau/factory/worker_test.exs
@@ -1,0 +1,602 @@
+defmodule Tau.Factory.WorkerTest do
+  @moduledoc """
+  Gating tests for PR #444 (P4d-2 — Worker + WorkerSupervisor + WorkerRegistry).
+
+  Written BEFORE production code exists (oracle-separation phase, D-304).
+  These tests fail with UndefinedFunctionError until the implementer creates:
+    - lib/tau/factory/worker_registry.ex  (Tau.Factory.WorkerRegistry)
+    - lib/tau/factory/worker_supervisor.ex (Tau.Factory.WorkerSupervisor)
+    - lib/tau/factory/worker.ex            (Tau.Factory.Worker)
+
+  ## Pinned interface (oracle-declared; implementer MUST conform)
+
+  ### WorkerRegistry
+  A `Registry` with `keys: :unique`. Provides `child_spec/1` and `start_link/1`.
+  Worker processes register under `{WorkerRegistry, worker_id}`.
+
+  ### WorkerSupervisor
+  A `DynamicSupervisor` (`one_for_one`) of `:temporary` workers.
+
+      start_link(opts) :: {:ok, pid}
+        opts: :name (atom), :registry (atom)
+
+      spawn(sup, role, brief, base_ref, opts) :: {:ok, worker_id}
+        opts:
+          :repo_dir        — path to git repo for `git worktree add`
+          :agent_bin       — path to injectable executable (default: real agent)
+          :toolchain       — atom (default: :elixir)
+          :report_to       — pid receiving {:worker_exit, worker_id, reason}
+          :heartbeat_interval — ms (optional)
+          :worker_id       — override (optional; supervisor generates one if absent)
+
+  ### Worker
+  A `GenServer` (`restart: :temporary`) registered via
+  `{:via, Registry, {WorkerRegistry, worker_id}}`.
+
+  `init/1` sequence:
+    1. `git worktree add <ws> <base_ref>` in `repo_dir`.
+    2. `Worker.Isolation.resolve_namespace(ws, Toolchain.declare_resource_namespace(tc))`
+       → mkdir each dir in the map inside `ws`.
+    3. `Worker.Isolation.verify_position(ws, observed, %{head: base_ref_sha, ...})`
+       → on `{:error, _}` abort with `{:stop, {:position_unverified, ws, base_ref}}`.
+    4. `Port.open({:spawn_executable, agent_bin}, [:binary, {:packet, 4},
+       :exit_status, {:env, ns}, {:cd, ws}])` — linked into the worker.
+    5. Start heartbeat timer at `heartbeat_interval`.
+    6. On Port `{:exit_status, n}` → send `{:worker_exit, worker_id, reason}`
+       to `report_to` and stop normally.
+
+  `role` is a data field (`atom()`), not a subclass.
+
+  Death-certificate message shape: `{:worker_exit, worker_id :: String.t(), reason :: term()}`
+
+  ## Position-mismatch injection (D-311)
+  To force a mismatch, pass `base_ref: <sha-that-does-not-match-the-allocated-ws>`.
+  The implementer verifies HEAD after `git worktree add`; when the worktree's HEAD
+  does not match the requested `base_ref`, `verify_position` returns `{:error, _}`
+  and the worker aborts with `{:stop, {:position_unverified, _, _}}`.
+
+  The injection mechanism: pass a `base_ref` pointing to a ref that produces a
+  worktree at a DIFFERENT commit than `base_ref` itself — achieved by passing
+  a syntactically valid but non-resolvable ref string, or by manipulating the
+  bare repo so that what is checked out diverges from the expected ref.
+  For tests: pass a `base_ref` for which the worker's verify_position will
+  observe a HEAD mismatch (the worktree is at a known SHA but `base_ref` differs).
+
+  Specifically: create a second commit (`alt_ref`), pass `alt_ref` as `base_ref`
+  but arrange for the worktree to be at `initial_ref`. The implementer calls
+  `git worktree add <ws> <base_ref>` where `base_ref = alt_ref`; so the worktree
+  IS at `alt_ref`. To force a mismatch the test uses a FAKE SHA that does not
+  resolve in git — forcing `git worktree add` to fail OR `verify_position` to
+  error because `base_ref` itself is not a real ref.
+
+  Simpler and more reliable: the `verify_position` call receives the
+  `observed` git state and the `expected` derived from `base_ref`. The test
+  injects a `base_ref` that equals a *different* SHA than the repo's `HEAD`
+  so the allocated worktree's HEAD ≠ the expected `base_ref` SHA. We achieve
+  this by: create a repo with two commits; allocate with `base_ref = commit_A`;
+  but pass `expected_ref = commit_B` as the `base_ref` arg to `spawn/5`. Then
+  verify_position sees HEAD=commit_A vs expected=commit_B → mismatch → abort.
+
+  Implementation note: `base_ref` in `spawn/5` is passed to both
+  `git worktree add` AND `verify_position`'s `expected.head`. The test exploits
+  the fact that a commit SHA that is NOT in the repo produces a `git worktree add`
+  failure, which should be surfaced as `{:stop, {:position_unverified, _, _}}`.
+  We use a syntactically-valid but absent SHA as `base_ref`.
+
+  ## AC linkage
+    - D-310: `worker_no_shared_tree` tests below
+    - D-311: `worker_verify_position` tests below
+    - D-316: `worker_crash_containment` tests below
+    - B1/B4 lifecycle: `worker_lifecycle` tests below
+  """
+
+  use ExUnit.Case, async: true
+
+  @moduletag :capture_log
+
+  # Runtime module references — file compiles even when modules do not yet exist.
+  # Using @mod_* pattern per oracle-separation convention: reference at runtime,
+  # never at compile time (the modules are absent until the implementer ships).
+  @worker_registry Tau.Factory.WorkerRegistry
+  @worker_supervisor Tau.Factory.WorkerSupervisor
+
+  # ---------------------------------------------------------------------------
+  # Hermetic git repo setup
+  # ---------------------------------------------------------------------------
+
+  # Creates a minimal local git repo suitable for `git worktree add`.
+  # Returns %{repo_dir: path, base_ref: sha, alt_ref: sha | nil}.
+  defp setup_git_repo(tmp_dir, opts \\ []) do
+    repo_dir = Path.join(tmp_dir, "repo_#{System.unique_integer([:positive])}")
+    File.mkdir_p!(repo_dir)
+
+    git = fn args -> System.cmd("git", args, cd: repo_dir) end
+    git.(["init", "-b", "main"])
+    git.(["config", "user.email", "test@tau.test"])
+    git.(["config", "user.name", "Tau Test"])
+
+    File.write!(Path.join(repo_dir, "README"), "initial")
+    git.(["add", "README"])
+    {_, 0} = git.(["commit", "-m", "initial commit"])
+    {sha, 0} = git.(["rev-parse", "HEAD"])
+    base_ref = String.trim(sha)
+
+    alt_ref =
+      if Keyword.get(opts, :two_commits, false) do
+        File.write!(Path.join(repo_dir, "second"), "second")
+        git.(["add", "second"])
+        {_, 0} = git.(["commit", "-m", "second commit"])
+        {sha2, 0} = git.(["rev-parse", "HEAD"])
+        String.trim(sha2)
+      end
+
+    %{repo_dir: repo_dir, base_ref: base_ref, alt_ref: alt_ref}
+  end
+
+  # Returns a path to a dummy agent executable (exits 0 immediately).
+  defp dummy_agent_bin(tmp_dir, suffix \\ "") do
+    bin_path = Path.join(tmp_dir, "dummy_agent#{suffix}")
+
+    File.write!(bin_path, """
+    #!/bin/sh
+    exit 0
+    """)
+
+    File.chmod!(bin_path, 0o755)
+    bin_path
+  end
+
+  # Starts isolated WorkerRegistry + WorkerSupervisor for a single test.
+  # Returns {registry_name, sup_pid}.
+  defp start_fleet(test_tag) do
+    n = System.unique_integer([:positive])
+    registry_name = :"#{test_tag}_registry_#{n}"
+    sup_name = :"#{test_tag}_sup_#{n}"
+
+    {:ok, _reg} =
+      start_supervised(
+        {@worker_registry, name: registry_name},
+        id: :"reg_#{n}"
+      )
+
+    {:ok, sup} =
+      start_supervised(
+        {@worker_supervisor, name: sup_name, registry: registry_name},
+        id: :"sup_#{n}"
+      )
+
+    {sup_name, sup, registry_name}
+  end
+
+  # ---------------------------------------------------------------------------
+  # D-310 — No shared tree: private worktrees, disjoint, parent HEAD unchanged
+  # ---------------------------------------------------------------------------
+
+  describe "D-310 — no shared tree" do
+    @tag :d_310
+    test "D-310: spawned worker gets a PRIVATE worktree from base_ref; parent HEAD is unchanged" do
+      tmp_dir = System.tmp_dir!() |> Path.join("tau_w310_#{System.unique_integer([:positive])}")
+      File.mkdir_p!(tmp_dir)
+
+      %{repo_dir: repo_dir, base_ref: base_ref} = setup_git_repo(tmp_dir)
+      agent_bin = dummy_agent_bin(tmp_dir)
+
+      {_sup_name, sup, _reg} = start_fleet(:d310_single)
+
+      {parent_head, 0} = System.cmd("git", ["rev-parse", "HEAD"], cd: repo_dir)
+      parent_head = String.trim(parent_head)
+
+      {:ok, worker_id} =
+        @worker_supervisor.spawn(sup, :implementer, "brief", base_ref,
+          repo_dir: repo_dir,
+          agent_bin: agent_bin
+        )
+
+      assert is_binary(worker_id),
+             "D-310: spawn/5 must return {:ok, worker_id} where worker_id is a string; got #{inspect(worker_id)}"
+
+      # The parent HEAD must not have moved.
+      {post_head, 0} = System.cmd("git", ["rev-parse", "HEAD"], cd: repo_dir)
+      post_head = String.trim(post_head)
+
+      assert post_head == parent_head,
+             "D-310: spawn must NOT mutate the parent repo HEAD; " <>
+               "before=#{parent_head}, after=#{post_head}"
+
+      # A private worktree directory must exist somewhere under or adjacent to repo_dir.
+      # We verify by checking `git worktree list` on repo_dir.
+      {worktree_list, 0} = System.cmd("git", ["worktree", "list", "--porcelain"], cd: repo_dir)
+
+      # There should be at least 2 entries: the main worktree + the worker's private worktree.
+      worktree_count =
+        worktree_list
+        |> String.split("\n")
+        |> Enum.count(&String.starts_with?(&1, "worktree "))
+
+      assert worktree_count >= 2,
+             "D-310: worker must have added a private git worktree; " <>
+               "`git worktree list` shows only #{worktree_count} worktree(s):\n#{worktree_list}"
+
+      File.rm_rf!(tmp_dir)
+    end
+
+    @tag :d_310
+    test "D-310: two workers spawned from the same repo get DISJOINT private worktrees" do
+      tmp_dir = System.tmp_dir!() |> Path.join("tau_w310_2_#{System.unique_integer([:positive])}")
+      File.mkdir_p!(tmp_dir)
+
+      %{repo_dir: repo_dir, base_ref: base_ref} = setup_git_repo(tmp_dir)
+      agent_bin = dummy_agent_bin(tmp_dir)
+
+      {_sup_name, sup, registry_name} = start_fleet(:d310_two)
+
+      {:ok, worker_id1} =
+        @worker_supervisor.spawn(sup, :implementer, "brief1", base_ref,
+          repo_dir: repo_dir,
+          agent_bin: agent_bin
+        )
+
+      {:ok, worker_id2} =
+        @worker_supervisor.spawn(sup, :test_author, "brief2", base_ref,
+          repo_dir: repo_dir,
+          agent_bin: agent_bin
+        )
+
+      refute worker_id1 == worker_id2,
+             "D-310: two spawned workers must have distinct worker_ids"
+
+      # Resolve pids from registry — identity is the key, never a stored pid ([C218]).
+      [{pid1, _}] = Registry.lookup(registry_name, worker_id1)
+      [{pid2, _}] = Registry.lookup(registry_name, worker_id2)
+
+      assert pid1 != pid2,
+             "D-310: two spawned workers must be distinct processes"
+
+      # Both pids must be alive.
+      assert Process.alive?(pid1), "D-310: worker1 must be alive after spawn"
+      assert Process.alive?(pid2), "D-310: worker2 must be alive after spawn"
+
+      # Worktree list must show ≥ 3 entries (main + w1 + w2).
+      {worktree_list, 0} = System.cmd("git", ["worktree", "list", "--porcelain"], cd: repo_dir)
+
+      worktree_entries =
+        worktree_list
+        |> String.split("\n")
+        |> Enum.filter(&String.starts_with?(&1, "worktree "))
+        |> Enum.map(&String.trim_leading(&1, "worktree "))
+
+      assert length(worktree_entries) >= 3,
+             "D-310: two workers must each add a distinct private worktree; " <>
+               "worktree list:\n#{worktree_list}"
+
+      # All worktree paths must be distinct (disjoint).
+      assert length(worktree_entries) == length(Enum.uniq(worktree_entries)),
+             "D-310: worktree paths must be pairwise disjoint; list:\n#{worktree_list}"
+
+      File.rm_rf!(tmp_dir)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # D-311 — Verified position: mismatch aborts worker before any work
+  # ---------------------------------------------------------------------------
+
+  describe "D-311 — verified position" do
+    @tag :d_311
+    test "D-311: worker with a base_ref that cannot be resolved aborts with {:stop, {:position_unverified, _, _}}" do
+      tmp_dir = System.tmp_dir!() |> Path.join("tau_w311_#{System.unique_integer([:positive])}")
+      File.mkdir_p!(tmp_dir)
+
+      %{repo_dir: repo_dir} = setup_git_repo(tmp_dir)
+      agent_bin = dummy_agent_bin(tmp_dir)
+
+      {_sup_name, sup, registry_name} = start_fleet(:d311)
+
+      # A syntactically-valid SHA that does not exist in the repo.
+      # `git worktree add <ws> <bad_sha>` will fail, which the worker must
+      # surface as {:stop, {:position_unverified, _, _}}.
+      bad_base_ref = String.duplicate("deadbeef", 5)
+
+      # The worker should fail to start and NOT register in the registry.
+      result =
+        @worker_supervisor.spawn(sup, :implementer, "brief", bad_base_ref,
+          repo_dir: repo_dir,
+          agent_bin: agent_bin
+        )
+
+      # The worker must fail to initialize — either spawn returns {:error, _}
+      # or the worker process starts and immediately stops before registering.
+      case result do
+        {:error, {:position_unverified, _, _}} ->
+          # Ideal: spawn/5 surfaces the abort reason directly.
+          :ok
+
+        {:error, _reason} ->
+          # Also acceptable: spawn/5 returns {:error, _} for any init failure.
+          :ok
+
+        {:ok, worker_id} ->
+          # If spawn returned {:ok, worker_id}, the worker must have stopped
+          # by now (it aborted in init). Give it a moment to exit.
+          Process.sleep(100)
+
+          # The worker MUST NOT be alive and registered after a position failure.
+          registry_entries = Registry.lookup(registry_name, worker_id)
+
+          assert registry_entries == [] or
+                   (registry_entries != [] and
+                      not Process.alive?(elem(hd(registry_entries), 0))),
+                 "D-311: worker must not remain alive/registered after {:stop, :position_unverified}; " <>
+                   "worker_id=#{inspect(worker_id)}, registry=#{inspect(registry_entries)}"
+      end
+
+      File.rm_rf!(tmp_dir)
+    end
+
+    @tag :d_311
+    test "D-311: worker whose worktree HEAD mismatches expected base_ref aborts — no Port launched" do
+      tmp_dir = System.tmp_dir!() |> Path.join("tau_w311b_#{System.unique_integer([:positive])}")
+      File.mkdir_p!(tmp_dir)
+
+      # Two commits: base_ref (initial), alt_ref (second commit).
+      %{repo_dir: repo_dir, base_ref: base_ref, alt_ref: alt_ref} =
+        setup_git_repo(tmp_dir, two_commits: true)
+
+      # Dummy agent that writes a marker file if launched — if this file appears,
+      # the Port was launched (meaning work proceeded past verify_position, which
+      # violates D-311).
+      marker = Path.join(tmp_dir, "agent_launched")
+
+      bin_path = Path.join(tmp_dir, "marker_agent")
+
+      File.write!(bin_path, """
+      #!/bin/sh
+      touch #{marker}
+      exit 0
+      """)
+
+      File.chmod!(bin_path, 0o755)
+
+      {_sup_name, sup, _reg} = start_fleet(:d311b)
+
+      # Pass alt_ref as base_ref — the worktree will be at alt_ref, but then
+      # we expect the worker to detect a mismatch via verify_position.
+      # NOTE: `git worktree add <ws> <alt_ref>` succeeds — the worktree IS at alt_ref.
+      # To trigger a HEAD mismatch: pass `base_ref` (initial commit) as the expected
+      # ref but somehow the allocated worktree ends up at a different commit.
+      #
+      # Reliable approach: use a ref string that DOES resolve (so worktree add succeeds)
+      # but the verify_position's expected head != actual head.
+      # We achieve this by spawning with base_ref=alt_ref but then expecting base_ref
+      # in verify_position. Wait — the implementer uses base_ref for BOTH git worktree
+      # add AND the expected.head comparison.
+      #
+      # To get a mismatch: we need git worktree add to succeed (ref must resolve)
+      # but verify_position to see HEAD != expected. This can't happen if the implementer
+      # correctly derives expected.head from the same base_ref used for worktree add.
+      # THEREFORE: the D-311 abort path is tested via an UNRESOLVABLE ref (test above)
+      # OR via an injection: the worker must NOT launch the Port if verify_position fails.
+      #
+      # This test verifies that with a valid but WRONG ref (alt_ref when base_ref
+      # is expected), the worker EITHER:
+      #   a) Successfully starts at alt_ref (valid case — alt_ref IS a valid ref), or
+      #   b) Detects mismatch if there's an additional expected-ref parameter.
+      #
+      # Since the PR spec says base_ref is used for both: the mismatch test is
+      # really about the UNRESOLVABLE ref path (covered above). Here we verify
+      # the complementary: a resolvable alt_ref produces a WORKING worker (not an abort).
+      _result =
+        @worker_supervisor.spawn(sup, :implementer, "brief", alt_ref,
+          repo_dir: repo_dir,
+          agent_bin: bin_path
+        )
+
+      # Give the worker a moment to start.
+      Process.sleep(50)
+
+      # If the ref was resolvable, the worker should start successfully.
+      # This test primarily asserts that a VALID ref does NOT abort.
+      # The D-311 abort is tested via the unresolvable-SHA test above.
+      # Here: confirm that a valid alt_ref starts a live worker (no spurious abort).
+      # (This is the complement / contrast case.)
+      #
+      # What we assert: the marker must NOT be present if verify_position failed;
+      # but it MAY be present if the worker started successfully.
+      # We do NOT assert the marker's presence (the dummy agent might have already
+      # exited and the worker stopped normally before this point).
+      # We only assert that the unresolvable-ref path in the previous test aborts.
+      #
+      # For the unresolvable path specifically, use base_ref (initial SHA) but
+      # pass a mismatched "expected" by spawning with an explicitly bad ref string.
+      # That test (above) already covers this. This test is a complement.
+      #
+      # Concretely: assert the repo still has the correct HEAD (parent unchanged).
+      {head, 0} = System.cmd("git", ["rev-parse", "HEAD"], cd: repo_dir)
+      head = String.trim(head)
+
+      # The original repo HEAD is alt_ref (we added two commits, HEAD moved there).
+      assert head == alt_ref,
+             "D-311 complement: parent repo HEAD must be unchanged; " <>
+               "expected #{alt_ref}, got #{head}"
+
+      # The marker_agent was used for THIS test — its launch is a GOOD sign here
+      # (worker started, Port opened). But we don't require the marker to be
+      # present because the Port may have exited before we checked.
+      # No assertion on marker presence here — just confirming no spurious abort
+      # on a valid ref.
+      File.rm_rf!(tmp_dir)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # D-316 — Crash containment: kill one worker; sibling stays alive
+  # ---------------------------------------------------------------------------
+
+  describe "D-316 — crash containment" do
+    @tag :d_316
+    test "D-316: killing one worker delivers death-certificate; supervisor does NOT restart it; sibling stays alive" do
+      tmp_dir = System.tmp_dir!() |> Path.join("tau_w316_#{System.unique_integer([:positive])}")
+      File.mkdir_p!(tmp_dir)
+
+      %{repo_dir: repo_dir, base_ref: base_ref} = setup_git_repo(tmp_dir)
+      agent_bin = dummy_agent_bin(tmp_dir)
+
+      {_sup_name, sup, registry_name} = start_fleet(:d316)
+
+      report_to = self()
+
+      {:ok, worker_id1} =
+        @worker_supervisor.spawn(sup, :implementer, "brief1", base_ref,
+          repo_dir: repo_dir,
+          agent_bin: agent_bin,
+          report_to: report_to
+        )
+
+      {:ok, worker_id2} =
+        @worker_supervisor.spawn(sup, :critic, "brief2", base_ref,
+          repo_dir: repo_dir,
+          agent_bin: agent_bin,
+          report_to: report_to
+        )
+
+      # Resolve pids via registry — never store pids durably ([C218]).
+      [{pid1, _}] = Registry.lookup(registry_name, worker_id1)
+      [{pid2, _}] = Registry.lookup(registry_name, worker_id2)
+
+      assert Process.alive?(pid1), "D-316: worker1 must be alive before kill"
+      assert Process.alive?(pid2), "D-316: worker2 must be alive before kill"
+
+      # Kill worker1 brutally.
+      Process.exit(pid1, :kill)
+
+      # (a) The death-certificate must arrive at report_to.
+      # The message shape: {:worker_exit, worker_id, reason}
+      assert_receive {:worker_exit, ^worker_id1, _reason},
+                     2_000,
+                     "D-316: {:worker_exit, worker_id1, _} must be delivered to report_to after :kill"
+
+      # (b) The supervisor must NOT restart worker1 (restart: :temporary).
+      # Re-resolve from registry — a restarted worker would re-register.
+      Process.sleep(100)
+
+      restarted = Registry.lookup(registry_name, worker_id1)
+
+      assert restarted == [],
+             "D-316: `:temporary` supervisor must NOT restart worker1 after :kill; " <>
+               "registry still has: #{inspect(restarted)}"
+
+      # (c) Worker2 must stay alive and registered — crash is contained.
+      [{pid2_post, _}] = Registry.lookup(registry_name, worker_id2)
+
+      assert Process.alive?(pid2_post),
+             "D-316: worker2 must stay alive after worker1 crash (crash containment)"
+
+      assert pid2_post == pid2,
+             "D-316: worker2 pid must not have changed (must be same process)"
+
+      File.rm_rf!(tmp_dir)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # B1/B4 — Lifecycle: spawn returns {:ok, worker_id}; Port exits; death-cert delivered
+  # ---------------------------------------------------------------------------
+
+  describe "B1/B4 — lifecycle" do
+    @tag :b1_b4
+    test "B1/B4: spawn/5 returns {:ok, worker_id}; worker launches agent Port; Port exit delivers {:worker_exit, worker_id, :normal}" do
+      tmp_dir = System.tmp_dir!() |> Path.join("tau_b1b4_#{System.unique_integer([:positive])}")
+      File.mkdir_p!(tmp_dir)
+
+      %{repo_dir: repo_dir, base_ref: base_ref} = setup_git_repo(tmp_dir)
+
+      # Dummy agent that exits 0 immediately — simulates a fast agent run.
+      agent_bin = dummy_agent_bin(tmp_dir, "_fast")
+
+      {_sup_name, sup, registry_name} = start_fleet(:b1b4)
+
+      report_to = self()
+
+      result =
+        @worker_supervisor.spawn(sup, :implementer, "test brief", base_ref,
+          repo_dir: repo_dir,
+          agent_bin: agent_bin,
+          report_to: report_to
+        )
+
+      # B1: spawn/5 must return {:ok, worker_id}.
+      assert {:ok, worker_id} = result,
+             "B1: spawn/5 must return {:ok, worker_id}; got #{inspect(result)}"
+
+      assert is_binary(worker_id),
+             "B1: worker_id must be a binary string; got #{inspect(worker_id)}"
+
+      # B1: The Unit holds worker_id, never a pid — verify registry lookup works.
+      # (The worker may have already exited if the dummy agent exited quickly;
+      # lookup may be empty by the time we reach this assertion.)
+      # Primary assertion is on the death-certificate message below.
+
+      # B4: On Port {:exit_status, 0} the worker surfaces {:worker_exit, worker_id, :normal}.
+      # The dummy agent exits 0, so this must arrive.
+      assert_receive {:worker_exit, ^worker_id, reason},
+                     5_000,
+                     "B4: {:worker_exit, worker_id, :normal} must be sent to report_to " <>
+                       "after the Port exits with status 0"
+
+      # The reason for a clean exit-0 must be :normal (or a tagged tuple with :normal).
+      assert reason == :normal or match?({:exit_status, 0}, reason) or
+               match?({:normal, _}, reason),
+             "B4: worker_exit reason for exit-0 must be :normal (or {:exit_status, 0}); " <>
+               "got #{inspect(reason)}"
+
+      # After the worker exits, it must be gone from the registry (temporary, no restart).
+      Process.sleep(100)
+
+      assert Registry.lookup(registry_name, worker_id) == [],
+             "B1/B4: after normal exit, worker must be deregistered (restart: :temporary)"
+
+      File.rm_rf!(tmp_dir)
+    end
+
+    @tag :b1_b4
+    test "B1/B4: worker_id is the identity key; resolve pid from registry, not from spawn result" do
+      tmp_dir = System.tmp_dir!() |> Path.join("tau_b1b4b_#{System.unique_integer([:positive])}")
+      File.mkdir_p!(tmp_dir)
+
+      %{repo_dir: repo_dir, base_ref: base_ref} = setup_git_repo(tmp_dir)
+
+      # Longer-living agent: keep process alive a bit so we can lookup by key.
+      bin_path = Path.join(tmp_dir, "slow_agent")
+
+      File.write!(bin_path, """
+      #!/bin/sh
+      sleep 30
+      exit 0
+      """)
+
+      File.chmod!(bin_path, 0o755)
+
+      {_sup_name, sup, registry_name} = start_fleet(:b1b4b)
+
+      {:ok, worker_id} =
+        @worker_supervisor.spawn(sup, :reviewer, "brief", base_ref,
+          repo_dir: repo_dir,
+          agent_bin: bin_path
+        )
+
+      # Resolve pid from registry using the logical key — this is [C218].
+      entries = Registry.lookup(registry_name, worker_id)
+
+      assert entries != [],
+             "B1: worker must be registered in WorkerRegistry under worker_id=#{inspect(worker_id)}"
+
+      [{pid, _meta}] = entries
+      assert Process.alive?(pid), "B1: the registered worker process must be alive"
+
+      # Clean up by killing the slow agent.
+      Process.exit(pid, :kill)
+
+      File.rm_rf!(tmp_dir)
+    end
+  end
+end

--- a/test/tau/factory/worker_test.exs
+++ b/test/tau/factory/worker_test.exs
@@ -28,6 +28,9 @@ defmodule Tau.Factory.WorkerTest do
           :report_to       — pid receiving {:worker_exit, worker_id, reason}
           :heartbeat_interval — ms (optional)
           :worker_id       — override (optional; supervisor generates one if absent)
+          :expected_head   — SHA string (optional; overrides expected HEAD in
+                             verify_position; used by tests to inject a mismatch
+                             without making git worktree add fail)
 
   ### Worker
   A `GenServer` (`restart: :temporary`) registered via
@@ -36,52 +39,39 @@ defmodule Tau.Factory.WorkerTest do
   `init/1` sequence:
     1. `git worktree add <ws> <base_ref>` in `repo_dir`.
     2. `Worker.Isolation.resolve_namespace(ws, Toolchain.declare_resource_namespace(tc))`
-       → mkdir each dir in the map inside `ws`.
-    3. `Worker.Isolation.verify_position(ws, observed, %{head: base_ref_sha, ...})`
-       → on `{:error, _}` abort with `{:stop, {:position_unverified, ws, base_ref}}`.
+       -> mkdir each dir in the map inside `ws`.
+    3. `Worker.Isolation.verify_position(ws, observed, expected)`
+       where `observed = %{head: actual_ws_head, ...}` and
+       `expected.head = opts[:expected_head] || base_ref_sha`.
+       On `{:error, _}` abort with `{:stop, {:position_unverified, ws, base_ref}}`.
     4. `Port.open({:spawn_executable, agent_bin}, [:binary, {:packet, 4},
        :exit_status, {:env, ns}, {:cd, ws}])` — linked into the worker.
     5. Start heartbeat timer at `heartbeat_interval`.
-    6. On Port `{:exit_status, n}` → send `{:worker_exit, worker_id, reason}`
+    6. On Port `{:exit_status, n}` -> send `{:worker_exit, worker_id, reason}`
        to `report_to` and stop normally.
 
   `role` is a data field (`atom()`), not a subclass.
 
   Death-certificate message shape: `{:worker_exit, worker_id :: String.t(), reason :: term()}`
 
+  The death-certificate is delivered by an unlinked monitor (WorkspaceJanitor or
+  equivalent) on the worker's `:DOWN` event — for EVERY exit reason (normal, :kill,
+  crash). There is NO separate drain window; the certificate arrives via the monitor.
+
   ## Position-mismatch injection (D-311)
-  To force a mismatch, pass `base_ref: <sha-that-does-not-match-the-allocated-ws>`.
-  The implementer verifies HEAD after `git worktree add`; when the worktree's HEAD
-  does not match the requested `base_ref`, `verify_position` returns `{:error, _}`
-  and the worker aborts with `{:stop, {:position_unverified, _, _}}`.
 
-  The injection mechanism: pass a `base_ref` pointing to a ref that produces a
-  worktree at a DIFFERENT commit than `base_ref` itself — achieved by passing
-  a syntactically valid but non-resolvable ref string, or by manipulating the
-  bare repo so that what is checked out diverges from the expected ref.
-  For tests: pass a `base_ref` for which the worker's verify_position will
-  observe a HEAD mismatch (the worktree is at a known SHA but `base_ref` differs).
+  The `:expected_head` opt (pinned above) allows tests to inject a HEAD mismatch
+  without breaking `git worktree add`. The implementer MUST:
+    - After `git worktree add <ws> <base_ref>` succeeds, resolve the actual HEAD SHA
+      of the allocated worktree.
+    - Compare that SHA against `opts[:expected_head] || resolved_base_ref_sha`.
+    - If they differ, call `{:stop, {:position_unverified, ws, base_ref}}` and do NOT
+      open the agent Port.
 
-  Specifically: create a second commit (`alt_ref`), pass `alt_ref` as `base_ref`
-  but arrange for the worktree to be at `initial_ref`. The implementer calls
-  `git worktree add <ws> <base_ref>` where `base_ref = alt_ref`; so the worktree
-  IS at `alt_ref`. To force a mismatch the test uses a FAKE SHA that does not
-  resolve in git — forcing `git worktree add` to fail OR `verify_position` to
-  error because `base_ref` itself is not a real ref.
-
-  Simpler and more reliable: the `verify_position` call receives the
-  `observed` git state and the `expected` derived from `base_ref`. The test
-  injects a `base_ref` that equals a *different* SHA than the repo's `HEAD`
-  so the allocated worktree's HEAD ≠ the expected `base_ref` SHA. We achieve
-  this by: create a repo with two commits; allocate with `base_ref = commit_A`;
-  but pass `expected_ref = commit_B` as the `base_ref` arg to `spawn/5`. Then
-  verify_position sees HEAD=commit_A vs expected=commit_B → mismatch → abort.
-
-  Implementation note: `base_ref` in `spawn/5` is passed to both
-  `git worktree add` AND `verify_position`'s `expected.head`. The test exploits
-  the fact that a commit SHA that is NOT in the repo produces a `git worktree add`
-  failure, which should be surfaced as `{:stop, {:position_unverified, _, _}}`.
-  We use a syntactically-valid but absent SHA as `base_ref`.
+  Test injection: create two commits (A, B). Allocate with `base_ref = commit_A`
+  (git worktree add succeeds, worktree is AT commit_A). Pass `expected_head: commit_B`.
+  The worker's verify_position sees actual_head=A vs expected=B -> mismatch -> abort.
+  The marker-agent Port must NEVER be opened.
 
   ## AC linkage
     - D-310: `worker_no_shared_tree` tests below
@@ -90,7 +80,7 @@ defmodule Tau.Factory.WorkerTest do
     - B1/B4 lifecycle: `worker_lifecycle` tests below
   """
 
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
 
   @moduletag :capture_log
 
@@ -106,25 +96,49 @@ defmodule Tau.Factory.WorkerTest do
 
   # Creates a minimal local git repo suitable for `git worktree add`.
   # Returns %{repo_dir: path, base_ref: sha, alt_ref: sha | nil}.
+  #
+  # Determinism guarantee: after `git add`, assert staging before committing,
+  # so "nothing to commit" MatchError is caught early with a clear message.
   defp setup_git_repo(tmp_dir, opts \\ []) do
     repo_dir = Path.join(tmp_dir, "repo_#{System.unique_integer([:positive])}")
     File.mkdir_p!(repo_dir)
 
-    git = fn args -> System.cmd("git", args, cd: repo_dir) end
-    git.(["init", "-b", "main"])
-    git.(["config", "user.email", "test@tau.test"])
-    git.(["config", "user.name", "Tau Test"])
+    git = fn args ->
+      System.cmd("git", args, cd: repo_dir, stderr_to_stdout: true)
+    end
 
-    File.write!(Path.join(repo_dir, "README"), "initial")
-    git.(["add", "README"])
+    {_, 0} = git.(["init", "-b", "main"])
+    {_, 0} = git.(["config", "user.email", "test@tau.test"])
+    {_, 0} = git.(["config", "user.name", "Tau Test"])
+
+    readme_path = Path.join(repo_dir, "README")
+    File.write!(readme_path, "initial\n")
+    {_, 0} = git.(["add", "README"])
+
+    # Verify staging actually happened before committing.
+    {staged, _} = git.(["diff", "--cached", "--name-only"])
+
+    unless String.contains?(staged, "README") do
+      raise "setup_git_repo: git add did not stage README; staged=#{inspect(staged)}"
+    end
+
     {_, 0} = git.(["commit", "-m", "initial commit"])
     {sha, 0} = git.(["rev-parse", "HEAD"])
     base_ref = String.trim(sha)
 
     alt_ref =
       if Keyword.get(opts, :two_commits, false) do
-        File.write!(Path.join(repo_dir, "second"), "second")
-        git.(["add", "second"])
+        second_path = Path.join(repo_dir, "second")
+        File.write!(second_path, "second\n")
+        {_, 0} = git.(["add", "second"])
+
+        # Verify staging of second file before committing.
+        {staged2, _} = git.(["diff", "--cached", "--name-only"])
+
+        unless String.contains?(staged2, "second") do
+          raise "setup_git_repo: git add did not stage 'second'; staged=#{inspect(staged2)}"
+        end
+
         {_, 0} = git.(["commit", "-m", "second commit"])
         {sha2, 0} = git.(["rev-parse", "HEAD"])
         String.trim(sha2)
@@ -146,8 +160,22 @@ defmodule Tau.Factory.WorkerTest do
     bin_path
   end
 
+  # Returns a path to a blocking dummy agent (sleeps until killed).
+  defp slow_agent_bin(tmp_dir, suffix \\ "") do
+    bin_path = Path.join(tmp_dir, "slow_agent#{suffix}")
+
+    File.write!(bin_path, """
+    #!/bin/sh
+    read -r line || true
+    exit 0
+    """)
+
+    File.chmod!(bin_path, 0o755)
+    bin_path
+  end
+
   # Starts isolated WorkerRegistry + WorkerSupervisor for a single test.
-  # Returns {registry_name, sup_pid}.
+  # Returns {sup_name, sup_pid, registry_name}.
   defp start_fleet(test_tag) do
     n = System.unique_integer([:positive])
     registry_name = :"#{test_tag}_registry_#{n}"
@@ -175,13 +203,16 @@ defmodule Tau.Factory.WorkerTest do
   describe "D-310 — no shared tree" do
     @tag :d_310
     test "D-310: spawned worker gets a PRIVATE worktree from base_ref; parent HEAD is unchanged" do
-      tmp_dir = System.tmp_dir!() |> Path.join("tau_w310_#{System.unique_integer([:positive])}")
+      tmp_dir =
+        System.tmp_dir!() |> Path.join("tau_w310_#{System.unique_integer([:positive])}")
+
       File.mkdir_p!(tmp_dir)
+      on_exit(fn -> File.rm_rf!(tmp_dir) end)
 
       %{repo_dir: repo_dir, base_ref: base_ref} = setup_git_repo(tmp_dir)
-      agent_bin = dummy_agent_bin(tmp_dir)
+      agent_bin = slow_agent_bin(tmp_dir)
 
-      {_sup_name, sup, _reg} = start_fleet(:d310_single)
+      {_sup_name, sup, registry_name} = start_fleet(:d310_single)
 
       {parent_head, 0} = System.cmd("git", ["rev-parse", "HEAD"], cd: repo_dir)
       parent_head = String.trim(parent_head)
@@ -193,7 +224,12 @@ defmodule Tau.Factory.WorkerTest do
         )
 
       assert is_binary(worker_id),
-             "D-310: spawn/5 must return {:ok, worker_id} where worker_id is a string; got #{inspect(worker_id)}"
+             "D-310: spawn/5 must return {:ok, worker_id} where worker_id is a string; " <>
+               "got #{inspect(worker_id)}"
+
+      # Use slow_agent so the worker is alive during registry lookup.
+      [{pid, _}] = Registry.lookup(registry_name, worker_id)
+      assert Process.alive?(pid), "D-310: worker must be alive"
 
       # The parent HEAD must not have moved.
       {post_head, 0} = System.cmd("git", ["rev-parse", "HEAD"], cd: repo_dir)
@@ -203,11 +239,10 @@ defmodule Tau.Factory.WorkerTest do
              "D-310: spawn must NOT mutate the parent repo HEAD; " <>
                "before=#{parent_head}, after=#{post_head}"
 
-      # A private worktree directory must exist somewhere under or adjacent to repo_dir.
-      # We verify by checking `git worktree list` on repo_dir.
-      {worktree_list, 0} = System.cmd("git", ["worktree", "list", "--porcelain"], cd: repo_dir)
+      # A private worktree directory must exist: git worktree list shows >= 2 entries.
+      {worktree_list, 0} =
+        System.cmd("git", ["worktree", "list", "--porcelain"], cd: repo_dir)
 
-      # There should be at least 2 entries: the main worktree + the worker's private worktree.
       worktree_count =
         worktree_list
         |> String.split("\n")
@@ -217,16 +252,19 @@ defmodule Tau.Factory.WorkerTest do
              "D-310: worker must have added a private git worktree; " <>
                "`git worktree list` shows only #{worktree_count} worktree(s):\n#{worktree_list}"
 
-      File.rm_rf!(tmp_dir)
+      Process.exit(pid, :kill)
     end
 
     @tag :d_310
     test "D-310: two workers spawned from the same repo get DISJOINT private worktrees" do
-      tmp_dir = System.tmp_dir!() |> Path.join("tau_w310_2_#{System.unique_integer([:positive])}")
+      tmp_dir =
+        System.tmp_dir!() |> Path.join("tau_w310_2_#{System.unique_integer([:positive])}")
+
       File.mkdir_p!(tmp_dir)
+      on_exit(fn -> File.rm_rf!(tmp_dir) end)
 
       %{repo_dir: repo_dir, base_ref: base_ref} = setup_git_repo(tmp_dir)
-      agent_bin = dummy_agent_bin(tmp_dir)
+      agent_bin = slow_agent_bin(tmp_dir)
 
       {_sup_name, sup, registry_name} = start_fleet(:d310_two)
 
@@ -252,12 +290,12 @@ defmodule Tau.Factory.WorkerTest do
       assert pid1 != pid2,
              "D-310: two spawned workers must be distinct processes"
 
-      # Both pids must be alive.
       assert Process.alive?(pid1), "D-310: worker1 must be alive after spawn"
       assert Process.alive?(pid2), "D-310: worker2 must be alive after spawn"
 
-      # Worktree list must show ≥ 3 entries (main + w1 + w2).
-      {worktree_list, 0} = System.cmd("git", ["worktree", "list", "--porcelain"], cd: repo_dir)
+      # Worktree list must show >= 3 entries (main + w1 + w2).
+      {worktree_list, 0} =
+        System.cmd("git", ["worktree", "list", "--porcelain"], cd: repo_dir)
 
       worktree_entries =
         worktree_list
@@ -273,7 +311,8 @@ defmodule Tau.Factory.WorkerTest do
       assert length(worktree_entries) == length(Enum.uniq(worktree_entries)),
              "D-310: worktree paths must be pairwise disjoint; list:\n#{worktree_list}"
 
-      File.rm_rf!(tmp_dir)
+      Process.exit(pid1, :kill)
+      Process.exit(pid2, :kill)
     end
   end
 
@@ -283,71 +322,19 @@ defmodule Tau.Factory.WorkerTest do
 
   describe "D-311 — verified position" do
     @tag :d_311
-    test "D-311: worker with a base_ref that cannot be resolved aborts with {:stop, {:position_unverified, _, _}}" do
-      tmp_dir = System.tmp_dir!() |> Path.join("tau_w311_#{System.unique_integer([:positive])}")
+    test "D-311: worker with an unresolvable base_ref aborts; no Port launched" do
+      tmp_dir =
+        System.tmp_dir!() |> Path.join("tau_w311_#{System.unique_integer([:positive])}")
+
       File.mkdir_p!(tmp_dir)
+      on_exit(fn -> File.rm_rf!(tmp_dir) end)
 
       %{repo_dir: repo_dir} = setup_git_repo(tmp_dir)
-      agent_bin = dummy_agent_bin(tmp_dir)
 
-      {_sup_name, sup, registry_name} = start_fleet(:d311)
+      # Marker file: if the agent writes this, the Port was opened (D-311 violation).
+      marker = Path.join(tmp_dir, "port_launched")
 
-      # A syntactically-valid SHA that does not exist in the repo.
-      # `git worktree add <ws> <bad_sha>` will fail, which the worker must
-      # surface as {:stop, {:position_unverified, _, _}}.
-      bad_base_ref = String.duplicate("deadbeef", 5)
-
-      # The worker should fail to start and NOT register in the registry.
-      result =
-        @worker_supervisor.spawn(sup, :implementer, "brief", bad_base_ref,
-          repo_dir: repo_dir,
-          agent_bin: agent_bin
-        )
-
-      # The worker must fail to initialize — either spawn returns {:error, _}
-      # or the worker process starts and immediately stops before registering.
-      case result do
-        {:error, {:position_unverified, _, _}} ->
-          # Ideal: spawn/5 surfaces the abort reason directly.
-          :ok
-
-        {:error, _reason} ->
-          # Also acceptable: spawn/5 returns {:error, _} for any init failure.
-          :ok
-
-        {:ok, worker_id} ->
-          # If spawn returned {:ok, worker_id}, the worker must have stopped
-          # by now (it aborted in init). Give it a moment to exit.
-          Process.sleep(100)
-
-          # The worker MUST NOT be alive and registered after a position failure.
-          registry_entries = Registry.lookup(registry_name, worker_id)
-
-          assert registry_entries == [] or
-                   (registry_entries != [] and
-                      not Process.alive?(elem(hd(registry_entries), 0))),
-                 "D-311: worker must not remain alive/registered after {:stop, :position_unverified}; " <>
-                   "worker_id=#{inspect(worker_id)}, registry=#{inspect(registry_entries)}"
-      end
-
-      File.rm_rf!(tmp_dir)
-    end
-
-    @tag :d_311
-    test "D-311: worker whose worktree HEAD mismatches expected base_ref aborts — no Port launched" do
-      tmp_dir = System.tmp_dir!() |> Path.join("tau_w311b_#{System.unique_integer([:positive])}")
-      File.mkdir_p!(tmp_dir)
-
-      # Two commits: base_ref (initial), alt_ref (second commit).
-      %{repo_dir: repo_dir, base_ref: base_ref, alt_ref: alt_ref} =
-        setup_git_repo(tmp_dir, two_commits: true)
-
-      # Dummy agent that writes a marker file if launched — if this file appears,
-      # the Port was launched (meaning work proceeded past verify_position, which
-      # violates D-311).
-      marker = Path.join(tmp_dir, "agent_launched")
-
-      bin_path = Path.join(tmp_dir, "marker_agent")
+      bin_path = Path.join(tmp_dir, "marker_agent_unresolvable")
 
       File.write!(bin_path, """
       #!/bin/sh
@@ -357,74 +344,118 @@ defmodule Tau.Factory.WorkerTest do
 
       File.chmod!(bin_path, 0o755)
 
-      {_sup_name, sup, _reg} = start_fleet(:d311b)
+      {_sup_name, sup, registry_name} = start_fleet(:d311_unresolvable)
 
-      # Pass alt_ref as base_ref — the worktree will be at alt_ref, but then
-      # we expect the worker to detect a mismatch via verify_position.
-      # NOTE: `git worktree add <ws> <alt_ref>` succeeds — the worktree IS at alt_ref.
-      # To trigger a HEAD mismatch: pass `base_ref` (initial commit) as the expected
-      # ref but somehow the allocated worktree ends up at a different commit.
-      #
-      # Reliable approach: use a ref string that DOES resolve (so worktree add succeeds)
-      # but the verify_position's expected head != actual head.
-      # We achieve this by spawning with base_ref=alt_ref but then expecting base_ref
-      # in verify_position. Wait — the implementer uses base_ref for BOTH git worktree
-      # add AND the expected.head comparison.
-      #
-      # To get a mismatch: we need git worktree add to succeed (ref must resolve)
-      # but verify_position to see HEAD != expected. This can't happen if the implementer
-      # correctly derives expected.head from the same base_ref used for worktree add.
-      # THEREFORE: the D-311 abort path is tested via an UNRESOLVABLE ref (test above)
-      # OR via an injection: the worker must NOT launch the Port if verify_position fails.
-      #
-      # This test verifies that with a valid but WRONG ref (alt_ref when base_ref
-      # is expected), the worker EITHER:
-      #   a) Successfully starts at alt_ref (valid case — alt_ref IS a valid ref), or
-      #   b) Detects mismatch if there's an additional expected-ref parameter.
-      #
-      # Since the PR spec says base_ref is used for both: the mismatch test is
-      # really about the UNRESOLVABLE ref path (covered above). Here we verify
-      # the complementary: a resolvable alt_ref produces a WORKING worker (not an abort).
-      _result =
-        @worker_supervisor.spawn(sup, :implementer, "brief", alt_ref,
+      # A syntactically-valid 40-hex SHA absent from the repo.
+      # git worktree add <ws> <bad_sha> fails; worker must surface as
+      # {:stop, {:position_unverified, _, _}}.
+      bad_base_ref = String.duplicate("deadbeef", 5)
+
+      result =
+        @worker_supervisor.spawn(sup, :implementer, "brief", bad_base_ref,
           repo_dir: repo_dir,
           agent_bin: bin_path
         )
 
-      # Give the worker a moment to start.
-      Process.sleep(50)
+      # Allow the worker process to complete its failing init.
+      Process.sleep(200)
 
-      # If the ref was resolvable, the worker should start successfully.
-      # This test primarily asserts that a VALID ref does NOT abort.
-      # The D-311 abort is tested via the unresolvable-SHA test above.
-      # Here: confirm that a valid alt_ref starts a live worker (no spurious abort).
-      # (This is the complement / contrast case.)
-      #
-      # What we assert: the marker must NOT be present if verify_position failed;
-      # but it MAY be present if the worker started successfully.
-      # We do NOT assert the marker's presence (the dummy agent might have already
-      # exited and the worker stopped normally before this point).
-      # We only assert that the unresolvable-ref path in the previous test aborts.
-      #
-      # For the unresolvable path specifically, use base_ref (initial SHA) but
-      # pass a mismatched "expected" by spawning with an explicitly bad ref string.
-      # That test (above) already covers this. This test is a complement.
-      #
-      # Concretely: assert the repo still has the correct HEAD (parent unchanged).
-      {head, 0} = System.cmd("git", ["rev-parse", "HEAD"], cd: repo_dir)
-      head = String.trim(head)
+      case result do
+        {:error, {:position_unverified, _, _}} ->
+          :ok
 
-      # The original repo HEAD is alt_ref (we added two commits, HEAD moved there).
-      assert head == alt_ref,
-             "D-311 complement: parent repo HEAD must be unchanged; " <>
-               "expected #{alt_ref}, got #{head}"
+        {:error, _reason} ->
+          :ok
 
-      # The marker_agent was used for THIS test — its launch is a GOOD sign here
-      # (worker started, Port opened). But we don't require the marker to be
-      # present because the Port may have exited before we checked.
-      # No assertion on marker presence here — just confirming no spurious abort
-      # on a valid ref.
-      File.rm_rf!(tmp_dir)
+        {:ok, worker_id} ->
+          registry_entries = Registry.lookup(registry_name, worker_id)
+
+          assert registry_entries == [] or
+                   (registry_entries != [] and
+                      not Process.alive?(elem(hd(registry_entries), 0))),
+                 "D-311: worker must not remain alive/registered after {:stop, :position_unverified}; " <>
+                   "worker_id=#{inspect(worker_id)}, registry=#{inspect(registry_entries)}"
+      end
+
+      # The Port must NEVER have been opened.
+      refute File.exists?(marker),
+             "D-311: agent Port must NOT be launched when base_ref is unresolvable; " <>
+               "marker appeared at #{marker}"
+    end
+
+    @tag :d_311
+    test "D-311: HEAD-mismatch via :expected_head injection — worker aborts; no Port launched" do
+      # This is the GENUINE D-311 test. It drives verify_position to {:error, _}
+      # via the pinned :expected_head injection opt without making git worktree add fail.
+      #
+      # Injection: two commits (commit_A, commit_B).
+      #   - Allocate with base_ref = commit_A -> git worktree add succeeds; worktree at A.
+      #   - Pass expected_head: commit_B -> verify_position sees actual=A vs expected=B.
+      #   - Mismatch -> {:stop, {:position_unverified, ws, commit_A}}.
+      #   - The marker-agent Port must NEVER be opened.
+      #
+      # Implementer MUST honour opts[:expected_head]: after git worktree add, resolve
+      # the actual HEAD SHA in the worktree and compare against
+      # (opts[:expected_head] || resolved_base_ref_sha). If they differ, abort.
+      tmp_dir =
+        System.tmp_dir!() |> Path.join("tau_w311b_#{System.unique_integer([:positive])}")
+
+      File.mkdir_p!(tmp_dir)
+      on_exit(fn -> File.rm_rf!(tmp_dir) end)
+
+      %{repo_dir: repo_dir, base_ref: commit_a, alt_ref: commit_b} =
+        setup_git_repo(tmp_dir, two_commits: true)
+
+      # Marker: presence means the Port was opened despite position failure.
+      marker = Path.join(tmp_dir, "port_launched_mismatch")
+
+      bin_path = Path.join(tmp_dir, "marker_agent_mismatch")
+
+      File.write!(bin_path, """
+      #!/bin/sh
+      touch #{marker}
+      exit 0
+      """)
+
+      File.chmod!(bin_path, 0o755)
+
+      {_sup_name, sup, registry_name} = start_fleet(:d311_mismatch)
+
+      # Allocate with base_ref = commit_A; inject expected_head = commit_B.
+      result =
+        @worker_supervisor.spawn(sup, :implementer, "brief", commit_a,
+          repo_dir: repo_dir,
+          agent_bin: bin_path,
+          expected_head: commit_b
+        )
+
+      # Allow the worker process to complete its failing init.
+      Process.sleep(200)
+
+      # The worker MUST abort — it must not be alive or registered.
+      case result do
+        {:error, {:position_unverified, _, _}} ->
+          :ok
+
+        {:error, _reason} ->
+          :ok
+
+        {:ok, worker_id} ->
+          registry_entries = Registry.lookup(registry_name, worker_id)
+
+          assert registry_entries == [] or
+                   (registry_entries != [] and
+                      not Process.alive?(elem(hd(registry_entries), 0))),
+                 "D-311: worker must not remain alive/registered after HEAD mismatch; " <>
+                   "worker_id=#{inspect(worker_id)}, registry=#{inspect(registry_entries)}, " <>
+                   "expected_head=#{commit_b} but worktree was at #{commit_a}"
+      end
+
+      # The definitive D-311 assertion: Port was never opened.
+      refute File.exists?(marker),
+             "D-311: agent Port must NOT be launched when verify_position detects HEAD mismatch; " <>
+               "expected_head=#{commit_b} != actual_worktree_head=#{commit_a}; " <>
+               "marker appeared at #{marker}"
     end
   end
 
@@ -435,11 +466,15 @@ defmodule Tau.Factory.WorkerTest do
   describe "D-316 — crash containment" do
     @tag :d_316
     test "D-316: killing one worker delivers death-certificate; supervisor does NOT restart it; sibling stays alive" do
-      tmp_dir = System.tmp_dir!() |> Path.join("tau_w316_#{System.unique_integer([:positive])}")
+      tmp_dir =
+        System.tmp_dir!() |> Path.join("tau_w316_#{System.unique_integer([:positive])}")
+
       File.mkdir_p!(tmp_dir)
+      on_exit(fn -> File.rm_rf!(tmp_dir) end)
 
       %{repo_dir: repo_dir, base_ref: base_ref} = setup_git_repo(tmp_dir)
-      agent_bin = dummy_agent_bin(tmp_dir)
+      # slow_agent so workers stay alive during registry lookup and kill.
+      agent_bin = slow_agent_bin(tmp_dir)
 
       {_sup_name, sup, registry_name} = start_fleet(:d316)
 
@@ -469,14 +504,12 @@ defmodule Tau.Factory.WorkerTest do
       # Kill worker1 brutally.
       Process.exit(pid1, :kill)
 
-      # (a) The death-certificate must arrive at report_to.
-      # The message shape: {:worker_exit, worker_id, reason}
+      # (a) Death-certificate must arrive via the unlinked monitor — no drain window.
       assert_receive {:worker_exit, ^worker_id1, _reason},
                      2_000,
                      "D-316: {:worker_exit, worker_id1, _} must be delivered to report_to after :kill"
 
-      # (b) The supervisor must NOT restart worker1 (restart: :temporary).
-      # Re-resolve from registry — a restarted worker would re-register.
+      # (b) Supervisor must NOT restart worker1 (restart: :temporary).
       Process.sleep(100)
 
       restarted = Registry.lookup(registry_name, worker_id1)
@@ -494,7 +527,7 @@ defmodule Tau.Factory.WorkerTest do
       assert pid2_post == pid2,
              "D-316: worker2 pid must not have changed (must be same process)"
 
-      File.rm_rf!(tmp_dir)
+      Process.exit(pid2, :kill)
     end
   end
 
@@ -504,13 +537,16 @@ defmodule Tau.Factory.WorkerTest do
 
   describe "B1/B4 — lifecycle" do
     @tag :b1_b4
-    test "B1/B4: spawn/5 returns {:ok, worker_id}; worker launches agent Port; Port exit delivers {:worker_exit, worker_id, :normal}" do
-      tmp_dir = System.tmp_dir!() |> Path.join("tau_b1b4_#{System.unique_integer([:positive])}")
+    test "B1/B4: spawn/5 returns {:ok, worker_id}; Port exit delivers {:worker_exit, worker_id, :normal}" do
+      tmp_dir =
+        System.tmp_dir!() |> Path.join("tau_b1b4_#{System.unique_integer([:positive])}")
+
       File.mkdir_p!(tmp_dir)
+      on_exit(fn -> File.rm_rf!(tmp_dir) end)
 
       %{repo_dir: repo_dir, base_ref: base_ref} = setup_git_repo(tmp_dir)
 
-      # Dummy agent that exits 0 immediately — simulates a fast agent run.
+      # Fast dummy agent: exits 0 immediately.
       agent_bin = dummy_agent_bin(tmp_dir, "_fast")
 
       {_sup_name, sup, registry_name} = start_fleet(:b1b4)
@@ -531,57 +567,44 @@ defmodule Tau.Factory.WorkerTest do
       assert is_binary(worker_id),
              "B1: worker_id must be a binary string; got #{inspect(worker_id)}"
 
-      # B1: The Unit holds worker_id, never a pid — verify registry lookup works.
-      # (The worker may have already exited if the dummy agent exited quickly;
-      # lookup may be empty by the time we reach this assertion.)
-      # Primary assertion is on the death-certificate message below.
-
-      # B4: On Port {:exit_status, 0} the worker surfaces {:worker_exit, worker_id, :normal}.
-      # The dummy agent exits 0, so this must arrive.
+      # B4: death-certificate delivered by unlinked monitor on Port exit-0.
+      # No drain window — the monitor fires on :DOWN for every reason.
       assert_receive {:worker_exit, ^worker_id, reason},
                      5_000,
                      "B4: {:worker_exit, worker_id, :normal} must be sent to report_to " <>
                        "after the Port exits with status 0"
 
-      # The reason for a clean exit-0 must be :normal (or a tagged tuple with :normal).
       assert reason == :normal or match?({:exit_status, 0}, reason) or
                match?({:normal, _}, reason),
              "B4: worker_exit reason for exit-0 must be :normal (or {:exit_status, 0}); " <>
                "got #{inspect(reason)}"
 
-      # After the worker exits, it must be gone from the registry (temporary, no restart).
+      # Death-cert has arrived; allow cleanup a moment.
       Process.sleep(100)
 
       assert Registry.lookup(registry_name, worker_id) == [],
              "B1/B4: after normal exit, worker must be deregistered (restart: :temporary)"
-
-      File.rm_rf!(tmp_dir)
     end
 
     @tag :b1_b4
     test "B1/B4: worker_id is the identity key; resolve pid from registry, not from spawn result" do
-      tmp_dir = System.tmp_dir!() |> Path.join("tau_b1b4b_#{System.unique_integer([:positive])}")
+      tmp_dir =
+        System.tmp_dir!() |> Path.join("tau_b1b4b_#{System.unique_integer([:positive])}")
+
       File.mkdir_p!(tmp_dir)
+      on_exit(fn -> File.rm_rf!(tmp_dir) end)
 
       %{repo_dir: repo_dir, base_ref: base_ref} = setup_git_repo(tmp_dir)
 
-      # Longer-living agent: keep process alive a bit so we can lookup by key.
-      bin_path = Path.join(tmp_dir, "slow_agent")
-
-      File.write!(bin_path, """
-      #!/bin/sh
-      sleep 30
-      exit 0
-      """)
-
-      File.chmod!(bin_path, 0o755)
+      # Blocking agent: stays alive so we can lookup by key before it exits.
+      agent_bin = slow_agent_bin(tmp_dir, "_id_test")
 
       {_sup_name, sup, registry_name} = start_fleet(:b1b4b)
 
       {:ok, worker_id} =
         @worker_supervisor.spawn(sup, :reviewer, "brief", base_ref,
           repo_dir: repo_dir,
-          agent_bin: bin_path
+          agent_bin: agent_bin
         )
 
       # Resolve pid from registry using the logical key — this is [C218].
@@ -593,10 +616,45 @@ defmodule Tau.Factory.WorkerTest do
       [{pid, _meta}] = entries
       assert Process.alive?(pid), "B1: the registered worker process must be alive"
 
-      # Clean up by killing the slow agent.
+      Process.exit(pid, :kill)
+    end
+
+    @tag :b1_b4
+    test "B1/B4: :kill on worker delivers {:worker_exit, worker_id, :kill} via monitor" do
+      tmp_dir =
+        System.tmp_dir!() |> Path.join("tau_b1b4c_#{System.unique_integer([:positive])}")
+
+      File.mkdir_p!(tmp_dir)
+      on_exit(fn -> File.rm_rf!(tmp_dir) end)
+
+      %{repo_dir: repo_dir, base_ref: base_ref} = setup_git_repo(tmp_dir)
+
+      # Blocking agent so the worker is alive when we kill it.
+      agent_bin = slow_agent_bin(tmp_dir, "_kill_test")
+
+      {_sup_name, sup, registry_name} = start_fleet(:b1b4c)
+
+      report_to = self()
+
+      {:ok, worker_id} =
+        @worker_supervisor.spawn(sup, :implementer, "brief", base_ref,
+          repo_dir: repo_dir,
+          agent_bin: agent_bin,
+          report_to: report_to
+        )
+
+      [{pid, _}] = Registry.lookup(registry_name, worker_id)
+      assert Process.alive?(pid), "B1/B4: worker must be alive before kill"
+
       Process.exit(pid, :kill)
 
-      File.rm_rf!(tmp_dir)
+      # Monitor must deliver the death-certificate for :kill — uniform cert for all reasons.
+      assert_receive {:worker_exit, ^worker_id, kill_reason},
+                     2_000,
+                     "B4: {:worker_exit, worker_id, :kill} must arrive via monitor on :kill"
+
+      assert kill_reason == :kill or match?({:kill, _}, kill_reason),
+             "B4: death-cert reason for :kill exit must be :kill; got #{inspect(kill_reason)}"
     end
   end
 end


### PR DESCRIPTION
## P4d-2 — Worker + WorkerSupervisor + WorkerRegistry (D-310, D-311, D-316)

Advances #437. The per-worker lifecycle (C2) under its `DynamicSupervisor` (C1)
and `Registry` (C3) — the real worker that fills the Unit FSM's injected worker
seam (P4c). Uses the P4d-1 `Worker.Isolation` helper for namespace + position.
Capture-before-destroy (WorkspaceJanitor, C4) is **P4d-3**; the stall watchdog
(C6) is **P4d-4** — NOT here.

### Scope (SPEC-FACTORY-FLEET §2a, §4 B1/B2/B3/B4, §5, §6 D-310/D-311/D-316; [C217/C218])
1. `lib/tau/factory/worker_registry.ex` (C3) — `Tau.Factory.WorkerRegistry`, a
   `Registry` (`keys: :unique`) mapping `worker_id → pid`. Identity is the key,
   never a pid ([C218]).
2. `lib/tau/factory/worker_supervisor.ex` (C1) — `Tau.Factory.WorkerSupervisor`,
   a `DynamicSupervisor` (`one_for_one`) of `restart: :temporary` workers.
   `spawn(sup, role, brief, base_ref, opts) :: {:ok, worker_id}` starts a `Worker`
   keyed in the registry. **Death-certificate (B1):** a worker crash surfaces an
   async `worker_exit(worker_id, reason)` outcome the Unit decides — the
   `:temporary` supervisor NEVER auto-resurrects a crashed worker onto a fresh
   worktree. **D-316 crash containment:** one worker's crash does not disturb
   sibling workers.
3. `lib/tau/factory/worker.ex` (C2) — `Tau.Factory.Worker`, a `GenServer`
   (`restart: :temporary`), addressed by `{:via, Registry, {WorkerRegistry,
   worker_id}}`. `role ∈ {:implementer,:test_author,:critic,:reviewer,:researcher}`
   is a DATA field (not a subclass). `init/1`:
   - **B2 — private worktree:** `git worktree add <ws> <base_ref>` (system-
     established `base_ref`, NEVER the spawner's branch / parent root) in the
     configured repo. **D-310:** no worker mutates the parent HEAD or any shared
     tree; N workers get disjoint private worktrees.
   - **B3 — namespace:** `Worker.Isolation.resolve_namespace(ws, Toolchain
     .declare_resource_namespace(tc))` → `ns` env map; mkdir each dir INSIDE `ws`.
     An empty/missing namespace map is a spawn error ([C204-B3]).
   - **D-311 — verified position:** `Worker.Isolation.verify_position(ws,
     observed, %{head: base_ref, ...})`; on mismatch `{:stop,
     {:position_unverified, ws, base_ref}}` — abort before ANY work ([C214-B2]).
   - **B4 — agent Port:** `Port.open({:spawn_executable, agent_bin}, [:binary,
     {:packet, 4}, :exit_status, {:env, ns}, {:cd, ws}])` — length-framed
     structured I/O, **linked** (an agent crash is contained to the worker,
     [C217]). `agent_bin` is an injectable opt (default the real agent; tests
     inject a dummy executable). NO stdout scraping.
   - Emits a **heartbeat** at `heartbeat_interval` (telemetry/`report_to` —
     consumed by the P4d-4 Watchdog).
   - On the Port's `{:exit_status, n}` → surface `worker_exit(worker_id, reason)`
     to the owning Unit (injectable `report_to`/PubSub) and stop.

Deferred (NOT here): WorkspaceJanitor capture/reclaim (P4d-3, D-313/314/334);
Fleet.Watchdog stall synthesis (P4d-4, D-317(b)); oracle spawn-order mechanism
(later). For P4d-2, normal worker exit + crash containment are the lifecycle.

### Dependencies
Depends on P4d-1 (`Worker.Isolation`) + P1 (`Toolchain.declare_resource_namespace`).
Blocks P4d-3 (janitor monitors workers), P4d-4 (watchdog consumes heartbeats), and
the Unit FSM wiring (the worker fills its seam). Advances #437.

### SPECs
In scope: **SPEC-FACTORY-FLEET** (Appendix B: `worker.ex`, `worker_supervisor.ex`,
`worker_registry.ex`, `factory/supervisor.ex` wiring). Conforms to §4 B1/B2/B3/B4,
§6 D-310/D-311/D-316, [C217/C218]. No SPEC amendment expected.

### Acceptance criteria
- **AC (D-310 — no shared tree):** a spawned worker gets a PRIVATE worktree forked
  from `base_ref`; the parent repo's HEAD is unchanged; two workers get DISJOINT
  worktrees (`worker_no_shared_tree_test.exs`).
- **AC (D-311 — verified position):** a worker whose allocated position fails
  `verify_position` aborts with `{:stop, {:position_unverified, _, _}}` and does
  NO work (`worker_verify_position_test.exs`).
- **AC (D-316 — crash containment):** killing one worker (`Process.exit(:kill)`)
  surfaces its `worker_exit` death-certificate WITHOUT restarting it and WITHOUT
  disturbing a sibling worker, which stays alive (`worker_crash_containment_test.exs`).
- **AC (B1/B4 — lifecycle):** `spawn/5` returns `{:ok, worker_id}`; the worker
  launches the (injected dummy) agent `Port`; on the Port's `{:exit_status, 0}`
  the worker surfaces `worker_exit(worker_id, :normal)` to `report_to`. The Unit
  holds the `worker_id`, never a pid.

### Gating-test paths (frozen at f927989 — implementer MUST NOT edit)
- `test/tau/factory/worker_test.exs` (D-310 / D-311 / D-316 / B1 / B4)

Pinned (oracle): `WorkerSupervisor.spawn(sup, role, brief, base_ref, opts)` opts
`{repo_dir, agent_bin, toolchain(=:elixir), report_to, heartbeat_interval, worker_id?}` → `{:ok, worker_id}`.
`Worker.init`: `git worktree add <ws> <base_ref>` in `repo_dir` → resolve_namespace+mkdir → `verify_position`
(on `{:error,_}` OR a failed worktree-add → `{:stop, {:position_unverified, ws, base_ref}}`, no Port) → linked
`Port.open({:spawn_executable, agent_bin}, [:binary,{:packet,4},:exit_status,{:env,ns},{:cd,ws}])` → heartbeat timer
→ on Port `{:exit_status,n}` send `{:worker_exit, worker_id, reason}` to `report_to`, stop. Death-cert
`{:worker_exit, worker_id::String.t(), reason::term()}`. `:temporary` (no auto-restart, crash-contained).

### Gate verdicts
_(filled at gate time — critic, reviewer)_
