### PR TITLE
fix(test): reap blocking factory dummy-agents so mix test exits promptly

### DIFF
--- a/test/tau/factory/artifact_conservation_test.exs
+++ b/test/tau/factory/artifact_conservation_test.exs
@@ -53,9 +53,14 @@ defmodule Tau.Factory.ArtifactConservationTest do
   defp slow_agent_bin(tmp_dir, suffix \\ "") do
     bin_path = Path.join(tmp_dir, "slow_cons#{suffix}")
 
+    # Block until the Port closes with NO un-reaped grandchild. `exec cat`
+    # replaces the shell so the BEAM SIGKILLs the actual blocker on Port
+    # close; `cat` exits on EOF. `while true; do sleep 60; done` leaked an
+    # orphaned `sleep` (reparented to init) holding the Port pipe FD open,
+    # stalling BEAM shutdown and hanging `mix test` after the summary.
     File.write!(bin_path, """
     #!/bin/sh
-    while true; do sleep 60; done
+    exec cat
     """)
 
     File.chmod!(bin_path, 0o755)

--- a/test/tau/factory/worker_reclaim_test.exs
+++ b/test/tau/factory/worker_reclaim_test.exs
@@ -50,9 +50,19 @@ defmodule Tau.Factory.WorkerReclaimTest do
   defp slow_agent_bin(tmp_dir, suffix \\ "") do
     bin_path = Path.join(tmp_dir, "slow_reclaim#{suffix}")
 
+    # Block until the Port closes, with NO un-reaped grandchild.
+    #
+    # `exec cat` REPLACES the shell, so the process the BEAM linked to (and
+    # SIGKILLs on Port close) IS the blocking process. `cat` with no args
+    # reads the Port's stdin pipe and exits on EOF when the Port closes.
+    #
+    # The previous `while true; do sleep 60; done` spawned a `sleep 60`
+    # grandchild that SIGKILL-to-the-shell did NOT reach: the orphaned
+    # `sleep` was reparented to init, kept the Port pipe FD open, and stalled
+    # BEAM shutdown — hanging `mix test` after the suite summary printed.
     File.write!(bin_path, """
     #!/bin/sh
-    while true; do sleep 60; done
+    exec cat
     """)
 
     File.chmod!(bin_path, 0o755)

--- a/test/tau/factory/workspace_janitor_test.exs
+++ b/test/tau/factory/workspace_janitor_test.exs
@@ -104,10 +104,15 @@ defmodule Tau.Factory.WorkspaceJanitorTest do
   defp slow_agent_bin(tmp_dir, suffix \\ "") do
     bin_path = Path.join(tmp_dir, "slow_janitor_agent#{suffix}")
 
+    # Blocking agent that stays alive until the Port closes, with NO
+    # un-reaped grandchild. `exec cat` REPLACES the shell so the process the
+    # BEAM SIGKILLs on Port close IS the blocker; `cat` reads the Port's
+    # stdin pipe and exits on EOF. A `while true; do sleep 60; done` would
+    # leak an orphaned `sleep` (reparented to init) that holds the Port pipe
+    # FD open and stalls BEAM shutdown — hanging `mix test` post-summary.
     File.write!(bin_path, """
     #!/bin/sh
-    # blocking agent — stays alive until the process is killed
-    while true; do sleep 60; done
+    exec cat
     """)
 
     File.chmod!(bin_path, 0o755)


### PR DESCRIPTION
## Root cause

CI jobs `test (Elixir 1.18.1 …)`, `test (Elixir 1.17.3 …)`, and `binary-qa` hung
**after** the suite completed: the log showed `Finished in … 1541 tests, 0 failures`,
yet the `mix test` OS process never returned, hanging until the CI timeout
(run 27417948369). The intentional `CrashCompactor` raise is a test fixture, not the bug.

The leak is a **reaped-only-the-direct-child Port problem** in three factory test
files. Their blocking dummy-agent scripts were:

```sh
#!/bin/sh
while true; do sleep 60; done
```

A factory `Worker` opens a linked `Port` to this script (`lib/tau/factory/worker.ex:277`).
When the Worker terminates (kill / shutdown / normal Port-exit), the BEAM sends
SIGKILL to the **direct child of the Port — the `/bin/sh`** — but that shell had
already spawned a `sleep 60` **grandchild**. SIGKILL to the shell does **not** reach
the grandchild: the orphaned `sleep` is reparented to init (PPID 1) and keeps the
Port's stdin pipe file descriptor open.

Across the factory suite these accumulate — **633 orphaned subprocesses observed in
a single full run** (via an `ExUnit.after_suite` `Port.list/0` + `ps` probe). The
FD-holding orphans stall BEAM shutdown, so `mix test` never returns after printing
its summary. Intermittent in CI because each orphan lives only up to its 60s `sleep`
window; the hang fires when enough orphans overlap the shutdown.

Lingering owner (file:line):
- `test/tau/factory/worker_reclaim_test.exs:55`  (`slow_reclaim*` agents)
- `test/tau/factory/workspace_janitor_test.exs:110`  (`slow_janitor_agent*`)
- `test/tau/factory/artifact_conservation_test.exs:58`  (`slow_cons*`)

`test/tau/factory/worker_test.exs:169` already used the **safe** form
`read -r line || true` — `read` is a shell builtin (no grandchild) that gets EOF on
Port close — so it is left unchanged.

## Fix

Replace the loop with `exec cat`:

```sh
#!/bin/sh
exec cat
```

`exec` **replaces** the shell, so the process the BEAM links to and SIGKILLs on Port
close **is** the blocker (no grandchild to orphan). `cat` with no args blocks reading
the Port's stdin pipe and exits cleanly on EOF when the Port closes. Same blocking
semantics, no leaked OS subprocess.

## Before / after evidence

Probe: temporary `ExUnit.after_suite` callback dumping `Port.list/0` + `ps` of
`slow_*`/`sleep 60` processes (reverted; not in this PR).

| | leaked `slow_*` / `sleep 60` subprocesses after a full `mix test --cover` | post-summary process return |
|---|---|---|
| **before** | 633 | stalls / hangs (CI timeout) |
| **after**  | 0   | returns promptly (~10s `--cover` analysis tail, no hang) |

Reproduced locally: `worker_reclaim_test.exs` alone leaked hundreds of `sleep 60`
orphans before; 0 after. Full-suite runs post-fix: `EXIT` is 0/2 (2 = coverage
threshold, not a hang), never timeout-killed (124); `Finished in ~121s`, process
returns ~130s.

## Gates

- `mix compile --warnings-as-errors` — clean
- `mix format --check-formatted` — clean
- `mix credo diff --strict --from-git-merge-base origin/main` — added no issues
- The three changed files: `11 tests, 0 failures`

**No AC — CI-hang / test-hygiene fix.** Assertions intact; no masking.

## Flaky test flagged (pre-existing, unrelated)

During full-suite verification, `test/tau/coding_agent/dispatcher_test.exs:150`
("registers, runs to completion, exits cleanly (zero zombies)") intermittently failed
with `assert_receive … no matching message after 2000ms`. It passed 3/3 in isolation
and touches none of the files in this PR — a pre-existing flaky timing assertion
(2000ms `assert_receive` under full-suite load), not a regression from this change.
Worth a separate follow-up to raise its timeout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)