### PR TITLE
P5c-3a — implement D-326: Worker work_ready → Unit implementing→gating trigger

### DIFF
--- a/docs/spec/SPEC-FACTORY-CORE.md
+++ b/docs/spec/SPEC-FACTORY-CORE.md
@@ -389,6 +389,15 @@ callers that pass no `:ledger` opt are unaffected (back-compat).
   `worker_exit(w, :no_work_product)` (**D-326, cited owner: SPEC-FACTORY-FLEET**).
   W owns isolation/capture D-309..D-311, D-313, D-314, D-316 and the completion
   contract D-326.
+- **Pinned Unit seam (D-326 / PR #468 amendment).** The `worker_fun` injectable
+  returns `{:ok, worker_pid :: pid(), worker_id :: String.t()}` (3-tuple) for
+  D-326-aware workers; the Unit stores `data.worker_id` (test-observable via
+  `:sys.get_state/1`) and gates `implementing → gating` ONLY on
+  `{:work_ready, ^worker_id, _, _}` — discarding `{:work_ready, other_id, _, _}`
+  (stale-worker events, B8 invariant). The legacy 2-tuple `{:ok, worker_pid}`
+  form is preserved for back-compat but does NOT carry a `worker_id` — the
+  `data.worker_id` field is `nil` in that path and the Unit falls back to the
+  `{:worker_done, ^worker_pid}` trigger.
 
 ### B9: KillSwitch (C9) ↔ Coordinator (C3)
 

--- a/docs/spec/SPEC-FACTORY-FLEET.md
+++ b/docs/spec/SPEC-FACTORY-FLEET.md
@@ -327,6 +327,18 @@ Format: `[Cn-Bm]` = constraint number + boundary. **★** marks non-obvious.
   certificate (single-writer discipline: the worker is the sole forwarder of
   `work_ready`, just as the independent monitor is the sole writer of
   `worker_exit`).
+- **Pinned wire encoding (D-326 / PR #468 amendment).** The `{:packet,4}` frame
+  payload is a JSON object (stream-json-consistent; `Jason.decode/1`):
+  ```
+  {"type":"work_ready","branch":"<branch>","head_sha":"<sha>"}
+  ```
+  The BEAM strips the 4-byte big-endian length prefix; the Worker's
+  `handle_info({port, {:data, frame}}, …)` receives the raw JSON bytes.
+  Decoded into `%Tau.Provider.Event.WorkReady{branch: branch, head_sha: head_sha}`
+  (the typed struct — never a raw map).
+- **Pinned Worker→Unit message shapes (D-326 / PR #468 amendment).**
+  - Success: `{:work_ready, worker_id :: String.t(), branch :: String.t(), head_sha :: String.t()}` — the sole `implementing → gating` trigger (B1/B8).
+  - Fail-closed: `{:worker_exit, worker_id :: String.t(), :no_work_product}` — reuses the death-cert channel; exit-0 with no prior `work_ready` surfaces here, routed to the retry ladder, never gated.
 - **Ordering (the V1-load-bearing fact).** A single `Port`'s `{:data, _}` frames
   and its `{:exit_status, n}` are delivered to the owning process **in order** —
   the BEAM flushes all buffered Port output to the worker mailbox *before* the

--- a/lib/tau/factory/unit.ex
+++ b/lib/tau/factory/unit.ex
@@ -83,9 +83,14 @@ defmodule Tau.Factory.Unit do
     - `:hash`           — `String.t()`; content hash for the PR.
     - `:scheduler`      — atom or pid of a running `Tau.Factory.Scheduler`.
     - `:report_to`      — pid receiving `{:unit_terminal, unit_id, outcome, provenance}`.
-    - `:worker_fun`     — `(role :: atom() -> {:ok, worker_pid :: pid()} | {:error, reason})`.
+    - `:worker_fun`     — `(role :: atom() -> {:ok, worker_pid :: pid()} | {:ok, worker_pid :: pid(), worker_id :: String.t()} | {:error, reason})`.
                          Returns a real process pid; the Unit monitors it via
                          `Process.monitor/1` for liveness (B8).
+                         When the 3-tuple form is returned, the Unit stores `worker_id`
+                         under `data.worker_id` and gates `implementing → gating` ONLY
+                         on `{:work_ready, ^worker_id, _, _}` (D-326/SPEC-FACTORY-CORE §4 B8).
+                         When the 2-tuple form is returned (legacy), the Unit matches
+                         `{:worker_done, ^worker_pid}` for normal completion.
     - `:gate_fun`       — `(-> :pass | {:fail, findings :: [term()]})`.
     - `:merge_fun`      — `(unit_id, hash -> :queued | {:error, reason})`.
 
@@ -147,6 +152,10 @@ defmodule Tau.Factory.Unit do
       state_timeout_ms: state_timeout_ms,
       # Current worker pid (B8 — real process, monitorable).
       worker_pid: nil,
+      # D-326: logical worker_id keying work_ready events (nil when worker_fun
+      # returns 2-tuple legacy form). Stored under :worker_id so tests can
+      # observe it via :sys.get_state/1.
+      worker_id: nil,
       # Monitor ref for the current worker.
       worker_mref: nil,
       # Retry counters.
@@ -199,9 +208,15 @@ defmodule Tau.Factory.Unit do
     data = snapshot_state(:oracle, data)
 
     case data.worker_fun.(:test_author) do
+      {:ok, worker_pid, worker_id} ->
+        mref = Process.monitor(worker_pid)
+        new_data = %{data | worker_pid: worker_pid, worker_id: worker_id, worker_mref: mref}
+        timeout_ms = data.state_timeout_ms
+        {:keep_state, new_data, [{:state_timeout, timeout_ms, :worker_stalled}]}
+
       {:ok, worker_pid} ->
         mref = Process.monitor(worker_pid)
-        new_data = %{data | worker_pid: worker_pid, worker_mref: mref}
+        new_data = %{data | worker_pid: worker_pid, worker_id: nil, worker_mref: mref}
         timeout_ms = data.state_timeout_ms
         {:keep_state, new_data, [{:state_timeout, timeout_ms, :worker_stalled}]}
 
@@ -209,6 +224,19 @@ defmodule Tau.Factory.Unit do
         Logger.warning("[Unit #{data.unit_id}] worker_fun(:test_author) error: #{inspect(reason)}")
         escalate(data, :E_WORKER_ERROR)
     end
+  end
+
+  # D-326: gate on work_ready keyed by the CURRENT worker_id (3-tuple seam).
+  def oracle(:info, {:work_ready, worker_id, _branch, _head_sha}, %{worker_id: worker_id} = data)
+      when not is_nil(worker_id) do
+    Process.demonitor(data.worker_mref, [:flush])
+    new_data = %{data | worker_pid: nil, worker_id: nil, worker_mref: nil}
+    {:next_state, :implementing, new_data, [{:next_event, :internal, :on_enter}]}
+  end
+
+  # Discard work_ready from a superseded worker_id (stale-worker discard, B8).
+  def oracle(:info, {:work_ready, _other_id, _branch, _head_sha}, data) do
+    {:keep_state, data}
   end
 
   def oracle(:info, {:worker_done, worker_pid}, %{worker_pid: worker_pid} = data)
@@ -253,9 +281,15 @@ defmodule Tau.Factory.Unit do
     new_data = snapshot_state(:implementing, new_data)
 
     case new_data.worker_fun.(:implementer) do
+      {:ok, worker_pid, worker_id} ->
+        mref = Process.monitor(worker_pid)
+        updated_data = %{new_data | worker_pid: worker_pid, worker_id: worker_id, worker_mref: mref}
+        timeout_ms = updated_data.state_timeout_ms
+        {:keep_state, updated_data, [{:state_timeout, timeout_ms, :worker_stalled}]}
+
       {:ok, worker_pid} ->
         mref = Process.monitor(worker_pid)
-        updated_data = %{new_data | worker_pid: worker_pid, worker_mref: mref}
+        updated_data = %{new_data | worker_pid: worker_pid, worker_id: nil, worker_mref: mref}
         timeout_ms = updated_data.state_timeout_ms
         {:keep_state, updated_data, [{:state_timeout, timeout_ms, :worker_stalled}]}
 
@@ -268,6 +302,25 @@ defmodule Tau.Factory.Unit do
     end
   end
 
+  # D-326 §4 B8: gate implementing → gating ONLY on work_ready keyed by the
+  # CURRENT worker_id (the sole completion trigger — never bare exit / :worker_done).
+  def implementing(
+        :info,
+        {:work_ready, worker_id, _branch, _head_sha},
+        %{worker_id: worker_id} = data
+      )
+      when not is_nil(worker_id) do
+    Process.demonitor(data.worker_mref, [:flush])
+    new_data = %{data | worker_pid: nil, worker_id: nil, worker_mref: nil}
+    {:next_state, :gating, new_data, [{:next_event, :internal, :on_enter}]}
+  end
+
+  # Stale-worker discard (B8): work_ready from a superseded worker_id is ignored.
+  def implementing(:info, {:work_ready, _other_id, _branch, _head_sha}, data) do
+    {:keep_state, data}
+  end
+
+  # Legacy 2-tuple worker_fun seam: {:worker_done, worker_pid} (back-compat).
   def implementing(:info, {:worker_done, worker_pid}, %{worker_pid: worker_pid} = data)
       when not is_nil(worker_pid) do
     Process.demonitor(data.worker_mref, [:flush])

--- a/lib/tau/factory/worker.ex
+++ b/lib/tau/factory/worker.ex
@@ -42,6 +42,7 @@ defmodule Tau.Factory.Worker do
   alias Tau.Factory.Worker.Isolation
   alias Tau.Factory.Toolchain
   alias Tau.Factory.WorkspaceJanitor
+  alias Tau.Provider.Event.WorkReady
 
   # ---------------------------------------------------------------------------
   # Public API
@@ -142,6 +143,11 @@ defmodule Tau.Factory.Worker do
 
   # Port exited: stop the worker. The death-certificate is delivered by the
   # unlinked monitor, NOT by the worker itself (C202 single-writer discipline).
+  #
+  # D-326 fail-closed: exit-0 WITHOUT a prior work_ready is a semantic
+  # non-completion. We stop with {:shutdown, :no_work_product} so the
+  # independent monitor maps that to {:worker_exit, worker_id, :no_work_product}.
+  # A normal exit AFTER work_ready is unchanged (just :normal).
   @impl GenServer
   def handle_info({port, {:exit_status, n}}, %{port: port} = state) do
     :telemetry.execute(
@@ -150,13 +156,23 @@ defmodule Tau.Factory.Worker do
       %{worker_id: state.worker_id, role: state.role}
     )
 
-    reason = if n == 0, do: :normal, else: {:exit_status, n}
+    reason =
+      cond do
+        n == 0 and not state.work_ready_seen? -> {:shutdown, :no_work_product}
+        n == 0 -> :normal
+        true -> {:exit_status, n}
+      end
+
     {:stop, reason, state}
   end
 
-  # Data from agent — ignore for now (future: forward to Unit FSM).
-  def handle_info({port, {:data, _data}}, %{port: port} = state) do
-    {:noreply, state}
+  # Data from the agent: decode the {packet,4}-framed JSON into a typed event
+  # and dispatch. D-326: a work_ready frame is forwarded to report_to exactly
+  # ONCE and sets work_ready_seen? true (single-writer discipline, mirrors
+  # independent monitor's sole ownership of worker_exit).
+  def handle_info({port, {:data, frame}}, %{port: port} = state) do
+    new_state = dispatch(decode_event(frame), state)
+    {:noreply, new_state}
   end
 
   # Heartbeat tick: emit telemetry + optional report_to message, re-arm timer.
@@ -306,7 +322,10 @@ defmodule Tau.Factory.Worker do
        report_to: report_to,
        registry: registry,
        heartbeat_interval: heartbeat_interval,
-       heartbeat_timer: timer
+       heartbeat_timer: timer,
+       # D-326: set to true when the agent emits work_ready before exiting.
+       # Exit-0 without work_ready is fail-closed → :no_work_product.
+       work_ready_seen?: false
      }}
   end
 
@@ -316,10 +335,11 @@ defmodule Tau.Factory.Worker do
   # This is the SOLE writer of `{:worker_exit, worker_id, reason}` (C202).
   # The worker itself does NOT send the certificate — it just stops.
   #
-  # Reason mapping:
-  #   :normal  → {:worker_exit, id, :normal}
-  #   :killed  → {:worker_exit, id, :kill}
-  #   other    → {:worker_exit, id, other}
+  # Reason mapping (D-326 — :no_work_product is a semantic non-completion):
+  #   :normal                       → {:worker_exit, id, :normal}
+  #   {:shutdown, :no_work_product} → {:worker_exit, id, :no_work_product}
+  #   :killed                       → {:worker_exit, id, :kill}
+  #   other                         → {:worker_exit, id, other}
   defp spawn_death_monitor(_worker_id, nil), do: :ok
 
   defp spawn_death_monitor(worker_id, report_to) do
@@ -334,6 +354,7 @@ defmodule Tau.Factory.Worker do
             cert_reason =
               case reason do
                 :normal -> :normal
+                {:shutdown, :no_work_product} -> :no_work_product
                 :killed -> :kill
                 other -> other
               end
@@ -343,6 +364,41 @@ defmodule Tau.Factory.Worker do
       end,
       []
     )
