### PR TITLE
#462 — Durable merge-outcome Ledger row (RPO=0 at the merge boundary)

### DIFF
--- a/docs/spec/SPEC-FACTORY-CORE.md
+++ b/docs/spec/SPEC-FACTORY-CORE.md
@@ -301,7 +301,7 @@ Used exclusively by `Coordinator.init/1` to rebuild the in-flight set on
 resume (D-344). Terminal units (`:merged`/`:escalated`) appear in the map;
 the Coordinator filters them. Returns `%{}` when no snapshots exist.
 
-#### B3 — Unit `:ledger` start option (durable per-transition snapshotting, D-318 / P5c-1)
+#### B3 — Unit `:ledger` start option (durable per-transition snapshotting, D-318 / P5c-1; D-355 merge-outcome reconcile / PR #465)
 
 `Unit.start_link/1` accepts an optional `:ledger` key:
 
@@ -314,6 +314,20 @@ When `:ledger` is present and non-nil, the Unit calls
 state's external effect (WAL-before-ack, D-315). This makes the Unit's FSM
 state crash-durable and enables the Coordinator's D-344 resume to rehydrate
 **real** units (not only the injected test seam).
+
+**D-355 reconcile-on-entry amendment (PR #465):** additionally, when entering
+`:awaiting_merge`, the Unit reads `Ledger.Reader.merge_outcome_for(ledger, unit_id)`
+(routed via `Ledger.Writer`) **before** calling `merge_fun`:
+
+- `{:merged, sha}` → the merge already landed; transition immediately to terminal
+  `:merged` WITHOUT calling `merge_fun` (no double-submit, D-344).
+- `{:rejected, reason}` → the merge was rejected; route back to `:gating`
+  (re-gate, INV-2) WITHOUT calling `merge_fun`.
+- `:none` → no prior outcome; call `merge_fun` (current behaviour, unchanged).
+
+This composes with D-344: the Coordinator rehydrates the Unit at `:awaiting_merge`
+and the Unit reconciles on re-entry — exactly-once on resume. When `:ledger` is
+`nil` or absent, reconcile is a no-op (back-compat).
 
 The `idempotency_key` coordinate is `"<unit_id>:snapshot:<entry_seq>"` —
 per-entry-unique because `entry_seq` is a monotonic counter (initialised to 0
@@ -560,6 +574,14 @@ reachable admit→withdraw→re-admit cycle. Enforced by `conflict_check_propert
 resumes from L and continues; in-flight units rehydrate at their snapshotted
 state; no terminal work is re-done. Enforced by `coordinator_recovery_test.exs`
 (kill the Coordinator mid-drive; assert resume + idempotent rehydrate).
+
+*Amendment (PR #465 / D-355):* a Unit resuming at `:awaiting_merge` reconciles
+against the durable merge-outcome (via `Ledger.Reader.merge_outcome_for/2`) on
+re-entry **before** calling `merge_fun` — so a merge that already landed is
+never re-submitted on crash-resume. This closes the lone RPO=0 hole identified
+by PR #465 (the ephemeral-telemetry-only outcome path). D-355 (owned by
+SPEC-FACTORY-MERGE §6) is the invariant enforcing the write ordering; D-344
+consumes it to guarantee no double-submit on resume.
 
 ## 7. Acceptance criteria
 

--- a/docs/spec/SPEC-FACTORY-MERGE.md
+++ b/docs/spec/SPEC-FACTORY-MERGE.md
@@ -16,6 +16,12 @@ what makes the read sound), D-306 + D-303-health-via-Toolchain
 SPEC-FACTORY-GOV). Verdict store is L (SQLite/Exqlite, SPEC-FACTORY-CORE);
 `origin/main` mutation is via `git` subprocesses only.
 
+**Amendment (2026-06-12, PR #465):** Introduces D-355 (durable merge-outcome,
+RPO=0). Adds §4 B9 (M COMMIT → L merge-outcome write, WAL-before-ack, BEFORE
+telemetry projection). Updates §5 `:committing` exit description and §6 D-NNN
+block. Cited by SPEC-FACTORY-CORE §4 B3 (Unit `:awaiting_merge` reconcile-on-entry,
+D-344 amendment).
+
 ## 0. Why this spec exists
 
 M is the **crux** of the autonomous factory: it is the one component where the
@@ -301,6 +307,25 @@ Format: `[Cn-Bm]` = constraint number + boundary. **★** marks non-obvious.
   Spans also feed the `T_int` model the §sizing rule depends on — measurement is
   a binding input, not optional instrumentation.
 
+### B9: Merge Authority COMMIT (C1) ↔ Ledger merge-outcome write (*D-355, PR #465*)
+
+- `record_merge_outcome/2 :: (ledger, attrs) -> {:ok, ref}` — append-only row in
+  `merge_outcomes`; WAL-before-ack (D-315 / RPO=0). `attrs` carries `:unit_id`,
+  `:outcome` (`:merged`), `:commit_sha` (the landed tip), `:reason` (`nil` for
+  `:merged`), `:run`.
+- **Ordering constraint (D-355):** M appends the durable outcome row **BEFORE** the
+  ephemeral `telemetry(:merged, …)` projection fires. Telemetry/PubSub is a derived
+  projection of the durable row — not the primary decision record.
+- Pre: `cas_push` returned `:ok` (the ref advanced atomically).
+- Post: the outcome row is WAL-committed and readable via
+  `Ledger.Reader.merge_outcome_for/2` by the time any observer receives the
+  telemetry projection (WAL-before-ack: `GenServer.call` reply arrives only after
+  `step/2` returns).
+- Invariant (**D-355**, durable-merge-outcome): every landed merge is recorded in L
+  before its ephemeral projection fires; the outcome survives the producer's death
+  (RPO=0). Enforced by `merge_outcome_durability_test.exs` — oracle-separated gating
+  test; PR #465.
+
 ## 5. State enumeration
 
 ### Merge Authority (M) — `gen_statem`, `state_functions`
@@ -336,7 +361,7 @@ submitted(green) ─enqueue→ wait-queue (FIFO + aging by restale_count)
        assert_all_verdicts_live(train):
          {:revoked,u} → eject u, retry rest         (FC-4 — value-staleness)
          :all_pass    → cas_push(tip, base):
-            :ok        → COMMIT: broadcast :merged ∀ member; advance origin/main
+            :ok        → COMMIT: record_merge_outcome(L) WAL-before-ack (D-355); broadcast :merged ∀ member; advance origin/main
             :stale_ref → requeue all, rebase onto new head, re-gate  (FC-3 — TOCTOU)
   post-merge main re-check RED → E-RED-MAIN (global halt; main left red, named)
 ```
@@ -405,6 +430,18 @@ halts the loop with `main` red and named. Enforced by `merge_health_test.exs`: a
 red batch tip ⇒ bisect + eject, no push; a post-merge red main ⇒ `E-RED-MAIN` +
 no further push. (Health-recipe ownership cited from SPEC-FACTORY-GATE.)
 
+**D-355 — Durable merge outcome, WAL-before-ack (RPO=0):**
+Every successfully-landed merge is recorded in a durable, append-only
+`merge_outcomes` row in L (via `Ledger.Writer.record_merge_outcome/2`,
+WAL-before-ack, D-315) **before** the ephemeral `telemetry(:merged, …)`
+projection fires. The row survives the producer (MergeAuthority) dying — RPO=0.
+`Ledger.Reader.merge_outcome_for/2` returns `{:merged, commit_sha}` from this
+row, enabling U to reconcile on resume without re-submitting an already-landed
+merge (D-344 / PR #465). Owned by this SPEC (§4 B9); cited by
+SPEC-FACTORY-CORE (Unit `:awaiting_merge` reconcile, D-344 amendment).
+Enforced by `merge_outcome_durability_test.exs` (oracle-separated; the
+MergeAuthority/Unit gating test for PR #465).
+
 **D-341 — Fair merge progress, no starvation (LIV-2):**
 M serves merge-ready units from a **FIFO + aging** wait-queue;
 `effective_priority(seq, restale_count) = seq − aging_weight · restale_count` is
@@ -464,8 +501,14 @@ Each is expressed against an observable signal. PR groupings are indicative.
 
 Files that bring a PR into scope of this SPEC (`D-NNN`/`C-N` → file:symbol):
 
-- `lib/tau/factory/merge_authority.ex` (C1; D-300, D-301, D-302, D-303, D-341 —
-  the `gen_statem`, `:idle`/`:integrating`/`:committing`) — PR-MERGE-1..4
+- `lib/tau/factory/merge_authority.ex` (C1; D-300, D-301, D-302, D-303, D-341,
+  D-355 — the `gen_statem`, `:idle`/`:integrating`/`:committing`) — PR-MERGE-1..5/PR#465
+- `lib/tau/factory/ledger/migrations.ex` (D-355 migration `20260612_010_merge_outcomes`) — PR#465
+- `lib/tau/factory/ledger/writer.ex` (D-355 `record_merge_outcome/2`,
+  `merge_outcome_for/2`) — PR#465
+- `lib/tau/factory/ledger/reader.ex` (D-355 `merge_outcome_for/2` projection) — PR#465
+- `lib/tau/factory/unit.ex` (D-355/D-344 reconcile-on-entry in `:awaiting_merge`) — PR#465
+- `test/tau/factory/merge_outcome_durability_test.exs` (D-355/D-344 gating test) — PR#465
 - `lib/tau/factory/merge/train.ex` (C2; assemble/bisect, D-303 tip) — PR-MERGE-3
 - `lib/tau/factory/merge/cas.ex` (C3; `assert_all_verdicts_live` + `cas_push`,
   D-300, D-301) — PR-MERGE-2/3

--- a/lib/tau/factory/ledger/migrations.ex
+++ b/lib/tau/factory/ledger/migrations.ex
@@ -111,6 +111,21 @@ defmodule Tau.Factory.Ledger.Migrations do
      CREATE UNIQUE INDEX IF NOT EXISTS verdicts_v2_original_uidx
        ON verdicts_v2 (hash, run, half)
        WHERE supersedes_id IS NULL
+     """},
+    # PR #465 (D-355): Durable merge-outcome row. Append-only; no UPDATE/DELETE.
+    # WAL-before-ack (D-315): the Writer replies only after step/2 (WAL commit)
+    # returns. outcome CHECK restricts to the two valid terminal outcomes.
+    {"20260612_010_merge_outcomes",
+     """
+     CREATE TABLE IF NOT EXISTS merge_outcomes (
+       id          INTEGER PRIMARY KEY AUTOINCREMENT,
+       unit_id     TEXT    NOT NULL,
+       outcome     TEXT    NOT NULL CHECK (outcome IN ('merged', 'rejected')),
+       commit_sha  TEXT,
+       reason      TEXT,
+       run         TEXT    NOT NULL,
+       inserted_at TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+     )
      """}
   ]
 

--- a/lib/tau/factory/ledger/reader.ex
+++ b/lib/tau/factory/ledger/reader.ex
@@ -12,6 +12,9 @@ defmodule Tau.Factory.Ledger.Reader do
     `unit_id` (highest row id wins) across the whole ledger. Used by
     `Tau.Factory.Coordinator.init/1` to resume from the durable Ledger after a
     crash (D-344, D-315 / RPO=0).
+  - `merge_outcome_for/2` — return the latest durable merge outcome for a unit
+    (D-355 / RPO=0). Used by `Tau.Factory.Unit` at `:awaiting_merge` entry to
+    reconcile without re-submitting an already-landed merge (D-344).
 
   ## Why reads go through the Writer process
 
@@ -21,6 +24,8 @@ defmodule Tau.Factory.Ledger.Reader do
   reads are rare (once per Coordinator restart) the marginal cost of routing
   through the Writer's mailbox is negligible, and the design stays simple.
   """
+
+  alias Tau.Factory.Ledger.Writer
 
   @doc """
   Return the latest snapshotted Unit FSM state per `unit_id`.
@@ -36,5 +41,22 @@ defmodule Tau.Factory.Ledger.Reader do
   @spec latest_unit_snapshots(GenServer.server()) :: %{String.t() => atom()}
   def latest_unit_snapshots(server) do
     GenServer.call(server, :latest_unit_snapshots)
+  end
+
+  @doc """
+  Return the latest durable merge outcome for `unit_id` (D-355 / RPO=0).
+
+  Used by `Tau.Factory.Unit` at `:awaiting_merge` on-entry to reconcile against
+  the Ledger before re-calling `merge_fun` (D-344 — re-does no terminal work).
+
+  Returns:
+    - `{:merged, commit_sha}` — the unit was merged; `commit_sha` is the tip.
+    - `{:rejected, reason}` — the unit's merge was rejected.
+    - `:none` — no outcome row exists (fresh; proceed with `merge_fun`).
+  """
+  @spec merge_outcome_for(GenServer.server(), String.t()) ::
+          {:merged, String.t()} | {:rejected, term()} | :none
+  def merge_outcome_for(server, unit_id) do
+    Writer.merge_outcome_for(server, unit_id)
   end
 end

--- a/lib/tau/factory/ledger/writer.ex
+++ b/lib/tau/factory/ledger/writer.ex
@@ -196,6 +196,54 @@ defmodule Tau.Factory.Ledger.Writer do
     GenServer.call(server, {:captures_for, worker_id})
   end
 
+  @type merge_outcome_attrs :: %{
+          unit_id: String.t(),
+          outcome: :merged | :rejected,
+          commit_sha: String.t() | nil,
+          reason: term() | nil,
+          run: String.t()
+        }
+
+  @doc """
+  Append a durable merge-outcome row for `unit_id`.
+
+  Append-only — no UPDATE/DELETE path (D-355). WAL-before-ack (D-315): the
+  `{:ok, ref}` reply arrives only after the SQLite WAL commit is durable, so
+  the caller's ack is strictly ordered after the write's visibility.
+
+  `attrs` fields:
+    - `:unit_id`    — `String.t()`; the unit's `:id`.
+    - `:outcome`    — `:merged | :rejected`.
+    - `:commit_sha` — `String.t() | nil`; the merged tip for `:merged`; `nil`
+                      for `:rejected`.
+    - `:reason`     — `term() | nil`; the reject reason for `:rejected`; `nil`
+                      for `:merged`.
+    - `:run`        — `String.t()`; the unit's run id.
+
+  Returns `{:ok, ref}` where `ref` is the inserted row id.
+  """
+  @spec record_merge_outcome(GenServer.server(), merge_outcome_attrs()) :: {:ok, ref()}
+  def record_merge_outcome(server, attrs) do
+    GenServer.call(server, {:record_merge_outcome, attrs})
+  end
+
+  @doc """
+  Return the latest merge outcome for `unit_id`.
+
+  Reads from `merge_outcomes` (PR #465, D-355). Rows are append-only; the
+  latest outcome is the row with the highest `id` for the given `unit_id`.
+
+  Returns:
+    - `{:merged, commit_sha}` — the unit was merged; `commit_sha` is the tip.
+    - `{:rejected, reason}` — the unit's merge was rejected.
+    - `:none` — no outcome row exists for this `unit_id`.
+  """
+  @spec merge_outcome_for(GenServer.server(), String.t()) ::
+          {:merged, String.t()} | {:rejected, term()} | :none
+  def merge_outcome_for(server, unit_id) do
+    GenServer.call(server, {:merge_outcome_for, unit_id})
+  end
+
   # ---------------------------------------------------------------------------
   # GenServer callbacks
   # ---------------------------------------------------------------------------
@@ -259,6 +307,16 @@ defmodule Tau.Factory.Ledger.Writer do
 
   def handle_call({:captures_for, worker_id}, _from, %{db: db} = state) do
     result = do_captures_for(db, worker_id)
+    {:reply, result, state}
+  end
+
+  def handle_call({:record_merge_outcome, attrs}, _from, %{db: db} = state) do
+    result = do_record_merge_outcome(db, attrs)
+    {:reply, result, state}
+  end
+
+  def handle_call({:merge_outcome_for, unit_id}, _from, %{db: db} = state) do
+    result = do_merge_outcome_for(db, unit_id)
     {:reply, result, state}
   end
 
@@ -623,6 +681,80 @@ defmodule Tau.Factory.Ledger.Writer do
       _ -> []
     end
   end
+
+  # Insert an append-only merge-outcome row. No UPDATE/DELETE path (D-355).
+  # WAL-before-ack: reply sent only after step/2 (WAL commit) returns (D-315).
+  # reason is serialised via inspect/1 so arbitrary terms are stored as text.
+  defp do_record_merge_outcome(db, %{
+         unit_id: unit_id,
+         outcome: outcome,
+         commit_sha: commit_sha,
+         reason: reason,
+         run: run
+       }) do
+    outcome_text = atom_to_outcome(outcome)
+    reason_text = if reason == nil, do: nil, else: inspect(reason)
+
+    sql = """
+    INSERT INTO merge_outcomes (unit_id, outcome, commit_sha, reason, run)
+    VALUES (?1, ?2, ?3, ?4, ?5)
+    """
+
+    with {:ok, stmt} <- Exqlite.Sqlite3.prepare(db, String.trim(sql)),
+         :ok <- Exqlite.Sqlite3.bind(stmt, [unit_id, outcome_text, commit_sha, reason_text, run]),
+         step_result <- Exqlite.Sqlite3.step(db, stmt),
+         :ok <- Exqlite.Sqlite3.release(db, stmt) do
+      case step_result do
+        :done -> {:ok, fetch_last_rowid(db)}
+        {:error, reason_err} -> {:error, reason_err}
+      end
+    end
+  end
+
+  # Return the latest merge outcome for unit_id (highest id row).
+  # Returns {:merged, commit_sha} | {:rejected, reason_term} | :none.
+  # reason is stored as inspect/1 text; we return it as-is (a string) since
+  # the test checks against the originally-stored term shape.
+  defp do_merge_outcome_for(db, unit_id) do
+    sql = """
+    SELECT outcome, commit_sha, reason
+    FROM merge_outcomes
+    WHERE unit_id = ?1
+    ORDER BY id DESC
+    LIMIT 1
+    """
+
+    with {:ok, stmt} <- Exqlite.Sqlite3.prepare(db, String.trim(sql)),
+         :ok <- Exqlite.Sqlite3.bind(stmt, [unit_id]),
+         {:ok, rows} <- Exqlite.Sqlite3.fetch_all(db, stmt),
+         :ok <- Exqlite.Sqlite3.release(db, stmt) do
+      case rows do
+        [["merged", commit_sha, _reason]] ->
+          {:merged, commit_sha}
+
+        [["rejected", _commit_sha, reason_text]] ->
+          {:rejected, parse_reason(reason_text)}
+
+        [] ->
+          :none
+      end
+    end
+  end
+
+  # Parse a stored reason: try Code.eval_string for simple atoms/terms,
+  # fall back to the raw string on any error.
+  defp parse_reason(nil), do: nil
+
+  defp parse_reason(text) do
+    case Code.eval_string(text) do
+      {term, _} -> term
+    end
+  rescue
+    _ -> text
+  end
+
+  defp atom_to_outcome(:merged), do: "merged"
+  defp atom_to_outcome(:rejected), do: "rejected"
 
   defp atom_to_half(:critic), do: "critic"
   defp atom_to_half(:reviewer), do: "reviewer"

--- a/lib/tau/factory/merge_authority.ex
+++ b/lib/tau/factory/merge_authority.ex
@@ -18,6 +18,7 @@ defmodule Tau.Factory.MergeAuthority do
 
   @behaviour :gen_statem
 
+  alias Tau.Factory.Ledger.Writer, as: LedgerWriter
   alias Tau.Factory.Merge.Cas
   alias Tau.Factory.Merge.Health
 
@@ -261,6 +262,21 @@ defmodule Tau.Factory.MergeAuthority do
         case cas.cas_push(repo_dir, tip, base) do
           :ok ->
             Logger.info("[MergeAuthority] merged tip #{tip}")
+
+            # D-355 / WAL-before-ack: write the durable merge-outcome row BEFORE
+            # the ephemeral telemetry projection fires. Telemetry/PubSub becomes a
+            # derived projection of the durable row. reply arrives only after the
+            # WAL commit is durable (D-315, RPO=0).
+            Enum.each(units, fn unit ->
+              LedgerWriter.record_merge_outcome(ledger, %{
+                unit_id: unit.id,
+                outcome: :merged,
+                commit_sha: tip,
+                reason: nil,
+                run: unit.run
+              })
+            end)
+
             telemetry(:merged, %{hash: hd_hash(units)}, %{tip: tip, units: units})
             transition_from_idle(data)
 

--- a/lib/tau/factory/unit.ex
+++ b/lib/tau/factory/unit.ex
@@ -49,6 +49,7 @@ defmodule Tau.Factory.Unit do
 
   @behaviour :gen_statem
 
+  alias Tau.Factory.Ledger.Reader, as: LedgerReader
   alias Tau.Factory.Ledger.Writer, as: LedgerWriter
   alias Tau.Factory.Retry
   alias Tau.Factory.Scheduler
@@ -365,9 +366,26 @@ defmodule Tau.Factory.Unit do
 
   def awaiting_merge(:internal, :on_enter, data) do
     data = snapshot_state(:awaiting_merge, data)
-    _result = data.merge_fun.(data.unit_id, data.hash)
-    timeout_ms = data.state_timeout_ms
-    {:keep_state, data, [{:state_timeout, timeout_ms, :merge_stalled}]}
+
+    # D-355 / D-344 — Reconcile-on-entry: before calling merge_fun, check the
+    # durable Ledger for an already-decided outcome. This prevents re-doing
+    # terminal work after a crash-resume (D-344 "re-does no terminal work"):
+    #   :merged   → already landed; transition to terminal :merged immediately.
+    #   :rejected → was rejected (INV-2); re-gate without re-calling merge_fun.
+    #   :none     → no prior outcome; proceed with the normal merge_fun call.
+    case reconcile_merge_outcome(data) do
+      {:merged, _commit_sha} ->
+        terminal(data, :merged, nil, nil)
+
+      {:rejected, _reason} ->
+        # INV-2: re-gate on rejection (same as receiving {:merge_result, :rejected}).
+        {:next_state, :gating, data, [{:next_event, :internal, :on_enter}]}
+
+      :none ->
+        _result = data.merge_fun.(data.unit_id, data.hash)
+        timeout_ms = data.state_timeout_ms
+        {:keep_state, data, [{:state_timeout, timeout_ms, :merge_stalled}]}
+    end
   end
 
   def awaiting_merge(:info, {:merge_result, :merged}, data) do
@@ -482,6 +500,18 @@ defmodule Tau.Factory.Unit do
     })
 
     %{data | entry_seq: seq + 1}
+  end
+
+  # D-355 / D-344 — read the durable merge outcome from the Ledger.
+  # Returns {:merged, sha} | {:rejected, reason} | :none.
+  # When ledger is nil (snapshot disabled), always returns :none so the
+  # existing merge_fun path is taken unchanged (back-compat).
+  @spec reconcile_merge_outcome(map()) ::
+          {:merged, String.t()} | {:rejected, term()} | :none
+  defp reconcile_merge_outcome(%{ledger: nil}), do: :none
+
+  defp reconcile_merge_outcome(%{ledger: ledger, unit_id: unit_id}) do
+    LedgerReader.merge_outcome_for(ledger, unit_id)
   end
 
   # Drop a spurious internal on_enter if it arrives in a terminal state,

--- a/test/tau/factory/merge_outcome_durability_test.exs
+++ b/test/tau/factory/merge_outcome_durability_test.exs
@@ -1,0 +1,522 @@
+defmodule Tau.Factory.MergeOutcomeDurabilityTest do
+  @moduledoc """
+  Gating test for PR #465 (#462 — the durable merge-outcome Ledger row, RPO=0 at
+  the merge boundary).
+
+  ## What this enforces
+
+  Today the merge outcome (`:merged` / `:rejected`) is carried SOLELY by
+  ephemeral telemetry (`lib/tau/factory/merge_authority.ex` ~line 264 —
+  `telemetry(:merged, ...)`). It is the only terminal-deciding control-loop fact
+  NOT in the durable Ledger — the lone hole in RPO=0 / D-315. The crash window:
+  a Unit resuming at `:awaiting_merge` (D-344) UNCONDITIONALLY re-calls
+  `merge_fun` (`unit.ex` `awaiting_merge(:internal, :on_enter, ...)`), so a merge
+  that already LANDED is re-submitted on crash-resume — re-doing terminal work
+  (`--force-with-lease` protects the ref, not the per-unit outcome under train
+  batching) and able to escalate an already-merged PR as `E_MERGE_STALLED`.
+
+  The fix this test pins:
+
+    1. The MergeAuthority appends a DURABLE, append-only `merge_outcomes` row
+       (`Ledger.Writer.record_merge_outcome/2`) WAL-before-ack, and does so
+       BEFORE the ephemeral telemetry projection fires. Telemetry/PubSub becomes
+       a derived projection of the durable row.
+    2. The outcome is readable via `Ledger.Reader.merge_outcome_for/2` and
+       survives the producer (MergeAuthority) process dying — read from a
+       SEPARATELY-supervised Ledger (RPO=0 / D-315).
+    3. Reconcile-on-resume (load-bearing): a Unit resuming at `:awaiting_merge`
+       for a unit whose `:merged` outcome is ALREADY in L MUST NOT re-call
+       `merge_fun` (no double-submit, D-344 "re-does no terminal work"). A
+       `:rejected` outcome routes to re-gate, NOT re-merge (INV-2).
+
+  ## Pinned contract (the implementer MUST conform; SPEC §4/§6 amendment lands
+  in this PR)
+
+    - `Ledger.Writer.record_merge_outcome(ledger, attrs)` — append-only, no
+      UPDATE/DELETE. WAL-before-ack (D-315). `attrs` fields:
+        * `:unit_id`    — `String.t()`; the unit's `:id`.
+        * `:outcome`    — `:merged | :rejected`.
+        * `:commit_sha` — `String.t() | nil`; present (the merged tip) for
+                          `:merged`, `nil` for `:rejected`.
+        * `:reason`     — `term() | nil`; the reject reason for `:rejected`,
+                          `nil` for `:merged`.
+        * `:run`        — `String.t()`; the unit's run id.
+      Returns `{:ok, ref}`.
+    - `Ledger.Reader.merge_outcome_for(ledger, unit_id)` — the LATEST outcome
+      for `unit_id`, or `:none`. Shape:
+        * `{:merged, commit_sha}` for a merged unit;
+        * `{:rejected, reason}` for a rejected unit;
+        * `:none` when no outcome row exists.
+    - `Tau.Factory.Unit` at `:awaiting_merge` on entry reconciles against the
+      durable outcome via the unit's existing `:ledger` opt before calling
+      `merge_fun`: if a `:merged` outcome is present it does NOT call `merge_fun`
+      (idempotent resume → terminal :merged); if a `:rejected` outcome is present
+      it routes to `:gating` (re-gate); only with `:none` does it call
+      `merge_fun`.
+
+  ## Fail-before validity (oracle separation, factory-loop §4b)
+
+  On THIS branch (no implementer yet) `Ledger.Writer.record_merge_outcome/2` and
+  `Ledger.Reader.merge_outcome_for/2` do NOT exist, and the MergeAuthority writes
+  no outcome row; the Unit's `:awaiting_merge` entry unconditionally calls
+  `merge_fun`. Every assertion below therefore FAILS (UndefinedFunctionError on
+  the new ops; the no-double-submit assertion fails because the current Unit
+  always re-submits). A test that passed against the current code would be
+  vacuous.
+
+  D-NNN linkage: this PR allocates a NEW invariant id (durable merge outcome) in
+  its SPEC §4/§6 amendment. Until that id is pinned, the new-invariant tag is the
+  descriptive placeholder `:merge_outcome_durable`; the apt established tags
+  `:d_315` (RPO=0 / WAL-before-ack) and `:d_344` (resume reconcile) also apply.
+  """
+
+  use ExUnit.Case, async: false
+
+  alias Tau.Factory.Ledger.Reader, as: LedgerReader
+  alias Tau.Factory.Ledger.Writer, as: LedgerWriter
+  alias Tau.Factory.MergeAuthority
+
+  @moduletag :capture_log
+  @moduletag :merge_outcome_durable
+  @moduletag :d_315
+  @moduletag :d_344
+
+  @unit_supervisor Tau.Factory.UnitSupervisor
+  @scheduler Tau.Factory.Scheduler
+
+  # ---------------------------------------------------------------------------
+  # Injected CAS seam — drives a MergeAuthority merge to completion WITHOUT real
+  # git. The MergeAuthority accepts a `:cas` module (default Tau.Factory.Merge.Cas).
+  # This stub returns :all_pass (verdicts live) and :ok (push lands), so the
+  # :committing state reaches the :merged branch deterministically.
+  # ---------------------------------------------------------------------------
+
+  defmodule PassingCas do
+    @moduledoc false
+    def assert_all_verdicts_live(_ledger, _units, _required_halves), do: :all_pass
+    def cas_push(_repo_dir, _tip, _base), do: :ok
+  end
+
+  # ---------------------------------------------------------------------------
+  # Helpers
+  # ---------------------------------------------------------------------------
+
+  defp unique(base), do: :"#{base}_#{System.unique_integer([:positive])}"
+
+  # Start a REAL, SEPARATELY-supervised Ledger.Writer against an isolated temp DB
+  # (the durable store outlives any producer that writes to it). Returns its name.
+  defp start_ledger do
+    db_path = Briefly.create!(extname: ".db")
+    writer_name = unique(:merge_outcome_ledger)
+
+    start_supervised!(
+      {LedgerWriter, db_path: db_path, name: writer_name},
+      id: writer_name
+    )
+
+    writer_name
+  end
+
+  # build_fun that returns a built train immediately, carrying the REAL committed
+  # `tip` so the durable outcome's commit_sha is a real oid. `base` is the real
+  # origin/main oid M captured (start_build runs `git rev-parse origin/main`).
+  defp built_build_fun(tip) do
+    fn units, base -> {:built, units, base, tip} end
+  end
+
+  # Set up a real git topology so MergeAuthority.start_build's `fetch_main_oid`
+  # (git fetch + rev-parse origin/main) succeeds. Mirrors the idiom in
+  # merge_serialized_test.exs / merge_force_with_lease_test.exs. Returns the work
+  # dir path and the unit branch tip oid (a real commit sha).
+  defp setup_git_repo(unit) do
+    tmp_dir = Briefly.create!(type: :directory)
+    work_path = Path.join(tmp_dir, "work")
+    origin_path = Path.join(tmp_dir, "origin.git")
+
+    {_, 0} = System.cmd("git", ["init", "-b", "main", work_path])
+    git_work = fn args -> System.cmd("git", args, cd: work_path) end
+    git_work.(["config", "user.email", "test@tau.test"])
+    git_work.(["config", "user.name", "Tau Test"])
+
+    File.write!(Path.join(work_path, "README"), "initial")
+    git_work.(["add", "README"])
+    {_, 0} = git_work.(["commit", "-m", "initial commit"])
+
+    {_, 0} = System.cmd("git", ["init", "--bare", origin_path])
+    {_, 0} = System.cmd("git", ["symbolic-ref", "HEAD", "refs/heads/main"], cd: origin_path)
+    {_, 0} = git_work.(["remote", "add", "origin", origin_path])
+    {_, 0} = git_work.(["push", "-u", "origin", "main"])
+
+    feature_name = String.replace(unit.branch, "/", "_")
+    {_, 0} = git_work.(["checkout", "-b", unit.branch])
+    File.write!(Path.join(work_path, "feature_#{feature_name}"), "feature work")
+    {_, 0} = git_work.(["add", "."])
+    {_, 0} = git_work.(["commit", "-m", "feature commit for #{unit.branch}"])
+    {tip, 0} = git_work.(["rev-parse", "HEAD"])
+    tip = String.trim(tip)
+    {_, 0} = git_work.(["push", "origin", unit.branch])
+    {_, 0} = git_work.(["checkout", "main"])
+
+    {work_path, tip}
+  end
+
+  # Start a MergeAuthority with the injected build_fun + PassingCas seam against a
+  # real git work dir.
+  defp start_merge_authority(ledger, repo_dir, build_fun) do
+    ma_name = unique(:merge_outcome_ma)
+    tasks_name = unique(:merge_outcome_tasks)
+
+    start_supervised!(
+      {MergeAuthority,
+       name: ma_name,
+       ledger: ledger,
+       repo_dir: repo_dir,
+       required_halves: [:critic, :reviewer],
+       tasks_name: tasks_name,
+       cas: PassingCas,
+       build_fun: build_fun},
+      id: ma_name
+    )
+
+    ma_name
+  end
+
+  defp empty_scope do
+    %{
+      deps: [],
+      files: MapSet.new(),
+      codepoints: MapSet.new(),
+      specs: MapSet.new(),
+      resources: MapSet.new()
+    }
+  end
+
+  defp start_scheduler(name) do
+    start_supervised!({@scheduler, name: name, w_cap: 10}, id: name)
+  end
+
+  defp spawn_worker do
+    spawn(fn ->
+      receive do
+        :stop -> :ok
+      end
+    end)
+  end
+
+  # ---------------------------------------------------------------------------
+  # ORACLE 1 — Durable outcome, WAL-before-ack ordering.
+  #
+  # Drive a real MergeAuthority to complete a merge for a unit; assert the merge
+  # outcome is in L (Ledger.Reader.merge_outcome_for/2 returns {:merged, tip}),
+  # and that the durable row is already present when the telemetry projection
+  # fires (WAL-before-ack: durable BEFORE the ephemeral projection).
+  # ---------------------------------------------------------------------------
+
+  describe "merge_outcome_durable / d_315 — outcome is a durable Ledger row written WAL-before-ack" do
+    @tag :merge_outcome_durable
+    @tag :d_315
+    test "merge_outcome_durable/d_315: a completed merge records {:merged, commit_sha} in L, durable before the telemetry projection" do
+      ledger = start_ledger()
+      test_pid = self()
+
+      unit = %{
+        id: "u-merged-#{System.unique_integer([:positive])}",
+        hash: "hash-#{System.unique_integer([:positive])}",
+        run: "run-#{System.unique_integer([:positive])}",
+        branch: "feat/merge-outcome-durable-#{System.unique_integer([:positive])}"
+      }
+
+      {work_path, tip} = setup_git_repo(unit)
+      ma = start_merge_authority(ledger, work_path, built_build_fun(tip))
+
+      # Attach a telemetry handler on the :merged projection. WAL-before-ack means
+      # the durable row MUST already be readable from L at the instant the
+      # ephemeral telemetry projection fires. The handler only SIGNALS the firing;
+      # the durable read is done in the test body so a missing read op surfaces as
+      # a clean UndefinedFunctionError, not a detached-handler timeout.
+      handler_id = "merge-outcome-durable-#{System.unique_integer([:positive])}"
+
+      :telemetry.attach(
+        handler_id,
+        [:tau, :factory, :merge, :merged],
+        fn _event, _measurements, _metadata, _config -> send(test_pid, :merged_fired) end,
+        nil
+      )
+
+      on_exit(fn -> :telemetry.detach(handler_id) end)
+
+      assert :queued = MergeAuthority.request_merge(ma, unit)
+
+      # The merge runs off M's mailbox; allow it to reach :committing → :merged.
+      assert_receive :merged_fired,
+                     5_000,
+                     "merge_outcome_durable/d_315: the :merged telemetry projection never fired"
+
+      # WAL-before-ack: the durable write happens BEFORE the synchronous
+      # telemetry projection (`telemetry(:merged, ...)` at merge_authority.ex:264
+      # runs after the durable append returns). Because telemetry is dispatched
+      # synchronously inside the M process, by the time we observe :merged_fired
+      # the durable row is already WAL-committed and therefore readable. A :none
+      # here means the producer emitted the telemetry BEFORE the durable write
+      # (ordering violation) — or never wrote the durable row at all.
+      assert {:merged, ^tip} = LedgerReader.merge_outcome_for(ledger, unit.id),
+             "merge_outcome_durable/d_315: the durable merge-outcome row MUST be present " <>
+               "in L (and equal {:merged, #{inspect(tip)}}) by the time the telemetry " <>
+               "projection fires (WAL-before-ack, D-315). merge_outcome_for/2 returned " <>
+               "#{inspect(LedgerReader.merge_outcome_for(ledger, unit.id))} — the outcome is " <>
+               "still ephemeral-only."
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # ORACLE 2 — Survives a producer crash (RPO=0).
+  #
+  # Read the outcome from the SEPARATELY-supervised Ledger AFTER the
+  # MergeAuthority (the producer) process is killed. The durable row must still
+  # be there — the merge outcome's RPO is 0.
+  # ---------------------------------------------------------------------------
+
+  describe "merge_outcome_durable / d_315 — the outcome survives a producer crash (RPO=0)" do
+    @tag :merge_outcome_durable
+    @tag :d_315
+    test "merge_outcome_durable/d_315: after the MergeAuthority dies, the merged outcome is still in L" do
+      ledger = start_ledger()
+      test_pid = self()
+
+      unit = %{
+        id: "u-crash-#{System.unique_integer([:positive])}",
+        hash: "hash-crash-#{System.unique_integer([:positive])}",
+        run: "run-crash-#{System.unique_integer([:positive])}",
+        branch: "feat/merge-outcome-crash-#{System.unique_integer([:positive])}"
+      }
+
+      {work_path, tip} = setup_git_repo(unit)
+      ma = start_merge_authority(ledger, work_path, built_build_fun(tip))
+
+      handler_id = "merge-outcome-crash-#{System.unique_integer([:positive])}"
+
+      :telemetry.attach(
+        handler_id,
+        [:tau, :factory, :merge, :merged],
+        fn _event, _measurements, _metadata, _config -> send(test_pid, :merged_fired) end,
+        nil
+      )
+
+      on_exit(fn -> :telemetry.detach(handler_id) end)
+
+      assert :queued = MergeAuthority.request_merge(ma, unit)
+      assert_receive :merged_fired, 5_000, "the merge never completed"
+
+      # KILL the producer (MergeAuthority). The durably-supervised Ledger is a
+      # different process and is unaffected.
+      ma_pid = Process.whereis(ma)
+      assert is_pid(ma_pid)
+      Process.exit(ma_pid, :kill)
+
+      # The outcome MUST still be readable from L after the producer is gone (RPO=0).
+      assert {:merged, ^tip} = LedgerReader.merge_outcome_for(ledger, unit.id),
+             "merge_outcome_durable/d_315 (RPO=0): the merge outcome must survive the " <>
+               "producer's death. After killing the MergeAuthority, " <>
+               "merge_outcome_for/2 returned " <>
+               "#{inspect(LedgerReader.merge_outcome_for(ledger, unit.id))} — a non-merged " <>
+               "result means the outcome was ephemeral (lost with the producer), not durable."
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # ORACLE 3 — Reconcile-on-resume: no double-submit (the load-bearing crux).
+  #
+  # A Unit resuming at :awaiting_merge for a unit whose :merged outcome is ALREADY
+  # in L MUST NOT re-call merge_fun. We seed the durable :merged outcome directly
+  # in L, then start a REAL Unit (via UnitSupervisor.start_unit) wired with the
+  # :ledger opt and a merge_fun that RECORDS every call into an external Agent.
+  # The Unit is driven to :awaiting_merge; on entry it must reconcile against the
+  # durable outcome and reach :merged WITHOUT the already-decided unit's id ever
+  # appearing in the recorded merge_fun calls.
+  # ---------------------------------------------------------------------------
+
+  describe "merge_outcome_durable / d_344 — reconcile-on-resume does not re-submit an already-landed merge" do
+    @tag :merge_outcome_durable
+    @tag :d_344
+    test "merge_outcome_durable/d_344: a Unit reaching :awaiting_merge with a recorded :merged outcome does NOT call merge_fun" do
+      ledger = start_ledger()
+      test_pid = self()
+
+      tip = "tip-resume-#{System.unique_integer([:positive])}"
+      unit_id = "u-resume-merged-#{System.unique_integer([:positive])}"
+      run = "run-resume-#{System.unique_integer([:positive])}"
+
+      sched = unique(:sched_resume_merged)
+      sup = unique(:sup_resume_merged)
+      start_scheduler(sched)
+      start_supervised!({@unit_supervisor, name: sup}, id: sup)
+
+      # Seed the DURABLE :merged outcome BEFORE the Unit reaches :awaiting_merge —
+      # this models a merge that already landed prior to the (resumed) Unit.
+      {:ok, _} =
+        LedgerWriter.record_merge_outcome(ledger, %{
+          unit_id: unit_id,
+          outcome: :merged,
+          commit_sha: tip,
+          reason: nil,
+          run: run
+        })
+
+      # Sanity: the durable outcome is readable.
+      assert {:merged, ^tip} = LedgerReader.merge_outcome_for(ledger, unit_id)
+
+      # merge_fun records the unit_id of every call into an external Agent. The
+      # already-decided unit MUST NOT appear.
+      {:ok, calls} = Agent.start_link(fn -> [] end)
+      on_exit(fn -> if Process.alive?(calls), do: Agent.stop(calls) end)
+
+      merge_fun = fn uid, _hash ->
+        Agent.update(calls, fn acc -> [uid | acc] end)
+        :queued
+      end
+
+      opts = [
+        unit_id: unit_id,
+        declared_scope: empty_scope(),
+        hash: "hash-#{unit_id}",
+        scheduler: sched,
+        report_to: test_pid,
+        ledger: ledger,
+        worker_fun: fn _role -> {:ok, spawn_worker()} end,
+        gate_fun: fn -> :pass end,
+        merge_fun: merge_fun,
+        timeouts: [state_timeout_ms: 5_000]
+      ]
+
+      unit_pid = @unit_supervisor.start_unit(sup, opts)
+      assert is_pid(unit_pid)
+
+      # Drive oracle → implementing → gating(:pass) → awaiting_merge.
+      drive_to_awaiting_merge(unit_pid)
+
+      # On entering :awaiting_merge, the Unit reconciles against the durable
+      # :merged outcome and reaches :merged WITHOUT re-submitting.
+      assert_receive {:unit_terminal, ^unit_id, :merged, _provenance},
+                     5_000,
+                     "merge_outcome_durable/d_344: a Unit whose :merged outcome is already " <>
+                       "durable in L must reconcile to :merged on :awaiting_merge entry"
+
+      :timer.sleep(50)
+      recorded = Agent.get(calls, & &1)
+
+      refute unit_id in recorded,
+             "merge_outcome_durable/d_344: the Unit re-called merge_fun for a unit whose " <>
+               ":merged outcome was ALREADY durable in L (double-submit). Recorded merge_fun " <>
+               "calls: #{inspect(recorded)}. The :awaiting_merge entry MUST reconcile against " <>
+               "merge_outcome_for/2 and skip the re-submit (D-344 — re-does no terminal work)."
+    end
+
+    @tag :merge_outcome_durable
+    @tag :d_344
+    test "merge_outcome_durable/d_344: a Unit reaching :awaiting_merge with a recorded :rejected outcome routes to re-gate, not re-merge" do
+      ledger = start_ledger()
+      test_pid = self()
+
+      unit_id = "u-resume-rejected-#{System.unique_integer([:positive])}"
+      run = "run-resume-rej-#{System.unique_integer([:positive])}"
+
+      sched = unique(:sched_resume_rejected)
+      sup = unique(:sup_resume_rejected)
+      start_scheduler(sched)
+      start_supervised!({@unit_supervisor, name: sup}, id: sup)
+
+      # Seed a DURABLE :rejected outcome.
+      {:ok, _} =
+        LedgerWriter.record_merge_outcome(ledger, %{
+          unit_id: unit_id,
+          outcome: :rejected,
+          commit_sha: nil,
+          reason: :stale_ref,
+          run: run
+        })
+
+      assert {:rejected, :stale_ref} = LedgerReader.merge_outcome_for(ledger, unit_id)
+
+      {:ok, calls} = Agent.start_link(fn -> [] end)
+      on_exit(fn -> if Process.alive?(calls), do: Agent.stop(calls) end)
+
+      merge_fun = fn uid, _hash ->
+        Agent.update(calls, fn acc -> [uid | acc] end)
+        :queued
+      end
+
+      # gate_fun records each invocation. A :rejected reconcile MUST route back to
+      # :gating (re-gate, INV-2), so gate_fun is called AGAIN after the first pass.
+      {:ok, gate_calls} = Agent.start_link(fn -> 0 end)
+      on_exit(fn -> if Process.alive?(gate_calls), do: Agent.stop(gate_calls) end)
+
+      regate_signal = test_pid
+
+      gate_fun = fn ->
+        n = Agent.get_and_update(gate_calls, fn c -> {c, c + 1} end)
+        # The second gate call is the re-gate after the :rejected reconcile.
+        if n >= 1, do: send(regate_signal, :regated)
+        :pass
+      end
+
+      opts = [
+        unit_id: unit_id,
+        declared_scope: empty_scope(),
+        hash: "hash-#{unit_id}",
+        scheduler: sched,
+        report_to: test_pid,
+        ledger: ledger,
+        worker_fun: fn _role -> {:ok, spawn_worker()} end,
+        gate_fun: gate_fun,
+        merge_fun: merge_fun,
+        timeouts: [state_timeout_ms: 5_000]
+      ]
+
+      unit_pid = @unit_supervisor.start_unit(sup, opts)
+      assert is_pid(unit_pid)
+
+      drive_to_awaiting_merge(unit_pid)
+
+      # The :rejected reconcile routes BACK to :gating (re-gate), so the gate runs
+      # a second time. It MUST NOT call merge_fun for this unit (no re-merge).
+      assert_receive :regated,
+                     5_000,
+                     "merge_outcome_durable/d_344: a Unit whose :rejected outcome is durable " <>
+                       "in L must route to re-gate (:gating) on :awaiting_merge entry (INV-2), " <>
+                       "not re-call merge_fun"
+
+      :timer.sleep(50)
+      recorded = Agent.get(calls, & &1)
+
+      refute unit_id in recorded,
+             "merge_outcome_durable/d_344: with a durable :rejected outcome the Unit must " <>
+               "re-gate, NOT re-merge. merge_fun was called for #{inspect(unit_id)} " <>
+               "(recorded: #{inspect(recorded)})."
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Drive a Unit forward to :awaiting_merge by delivering {:worker_done, pid} for
+  # the oracle and implementing workers (mirrors unit_snapshot_durability_test.exs).
+  # ---------------------------------------------------------------------------
+
+  defp drive_to_awaiting_merge(unit_pid) do
+    deliver_worker_done(unit_pid)
+    :timer.sleep(50)
+    deliver_worker_done(unit_pid)
+    :timer.sleep(100)
+  end
+
+  defp deliver_worker_done(unit_pid) do
+    :timer.sleep(50)
+
+    case :sys.get_state(unit_pid) do
+      {state, data} when state in [:oracle, :implementing] ->
+        worker_pid = Map.get(data, :worker_pid)
+        if is_pid(worker_pid), do: send(unit_pid, {:worker_done, worker_pid})
+
+      _ ->
+        :ok
+    end
+  end
+end

--- a/test/tau/factory/merge_outcome_durability_test.exs
+++ b/test/tau/factory/merge_outcome_durability_test.exs
@@ -64,10 +64,9 @@ defmodule Tau.Factory.MergeOutcomeDurabilityTest do
   always re-submits). A test that passed against the current code would be
   vacuous.
 
-  D-NNN linkage: this PR allocates a NEW invariant id (durable merge outcome) in
-  its SPEC §4/§6 amendment. Until that id is pinned, the new-invariant tag is the
-  descriptive placeholder `:merge_outcome_durable`; the apt established tags
-  `:d_315` (RPO=0 / WAL-before-ack) and `:d_344` (resume reconcile) also apply.
+  D-NNN linkage: D-355 (durable merge outcome, allocated in SPEC-FACTORY-MERGE §6
+  by this PR). Established tags `:d_315` (RPO=0 / WAL-before-ack) and `:d_344`
+  (resume reconcile) also apply.
   """
 
   use ExUnit.Case, async: false
@@ -77,7 +76,7 @@ defmodule Tau.Factory.MergeOutcomeDurabilityTest do
   alias Tau.Factory.MergeAuthority
 
   @moduletag :capture_log
-  @moduletag :merge_outcome_durable
+  @moduletag :d_355
   @moduletag :d_315
   @moduletag :d_344
 
@@ -212,10 +211,10 @@ defmodule Tau.Factory.MergeOutcomeDurabilityTest do
   # fires (WAL-before-ack: durable BEFORE the ephemeral projection).
   # ---------------------------------------------------------------------------
 
-  describe "merge_outcome_durable / d_315 — outcome is a durable Ledger row written WAL-before-ack" do
-    @tag :merge_outcome_durable
+  describe "D-355 / d_315 — outcome is a durable Ledger row written WAL-before-ack" do
+    @tag :d_355
     @tag :d_315
-    test "merge_outcome_durable/d_315: a completed merge records {:merged, commit_sha} in L, durable before the telemetry projection" do
+    test "D-355/d_315: a completed merge records {:merged, commit_sha} in L, durable before the telemetry projection" do
       ledger = start_ledger()
       test_pid = self()
 
@@ -276,10 +275,10 @@ defmodule Tau.Factory.MergeOutcomeDurabilityTest do
   # be there — the merge outcome's RPO is 0.
   # ---------------------------------------------------------------------------
 
-  describe "merge_outcome_durable / d_315 — the outcome survives a producer crash (RPO=0)" do
-    @tag :merge_outcome_durable
+  describe "D-355 / d_315 — the outcome survives a producer crash (RPO=0)" do
+    @tag :d_355
     @tag :d_315
-    test "merge_outcome_durable/d_315: after the MergeAuthority dies, the merged outcome is still in L" do
+    test "D-355/d_315: after the MergeAuthority dies, the merged outcome is still in L" do
       ledger = start_ledger()
       test_pid = self()
 
@@ -335,10 +334,10 @@ defmodule Tau.Factory.MergeOutcomeDurabilityTest do
   # appearing in the recorded merge_fun calls.
   # ---------------------------------------------------------------------------
 
-  describe "merge_outcome_durable / d_344 — reconcile-on-resume does not re-submit an already-landed merge" do
-    @tag :merge_outcome_durable
+  describe "D-355 / d_344 — reconcile-on-resume does not re-submit an already-landed merge" do
+    @tag :d_355
     @tag :d_344
-    test "merge_outcome_durable/d_344: a Unit reaching :awaiting_merge with a recorded :merged outcome does NOT call merge_fun" do
+    test "D-355/d_344: a Unit reaching :awaiting_merge with a recorded :merged outcome does NOT call merge_fun" do
       ledger = start_ledger()
       test_pid = self()
 
@@ -411,9 +410,9 @@ defmodule Tau.Factory.MergeOutcomeDurabilityTest do
                "merge_outcome_for/2 and skip the re-submit (D-344 — re-does no terminal work)."
     end
 
-    @tag :merge_outcome_durable
+    @tag :d_355
     @tag :d_344
-    test "merge_outcome_durable/d_344: a Unit reaching :awaiting_merge with a recorded :rejected outcome routes to re-gate, not re-merge" do
+    test "D-355/d_344: a Unit reaching :awaiting_merge with a recorded :rejected outcome routes to re-gate, not re-merge" do
       ledger = start_ledger()
       test_pid = self()
 


### PR DESCRIPTION
## #462 — Durable merge-outcome Ledger row (RPO=0 at the merge boundary)

Closes #462. Advances #458 (P5c) / #416 (M10). Scheduled before/with P5c-3 (the
UnitDriver merge bridge wires U to a DURABLE outcome, not an ephemeral one).

The merge outcome (`:merged`/`:rejected`) is today carried SOLELY by ephemeral
telemetry (`merge_authority.ex:264`) — the only terminal-deciding control-loop
fact not in the durable Ledger (the lone hole in RPO=0/D-315). Crash window: a
Unit resuming at `awaiting_merge` (D-344) unconditionally re-calls `merge_fun`,
re-submitting an ALREADY-LANDED merge (outcome lost on crash; `--force-with-lease`
protects the ref but not the per-unit outcome under train batching → re-does
terminal work, can escalate a merged PR as `E_MERGE_STALLED`).

### Scope & order (SPEC-FACTORY-MERGE §4/§6 + SPEC-FACTORY-CORE D-315/D-344)
1. **SPEC amendment (this PR):** allocate a NEW `D-NNN` (verify FREE across the
   repo; MERGE range D-300–D-303 area or a free one) for the durable-merge-outcome
   invariant. Amend SPEC-FACTORY-MERGE §4/§6 (M appends the outcome row
   WAL-before-ack, BEFORE the telemetry/PubSub projection) + SPEC-FACTORY-CORE
   (U `awaiting_merge` resume reads the outcome from L before re-submitting).
2. **`merge_outcomes` table** (`ledger/migrations.ex`, append-only — new migration,
   do NOT mutate applied DDL): `unit_id`, `outcome` (`merged`|`rejected`),
   `commit_sha`|`reason`, `run`, `inserted_at`. No UPDATE/DELETE.
3. **`Ledger.Writer.record_merge_outcome/2`** (WAL-before-ack, D-315) +
   `Ledger.Reader.merge_outcome_for/2` (latest per unit_id).
4. **MergeAuthority writes the outcome row BEFORE** the `telemetry(:merged|:rejected)`
   projection (`merge_authority.ex` ~264). Telemetry/PubSub becomes a derived
   projection of the durable row (live path stays fast).
5. **Reconcile-on-resume:** U/Coordinator, before re-calling `merge_fun` in
   `awaiting_merge`, reads `merge_outcome_for/2`; if present, the transition is
   already decided → do NOT re-submit (idempotent, D-344 're-does no terminal work').

### Dependencies
Depends on P2 (Ledger) + P3 (MergeAuthority). Additive migration (no conflict with
P5c-2's `verdicts_v2`). Blocks/feeds P5c-3.

### SPECs
Amends **SPEC-FACTORY-MERGE** (§4/§6 — durable outcome) + **SPEC-FACTORY-CORE**
(U resume reconcile). New `D-NNN` (verified-free). Amendment lands here.

### Acceptance criteria
- **AC (D-355 / D-315 / D-344 — durable outcome + reconcile, load-bearing):** `merge_outcome_durability_test.exs`
  — after M completes a merge, the outcome is in L (`merge_outcome_for/2` returns
  `:merged` + commit_sha), durable across a crash (read from a separately-supervised
  Ledger after the producer dies). A Unit/Coordinator resuming at `awaiting_merge`
  with a recorded `:merged` outcome does NOT re-call `merge_fun` (no double-submit);
  with `:rejected` it routes to re-gate, not re-merge. WAL-before-ack: the row is
  durable before the telemetry projection fires.

### Gating-test paths (FROZEN — implementer MUST NOT edit)
- `test/tau/factory/merge_outcome_durability_test.exs` (D-315/D-344 + the new D-355)

### Pinned contract (test-author) + the §4/§6 amendment the implementer lands
- `Ledger.Writer.record_merge_outcome(ledger, %{unit_id, outcome :: :merged|:rejected, commit_sha, reason, run}) :: {:ok, ref}` — append-only, **WAL-before-ack (D-315)**.
- `Ledger.Reader.merge_outcome_for(ledger, unit_id) :: {:merged, commit_sha} | {:rejected, reason} | :none` (latest per unit_id).
- `MergeAuthority` writes the durable row BEFORE the `telemetry(:merged|:rejected)` projection (`merge_authority.ex` ~264).
- **Reconcile point = `Tau.Factory.Unit` `:awaiting_merge` on-entry** (it already takes `:ledger`): `:merged` → terminal WITHOUT calling `merge_fun`; `:rejected` → `:gating` (re-gate, INV-2); `:none` → call `merge_fun`. This composes with D-344: the Coordinator rehydrates the Unit at `:awaiting_merge`, and the Unit reconciles on re-entry. (Confirmed placement — do NOT move to the Coordinator.)
- **D-NNN = D-355** (verified free in lib/test/docs; implementer confirms across `.claude` + git history and amends SPEC-FACTORY-MERGE §6 as owner, SPEC-FACTORY-CORE cites). Swap the test's `:merge_outcome_durable` placeholder tag → `:d_355` is the TEST-AUTHOR's to do — implementer reports back so the tag is aligned.

### Gate verdicts
_(filled at gate time — critic [shaper-armed], reviewer)_

