### PR TITLE
P5c-4 — IssueSelector: the real select_fun (B10)

### DIFF
--- a/docs/spec/SPEC-FACTORY-CORE.md
+++ b/docs/spec/SPEC-FACTORY-CORE.md
@@ -411,6 +411,28 @@ callers that pass no `:ledger` opt are unaffected (back-compat).
   `reconcile` is a read-only projection used to discharge CON-2 (D-331). The
   tracker is never a second writer of L.
 
+**Amendment (PR #470 / B10):** pins the `IssueSelector` contract that
+implements `select_next`:
+
+- **Entry point:** `Tau.Factory.IssueSelector.select(opts :: keyword()) ::
+  work_item | nil`.
+- **opts:** `:ledger` (`GenServer.server()` — running `Ledger.Writer`, read-only
+  projection source); `:milestone` (`String.t()`); `:gh_fun`
+  (`(String.t() -> {:ok, [issue_map]})` — stubbable read-only `gh` adapter;
+  `issue_map` carries at minimum `"number"` and `"title"` keys; NO network in
+  tests). Follows the codebase's canonical `*_fun` injection pattern.
+- **`unit_id` derivation:** `"unit-<number>"` — a stable, issue-number-derived
+  id ensuring the L-projection aligns with the ids the rest of the factory
+  snapshots under (D-331 [C112-B10]).
+- **`work_item` shape:** `{issue, scope, hash, branch}` — a 4-tuple where
+  `scope` is a non-nil frozen declared scope string, `hash` is a non-empty
+  content-hash string, and `branch` is a non-empty feature-branch name string.
+  `issue` carries the issue number (at minimum as `"number"` key).
+- **Return:** `work_item` when an open, non-terminal-in-L issue exists; `nil`
+  when the milestone is drained or every open issue is terminal in L (D-342).
+- **L is read-only:** the selector NEVER writes L; the tracker is not a second
+  writer of L (D-331 [C112-B10]).
+
 ## 5. State enumeration
 
 ### Coordinator (K) — `gen_statem`, `state_functions`

--- a/lib/tau/factory/issue_selector.ex
+++ b/lib/tau/factory/issue_selector.ex
@@ -1,0 +1,147 @@
+defmodule Tau.Factory.IssueSelector do
+  @moduledoc """
+  Real `select_fun` for the Coordinator loop (K) — B10 / D-331 / D-342.
+
+  `IssueSelector.select/1` is the real `select_fun` the Coordinator calls to
+  turn "open issues in the assigned milestone" into admittable work. It:
+
+    1. Reads open milestone issues via a **stubbable, read-only `gh` adapter**
+       injected as the `:gh_fun` seam — the default real implementation shells
+       out `gh issue list --milestone <m> --state open --json number,title,body,labels`
+       and decodes the result. Tests inject a stub; NO network call occurs in
+       tests (D-331 §4 [C112-B10]).
+
+    2. **Projects against the Ledger** (`Ledger.Reader.latest_unit_snapshots/1`)
+       to DROP issues whose unit is already terminal (`:merged` / `:escalated`).
+       The projection is READ-ONLY — L is the authority for *what is done* and is
+       NEVER written by the selector (D-331, §4 [C112-B10]).
+
+    3. Picks the smallest shippable increment (first admittable open issue in
+       tracker order) and freezes a declared scope.
+
+    4. Returns a `work_item` `{issue, scope, hash, branch}`, or `nil` when no
+       admittable open issue remains (D-342 — milestone termination signal).
+
+  ## Pinned contract (§4 B10 amendment, PR #470)
+
+    - **Entry point:** `select(opts :: keyword()) :: work_item | nil`.
+
+    - **opts:**
+        * `:ledger`    — `GenServer.server()` of a running `Ledger.Writer`
+                         (projection source, read-only).
+        * `:milestone` — `String.t()`; the assigned milestone title.
+        * `:gh_fun`    — `(milestone :: String.t() -> {:ok, [issue_map]})`;
+                         the stubbable read-only `gh` adapter. When absent,
+                         the real default is used. `issue_map` carries at
+                         minimum `"number"` and `"title"` keys (the `--json`
+                         projection). This seam follows the codebase's
+                         canonical `*_fun` injection pattern.
+
+    - **`unit_id` derivation:** `"unit-<number>"` — a stable, issue-derived id
+      so the L-projection aligns with the ids the rest of the factory snapshots
+      under (D-331 §4 [C112-B10], pinned in this PR).
+
+    - **Return:** `{issue, scope, hash, branch}` (4-tuple `work_item`) or `nil`.
+      `scope` is a non-nil frozen declared scope string; `hash` and `branch` are
+      non-empty strings.
+
+  This module is a plain functional module — no GenServer. Pure given injected
+  seams (OTP non-negotiable §3: no GenServer wrapping stateless logic).
+  """
+
+  alias Tau.Factory.Ledger.Reader, as: LedgerReader
+
+  @terminal_states [:merged, :escalated]
+
+  @typedoc """
+  The 4-tuple returned by `select/1` when an admittable issue exists.
+
+  - `issue`  — the raw `issue_map` (or normalised form) carrying at minimum
+               `"number"` and `"title"`.
+  - `scope`  — frozen declared scope string (non-nil).
+  - `hash`   — content hash string (non-empty).
+  - `branch` — feature branch name string (non-empty).
+  """
+  @type work_item ::
+          {issue_map :: map(), scope :: String.t(), hash :: String.t(), branch :: String.t()}
+
+  @doc """
+  Select the next admittable work item from the assigned milestone.
+
+  ## Options
+
+    - `:ledger`    — `GenServer.server()`; a running `Ledger.Writer`.
+    - `:milestone` — `String.t()`; the milestone title to query.
+    - `:gh_fun`    — optional; `(String.t() -> {:ok, [map()]})`. Defaults to
+                     the real `gh issue list` shell adapter.
+
+  Returns a `work_item` 4-tuple or `nil`.
+  """
+  @spec select(keyword()) :: work_item() | nil
+  def select(opts) do
+    ledger = Keyword.fetch!(opts, :ledger)
+    milestone = Keyword.fetch!(opts, :milestone)
+    gh_fun = Keyword.get(opts, :gh_fun, &default_gh_fun/1)
+
+    {:ok, issues} = gh_fun.(milestone)
+
+    snapshots = LedgerReader.latest_unit_snapshots(ledger)
+
+    issues
+    |> Enum.reject(&terminal_in_ledger?(&1, snapshots))
+    |> pick_work_item()
+  end
+
+  # ---------------------------------------------------------------------------
+  # Private helpers
+  # ---------------------------------------------------------------------------
+
+  # Derive the unit_id for an issue using the factory-test convention.
+  # MUST match `"unit-<number>"` so the L-projection aligns with ids the rest
+  # of the factory snapshots under (D-331 §4 [C112-B10], pinned PR #470).
+  defp unit_id_for(%{"number" => number}), do: "unit-#{number}"
+
+  # True when the issue's derived unit_id has a terminal state in L.
+  defp terminal_in_ledger?(issue, snapshots) do
+    uid = unit_id_for(issue)
+    Map.get(snapshots, uid) in @terminal_states
+  end
+
+  # Pick the smallest shippable increment: first in tracker order.
+  # Freezes a declared scope and derives a deterministic hash and branch name.
+  defp pick_work_item([]), do: nil
+
+  defp pick_work_item([issue | _rest]) do
+    number = Map.fetch!(issue, "number")
+    title = Map.get(issue, "title", "")
+
+    scope = "#{number}: #{title}"
+    hash = content_hash(number, title)
+    branch = "unit-#{number}"
+
+    {issue, scope, hash, branch}
+  end
+
+  # Deterministic content hash for the scope — SHA-256 of "number:title".
+  defp content_hash(number, title) do
+    :crypto.hash(:sha256, "#{number}:#{title}")
+    |> Base.encode16(case: :lower)
+  end
+
+  # Default real `gh` adapter: shells out to `gh issue list`.
+  # Tests MUST inject a stub via `:gh_fun` — this path is NOT exercised in tests.
+  defp default_gh_fun(milestone) do
+    cmd =
+      "gh issue list --milestone #{shell_escape(milestone)} --state open --json number,title,body,labels"
+
+    case System.cmd("sh", ["-c", cmd], stderr_to_stdout: false) do
+      {output, 0} ->
+        Jason.decode(output)
+
+      {output, code} ->
+        {:error, {:gh_exit, code, output}}
+    end
+  end
+
+  defp shell_escape(s), do: "'" <> String.replace(s, "'", "'\\''") <> "'"
+end

--- a/test/tau/factory/issue_selector_test.exs
+++ b/test/tau/factory/issue_selector_test.exs
@@ -1,0 +1,274 @@
+defmodule Tau.Factory.IssueSelectorTest do
+  @moduledoc """
+  Gating test for `Tau.Factory.IssueSelector` — the real `select_fun` (B10).
+
+  P5c-4 / #469. Advances #458 (P5c) / #416 (M10).
+
+  ## What the selector is (SPEC-FACTORY-CORE §4 B10, D-331, D-342)
+
+  `IssueSelector.select/1` is the real `select_fun` the Coordinator loop
+  (`lib/tau/factory/coordinator.ex` — `select_fun: (-> work_item | nil)`) calls
+  to turn "open issues in the assigned milestone" into admittable work. It:
+
+    1. reads open milestone issues via a **stubbable, read-only `gh` adapter**
+       (`gh issue list --milestone <m> --state open --json number,title,...`),
+       injected as a seam so the test never touches the network;
+    2. **projects against the Ledger** (`Ledger.Reader.latest_unit_snapshots/1`)
+       to DROP issues whose unit is already terminal (`:merged` / `:escalated`)
+       — a READ-ONLY projection: L is the authority for *what is done* and is
+       NEVER written by the selector (D-331, §4 [C112-B10]);
+    3. picks the smallest shippable increment and freezes a declared scope;
+    4. returns a `work_item` `{issue, scope, hash, branch}`, or `nil` when no
+       admittable open issue remains (D-342 — milestone termination).
+
+  ## Pinned contract this test asserts against
+
+    - **Entry point:** `Tau.Factory.IssueSelector.select(opts :: keyword())`.
+      `opts` carries:
+        * `:ledger`    — `GenServer.server()` of a running `Ledger.Writer`
+                         (the projection source, read-only).
+        * `:milestone` — `String.t()`; the assigned milestone title.
+        * `:gh_fun`    — the stubbable read-only `gh` adapter: a 1-arity fun
+                         `(milestone :: String.t() -> {:ok, [issue_map]})`,
+                         where `issue_map` has at least `"number"` and
+                         `"title"` keys (the `--json` projection).
+      The injected seam follows the codebase's canonical `*_fun` injection
+      pattern (cf. `Coordinator` `:select_fun`/`:drive_fun`,
+      `MergeAuthority` `build_fun`).
+
+    - **Return:** `{issue, scope, hash, branch}` (a 4-tuple `work_item`,
+      co-designed with P5c-3b) when an open, non-terminal-in-L issue exists;
+      `nil` when the milestone is drained or every open issue is terminal in L.
+
+  This file is the frozen gating-test path for PR #470. It MUST FAIL on `main`
+  (module absent) and pass only once `IssueSelector` lands. It exercises the
+  REAL selector against a REAL supervised Ledger — never a hand-built struct.
+  """
+
+  use ExUnit.Case, async: false
+
+  alias Tau.Factory.IssueSelector
+  alias Tau.Factory.Ledger.Reader
+  alias Tau.Factory.Ledger.Writer
+
+  @writer Writer
+
+  # ---------------------------------------------------------------------------
+  # Helpers
+  # ---------------------------------------------------------------------------
+
+  defp unique_name(base) do
+    suffix = System.unique_integer([:positive])
+    :"#{base}_#{suffix}"
+  end
+
+  # Start a real, supervised Ledger.Writer against an isolated temp DB; return
+  # its registered name. Mirrors coordinator_recovery_test.exs's start_ledger/0.
+  defp start_ledger do
+    db_path = Briefly.create!(extname: ".db")
+    writer_name = unique_name(:issue_sel_ledger)
+
+    start_supervised!(
+      {@writer, db_path: db_path, name: writer_name},
+      id: writer_name
+    )
+
+    writer_name
+  end
+
+  # A stubbable read-only `gh` adapter: returns the given fixed issue list for
+  # ANY milestone, and records that it was called (so the test can prove the
+  # selector consulted the tracker, not a hidden network call).
+  defp gh_stub(issues) do
+    test_pid = self()
+
+    fn milestone ->
+      send(test_pid, {:gh_called, milestone})
+      {:ok, issues}
+    end
+  end
+
+  # The unit_id the selector derives for a given issue. The selector must use a
+  # stable, issue-derived unit_id so its L-projection lines up with the ids the
+  # rest of the factory snapshots under. The conventional form across the
+  # factory tests is "unit-<number>"; this helper encodes that convention so
+  # the seeded terminal snapshot collides with the selector's projection.
+  defp unit_id_for(issue_number), do: "unit-#{issue_number}"
+
+  defp issue(number, title, opts \\ []) do
+    %{
+      "number" => number,
+      "title" => title,
+      "body" => Keyword.get(opts, :body, ""),
+      "labels" => Keyword.get(opts, :labels, [])
+    }
+  end
+
+  # ---------------------------------------------------------------------------
+  # 1. Selects an open, non-terminal issue (B10).
+  #
+  # gh returns one open milestone issue; L is empty (no terminal units). The
+  # selector MUST return a work_item {issue, scope, hash, branch} for that
+  # issue — exercised through the REAL select/1, not a hand-built struct.
+  # ---------------------------------------------------------------------------
+  @tag :b10
+  @tag :d_331
+  @tag :d_342
+  test "B10/D-331/D-342: select/1 returns a work_item for an open non-terminal issue" do
+    ledger = start_ledger()
+    milestone = "M10"
+
+    open_issue = issue(469, "P5c-4 — IssueSelector")
+    gh_fun = gh_stub([open_issue])
+
+    result =
+      IssueSelector.select(
+        ledger: ledger,
+        milestone: milestone,
+        gh_fun: gh_fun
+      )
+
+    # The selector actually consulted the (stubbed) tracker for THIS milestone.
+    assert_received {:gh_called, ^milestone}
+
+    # Strong assertion on the pinned work_item shape: a 4-tuple
+    # {issue, scope, hash, branch}, carrying the selected issue.
+    assert {selected_issue, scope, hash, branch} = result,
+           "expected a {issue, scope, hash, branch} work_item, got: #{inspect(result)}"
+
+    # The work_item carries the open issue the selector picked.
+    assert issue_carries_number?(selected_issue, 469),
+           "work_item issue did not carry issue #469: #{inspect(selected_issue)}"
+
+    # The remaining fields are populated (a frozen scope, a content hash, a
+    # branch) — none may be nil for an admittable issue.
+    refute is_nil(scope), "scope must be a frozen declared scope, not nil"
+    assert is_binary(hash) and hash != "", "hash must be a non-empty string"
+    assert is_binary(branch) and branch != "", "branch must be a non-empty string"
+  end
+
+  # ---------------------------------------------------------------------------
+  # 2. Drops terminal-in-L issues (D-331).
+  #
+  # gh returns one open issue, but that issue's unit is ALREADY :merged in L
+  # (seeded via the REAL durable Writer.snapshot_unit/2). The read-only
+  # projection MUST drop it — so with no OTHER open issue, select/1 returns nil.
+  # ---------------------------------------------------------------------------
+  @tag :b10
+  @tag :d_331
+  test "B10/D-331: select/1 drops an issue whose unit is already terminal in L" do
+    ledger = start_ledger()
+    milestone = "M10"
+
+    terminal_issue_number = 469
+    open_issue = issue(terminal_issue_number, "already-merged increment")
+    gh_fun = gh_stub([open_issue])
+
+    # Seed L: the open issue's unit is already at a terminal sink (:merged),
+    # via the REAL durable write op.
+    unit_id = unit_id_for(terminal_issue_number)
+
+    assert {:ok, _} =
+             @writer.snapshot_unit(ledger, %{
+               unit_id: unit_id,
+               state: :merged,
+               idempotency_key: "#{unit_id}:snapshot:merged"
+             })
+
+    result =
+      IssueSelector.select(
+        ledger: ledger,
+        milestone: milestone,
+        gh_fun: gh_fun
+      )
+
+    # The only open issue is terminal in L → it is dropped → nothing admittable.
+    assert result == nil,
+           "D-331 violation: an issue terminal-in-L (:merged) was NOT dropped; " <>
+             "select/1 returned #{inspect(result)} instead of nil"
+  end
+
+  # ---------------------------------------------------------------------------
+  # 3. `nil` on drained (D-342).
+  #
+  # gh returns NO open issues. select/1 MUST return nil — the milestone has
+  # reached zero open issues (D-342 termination signal).
+  # ---------------------------------------------------------------------------
+  @tag :b10
+  @tag :d_342
+  test "B10/D-342: select/1 returns nil when the milestone has no open issues" do
+    ledger = start_ledger()
+    milestone = "M10"
+
+    gh_fun = gh_stub([])
+
+    result =
+      IssueSelector.select(
+        ledger: ledger,
+        milestone: milestone,
+        gh_fun: gh_fun
+      )
+
+    assert result == nil,
+           "D-342 violation: a drained milestone (no open issues) did not yield " <>
+             "nil; select/1 returned #{inspect(result)}"
+  end
+
+  # ---------------------------------------------------------------------------
+  # 4. L is read-only (D-331).
+  #
+  # The selector projects L but MUST NEVER write it (the tracker is never a
+  # second writer of L). Assert the unit-snapshot population in L is unchanged
+  # across a select/1 call — including a call that selects a work_item.
+  # ---------------------------------------------------------------------------
+  @tag :b10
+  @tag :d_331
+  test "B10/D-331: select/1 never writes the Ledger (read-only projection)" do
+    ledger = start_ledger()
+    milestone = "M10"
+
+    # Seed one terminal unit so L starts non-empty and the snapshot count is a
+    # meaningful, observable quantity.
+    seeded_unit = unit_id_for(999)
+
+    assert {:ok, _} =
+             @writer.snapshot_unit(ledger, %{
+               unit_id: seeded_unit,
+               state: :escalated,
+               idempotency_key: "#{seeded_unit}:snapshot:escalated"
+             })
+
+    snapshots_before = Reader.latest_unit_snapshots(ledger)
+
+    # An open, non-terminal issue → select/1 returns a work_item. Even on the
+    # admit path, L MUST NOT be written.
+    open_issue = issue(469, "fresh admittable increment")
+    gh_fun = gh_stub([open_issue])
+
+    _result =
+      IssueSelector.select(
+        ledger: ledger,
+        milestone: milestone,
+        gh_fun: gh_fun
+      )
+
+    snapshots_after = Reader.latest_unit_snapshots(ledger)
+
+    assert snapshots_after == snapshots_before,
+           "D-331 violation: select/1 mutated L. The selector's projection MUST " <>
+             "be read-only (the tracker is never a second writer of L). " <>
+             "before=#{inspect(snapshots_before)} after=#{inspect(snapshots_after)}"
+  end
+
+  # ---------------------------------------------------------------------------
+  # Shape-tolerant accessor: the work_item's first element is "the issue". The
+  # selector may carry it as the raw gh map, a normalised struct, or the bare
+  # number; this predicate accepts any representation that preserves the issue
+  # number, so the gating test pins the CONTRACT (the right issue is selected)
+  # without over-constraining the issue representation P5c-3b co-designs.
+  # ---------------------------------------------------------------------------
+  defp issue_carries_number?(%{"number" => n}, n), do: true
+  defp issue_carries_number?(%{number: n}, n), do: true
+  defp issue_carries_number?(n, n) when is_integer(n), do: true
+  defp issue_carries_number?(_, _), do: false
+end


### PR DESCRIPTION
## P5c-4 — IssueSelector: the real `select_fun` (B10)

Closes #469. Advances #458 (P5c) / #416 (M10). Independent of P5c-3a/3b — runs in parallel.

The real `select_fun` the Coordinator loop calls to turn "open issues in the assigned
milestone" into admittable work. Today the seam is injected; this is the minimal real selector.

### Scope (SPEC-FACTORY-CORE B10, D-331/D-342)
`lib/tau/factory/issue_selector.ex` — read open milestone issues via a **stubbable `gh`
adapter** (read-only: `gh issue list --milestone <m> --state open --json number,title,body,labels`);
project against L (`Ledger.Reader.latest_unit_snapshots/1`) to DROP already-terminal units
(D-331, read-only projection — the tracker is NEVER written); pick the smallest shippable
increment; freeze a declared scope; return a `work_item` `{issue, scope, hash, branch}`, or
`nil` when no admittable open issue remains (D-342 termination).

### Acceptance criteria
- **AC (B10/D-331/D-342):** `issue_selector_test.exs` — with a stubbed `gh` adapter: returns
  the expected `work_item` when an issue is open AND not terminal in L; returns `nil` when the
  milestone is drained or every open issue is already terminal in L; L is NEVER written.

### Dependencies
Independent of P5c-3a/3b (new file, disjoint). Co-design the `work_item` shape with P5c-3b.
SPEC: SPEC-FACTORY-CORE (B10, D-331, D-342). Amendment only if a new constraint surfaces.

### Gating-test paths (FROZEN — implementer MUST NOT edit)
- `test/tau/factory/issue_selector_test.exs` (B10/D-331/D-342)

### Pinned contract (test-author) — implementer conforms or lands a §4 amendment
- `Tau.Factory.IssueSelector.select(opts :: keyword()) :: work_item | nil`.
- opts: `:ledger` (running `Ledger.Writer`, read-only projection source), `:milestone`
  (String), `:gh_fun` (`(String.t() -> {:ok, [issue_map]})`, injected read-only seam — NO
  network in test; `issue_map` has `"number"`/`"title"`).
- `work_item = {issue, scope, hash, branch}` (scope non-nil, hash/branch non-empty, issue
  carries the number). Co-design with P5c-3b.
- **L-projection unit_id derivation = `"unit-<number>"`** (the factory-test convention the
  frozen test uses — the implementer MUST derive the same id so the terminal-drop projection
  lines up). Pin this + the `:gh_fun` seam in a §4 amendment (SPEC-FACTORY-CORE B10).

### Gate verdicts
_(filled at gate time — critic, reviewer)_

