### PR TITLE
P4d-4: Fleet.Watchdog heartbeat→worker_stalled (feeds CORE D-317(b)) — advances #437

### DIFF
--- a/lib/tau/factory/fleet/watchdog.ex
+++ b/lib/tau/factory/fleet/watchdog.ex
@@ -1,0 +1,216 @@
+defmodule Tau.Factory.Fleet.Watchdog do
+  @moduledoc """
+  Heartbeat-absence watchdog for the Factory Worker fleet (W).
+
+  The Watchdog monitors registered workers by observing
+  `[:tau, :factory, :worker, :heartbeat]` telemetry events keyed by
+  `%{worker_id: worker_id}` in the event metadata. When a registered worker
+  has not emitted a heartbeat for longer than its configured
+  `heartbeat_timeout`, the Watchdog sends `{:worker_stalled, worker_id}` to
+  the registered `report_to` pid **exactly once per stall window** (C213).
+
+  A stall window begins when the worker's heartbeat goes silent and ends when
+  a fresh heartbeat arrives. On the leading edge of each new window the
+  Watchdog fires the notification exactly once; subsequent scan cycles in the
+  same window are suppressed by the `stalled?` flag.
+
+  A `:DOWN` event (crash/exit) deregisters the worker without sending a
+  `{:worker_stalled, _}` message — crash handling is the WorkspaceJanitor's
+  responsibility (D-309, C217).
+
+  ## Telemetry-handler discipline
+
+  The telemetry handler is attached at `init/1` and detached in `terminate/2`.
+  It runs in the **emitting process** (the Worker), so the handler does ONLY
+  a `GenServer.cast` — no blocking operations (OTP non-negotiable: telemetry
+  handlers must be non-blocking).
+
+  ## Monotonic clock
+
+  All timeout arithmetic uses `System.monotonic_time(:millisecond)` (not the
+  wall clock) to avoid skew from NTP adjustments or DST.
+
+  See `docs/spec/SPEC-FACTORY-FLEET.md`, D-309, D-317, C206, C213, C217.
+  """
+
+  use GenServer
+
+  require Logger
+
+  # ---------------------------------------------------------------------------
+  # Public API
+  # ---------------------------------------------------------------------------
+
+  @doc """
+  Start the Watchdog as a supervised GenServer.
+
+  Required opts:
+    - `:name`            — atom; registered name for this GenServer.
+    - `:check_interval`  — ms; how often the Watchdog scans for stalled workers.
+  """
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(opts) do
+    name = Keyword.fetch!(opts, :name)
+    GenServer.start_link(__MODULE__, opts, name: name)
+  end
+
+  @doc """
+  Register a worker with the Watchdog.
+
+  The Watchdog calls `Process.monitor(worker_pid)`. If the worker has not
+  emitted a `[:tau, :factory, :worker, :heartbeat]` telemetry event with
+  `%{worker_id: worker_id}` in metadata for longer than `heartbeat_timeout`
+  ms, the Watchdog sends `{:worker_stalled, worker_id}` to `report_to`
+  **exactly once per stall window** (C213).
+
+  On receiving a `:DOWN` for `worker_pid` the Watchdog deregisters the worker
+  without sending a stall message (C217).
+
+  Required keyword opts:
+    - `:heartbeat_timeout` — ms; maximum acceptable silence window.
+  """
+  @spec register(
+          GenServer.server(),
+          String.t(),
+          pid(),
+          pid(),
+          keyword()
+        ) :: :ok
+  def register(watchdog, worker_id, worker_pid, report_to, opts) do
+    timeout = Keyword.fetch!(opts, :heartbeat_timeout)
+    GenServer.call(watchdog, {:register, worker_id, worker_pid, report_to, timeout})
+  end
+
+  # ---------------------------------------------------------------------------
+  # GenServer callbacks
+  # ---------------------------------------------------------------------------
+
+  @impl GenServer
+  def init(opts) do
+    check_interval = Keyword.fetch!(opts, :check_interval)
+
+    # Unique handler id prevents attach conflicts when multiple Watchdog
+    # instances coexist (e.g. in async: false tests each with a unique :name).
+    handler_id = {__MODULE__, self()}
+
+    :telemetry.attach(
+      handler_id,
+      [:tau, :factory, :worker, :heartbeat],
+      &__MODULE__.handle_heartbeat_event/4,
+      self()
+    )
+
+    Process.send_after(self(), :scan, check_interval)
+
+    {:ok,
+     %{
+       check_interval: check_interval,
+       handler_id: handler_id,
+       # worker_id => %{report_to, timeout, last_seen, stalled?, ref}
+       workers: %{},
+       # ref => worker_id (reverse index for :DOWN lookup)
+       refs: %{}
+     }}
+  end
+
+  @impl GenServer
+  def handle_call({:register, worker_id, worker_pid, report_to, timeout}, _from, state) do
+    ref = Process.monitor(worker_pid)
+    now = System.monotonic_time(:millisecond)
+
+    entry = %{
+      report_to: report_to,
+      timeout: timeout,
+      last_seen: now,
+      stalled?: false,
+      ref: ref
+    }
+
+    new_workers = Map.put(state.workers, worker_id, entry)
+    new_refs = Map.put(state.refs, ref, worker_id)
+
+    {:reply, :ok, %{state | workers: new_workers, refs: new_refs}}
+  end
+
+  @impl GenServer
+  def handle_cast({:heartbeat, worker_id}, state) do
+    case Map.get(state.workers, worker_id) do
+      nil ->
+        # Heartbeat from an unknown worker — ignore.
+        {:noreply, state}
+
+      entry ->
+        now = System.monotonic_time(:millisecond)
+        updated_entry = %{entry | last_seen: now, stalled?: false}
+        new_workers = Map.put(state.workers, worker_id, updated_entry)
+        {:noreply, %{state | workers: new_workers}}
+    end
+  end
+
+  @impl GenServer
+  def handle_info(:scan, state) do
+    now = System.monotonic_time(:millisecond)
+
+    new_workers =
+      Map.new(state.workers, fn {worker_id, entry} ->
+        elapsed = now - entry.last_seen
+
+        updated_entry =
+          if elapsed > entry.timeout and not entry.stalled? do
+            # Leading edge of a stall window: notify exactly once (C213).
+            send(entry.report_to, {:worker_stalled, worker_id})
+            %{entry | stalled?: true}
+          else
+            entry
+          end
+
+        {worker_id, updated_entry}
+      end)
+
+    Process.send_after(self(), :scan, state.check_interval)
+
+    {:noreply, %{state | workers: new_workers}}
+  end
+
+  def handle_info({:DOWN, ref, :process, _pid, _reason}, state) do
+    case Map.get(state.refs, ref) do
+      nil ->
+        # Unknown ref — ignore.
+        {:noreply, state}
+
+      worker_id ->
+        Process.demonitor(ref, [:flush])
+        new_workers = Map.delete(state.workers, worker_id)
+        new_refs = Map.delete(state.refs, ref)
+        {:noreply, %{state | workers: new_workers, refs: new_refs}}
+    end
+  end
+
+  def handle_info(_msg, state) do
+    {:noreply, state}
+  end
+
+  @impl GenServer
+  def terminate(_reason, state) do
+    :telemetry.detach(state.handler_id)
+    :ok
+  end
+
+  # ---------------------------------------------------------------------------
+  # Telemetry handler (runs in the EMITTING process — only cast, no blocking)
+  # ---------------------------------------------------------------------------
+
+  @doc false
+  @spec handle_heartbeat_event(
+          [atom()],
+          map(),
+          %{worker_id: String.t()},
+          pid()
+        ) :: :ok
+  def handle_heartbeat_event(_event, _measurements, %{worker_id: worker_id}, watchdog_pid) do
+    GenServer.cast(watchdog_pid, {:heartbeat, worker_id})
+  end
+
+  # Guard: ignore malformed metadata rather than crashing the emitting process.
+  def handle_heartbeat_event(_event, _measurements, _metadata, _watchdog_pid), do: :ok
+end

