### PR TITLE
refactor: WorkerSupervisor → plain DynamicSupervisor (drop GenServer wrapper, refs #444)

### DIFF
--- a/lib/tau/factory/worker_supervisor.ex
+++ b/lib/tau/factory/worker_supervisor.ex
@@ -9,26 +9,25 @@ defmodule Tau.Factory.WorkerSupervisor do
   Workers are addressed via `Tau.Factory.WorkerRegistry` by their logical
   `worker_id` string key; pids are never stored durably ([C218]).
 
-  Implemented as a `GenServer` that owns an inner `DynamicSupervisor`.
-  The registry atom is held in the GenServer's state and retrieved via
-  a single `GenServer.call/2` at spawn time — no global mutable ETS.
+  Implemented as a plain `DynamicSupervisor`. The registry atom is passed
+  per-call via `spawn/5` opts — no GenServer wrapper, no inner-sup-inside-init,
+  no ETS.
 
   See `docs/spec/SPEC-FACTORY-FLEET.md`, D-309, D-316.
   """
 
-  use GenServer
+  use DynamicSupervisor
 
   @doc """
   Start the WorkerSupervisor and register it under `:name`.
 
   Options:
-    - `:name`     — atom; registered name for this GenServer (required).
-    - `:registry` — atom; registered name of the `WorkerRegistry` (required).
+    - `:name` — atom; registered name for this DynamicSupervisor (required).
   """
   @spec start_link(keyword()) :: Supervisor.on_start()
   def start_link(opts) do
     name = Keyword.fetch!(opts, :name)
-    GenServer.start_link(__MODULE__, opts, name: name)
+    DynamicSupervisor.start_link(__MODULE__, opts, name: name)
   end
 
   @doc """
@@ -41,10 +40,15 @@ defmodule Tau.Factory.WorkerSupervisor do
     %{
       id: name,
       start: {__MODULE__, :start_link, [opts]},
-      type: :worker,
+      type: :supervisor,
       restart: :permanent,
-      shutdown: 5_000
+      shutdown: :infinity
     }
+  end
+
+  @impl DynamicSupervisor
+  def init(_opts) do
+    DynamicSupervisor.init(strategy: :one_for_one)
   end
 
   @doc """
@@ -60,6 +64,7 @@ defmodule Tau.Factory.WorkerSupervisor do
   the worker may still stop asynchronously if `init/1` fails.
 
   Options (all passed through to `Tau.Factory.Worker`):
+    - `:registry`            — atom; registered name of the WorkerRegistry (required).
     - `:repo_dir`            — path to the git repo (required).
     - `:agent_bin`           — path to the executable (required).
     - `:toolchain`           — atom (default: `:elixir`).
@@ -72,27 +77,8 @@ defmodule Tau.Factory.WorkerSupervisor do
   @spec spawn(atom() | pid(), atom(), String.t(), String.t(), keyword()) ::
           {:ok, String.t()} | {:error, term()}
   def spawn(supervisor, role, brief, base_ref, opts) do
-    GenServer.call(supervisor, {:spawn_worker, role, brief, base_ref, opts})
-  end
-
-  # ---------------------------------------------------------------------------
-  # GenServer callbacks
-  # ---------------------------------------------------------------------------
-
-  @impl GenServer
-  def init(opts) do
-    registry = Keyword.fetch!(opts, :registry)
-
-    # Start the inner DynamicSupervisor linked to this GenServer.
-    {:ok, dyn_sup} =
-      DynamicSupervisor.start_link(strategy: :one_for_one)
-
-    {:ok, %{registry: registry, dyn_sup: dyn_sup}}
-  end
-
-  @impl GenServer
-  def handle_call({:spawn_worker, role, brief, base_ref, opts}, _from, state) do
     worker_id = Keyword.get(opts, :worker_id, generate_worker_id())
+    registry = Keyword.fetch!(opts, :registry)
 
     worker_opts =
       opts
@@ -100,7 +86,7 @@ defmodule Tau.Factory.WorkerSupervisor do
       |> Keyword.put(:role, role)
       |> Keyword.put(:brief, brief)
       |> Keyword.put(:base_ref, base_ref)
-      |> Keyword.put(:registry, state.registry)
+      |> Keyword.put(:registry, registry)
 
     child_spec = %{
       id: make_ref(),
@@ -109,22 +95,19 @@ defmodule Tau.Factory.WorkerSupervisor do
       type: :worker
     }
 
-    result =
-      case DynamicSupervisor.start_child(state.dyn_sup, child_spec) do
-        {:ok, _pid} ->
-          {:ok, worker_id}
+    case DynamicSupervisor.start_child(supervisor, child_spec) do
+      {:ok, _pid} ->
+        {:ok, worker_id}
 
-        {:ok, _pid, _info} ->
-          {:ok, worker_id}
+      {:ok, _pid, _info} ->
+        {:ok, worker_id}
 
-        {:error, {:already_started, _pid}} ->
-          {:ok, worker_id}
+      {:error, {:already_started, _pid}} ->
+        {:ok, worker_id}
 
-        {:error, reason} ->
-          {:error, reason}
-      end
-
-    {:reply, result, state}
+      {:error, reason} ->
+        {:error, reason}
+    end
   end
 
   # ---------------------------------------------------------------------------

--- a/test/tau/factory/worker_test.exs
+++ b/test/tau/factory/worker_test.exs
@@ -220,7 +220,8 @@ defmodule Tau.Factory.WorkerTest do
       {:ok, worker_id} =
         @worker_supervisor.spawn(sup, :implementer, "brief", base_ref,
           repo_dir: repo_dir,
-          agent_bin: agent_bin
+          agent_bin: agent_bin,
+          registry: registry_name
         )
 
       assert is_binary(worker_id),
@@ -271,13 +272,15 @@ defmodule Tau.Factory.WorkerTest do
       {:ok, worker_id1} =
         @worker_supervisor.spawn(sup, :implementer, "brief1", base_ref,
           repo_dir: repo_dir,
-          agent_bin: agent_bin
+          agent_bin: agent_bin,
+          registry: registry_name
         )
 
       {:ok, worker_id2} =
         @worker_supervisor.spawn(sup, :test_author, "brief2", base_ref,
           repo_dir: repo_dir,
-          agent_bin: agent_bin
+          agent_bin: agent_bin,
+          registry: registry_name
         )
 
       refute worker_id1 == worker_id2,
@@ -354,7 +357,8 @@ defmodule Tau.Factory.WorkerTest do
       result =
         @worker_supervisor.spawn(sup, :implementer, "brief", bad_base_ref,
           repo_dir: repo_dir,
-          agent_bin: bin_path
+          agent_bin: bin_path,
+          registry: registry_name
         )
 
       # Allow the worker process to complete its failing init.
@@ -426,7 +430,8 @@ defmodule Tau.Factory.WorkerTest do
         @worker_supervisor.spawn(sup, :implementer, "brief", commit_a,
           repo_dir: repo_dir,
           agent_bin: bin_path,
-          expected_head: commit_b
+          expected_head: commit_b,
+          registry: registry_name
         )
 
       # Allow the worker process to complete its failing init.
@@ -484,14 +489,16 @@ defmodule Tau.Factory.WorkerTest do
         @worker_supervisor.spawn(sup, :implementer, "brief1", base_ref,
           repo_dir: repo_dir,
           agent_bin: agent_bin,
-          report_to: report_to
+          report_to: report_to,
+          registry: registry_name
         )
 
       {:ok, worker_id2} =
         @worker_supervisor.spawn(sup, :critic, "brief2", base_ref,
           repo_dir: repo_dir,
           agent_bin: agent_bin,
-          report_to: report_to
+          report_to: report_to,
+          registry: registry_name
         )
 
       # Resolve pids via registry — never store pids durably ([C218]).
@@ -557,7 +564,8 @@ defmodule Tau.Factory.WorkerTest do
         @worker_supervisor.spawn(sup, :implementer, "test brief", base_ref,
           repo_dir: repo_dir,
           agent_bin: agent_bin,
-          report_to: report_to
+          report_to: report_to,
+          registry: registry_name
         )
 
       # B1: spawn/5 must return {:ok, worker_id}.
@@ -604,7 +612,8 @@ defmodule Tau.Factory.WorkerTest do
       {:ok, worker_id} =
         @worker_supervisor.spawn(sup, :reviewer, "brief", base_ref,
           repo_dir: repo_dir,
-          agent_bin: agent_bin
+          agent_bin: agent_bin,
+          registry: registry_name
         )
 
       # Resolve pid from registry using the logical key — this is [C218].
@@ -640,7 +649,8 @@ defmodule Tau.Factory.WorkerTest do
         @worker_supervisor.spawn(sup, :implementer, "brief", base_ref,
           repo_dir: repo_dir,
           agent_bin: agent_bin,
-          report_to: report_to
+          report_to: report_to,
+          registry: registry_name
         )
 
       [{pid, _}] = Registry.lookup(registry_name, worker_id)

--- a/test/tau/factory/worker_test.exs
+++ b/test/tau/factory/worker_test.exs
@@ -628,6 +628,48 @@ defmodule Tau.Factory.WorkerTest do
       Process.exit(pid, :kill)
     end
 
+    @tag :dynsup_contract
+    test "spawn/5 requires :registry — fail-closed contract of the DynamicSupervisor design" do
+      # Discriminating test for gate 5.3.
+      #
+      # OLD code: WorkerSupervisor held the registry in GenServer state and
+      # tolerated a missing per-call :registry opt — spawn would succeed.
+      #
+      # NEW code: WorkerSupervisor is a plain DynamicSupervisor; the registry
+      # is a REQUIRED per-call opt resolved via `Keyword.fetch!(opts, :registry)`.
+      # Omitting :registry raises KeyError immediately — no partial execution.
+      #
+      # TRUE for the new contract, FALSE for the old: genuine gate 5.3 discriminator.
+      tmp_dir =
+        System.tmp_dir!() |> Path.join("tau_dynsup_#{System.unique_integer([:positive])}")
+
+      File.mkdir_p!(tmp_dir)
+      on_exit(fn -> File.rm_rf!(tmp_dir) end)
+
+      %{repo_dir: repo_dir, base_ref: base_ref} = setup_git_repo(tmp_dir)
+      agent_bin = dummy_agent_bin(tmp_dir, "_dynsup")
+
+      n = System.unique_integer([:positive])
+      sup_name = :"dynsup_contract_sup_#{n}"
+
+      {:ok, sup} =
+        start_supervised(
+          {@worker_supervisor, name: sup_name},
+          id: :"dynsup_sup_#{n}"
+        )
+
+      # Calling spawn/5 WITHOUT :registry MUST raise KeyError.
+      # The DynamicSupervisor design enforces fail-closed: no registry in state,
+      # so per-call :registry is always required.
+      assert_raise KeyError, fn ->
+        @worker_supervisor.spawn(sup, :implementer, "brief", base_ref,
+          repo_dir: repo_dir,
+          agent_bin: agent_bin
+          # :registry intentionally omitted
+        )
+      end
+    end
+
     @tag :b1_b4
     test "B1/B4: :kill on worker delivers {:worker_exit, worker_id, :kill} via monitor" do
       tmp_dir =


### PR DESCRIPTION
## Refactor — WorkerSupervisor → plain DynamicSupervisor (drop the GenServer wrapper)

Adopts both gates' P4d-2 (#444) recommendation (tracked in #435): `Tau.Factory.WorkerSupervisor` was made a GenServer wrapping an inner DynamicSupervisor (to hold the registry atom in state, avoiding a `:public` ETS) — a V12 / OTP-NN#3 smell deviating from SPEC §2 C1 ("WorkerSupervisor IS a DynamicSupervisor"). Both gates ruled it non-blocking but recommended revisiting before P4d-3 touches the fleet.

**This is a behavior-preserving refactor** — no new AC; it RE-asserts the same D-310/D-311/D-316 / B1/B4 contracts via the existing `worker_test.exs`.

### Scope
1. `lib/tau/factory/worker_supervisor.ex` — `use DynamicSupervisor` (plain, `strategy: :one_for_one`). `spawn(sup, role, brief, base_ref, opts)` reads `:registry` from `opts` (the caller already holds it) and `DynamicSupervisor.start_child`s a `:temporary` `Worker` with `:registry` in its child opts. No GenServer state, no `GenServer.call` hop, no inner-sup link.
2. `lib/tau/factory/worker.ex` — `init/1` reads `:registry` from opts and registers `{:via, Registry, {registry, worker_id}}` (likely already does; confirm).
3. `test/tau/factory/worker_test.exs` — **wiring only**: start `WorkerSupervisor` as a plain DynamicSupervisor and pass `:registry` in the `spawn/5` opts. **Every behavioral assertion is preserved** (D-310 disjoint/parent-HEAD-unchanged, D-311 marker `refute`, D-316 containment, the cert `assert_receive`, the `:kill` cert, the genuine HEAD-mismatch). NO assertion weakened/removed.

### Acceptance criteria
- D-310/D-311/D-316/B1/B4 still hold (same `worker_test.exs` assertions, green across ≥20 seeds — the flake stays fixed).
- `WorkerSupervisor` is a plain `DynamicSupervisor` (no GenServer, no ETS); crash-containment unchanged.

### Gating-test paths
- `test/tau/factory/worker_test.exs` (D-310/311/316/B1/B4 — wiring-adapted, assertions preserved)

### Gate verdicts
_(filled at gate)_