+  end
+
+  # ---------------------------------------------------------------------------
+  # D-326 — decode and dispatch typed agent events from Port data frames
+  # ---------------------------------------------------------------------------
+
+  # Decode a {packet,4}-framed JSON payload into a typed event struct.
+  # The BEAM strips the 4-byte BE length prefix, so `frame` is raw JSON bytes.
+  # Extend Tau.Provider.Event; never use ad-hoc formats (OTP non-negotiable).
+  @spec decode_event(binary()) :: WorkReady.t() | {:unknown, binary()}
+  defp decode_event(frame) do
+    case Jason.decode(frame) do
+      {:ok, %{"type" => "work_ready", "branch" => branch, "head_sha" => head_sha}} ->
+        %WorkReady{branch: branch, head_sha: head_sha}
+
+      _ ->
+        {:unknown, frame}
+    end
+  end
+
+  # Dispatch a decoded typed event, updating state accordingly.
+  # D-326: the Worker is the SOLE forwarder of work_ready to report_to
+  # (single-writer discipline — mirrors the independent monitor's sole
+  # ownership of worker_exit). Forward ONCE and set work_ready_seen? true.
+  @spec dispatch(WorkReady.t() | {:unknown, binary()}, map()) :: map()
+  defp dispatch(%WorkReady{branch: branch, head_sha: head_sha}, state) do
+    if not is_nil(state.report_to) and not state.work_ready_seen? do
+      send(state.report_to, {:work_ready, state.worker_id, branch, head_sha})
+    end
+
+    %{state | work_ready_seen?: true}
+  end
+
+  defp dispatch({:unknown, _frame}, state) do
+    state
   end
 
   # ---------------------------------------------------------------------------