--- a/test/tau/factory/worker_stalled_test.exs
+++ b/test/tau/factory/worker_stalled_test.exs
@@ -1,0 +1,204 @@
+defmodule Tau.Factory.WorkerStalledTest do
+  @moduledoc """
+  Gating tests for PR #447 (P4d-4 — Fleet.Watchdog heartbeat→worker_stalled).
+
+  Written BEFORE production code exists (oracle-separation phase, factory-loop §4b).
+  Tests fail at runtime (UndefinedFunctionError on Tau.Factory.Fleet.Watchdog) until
+  the implementer creates `lib/tau/factory/fleet/watchdog.ex`.
+
+  ## Pinned interface (oracle-declared; implementer MUST conform)
+
+  ### Tau.Factory.Fleet.Watchdog (supervised GenServer)
+
+      start_link(opts) :: GenServer.on_start()
+        Required options:
+          :name             — atom; registered name for the GenServer.
+          :check_interval   — ms; how often the watchdog scans for stalled workers.
+
+      register(watchdog, worker_id, worker_pid, report_to, heartbeat_timeout: ms) :: :ok
+        Registers the worker. The watchdog calls Process.monitor(worker_pid).
+        When the worker is alive but has not emitted a
+        [:tau, :factory, :worker, :heartbeat] telemetry event (keyed by
+        %{worker_id: worker_id} in metadata) for longer than heartbeat_timeout ms,
+        the watchdog sends {:worker_stalled, worker_id} to report_to EXACTLY ONCE
+        per stall window (C213). On receiving :DOWN for the worker_pid the watchdog
+        deregisters — no {:worker_stalled, _} message is sent for a crash.
+
+  ## Heartbeat driving (deterministic harness)
+
+  These tests do NOT use a real Worker process. Heartbeats are driven by emitting
+  the real telemetry event directly:
+
+      :telemetry.execute([:tau, :factory, :worker, :heartbeat], %{}, %{worker_id: id})
+
+  A wedged worker is a spawned process that blocks on receive — alive but emitting
+  no heartbeat.
+
+  ## AC / D-NNN linkage (Gate 5.1)
+
+  - AC-10 (SPEC-FACTORY-FLEET §7): wedged worker → exactly one worker_stalled
+  - D-317 (SPEC-FACTORY-CORE): heartbeat absence synthesizes the worker_stalled trigger
+  - C213 (SPEC-FACTORY-FLEET §3 Q5): exactly one stall message per stall window
+  - C206 (SPEC-FACTORY-FLEET §3 Q3): watchdog, not supervisor, handles liveness
+  """
+
+  use ExUnit.Case, async: false
+
+  # Avoid compile-time alias of the absent module.
+  # Module.concat/1 is evaluated at compile time to produce an atom, but the
+  # function calls @watchdog.fun(args) are dispatched at runtime only, so no
+  # UndefinedFunctionError at compile time.
+  @watchdog Module.concat(["Tau", "Factory", "Fleet", "Watchdog"])
+
+  # Timing constants — generous relative to the short intervals to avoid flakiness.
+  # check_interval: 30ms, heartbeat_timeout: 60ms (2 scan cycles).
+  # assert_receive window: 300ms (5× timeout, accounts for scheduler jitter).
+  # refute_receive window: 500ms (8× timeout, spans several scan cycles).
+  @check_interval 30
+  @heartbeat_timeout 60
+  # how often the "alive" worker drives heartbeats in the no-stall test
+  @heartbeat_drive_interval 20
+
+  setup do
+    name = :"watchdog_#{:erlang.unique_integer([:positive])}"
+
+    {:ok, pid} =
+      @watchdog.start_link(
+        name: name,
+        check_interval: @check_interval
+      )
+
+    on_exit(fn ->
+      if Process.alive?(pid) do
+        GenServer.stop(pid, :normal, 1_000)
+      end
+    end)
+
+    {:ok, watchdog: name, watchdog_pid: pid}
+  end
+
+  describe "AC-10 / D-317 — wedged worker (alive, no heartbeat) → worker_stalled" do
+    @tag :ac_10
+    @tag :d_317
+    test "registers a wedged worker and receives exactly one {:worker_stalled, worker_id}",
+         %{watchdog: watchdog} do
+      worker_id = "wedged-w1-#{:erlang.unique_integer([:positive])}"
+      # A dummy process that stays alive but never emits a heartbeat.
+      wedged = spawn(fn -> receive do: (:stop -> :ok) end)
+      assert Process.alive?(wedged)
+
+      :ok =
+        @watchdog.register(watchdog, worker_id, wedged, self(),
+          heartbeat_timeout: @heartbeat_timeout
+        )
+
+      # Wait long enough for the watchdog to detect the stall (timeout + 2 scans).
+      assert_receive {:worker_stalled, ^worker_id}, 300
+
+      # Clean up
+      send(wedged, :stop)
+    end
+  end
+
+  describe "C206 — no false stall when heartbeats arrive on time" do
+    @tag :c_206
+    @tag :ac_10
+    test "no {:worker_stalled, _} when heartbeats are driven faster than timeout",
+         %{watchdog: watchdog} do
+      worker_id = "alive-w2-#{:erlang.unique_integer([:positive])}"
+      # A dummy process that stays alive.
+      dummy = spawn(fn -> receive do: (:stop -> :ok) end)
+      assert Process.alive?(dummy)
+
+      :ok =
+        @watchdog.register(watchdog, worker_id, dummy, self(),
+          heartbeat_timeout: @heartbeat_timeout
+        )
+
+      # Drive heartbeats from the test process, faster than the timeout.
+      # 500ms window spans 500/@heartbeat_drive_interval ≈ 25 heartbeats — well
+      # above what the watchdog needs to stay satisfied.
+      driver =
+        spawn(fn ->
+          heartbeat_loop(worker_id, @heartbeat_drive_interval, 500)
+        end)
+
+      refute_receive {:worker_stalled, _}, 500
+
+      send(driver, :stop)
+      send(dummy, :stop)
+    end
+  end
+
+  describe "C213 — exactly one worker_stalled per stall window, no retry" do
+    @tag :c_213
+    @tag :ac_10
+    test "wedged worker yields EXACTLY ONE worker_stalled across multiple scan intervals",
+         %{watchdog: watchdog} do
+      worker_id = "wedged-once-w3-#{:erlang.unique_integer([:positive])}"
+      wedged = spawn(fn -> receive do: (:stop -> :ok) end)
+      assert Process.alive?(wedged)
+
+      :ok =
+        @watchdog.register(watchdog, worker_id, wedged, self(),
+          heartbeat_timeout: @heartbeat_timeout
+        )
+
+      # Receive the first (and only expected) stall message.
+      assert_receive {:worker_stalled, ^worker_id}, 300
+
+      # Wait long enough for at least 2-3 additional scan cycles to fire.
+      # The watchdog MUST NOT send a second message (C213: one per stall window).
+      refute_receive {:worker_stalled, _}, 150
+
+      send(wedged, :stop)
+    end
+  end
+
+  describe "D-309 / C217 — :DOWN is not a stall (crash is janitor's concern)" do
+    @tag :c_217
+    @tag :ac_10
+    test "killing a registered worker emits no {:worker_stalled, _}",
+         %{watchdog: watchdog} do
+      worker_id = "killed-w4-#{:erlang.unique_integer([:positive])}"
+      dummy = spawn(fn -> receive do: (:stop -> :ok) end)
+      assert Process.alive?(dummy)
+
+      :ok =
+        @watchdog.register(watchdog, worker_id, dummy, self(),
+          heartbeat_timeout: @heartbeat_timeout
+        )
+
+      # Kill the process before it can stall — the watchdog should deregister on :DOWN.
+      Process.exit(dummy, :kill)
+      refute Process.alive?(dummy)
+
+      # Give the watchdog enough time to process the :DOWN and multiple scan cycles.
+      # If it were going to send a stall message it would have done so by 300ms.
+      refute_receive {:worker_stalled, _}, 300
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Private helpers
+  # ---------------------------------------------------------------------------
+
+  # Emits the real heartbeat telemetry event at interval_ms for up_to_ms total.
+  # The process exits when it receives :stop or when up_to_ms has elapsed.
+  defp heartbeat_loop(worker_id, interval_ms, up_to_ms) when up_to_ms > 0 do
+    :telemetry.execute(
+      [:tau, :factory, :worker, :heartbeat],
+      %{},
+      %{worker_id: worker_id}
+    )
+
+    receive do
+      :stop -> :ok
+    after
+      interval_ms ->
+        heartbeat_loop(worker_id, interval_ms, up_to_ms - interval_ms)
+    end
+  end
+
+  defp heartbeat_loop(_worker_id, _interval_ms, _up_to_ms), do: :ok
+end


