### PR TITLE
P4d-3: WorkspaceJanitor capture-before-destroy (D-313/314/334) — advances #437

### DIFF
--- a/lib/tau/factory/ledger/migrations.ex
+++ b/lib/tau/factory/ledger/migrations.ex
@@ -56,6 +56,18 @@ defmodule Tau.Factory.Ledger.Migrations do
        cost        INTEGER NOT NULL,
        inserted_at TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
      )
+     """},
+    {"20260611_005_captures",
+     """
+     CREATE TABLE IF NOT EXISTS captures (
+       id             INTEGER PRIMARY KEY AUTOINCREMENT,
+       worker_id      TEXT    NOT NULL,
+       patch          TEXT    NOT NULL DEFAULT '',
+       untracked_tgz  BLOB,
+       status         TEXT    NOT NULL DEFAULT '',
+       disposition    TEXT    NOT NULL DEFAULT 'captured',
+       inserted_at    TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+     )
      """}
   ]
 

--- a/lib/tau/factory/ledger/writer.ex
+++ b/lib/tau/factory/ledger/writer.ex
@@ -134,6 +134,40 @@ defmodule Tau.Factory.Ledger.Writer do
     GenServer.call(server, :budget_debited)
   end
 
+  @type capture_attrs :: %{
+          patch: binary(),
+          untracked_tgz: binary() | nil,
+          status: binary(),
+          disposition: atom()
+        }
+
+  @doc """
+  Append a capture row for the given `worker_id`.
+
+  Append-only — no UPDATE path. WAL-before-ack: the `{:ok, ref}` reply
+  arrives only after the SQLite WAL commit is durable (D-315, D-334).
+
+  `attrs.untracked_tgz` may be `nil` (no untracked files) or a binary
+  holding gzip-compressed tar bytes.
+
+  Returns `{:ok, ref}` where `ref` is the inserted row id.
+  """
+  @spec capture(GenServer.server(), String.t(), capture_attrs()) :: {:ok, ref()}
+  def capture(server, worker_id, attrs) do
+    GenServer.call(server, {:capture, worker_id, attrs})
+  end
+
+  @doc """
+  Return all capture rows for `worker_id`, most-recent-first.
+
+  Each row is a map `%{patch: binary, untracked_tgz: binary | nil,
+  status: binary, disposition: atom}`.
+  """
+  @spec captures_for(GenServer.server(), String.t()) :: [map()]
+  def captures_for(server, worker_id) do
+    GenServer.call(server, {:captures_for, worker_id})
+  end
+
   # ---------------------------------------------------------------------------
   # GenServer callbacks
   # ---------------------------------------------------------------------------
@@ -177,6 +211,16 @@ defmodule Tau.Factory.Ledger.Writer do
 
   def handle_call(:budget_debited, _from, %{db: db} = state) do
     result = do_budget_debited(db)
+    {:reply, result, state}
+  end
+
+  def handle_call({:capture, worker_id, attrs}, _from, %{db: db} = state) do
+    result = do_capture(db, worker_id, attrs)
+    {:reply, result, state}
+  end
+
+  def handle_call({:captures_for, worker_id}, _from, %{db: db} = state) do
+    result = do_captures_for(db, worker_id)
     {:reply, result, state}
   end
 
@@ -397,6 +441,67 @@ defmodule Tau.Factory.Ledger.Writer do
     {:ok, String.to_existing_atom(text)}
   rescue
     ArgumentError -> :error
+  end
+
+  # Insert an append-only capture row. No UPDATE/upsert path.
+  # WAL-before-ack: reply sent only after step/2 (commit) returns.
+  # untracked_tgz is stored as a BLOB (binary or nil).
+  defp do_capture(db, worker_id, %{
+         patch: patch,
+         untracked_tgz: untracked_tgz,
+         status: status,
+         disposition: disposition
+       }) do
+    disposition_text = Atom.to_string(disposition)
+
+    sql = """
+    INSERT INTO captures (worker_id, patch, untracked_tgz, status, disposition)
+    VALUES (?1, ?2, ?3, ?4, ?5)
+    """
+
+    with {:ok, stmt} <- Exqlite.Sqlite3.prepare(db, String.trim(sql)),
+         :ok <-
+           Exqlite.Sqlite3.bind(stmt, [worker_id, patch, untracked_tgz, status, disposition_text]),
+         step_result <- Exqlite.Sqlite3.step(db, stmt),
+         :ok <- Exqlite.Sqlite3.release(db, stmt) do
+      case step_result do
+        :done -> {:ok, fetch_last_rowid(db)}
+        {:error, reason} -> {:error, reason}
+      end
+    end
+  end
+
+  # SELECT captures for worker_id, most-recent-first.
+  # Returns a list of maps with string->atom conversion for disposition.
+  defp do_captures_for(db, worker_id) do
+    sql = """
+    SELECT patch, untracked_tgz, status, disposition
+    FROM captures
+    WHERE worker_id = ?1
+    ORDER BY id DESC
+    """
+
+    with {:ok, stmt} <- Exqlite.Sqlite3.prepare(db, String.trim(sql)),
+         :ok <- Exqlite.Sqlite3.bind(stmt, [worker_id]),
+         {:ok, rows} <- Exqlite.Sqlite3.fetch_all(db, stmt),
+         :ok <- Exqlite.Sqlite3.release(db, stmt) do
+      Enum.map(rows, fn [patch, untracked_tgz, status, disposition_text] ->
+        disposition =
+          case safe_to_existing_atom(disposition_text) do
+            {:ok, atom} -> atom
+            :error -> String.to_atom(disposition_text)
+          end
+
+        %{
+          patch: patch || "",
+          untracked_tgz: untracked_tgz,
+          status: status || "",
+          disposition: disposition
+        }
+      end)
+    else
+      _ -> []
+    end
   end
 
   defp atom_to_half(:critic), do: "critic"

--- a/lib/tau/factory/ledger/writer.ex
+++ b/lib/tau/factory/ledger/writer.ex
@@ -152,7 +152,7 @@ defmodule Tau.Factory.Ledger.Writer do
 
   Returns `{:ok, ref}` where `ref` is the inserted row id.
   """
-  @spec capture(GenServer.server(), String.t(), capture_attrs()) :: {:ok, ref()}
+  @spec capture(GenServer.server(), String.t(), capture_attrs()) :: {:ok, ref()} | {:error, term()}
   def capture(server, worker_id, attrs) do
     GenServer.call(server, {:capture, worker_id, attrs})
   end

--- a/lib/tau/factory/worker.ex
+++ b/lib/tau/factory/worker.ex
@@ -41,6 +41,7 @@ defmodule Tau.Factory.Worker do
 
   alias Tau.Factory.Worker.Isolation
   alias Tau.Factory.Toolchain
+  alias Tau.Factory.WorkspaceJanitor
 
   # ---------------------------------------------------------------------------
   # Public API
@@ -65,6 +66,9 @@ defmodule Tau.Factory.Worker do
     - `:heartbeat_interval`  — ms; enables periodic heartbeat telemetry.
     - `:expected_head`       — SHA string; expected HEAD after worktree add
                                (overrides resolved base_ref SHA for testing).