--- a/lib/tau/provider/event.ex
+++ b/lib/tau/provider/event.ex
@@ -105,6 +105,22 @@ defmodule Tau.Provider.Event do
     @type t :: %__MODULE__{reason: term(), retryable?: boolean()}
   end
 
+  defmodule WorkReady do
+    @moduledoc """
+    A factory Worker agent declared a stable work product (D-326).
+
+    Emitted in-band over the agent's `{:packet, 4}` Port as a JSON frame
+    `{"type":"work_ready","branch":"<branch>","head_sha":"<sha>"}` BEFORE
+    the agent exits. The Worker decodes the frame, constructs this struct,
+    and forwards `{:work_ready, worker_id, branch, head_sha}` to its owning
+    Unit as the sole `implementing → gating` trigger (SPEC-FACTORY-FLEET §4
+    B4, SPEC-FACTORY-CORE §4 B8).
+    """
+    @enforce_keys [:branch, :head_sha]
+    defstruct [:branch, :head_sha]
+    @type t :: %__MODULE__{branch: String.t(), head_sha: String.t()}
+  end
+
   @type t ::
           Start.t()
           | TextStart.t()
@@ -118,4 +134,5 @@ defmodule Tau.Provider.Event do
           | ToolCallEnd.t()
           | Done.t()
           | Error.t()
+          | WorkReady.t()
 end