### PR DESCRIPTION
## P4d-4 — Fleet.Watchdog: heartbeat → worker_stalled (feeds CORE D-317(b))

Advances #437. The supervised `Fleet.Watchdog` (C6) that detects a
**wedged-but-not-crashed** worker (agent `Port` alive, no heartbeat, NO `:DOWN`)
by heartbeat absence and synthesizes exactly one `worker_stalled(worker_id)` to
the owning Unit — the **trigger source** SPEC-FACTORY-CORE's total-escalation
argument (D-317(b)) depends on (a wedged worker emits no trigger of its own, so
without this the loop would silently livelock). A stall (`worker_stalled`) is a
*liveness* signal **distinct** from a crash (`worker_exit`/`:DOWN`).

### Scope (SPEC-FACTORY-FLEET §4 B7, §5 Watchdog, §6 [C206/C213/C217])
1. `lib/tau/factory/fleet/watchdog.ex` (C6) — `Tau.Factory.Fleet.Watchdog`,
   a supervised `GenServer`:
   - `start_link(opts)`: `:name`, `:check_interval` (ms; how often it scans).
   - `register(watchdog, worker_id, worker_pid, report_to, heartbeat_timeout)`
     — store `%{worker_id => {report_to, timeout, last_seen, stalled?, ref}}`;
     `Process.monitor(worker_pid)` (to DEREGISTER on `:DOWN` — a crash is NOT a
     stall; the janitor handles `:DOWN`).
   - **Consume heartbeats:** in `init/1`, `:telemetry.attach` a handler on
     `[:tau, :factory, :worker, :heartbeat]` that `cast`s `{:heartbeat,
     worker_id}` to the watchdog → update `last_seen` and clear `stalled?`
     (a fresh heartbeat ends the stall window). (Decouples the worker from the
     watchdog — the worker just emits telemetry.)
   - **Periodic scan** (`Process.send_after(self(), :scan, check_interval)`):
     for each registered worker, if `now - last_seen > heartbeat_timeout`
     **AND** `not stalled?` → send `{:worker_stalled, worker_id}` to `report_to`
     and set `stalled? = true`. **C213:** at most ONE `worker_stalled` per worker
     per stall window — NO retry (the Unit owns the response via its retry
     ladder). Re-arm the scan timer.
   - `handle_info({:DOWN, ref, :process, _pid, _reason}, st)` — deregister the
     worker (`Process.demonitor`); a terminated worker does NOT get a stall.
   - **C217:** liveness via heartbeats + monitored refs, NEVER `:global` /
     `Process.whereis |> send`.