+    - `:janitor`             — pid or name of `WorkspaceJanitor`; when present,
+                               the janitor is used as the independent monitor
+                               instead of the built-in death-monitor process.
   """
   @spec start_link(keyword()) :: GenServer.on_start()
   def start_link(opts) do
@@ -95,6 +99,7 @@ defmodule Tau.Factory.Worker do
     report_to = Keyword.get(opts, :report_to)
     heartbeat_interval = Keyword.get(opts, :heartbeat_interval)
     expected_head_override = Keyword.get(opts, :expected_head)
+    janitor = Keyword.get(opts, :janitor)
 
     # Unique private worktree path under the parent repo's parent dir.
     ws = Path.join([Path.dirname(repo_dir), ".worker-wt-#{worker_id}"])
@@ -117,6 +122,7 @@ defmodule Tau.Factory.Worker do
           report_to: report_to,
           heartbeat_interval: heartbeat_interval,
           expected_head_override: expected_head_override,
+          janitor: janitor,
           ws: ws
         }
 
@@ -127,6 +133,11 @@ defmodule Tau.Factory.Worker do
         # Surface as position_unverified (D-311).
         {:stop, {:position_unverified, ws, base_ref}}
     end
+  end
+
+  @impl GenServer
+  def handle_call(:get_ws, _from, state) do
+    {:reply, {:ok, state.ws}, state}
   end
 
   # Port exited: stop the worker. The death-certificate is delivered by the
@@ -240,6 +251,7 @@ defmodule Tau.Factory.Worker do
       registry: registry,
       report_to: report_to,
       heartbeat_interval: heartbeat_interval,
+      janitor: janitor,
       ws: ws,
       ns: ns
     } = ctx
@@ -259,9 +271,16 @@ defmodule Tau.Factory.Worker do
         {:cd, ws}
       ])
 
-    # Spawn the unlinked monitor — sole writer of the death-certificate.
-    # It fires on the `:DOWN` event for ALL exit reasons (C202).
-    spawn_death_monitor(worker_id, report_to)
+    # When a janitor is provided, register with it (it becomes the sole writer
+    # of the death-certificate and the capture-before-destroy executor).
+    # Otherwise fall back to the P4d-2 built-in unlinked death-monitor.
+    ns_dirs = Map.values(ns)
+
+    if janitor do
+      WorkspaceJanitor.register(janitor, worker_id, self(), ws, ns_dirs, report_to)
+    else
+      spawn_death_monitor(worker_id, report_to)
+    end
 
     # Step 5: arm heartbeat timer.
     timer =

--- a/lib/tau/factory/worker.ex
+++ b/lib/tau/factory/worker.ex
@@ -256,7 +256,18 @@ defmodule Tau.Factory.Worker do
       ns: ns
     } = ctx
 
-    # Step 4: open Port (linked by default — agent crash propagates to worker).
+    # Step 4: register with the janitor (or arm the death-monitor) BEFORE
+    # opening the Port, so that any raise during Port.open is caught by the
+    # janitor's :DOWN handler — no unmonitored worktree leak (D-314, SPEC B5).
+    ns_dirs = Map.values(ns)
+
+    if janitor do
+      WorkspaceJanitor.register(janitor, worker_id, self(), ws, ns_dirs, report_to)
+    else
+      spawn_death_monitor(worker_id, report_to)
+    end
+
+    # Step 5: open Port (linked by default — agent crash propagates to worker).
     env_list =
       Enum.map(ns, fn {var, dir} ->
         {String.to_charlist(var), String.to_charlist(dir)}
@@ -271,18 +282,7 @@ defmodule Tau.Factory.Worker do
         {:cd, ws}
       ])
 
-    # When a janitor is provided, register with it (it becomes the sole writer
-    # of the death-certificate and the capture-before-destroy executor).
-    # Otherwise fall back to the P4d-2 built-in unlinked death-monitor.
-    ns_dirs = Map.values(ns)
-
-    if janitor do
-      WorkspaceJanitor.register(janitor, worker_id, self(), ws, ns_dirs, report_to)
-    else
-      spawn_death_monitor(worker_id, report_to)
-    end
-
-    # Step 5: arm heartbeat timer.
+    # Step 6: arm heartbeat timer.
     timer =
       if heartbeat_interval do
         Process.send_after(self(), :heartbeat, heartbeat_interval)

--- a/lib/tau/factory/workspace_janitor.ex
+++ b/lib/tau/factory/workspace_janitor.ex
@@ -1,0 +1,277 @@
+defmodule Tau.Factory.WorkspaceJanitor do
+  @moduledoc """
+  Independent monitor for `Tau.Factory.Worker` processes.
+
+  The janitor `Process.monitor/1`s each registered worker (NEVER links).
+  On a `:DOWN` event — for ANY exit reason including `:kill` — it executes
+  the capture-before-destroy sequence in strict order (D-313, C203):
+
+    1. Run `git diff HEAD` to capture staged + unstaged modifications (patch).
+    2. Run `git ls-files --others --exclude-standard`; if non-empty, archive
+       the listed files into a gzip-compressed tar binary (untracked_tgz).
+    3. Run `git status --short` (status).
+    4. Write a capture row to the Ledger (WAL-before-ack, D-315) — BEFORE
+       any filesystem side-effect (reclaim).
+    5. Reclaim the worktree: `git worktree remove --force <ws>` followed by
+       `File.rm_rf!/1` as a fallback, then remove each namespace dir.
+    6. Send `{:worker_exit, worker_id, reason}` to the effective `report_to`
+       (per-worker if non-nil, otherwise the janitor's default).
+
+  On start, if `:orphan_dirs` is given, the janitor reclaims each listed
+  directory that still exists (D-314 orphan reconciliation).
+
+  ## Independence guarantee (C207, SPEC-FACTORY-FLEET §4 B5)
+
+  The janitor is NOT linked to any worker. A `:kill` on a worker does NOT
+  propagate to the janitor. Capture always fires via the `:DOWN` message.
+
+  ## Capture-failure isolation
+
+  A git or tar failure during capture is logged and tagged; the janitor
+  continues to reclaim and deliver the death-certificate rather than
+  crashing and orphaning the worktree.
+
+  See `docs/spec/SPEC-FACTORY-FLEET.md`, D-309, D-313, D-314, D-334.
+  """
+
+  use GenServer
+
+  alias Tau.Factory.Ledger.Writer
+
+  require Logger
+
+  # ---------------------------------------------------------------------------
+  # Public API
+  # ---------------------------------------------------------------------------
+
+  @doc """
+  Start the WorkspaceJanitor.
+
+  Required opts:
+    - `:ledger`  — pid or registered name of `Tau.Factory.Ledger.Writer`.
+    - `:name`    — atom; registered name for this GenServer.
+
+  Optional opts:
+    - `:report_to`   — default pid to receive `{:worker_exit, worker_id, reason}`.
+    - `:orphan_dirs` — list of absolute paths to reclaim on init (D-314).
+  """
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(opts) do
+    # Register under __MODULE__ so callers can find this instance via
+    # Process.whereis(Tau.Factory.WorkspaceJanitor).  The :name opt is used
+    # only as the child id for supervisor deduplication; a process can have
+    # only one registered atom name, so we always use the module name here.
+    # Tests run async: false so only one janitor is alive at a time.
+    GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+  end
+
+  @doc """
+  Returns the child spec for embedding in a supervisor tree.
+  """
+  @spec child_spec(keyword()) :: map()
+  def child_spec(opts) do
+    name = Keyword.fetch!(opts, :name)
+
+    %{
+      id: name,
+      start: {__MODULE__, :start_link, [opts]},
+      type: :worker,
+      restart: :permanent,
+      shutdown: 5_000
+    }
+  end
+
+  @doc """
+  Register a worker with the janitor.
+
+  The janitor monitors `worker_pid` (does NOT link). On `:DOWN`, it
+  captures the state of `ws`, writes to the Ledger, reclaims `ws` and
+  `ns_dirs`, then sends `{:worker_exit, worker_id, reason}` to
+  `report_to` (or the janitor's default `report_to` when `nil`).
+
+  - `worker_id` — String; the logical worker identity.
+  - `worker_pid` — pid of the live Worker process.
+  - `ws` — absolute path to the worker's private worktree.
+  - `ns_dirs` — list of additional dirs inside `ws` to reclaim.
+  - `report_to` — pid to notify, or `nil` to use the janitor default.
+  """
+  @spec register(
+          GenServer.server(),
+          String.t(),
+          pid(),
+          String.t(),
+          [String.t()],
+          pid() | nil
+        ) :: :ok
+  def register(janitor, worker_id, worker_pid, ws, ns_dirs, report_to) do
+    GenServer.call(janitor, {:register, worker_id, worker_pid, ws, ns_dirs, report_to})
+  end
+
+  # ---------------------------------------------------------------------------
+  # GenServer callbacks
+  # ---------------------------------------------------------------------------
+
+  @impl GenServer
+  def init(opts) do
+    ledger = Keyword.fetch!(opts, :ledger)
+    default_report_to = Keyword.get(opts, :report_to)
+    orphan_dirs = Keyword.get(opts, :orphan_dirs, [])
+
+    # Reconcile orphans on restart (D-314).
+    Enum.each(orphan_dirs, fn dir ->
+      if File.exists?(dir) do
+        Logger.info("[WorkspaceJanitor] reclaiming orphan dir: #{dir}")
+        File.rm_rf!(dir)
+      end
+    end)
+
+    {:ok,
+     %{
+       ledger: ledger,
+       default_report_to: default_report_to,
+       # Map from monitor ref -> {worker_id, ws, ns_dirs, effective_report_to}
+       workers: %{}
+     }}
+  end
+
+  @impl GenServer
+  def handle_call({:register, worker_id, worker_pid, ws, ns_dirs, report_to}, _from, state) do
+    ref = Process.monitor(worker_pid)
+
+    effective_report_to = report_to || state.default_report_to
+
+    entry = {worker_id, ws, ns_dirs, effective_report_to}
+    new_workers = Map.put(state.workers, ref, entry)
+
+    {:reply, :ok, %{state | workers: new_workers}}
+  end
+
+  @impl GenServer
+  def handle_info({:DOWN, ref, :process, _pid, reason}, state) do
+    case Map.pop(state.workers, ref) do
+      {nil, _} ->
+        # Unknown ref — ignore.
+        {:noreply, state}
+
+      {{worker_id, ws, _ns_dirs, report_to}, new_workers} ->
+        Process.demonitor(ref, [:flush])
+
+        cert_reason = normalize_reason(reason)
+
+        # Capture-before-reclaim, in order (D-313, C203).
+        capture_result = capture_workspace(state.ledger, worker_id, ws)
+
+        case capture_result do
+          {:ok, _} ->
+            :ok
+
+          {:error, err} ->
+            Logger.error("[WorkspaceJanitor] capture failed for #{worker_id}: #{inspect(err)}")
+        end
+
+        # Reclaim the workspace (after the durable write).
+        reclaim_workspace(ws)
+
+        # Deliver death-certificate.
+        if report_to do
+          send(report_to, {:worker_exit, worker_id, cert_reason})
+        end
+
+        :telemetry.execute(
+          [:tau, :factory, :janitor, :reclaim],
+          %{},
+          %{worker_id: worker_id, reason: cert_reason}
+        )
+
+        {:noreply, %{state | workers: new_workers}}
+    end
+  end
+
+  def handle_info(_msg, state) do
+    {:noreply, state}
+  end
+
+  # ---------------------------------------------------------------------------
+  # Private helpers
+  # ---------------------------------------------------------------------------
+
+  # Normalize the `:DOWN` reason to the death-certificate reason.
+  defp normalize_reason(:killed), do: :kill
+  defp normalize_reason(:normal), do: :normal
+  defp normalize_reason(other), do: other
+
+  # Run all three capture kinds, write to Ledger, return {:ok, ref} or {:error, reason}.
+  defp capture_workspace(ledger, worker_id, ws) do
+    patch = run_git_patch(ws)
+    untracked_files = run_git_untracked(ws)
+    untracked_tgz = maybe_tar_untracked(ws, untracked_files)
+    status = run_git_status(ws)
+
+    attrs = %{
+      patch: patch,
+      untracked_tgz: untracked_tgz,
+      status: status,
+      disposition: :captured
+    }
+
+    Writer.capture(ledger, worker_id, attrs)
+  end
+
+  # git diff HEAD — captures staged AND unstaged modifications.
+  defp run_git_patch(ws) do
+    case System.cmd("git", ["-C", ws, "diff", "HEAD"], stderr_to_stdout: true) do
+      {out, _} -> out
+    end
+  end
+
+  # git ls-files --others --exclude-standard — returns newline-separated list of untracked files.
+  defp run_git_untracked(ws) do
+    case System.cmd("git", ["-C", ws, "ls-files", "--others", "--exclude-standard"],
+           stderr_to_stdout: true
+         ) do
+      {out, _} ->
+        out
+        |> String.trim()
+        |> then(fn s -> if s == "", do: [], else: String.split(s, "\n") end)
+    end
+  end
+
+  # git status --short
+  defp run_git_status(ws) do
+    case System.cmd("git", ["-C", ws, "status", "--short"], stderr_to_stdout: true) do
+      {out, _} -> out
+    end
+  end
+
+  # If there are untracked files, create a tar.gz binary of them.
+  # Uses `tar -C ws -czf - <files...>` and captures stdout as binary.
+  defp maybe_tar_untracked(_ws, []), do: nil
+
+  defp maybe_tar_untracked(ws, files) do
+    args = ["-C", ws, "-czf", "-"] ++ files
+
+    case System.cmd("tar", args) do
+      {tgz_bytes, 0} when byte_size(tgz_bytes) > 0 ->
+        tgz_bytes
+
+      _ ->
+        nil
+    end
+  end
+
+  # Reclaim the workspace directory:
+  # 1. Run `git -C ws worktree remove --force ws` (from inside the worktree so
+  #    git can follow the .git pointer back to the parent repo and deregister).
+  # 2. Always fall back to File.rm_rf!/1 to ensure filesystem removal even if
+  #    the git command fails (e.g. ws already partially removed).
+  defp reclaim_workspace(ws) do
+    if File.dir?(ws) do
+      System.cmd("git", ["-C", ws, "worktree", "remove", "--force", ws], stderr_to_stdout: true)
+    end
+
+    # Ensure filesystem removal regardless of git command result.
+    if File.exists?(ws) do
+      File.rm_rf!(ws)
+    end
+  end
+end

--- a/test/tau/factory/artifact_conservation_test.exs
+++ b/test/tau/factory/artifact_conservation_test.exs
@@ -1,0 +1,419 @@
+defmodule Tau.Factory.ArtifactConservationTest do
+  @moduledoc """
+  Gating tests for PR #446 (P4d-3 — WorkspaceJanitor capture-before-destroy).
+
+  Covers D-334 (artifact conservation / CON-5):
+    dirty(w) = committed(w) ⊎ captured(w) ⊎ discarded_by_decision(w)
+  The join covers every dirty hunk with no remainder.
+
+  Written BEFORE production code exists (oracle-separation phase, D-304).
+  Fails with UndefinedFunctionError until the implementer creates
+  Tau.Factory.WorkspaceJanitor and extends Ledger.Writer with capture/3 +
+  captures_for/2.
+
+  ## AC linkage
+    - D-334: all tests in this file
+  """
+
+  use ExUnit.Case, async: false
+
+  @moduletag :capture_log
+
+  @janitor Tau.Factory.WorkspaceJanitor
+  @writer Tau.Factory.Ledger.Writer
+  @worker_registry Tau.Factory.WorkerRegistry
+  @worker_supervisor Tau.Factory.WorkerSupervisor
+
+  # ---------------------------------------------------------------------------
+  # Hermetic git repo setup
+  # ---------------------------------------------------------------------------
+
+  defp setup_git_repo(tmp_dir) do
+    repo_dir = Path.join(tmp_dir, "repo_#{System.unique_integer([:positive])}")
+    File.mkdir_p!(repo_dir)
+
+    git = fn args ->
+      System.cmd("git", args, cd: repo_dir, stderr_to_stdout: true)
+    end
+
+    {_, 0} = git.(["init", "-b", "main"])
+    {_, 0} = git.(["config", "user.email", "test@tau.test"])
+    {_, 0} = git.(["config", "user.name", "Tau Test"])
+
+    # Two tracked files so we can create staged AND unstaged hunks independently.
+    File.write!(Path.join(repo_dir, "file_a.txt"), "original_a\n")
+    File.write!(Path.join(repo_dir, "file_b.txt"), "original_b\n")
+    {_, 0} = git.(["add", "file_a.txt", "file_b.txt"])
+    {_, 0} = git.(["commit", "-m", "initial commit"])
+    {sha, 0} = git.(["rev-parse", "HEAD"])
+
+    %{repo_dir: repo_dir, base_ref: String.trim(sha)}
+  end
+
+  defp slow_agent_bin(tmp_dir, suffix \\ "") do
+    bin_path = Path.join(tmp_dir, "slow_cons#{suffix}")
+
+    File.write!(bin_path, """
+    #!/bin/sh
+    while true; do sleep 60; done
+    """)
+
+    File.chmod!(bin_path, 0o755)
+    bin_path
+  end
+
+  defp start_ledger(tmp_dir, tag) do
+    n = System.unique_integer([:positive])
+    db_path = Path.join(tmp_dir, "ledger_cons_#{tag}_#{n}.db")
+    name = :"ledger_cons_#{tag}_#{n}"
+
+    {:ok, _} =
+      start_supervised(
+        {@writer, db_path: db_path, name: name},
+        id: :"ledger_cons_sv_#{n}"
+      )
+
+    name
+  end
+
+  defp start_fleet(tag) do
+    n = System.unique_integer([:positive])
+    registry_name = :"cons_reg_#{tag}_#{n}"
+    sup_name = :"cons_sup_#{tag}_#{n}"
+
+    {:ok, _} =
+      start_supervised(
+        {@worker_registry, name: registry_name},
+        id: :"cons_rreg_#{n}"
+      )
+
+    {:ok, sup} =
+      start_supervised(
+        {@worker_supervisor, name: sup_name, registry: registry_name},
+        id: :"cons_rsup_#{n}"
+      )
+
+    {sup_name, sup, registry_name}
+  end
+
+  defp start_janitor(ledger, tag, report_to \\ nil) do
+    n = System.unique_integer([:positive])
+    name = :"cons_jan_#{tag}_#{n}"
+
+    opts = [ledger: ledger, name: name]
+    opts = if report_to, do: Keyword.put(opts, :report_to, report_to), else: opts
+
+    {:ok, pid} =
+      start_supervised(
+        {@janitor, opts},
+        id: :"cons_jan_sv_#{n}"
+      )
+
+    {name, pid}
+  end
+
+  defp poll_captures(ledger, worker_id, timeout_ms, interval_ms \\ 100) do
+    deadline = System.monotonic_time(:millisecond) + timeout_ms
+    do_poll_captures(ledger, worker_id, deadline, interval_ms)
+  end
+
+  defp do_poll_captures(ledger, worker_id, deadline, interval_ms) do
+    captures = @writer.captures_for(ledger, worker_id)
+
+    cond do
+      captures != [] ->
+        captures
+
+      System.monotonic_time(:millisecond) >= deadline ->
+        []
+
+      true ->
+        Process.sleep(interval_ms)
+        do_poll_captures(ledger, worker_id, deadline, interval_ms)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # D-334 — Artifact conservation
+  # ---------------------------------------------------------------------------
+
+  describe "D-334 — artifact conservation" do
+    @tag :d_334
+    test "D-334: capture record accounts for ALL dirty hunks — committed ⊎ captured covers entire dirty state" do
+      # Drive a worker to hold one hunk of each dirty kind:
+      #   - committed:    a git commit made by the agent (file_a.txt second line)
+      #   - staged:       file_a.txt third line, git-added but not committed
+      #   - unstaged:     file_b.txt modified but not added
+      #   - untracked:    brand-new file never git-add'd
+      #
+      # After :kill, assert the capture record's patch + untracked_tgz covers
+      # the staged+unstaged+untracked state.  The committed hunk already lives
+      # in git history inside the worktree (captured as part of the workspace
+      # state pre-reclaim — the relevant assertion is that disposition == :captured
+      # and the Ledger row has non-empty patch and non-nil untracked_tgz).
+      #
+      # CON-5 balance: dirty(w) = committed(w) ⊎ captured(w) ⊎ discarded_by_decision(w)
+      # Here: committed=1 hunk, captured={staged_patch+unstaged_patch+untracked_tgz},
+      #        discarded_by_decision=0.
+      # The join covers every hunk: none falls outside the three sets.
+      tmp_dir =
+        System.tmp_dir!()
+        |> Path.join("tau_cons334_#{System.unique_integer([:positive])}")
+
+      File.mkdir_p!(tmp_dir)
+      on_exit(fn -> File.rm_rf!(tmp_dir) end)
+
+      %{repo_dir: repo_dir, base_ref: base_ref} = setup_git_repo(tmp_dir)
+      agent_bin = slow_agent_bin(tmp_dir)
+
+      ledger = start_ledger(tmp_dir, :d334)
+      {_sup_name, sup, registry_name} = start_fleet(:d334)
+      report_to = self()
+      {_jan_name, jan_pid} = start_janitor(ledger, :d334, report_to)
+
+      {:ok, worker_id} =
+        @worker_supervisor.spawn(sup, :implementer, "brief", base_ref,
+          repo_dir: repo_dir,
+          agent_bin: agent_bin,
+          registry: registry_name,
+          janitor: jan_pid
+        )
+
+      [{worker_pid, _}] = Registry.lookup(registry_name, worker_id)
+      {:ok, ws} = GenServer.call(worker_pid, :get_ws)
+      assert File.dir?(ws), "D-334: worker's worktree must exist"
+
+      git = fn args -> System.cmd("git", args, cd: ws, stderr_to_stdout: true) end
+
+      # --- Committed hunk ---
+      # (worker "does some work" and commits it inside its private worktree)
+      File.write!(Path.join(ws, "file_a.txt"), "original_a\ncommitted_line\n")
+      {_, 0} = git.(["add", "file_a.txt"])
+      {_, 0} = git.(["commit", "-m", "worker commit"])
+
+      committed_sha_out = elem(git.(["rev-parse", "HEAD"]), 0)
+      committed_sha = String.trim(committed_sha_out)
+
+      # --- Staged hunk ---
+      File.write!(Path.join(ws, "file_a.txt"), "original_a\ncommitted_line\nstaged_line\n")
+      {_, 0} = git.(["add", "file_a.txt"])
+
+      # --- Unstaged hunk ---
+      File.write!(
+        Path.join(ws, "file_b.txt"),
+        "original_b\nunstaged_modification\n"
+      )
+
+      # --- Untracked hunk ---
+      untracked_name = "untracked_work.txt"
+      untracked_content = "untracked-artifact-#{System.unique_integer([:positive])}\n"
+      File.write!(Path.join(ws, untracked_name), untracked_content)
+
+      # Verify all dirty kinds are present in the worktree before kill.
+      {status_out, _} = git.(["status", "--short"])
+
+      assert String.contains?(status_out, untracked_name),
+             "D-334: setup — untracked file must appear in status; status=#{inspect(status_out)}"
+
+      # Kill the worker.
+      Process.exit(worker_pid, :kill)
+
+      assert_receive {:worker_exit, ^worker_id, _reason},
+                     5_000,
+                     "D-334: death-cert must arrive after :kill"
+
+      # Wait for capture row.
+      captures = poll_captures(ledger, worker_id, 5_000)
+
+      assert captures != [],
+             "D-334: Ledger must have a capture row for worker_id=#{worker_id}"
+
+      [capture | _] = captures
+
+      # --- Assert CON-5 balance ---
+
+      # patch covers staged + unstaged.
+      assert is_binary(capture.patch) and byte_size(capture.patch) > 0,
+             "D-334: capture.patch must be non-empty (staged+unstaged diff)"
+
+      # untracked_tgz covers the untracked kind.
+      assert capture.untracked_tgz != nil,
+             "D-334: capture.untracked_tgz must be non-nil"
+
+      assert is_binary(capture.untracked_tgz) and byte_size(capture.untracked_tgz) > 0,
+             "D-334: capture.untracked_tgz must be non-empty"
+
+      # disposition must be :captured (CON-5 — nothing discarded by decision here).
+      assert capture.disposition == :captured,
+             "D-334: capture.disposition must be :captured; got #{inspect(capture.disposition)}"
+
+      # Extract tgz and confirm untracked file is byte-for-byte present.
+      extract_dir =
+        Path.join(tmp_dir, "extract_#{System.unique_integer([:positive])}")
+
+      File.mkdir_p!(extract_dir)
+      tgz_path = Path.join(tmp_dir, "cons_untracked.tgz")
+      File.write!(tgz_path, capture.untracked_tgz)
+      {_, 0} = System.cmd("tar", ["-C", extract_dir, "-xzf", tgz_path], stderr_to_stdout: true)
+
+      assert File.read!(Path.join(extract_dir, untracked_name)) == untracked_content,
+             "D-334: untracked file content must match exactly after extraction"
+
+      # patch must contain evidence of staged hunk (staged_line).
+      assert String.contains?(capture.patch, "staged_line"),
+             "D-334: patch must contain the staged hunk (staged_line)"
+
+      # patch must contain evidence of unstaged hunk (unstaged_modification).
+      assert String.contains?(capture.patch, "unstaged_modification"),
+             "D-334: patch must contain the unstaged hunk (unstaged_modification)"
+
+      # Committed work is already in git history (committed_sha exists);
+      # it is in the `committed(w)` set, not lost.
+      assert byte_size(committed_sha) == 40,
+             "D-334: committed SHA must be a valid 40-char SHA; got #{inspect(committed_sha)}"
+
+      # CON-5 remainder check: patch must NOT contain untracked_name
+      # (the untracked kind lives in the tar, not the patch).
+      refute String.contains?(capture.patch, untracked_name),
+             "D-334: untracked file '#{untracked_name}' must be in the tar, NOT in the patch"
+    end
+
+    @tag :d_334
+    test "D-334: clean worker exit — capture row recorded with empty patch and nil untracked_tgz" do
+      # A worker that does no dirty work before exit.
+      # dirty(w) = committed(w) ⊎ captured(w) ⊎ discarded_by_decision(w)
+      # Here committed=∅, captured={empty patch, nil tgz}, discarded=∅.
+      # The balance still holds; no hunk is lost.
+      tmp_dir =
+        System.tmp_dir!()
+        |> Path.join("tau_cons334_clean_#{System.unique_integer([:positive])}")
+
+      File.mkdir_p!(tmp_dir)
+      on_exit(fn -> File.rm_rf!(tmp_dir) end)
+
+      %{repo_dir: repo_dir, base_ref: base_ref} = setup_git_repo(tmp_dir)
+      agent_bin = slow_agent_bin(tmp_dir, "_clean")
+
+      ledger = start_ledger(tmp_dir, :clean)
+      {_sup_name, sup, registry_name} = start_fleet(:clean)
+      report_to = self()
+      {_jan_name, jan_pid} = start_janitor(ledger, :clean, report_to)
+
+      {:ok, worker_id} =
+        @worker_supervisor.spawn(sup, :implementer, "brief", base_ref,
+          repo_dir: repo_dir,
+          agent_bin: agent_bin,
+          registry: registry_name,
+          janitor: jan_pid
+        )
+
+      [{worker_pid, _}] = Registry.lookup(registry_name, worker_id)
+      assert Process.alive?(worker_pid)
+
+      # Kill without dirtying the worktree.
+      Process.exit(worker_pid, :kill)
+
+      assert_receive {:worker_exit, ^worker_id, _reason},
+                     5_000,
+                     "D-334/clean: death-cert must arrive"
+
+      captures = poll_captures(ledger, worker_id, 5_000)
+
+      assert captures != [],
+             "D-334/clean: Ledger must record a capture row even for a clean worker"
+
+      [capture | _] = captures
+
+      # For a clean worker: patch is empty or whitespace-only.
+      assert is_binary(capture.patch),
+             "D-334/clean: capture.patch must be a binary"
+
+      # untracked_tgz is nil or empty when there are no untracked files.
+      assert capture.untracked_tgz == nil or capture.untracked_tgz == "",
+             "D-334/clean: capture.untracked_tgz must be nil or empty for a clean worker; " <>
+               "got #{inspect(capture.untracked_tgz)}"
+
+      # disposition is :captured (nothing was discarded by decision).
+      assert capture.disposition == :captured,
+             "D-334/clean: disposition must be :captured; got #{inspect(capture.disposition)}"
+    end
+
+    @tag :d_334
+    test "D-334: capture record is durably persisted — Ledger query after reclaim returns rows" do
+      # After the worktree is reclaimed (gone from filesystem), the Ledger must
+      # still return the capture row.  This verifies WAL-before-ack: the DB write
+      # committed before the reclaim side-effect.
+      tmp_dir =
+        System.tmp_dir!()
+        |> Path.join("tau_cons334_durable_#{System.unique_integer([:positive])}")
+
+      File.mkdir_p!(tmp_dir)
+      on_exit(fn -> File.rm_rf!(tmp_dir) end)
+
+      %{repo_dir: repo_dir, base_ref: base_ref} = setup_git_repo(tmp_dir)
+      agent_bin = slow_agent_bin(tmp_dir, "_durable")
+
+      ledger = start_ledger(tmp_dir, :durable)
+      {_sup_name, sup, registry_name} = start_fleet(:durable)
+      report_to = self()
+      {_jan_name, jan_pid} = start_janitor(ledger, :durable, report_to)
+
+      {:ok, worker_id} =
+        @worker_supervisor.spawn(sup, :implementer, "brief", base_ref,
+          repo_dir: repo_dir,
+          agent_bin: agent_bin,
+          registry: registry_name,
+          janitor: jan_pid
+        )
+
+      [{worker_pid, _}] = Registry.lookup(registry_name, worker_id)
+      {:ok, ws} = GenServer.call(worker_pid, :get_ws)
+
+      # Write an untracked file to ensure non-trivial tgz.
+      untracked_content = "durable_test_#{System.unique_integer([:positive])}\n"
+      File.write!(Path.join(ws, "durable.txt"), untracked_content)
+
+      Process.exit(worker_pid, :kill)
+
+      assert_receive {:worker_exit, ^worker_id, _reason},
+                     5_000,
+                     "D-334/durable: death-cert must arrive"
+
+      # Wait for reclaim.
+      deadline = System.monotonic_time(:millisecond) + 5_000
+
+      reclaimed =
+        Enum.reduce_while(0..50, false, fn _, _ ->
+          cond do
+            not File.exists?(ws) ->
+              {:halt, true}
+
+            System.monotonic_time(:millisecond) > deadline ->
+              {:halt, false}
+
+            true ->
+              Process.sleep(100)
+              {:cont, false}
+          end
+        end)
+
+      assert reclaimed,
+             "D-334/durable: worktree #{ws} must be reclaimed before querying Ledger"
+
+      # AFTER reclaim, Ledger must still have the capture row.
+      captures = @writer.captures_for(ledger, worker_id)
+
+      assert captures != [],
+             "D-334/durable: Ledger must durably store the capture row even after " <>
+               "the worktree is reclaimed (WAL-before-ack, D-315)"
+
+      [capture | _] = captures
+
+      assert capture.disposition == :captured,
+             "D-334/durable: persisted row disposition must be :captured"
+
+      assert capture.untracked_tgz != nil and byte_size(capture.untracked_tgz) > 0,
+             "D-334/durable: persisted row must contain untracked_tgz"
+    end
+  end
+end

--- a/test/tau/factory/worker_reclaim_test.exs
+++ b/test/tau/factory/worker_reclaim_test.exs
@@ -1,0 +1,437 @@
+defmodule Tau.Factory.WorkerReclaimTest do
+  @moduledoc """
+  Gating tests for PR #446 (P4d-3 — WorkspaceJanitor capture-before-destroy).
+
+  Covers D-314 (supervised reclaim) — every exit reason leaves no leaked
+  worktree or namespace dir, and the janitor reconciles orphans on restart.
+
+  Written BEFORE production code exists (oracle-separation phase, D-304).
+  Fails with UndefinedFunctionError until the implementer creates
+  Tau.Factory.WorkspaceJanitor and extends Ledger.Writer with capture/3 +
+  captures_for/2.
+
+  ## AC linkage
+    - D-314: all tests in this file
+  """
+
+  use ExUnit.Case, async: false
+
+  @moduletag :capture_log
+
+  @janitor Tau.Factory.WorkspaceJanitor
+  @writer Tau.Factory.Ledger.Writer
+  @worker_registry Tau.Factory.WorkerRegistry
+  @worker_supervisor Tau.Factory.WorkerSupervisor
+
+  # ---------------------------------------------------------------------------
+  # Hermetic git repo setup (same idiom as worker_test.exs)
+  # ---------------------------------------------------------------------------
+
+  defp setup_git_repo(tmp_dir) do
+    repo_dir = Path.join(tmp_dir, "repo_#{System.unique_integer([:positive])}")
+    File.mkdir_p!(repo_dir)
+
+    git = fn args ->
+      System.cmd("git", args, cd: repo_dir, stderr_to_stdout: true)
+    end
+
+    {_, 0} = git.(["init", "-b", "main"])
+    {_, 0} = git.(["config", "user.email", "test@tau.test"])
+    {_, 0} = git.(["config", "user.name", "Tau Test"])
+
+    File.write!(Path.join(repo_dir, "README"), "initial\n")
+    {_, 0} = git.(["add", "README"])
+    {_, 0} = git.(["commit", "-m", "initial commit"])
+    {sha, 0} = git.(["rev-parse", "HEAD"])
+
+    %{repo_dir: repo_dir, base_ref: String.trim(sha)}
+  end
+
+  defp slow_agent_bin(tmp_dir, suffix \\ "") do
+    bin_path = Path.join(tmp_dir, "slow_reclaim#{suffix}")
+
+    File.write!(bin_path, """
+    #!/bin/sh
+    while true; do sleep 60; done
+    """)
+
+    File.chmod!(bin_path, 0o755)
+    bin_path
+  end
+
+  defp dummy_agent_bin(tmp_dir, suffix \\ "") do
+    bin_path = Path.join(tmp_dir, "dummy_reclaim#{suffix}")
+
+    File.write!(bin_path, """
+    #!/bin/sh
+    exit 0
+    """)
+
+    File.chmod!(bin_path, 0o755)
+    bin_path
+  end
+
+  # Agent that crashes with non-zero exit.
+  defp crash_agent_bin(tmp_dir, suffix \\ "") do
+    bin_path = Path.join(tmp_dir, "crash_reclaim#{suffix}")
+
+    File.write!(bin_path, """
+    #!/bin/sh
+    exit 1
+    """)
+
+    File.chmod!(bin_path, 0o755)
+    bin_path
+  end
+
+  defp start_ledger(tmp_dir, tag) do
+    n = System.unique_integer([:positive])
+    db_path = Path.join(tmp_dir, "ledger_rec_#{tag}_#{n}.db")
+    name = :"ledger_rec_#{tag}_#{n}"
+
+    {:ok, _} =
+      start_supervised(
+        {@writer, db_path: db_path, name: name},
+        id: :"ledger_rec_sv_#{n}"
+      )
+
+    name
+  end
+
+  defp start_fleet(tag) do
+    n = System.unique_integer([:positive])
+    registry_name = :"reclaim_reg_#{tag}_#{n}"
+    sup_name = :"reclaim_sup_#{tag}_#{n}"
+
+    {:ok, _} =
+      start_supervised(
+        {@worker_registry, name: registry_name},
+        id: :"rreg_#{n}"
+      )
+
+    {:ok, sup} =
+      start_supervised(
+        {@worker_supervisor, name: sup_name, registry: registry_name},
+        id: :"rsup_#{n}"
+      )
+
+    {sup_name, sup, registry_name}
+  end
+
+  defp start_janitor(ledger, tag, report_to \\ nil) do
+    n = System.unique_integer([:positive])
+    name = :"reclaim_jan_#{tag}_#{n}"
+
+    opts = [ledger: ledger, name: name]
+    opts = if report_to, do: Keyword.put(opts, :report_to, report_to), else: opts
+
+    {:ok, pid} =
+      start_supervised(
+        {@janitor, opts},
+        id: :"rjan_sv_#{n}"
+      )
+
+    {name, pid}
+  end
+
+  # Obtain a worker's ws path via the pinned GenServer.call(:get_ws) contract.
+  defp get_ws(worker_pid) do
+    {:ok, ws} = GenServer.call(worker_pid, :get_ws)
+    ws
+  end
+
+  # Poll until File.exists?(path) is false or timeout; returns :reclaimed | :leaked.
+  defp poll_reclaimed(path, timeout_ms, interval_ms \\ 100) do
+    deadline = System.monotonic_time(:millisecond) + timeout_ms
+    do_poll_reclaimed(path, deadline, interval_ms)
+  end
+
+  defp do_poll_reclaimed(path, deadline, interval_ms) do
+    cond do
+      not File.exists?(path) ->
+        :reclaimed
+
+      System.monotonic_time(:millisecond) >= deadline ->
+        :leaked
+
+      true ->
+        Process.sleep(interval_ms)
+        do_poll_reclaimed(path, deadline, interval_ms)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # D-314 — Supervised reclaim: every exit reason leaves no leaked worktree
+  # ---------------------------------------------------------------------------
+
+  describe "D-314 — supervised reclaim on every exit reason" do
+    @tag :d_314
+    test "D-314: normal Port exit (exit 0) — worktree is reclaimed, no leak" do
+      tmp_dir =
+        System.tmp_dir!()
+        |> Path.join("tau_rec314_normal_#{System.unique_integer([:positive])}")
+
+      File.mkdir_p!(tmp_dir)
+      on_exit(fn -> File.rm_rf!(tmp_dir) end)
+
+      %{repo_dir: repo_dir, base_ref: base_ref} = setup_git_repo(tmp_dir)
+      ledger = start_ledger(tmp_dir, :normal)
+      {_sup_name, sup, registry_name} = start_fleet(:normal)
+      {_jan_name, jan_pid} = start_janitor(ledger, :normal, self())
+
+      # slow agent first so we can get ws before the Port exits.
+      agent_bin = dummy_agent_bin(tmp_dir, "_normal")
+
+      {:ok, worker_id} =
+        @worker_supervisor.spawn(sup, :implementer, "brief", base_ref,
+          repo_dir: repo_dir,
+          agent_bin: agent_bin,
+          registry: registry_name,
+          janitor: jan_pid
+        )
+
+      # Wait for natural exit.
+      assert_receive {:worker_exit, ^worker_id, _reason},
+                     5_000,
+                     "D-314/normal: death-cert must arrive on normal exit"
+
+      # The worktree path: we cannot call get_ws after the worker is dead;
+      # instead we poll the git worktree list of the repo to verify nothing leaked.
+      {wt_list, _} =
+        System.cmd("git", ["worktree", "list", "--porcelain"],
+          cd: repo_dir,
+          stderr_to_stdout: true
+        )
+
+      worker_wt_entries =
+        wt_list
+        |> String.split("\n")
+        |> Enum.filter(&String.starts_with?(&1, "worktree "))
+        |> Enum.reject(&String.ends_with?(String.trim(&1), repo_dir))
+
+      assert worker_wt_entries == [],
+             "D-314/normal: all private worktrees must be reclaimed after normal exit; " <>
+               "leaked entries: #{inspect(worker_wt_entries)}"
+    end
+
+    @tag :d_314
+    test "D-314: crash (exit 1) — worktree is reclaimed, no leak" do
+      tmp_dir =
+        System.tmp_dir!()
+        |> Path.join("tau_rec314_crash_#{System.unique_integer([:positive])}")
+
+      File.mkdir_p!(tmp_dir)
+      on_exit(fn -> File.rm_rf!(tmp_dir) end)
+
+      %{repo_dir: repo_dir, base_ref: base_ref} = setup_git_repo(tmp_dir)
+      ledger = start_ledger(tmp_dir, :crash)
+      {_sup_name, sup, registry_name} = start_fleet(:crash)
+      {_jan_name, jan_pid} = start_janitor(ledger, :crash, self())
+
+      agent_bin = crash_agent_bin(tmp_dir, "_crash")
+
+      {:ok, worker_id} =
+        @worker_supervisor.spawn(sup, :implementer, "brief", base_ref,
+          repo_dir: repo_dir,
+          agent_bin: agent_bin,
+          registry: registry_name,
+          janitor: jan_pid
+        )
+
+      assert_receive {:worker_exit, ^worker_id, _reason},
+                     5_000,
+                     "D-314/crash: death-cert must arrive on crash (exit 1)"
+
+      {wt_list, _} =
+        System.cmd("git", ["worktree", "list", "--porcelain"],
+          cd: repo_dir,
+          stderr_to_stdout: true
+        )
+
+      worker_wt_entries =
+        wt_list
+        |> String.split("\n")
+        |> Enum.filter(&String.starts_with?(&1, "worktree "))
+        |> Enum.reject(fn line ->
+          trimmed = String.trim_leading(line, "worktree ")
+          line == "" or trimmed == repo_dir or String.starts_with?(trimmed, repo_dir <> "/")
+        end)
+
+      assert worker_wt_entries == [],
+             "D-314/crash: private worktrees must be reclaimed after Port crash; " <>
+               "leaked: #{inspect(worker_wt_entries)}"
+    end
+
+    @tag :d_314
+    test "D-314: :kill — worktree is reclaimed, no leak" do
+      tmp_dir =
+        System.tmp_dir!()
+        |> Path.join("tau_rec314_kill_#{System.unique_integer([:positive])}")
+
+      File.mkdir_p!(tmp_dir)
+      on_exit(fn -> File.rm_rf!(tmp_dir) end)
+
+      %{repo_dir: repo_dir, base_ref: base_ref} = setup_git_repo(tmp_dir)
+      ledger = start_ledger(tmp_dir, :kill)
+      {_sup_name, sup, registry_name} = start_fleet(:kill)
+      {_jan_name, jan_pid} = start_janitor(ledger, :kill, self())
+
+      agent_bin = slow_agent_bin(tmp_dir, "_kill")
+
+      {:ok, worker_id} =
+        @worker_supervisor.spawn(sup, :implementer, "brief", base_ref,
+          repo_dir: repo_dir,
+          agent_bin: agent_bin,
+          registry: registry_name,
+          janitor: jan_pid
+        )
+
+      [{worker_pid, _}] = Registry.lookup(registry_name, worker_id)
+      ws = get_ws(worker_pid)
+      assert File.dir?(ws), "D-314/kill: ws must exist before kill"
+
+      Process.exit(worker_pid, :kill)
+
+      assert_receive {:worker_exit, ^worker_id, _reason},
+                     5_000,
+                     "D-314/kill: death-cert must arrive after :kill"
+
+      assert poll_reclaimed(ws, 5_000) == :reclaimed,
+             "D-314/kill: worktree at #{ws} must be reclaimed (removed) after :kill"
+    end
+
+    @tag :d_314
+    test "D-314: :shutdown — worktree is reclaimed, no leak" do
+      tmp_dir =
+        System.tmp_dir!()
+        |> Path.join("tau_rec314_shutdown_#{System.unique_integer([:positive])}")
+
+      File.mkdir_p!(tmp_dir)
+      on_exit(fn -> File.rm_rf!(tmp_dir) end)
+
+      %{repo_dir: repo_dir, base_ref: base_ref} = setup_git_repo(tmp_dir)
+      ledger = start_ledger(tmp_dir, :shutdown)
+      {_sup_name, sup, registry_name} = start_fleet(:shutdown)
+      {_jan_name, jan_pid} = start_janitor(ledger, :shutdown, self())
+
+      agent_bin = slow_agent_bin(tmp_dir, "_shutdown")
+
+      {:ok, worker_id} =
+        @worker_supervisor.spawn(sup, :implementer, "brief", base_ref,
+          repo_dir: repo_dir,
+          agent_bin: agent_bin,
+          registry: registry_name,
+          janitor: jan_pid
+        )
+
+      [{worker_pid, _}] = Registry.lookup(registry_name, worker_id)
+      ws = get_ws(worker_pid)
+      assert File.dir?(ws), "D-314/shutdown: ws must exist before shutdown"
+
+      Process.exit(worker_pid, :shutdown)
+
+      assert_receive {:worker_exit, ^worker_id, _reason},
+                     5_000,
+                     "D-314/shutdown: death-cert must arrive after :shutdown"
+
+      assert poll_reclaimed(ws, 5_000) == :reclaimed,
+             "D-314/shutdown: worktree at #{ws} must be reclaimed after :shutdown"
+    end
+
+    @tag :d_314
+    test "D-314: namespace dirs inside ws are also reclaimed" do
+      # When the worker has namespace dirs (e.g. .factory-ns/XDG_DATA_HOME),
+      # they live inside ws; reclaiming ws reclaims them too.
+      # Assert that after reclaim, no .factory-ns subdir remains.
+      tmp_dir =
+        System.tmp_dir!()
+        |> Path.join("tau_rec314_ns_#{System.unique_integer([:positive])}")
+
+      File.mkdir_p!(tmp_dir)
+      on_exit(fn -> File.rm_rf!(tmp_dir) end)
+
+      %{repo_dir: repo_dir, base_ref: base_ref} = setup_git_repo(tmp_dir)
+      ledger = start_ledger(tmp_dir, :ns)
+      {_sup_name, sup, registry_name} = start_fleet(:ns)
+      {_jan_name, jan_pid} = start_janitor(ledger, :ns, self())
+
+      agent_bin = slow_agent_bin(tmp_dir, "_ns")
+
+      {:ok, worker_id} =
+        @worker_supervisor.spawn(sup, :implementer, "brief", base_ref,
+          repo_dir: repo_dir,
+          agent_bin: agent_bin,
+          registry: registry_name,
+          janitor: jan_pid
+        )
+
+      [{worker_pid, _}] = Registry.lookup(registry_name, worker_id)
+      ws = get_ws(worker_pid)
+      ns_dir = Path.join(ws, ".factory-ns")
+
+      Process.exit(worker_pid, :kill)
+
+      assert_receive {:worker_exit, ^worker_id, _reason},
+                     5_000,
+                     "D-314/ns: death-cert must arrive"
+
+      assert poll_reclaimed(ws, 5_000) == :reclaimed,
+             "D-314/ns: ws must be reclaimed; still exists at #{ws}"
+
+      # If the ns dir was inside ws, it is gone too (subdir of reclaimed ws).
+      refute File.exists?(ns_dir),
+             "D-314/ns: namespace dir #{ns_dir} must also be gone after ws reclaim"
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # D-314 — Orphan reconciliation on janitor restart
+  # ---------------------------------------------------------------------------
+
+  describe "D-314 — orphan reconciliation on restart" do
+    @tag :d_314
+    test "D-314/orphan: janitor reconciles and reclaims an orphan worktree on init" do
+      # Simulate an orphan: manually create a worktree dir that is NOT registered
+      # in the live WorkerRegistry. The janitor, on startup, must reconcile:
+      # any worktree path it knows about (from the Ledger or its init-time
+      # worktree-directory scan) that has no live Registry entry is an orphan
+      # and must be reclaimed.
+      #
+      # PIN: WorkspaceJanitor.start_link accepts an :orphan_dirs opt —
+      # a list of absolute dir paths to treat as orphans on init.
+      # On init, any dir in :orphan_dirs that still exists is reclaimed
+      # (File.rm_rf!/1 equivalent).
+      tmp_dir =
+        System.tmp_dir!()
+        |> Path.join("tau_rec314_orphan_#{System.unique_integer([:positive])}")
+
+      File.mkdir_p!(tmp_dir)
+      on_exit(fn -> File.rm_rf!(tmp_dir) end)
+
+      # Create an orphan dir (simulates a leaked locked worktree).
+      orphan_dir = Path.join(tmp_dir, "orphan_wt_#{System.unique_integer([:positive])}")
+      File.mkdir_p!(orphan_dir)
+      File.write!(Path.join(orphan_dir, "stale_file"), "orphan content\n")
+      assert File.dir?(orphan_dir), "D-314/orphan: setup — orphan dir must exist"
+
+      ledger = start_ledger(tmp_dir, :orphan)
+
+      n = System.unique_integer([:positive])
+      jan_name = :"orphan_jan_#{n}"
+
+      # Start the janitor with :orphan_dirs declared.
+      {:ok, _jan_pid} =
+        start_supervised(
+          {@janitor, ledger: ledger, name: jan_name, orphan_dirs: [orphan_dir]},
+          id: :"orphan_jan_sv_#{n}"
+        )
+
+      # Allow init to complete reconciliation.
+      Process.sleep(300)
+
+      assert poll_reclaimed(orphan_dir, 3_000) == :reclaimed,
+             "D-314/orphan: janitor must reclaim the orphan dir #{orphan_dir} on init; " <>
+               "still exists"
+    end
+  end
+end

--- a/test/tau/factory/workspace_janitor_test.exs
+++ b/test/tau/factory/workspace_janitor_test.exs
@@ -1,0 +1,396 @@
+defmodule Tau.Factory.WorkspaceJanitorTest do
+  @moduledoc """
+  Gating tests for PR #446 (P4d-3 — WorkspaceJanitor capture-before-destroy).
+
+  Written BEFORE production code exists (oracle-separation phase, D-304).
+  These tests fail with UndefinedFunctionError / FunctionClauseError until
+  the implementer creates:
+    - lib/tau/factory/workspace_janitor.ex  (Tau.Factory.WorkspaceJanitor)
+    - Tau.Factory.Ledger.Writer gains capture/3 + captures_for/2
+
+  ## Pinned interface (oracle-declared; implementer MUST conform)
+
+  ### WorkspaceJanitor
+  A `GenServer` independent monitor (NOT linked to workers).
+
+      start_link(opts) :: {:ok, pid}
+        required opts:
+          :ledger   — pid/server ref for Tau.Factory.Ledger.Writer
+          :name     — atom registered name
+        optional opts:
+          :report_to — pid (may be omitted; janitor still reclaims)
+
+      register(janitor, worker_id, worker_pid, ws, ns_dirs, report_to) :: :ok
+        worker_id  — String.t()
+        worker_pid — pid()
+        ws         — abs path to the worker's private worktree
+        ns_dirs    — list of absolute dirs to reclaim (namespace dirs inside ws)
+        report_to  — pid() | nil; receives {:worker_exit, worker_id, reason}
+
+  On the monitored worker's :DOWN (for EVERY exit reason incl. :kill):
+    1. capture: run capture_commands(ws) — git diff HEAD (patch),
+       git ls-files --others --exclude-standard (untracked names),
+       git status --short (status)
+    2. if untracked names non-empty, tar them into a binary (untracked_tgz)
+    3. Ledger.Writer.capture(ledger, worker_id,
+         %{patch: binary, untracked_tgz: binary | nil, status: binary,
+           disposition: :captured})
+    4. reclaim: File.rm_rf!(ws) (or git worktree remove --force) + remove ns_dirs
+    5. if report_to non-nil: send {:worker_exit, worker_id, reason}
+
+  On restart: reconcile — any worktree dir in the capture registry that is NOT
+  in the live registry MUST be reclaimed (orphan reclaim — D-314).
+
+  ### Ledger.Writer additions
+  capture(server, worker_id, attrs) :: {:ok, ref}
+    attrs: %{patch: binary, untracked_tgz: binary | nil, status: binary,
+             disposition: atom}
+
+  captures_for(server, worker_id) :: [map()]
+    returns list of capture row maps for the worker_id (most-recent-first)
+
+  ## AC linkage
+    - D-313: the `:kill` recovery test (primary test in this file)
+    - D-334: see artifact_conservation_test.exs
+    - D-314: see worker_reclaim_test.exs
+  """
+
+  use ExUnit.Case, async: false
+
+  @moduletag :capture_log
+
+  # Runtime references — absent until implementer ships.
+  # Using module-attribute @mod pattern to avoid compile-time resolution of
+  # absent modules (credo strict: no apply/2,3).
+  @janitor Tau.Factory.WorkspaceJanitor
+  @writer Tau.Factory.Ledger.Writer
+  @worker_registry Tau.Factory.WorkerRegistry
+  @worker_supervisor Tau.Factory.WorkerSupervisor
+
+  # ---------------------------------------------------------------------------
+  # Hermetic git repo setup (reused from worker_test.exs idiom)
+  # ---------------------------------------------------------------------------
+
+  defp setup_git_repo(tmp_dir) do
+    repo_dir = Path.join(tmp_dir, "repo_#{System.unique_integer([:positive])}")
+    File.mkdir_p!(repo_dir)
+
+    git = fn args ->
+      System.cmd("git", args, cd: repo_dir, stderr_to_stdout: true)
+    end
+
+    {_, 0} = git.(["init", "-b", "main"])
+    {_, 0} = git.(["config", "user.email", "test@tau.test"])
+    {_, 0} = git.(["config", "user.name", "Tau Test"])
+
+    tracked_path = Path.join(repo_dir, "README")
+    File.write!(tracked_path, "initial\n")
+    {_, 0} = git.(["add", "README"])
+
+    {staged, _} = git.(["diff", "--cached", "--name-only"])
+
+    unless String.contains?(staged, "README") do
+      raise "setup_git_repo: git add did not stage README; staged=#{inspect(staged)}"
+    end
+
+    {_, 0} = git.(["commit", "-m", "initial commit"])
+    {sha, 0} = git.(["rev-parse", "HEAD"])
+    base_ref = String.trim(sha)
+
+    %{repo_dir: repo_dir, base_ref: base_ref}
+  end
+
+  # Returns a blocking agent bin — stays alive until killed.
+  defp slow_agent_bin(tmp_dir, suffix \\ "") do
+    bin_path = Path.join(tmp_dir, "slow_janitor_agent#{suffix}")
+
+    File.write!(bin_path, """
+    #!/bin/sh
+    # blocking agent — stays alive until the process is killed
+    while true; do sleep 60; done
+    """)
+
+    File.chmod!(bin_path, 0o755)
+    bin_path
+  end
+
+  # Start an isolated Ledger.Writer for a single test.
+  defp start_ledger(tmp_dir, tag) do
+    n = System.unique_integer([:positive])
+    db_path = Path.join(tmp_dir, "ledger_#{tag}_#{n}.db")
+    name = :"ledger_#{tag}_#{n}"
+
+    {:ok, pid} =
+      start_supervised(
+        {@writer, db_path: db_path, name: name},
+        id: :"ledger_sv_#{n}"
+      )
+
+    {name, pid}
+  end
+
+  # Start an isolated WorkerRegistry + WorkerSupervisor.
+  defp start_fleet(tag) do
+    n = System.unique_integer([:positive])
+    registry_name = :"jtest_registry_#{tag}_#{n}"
+    sup_name = :"jtest_sup_#{tag}_#{n}"
+
+    {:ok, _} =
+      start_supervised(
+        {@worker_registry, name: registry_name},
+        id: :"jreg_#{n}"
+      )
+
+    {:ok, sup} =
+      start_supervised(
+        {@worker_supervisor, name: sup_name, registry: registry_name},
+        id: :"jsup_#{n}"
+      )
+
+    {sup_name, sup, registry_name}
+  end
+
+  # Start an isolated WorkspaceJanitor.
+  defp start_janitor(ledger, tag, report_to \\ nil) do
+    n = System.unique_integer([:positive])
+    name = :"janitor_#{tag}_#{n}"
+
+    opts = [ledger: ledger, name: name]
+    opts = if report_to, do: Keyword.put(opts, :report_to, report_to), else: opts
+
+    {:ok, pid} =
+      start_supervised(
+        {@janitor, opts},
+        id: :"jan_sv_#{n}"
+      )
+
+    {name, pid}
+  end
+
+  # ---------------------------------------------------------------------------
+  # D-313 — Capture-before-destroy, all three dirty kinds (the :kill recovery test)
+  # ---------------------------------------------------------------------------
+  #
+  # This is the PRIMARY gate for D-313.  AC-5 from SPEC-FACTORY-FLEET §7:
+  # "a worker holding an untracked file is :kill-ed and the untracked file is
+  # recovered from the capture artifact"
+  # ---------------------------------------------------------------------------
+
+  describe "D-313 — capture-before-destroy (:kill recovery)" do
+    @tag :d_313
+    test "D-313: :kill a dirty worker — all three kinds captured; untracked file is byte-for-byte recoverable" do
+      tmp_dir =
+        System.tmp_dir!()
+        |> Path.join("tau_jan313_#{System.unique_integer([:positive])}")
+
+      File.mkdir_p!(tmp_dir)
+      on_exit(fn -> File.rm_rf!(tmp_dir) end)
+
+      %{repo_dir: repo_dir, base_ref: base_ref} = setup_git_repo(tmp_dir)
+      agent_bin = slow_agent_bin(tmp_dir, "_d313")
+
+      {ledger_name, _ledger_pid} = start_ledger(tmp_dir, :d313)
+      {_sup_name, sup, registry_name} = start_fleet(:d313)
+      report_to = self()
+      {_jan_name, _jan_pid} = start_janitor(ledger_name, :d313, report_to)
+
+      # Spawn worker WITH the janitor registered.
+      janitor_server = @janitor |> Process.whereis() || ledger_name
+
+      {:ok, worker_id} =
+        @worker_supervisor.spawn(sup, :implementer, "brief", base_ref,
+          repo_dir: repo_dir,
+          agent_bin: agent_bin,
+          registry: registry_name,
+          janitor: janitor_server
+        )
+
+      # Resolve worker pid via registry (identity by key, never stored pid — C218).
+      [{worker_pid, _}] = Registry.lookup(registry_name, worker_id)
+      assert Process.alive?(worker_pid), "D-313: worker must be alive before kill"
+
+      # Obtain the worker's private worktree path — the janitor must expose it
+      # OR the Worker exposes it; we use GenServer.call to retrieve state.
+      # PIN: Worker exposes `ws` via GenServer.call(pid, :get_ws) :: {:ok, String.t()}
+      {:ok, ws} = GenServer.call(worker_pid, :get_ws)
+
+      assert File.dir?(ws), "D-313: worker's private worktree must exist before kill; ws=#{ws}"
+
+      # --- Make the worktree dirty in ALL THREE kinds ---
+
+      # Kind 1: STAGED change — modify a tracked file and git add it.
+      readme = Path.join(ws, "README")
+      File.write!(readme, "staged modification\n")
+      {_, 0} = System.cmd("git", ["add", "README"], cd: ws, stderr_to_stdout: true)
+
+      # Kind 2: UNSTAGED change — modify a tracked file WITHOUT git add.
+      File.write!(readme, "staged modification\nunstaged modification\n")
+
+      # Kind 3: UNTRACKED new file — never git-add'd.
+      untracked_name = "secret_output.txt"
+      untracked_content = "untracked-content-#{System.unique_integer([:positive])}\n"
+      File.write!(Path.join(ws, untracked_name), untracked_content)
+
+      # Verify setup — git status must show all three kinds.
+      {status_out, _} = System.cmd("git", ["status", "--short"], cd: ws, stderr_to_stdout: true)
+
+      assert String.contains?(status_out, untracked_name),
+             "D-313: test setup: untracked file must appear in git status --short; " <>
+               "status=#{inspect(status_out)}"
+
+      # --- Kill the worker brutally (terminate/2 NEVER runs) ---
+      Process.exit(worker_pid, :kill)
+
+      # (a) Death-certificate must arrive via janitor monitor.
+      assert_receive {:worker_exit, ^worker_id, kill_reason},
+                     5_000,
+                     "D-313: {:worker_exit, worker_id, :kill} must arrive after Process.exit(pid, :kill)"
+
+      assert kill_reason == :kill or match?({:kill, _}, kill_reason),
+             "D-313: death-cert reason must be :kill; got #{inspect(kill_reason)}"
+
+      # (b) Ledger must have a capture row for this worker.
+      # Poll — capture write is async after :DOWN fires.
+      captures = poll_captures(ledger_name, worker_id, 5_000)
+
+      assert captures != [],
+             "D-313: Ledger must have at least one capture row for worker_id=#{worker_id} " <>
+               "after :kill; got []"
+
+      [capture | _] = captures
+
+      # (c) patch (staged + unstaged diff) must be non-empty.
+      assert is_binary(capture.patch),
+             "D-313: capture.patch must be a binary; got #{inspect(capture.patch)}"
+
+      assert byte_size(capture.patch) > 0,
+             "D-313: capture.patch must be non-empty (staged+unstaged diff); " <>
+               "patch=#{inspect(capture.patch)}"
+
+      # (d) status must be non-empty.
+      assert is_binary(capture.status),
+             "D-313: capture.status must be a binary"
+
+      assert byte_size(capture.status) > 0,
+             "D-313: capture.status must be non-empty; status=#{inspect(capture.status)}"
+
+      # (e) untracked_tgz must be non-nil and non-empty.
+      assert capture.untracked_tgz != nil,
+             "D-313: capture.untracked_tgz must be non-nil (untracked file present); " <>
+               "a naïve git diff would have missed it (F-4)"
+
+      assert is_binary(capture.untracked_tgz),
+             "D-313: capture.untracked_tgz must be a binary"
+
+      assert byte_size(capture.untracked_tgz) > 0,
+             "D-313: capture.untracked_tgz must be non-empty"
+
+      # (f) THE LOAD-BEARING F-4 ASSERTION:
+      # Extract the tar and verify the untracked file is byte-for-byte present.
+      extract_dir =
+        Path.join(tmp_dir, "extracted_#{System.unique_integer([:positive])}")
+
+      File.mkdir_p!(extract_dir)
+
+      tgz_path = Path.join(tmp_dir, "wip_untracked.tgz")
+      File.write!(tgz_path, capture.untracked_tgz)
+
+      {_, 0} =
+        System.cmd("tar", ["-C", extract_dir, "-xzf", tgz_path], stderr_to_stdout: true)
+
+      recovered_path = Path.join(extract_dir, untracked_name)
+
+      assert File.exists?(recovered_path),
+             "D-313: untracked file '#{untracked_name}' must be recoverable from " <>
+               "the captured tar; file NOT found at #{recovered_path}"
+
+      assert File.read!(recovered_path) == untracked_content,
+             "D-313: recovered file content must match exactly; " <>
+               "expected=#{inspect(untracked_content)}, " <>
+               "got=#{inspect(File.read!(recovered_path))}"
+
+      # (g) AFTER capture, the worktree must be reclaimed.
+      refute File.exists?(ws),
+             "D-313: worktree must be reclaimed (removed) after capture; ws=#{ws} still exists"
+
+      # Companion assertion (SPEC-FACTORY-FLEET §6 D-313):
+      # Verify that a naïve git diff HEAD would NOT have caught the untracked file.
+      # (The untracked file was never git-added, so diff HEAD produces no line for it.)
+      # We verify this by checking that `untracked_name` is NOT in the patch.
+      refute String.contains?(capture.patch, untracked_name),
+             "D-313 companion: the untracked file '#{untracked_name}' must NOT appear " <>
+               "in the git diff HEAD patch — proving the tar path was required (F-4)"
+    end
+
+    @tag :d_313
+    test "D-313: janitor uses monitor not terminate/2 — capture fires on :kill where terminate/2 is never called" do
+      # Structural verification: the WorkspaceJanitor must be a monitor, not linked.
+      # If the janitor were linked, a :kill on the worker would kill the janitor too.
+      # We verify the janitor stays alive after the worker is killed.
+      tmp_dir =
+        System.tmp_dir!()
+        |> Path.join("tau_jan313b_#{System.unique_integer([:positive])}")
+
+      File.mkdir_p!(tmp_dir)
+      on_exit(fn -> File.rm_rf!(tmp_dir) end)
+
+      %{repo_dir: repo_dir, base_ref: base_ref} = setup_git_repo(tmp_dir)
+      agent_bin = slow_agent_bin(tmp_dir, "_d313b")
+
+      {ledger_name, _} = start_ledger(tmp_dir, :d313b)
+      {_sup_name, sup, registry_name} = start_fleet(:d313b)
+      {_jan_name, jan_pid} = start_janitor(ledger_name, :d313b, self())
+
+      {:ok, worker_id} =
+        @worker_supervisor.spawn(sup, :implementer, "brief", base_ref,
+          repo_dir: repo_dir,
+          agent_bin: agent_bin,
+          registry: registry_name,
+          janitor: jan_pid
+        )
+
+      [{worker_pid, _}] = Registry.lookup(registry_name, worker_id)
+      assert Process.alive?(worker_pid), "D-313b: worker must be alive before kill"
+      assert Process.alive?(jan_pid), "D-313b: janitor must be alive before kill"
+
+      Process.exit(worker_pid, :kill)
+
+      # Death-cert must arrive.
+      assert_receive {:worker_exit, ^worker_id, _reason},
+                     5_000,
+                     "D-313b: death-cert must arrive"
+
+      # Janitor must STILL be alive — it is a monitor, not linked.
+      assert Process.alive?(jan_pid),
+             "D-313b: WorkspaceJanitor must survive worker :kill — it is a monitor, " <>
+               "NOT linked (C207/SPEC-FACTORY-FLEET §4 B5)"
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Helpers
+  # ---------------------------------------------------------------------------
+
+  # Poll Ledger for captures; returns list or [] after timeout.
+  defp poll_captures(ledger, worker_id, timeout_ms, interval_ms \\ 100) do
+    deadline = System.monotonic_time(:millisecond) + timeout_ms
+
+    do_poll_captures(ledger, worker_id, deadline, interval_ms)
+  end
+
+  defp do_poll_captures(ledger, worker_id, deadline, interval_ms) do
+    captures = @writer.captures_for(ledger, worker_id)
+
+    cond do
+      captures != [] ->
+        captures
+
+      System.monotonic_time(:millisecond) >= deadline ->
+        []
+
+      true ->
+        Process.sleep(interval_ms)
+        do_poll_captures(ledger, worker_id, deadline, interval_ms)
+    end
+  end
+end


### PR DESCRIPTION
## P4d-3 — WorkspaceJanitor: capture-before-destroy (D-313, D-314, D-334)

Advances #437. The independent monitoring `GenServer` (C4) that captures a dying
worker's dirty state — **all three kinds** — *before* reclaiming its worktree +
namespace, on **every** exit including `:kill` (which `terminate/2` cannot
catch). Records the disposition to the Ledger (B6/D-315). Replaces P4d-2's
minimal self-monitor (kept as the no-janitor fallback so P4d-2's `worker_test`
stays green). The stall watchdog (C6) is **P4d-4** — NOT here.

### Scope (SPEC-FACTORY-FLEET §4 B5/B6, §5 janitor, §6 D-313/D-314/D-334; [C202/C203/C208/C209])
1. `lib/tau/factory/ledger/migrations.ex` (EXTEND) — append-only `captures`
   table (`id`, `worker_id`, `patch` TEXT, `untracked_tgz` BLOB|path, `status`
   TEXT, `disposition` TEXT, `inserted_at`). No UPDATE/DELETE.
2. `lib/tau/factory/ledger/writer.ex` (EXTEND) — `capture(server, worker_id,
   %{patch, untracked_tgz, status, disposition}) :: {:ok, ref}` — append one
   capture row, **WAL-before-ack** (D-315). Single writer-of-record (B6).
3. `lib/tau/factory/workspace_janitor.ex` (C4) — `Tau.Factory.WorkspaceJanitor`,
   a `GenServer` **independent monitor** (NOT linked to workers). State:
   `%{worker_id => {ws, ns, monitor_ref, report_to}}`.
   - `register(janitor, worker_id, worker_pid, ws, ns, report_to)` — `Process
     .monitor(worker_pid)`, store the record. Called by the Worker once it has
     allocated `ws`/`ns` (B5; "monitor every worker at spawn").
   - `handle_info({:DOWN, ref, :process, pid, reason}, st)` — fires for EVERY
     reason (crash/`:kill`/`:shutdown`/normal). **Capture-before-reclaim
     sequence ([C203], D-313):** (1) `patch = git -C ws diff HEAD` (staged AND
     unstaged); (2) `untracked = git -C ws ls-files --others --exclude-standard`;
     if non-empty, `tar -C ws -czf <wip.tgz> -T -` over it (the kind NO `git
     diff` catches — F-4); (3) `status = git -C ws status --short`; (4)
     `Ledger.capture(worker_id, %{patch, untracked_tgz, status, disposition})`
     (WAL-before-ack); (5) **then** `reclaim(ws, ns)` — `git worktree remove
     -f ws` + remove every namespaced dir. (6) emit `{:worker_exit, worker_id,
     reason}` to `report_to` (the death-certificate, the single :DOWN authority
     now). Drop the worker from state.
   - **D-314 reclaim on every exit + reconcile-on-restart:** on `init/1`, scan
     the worktree-parent dir against the (empty, post-restart) registry and
     reclaim ORPHAN worktrees (the only recovery path; F-7's manual checklist is
     obviated). [C208] — if the janitor crashed mid-handler, restart re-reconciles.
   - Independent monitor (NOT `link`, NOT `terminate/2`) → survives any worker
     crash; a `:kill`ed worker's `terminate/2` never runs, but the monitor's
     `:DOWN` always fires (INV-17).
4. `lib/tau/factory/worker.ex` (EDIT — minimal, additive) — when started with a
   `:janitor` opt, after allocating `ws`/`ns` (before the Port) call
   `WorkspaceJanitor.register(...)` and DO NOT spawn the P4d-2 self-monitor (the
   janitor owns `:DOWN` capture+reclaim+cert). With NO `:janitor` opt, the
   P4d-2 self-monitor path is UNCHANGED (so `worker_test.exs` stays green).
5. `lib/tau/factory/supervisor.ex` (EDIT) — start `WorkspaceJanitor` high in the
   W subtree (before workers, so it can monitor them), name/`:ledger`-scoped.

### Dependencies
Depends on P4d-1 (`capture_commands` informs the sequence), P4d-2 (the Worker),
P2/P4b-1 (Ledger.Writer). Advances #437.

### SPECs
In scope: **SPEC-FACTORY-FLEET** (Appendix B: `workspace_janitor.ex`,
`worker.ex`, `ledger/writer.ex`+`migrations.ex` for the capture row,
`factory/supervisor.ex`). Conforms to §4 B5/B6, §6 D-313/D-314/D-334,
[C202/C203/C208/C209]. No SPEC amendment expected.

### Acceptance criteria
- **AC (D-313/D-334 — the `:kill` recovery, load-bearing):**
  `workspace_janitor_test.exs` — a worker holding a STAGED change, an UNSTAGED
  change, AND an **untracked file** is `Process.exit(:kill)`ed; the janitor
  captures all three (the Ledger `captures` row holds the patch + the untracked
  tgz + status) BEFORE reclaim; **the untracked file is RECOVERABLE** from the
  tgz; the worktree is then reclaimed. `terminate/2` never ran (`:kill`).
- **AC (D-314 — reclaim on every exit):** `worker_reclaim_test.exs` — terminate a
  worker by each reason (normal, crash, `:kill`) ⇒ the worktree + namespace dirs
  are gone (no leak); and a janitor restart reconciles/reclaims an orphan worktree.
- **AC (D-334 — artifact conservation):** `artifact_conservation_test.exs` —
  `dirty(w) = committed ⊎ captured ⊎ discarded_by_decision`; every dirty hunk
  resolves to exactly one recorded disposition; none lost by omission.

### Gating-test paths (frozen at 36465e6 — implementer MUST NOT edit)
- `test/tau/factory/workspace_janitor_test.exs` (D-313/D-334)
- `test/tau/factory/worker_reclaim_test.exs` (D-314)
- `test/tau/factory/artifact_conservation_test.exs` (D-334)

Pinned (oracle): `WorkspaceJanitor.start_link(ledger:, name:, [report_to:], [orphan_dirs:])`;
`register(janitor, worker_id, worker_pid, ws, ns_dirs, report_to) :: :ok`; on `:DOWN` (any reason)
capture→`Ledger.Writer.capture(server, worker_id, %{patch, untracked_tgz, status, disposition}) :: {:ok,ref}`
→reclaim `ws`→`{:worker_exit, worker_id, reason}` to report_to; init reclaims `:orphan_dirs`.
`Ledger.Writer.captures_for(server, worker_id) :: [map]` (most-recent-first).
`Worker`: `GenServer.call(pid, :get_ws) :: {:ok, ws}` + `:janitor` opt (register vs self-monitor);
`WorkerSupervisor.spawn/5` passes `:janitor` through.

### Gate verdicts
_(filled at gate time — critic, reviewer)_