--- a/test/tau/factory/worker_completion_event_test.exs
+++ b/test/tau/factory/worker_completion_event_test.exs
@@ -1,0 +1,493 @@
+defmodule Tau.Factory.WorkerCompletionEventTest do
+  @moduledoc """
+  Gating test for PR #468 (P5c-3a — implement D-326: Worker `work_ready`
+  completion event → Unit `implementing → gating` trigger).
+
+  Closes #467. Advances AC-13 (SPEC-FACTORY-FLEET §4 B4, D-326) and the cited
+  Unit-trigger contract (SPEC-FACTORY-CORE §4 B8).
+
+  Written BEFORE production code exists (oracle-separation phase, factory-loop
+  §4b). These tests MUST FAIL against current `main`:
+
+    * `Tau.Factory.Worker.handle_info({port, {:data, _}}, …)` currently IGNORES
+      agent Port output ("future: forward to Unit FSM") — so NO `work_ready` is
+      ever forwarded to `report_to`.
+    * `Tau.Factory.Unit` consumes the `{:worker_done, worker_pid}` placeholder,
+      NOT `work_ready(worker_id, branch, head_sha)` — so it never gates on
+      `work_ready` and never discards a stale-worker `work_ready`.
+
+  A compile/timeout/assertion failure here is the correct fail-before state; it
+  is NOT to be resolved by writing production code.
+
+  ## The contract under test (D-326 / AC-13)
+
+  SPEC-FACTORY-FLEET §4 B4 (the agent Port) and §4 B1 + D-326 (lines 269-279,
+  318-337, 494-514); SPEC-FACTORY-CORE §4 B8 (lines 378-391):
+
+    * A normally-completing agent emits an in-band `work_ready(branch, head_sha)`
+      frame over its `{:packet,4}` Port BEFORE it exits.
+    * The **Worker** decodes that frame and is the SOLE forwarder of
+      `work_ready(worker_id, branch, head_sha)` to its owning Unit (`report_to`),
+      keyed by `worker_id` — the single-writer discipline that mirrors the
+      independent monitor's sole ownership of `worker_exit`.
+    * `work_ready` is the ONLY trigger of U's `implementing → gating` edge.
+    * `{:exit_status, 0}` with NO prior `work_ready` is fail-closed: surfaced as
+      `worker_exit(worker_id, :no_work_product)`, a semantic non-completion routed
+      to U's retry ladder, NEVER gated.
+    * U tags the CURRENT `worker_id` and DISCARDS `work_ready` from a superseded
+      worker.
+
+  ## PINNED shapes (oracle-declared; see "SPEC gap" in the PR report)
+
+  The §4 contracts name the events and their payloads but DO NOT pin (a) the
+  exact wire encoding inside the `{:packet,4}` frame, (b) the exact Worker→Unit
+  message tuple, nor (c) how the Unit's `worker_fun` seam surfaces a `worker_id`.
+  Pending the §3 amendment, this oracle pins defensible, SPEC-consistent shapes
+  the implementer MUST conform to (or the test-author corrects on amendment):
+
+  ### Wire frame (agent → Worker, decoded by `handle_info({port,{:data,_}},…)`)
+  A `{:packet,4}` frame whose payload is a JSON object (the shell-writable,
+  stream-json-consistent encoding; `Jason.decode/1`):
+
+      {"type":"work_ready","branch":"<branch>","head_sha":"<sha>"}
+
+  With `{:packet, 4}` the BEAM strips the 4-byte big-endian length header, so the
+  Worker's `{:data, payload}` carries exactly the JSON bytes. The dummy agent
+  below writes the 4-byte BE length prefix itself, then the JSON, then exits 0.
+
+  ### Worker → Unit (`report_to`) message — the SUCCESS counterpart of
+  `{:worker_exit, worker_id, reason}`:
+
+      {:work_ready, worker_id :: String.t(), branch :: String.t(), head_sha :: String.t()}
+
+  ### Fail-closed exit-0-without-work_ready — reuses the death-cert channel:
+
+      {:worker_exit, worker_id :: String.t(), :no_work_product}
+
+  ### Unit consumes `work_ready` keyed by `worker_id`
+  The Unit, on entering `implementing`, holds the CURRENT worker's `worker_id`
+  (test-observable via `:sys.get_state/1` under `data.worker_id`). It transitions
+  `implementing → gating` on `{:work_ready, ^worker_id, _branch, _sha}` and
+  IGNORES `{:work_ready, other_id, _, _}` (stale-worker discard, B8).
+
+  ## AC linkage
+    - AC-13 / D-326 — every test below.
+  """
+
+  use ExUnit.Case, async: false
+
+  @moduletag :capture_log
+  @moduletag :ac_13
+  @moduletag :d_326
+
+  # Runtime module references — file compiles even when the D-326 wiring is
+  # absent. @mod.fun form (Credo strict), never apply/2,3.
+  @worker_registry Tau.Factory.WorkerRegistry
+  @worker_supervisor Tau.Factory.WorkerSupervisor
+  @unit_supervisor Tau.Factory.UnitSupervisor
+  @scheduler Tau.Factory.Scheduler
+
+  # ---------------------------------------------------------------------------
+  # Hermetic git repo (mirrors worker_test.exs idiom)
+  # ---------------------------------------------------------------------------
+
+  defp setup_git_repo(tmp_dir) do
+    repo_dir = Path.join(tmp_dir, "repo_#{System.unique_integer([:positive])}")
+    File.mkdir_p!(repo_dir)
+
+    git = fn args ->
+      System.cmd("git", args, cd: repo_dir, stderr_to_stdout: true)
+    end
+
+    {_, 0} = git.(["init", "-b", "main"])
+    {_, 0} = git.(["config", "user.email", "test@tau.test"])
+    {_, 0} = git.(["config", "user.name", "Tau Test"])
+
+    File.write!(Path.join(repo_dir, "README"), "initial\n")
+    {_, 0} = git.(["add", "README"])
+    {_, 0} = git.(["commit", "-m", "initial commit"])
+    {sha, 0} = git.(["rev-parse", "HEAD"])
+
+    %{repo_dir: repo_dir, base_ref: String.trim(sha)}
+  end
+
+  # An agent_bin that emits ONE `{:packet,4}`-framed JSON `work_ready` frame and
+  # then exits 0. Writes the 4-byte big-endian length prefix itself (the framing
+  # the Worker's `{:packet,4}` Port strips on receive), so the Worker observes a
+  # single `{:data, json}` frame BEFORE the `{:exit_status, 0}`.
+  #
+  # The branch/head_sha are interpolated so the test can assert the EXACT payload
+  # the Worker forwards (non-vacuous: the forwarded values must round-trip).
+  defp work_ready_agent_bin(tmp_dir, branch, head_sha, suffix \\ "") do
+    bin_path = Path.join(tmp_dir, "work_ready_agent#{suffix}")
+
+    json = ~s({"type":"work_ready","branch":"#{branch}","head_sha":"#{head_sha}"})
+    len = byte_size(json)
+
+    # 4-byte big-endian length as octal \NNN escapes for printf.
+    b0 = Bitwise.band(Bitwise.bsr(len, 24), 0xFF)
+    b1 = Bitwise.band(Bitwise.bsr(len, 16), 0xFF)
+    b2 = Bitwise.band(Bitwise.bsr(len, 8), 0xFF)
+    b3 = Bitwise.band(len, 0xFF)
+
+    oct = fn b -> "\\" <> (b |> Integer.to_string(8) |> String.pad_leading(3, "0")) end
+    len_prefix = oct.(b0) <> oct.(b1) <> oct.(b2) <> oct.(b3)
+
+    File.write!(bin_path, """
+    #!/bin/sh
+    # Write the 4-byte BE length prefix, then the JSON payload, then exit 0.
+    printf '#{len_prefix}'
+    printf '%s' '#{json}'
+    exit 0
+    """)
+
+    File.chmod!(bin_path, 0o755)
+    bin_path
+  end
+
+  # An agent_bin that exits 0 WITHOUT ever emitting a work_ready frame.
+  defp silent_exit0_agent_bin(tmp_dir, suffix \\ "") do
+    bin_path = Path.join(tmp_dir, "silent_agent#{suffix}")
+
+    File.write!(bin_path, """
+    #!/bin/sh
+    exit 0
+    """)
+
+    File.chmod!(bin_path, 0o755)
+    bin_path
+  end
+
+  defp start_fleet(tag) do
+    n = System.unique_integer([:positive])
+    registry_name = :"#{tag}_registry_#{n}"
+    sup_name = :"#{tag}_sup_#{n}"
+
+    {:ok, _reg} =
+      start_supervised({@worker_registry, name: registry_name}, id: :"reg_#{n}")
+
+    {:ok, sup} =
+      start_supervised(
+        {@worker_supervisor, name: sup_name, registry: registry_name},
+        id: :"sup_#{n}"
+      )
+
+    {sup, registry_name}
+  end
+
+  defp mk_tmp(tag) do
+    tmp_dir = Path.join(System.tmp_dir!(), "tau_#{tag}_#{System.unique_integer([:positive])}")
+    File.mkdir_p!(tmp_dir)
+    on_exit(fn -> File.rm_rf!(tmp_dir) end)
+    tmp_dir
+  end
+
+  # ---------------------------------------------------------------------------
+  # Oracle 1 — Worker FORWARDS work_ready on the in-band frame (keyed by worker_id)
+  # ---------------------------------------------------------------------------
+
+  describe "AC-13 / D-326 — Worker forwards work_ready on the in-band frame" do
+    @tag :ac_13
+    @tag :d_326
+    test "AC-13/D-326: Worker decodes the in-band work_ready frame and forwards exactly one {:work_ready, worker_id, branch, head_sha} to report_to" do
+      tmp_dir = mk_tmp("wr_forward")
+      %{repo_dir: repo_dir, base_ref: base_ref} = setup_git_repo(tmp_dir)
+
+      branch = "feat/agent-branch"
+      head_sha = String.duplicate("ab12cd34", 5)
+      agent_bin = work_ready_agent_bin(tmp_dir, branch, head_sha)
+
+      {sup, registry_name} = start_fleet(:wr_forward)
+      report_to = self()
+
+      {:ok, worker_id} =
+        @worker_supervisor.spawn(sup, :implementer, "brief", base_ref,
+          repo_dir: repo_dir,
+          agent_bin: agent_bin,
+          report_to: report_to,
+          registry: registry_name
+        )
+
+      assert is_binary(worker_id),
+             "AC-13: spawn/5 must return {:ok, worker_id}; got #{inspect(worker_id)}"
+
+      # The Worker must forward the success event keyed by the REAL worker_id,
+      # carrying the EXACT branch/head_sha the agent asserted in-band (D-326).
+      assert_receive {:work_ready, ^worker_id, ^branch, ^head_sha},
+                     5_000,
+                     "AC-13/D-326: Worker must forward {:work_ready, worker_id, branch, head_sha} " <>
+                       "to report_to on decoding the in-band work_ready frame. " <>
+                       "On current main the Worker IGNORES Port {:data,_} (no forward)."
+
+      # SINGLE-writer discipline (D-326): exactly ONE work_ready, and the clean
+      # exit-0 that followed it must NOT also surface as a separate completion or
+      # a :no_work_product (the work_ready was seen).
+      refute_received {:work_ready, ^worker_id, _b, _h},
+                      "AC-13/D-326: the Worker is the SOLE forwarder — exactly one work_ready per worker"
+
+      refute_received {:worker_exit, ^worker_id, :no_work_product},
+                      "AC-13/D-326: a worker that emitted work_ready must NOT also surface :no_work_product"
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Oracle 2 — Unit GATES on work_ready (not bare exit)
+  # ---------------------------------------------------------------------------
+
+  describe "AC-13 / D-326 — Unit transitions implementing → gating on work_ready" do
+    @tag :ac_13
+    @tag :d_326
+    test "AC-13/D-326: a real Unit in implementing gates ON {:work_ready, worker_id, _, _}, NOT on a bare worker exit" do
+      test_pid = self()
+      n = System.unique_integer([:positive])
+      unit_id = "u-wr-#{n}"
+      scheduler_name = :"sched_wr_#{n}"
+      sup_name = :"unitsup_wr_#{n}"
+
+      start_supervised!({@scheduler, name: scheduler_name, w_cap: 10}, id: scheduler_name)
+      start_supervised!({@unit_supervisor, name: sup_name}, id: sup_name)
+
+      # The Unit's worker_fun must surface a worker_id (D-326 keys events by it).
+      # Pinned seam: worker_fun.(role) -> {:ok, worker_pid, worker_id}; the Unit
+      # stores worker_id under data.worker_id (test-observable).
+      worker_id = "w-#{n}"
+      worker_pid = spawn(fn -> receive do: (:stop -> :ok) end)
+
+      # gate_fun records that the gate WAS reached — the discriminating signal
+      # that the Unit gated on work_ready rather than ignoring it.
+      gate_fun = fn ->
+        send(test_pid, {:gate_called, unit_id})
+        {:fail, [:stop_here]}
+      end
+
+      opts = [
+        unit_id: unit_id,
+        declared_scope: %{
+          deps: [],
+          files: MapSet.new(),
+          codepoints: MapSet.new(),
+          specs: MapSet.new(),
+          resources: MapSet.new()
+        },
+        hash: "hash-#{unit_id}",
+        scheduler: scheduler_name,
+        report_to: test_pid,
+        worker_fun: fn _role -> {:ok, worker_pid, worker_id} end,
+        gate_fun: gate_fun,
+        merge_fun: fn _uid, _hash -> :queued end,
+        timeouts: [state_timeout_ms: 5_000]
+      ]
+
+      unit_pid = @unit_supervisor.start_unit(sup_name, opts)
+      assert is_pid(unit_pid), "start_unit must return a pid"
+
+      # Advance oracle → implementing. The oracle worker also completes via
+      # work_ready (D-326 is the sole completion trigger in BOTH oracle and
+      # implementing per §5). Drive each phase by delivering work_ready keyed by
+      # the CURRENT worker_id the FSM is waiting on.
+      drive_work_ready(unit_pid, worker_id)
+      :timer.sleep(50)
+      drive_work_ready(unit_pid, worker_id)
+
+      # The gate must have been called — i.e. the Unit reached :gating BECAUSE of
+      # work_ready (not a bare exit, which the Unit must not treat as completion).
+      assert_receive {:gate_called, ^unit_id},
+                     5_000,
+                     "AC-13/D-326: the Unit must transition implementing → gating ON work_ready. " <>
+                       "On current main the Unit consumes {:worker_done, pid}, not " <>
+                       "{:work_ready, worker_id, _, _}, so the gate is never reached this way."
+    end
+  end
+
+  # Deliver {:work_ready, worker_id, branch, head_sha} to the Unit for whichever
+  # waiting state (oracle | implementing) it is currently in, keyed by the
+  # CURRENT worker_id (D-326 / B8). The Unit MUST expose data.worker_id.
+  defp drive_work_ready(unit_pid, expected_worker_id) do
+    :timer.sleep(50)
+
+    case :sys.get_state(unit_pid) do
+      {state, data} when state in [:oracle, :implementing] ->
+        wid = Map.get(data, :worker_id, expected_worker_id)
+        send(unit_pid, {:work_ready, wid, "feat/x", "deadbeef"})
+
+      _ ->
+        :ok
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Oracle 3 — Fail-closed: exit-0 WITHOUT work_ready → :no_work_product, no gate
+  # ---------------------------------------------------------------------------
+
+  describe "AC-13 / D-326 — exit-0 without work_ready is fail-closed (:no_work_product)" do
+    @tag :ac_13
+    @tag :d_326
+    test "AC-13/D-326: a Worker whose agent exits 0 WITHOUT work_ready yields worker_exit(:no_work_product), NOT a completion" do
+      tmp_dir = mk_tmp("wr_noproduct")
+      %{repo_dir: repo_dir, base_ref: base_ref} = setup_git_repo(tmp_dir)
+
+      agent_bin = silent_exit0_agent_bin(tmp_dir)
+      {sup, registry_name} = start_fleet(:wr_noproduct)
+      report_to = self()
+
+      {:ok, worker_id} =
+        @worker_supervisor.spawn(sup, :implementer, "brief", base_ref,
+          repo_dir: repo_dir,
+          agent_bin: agent_bin,
+          report_to: report_to,
+          registry: registry_name
+        )
+
+      # Fail-closed: a clean exit with NO work_ready is a semantic non-completion.
+      assert_receive {:worker_exit, ^worker_id, :no_work_product},
+                     5_000,
+                     "AC-13/D-326: exit-0 without a prior work_ready MUST surface " <>
+                       "{:worker_exit, worker_id, :no_work_product}. On current main the " <>
+                       "monitor reports {:worker_exit, worker_id, :normal} — a clean exit is " <>
+                       "wrongly treated as benign completion, not fail-closed."
+
+      # It must NEVER surface as a success.
+      refute_received {:work_ready, ^worker_id, _b, _h},
+                      "AC-13/D-326: a silent exit-0 worker must NOT forge a work_ready completion"
+    end
+
+    @tag :ac_13
+    @tag :d_326
+    test "AC-13/D-326: a Unit does NOT gate on a worker that produced no work_ready (clean exit ≠ completion)" do
+      test_pid = self()
+      n = System.unique_integer([:positive])
+      unit_id = "u-noprod-#{n}"
+      scheduler_name = :"sched_noprod_#{n}"
+      sup_name = :"unitsup_noprod_#{n}"
+
+      start_supervised!({@scheduler, name: scheduler_name, w_cap: 10}, id: scheduler_name)
+      start_supervised!({@unit_supervisor, name: sup_name}, id: sup_name)
+
+      worker_id = "w-noprod-#{n}"
+      worker_pid = spawn(fn -> receive do: (:stop -> :ok) end)
+
+      gate_fun = fn ->
+        send(test_pid, {:gate_called, unit_id})
+        :pass
+      end
+
+      opts = [
+        unit_id: unit_id,
+        declared_scope: %{
+          deps: [],
+          files: MapSet.new(),
+          codepoints: MapSet.new(),
+          specs: MapSet.new(),
+          resources: MapSet.new()
+        },
+        hash: "hash-#{unit_id}",
+        scheduler: scheduler_name,
+        report_to: test_pid,
+        worker_fun: fn _role -> {:ok, worker_pid, worker_id} end,
+        gate_fun: gate_fun,
+        merge_fun: fn _uid, _hash -> :queued end,
+        timeouts: [state_timeout_ms: 5_000]
+      ]
+
+      unit_pid = @unit_supervisor.start_unit(sup_name, opts)
+      assert is_pid(unit_pid), "start_unit must return a pid"
+
+      # Advance oracle → implementing via work_ready.
+      drive_work_ready(unit_pid, worker_id)
+      :timer.sleep(50)
+
+      # Now deliver the FAIL-CLOSED exit (no_work_product) for the current worker
+      # while the Unit is in implementing. This must NOT drive the gating edge —
+      # a clean exit without work_ready is a non-completion, routed to the retry
+      # ladder, NEVER gated (D-326 / B8).
+      case :sys.get_state(unit_pid) do
+        {:implementing, data} ->
+          wid = Map.get(data, :worker_id, worker_id)
+          send(unit_pid, {:worker_exit, wid, :no_work_product})
+
+        {state, _data} ->
+          flunk(
+            "AC-13/D-326: Unit must be in :implementing after work_ready; was #{inspect(state)}. " <>
+              "On current main the Unit does not consume work_ready, so it never reaches " <>
+              "implementing this way."
+          )
+      end
+
+      # The gate must NOT have been called as a result of the no_work_product exit.
+      refute_receive {:gate_called, ^unit_id},
+                     1_000,
+                     "AC-13/D-326: a :no_work_product exit must NOT trigger implementing → gating " <>
+                       "(clean exit is never completion)."
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Oracle 4 — Stale-worker work_ready is discarded
+  # ---------------------------------------------------------------------------
+
+  describe "AC-13 / D-326 — stale-worker work_ready is discarded" do
+    @tag :ac_13
+    @tag :d_326
+    test "AC-13/D-326: a work_ready carrying a worker_id that is NOT the Unit's current worker is discarded (Unit does not gate)" do
+      test_pid = self()
+      n = System.unique_integer([:positive])
+      unit_id = "u-stale-#{n}"
+      scheduler_name = :"sched_stale_#{n}"
+      sup_name = :"unitsup_stale_#{n}"
+
+      start_supervised!({@scheduler, name: scheduler_name, w_cap: 10}, id: scheduler_name)
+      start_supervised!({@unit_supervisor, name: sup_name}, id: sup_name)
+
+      current_worker_id = "w-current-#{n}"
+      worker_pid = spawn(fn -> receive do: (:stop -> :ok) end)
+
+      gate_fun = fn ->
+        send(test_pid, {:gate_called, unit_id})
+        :pass
+      end
+
+      opts = [
+        unit_id: unit_id,
+        declared_scope: %{
+          deps: [],
+          files: MapSet.new(),
+          codepoints: MapSet.new(),
+          specs: MapSet.new(),
+          resources: MapSet.new()
+        },
+        hash: "hash-#{unit_id}",
+        scheduler: scheduler_name,
+        report_to: test_pid,
+        worker_fun: fn _role -> {:ok, worker_pid, current_worker_id} end,
+        gate_fun: gate_fun,
+        merge_fun: fn _uid, _hash -> :queued end,
+        timeouts: [state_timeout_ms: 5_000]
+      ]
+
+      unit_pid = @unit_supervisor.start_unit(sup_name, opts)
+      assert is_pid(unit_pid), "start_unit must return a pid"
+
+      # Advance oracle → implementing via a CURRENT-worker work_ready.
+      drive_work_ready(unit_pid, current_worker_id)
+      :timer.sleep(50)
+
+      # Confirm we are in implementing with the current worker.
+      assert {:implementing, _data} = :sys.get_state(unit_pid),
+             "AC-13/D-326: Unit must be in :implementing before the stale-event test"
+
+      # Deliver a work_ready for a SUPERSEDED worker_id — must be discarded (B8).
+      stale_worker_id = "w-stale-#{n}"
+      send(unit_pid, {:work_ready, stale_worker_id, "feat/stale", "cafebabe"})
+
+      # The stale event must NOT drive the gating edge.
+      refute_receive {:gate_called, ^unit_id},
+                     1_000,
+                     "AC-13/D-326: a work_ready from a superseded worker_id MUST be discarded; " <>
+                       "the Unit must not transition implementing → gating on it."
+
+      # And the Unit must still be in :implementing, awaiting its current worker.
+      assert {:implementing, _data} = :sys.get_state(unit_pid),
+             "AC-13/D-326: after a discarded stale work_ready, the Unit stays in :implementing"
+    end
+  end
+end

