### PR TITLE
fix(ci): bump Erlang/OTP 27.2 → 27.2.4 to fix hex.pm TLS cert rejection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -234,7 +234,7 @@ jobs:
       matrix:
         include:
           - elixir: "1.18.1"
-            otp: "27.2"
+            otp: "27.2.4"
           - elixir: "1.17.3"
             otp: "26.2"
     steps:

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-erlang 27.2
+erlang 27.2.4
 elixir 1.18.1-otp-27


### PR DESCRIPTION
## Summary

CI is fully red: every job dies at `Setup BEAM` because **OTP 27.2** rejects `builds.hex.pm`'s certificate chain during `mix local.rebar` / `local.hex` / `deps.get` with:

```
{:tls_alert, {:unsupported_certificate, ... key_usage_mismatch,
 keyUsage:[keyCertSign,cRLSign] + extKeyUsage:[serverAuth] ...}}
```

This is an **OTP-27.2 cert-validation over-strictness regression**: a CA cert in hex.pm's chain carries `keyCertSign` together with a `serverAuth` EKU, which OTP 27.2 wrongly refused. The OTP-26.2 matrix job is unaffected (less-strict TLS), confirming it is OTP-27.2-specific.

## Fix

Upstream fix landed in **OTP 27.2.2** (`public_key-1.17.1`, GH-9208 / PR-9286, 2025-02-06): *"Consider keyCertSign compatible with extended key usage for TLS client/server auth in CAs, adhere to widespread implementations."* This PR bumps to the latest 27.2.x patch, **27.2.4** (2025-02-20), which carries that fix forward.

- `.tool-versions`: `erlang 27.2` → `27.2.4` (drives lint/dialyzer/web/mutation-check jobs via `version-file` + `version-type: strict`).
- `.github/workflows/ci.yml`: `test`-matrix `otp: "27.2"` → `"27.2.4"`. The `26.2` entry is left as-is. Elixir stays `1.18.1` / `1.18.1-otp-27` (same OTP-27 ABI; both 27.2.4 and 1.18.1-otp-27 verified present on builds.hex.pm).

Minimal change: 2 files, 2 lines.

## Validation

The `push` trigger runs the full CI suite on the new OTP. The decisive signal is that `Setup BEAM` now passes and `lint`, `dialyzer`, both `test` matrices, `web`, and `binary-qa` (Burrito single-binary build) all go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)