2. `lib/tau/factory/worker.ex` (EDIT — minimal, additive) — a `:watchdog` opt;
   when present, register with the watchdog at spawn (alongside the janitor).
   No-`:watchdog` path is UNCHANGED (P4d-2/P4d-3 tests stay green).
3. `lib/tau/factory/supervisor.ex` (EDIT) — start `Fleet.Watchdog` in the W
   subtree (name/`:check_interval`-scoped, gated on opts).

### Dependencies
Depends on P4d-2 (the Worker's `[:tau, :factory, :worker, :heartbeat]`
telemetry). Feeds the Unit FSM (P4c) `worker_stalled` stall path (B8/D-317(b)).
Advances #437. After this, **P4d (worker fleet) is complete.**

### SPECs
In scope: **SPEC-FACTORY-FLEET** (Appendix B: `fleet/watchdog.ex`, `worker.ex`,
`factory/supervisor.ex`). Conforms to §4 B7, §6 [C206/C213/C217]; cites CORE
D-317(b) (consumer). No SPEC amendment expected.

### Acceptance criteria
- **AC-10 (feeds D-317(b) / C206):** `worker_stalled_test.exs` — a worker
  registered with the watchdog that STOPS heartbeating (wedged; no exit, no
  crash) yields **exactly one** `{:worker_stalled, worker_id}` to its
  `report_to` once `heartbeat_timeout` elapses; the Unit observes the stall, not
  a silent spin.