--- a/test/tau/factory/worker_test.exs
+++ b/test/tau/factory/worker_test.exs
@@ -577,14 +577,16 @@ defmodule Tau.Factory.WorkerTest do
 
       # B4: death-certificate delivered by unlinked monitor on Port exit-0.
       # No drain window — the monitor fires on :DOWN for every reason.
+      # D-326: a dummy agent that emits no work_ready frame yields :no_work_product
+      # (fail-closed). A :normal exit after work_ready would yield :normal.
       assert_receive {:worker_exit, ^worker_id, reason},
                      5_000,
-                     "B4: {:worker_exit, worker_id, :normal} must be sent to report_to " <>
+                     "B4: {:worker_exit, worker_id, _} must be sent to report_to " <>
                        "after the Port exits with status 0"
 
-      assert reason == :normal or match?({:exit_status, 0}, reason) or
+      assert reason in [:normal, :no_work_product] or match?({:exit_status, 0}, reason) or
                match?({:normal, _}, reason),
-             "B4: worker_exit reason for exit-0 must be :normal (or {:exit_status, 0}); " <>
+             "B4: worker_exit reason for exit-0 must be :normal or :no_work_product (D-326); " <>
                "got #{inspect(reason)}"
 
       # Death-cert has arrived; allow cleanup a moment.


