### PR TITLE
Design the worker→Unit completion contract (ARCH-GAP #460)

### DIFF
--- a/docs/arch/03-system-architecture/system-architecture.md
+++ b/docs/arch/03-system-architecture/system-architecture.md
@@ -80,8 +80,14 @@ justified by the distinct invariant(s) it structurally enforces.
 - **S:** live workers; per-worker isolation boundary (private checkout +
   complete resource namespace declared by the Toolchain adapter).
 - **E_in:** `spawn(role, brief, ref)`, `worker_exit(w, reason)`.
-- **E_out:** `workspace_ready(w)`, `captured(w, dirty)`, `reclaimed(w)`,
-  structured agent I/O events.
+- **E_out:** `workspace_ready(w)`, `work_ready(w, branch, head_sha)`,
+  `captured(w, dirty)`, `reclaimed(w)`, `worker_heartbeat(w)`,
+  `worker_stalled(w)`, structured agent I/O events. `work_ready` is the
+  **success** counterpart of `worker_exit` (the death certificate): an explicit
+  *work-product-ready* signal carried **in-band over the agent `Port` before the
+  agent exits**, keyed by `worker_id`. It is the sole trigger for the U
+  `implementing ──request_gate──▶ gating` edge; clean Port exit (`:exit_status
+  0`) alone is NOT treated as completion (D-326).
 - **δ:** spawn allocates a *complete* isolation boundary (git + HOME/cache/XDG +
   network-cache namespace) and sets position; the worker verifies its own
   position before work (HR via INV-12). On exit (incl. crash): **capture all
@@ -96,6 +102,13 @@ justified by the distinct invariant(s) it structurally enforces.
 - **S:** `state ∈ {planned, oracle, implementing, gating, refine_k,
   awaiting_merge, merged, escalated}`; attempt count k; frozen scope; policy pin.
 - **E_in:** `gate_outcome`, `worker_event`, `challenge_event`, `merge_result`.
+  `worker_event` is the family of worker-originated triggers U consumes; it is
+  the **disjoint sum** of three keyed-by-`worker_id` cases U must distinguish
+  (D-326): `work_ready(w, branch, head_sha)` (success — the agent reported a
+  stable diff; → `request_gate`), `worker_exit(w, reason)` (crash/death cert —
+  infra-failure path, gate NOT called), and `worker_stalled(w)` (the watchdog's
+  synthetic wedged-worker trigger). U tags the **current** worker by `worker_id`
+  and discards events from a stale/superseded worker.
 - **E_out:** `request_gate`, `request_merge`, `unit_terminal(u,outcome)`,
   `escalate(e)`.
 - **δ:** the per-unit lifecycle is owned by **one** component (not smeared —
@@ -165,7 +178,7 @@ justified by the distinct invariant(s) it structurally enforces.
 |------|----------------------------|----------------|
 | K→S select | one candidate at a time; FIFO+priority | K crash ⇒ resume from L (INV-16); no double-select (idempotent on L) |
 | S→U admit | only after conflict-check clears on *declared* sets | admit denied ⇒ defer, monotone (LIV-4) |
-| U→W spawn | test-author frozen *before* implementer; identity recorded | worker crash ⇒ W captures dirty + reclaims (INV-14/15/17); U sees `worker_exit`, decides outcome (not a restart) |
+| U→W spawn | test-author frozen *before* implementer; identity recorded; on normal completion the agent emits `work_ready(w, branch, head_sha)` in-band, keyed by `worker_id` (D-326) ⇒ U fires `request_gate` | worker crash ⇒ W captures dirty + reclaims (INV-14/15/17); U sees `worker_exit`, decides outcome (not a restart); wedged worker ⇒ watchdog `worker_stalled` (no `work_ready`, no `:DOWN`) |
 | W→agents | structured I/O, isolated workspace | agent crash blast-radius = {agent} (INV-17) |
 | U→G gate | full gate on exact `diff`; floor non-shrinkable | gate FAIL ⇒ U refine/pivot (FR-8.2), not a crash |
 | G→L verdict | append-only, immutable per (hash,run) | a later finding ⇒ G appends revoke; never mutates (HR-2) |

--- a/docs/arch/04-software-architecture/control-plane.md
+++ b/docs/arch/04-software-architecture/control-plane.md
@@ -341,7 +341,8 @@ state ∈ {planned, oracle, implementing, gating, refine_k, awaiting_merge, merg
 
   planned ──admit(S)──▶ oracle ──test-author frozen (INV-5)──▶ implementing
                                                                   │
-                                            request_gate (stable diff)
+                            work_ready(w,branch,head_sha) ⇒ request_gate
+                                  (D-326: in-band success signal; NOT exit 0)
                                                                   ▼
                                                                gating
                           ┌──────────── gate FAIL (FR-8.2, an OUTCOME) ──────────┐
@@ -424,6 +425,51 @@ reachable non-progress state eventually produces a trigger**, which the
 classifier (§1.4) then maps to exactly one `e ∈ E`. Totality over `classify/1`'s
 domain is necessary but not sufficient on its own; the mandatory timeouts make it
 sufficient over reachable *states*.
+
+### 3.2.1 The `implementing ──request_gate──▶ gating` trigger (D-326)
+
+The `implementing → gating` edge has exactly **one** trigger: a `work_ready`
+*work-product-ready* event the agent emits **in-band over its `Port`**, decoded
+to a typed struct (`worker-fleet.md` §4 — `dispatch(decode_event(frame), st)`),
+and surfaced by the worker to its owning U keyed by `worker_id`:
+
+```elixir
+# implementing: the ONLY legal completion trigger is the in-band work_ready event.
+def implementing(:info, {:work_ready, w, branch, head_sha}, %{worker_id: w} = data) do
+  # The agent has declared a stable diff; verify it is non-empty before gating
+  # (a clean exit conflates "did the work" with "ran and pushed nothing" — V1).
+  {:next_state, :gating, %{data | branch: branch, head_sha: head_sha},
+   [{:next_event, :internal, :request_gate}]}
+end
+# A work_ready from a SUPERSEDED worker (stale worker_id) is discarded, not gated.
+def implementing(:info, {:work_ready, _other, _b, _s}, data), do: {:keep_state, data}
+```
+
+Three keyed-by-`worker_id` worker triggers are **disjoint** and U distinguishes
+them structurally (the `worker_event` family of system-architecture.md §1, U
+`E_in`):
+
+| trigger | meaning | U action |
+|---------|---------|----------|
+| `work_ready(w, branch, head_sha)` | agent declared a **stable diff** (success) | → `gating` (`request_gate`) |
+| `worker_exit(w, reason)` (`:DOWN`) | worker/agent **crashed or exited** | infra path → `escalated`; gate NOT called (FR-8.2) |
+| `worker_stalled(w)` | watchdog saw **heartbeat absence** (wedged, no `:DOWN`) | retry ladder (semantic stall) → refine/pivot/escalate |
+
+**Why a clean Port exit is NOT the completion trigger (the load-bearing
+decision).** The discriminating question is operational: *can a normally-exiting
+agent ("did the work, pushed a real diff") be distinguished from a no-op exit
+("ran, pushed nothing") and from a crash that happens to exit 0, by exit status
+alone?* It cannot — `:exit_status 0` is a single bit that conflates all three.
+Trusting it would let U fire `request_gate` on an **empty or absent diff**, and
+the gate's mutation check (D-306, "≥1 gating test fails on the reverted tree")
+silently degenerates when there is no production change to revert — a false-green
+path into merge. The in-band `work_ready(branch, head_sha)` frame carries the
+**evidence** (the branch and head SHA the agent pushed) U needs to confirm the
+diff is real *before* gating; exit status remains only the `worker_exit`
+death-certificate input, never a success signal. This mirrors the existing
+in-band `{:coding_agent_event, pid, %Event.Done{}}` contract in `Tau.Session`:
+completion is a typed event the agent *asserts*, never an exit code the harness
+*infers* (D-326; OTP non-negotiable — extend `Tau.Provider.Event`, never scrape).
 
 ### 3.3 Bounded retry ladder (INV-19, HR-8 clamp)
 
@@ -548,8 +594,8 @@ never `Process.whereis |> send`** (OTP non-negotiable #4; research §6).
 | K → S `admit(unit, scope)` | `GenServer.call` | **`call`** — the admit/defer reply *is* back-pressure on the control path; a `cast` would let K outrun S's view of `F` (research §3). |
 | K → U drive / S → U admitted | `gen_statem` event (`call` for the synchronous handshake) | **`call`** on the control path; the reply gates K's next select. |
 | U → G `request_gate` | monitored `Task` (gate fan-out) + result message | `async_nolink` + monitor: a gate-task crash is *data* (a `:DOWN`), not a cascade into U (research §5). |
-| U → M `request_merge` | `GenServer.call` to MergeAuthority | **`call`** — M is concurrency-1; the reply (merged / rejected) is the merge back-pressure; a `cast` into M is a mailbox time-bomb (supervision-tree.md Step 4). |
-| U → W spawn / `:DOWN` | `DynamicSupervisor.start_child` + `Process.monitor` | monitored ref for point-to-point liveness (§3.4). |
+| U → M `request_merge` ; M → U `merge_result` | `cast`/enqueue to MergeAuthority **+ async result on PubSub `"factory:pr:#{id}"`** | **NOT a blocking `call`** — M is concurrency-1 and a single integration is a *minutes-long* merge-train build; a synchronous `call` across it would block U (and pin a caller process) for the whole build and risk a `call` timeout misclassifying "still merging" as failure (final-validation H-1b). U enqueues the request, then `awaiting_merge` consumes `{:merge_result, :merged \| :rejected}` from the per-PR PubSub topic; M's reply *is* the back-pressure, decoupled. A `:rejected` (stale/revoked verdict, ref moved) re-gates (INV-2). |
+| U → W spawn / `work_ready` / `:DOWN` | `DynamicSupervisor.start_child` + `Process.monitor` + in-band `Port` event | monitored ref for point-to-point liveness (the `:DOWN` → `worker_exit`, §3.4); the **success** trigger `work_ready(w, branch, head_sha)` arrives as a decoded in-band `Port` event keyed by `worker_id` (§3.2.1, D-326) — never inferred from exit status. |
 | K/U/M → L record/verdict/debit | `GenServer.call` to the single writer | **`call`** — WAL-before-ack; a `cast` would risk losing a decision on crash (INV-16). |
 | any → K `escalation` | `GenServer.call` (or PubSub for fan-out notice) | **`call`** for the control decision; PubSub `"factory:escalation"` for the *observer* fan-out (dashboard, OTel). |
 | KillSwitch → K | PubSub `"factory:control"` | a *fan-out* control signal K consumes at a unit boundary (§1.5); not request/reply. |

--- a/docs/arch/04-software-architecture/worker-fleet.md
+++ b/docs/arch/04-software-architecture/worker-fleet.md
@@ -221,7 +221,34 @@ port = Port.open({:spawn_executable, agent_bin},
 # Inbound frames decode to typed events — extend Tau.Provider.Event, never an ad-hoc format:
 def handle_info({port, {:data, frame}}, st), do: dispatch(decode_event(frame), st)
 def handle_info({port, {:exit_status, n}}, st), do: handle_agent_exit(n, st)
+
+# D-326: a normal completion is an ASSERTED in-band event, not exit status.
+# The agent emits a typed work-product-ready frame BEFORE exiting; on decoding
+# it the worker forwards work_ready(worker_id, branch, head_sha) to its Unit.
+defp dispatch(%WorkReady{branch: b, head: h}, st) do
+  send(st.report_to, {:work_ready, st.worker_id, b, h})   # the U `implementing → gating` trigger
+  {:noreply, %{st | work_ready_seen?: true}}
+end
+# An exit 0 with NO prior work_ready is a no-op, surfaced as a death cert, NOT success:
+defp handle_agent_exit(0, %{work_ready_seen?: false} = st),
+  do: {:stop, {:shutdown, :no_work_product}, st}          # → worker_exit(id, :no_work_product)
 ```
+
+**Completion is an asserted event, not an exit code (D-326, closes ARCH-GAP
+#460).** A clean Port exit (`:exit_status 0`) carries a single bit and cannot
+distinguish "did the work / pushed a real diff" from "ran and pushed nothing"
+from "crashed but exited 0". So the agent's *success* is signalled by an in-band
+`work_ready(branch, head_sha)` frame (a struct under the same event taxonomy,
+mirroring the in-band `%Tau.CodingAgent.Event.Done{}` already used by
+`Tau.Session`), decoded and forwarded as `work_ready(worker_id, branch,
+head_sha)` — the **sole** trigger of U's `implementing → gating` edge. The
+`branch`/`head_sha` payload is the evidence U needs to confirm a non-empty diff
+before gating. `work_ready` is the success counterpart of the `worker_exit`
+death certificate (§6); the two are disjoint, and an `exit_status 0` without a
+prior `work_ready` is surfaced as `worker_exit(worker_id, :no_work_product)`,
+routed to the Unit's retry ladder, never gated. This realises today's
+`handle_info({port, {:data, _}}, st)` "future: forward to Unit FSM" stub (the
+conforming wiring is P5c-3).
 
 - **Structured events, not scraping.** Inbound frames decode to typed
   `%Tau.Provider.Event{}` / agent-event structs; a tool result is structured

--- a/docs/spec/SPEC-FACTORY-CORE.md
+++ b/docs/spec/SPEC-FACTORY-CORE.md
@@ -18,9 +18,11 @@ op, routed through Writer); §5 — adds Coordinator `:ledger` start option and
 constraint. D-344 is now fully specified and enforced by
 `coordinator_recovery_test.exs`.
 D-304–D-308/D-322/D-323 (SPEC-FACTORY-GATE),
-D-309–D-311/D-313/D-314/D-316/**D-334** (SPEC-FACTORY-FLEET — D-334/CON-5 is
-owned by FLEET, whose capture mechanism is the enforcer; CORE only audits the
-disposition), D-319 (SPEC-FACTORY-GOV). Durable store decided:
+D-309–D-311/D-313/D-314/D-316/**D-334**/**D-326** (SPEC-FACTORY-FLEET — D-334/CON-5
+is owned by FLEET, whose capture mechanism is the enforcer, and **D-326** the
+worker-completion `work_ready` contract; CORE only audits the disposition and
+consumes the `worker_event` set at U's `implementing → gating` edge — §4 B8,
+[C111b-B8]), D-319 (SPEC-FACTORY-GOV). Durable store decided:
 **SQLite/Exqlite** (arch OQ-1).
 
 ## 0. Why this spec exists
@@ -167,6 +169,17 @@ Format: `[Cn-Bm]` = constraint number + boundary. **★** marks non-obvious.
   `escalated` / `rejected`) is preserved with its full provenance (attempt count,
   last verdict hash, challenge log). No outcome is reduced to a bare boolean —
   the conservation laws need the full lineage (NFR-AUDIT).
+- **★ [C111b-B8]** **Worker completion crosses as an asserted event, not an exit
+  code (cited D-326, owned by FLEET).** The fact "the agent produced a stable
+  diff" crosses to U **only** as `work_ready(worker_id, branch, head_sha)` — an
+  in-band frame the agent emits before exit. A clean Port exit (`:exit_status 0`)
+  carries one bit and **loses** the distinction between "did the work / pushed a
+  real diff", "ran and pushed nothing", and "crashed but exited 0"; U must not
+  infer completion from it. The `branch`/`head_sha` is the evidence U needs to
+  confirm a non-empty diff before `request_gate`; exit-0-without-`work_ready`
+  crosses as `worker_exit(w, :no_work_product)` and is routed to the retry
+  ladder, never gated. The three worker-outcome events (`work_ready`,
+  `worker_exit`, `worker_stalled`) are disjoint and keyed by `worker_id`.
 - **[C112-B10]** The external tracker is the authority for *what to build*; L is
   the authority for *what has been done*. The reconciliation pass crosses this
   boundary read-only (the tracker is projected, never a second writer of L).
@@ -321,9 +334,18 @@ the Coordinator filters them. Returns `%{}` when no snapshots exist.
 
 ### B8: Unit (C6) ↔ Worker fleet (W) — *cited, SPEC-FACTORY-FLEET*
 
-- `spawn(role, brief, ref)`; U holds a `Process.monitor/1` ref for liveness; W
-  emits heartbeats and a `worker_stalled` synthetic event on absence ([C107]).
-  W owns isolation/capture D-309..D-311, D-313, D-314, D-316.
+- `spawn(role, brief, ref)`; U holds a `Process.monitor/1` ref for liveness. W
+  surfaces the **disjoint** `worker_event` set, all keyed by `worker_id`, which U
+  consumes (U `E_in`): `work_ready(w, branch, head_sha)` (**success** — the agent
+  asserted a stable diff in-band; the sole trigger of `implementing → gating`),
+  `worker_exit(w, reason)` (the `:DOWN` death certificate — infra path,
+  gate NOT called), and `worker_stalled(w)` (the watchdog's synthetic
+  heartbeat-absence trigger, [C107]). U tags the **current** `worker_id` and
+  discards events from a superseded worker. Clean Port exit (`:exit_status 0`)
+  without `work_ready` is NOT completion — it arrives as
+  `worker_exit(w, :no_work_product)` (**D-326, cited owner: SPEC-FACTORY-FLEET**).
+  W owns isolation/capture D-309..D-311, D-313, D-314, D-316 and the completion
+  contract D-326.
 
 ### B9: KillSwitch (C9) ↔ Coordinator (C3)
 
@@ -377,7 +399,8 @@ records which unit_ids were resumed (observable via `:sys.get_state/1`).
 ```
 state ∈ {planned, oracle, implementing, gating, refine_k, awaiting_merge, merged, escalated}
 
- planned ─admit(S)→ oracle ─test-author frozen→ implementing ─request_gate→ gating
+ planned ─admit(S)→ oracle ─test-author frozen→ implementing ─work_ready(w,branch,head_sha) ⇒ request_gate→ gating
+                                                            (D-326: in-band success event keyed by worker_id; NOT exit 0)
    gating + :pass            → awaiting_merge ─M :merged→ merged (terminal)
    gating + {:fail,f}        → refine_k        (k<N → implementing; k=N → pivot → implementing; pivot red → escalated [E-RETRY-EXHAUSTED])
    awaiting_merge + M reject → gating          (re-gate; INV-2)

--- a/docs/spec/SPEC-FACTORY-FLEET.md
+++ b/docs/spec/SPEC-FACTORY-FLEET.md
@@ -9,7 +9,10 @@
 | **Issue** | TBD — file before the first implementation PR (`tau-github-workflow`); reference as `Closes #N`. |
 
 **Changelog:** Initial draft — §0–§7 + Appendix B. Introduces D-309, D-310,
-D-311, D-313, D-314, D-316, D-334. Cites (does not own) D-304/D-305/D-306
+D-311, D-313, D-314, D-316, D-334.
+ARCH-GAP #460 amendment — adds **D-326** (worker completion is an asserted
+in-band `work_ready` event, the success counterpart of the `worker_exit` death
+certificate; §3 C210b-B9, §4 B1/B4, §6). Cites (does not own) D-304/D-305/D-306
 (SPEC-FACTORY-GATE — the worker enforces only the spawn-order + author-identity
 *mechanism* of D-304, HR-7; the invariant is GATE's), D-300–D-303
 (SPEC-FACTORY-MERGE — sole `origin/main` writer, the other half of INV-11),
@@ -82,7 +85,7 @@ Boundaries (B-N attach contracts in §4):
 
 | # | Boundary | Operation |
 |---|----------|-----------|
-| B1 | **U** (SPEC-FACTORY-CORE) ↔ C1 WorkerSupervisor | `spawn(role, brief, base_ref)` → `{:ok, worker_id}`; async `worker_exit(worker_id, reason)`. **Cited owner: CORE (B8).** |
+| B1 | **U** (SPEC-FACTORY-CORE) ↔ C1 WorkerSupervisor | `spawn(role, brief, base_ref)` → `{:ok, worker_id}`; async `work_ready(worker_id, branch, head_sha)` (success, D-326) ∥ `worker_exit(worker_id, reason)` (death cert). **Cited owner: CORE (B8).** |
 | B2 | C2 Worker ↔ git checkout | private worktree fork from a *system-established* `base_ref`; self-verify pwd/HEAD/branch, abort on mismatch. |
 | B3 | C2 Worker ↔ C5 Isolation (resource namespace) | `resolve_namespace(ws, Toolchain.resource_namespace(tc))` → total `env` map of per-worker dirs **inside** the worktree. |
 | B4 | C2 Worker ↔ agent `Port` | length-framed structured I/O (`{:packet,4}`, `:exit_status`); launched with `env: ns`, `cd: ws`; linked into the worker (agent crash domain ⊆ worker crash domain). |
@@ -176,6 +179,17 @@ Format: `[Cn-Bm]` = constraint number + boundary. **★** marks non-obvious.
   formats and `IO`-scraping are forbidden (OTP non-negotiable; GAP-4). The
   per-worker namespace (`env: ns`) crosses into the `Port`'s subprocess so the
   sub-agent inherits isolation too.
+- **★ [C210b-B9]** **Normal completion is an explicit in-band event, not an exit
+  status (D-326).** When the agent finishes successfully it emits a
+  `work_ready(branch, head_sha)` frame over its `Port` *before* exiting; the
+  worker decodes it (the same `decode_event` path as C210-B4) and surfaces
+  `work_ready(worker_id, branch, head_sha)` to the owning Unit. Clean Port exit
+  (`:exit_status 0`) is **not** completion: a single exit bit cannot distinguish
+  "did the work, pushed a real diff" from "ran and pushed nothing" from "crashed
+  but happened to exit 0". The `branch`/`head_sha` payload is the **evidence** U
+  needs to confirm a non-empty diff before gating — without it the mutation gate
+  (D-306) degenerates on an empty diff into a false-green. The success event and
+  the death certificate are **disjoint**: `work_ready` ≠ `worker_exit`.
 - **[C211-B1]** A worker `:DOWN` crosses to the Unit FSM as `worker_exit(id,
   reason)` carrying the reason — an **outcome to decide**, never an instruction
   to auto-restart. A gate FAIL or bad LLM output is a *semantic* outcome (Unit
@@ -243,9 +257,26 @@ Format: `[Cn-Bm]` = constraint number + boundary. **★** marks non-obvious.
   `WorkerRegistry`. The Unit holds `worker_id`, never a pid.
 - `worker_exit(worker_id, reason)` is surfaced asynchronously (the
   death-certificate). It is an **outcome the Unit decides**, never an auto-restart.
+- `work_ready(worker_id, branch, head_sha)` is the **success** counterpart of
+  `worker_exit`, surfaced asynchronously when the agent reports a stable diff
+  (D-326). The two are **disjoint** worker-outcome events keyed by `worker_id`;
+  together with the watchdog's `worker_stalled(worker_id)` (B7) they form the
+  complete `worker_event` set the Unit FSM consumes. `work_ready` is the **only**
+  trigger of U's `implementing → gating` edge.
 - Invariant (**D-316, crash containment**): `crashes(w) → blast_radius(w) = {w}`
   — the `:temporary` supervisor issues the certificate without disturbing other
   workers or the coordinator. No `try/rescue`/`:exit`-catch crosses the boundary.
+- Invariant (**D-326, completion is an asserted in-band event**): a worker's
+  *normal completion* is signalled **only** by an in-band `work_ready` frame the
+  agent emits over its `Port` (B4) before exit; clean Port exit (`:exit_status
+  0`) is **never** by itself surfaced as completion. Formally, with
+  `wire(w) ∈ {work_ready(w,b,h), exit_status(w,n), —}` the agent's last frame
+  and exit:
+  `□( surfaces_work_ready(w) ⇒ ∃ b,h. wire-frame work_ready(w,b,h) was received )`
+  ∧ `□( exit_status(w,0) ∧ ¬received work_ready(w,_,_) ⇒ surfaces worker_exit(w,:no_work_product), NOT work_ready )`.
+  The `branch`/`head_sha` payload lets U confirm a non-empty diff before
+  `request_gate`; an exit-0-without-`work_ready` is a *no-op*, routed to the
+  Unit's retry ladder as a semantic non-completion, never gated.
 
 ### B2: Worker (C2) ↔ git checkout
 
@@ -284,8 +315,26 @@ Format: `[Cn-Bm]` = constraint number + boundary. **★** marks non-obvious.
 - Inbound frames decode to typed `%Tau.Provider.Event{}` / agent-event structs;
   `{:exit_status, n}` is the agent terminal signal. **No** stdout scraping, **no**
   ad-hoc event format.
-- Invariant (**D-316**): the agent's crash domain ⊆ the worker's crash domain — an
-  agent crash is contained to one worker, never the fleet, never the coordinator.
+- **Completion frame (D-326).** Among the decoded event types is a terminal
+  *work-product-ready* frame — modelled as a struct under the existing event
+  taxonomy (extend `Tau.Provider.Event`, mirroring the in-band
+  `%Tau.CodingAgent.Event.Done{}` already used by `Tau.Session`; **never** an
+  ad-hoc format). On decoding it the worker emits `work_ready(worker_id, branch,
+  head_sha)` to `report_to`. The worker forwarding this frame is the **only**
+  source of a U completion trigger; `{:exit_status, 0}` arriving with no prior
+  `work_ready` is surfaced as `worker_exit(worker_id, :no_work_product)`, not as
+  a success. This is the success counterpart of the `worker_exit` death
+  certificate (single-writer discipline: the worker is the sole forwarder of
+  `work_ready`, just as the independent monitor is the sole writer of
+  `worker_exit`).
+- **Ordering (the V1-load-bearing fact).** A single `Port`'s `{:data, _}` frames
+  and its `{:exit_status, n}` are delivered to the owning process **in order** —
+  the BEAM flushes all buffered Port output to the worker mailbox *before* the
+  `:exit_status` message. So a `work_ready` frame the agent writes before exit is
+  observed by the worker *before* the exit, making the `work_ready_seen?`
+  predicate well-defined at exit time. This holds **only within one Port**; it is
+  NOT a cross-process ordering claim (no wall-clock, no cross-worker order — the
+  ordering invariant is per-`worker_id`, V9-clean).
 
 ### B5: WorkspaceJanitor (C4) ↔ Worker (C2) — the `:DOWN` capture
 
@@ -442,6 +491,28 @@ untracked kind is conserved explicitly (a naïve `git diff` omits it). Enforced 
 kind, terminate it, and assert the join `committed ⊎ captured ⊎
 discarded_by_decision` covers every hunk with no remainder).
 
+**D-326 — Worker completion is an asserted in-band event, not an exit status
+(closes ARCH-GAP #460):**
+A worker's *normal completion* crosses to the owning Unit FSM **only** as
+`work_ready(worker_id, branch, head_sha)` — a typed frame the agent emits over
+its `Port` (extending `Tau.Provider.Event`, mirroring
+`%Tau.CodingAgent.Event.Done{}`) **before** it exits, decoded and forwarded by
+the worker. `work_ready`, `worker_exit` (death certificate), and `worker_stalled`
+(watchdog) are **disjoint** worker-outcome events, all keyed by `worker_id`; they
+constitute the complete `worker_event` set U consumes, and `work_ready` is the
+sole trigger of U's `implementing → gating` edge. Clean Port exit (`:exit_status
+0`) without a prior `work_ready` is surfaced as
+`worker_exit(worker_id, :no_work_product)` — a semantic non-completion routed to
+U's retry ladder, **never** gated. The `branch`/`head_sha` payload is the
+evidence U uses to confirm a non-empty diff before `request_gate` (without it the
+mutation gate D-306 degenerates on an empty diff into a false-green). Enforced by
+`worker_completion_event_test.exs`: (a) an agent that emits `work_ready` then
+exits 0 surfaces `work_ready(id, branch, head_sha)` to its Unit and drives
+`implementing → gating`; (b) an agent that exits 0 **without** emitting
+`work_ready` surfaces `worker_exit(id, :no_work_product)` and does **not** reach
+`gating`; (c) a `work_ready` from a superseded `worker_id` is discarded. The
+boundary is the **typed event**, never the exit code.
+
 ## 7. Acceptance criteria
 
 Each is expressed against the user-facing path with an observable signal. PR
@@ -496,13 +567,20 @@ groupings are indicative.
 - **AC-12 (meta):** the gating tests above run in CI as a blocking job under a
   per-worker `XDG_DATA_HOME` so the F-5 reproduction (AC-4) is itself isolated.
   *(meta — verified by CI wiring; exempt from the unit-test-linkage check.)*
+- **AC-13 (PR-FLEET / P5c-3, D-326):** `worker_completion_event_test.exs` passes —
+  an agent emitting `work_ready` then exiting 0 surfaces
+  `work_ready(worker_id, branch, head_sha)` to its Unit (driving
+  `implementing → gating`); an agent exiting 0 **without** `work_ready` surfaces
+  `worker_exit(worker_id, :no_work_product)` and does **not** reach `gating`; a
+  `work_ready` from a superseded `worker_id` is discarded. Signal: the Unit's
+  observable state after each case matches the disjoint-outcome table.
 
 ## Appendix B — Source map
 
 Files that bring a PR into scope of this SPEC (`D-NNN`/`C-N` → file:symbol):
 
 - `lib/tau/factory/worker_supervisor.ex` (C1; D-316, death-certificate) — PR-FLEET-1
-- `lib/tau/factory/worker.ex` (C2; D-309, D-310, D-311, D-316 + heartbeat emission) — PR-FLEET-1/2
+- `lib/tau/factory/worker.ex` (C2; D-309, D-310, D-311, D-316 + heartbeat emission; D-326 `work_ready` decode/forward in `handle_info({port,{:data,_}},…)`) — PR-FLEET-1/2; D-326 wiring is P5c-3
 - `lib/tau/factory/worker_registry.ex` (C3; key-not-pid identity) — PR-FLEET-1
 - `lib/tau/factory/worker/isolation.ex` (C5; D-309, D-311 — pure namespace/verify helpers) — PR-FLEET-2
 - `lib/tau/factory/workspace_janitor.ex` (C4; D-313, D-314, D-334 — `:DOWN` monitor) — PR-FLEET-3
@@ -517,6 +595,7 @@ Files that bring a PR into scope of this SPEC (`D-NNN`/`C-N` → file:symbol):
 - `test/tau/factory/worker_crash_containment_test.exs` (D-316) — PR-FLEET-4
 - `test/tau/factory/worker_no_shared_tree_test.exs` (D-310) — PR-FLEET-4
 - `test/tau/factory/worker_stalled_test.exs` (watchdog; feeds CORE D-317) — PR-FLEET-4
+- `test/tau/factory/worker_completion_event_test.exs` (D-326 — `work_ready` vs exit-0 no-op vs stale `worker_id`) — P5c-3
 - `test/tau/factory/oracle_spawn_order_test.exs` (D-304 mechanism, cited) — PR-FLEET-4
 
 **Cross-SPEC boundaries (cited, not owned here):** B1/B6/B7 → `SPEC-FACTORY-CORE`


### PR DESCRIPTION
## Design the worker→Unit completion ("work-product-ready") contract (ARCH-GAP #460)

Closes #460. Advances #458 (P5c) / #416 (M10). Unblocks **P5c-3** (the UnitDriver).

An architecture audit classified the 3 P5c glue gaps: two are implementation drift
from a coherent design; **this one is a true architecture gap.** `docs/arch/**`
specifies the worker's death/capture path (`worker_exit`) in full but **never
specifies a worker success / "work-product-ready" event** — U's input
`worker_event` is named but undefined; the FSM edge `implementing ──request_gate
(stable diff)──▶ gating` has no specified trigger. The code's `{:worker_done,
pid}` (Unit waits) vs `{:worker_exit, worker_id, reason}` (Worker emits) mismatch
has **no arch contract to conform to** — it must be DESIGNED, not adapted.

### Scope (design + docs only; no production code — that is P5c-3)
1. **Design** the worker→Unit completion contract via the solution-shaper +
   OTP-thinking discipline: the completion EVENT, what it is keyed by
   (`worker_id` + a monitorable handle), how it composes with the death
   certificate (`worker_exit`) so a Unit can distinguish "done" from "crashed,"
   and the load-bearing decision: **does the agent signal completion by clean
   Port exit (`:exit_status 0`) only, or an in-band message?** (The Worker
   currently IGNORES agent Port output.) Surface the discriminating question and
   its cost asymmetry.
2. **Amend `docs/arch/**`** — `03-system-architecture/system-architecture.md`
   (W `E_out` + U `E_in`/`worker_event`), `04-software-architecture/control-plane.md`
   (the `implementing → gating` trigger clause) — to define the event.
3. **Amend `docs/spec/SPEC-FACTORY-{FLEET,CORE}.md` §4** with the derived
   boundary contract, and allocate a NEW `D-NNN` (verify free across the repo)
   for the completion-event invariant.
4. **Cleanup:** fix the stale `control-plane.md:551` row that still describes
   U→M as a synchronous `GenServer.call` (superseded by `final-validation.md`
   H-1b's async PubSub merge-result contract — a separate, already-correct gap).

### SPECs
Amends **SPEC-FACTORY-FLEET** (worker→unit boundary) + **SPEC-FACTORY-CORE** (U
input contract). Design-level; the conforming production wiring is P5c-3.

### Acceptance criteria
- **AC (meta — design/spec amendment):** `docs/arch/**` and SPEC-FACTORY-{FLEET,
  CORE} §4 define the worker→Unit completion event (key, monitorable handle,
  composition with `worker_exit`, agent-signal mechanism) under a new verified-
  free `D-NNN`; the FSM `implementing → gating` trigger is specified; the stale
  `control-plane.md:551` sync-call row is corrected. No production code in this PR.

### Gate verdicts
_(filled at gate time — critic [shaper-armed], reviewer)_