- **AC (no false stall):** a worker that keeps heartbeating gets NO
  `worker_stalled` (fresh heartbeats reset `last_seen`/`stalled?`).
- **AC (C213 — one per window):** the wedged worker yields exactly ONE
  `worker_stalled` across multiple scan intervals (no retry/repeat); and a
  worker that `:DOWN`s (crash/exit) gets NO stall (deregistered on `:DOWN`).

### Gating-test paths (frozen at aeda265 — implementer MUST NOT edit)
- `test/tau/factory/worker_stalled_test.exs` (AC-10 / D-317 / C206 / C213 / C217)

Pinned (oracle): `Fleet.Watchdog.start_link(name:, check_interval:)`;
`register(watchdog, worker_id, worker_pid, report_to, heartbeat_timeout: ms) :: :ok` (5-arity);
consumes `:telemetry [:tau,:factory,:worker,:heartbeat] %{worker_id}` → updates last_seen/clears stall;
scan → `{:worker_stalled, worker_id}` to report_to (EXACTLY ONE per stall window, C213, no retry);
`:DOWN` → deregister silently (no stall). Tests drive heartbeats via direct `:telemetry.execute`,
wedged workers are spawned dummy processes blocking on `receive`.

### Gate verdicts
_(filled at gate time — critic, reviewer)_