### PR DESCRIPTION
## P5c-3a — implement D-326: Worker `work_ready` → Unit `implementing→gating` trigger

Closes #467. Advances #458 (P5c) / #416 (M10). Implements the **D-326** worker→Unit
completion contract designed in #460/#461 (the one true architecture gap). Closes the
worker-signal mismatch ahead of the UnitDriver (P5c-3b).

### Background
The Unit FSM today waits for an injected `{:worker_done, worker_pid}` placeholder; the
real Worker fleet emits only `{:worker_exit, worker_id, reason}` (death cert). #461
designed the fix: a normally-completing agent emits an in-band `work_ready(branch,
head_sha)` frame BEFORE exit; the Worker forwards `work_ready(worker_id, …)` to its Unit
as the SOLE `implementing → gating` trigger. Exit-0 without `work_ready` is fail-closed
(`worker_exit(:no_work_product)`) — a crash/no-op cannot forge completion.

### Authoritative semantics — READ THE ARCH (not just the SPEC §-refs)
D-326 originated as a docs/arch gap (#460); #461 worked out its semantics in the
arch files, which are the most carefully-reasoned source. The implementer MUST read:
- `docs/arch/04-software-architecture/control-plane.md` **§3.2.1** — the
  `implementing → gating` trigger clause, the disjoint `worker_event` table
  (`work_ready | worker_exit | worker_stalled`), and the load-bearing in-band-vs-exit
  decision.
- `docs/arch/04-software-architecture/worker-fleet.md` **§4** — the agent→Worker
  in-band `work_ready` Port frame, the decode/dispatch path, and the exit-code /
  `:no_work_product` fail-closed rule (the Port `{:data}`-before-`{:exit_status}`
  ordering guarantee, scoped per worker_id).
- `docs/arch/03-system-architecture/system-architecture.md` — W `E_out` (`work_ready`)
  and U `E_in` (`worker_event` disjoint sum).
The SPEC-FACTORY-{FLEET,CORE} §-refs below are the derived contract; the arch sections
above govern where they are silent or terser.

### Scope & order (SPEC-FACTORY-FLEET D-326/AC-13; SPEC-FACTORY-CORE §4 B8)
1. `lib/tau/factory/worker.ex` — parse the agent's in-band `work_ready(branch, head_sha)`
   frame from the `{:packet,4}` Port (`handle_info({port,{:data,_}},…)` currently IGNORES
   agent output), and FORWARD `work_ready(worker_id, branch, head_sha)` to the owning Unit
   (`report_to`), keyed by `worker_id`. The Worker is the SOLE forwarder (the D-326
   enforcer — like the independent monitor is the sole `worker_exit` writer). `exit_status
   0` with NO prior `work_ready` → `worker_exit(:no_work_product)` (fail-closed).
2. `lib/tau/factory/unit.ex` — consume `work_ready(worker_id, …)` as the `implementing →
   gating` trigger (§4 B8), REPLACING the `{:worker_done, worker_pid}` placeholder.
   Re-resolve by `worker_id` (per §4.5 monitor-by-key); discard stale-worker events.
   Preserve the crash path (`worker_exit`/`:DOWN`) + snapshot-on-entry (P5c-1).
3. Keep the seams INJECTABLE for tests (the real Port-frame decode path + a test seam to
   deliver `work_ready`).

### Dependencies
Depends on #461 (D-326 design). Blocks P5c-3b (UnitDriver). Additive.

### SPECs
In scope: **SPEC-FACTORY-FLEET** (D-326/AC-13 — the Worker frame + forward) +
**SPEC-FACTORY-CORE** (§4 B8 — the Unit trigger). Conforms to the #461 design; amendment
only if a new constraint surfaces.

### Acceptance criteria
- **AC-13 (D-326, load-bearing):** `worker_completion_event_test.exs` — a Worker that
  receives an in-band `work_ready` frame forwards exactly one `work_ready(worker_id,
  branch, head_sha)` to its Unit; the Unit transitions `implementing → gating` on it (NOT
  on bare exit). A clean exit WITHOUT `work_ready` yields `worker_exit(:no_work_product)`
  (fail-closed) and the Unit does NOT gate. A stale-worker `work_ready` (wrong `worker_id`)
  is discarded.

### Gating-test paths (FROZEN — implementer MUST NOT edit)
- `test/tau/factory/worker_completion_event_test.exs` (AC-13 / D-326)

### Cross-check vs the arch (coordinator) + the §4 interface details to pin in-PR
The test-author's pinned contract was cross-checked against `worker-fleet.md §4`
and `control-plane.md §3.2.1` — **the message shapes are arch-faithful** and the
JSON codec is arch-consistent (the existing agent protocol IS stream-json —
`coding_agent/event.ex`, `cost.ex:201`). Pin these in a §4 amendment (SPEC-FACTORY-FLEET
§4 B4 + SPEC-FACTORY-CORE §4 B8), conforming to the arch + the frozen test:
1. **Wire codec = JSON** (stream-json-consistent) inside the `{:packet,4}` frame:
   `{"type":"work_ready","branch":…,"head_sha":…}`. **Decode it into a TYPED event**
   (extend `Tau.Provider.Event` per the arch — `worker-fleet.md:221,241-243`; "never an
   ad-hoc format / no line-scraping"), not a raw map.
2. **Worker→Unit message:** `{:work_ready, worker_id, branch, head_sha}` (the success
   twin of `{:worker_exit, worker_id, reason}`); fail-closed `{:worker_exit, worker_id,
   :no_work_product}` (matches `worker-fleet.md:229,233-234`).
3. **Unit seam:** `worker_fun.(role) -> {:ok, worker_pid, worker_id}`; the Unit stores
   `data.worker_id` and gates on `{:work_ready, ^worker_id, _, _}`, discarding stale-id
   events (matches `control-plane.md:438,445`). This is the load-bearing seam change.

### Gate verdicts
_(filled at gate time — critic, reviewer)_


