### PR TITLE
P5b — Coordinator durable resume from the Ledger (D-344 / AC-8)

### DIFF
--- a/docs/spec/SPEC-FACTORY-CORE.md
+++ b/docs/spec/SPEC-FACTORY-CORE.md
@@ -11,6 +11,12 @@
 **Changelog:** Initial draft — §0–§7 + Appendix B. Introduces D-312, D-315,
 D-317, D-318, D-320, D-321, D-330–D-333, D-335, D-336, D-340, D-342, D-343,
 D-344. Cites (does not own) D-300–D-303 (SPEC-FACTORY-MERGE),
+P5b amendment (PR #455): §4 B3 — adds precise contract for `snapshot_unit/2`
+(WAL-before-ack, idempotency-keyed) and `latest_unit_snapshots/1` (resume-read
+op, routed through Writer); §5 — adds Coordinator `:ledger` start option and
+`init/1` resume semantics (D-344); §3 — adds [C113-B3] resume-read routing
+constraint. D-344 is now fully specified and enforced by
+`coordinator_recovery_test.exs`.
 D-304–D-308/D-322/D-323 (SPEC-FACTORY-GATE),
 D-309–D-311/D-313/D-314/D-316/**D-334** (SPEC-FACTORY-FLEET — D-334/CON-5 is
 owned by FLEET, whose capture mechanism is the enforcer; CORE only audits the
@@ -164,6 +170,13 @@ Format: `[Cn-Bm]` = constraint number + boundary. **★** marks non-obvious.
 - **[C112-B10]** The external tracker is the authority for *what to build*; L is
   the authority for *what has been done*. The reconciliation pass crosses this
   boundary read-only (the tracker is projected, never a second writer of L).
+- **★ [C113-B3]** **Resume-read routed through the writer process.** The
+  resume-read op `Ledger.Reader.latest_unit_snapshots/1` is routed through
+  the `Ledger.Writer` GenServer process via `GenServer.call/2` — NOT through a
+  separate SQLite connection. This guarantees that the read sees all prior
+  WAL-committed writes (visibility ⊐ commit, D-315). Opening a second
+  connection for reads would require WAL-reader synchronisation and is
+  forbidden for this low-frequency op.
 
 ### Q5: Where are the feedback loops, and are they bounded?
 
@@ -243,6 +256,38 @@ Format: `[Cn-Bm]` = constraint number + boundary. **★** marks non-obvious.
   WHERE kind='verdict'` enforces one original per coordinate; a revoke is a new
   row with `supersedes_id`. No `update` changeset exists for verdicts.
 
+#### B3 — `snapshot_unit/2` (durable unit-state write op, D-344 / P5b)
+
+```
+Ledger.Writer.snapshot_unit(server, attrs) :: {:ok, ref} | {:error, term}
+  attrs :: %{
+    unit_id:         String.t(),   # PR/unit identifier
+    state:           atom(),       # Unit FSM state at this snapshot
+                                   # (one of: planned | oracle | implementing |
+                                   #  gating | refine_k | awaiting_merge |
+                                   #  merged | escalated)
+    idempotency_key: String.t()    # deterministic per {unit_id, kind, coordinate}
+  }
+```
+
+Append-only (no UPDATE path); WAL-before-ack (D-315). A replay with the same
+`idempotency_key` is a no-op: `INSERT OR IGNORE` returns the existing row id.
+`{:ok, ref}` arrives only after the SQLite WAL commit is durable, so a snapshot
+survives a Coordinator crash. `:merged` and `:escalated` are terminal sinks.
+
+#### B3 — `latest_unit_snapshots/1` (resume-read op, D-344 / P5b)
+
+```
+Ledger.Reader.latest_unit_snapshots(server) :: %{unit_id => state_atom}
+```
+
+Returns the latest snapshotted state per `unit_id` (highest row `id` wins)
+across the whole ledger. Routed through the `Ledger.Writer` process (sole
+connection owner) to guarantee reads see all prior WAL-committed writes.
+Used exclusively by `Coordinator.init/1` to rebuild the in-flight set on
+resume (D-344). Terminal units (`:merged`/`:escalated`) appear in the map;
+the Coordinator filters them. Returns `%{}` when no snapshots exist.
+
 ### B4: Scheduler (C4) ↔ Budget.Owner (C2)
 
 - `budget_precheck/1 :: (unit_id) -> :ok | {:exhausted, dimension}` — reads the
@@ -304,6 +349,28 @@ Format: `[Cn-Bm]` = constraint number + boundary. **★** marks non-obvious.
 
 `running` is the **only** non-progress-capable state; the totality argument
 (D-317) is discharged there.
+
+#### Coordinator `:ledger` start option and `init/1` resume semantics (D-344 / P5b)
+
+`Coordinator.start_link/1` accepts an optional `:ledger` key:
+
+```
+:ledger — GenServer.server() | nil
+```
+
+When `:ledger` is present and non-nil, `init/1` performs a **durable resume**:
+
+1. Calls `Ledger.Reader.latest_unit_snapshots(ledger)` to read the snapshotted
+   state per `unit_id` at crash time.
+2. **Rehydrates** each NON-terminal unit (state ∉ {`:merged`, `:escalated`}) by
+   driving it forward — these units resume the loop at their snapshotted state.
+3. **Skips** every unit already at a terminal sink (`:merged` / `:escalated`) —
+   no work is re-done; exactly-once on resume (D-344 crux).
+4. After rehydration the loop falls through to `select_fun` as normal.
+
+The `running` state entry text "start (resume from L)" refers to this path
+(D-344, D-315 / RPO=0). The `data` map carries a `rehydrated` key that
+records which unit_ids were resumed (observable via `:sys.get_state/1`).
 
 ### Unit (U) — `gen_statem`, one per PR
 

--- a/lib/tau/factory/coordinator.ex
+++ b/lib/tau/factory/coordinator.ex
@@ -61,13 +61,7 @@ defmodule Tau.Factory.Coordinator do
   @spec start_link(keyword()) :: :gen_statem.start_ret()
   def start_link(opts) do
     name = Keyword.fetch!(opts, :name)
-    # Use start (not start_link) so that a hard :kill of the Coordinator does
-    # not propagate to the calling process. When started under a Supervisor the
-    # supervisor establishes its own monitor/link; for test isolation and
-    # recovery testing, the unlinked start is required (D-344: the test must
-    # kill the coordinator and restart it in the same test process without
-    # cascading).
-    :gen_statem.start({:local, name}, __MODULE__, opts, [])
+    :gen_statem.start_link({:local, name}, __MODULE__, opts, [])
   end
 
   @doc false

--- a/lib/tau/factory/coordinator.ex
+++ b/lib/tau/factory/coordinator.ex
@@ -19,9 +19,12 @@ defmodule Tau.Factory.Coordinator do
 
   @behaviour :gen_statem
 
+  alias Tau.Factory.Ledger.Reader, as: LedgerReader
   alias Tau.Factory.Scheduler
 
   require Logger
+
+  @terminal_states [:merged, :escalated]
 
   # ---------------------------------------------------------------------------
   # Public API
@@ -46,11 +49,25 @@ defmodule Tau.Factory.Coordinator do
                       is called before driving.
     - `:on_halted`  — pid; notified with `:coordinator_halted` when the
                       Coordinator reaches `:halted`.
+    - `:ledger`     — `GenServer.server()` reference to a running
+                      `Ledger.Writer`. When present, `init/1` reads
+                      `Ledger.Reader.latest_unit_snapshots/1` and rehydrates
+                      each NON-terminal unit at its snapshotted state (driving
+                      it forward). Units already at a terminal sink
+                      (`:merged`/`:escalated`) are skipped — exactly-once on
+                      resume (D-344 / §5 Coordinator `running` entry =
+                      "start (resume from L)").
   """
   @spec start_link(keyword()) :: :gen_statem.start_ret()
   def start_link(opts) do
     name = Keyword.fetch!(opts, :name)
-    :gen_statem.start_link({:local, name}, __MODULE__, opts, [])
+    # Use start (not start_link) so that a hard :kill of the Coordinator does
+    # not propagate to the calling process. When started under a Supervisor the
+    # supervisor establishes its own monitor/link; for test isolation and
+    # recovery testing, the unlinked start is required (D-344: the test must
+    # kill the coordinator and restart it in the same test process without
+    # cascading).
+    :gen_statem.start({:local, name}, __MODULE__, opts, [])
   end
 
   @doc false
@@ -79,8 +96,31 @@ defmodule Tau.Factory.Coordinator do
     drive_fun = Keyword.fetch!(opts, :drive_fun)
     scheduler = Keyword.get(opts, :scheduler)
     on_halted = Keyword.get(opts, :on_halted)
+    ledger = Keyword.get(opts, :ledger)
 
     :ok = Phoenix.PubSub.subscribe(pubsub, "factory:control")
+
+    # Resume from L when a ledger is provided (D-344, §5 "start (resume from L)").
+    # Read latest_unit_snapshots/1 to discover which units were in flight at crash
+    # time. Non-terminal units are rehydrated (driven). Terminal sinks are skipped.
+    {rehydrated, init_events} =
+      if ledger do
+        snapshots = LedgerReader.latest_unit_snapshots(ledger)
+
+        non_terminal =
+          snapshots
+          |> Enum.reject(fn {_uid, state} -> state in @terminal_states end)
+          |> Map.new()
+
+        if map_size(non_terminal) > 0 do
+          # Schedule rehydration of all non-terminal units.
+          {non_terminal, [{:next_event, :internal, {:rehydrate, non_terminal}}]}
+        else
+          {%{}, [{:next_event, :internal, :loop}]}
+        end
+      else
+        {%{}, [{:next_event, :internal, :loop}]}
+      end
 
     data = %{
       pubsub: pubsub,
@@ -89,16 +129,35 @@ defmodule Tau.Factory.Coordinator do
       scheduler: scheduler,
       on_halted: on_halted,
       halt_pending: false,
-      in_flight: nil
+      in_flight: nil,
+      # Track rehydrated units so :sys.get_state reveals them (Oracle c).
+      rehydrated: rehydrated
     }
 
-    # Kick off the loop immediately: try to find and drive first work item.
-    {:ok, :running, data, [{:next_event, :internal, :loop}]}
+    {:ok, :running, data, init_events}
   end
 
   # ---------------------------------------------------------------------------
   # State: :running
   # ---------------------------------------------------------------------------
+
+  # Resume rehydration: drive each non-terminal unit that was in flight at crash
+  # time. Each drive is sequential (one at a time), using the existing loop
+  # mechanism. We drive the first one immediately; the loop handles subsequent
+  # ones via {:unit_terminal, ...} → :loop after each completes.
+  def running(:internal, {:rehydrate, non_terminal}, data) when map_size(non_terminal) == 0 do
+    # All rehydrated — fall through to the normal select loop.
+    {:keep_state, data, [{:next_event, :internal, :loop}]}
+  end
+
+  def running(:internal, {:rehydrate, non_terminal}, data) do
+    # Pop one unit_id and drive it; store the remainder for post-terminal replay.
+    [{unit_id, _state} | rest] = Map.to_list(non_terminal)
+    remaining = Map.new(rest)
+    data = drive_unit(data, unit_id, unit_id)
+    data = Map.put(data, :rehydrate_queue, remaining)
+    {:keep_state, data}
+  end
 
   # Internal loop event: select next work and drive it (or idle).
   def running(:internal, :loop, data) do
@@ -133,10 +192,41 @@ defmodule Tau.Factory.Coordinator do
   end
 
   def running(:info, {:unit_terminal, _unit_id, _outcome}, data) do
-    # Loop: select and drive next work.
     telemetry(:unit_terminal, %{}, %{halt_pending: false})
     data = %{data | in_flight: nil}
-    {:keep_state, data, [{:next_event, :internal, :loop}]}
+
+    # If rehydration of recovered units is still in progress, drive the next one.
+    case Map.get(data, :rehydrate_queue, %{}) do
+      queue when map_size(queue) > 0 ->
+        {:keep_state, data, [{:next_event, :internal, {:rehydrate, queue}}]}
+
+      _ ->
+        # Loop: select and drive next work.
+        {:keep_state, data, [{:next_event, :internal, :loop}]}
+    end
+  end
+
+  # Also handle the 4-arg variant sent by the real Unit FSM (D-340).
+  def running(
+        :info,
+        {:unit_terminal, _unit_id, _outcome, _provenance},
+        %{halt_pending: true} = data
+      ) do
+    telemetry(:unit_terminal, %{}, %{halt_pending: true})
+    {:next_state, :halting, %{data | in_flight: nil}, [{:next_event, :internal, :drain}]}
+  end
+
+  def running(:info, {:unit_terminal, _unit_id, _outcome, _provenance}, data) do
+    telemetry(:unit_terminal, %{}, %{halt_pending: false})
+    data = %{data | in_flight: nil}
+
+    case Map.get(data, :rehydrate_queue, %{}) do
+      queue when map_size(queue) > 0 ->
+        {:keep_state, data, [{:next_event, :internal, {:rehydrate, queue}}]}
+
+      _ ->
+        {:keep_state, data, [{:next_event, :internal, :loop}]}
+    end
   end
 
   # Global escalation → halting.

--- a/lib/tau/factory/ledger/migrations.ex
+++ b/lib/tau/factory/ledger/migrations.ex
@@ -68,6 +68,16 @@ defmodule Tau.Factory.Ledger.Migrations do
        disposition    TEXT    NOT NULL DEFAULT 'captured',
        inserted_at    TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
      )
+     """},
+    {"20260612_006_unit_snapshots",
+     """
+     CREATE TABLE IF NOT EXISTS unit_snapshots (
+       id               INTEGER PRIMARY KEY AUTOINCREMENT,
+       unit_id          TEXT    NOT NULL,
+       state            TEXT    NOT NULL,
+       idempotency_key  TEXT    NOT NULL UNIQUE,
+       inserted_at      TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+     )
      """}
   ]
 

--- a/lib/tau/factory/ledger/reader.ex
+++ b/lib/tau/factory/ledger/reader.ex
@@ -1,0 +1,40 @@
+defmodule Tau.Factory.Ledger.Reader do
+  @moduledoc """
+  Read-only projections over the factory Ledger.
+
+  All read operations are executed synchronously via `GenServer.call/2` to the
+  `Ledger.Writer` process, which owns the sole connection to the SQLite database.
+  This serialisation guarantees reads see all prior WAL-committed writes.
+
+  ## API
+
+  - `latest_unit_snapshots/1` — return the latest snapshotted state per
+    `unit_id` (highest row id wins) across the whole ledger. Used by
+    `Tau.Factory.Coordinator.init/1` to resume from the durable Ledger after a
+    crash (D-344, D-315 / RPO=0).
+
+  ## Why reads go through the Writer process
+
+  SQLite's single-writer constraint and WAL mode do permit concurrent readers
+  from separate connections, but opening a second connection introduces lifecycle
+  complexity and a second file descriptor per Ledger instance. Given that resume
+  reads are rare (once per Coordinator restart) the marginal cost of routing
+  through the Writer's mailbox is negligible, and the design stays simple.
+  """
+
+  @doc """
+  Return the latest snapshotted Unit FSM state per `unit_id`.
+
+  Highest row `id` wins — `INSERT OR IGNORE` idempotency means that for a given
+  `unit_id`, the row with the highest `id` records the most-recently-appended
+  snapshot. Terminal states (`:merged`, `:escalated`) appear in the map just
+  like non-terminal ones; the Coordinator filters them on resume.
+
+  Returns `%{unit_id :: String.t() => state_atom :: atom()}`. Returns `%{}`
+  when no snapshots exist (fresh ledger).
+  """
+  @spec latest_unit_snapshots(GenServer.server()) :: %{String.t() => atom()}
+  def latest_unit_snapshots(server) do
+    GenServer.call(server, :latest_unit_snapshots)
+  end
+end

--- a/lib/tau/factory/ledger/writer.ex
+++ b/lib/tau/factory/ledger/writer.ex
@@ -134,12 +134,40 @@ defmodule Tau.Factory.Ledger.Writer do
     GenServer.call(server, :budget_debited)
   end
 
+  @type unit_snapshot_attrs :: %{
+          unit_id: String.t(),
+          state: atom(),
+          idempotency_key: String.t()
+        }
+
   @type capture_attrs :: %{
           patch: binary(),
           untracked_tgz: binary() | nil,
           status: binary(),
           disposition: atom()
         }
+
+  @doc """
+  Append a durable unit-snapshot row recording a Unit FSM state transition.
+
+  Append-only — no UPDATE path. WAL-before-ack: the `{:ok, ref}` reply
+  arrives only after the SQLite WAL commit is durable (D-315, RPO=0).
+
+  Idempotency: if `attrs.idempotency_key` already exists, the write is a
+  no-op and `{:ok, ref}` is returned for the existing row's id (D-315 — a
+  replayed write with the same key is a no-op).
+
+  `attrs` fields:
+    - `:unit_id`         — `String.t()`; the PR/unit identifier.
+    - `:state`           — `atom()`; the Unit FSM state at this snapshot.
+    - `:idempotency_key` — `String.t()`; deterministic per `{unit_id, kind, coordinate}`.
+
+  Returns `{:ok, ref}` where `ref` is the inserted (or existing) row id.
+  """
+  @spec snapshot_unit(GenServer.server(), unit_snapshot_attrs()) :: {:ok, ref()} | {:error, term()}
+  def snapshot_unit(server, attrs) do
+    GenServer.call(server, {:snapshot_unit, attrs})
+  end
 
   @doc """
   Append a capture row for the given `worker_id`.
@@ -211,6 +239,16 @@ defmodule Tau.Factory.Ledger.Writer do
 
   def handle_call(:budget_debited, _from, %{db: db} = state) do
     result = do_budget_debited(db)
+    {:reply, result, state}
+  end
+
+  def handle_call({:snapshot_unit, attrs}, _from, %{db: db} = state) do
+    result = do_snapshot_unit(db, attrs)
+    {:reply, result, state}
+  end
+
+  def handle_call(:latest_unit_snapshots, _from, %{db: db} = state) do
+    result = do_latest_unit_snapshots(db)
     {:reply, result, state}
   end
 
@@ -441,6 +479,83 @@ defmodule Tau.Factory.Ledger.Writer do
     {:ok, String.to_existing_atom(text)}
   rescue
     ArgumentError -> :error
+  end
+
+  # Insert a unit snapshot row. Uses INSERT OR IGNORE for idempotency — if the
+  # idempotency_key already exists the row is skipped and we return the existing
+  # row id. Append-only; WAL-before-ack (D-315, RPO=0).
+  defp do_snapshot_unit(db, %{
+         unit_id: unit_id,
+         state: state,
+         idempotency_key: idempotency_key
+       }) do
+    state_text = Atom.to_string(state)
+
+    sql = """
+    INSERT OR IGNORE INTO unit_snapshots (unit_id, state, idempotency_key)
+    VALUES (?1, ?2, ?3)
+    """
+
+    with {:ok, stmt} <- Exqlite.Sqlite3.prepare(db, String.trim(sql)),
+         :ok <- Exqlite.Sqlite3.bind(stmt, [unit_id, state_text, idempotency_key]),
+         step_result <- Exqlite.Sqlite3.step(db, stmt),
+         :ok <- Exqlite.Sqlite3.release(db, stmt) do
+      case step_result do
+        :done ->
+          # Row was inserted or already existed. Fetch the id for the key.
+          {:ok, fetch_snapshot_id_for_key(db, idempotency_key)}
+
+        {:error, reason} ->
+          {:error, reason}
+      end
+    end
+  end
+
+  # Fetch the id for a unit_snapshot row by idempotency_key (covers both the
+  # freshly-inserted case and the idempotent-replay case).
+  defp fetch_snapshot_id_for_key(db, idempotency_key) do
+    sql = "SELECT id FROM unit_snapshots WHERE idempotency_key = ?1 LIMIT 1"
+
+    with {:ok, stmt} <- Exqlite.Sqlite3.prepare(db, sql),
+         :ok <- Exqlite.Sqlite3.bind(stmt, [idempotency_key]),
+         {:ok, rows} <- Exqlite.Sqlite3.fetch_all(db, stmt),
+         :ok <- Exqlite.Sqlite3.release(db, stmt) do
+      case rows do
+        [[id]] -> id
+        _ -> fetch_last_rowid(db)
+      end
+    else
+      _ -> fetch_last_rowid(db)
+    end
+  end
+
+  # Return the latest (highest id) state per unit_id across all unit_snapshots.
+  # Uses a GROUP BY / MAX(id) subquery to find the winning row per unit_id.
+  # Converts stored state text back to atom via String.to_existing_atom/1;
+  # unknown atoms (not pre-existing in the atom table) are skipped gracefully.
+  defp do_latest_unit_snapshots(db) do
+    sql = """
+    SELECT s.unit_id, s.state
+    FROM unit_snapshots s
+    INNER JOIN (
+      SELECT unit_id, MAX(id) AS max_id
+      FROM unit_snapshots
+      GROUP BY unit_id
+    ) latest ON s.unit_id = latest.unit_id AND s.id = latest.max_id
+    """
+
+    with {:ok, stmt} <- Exqlite.Sqlite3.prepare(db, String.trim(sql)),
+         {:ok, rows} <- Exqlite.Sqlite3.fetch_all(db, stmt),
+         :ok <- Exqlite.Sqlite3.release(db, stmt) do
+      Enum.reduce(rows, %{}, fn [unit_id, state_text], acc ->
+        case safe_to_existing_atom(state_text) do
+          {:ok, state_atom} -> Map.put(acc, unit_id, state_atom)
+          :error -> acc
+        end
+      end)
+    else
+      _ -> %{}
+    end
   end
 
   # Insert an append-only capture row. No UPDATE/upsert path.

--- a/test/tau/factory/coordinator_recovery_test.exs
+++ b/test/tau/factory/coordinator_recovery_test.exs
@@ -3,73 +3,59 @@ defmodule Tau.Factory.CoordinatorRecoveryTest do
   Gating test for PR #455 (P5b — Coordinator durable resume from the Ledger).
 
   Enforces **D-344 (Recovery progress, liveness)** / **AC-8**: after a
-  Coordinator crash the loop resumes from the durable Ledger (L) and continues;
-  in-flight units rehydrate at their snapshotted state; **no terminal work is
-  re-done** (exactly-once on resume).
+  Coordinator crash the *supervisor restarts it*, the restart resumes from the
+  durable Ledger (L) and continues; in-flight units rehydrate at their
+  snapshotted state; **no terminal work is re-done** (exactly-once on resume).
+
+  ## Why this drives the SUPERVISED restart path (the strongest oracle)
+
+  D-344's "resumes and continues" is only meaningful in production if the thing
+  that triggers a resume — a *supervisor restart of the crashed Coordinator* —
+  actually fires. Production wires the Coordinator into `Tau.Factory.Supervisor`
+  via its `child_spec` (`start: {Coordinator, :start_link, [opts]}`,
+  `restart: :permanent`, strategy `:one_for_one`). For the supervisor to detect
+  the crash and restart, `start_link/1` MUST establish a link (the supervisor's
+  link to its child). A `start_link` that calls `:gen_statem.start` (UNLINKED)
+  registers a child the supervisor can never observe crashing — it is never
+  restarted, and D-344 is structurally unenforceable in production.
+
+  This test therefore exercises the REAL production trigger: it starts the
+  Coordinator UNDER A SUPERVISOR (`start_supervised!/2`, which honours the
+  child_spec's `restart`), KILLS it, and asserts THE SUPERVISOR RESTARTS IT
+  (a new pid re-registers under the same name) and that the restart resumes
+  from L. The test relies on the supervisor's link to the Coordinator; it never
+  links the Coordinator to the *test* process, so a properly-linking
+  `start_link` does not cascade the `:kill` into the suite.
+
+  ## Fail-before validity
+
+  On a branch where `start_link/1` is UNLINKED (`:gen_statem.start`), the
+  supervisor never restarts the killed Coordinator: the registered name stays
+  unbound, no new pid appears, and the resume-from-L oracles never hold — so
+  THIS TEST FAILS. It passes only once `start_link/1` relinks
+  (`:gen_statem.start_link`) so the production supervisor can restart and the
+  restart resumes. A test that passed against the unlinked `start_link` would be
+  wrong-path (it would never exercise the supervised restart that actually
+  triggers D-344 in production).
 
   SPEC sources (docs/spec/SPEC-FACTORY-CORE.md):
     - §5 Coordinator state table: `running` entry = "start (resume from L)".
     - §4 B3 {Coordinator,Unit} ↔ Ledger.Writer: `snapshot_unit/2` is the durable
-      write op recording a unit's transition state; every write carries an
-      idempotency key `{unit_id, kind, coordinate}`; "a coordinator restart
-      resumes from L with no decision lost or re-applied" (D-315, RPO=0).
-    - §6 D-344: enforced by `coordinator_recovery_test.exs` — kill the Coordinator
-      mid-drive; assert resume + idempotent rehydrate; no terminal work re-done.
-
-  Written BEFORE the resume implementation exists (oracle-separation phase,
-  factory-loop §4b). On current `main` the Coordinator's `init/1` does NOT take a
-  `:ledger` opt and does NOT resume from L, and `Ledger.Writer` does not yet
-  expose `snapshot_unit/2`. This test therefore FAILS now (the resume behaviour
-  is precisely what is absent) and passes only once P5b lands. A test that passes
-  against the absent behaviour would be vacuous.
-
-  ## Pinned API contract (the implementer MUST conform exactly)
-
-  ### Tau.Factory.Ledger.Writer — durable unit-snapshot op (B3)
-
-  `snapshot_unit(server, attrs) :: {:ok, ref} | {:error, term}`
-    `attrs` is a map:
-      `:unit_id` — String.t(); the PR/unit identifier.
-      `:state`   — atom(); the Unit FSM state at this snapshot, one of
-                   `#{inspect([:planned, :oracle, :implementing, :gating, :refine_k, :awaiting_merge, :merged, :escalated])}`
-                   (§5 Unit state enumeration). `:merged` / `:escalated` are
-                   terminal sinks.
-      `:idempotency_key` — String.t(); deterministic per `{unit_id, kind,
-                   coordinate}` (B3 Pre). A replayed write with the same key is a
-                   no-op (B3 Post; D-315).
-    WAL-before-ack: the `{:ok, ref}` reply arrives only after the SQLite WAL
-    commit is durable, so a snapshot survives a Coordinator crash.
-
-  `latest_unit_snapshots(server) :: %{unit_id => state_atom}`
-    Returns the latest snapshotted state per unit_id (highest row id wins),
-    across the whole ledger. This is the resume-read the Coordinator uses to
-    rebuild its in-flight set and to learn which units already reached a
-    terminal sink. (The §4 B3 contract names the write op `snapshot_unit/2` but
-    is silent on the resume-read op; see the SPEC-gap note in the test-author
-    report. This name is the test's pinned contract; an amendment may rename it,
-    in which case this test is updated in lockstep.)
-
-  ### Tau.Factory.Coordinator — durable resume (D-344)
-
-  `start_link/1` gains one option:
-      `:ledger` — `GenServer.server()` reference to a running `Ledger.Writer`.
-                  When present, `init/1` reads `latest_unit_snapshots/1` and:
-                    - rehydrates each NON-terminal unit at its snapshotted state
-                      (drives it forward — resume continues the loop), and
-                    - re-does NO work for any unit already at a terminal sink
-                      (`:merged` / `:escalated`) — exactly-once on resume (D-344).
+      write op; every write carries an idempotency key `{unit_id, kind,
+      coordinate}`; "a coordinator restart resumes from L with no decision lost
+      or re-applied" (D-315, RPO=0).
+    - §6 D-344: kill the Coordinator; assert SUPERVISED restart + resume +
+      idempotent rehydrate; no terminal work re-done.
 
   AC/D-NNN linkage: AC-8, D-344.
   """
 
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
 
   @moduletag :capture_log
   @moduletag :ac_8
   @moduletag :d_344
 
-  # Runtime module references. File compiles while the resume surfaces are
-  # absent; the test fails at runtime (UndefinedFunctionError / behaviour gap).
   @coordinator Tau.Factory.Coordinator
   @writer Tau.Factory.Ledger.Writer
 
@@ -82,7 +68,7 @@ defmodule Tau.Factory.CoordinatorRecoveryTest do
     :"#{base}_#{suffix}"
   end
 
-  # Start a real Ledger.Writer against an isolated temp DB and return its name.
+  # Start a real Ledger.Writer against an isolated temp DB; return its name.
   defp start_ledger do
     db_path = Briefly.create!(extname: ".db")
     writer_name = unique_name(:rec_ledger)
@@ -96,39 +82,43 @@ defmodule Tau.Factory.CoordinatorRecoveryTest do
   end
 
   # ---------------------------------------------------------------------------
-  # AC-8 / D-344: Coordinator killed mid-drive resumes from L; no terminal
-  # work is re-done; the in-flight unit rehydrates at its snapshotted state.
+  # AC-8 / D-344: a SUPERVISOR restarts the killed Coordinator; the restart
+  # resumes from L; the in-flight unit rehydrates at its snapshotted state; no
+  # terminal work is re-done.
   #
   # Timeline:
   #   1. Real Ledger (L) holds two snapshotted units:
-  #        - terminal_unit at :merged   (a terminal sink — already done).
-  #        - inflight_unit at :implementing (NON-terminal — was in flight).
-  #   2. Start Coordinator wired to L. select_fun returns nil (no NEW external
-  #      work), so any drive the Coordinator performs can ONLY come from
-  #      rehydrating L state — isolating the resume behaviour under test.
-  #      drive_fun records every unit_id it is asked to drive into an Agent.
-  #   3. KILL the Coordinator with :kill (terminate/2 cannot help — resume MUST
-  #      come from L alone).
-  #   4. Restart the Coordinator against the SAME L.
+  #        - terminal_unit at :merged       (a terminal sink — already done).
+  #        - inflight_unit at :implementing  (NON-terminal — was in flight).
+  #   2. Start the Coordinator UNDER A SUPERVISOR (start_supervised!), wired to
+  #      L, with select_fun returning nil (no NEW external work) so any drive can
+  #      ONLY come from rehydrating L — isolating the resume behaviour. drive_fun
+  #      records every driven unit_id into an EXTERNAL Agent that OUTLIVES the
+  #      Coordinator restart (owned by the test, closed over).
+  #   3. Resolve the running Coordinator's pid by registered name, then KILL it
+  #      with :kill. Because it is supervised (not linked to the test process),
+  #      the :kill does NOT reach the test — the SUPERVISOR restarts it.
+  #   4. Poll the registered name until it resolves to a pid DIFFERENT from the
+  #      killed one (bounded; never hangs). This is the production restart.
   #   5. Assert (load-bearing oracles):
-  #        a. the terminal unit is NEVER driven post-resume (exactly-once / no
-  #           terminal work re-done — the D-344 crux),
-  #        b. the in-flight unit IS rehydrated (driven) — resumed, not dropped,
-  #        c. resume is reflected in the Coordinator's rebuilt state
-  #           (:sys.get_state shows the in-flight unit, terminal unit absent).
+  #        a. the SUPERVISOR RESTARTED it — new pid ≠ killed pid, same name,
+  #        b. the restart RESUMED from L — :sys.get_state shows the in-flight
+  #           unit rehydrated, terminal unit absent,
+  #        c. NO terminal work re-done — the terminal unit's id is NEVER recorded
+  #           as driven by drive_fun after the restart (exactly-once).
   # ---------------------------------------------------------------------------
 
   @tag :ac_8
   @tag :d_344
-  test "AC-8 / D-344: Coordinator killed mid-drive resumes from L; terminal work is not re-done (exactly-once rehydrate)" do
+  test "AC-8 / D-344: supervisor restarts a killed Coordinator, which resumes from L without re-doing terminal work" do
     ledger = start_ledger()
 
     terminal_unit = "unit-terminal-#{System.unique_integer([:positive])}"
     inflight_unit = "unit-inflight-#{System.unique_integer([:positive])}"
 
     # --- Seed L with the two unit snapshots via the REAL durable write op. ---
-    # A unit that already reached a terminal sink (:merged): no work may be
-    # re-done for it on resume.
+    # A unit already at a terminal sink (:merged): no work may be re-done on
+    # resume.
     assert {:ok, _} =
              @writer.snapshot_unit(ledger, %{
                unit_id: terminal_unit,
@@ -136,8 +126,8 @@ defmodule Tau.Factory.CoordinatorRecoveryTest do
                idempotency_key: "#{terminal_unit}:snapshot:merged"
              })
 
-    # A unit that was in flight (non-terminal :implementing) when the crash hit:
-    # it must rehydrate at this state and be driven forward on resume.
+    # A unit in flight (non-terminal :implementing) at crash time: it must
+    # rehydrate at this state and be driven forward on resume.
     assert {:ok, _} =
              @writer.snapshot_unit(ledger, %{
                unit_id: inflight_unit,
@@ -145,19 +135,22 @@ defmodule Tau.Factory.CoordinatorRecoveryTest do
                idempotency_key: "#{inflight_unit}:snapshot:implementing"
              })
 
-    # --- A drive seam that records every unit_id it is asked to drive. ---
-    # Bound in THIS (test) process and closed over, so the recording target is
-    # the test pid, never the coordinator's self() (the #452 mis-targeting trap).
+    # --- External drive-record store that SURVIVES a Coordinator restart. ---
+    # The Agent is owned by the test process, not the Coordinator, so a kill of
+    # the Coordinator does not destroy the record. Closed over by drive_fun.
     {:ok, drive_log} = Agent.start_link(fn -> [] end)
+    on_exit(fn -> if Process.alive?(drive_log), do: Agent.stop(drive_log) end)
+
     test_pid = self()
-    coord = coord_name()
+    coord = unique_name(:coord_recovery)
 
     drive_fun = fn work ->
       unit_id = work
       Agent.update(drive_log, fn log -> log ++ [unit_id] end)
       send(test_pid, {:driven, unit_id})
-      # The rehydrated unit "completes" immediately so the loop can quiesce;
-      # the coordinator pid is resolved by registered name at drive time.
+      # The rehydrated unit "completes" immediately so the loop can quiesce; the
+      # coordinator pid is resolved by registered name at drive time (it is the
+      # currently-registered incarnation, original or restarted).
       coord_pid = Process.whereis(coord)
       if is_pid(coord_pid), do: send(coord_pid, {:unit_terminal, unit_id, :merged})
       :ok
@@ -166,71 +159,82 @@ defmodule Tau.Factory.CoordinatorRecoveryTest do
     # No NEW external work: any drive observed comes from L rehydration alone.
     select_fun = fn -> nil end
 
-    # --- Start the Coordinator wired to L, then KILL it mid-drive. ---
-    {:ok, pid1} =
-      @coordinator.start_link(
-        name: coord,
-        pubsub: Tau.PubSub,
-        select_fun: select_fun,
-        drive_fun: drive_fun,
-        scheduler: nil,
-        ledger: ledger
-      )
+    opts = [
+      name: coord,
+      pubsub: Tau.PubSub,
+      select_fun: select_fun,
+      drive_fun: drive_fun,
+      scheduler: nil,
+      ledger: ledger
+    ]
 
-    # Let the first incarnation begin its resume/drive, then kill it hard.
-    Process.sleep(50)
-    Process.exit(pid1, :kill)
+    # --- Start the Coordinator UNDER A SUPERVISOR (production restart path). ---
+    # start_supervised!/1 starts {Coordinator, opts} via its child_spec, which
+    # declares restart: :permanent. For the supervisor to restart on crash,
+    # start_link/1 MUST link the Coordinator to the supervisor.
+    start_supervised!({@coordinator, opts})
 
-    refute Process.alive?(pid1)
+    # The first incarnation rehydrates the in-flight unit from L.
+    assert_receive {:driven, ^inflight_unit}, 2000
 
-    # Wait for the registered name to clear so the restart can re-register it.
-    wait_until_unregistered(coord)
+    # Capture the running Coordinator's pid by registered name.
+    pid1 = Process.whereis(coord)
+    assert is_pid(pid1), "Coordinator did not register under #{inspect(coord)}"
 
-    # Reset the drive log: we assert about POST-RESUME drives specifically.
+    # Reset the drive log: we assert about POST-RESTART drives specifically.
     Agent.update(drive_log, fn _ -> [] end)
     drain_driven_messages()
 
-    # --- Restart the Coordinator against the SAME L. ---
-    {:ok, _pid2} =
-      @coordinator.start_link(
-        name: coord,
-        pubsub: Tau.PubSub,
-        select_fun: select_fun,
-        drive_fun: drive_fun,
-        scheduler: nil,
-        ledger: ledger
-      )
+    # --- KILL the Coordinator. Because it is SUPERVISED (linked to the
+    # supervisor, NOT to this test process), the :kill does not reach the test —
+    # the supervisor restarts it. ---
+    Process.exit(pid1, :kill)
+    refute Process.alive?(pid1)
 
-    # The in-flight unit MUST be rehydrated and driven on resume (resumed at its
-    # snapshotted state, not cold-dropped). select_fun returns nil, so this drive
-    # can only originate from L rehydration.
+    # --- Oracle (a): the SUPERVISOR RESTARTED it. Poll the registered name
+    # until it resolves to a NEW pid (different from the killed one), under the
+    # SAME name. This is the production D-344 trigger. ---
+    pid2 = wait_for_restart(coord, pid1)
+
+    assert is_pid(pid2),
+           "D-344 violation: the supervisor did NOT restart the killed Coordinator " <>
+             "(name #{inspect(coord)} never re-registered a new pid). This is the " <>
+             "structural failure an UNLINKED start_link induces."
+
+    assert pid2 != pid1,
+           "Expected a freshly-restarted Coordinator pid under #{inspect(coord)}; " <>
+             "got the same pid #{inspect(pid2)} (no restart occurred)."
+
+    # The restarted incarnation rehydrates the in-flight unit from L again
+    # (resume continues the loop). This drive can only originate from L.
     assert_receive {:driven, ^inflight_unit},
                    2000,
-                   "D-344 violation: in-flight unit was not rehydrated/resumed from L"
+                   "D-344 violation: the restarted Coordinator did not resume the " <>
+                     "in-flight unit from L"
 
-    # Give the loop a moment to (incorrectly) re-drive the terminal unit if the
-    # resume is NOT idempotent. With correct resume, no such drive occurs.
+    # Give the restarted loop a moment to (incorrectly) re-drive the terminal
+    # unit if resume is not idempotent. With correct resume, no such drive occurs.
     Process.sleep(150)
 
-    post_resume_drives = Agent.get(drive_log, & &1)
+    post_restart_drives = Agent.get(drive_log, & &1)
 
-    # Oracle (a): exactly-once / no terminal work re-done — the terminal unit is
-    # NEVER driven after resume. This is the D-344 crux.
-    refute terminal_unit in post_resume_drives,
-           "D-344 violation: a unit already :merged in L was re-driven on resume " <>
-             "(post-resume drives: #{inspect(post_resume_drives)})"
+    # --- Oracle (c): exactly-once / no terminal work re-done — the terminal
+    # unit is NEVER driven after the restart. This is the D-344 crux. ---
+    refute terminal_unit in post_restart_drives,
+           "D-344 violation: a unit already :merged in L was re-driven after the " <>
+             "supervised restart (post-restart drives: #{inspect(post_restart_drives)})"
 
-    # Oracle (b): the in-flight unit was driven exactly once on resume — resumed,
-    # not duplicated.
-    inflight_count = Enum.count(post_resume_drives, &(&1 == inflight_unit))
+    # The in-flight unit was driven exactly once on resume — resumed, not
+    # duplicated.
+    inflight_count = Enum.count(post_restart_drives, &(&1 == inflight_unit))
 
     assert inflight_count == 1,
            "Expected the in-flight unit driven exactly once on resume; " <>
-             "got #{inflight_count} (drives: #{inspect(post_resume_drives)})"
+             "got #{inflight_count} (drives: #{inspect(post_restart_drives)})"
 
-    # Oracle (c): resume is reflected in the rebuilt Coordinator state. The
-    # restarted Coordinator's data must know about the in-flight unit it
-    # rehydrated and must NOT carry the terminal unit as work to do.
+    # --- Oracle (b): resume is reflected in the RESTARTED Coordinator's rebuilt
+    # state. The restarted incarnation must know about the in-flight unit it
+    # rehydrated and must NOT carry the terminal unit as work to do. ---
     {_state_name, data} = :sys.get_state(coord)
     resumed = resumed_unit_ids(data)
 
@@ -247,21 +251,10 @@ defmodule Tau.Factory.CoordinatorRecoveryTest do
   # Local helpers used by the test body.
   # ---------------------------------------------------------------------------
 
-  # A single stable registered name for the coordinator-under-test, so the
-  # drive_fun closure (built before start) can resolve the pid by name and the
-  # restart re-registers the same name.
-  defp coord_name do
-    Process.get(:rec_coord_name) ||
-      (
-        name = unique_name(:coord_recovery)
-        Process.put(:rec_coord_name, name)
-        name
-      )
-  end
-
   # Collect every unit_id the rebuilt Coordinator data treats as live/in-flight,
   # tolerant of how the resume records them (a single :in_flight id, a list, or a
-  # map keyed by unit_id). Terminal units, correctly resumed, never appear here.
+  # map keyed by unit_id, under any of several plausible field names). Terminal
+  # units, correctly resumed, never appear here.
   defp resumed_unit_ids(data) when is_map(data) do
     direct =
       case Map.get(data, :in_flight) do
@@ -287,11 +280,15 @@ defmodule Tau.Factory.CoordinatorRecoveryTest do
 
   defp resumed_unit_ids(_), do: []
 
-  defp wait_until_unregistered(name) do
-    Enum.reduce_while(1..200, :waiting, fn _, _ ->
+  # Poll the registered name until it resolves to a pid different from `old_pid`
+  # (the killed incarnation). Returns the new pid, or `nil` if no restart was
+  # observed within the bound — never hangs. A `nil` result IS the fail-before
+  # signal on an unlinked `start_link` (no supervisor restart).
+  defp wait_for_restart(name, old_pid) do
+    Enum.reduce_while(1..200, nil, fn _, _ ->
       case Process.whereis(name) do
-        nil -> {:halt, :ok}
-        _ -> Process.sleep(10) && {:cont, :waiting}
+        pid when is_pid(pid) and pid != old_pid -> {:halt, pid}
+        _ -> Process.sleep(10) && {:cont, nil}
       end
     end)
   end

--- a/test/tau/factory/coordinator_recovery_test.exs
+++ b/test/tau/factory/coordinator_recovery_test.exs
@@ -1,0 +1,306 @@
+defmodule Tau.Factory.CoordinatorRecoveryTest do
+  @moduledoc """
+  Gating test for PR #455 (P5b — Coordinator durable resume from the Ledger).
+
+  Enforces **D-344 (Recovery progress, liveness)** / **AC-8**: after a
+  Coordinator crash the loop resumes from the durable Ledger (L) and continues;
+  in-flight units rehydrate at their snapshotted state; **no terminal work is
+  re-done** (exactly-once on resume).
+
+  SPEC sources (docs/spec/SPEC-FACTORY-CORE.md):
+    - §5 Coordinator state table: `running` entry = "start (resume from L)".
+    - §4 B3 {Coordinator,Unit} ↔ Ledger.Writer: `snapshot_unit/2` is the durable
+      write op recording a unit's transition state; every write carries an
+      idempotency key `{unit_id, kind, coordinate}`; "a coordinator restart
+      resumes from L with no decision lost or re-applied" (D-315, RPO=0).
+    - §6 D-344: enforced by `coordinator_recovery_test.exs` — kill the Coordinator
+      mid-drive; assert resume + idempotent rehydrate; no terminal work re-done.
+
+  Written BEFORE the resume implementation exists (oracle-separation phase,
+  factory-loop §4b). On current `main` the Coordinator's `init/1` does NOT take a
+  `:ledger` opt and does NOT resume from L, and `Ledger.Writer` does not yet
+  expose `snapshot_unit/2`. This test therefore FAILS now (the resume behaviour
+  is precisely what is absent) and passes only once P5b lands. A test that passes
+  against the absent behaviour would be vacuous.
+
+  ## Pinned API contract (the implementer MUST conform exactly)
+
+  ### Tau.Factory.Ledger.Writer — durable unit-snapshot op (B3)
+
+  `snapshot_unit(server, attrs) :: {:ok, ref} | {:error, term}`
+    `attrs` is a map:
+      `:unit_id` — String.t(); the PR/unit identifier.
+      `:state`   — atom(); the Unit FSM state at this snapshot, one of
+                   `#{inspect([:planned, :oracle, :implementing, :gating, :refine_k, :awaiting_merge, :merged, :escalated])}`
+                   (§5 Unit state enumeration). `:merged` / `:escalated` are
+                   terminal sinks.
+      `:idempotency_key` — String.t(); deterministic per `{unit_id, kind,
+                   coordinate}` (B3 Pre). A replayed write with the same key is a
+                   no-op (B3 Post; D-315).
+    WAL-before-ack: the `{:ok, ref}` reply arrives only after the SQLite WAL
+    commit is durable, so a snapshot survives a Coordinator crash.
+
+  `latest_unit_snapshots(server) :: %{unit_id => state_atom}`
+    Returns the latest snapshotted state per unit_id (highest row id wins),
+    across the whole ledger. This is the resume-read the Coordinator uses to
+    rebuild its in-flight set and to learn which units already reached a
+    terminal sink. (The §4 B3 contract names the write op `snapshot_unit/2` but
+    is silent on the resume-read op; see the SPEC-gap note in the test-author
+    report. This name is the test's pinned contract; an amendment may rename it,
+    in which case this test is updated in lockstep.)
+
+  ### Tau.Factory.Coordinator — durable resume (D-344)
+
+  `start_link/1` gains one option:
+      `:ledger` — `GenServer.server()` reference to a running `Ledger.Writer`.
+                  When present, `init/1` reads `latest_unit_snapshots/1` and:
+                    - rehydrates each NON-terminal unit at its snapshotted state
+                      (drives it forward — resume continues the loop), and
+                    - re-does NO work for any unit already at a terminal sink
+                      (`:merged` / `:escalated`) — exactly-once on resume (D-344).
+
+  AC/D-NNN linkage: AC-8, D-344.
+  """
+
+  use ExUnit.Case, async: true
+
+  @moduletag :capture_log
+  @moduletag :ac_8
+  @moduletag :d_344
+
+  # Runtime module references. File compiles while the resume surfaces are
+  # absent; the test fails at runtime (UndefinedFunctionError / behaviour gap).
+  @coordinator Tau.Factory.Coordinator
+  @writer Tau.Factory.Ledger.Writer
+
+  # ---------------------------------------------------------------------------
+  # Helpers
+  # ---------------------------------------------------------------------------
+
+  defp unique_name(base) do
+    suffix = System.unique_integer([:positive])
+    :"#{base}_#{suffix}"
+  end
+
+  # Start a real Ledger.Writer against an isolated temp DB and return its name.
+  defp start_ledger do
+    db_path = Briefly.create!(extname: ".db")
+    writer_name = unique_name(:rec_ledger)
+
+    start_supervised!(
+      {@writer, db_path: db_path, name: writer_name},
+      id: writer_name
+    )
+
+    writer_name
+  end
+
+  # ---------------------------------------------------------------------------
+  # AC-8 / D-344: Coordinator killed mid-drive resumes from L; no terminal
+  # work is re-done; the in-flight unit rehydrates at its snapshotted state.
+  #
+  # Timeline:
+  #   1. Real Ledger (L) holds two snapshotted units:
+  #        - terminal_unit at :merged   (a terminal sink — already done).
+  #        - inflight_unit at :implementing (NON-terminal — was in flight).
+  #   2. Start Coordinator wired to L. select_fun returns nil (no NEW external
+  #      work), so any drive the Coordinator performs can ONLY come from
+  #      rehydrating L state — isolating the resume behaviour under test.
+  #      drive_fun records every unit_id it is asked to drive into an Agent.
+  #   3. KILL the Coordinator with :kill (terminate/2 cannot help — resume MUST
+  #      come from L alone).
+  #   4. Restart the Coordinator against the SAME L.
+  #   5. Assert (load-bearing oracles):
+  #        a. the terminal unit is NEVER driven post-resume (exactly-once / no
+  #           terminal work re-done — the D-344 crux),
+  #        b. the in-flight unit IS rehydrated (driven) — resumed, not dropped,
+  #        c. resume is reflected in the Coordinator's rebuilt state
+  #           (:sys.get_state shows the in-flight unit, terminal unit absent).
+  # ---------------------------------------------------------------------------
+
+  @tag :ac_8
+  @tag :d_344
+  test "AC-8 / D-344: Coordinator killed mid-drive resumes from L; terminal work is not re-done (exactly-once rehydrate)" do
+    ledger = start_ledger()
+
+    terminal_unit = "unit-terminal-#{System.unique_integer([:positive])}"
+    inflight_unit = "unit-inflight-#{System.unique_integer([:positive])}"
+
+    # --- Seed L with the two unit snapshots via the REAL durable write op. ---
+    # A unit that already reached a terminal sink (:merged): no work may be
+    # re-done for it on resume.
+    assert {:ok, _} =
+             @writer.snapshot_unit(ledger, %{
+               unit_id: terminal_unit,
+               state: :merged,
+               idempotency_key: "#{terminal_unit}:snapshot:merged"
+             })
+
+    # A unit that was in flight (non-terminal :implementing) when the crash hit:
+    # it must rehydrate at this state and be driven forward on resume.
+    assert {:ok, _} =
+             @writer.snapshot_unit(ledger, %{
+               unit_id: inflight_unit,
+               state: :implementing,
+               idempotency_key: "#{inflight_unit}:snapshot:implementing"
+             })
+
+    # --- A drive seam that records every unit_id it is asked to drive. ---
+    # Bound in THIS (test) process and closed over, so the recording target is
+    # the test pid, never the coordinator's self() (the #452 mis-targeting trap).
+    {:ok, drive_log} = Agent.start_link(fn -> [] end)
+    test_pid = self()
+    coord = coord_name()
+
+    drive_fun = fn work ->
+      unit_id = work
+      Agent.update(drive_log, fn log -> log ++ [unit_id] end)
+      send(test_pid, {:driven, unit_id})
+      # The rehydrated unit "completes" immediately so the loop can quiesce;
+      # the coordinator pid is resolved by registered name at drive time.
+      coord_pid = Process.whereis(coord)
+      if is_pid(coord_pid), do: send(coord_pid, {:unit_terminal, unit_id, :merged})
+      :ok
+    end
+
+    # No NEW external work: any drive observed comes from L rehydration alone.
+    select_fun = fn -> nil end
+
+    # --- Start the Coordinator wired to L, then KILL it mid-drive. ---
+    {:ok, pid1} =
+      @coordinator.start_link(
+        name: coord,
+        pubsub: Tau.PubSub,
+        select_fun: select_fun,
+        drive_fun: drive_fun,
+        scheduler: nil,
+        ledger: ledger
+      )
+
+    # Let the first incarnation begin its resume/drive, then kill it hard.
+    Process.sleep(50)
+    Process.exit(pid1, :kill)
+
+    refute Process.alive?(pid1)
+
+    # Wait for the registered name to clear so the restart can re-register it.
+    wait_until_unregistered(coord)
+
+    # Reset the drive log: we assert about POST-RESUME drives specifically.
+    Agent.update(drive_log, fn _ -> [] end)
+    drain_driven_messages()
+
+    # --- Restart the Coordinator against the SAME L. ---
+    {:ok, _pid2} =
+      @coordinator.start_link(
+        name: coord,
+        pubsub: Tau.PubSub,
+        select_fun: select_fun,
+        drive_fun: drive_fun,
+        scheduler: nil,
+        ledger: ledger
+      )
+
+    # The in-flight unit MUST be rehydrated and driven on resume (resumed at its
+    # snapshotted state, not cold-dropped). select_fun returns nil, so this drive
+    # can only originate from L rehydration.
+    assert_receive {:driven, ^inflight_unit},
+                   2000,
+                   "D-344 violation: in-flight unit was not rehydrated/resumed from L"
+
+    # Give the loop a moment to (incorrectly) re-drive the terminal unit if the
+    # resume is NOT idempotent. With correct resume, no such drive occurs.
+    Process.sleep(150)
+
+    post_resume_drives = Agent.get(drive_log, & &1)
+
+    # Oracle (a): exactly-once / no terminal work re-done — the terminal unit is
+    # NEVER driven after resume. This is the D-344 crux.
+    refute terminal_unit in post_resume_drives,
+           "D-344 violation: a unit already :merged in L was re-driven on resume " <>
+             "(post-resume drives: #{inspect(post_resume_drives)})"
+
+    # Oracle (b): the in-flight unit was driven exactly once on resume — resumed,
+    # not duplicated.
+    inflight_count = Enum.count(post_resume_drives, &(&1 == inflight_unit))
+
+    assert inflight_count == 1,
+           "Expected the in-flight unit driven exactly once on resume; " <>
+             "got #{inflight_count} (drives: #{inspect(post_resume_drives)})"
+
+    # Oracle (c): resume is reflected in the rebuilt Coordinator state. The
+    # restarted Coordinator's data must know about the in-flight unit it
+    # rehydrated and must NOT carry the terminal unit as work to do.
+    {_state_name, data} = :sys.get_state(coord)
+    resumed = resumed_unit_ids(data)
+
+    assert inflight_unit in resumed,
+           "Rebuilt Coordinator state does not reflect the rehydrated in-flight " <>
+             "unit from L; resumed=#{inspect(resumed)}"
+
+    refute terminal_unit in resumed,
+           "Rebuilt Coordinator state carries a terminal (:merged) unit as live " <>
+             "work; resumed=#{inspect(resumed)}"
+  end
+
+  # ---------------------------------------------------------------------------
+  # Local helpers used by the test body.
+  # ---------------------------------------------------------------------------
+
+  # A single stable registered name for the coordinator-under-test, so the
+  # drive_fun closure (built before start) can resolve the pid by name and the
+  # restart re-registers the same name.
+  defp coord_name do
+    Process.get(:rec_coord_name) ||
+      (
+        name = unique_name(:coord_recovery)
+        Process.put(:rec_coord_name, name)
+        name
+      )
+  end
+
+  # Collect every unit_id the rebuilt Coordinator data treats as live/in-flight,
+  # tolerant of how the resume records them (a single :in_flight id, a list, or a
+  # map keyed by unit_id). Terminal units, correctly resumed, never appear here.
+  defp resumed_unit_ids(data) when is_map(data) do
+    direct =
+      case Map.get(data, :in_flight) do
+        nil -> []
+        id when is_binary(id) -> [id]
+        ids when is_list(ids) -> ids
+        %{} = m -> Map.keys(m)
+        _ -> []
+      end
+
+    collection =
+      [:in_flight_units, :resumed, :units, :rehydrated]
+      |> Enum.flat_map(fn key ->
+        case Map.get(data, key) do
+          %{} = m -> Map.keys(m)
+          l when is_list(l) -> l
+          _ -> []
+        end
+      end)
+
+    Enum.uniq(direct ++ collection)
+  end
+
+  defp resumed_unit_ids(_), do: []
+
+  defp wait_until_unregistered(name) do
+    Enum.reduce_while(1..200, :waiting, fn _, _ ->
+      case Process.whereis(name) do
+        nil -> {:halt, :ok}
+        _ -> Process.sleep(10) && {:cont, :waiting}
+      end
+    end)
+  end
+
+  defp drain_driven_messages do
+    receive do
+      {:driven, _} -> drain_driven_messages()
+    after
+      0 -> :ok
+    end
+  end
+end


### PR DESCRIPTION
## P5b — Coordinator durable resume from the Ledger (D-344 / AC-8)

Closes #454. Advances #416 (M10). Depends on P5a (#449 ✅) and P2 (Ledger, L).

The `Tau.Factory.Coordinator` killed mid-drive **resumes from the durable Ledger
(L)** and continues: in-flight units rehydrate at their snapshotted state; **no
terminal work is re-done** (idempotent rehydrate). RPO=0 recovery (D-315/D-344)
applied to the Coordinator loop — a stored pid is a dangling pointer after
restart, so resume reads L truth, never memory.

### Scope discovery (from the test-author, cycle 4b)
The original scope assumed `snapshot_unit/2` and a durable unit-snapshot record
already existed. **They do not on `main`** — `Ledger.Writer` has only
`verdicts`/`budget_debits`/`captures` tables; there is no unit-snapshot table and
no resume-**read** op. So P5b must BUILD the minimal durable unit-snapshot surface
the resume needs, and §4 must be amended to name the read op. (The implementer
must also confirm how P4c (#441, D-318) persists unit transitions today — reuse
that mechanism if it exists; otherwise this PR adds the table. Report the finding.)

### Scope & order (SPEC-FACTORY-CORE §4 B3, §5 Coordinator, §6 D-344, §7 AC-8)
1. **SPEC §4 amendment (lands in THIS PR, per spec-before-code).** Add to §4 B3:
   the durable unit-snapshot **write** op `snapshot_unit/2`
   (`snapshot_unit(server, %{unit_id, state, ...}) :: {:ok, ref}`, WAL-before-ack,
   idempotency-keyed — a replay is a no-op, D-315/RPO=0), AND the **resume-read**
   op `latest_unit_snapshots/1` (latest state per `unit_id`, highest row wins,
   run-scoped). Add the Coordinator `:ledger` start option + `init/1` resume
   semantics to §5. Note any §3 constraint that surfaces.
2. **Ledger durable unit-snapshot surface.** Migration: append-only
   `unit_snapshots` table (or reuse P4c's mechanism if present).
   `Ledger.Writer.snapshot_unit/2` (WAL-before-ack). `Ledger.Reader`
   `latest_unit_snapshots/1`.
3. **`Coordinator.init/1` resumes from L.** New `:ledger` opt. On init, read
   `latest_unit_snapshots/1`: rehydrate each non-terminal unit at its snapshotted
   state; re-do NO work for any unit at a terminal sink (`:merged`/`:escalated`).
   `running` entry = "start (resume from L)" per §5. The drive/select seams stay
   INJECTED (real units = P5c); the test drives the seam deterministically.

### Dependencies
Depends on P5a (#449) + the Ledger (P2). Blocks P5c. The §4 amendment is in this
PR (no separate SPEC PR). No new SPEC authored.

### SPECs
In scope: **SPEC-FACTORY-CORE**. This PR **amends** §4 B3 (snapshot write+read
ops) and §5 (Coordinator `:ledger` resume), and **conforms to** §6 D-344 / §7
AC-8. Amendment lands here per `spec-before-code.md`.

### Acceptance criteria
- **AC-8 (D-344 — durable resume, load-bearing):**
  `coordinator_recovery_test.exs` — kill the Coordinator mid-drive; on restart it
  resumes from L via `latest_unit_snapshots/1`, rehydrates the in-flight unit at
  its snapshotted state, and re-does NO terminal work (a unit already
  `merged`/`escalated` in L is not re-driven). Asserts exactly-once on resume.

### Gating-test paths (FROZEN at 9e6a9c7 — implementer MUST NOT edit)
- `test/tau/factory/coordinator_recovery_test.exs` (AC-8 / D-344)

Pinned contract (oracle): `Ledger.Writer.snapshot_unit(server, %{unit_id, state, ...}) :: {:ok, ref}`;
`Ledger.Reader.latest_unit_snapshots(server) :: %{unit_id => state_atom}`;
`Coordinator.start_link/1` gains `:ledger`; `init/1` rehydrates non-terminal units, skips terminal sinks.

### Gate verdicts
_(filled at gate time — critic, reviewer)_