### PR TITLE
P5c-5 — escalation drain (#453) + dead-clause removal (#452)

### DIFF
--- a/lib/tau/factory/coordinator.ex
+++ b/lib/tau/factory/coordinator.ex
@@ -223,10 +223,14 @@ defmodule Tau.Factory.Coordinator do
     end
   end
 
-  # Global escalation → halting.
+  # Global escalation → halting (D-320).
+  # If a unit is in flight, route through :halting and AWAIT {:unit_terminal}
+  # so the in-flight unit is drained before reaching :halted (drain-first).
+  # If no unit is in flight, the existing halting(:internal, :drain) nil-branch
+  # transitions immediately to :halted.
   def running(:info, {:escalate, {_e, :global}}, data) do
     telemetry(:escalate, %{}, %{scope: :global})
-    {:next_state, :halting, %{data | in_flight: nil}, [{:next_event, :internal, :drain}]}
+    {:next_state, :halting, data, [{:next_event, :internal, :drain}]}
   end
 
   # Per-unit escalation → stay running; treat as a terminal for loop progress.
@@ -277,15 +281,6 @@ defmodule Tau.Factory.Coordinator do
   # ---------------------------------------------------------------------------
   # State: :halted
   # ---------------------------------------------------------------------------
-
-  # Forward unit_finished notifications to on_halted when the drive_fun was
-  # invoked from this process's context (self() = coordinator in the closure),
-  # so the test/caller receives the notification rather than losing it.
-  def halted(:info, {:unit_finished, _unit_id} = msg, %{on_halted: on_halted} = data)
-      when is_pid(on_halted) do
-    send(on_halted, msg)
-    {:keep_state, data}
-  end
 
   def halted(_event_type, _event, data) do
     {:keep_state, data}

--- a/test/tau/factory/escalation_drain_test.exs
+++ b/test/tau/factory/escalation_drain_test.exs
@@ -1,0 +1,184 @@
+defmodule Tau.Factory.EscalationDrainTest do
+  @moduledoc """
+  Gating test for PR #471 (P5c-5 — #453 / D-320 global-escalation drain).
+
+  Enforces the SPEC-FACTORY-CORE §5 `:halting` contract: the `halting` state
+  exists to **drain in-flight units to a clean checkpoint** when entered by a
+  global escalation. A global escalation delivered while a unit is in flight
+  MUST drain that unit (let it run to its `{:unit_terminal, …}`) BEFORE the
+  Coordinator reaches `:halted` — the in-flight unit is NOT abandoned.
+
+  This mirrors the D-321 clean-kill contract (`kill_switch_test.exs`), which
+  already drains the in-flight unit at a unit boundary. The global-escalation
+  path must observe the same drain-first discipline.
+
+  ## Fail-before (on current `main`)
+
+  The `running(:info, {:escalate, {_e, :global}}, data)` clause currently
+  zeroes `in_flight` and drains straight to `:halted` (`{:next_event,
+  :internal, :drain}` with `in_flight: nil`), ABANDONING the in-flight unit.
+  The unit's `{:unit_terminal, …}` is never awaited, so the
+  "unit reached terminal BEFORE :halted" assertion below FAILS until the drain
+  is implemented (route through `:halting` and await the in-flight unit's
+  terminal).
+
+  Drives a real `Tau.Factory.Coordinator` via the same injected seams
+  (`select_fun` / `drive_fun`) the kill-switch test uses, so the test exercises
+  the genuine gen_statem path — NOT a hand-built struct.
+
+  AC/D-NNN linkage: D-320 (#453).
+  """
+
+  use ExUnit.Case, async: true
+
+  @moduletag :capture_log
+  @moduletag :d_320
+
+  @coordinator Tau.Factory.Coordinator
+
+  defp unique_name(base) do
+    suffix = System.unique_integer([:positive])
+    :"#{base}_#{suffix}"
+  end
+
+  # ---------------------------------------------------------------------------
+  # D-320 / #453 — global escalation drains the in-flight unit before :halted.
+  #
+  # Timeline:
+  #   1. Start Coordinator; select_fun returns one work item then nil.
+  #   2. drive_fun spawns a blocking unit (holds in flight) and records when
+  #      it reaches terminal into an external order-log Agent.
+  #   3. Deliver a GLOBAL escalation {:escalate, {e, :global}} while the unit
+  #      is in flight.
+  #   4. Release the unit → it sends {:unit_terminal, …} to the Coordinator and
+  #      records :unit_terminal into the order-log; the Coordinator then reaches
+  #      :halted and the order-log records :halted (via on_halted).
+  #   5. Assert: the in-flight unit reached terminal (NOT abandoned), AND the
+  #      :unit_terminal event was recorded BEFORE :halted.
+  # ---------------------------------------------------------------------------
+
+  @tag :d_320
+  test "D-320 / #453: global escalation drains the in-flight unit (reaches terminal) before :halted" do
+    coord_name = unique_name(:coord_drain)
+    pubsub_name = Tau.PubSub
+    test_pid = self()
+
+    # External order-log: appends event atoms in the order they occur, so we can
+    # assert :unit_terminal precedes :halted (drain-first, not abandon).
+    {:ok, order_log} = Agent.start_link(fn -> [] end)
+
+    work_item = "unit-drain-#{System.unique_integer([:positive])}"
+    unit_id = work_item
+
+    # One work item, then nil.
+    {:ok, counter} = Agent.start_link(fn -> 0 end)
+
+    select_fun = fn ->
+      n = Agent.get_and_update(counter, fn c -> {c, c + 1} end)
+      if n == 0, do: work_item, else: nil
+    end
+
+    # Register the unit pid so the test can release it once it is in flight.
+    unit_pids = :ets.new(:drain_unit_pids, [:public, :set])
+
+    drive_fun = fn _work ->
+      coord_pid = Process.whereis(coord_name)
+
+      unit_pid =
+        spawn(fn ->
+          receive do
+            :finish ->
+              # Record that the in-flight unit reached terminal, THEN tell the
+              # Coordinator. Drain-first means this MUST be observed before
+              # :halted.
+              Agent.update(order_log, fn log -> log ++ [:unit_terminal] end)
+              send(coord_pid, {:unit_terminal, unit_id, :merged})
+              send(test_pid, {:unit_finished, unit_id})
+          end
+        end)
+
+      :ets.insert(unit_pids, {unit_id, unit_pid})
+      :ok
+    end
+
+    # on_halted: record :halted into the order-log AND notify the test.
+    on_halted_pid =
+      spawn_link(fn ->
+        receive do
+          :coordinator_halted ->
+            Agent.update(order_log, fn log -> log ++ [:halted] end)
+            send(test_pid, :coordinator_halted)
+        end
+      end)
+
+    start_supervised!(
+      {
+        @coordinator,
+        name: coord_name,
+        pubsub: pubsub_name,
+        select_fun: select_fun,
+        drive_fun: drive_fun,
+        scheduler: nil,
+        on_halted: on_halted_pid
+      },
+      id: coord_name
+    )
+
+    # Wait for the unit to be in flight.
+    assert_unit_in_flight = fn ->
+      Enum.reduce_while(1..100, :not_yet, fn _, _ ->
+        case :ets.lookup(unit_pids, unit_id) do
+          [{^unit_id, _pid}] -> {:halt, :ok}
+          [] -> Process.sleep(10) && {:cont, :not_yet}
+        end
+      end)
+    end
+
+    assert :ok == assert_unit_in_flight.()
+    [{^unit_id, unit_pid}] = :ets.lookup(unit_pids, unit_id)
+    assert Process.alive?(unit_pid)
+
+    # Deliver a GLOBAL escalation while the unit is in flight.
+    send(coord_name, {:escalate, {:E_UNCLASSIFIED, :global}})
+
+    # The drain contract: the Coordinator MUST NOT reach :halted while the unit
+    # is still in flight. Give it a moment, then assert the unit is still alive
+    # and the Coordinator has not yet halted.
+    Process.sleep(50)
+
+    refute_received :coordinator_halted
+
+    {state_after_esc, _} = :sys.get_state(coord_name)
+
+    assert state_after_esc in [:halting, :running],
+           "global escalation with an in-flight unit must drain (await terminal), " <>
+             "not jump to :halted; state=#{inspect(state_after_esc)}"
+
+    assert Process.alive?(unit_pid),
+           "D-320 drain violation: in-flight unit was abandoned by the global escalation"
+
+    # Release the unit so it can reach terminal.
+    send(unit_pid, :finish)
+
+    # The in-flight unit MUST run to terminal (not abandoned).
+    assert_receive {:unit_finished, ^unit_id}, 2000
+
+    # The Coordinator then reaches :halted.
+    assert_receive :coordinator_halted, 2000
+
+    {final_state, _} = :sys.get_state(coord_name)
+    assert final_state == :halted
+
+    # The crux: the in-flight unit's terminal was DRAINED (observed) BEFORE the
+    # Coordinator reached :halted. On current `main` the global-escalation
+    # clause zeroes in_flight and halts straight away, so :halted is recorded
+    # without :unit_terminal ever preceding it → this assertion fails.
+    order = Agent.get(order_log, & &1)
+
+    assert order == [:unit_terminal, :halted],
+           "global escalation must drain the in-flight unit to terminal BEFORE " <>
+             ":halted; observed order=#{inspect(order)}"
+
+    :ets.delete(unit_pids)
+  end
+end

--- a/test/tau/factory/kill_switch_test.exs
+++ b/test/tau/factory/kill_switch_test.exs
@@ -122,9 +122,17 @@ defmodule Tau.Factory.KillSwitchTest do
   # A controllable "unit" that blocks until the test sends it :finish.
   # On :finish, sends {:unit_terminal, unit_id, :merged} to the coordinator.
   # Returns {unit_pid, unit_id}.
-  defp spawn_blocking_unit(coordinator_pid, unit_id) do
-    test_pid = self()
-
+  #
+  # `test_pid` is passed in explicitly (bound in the TEST body) so the
+  # {:unit_finished, unit_id} probe reaches the real test process directly.
+  # Previously `test_pid = self()` was bound INSIDE this function, but the
+  # function is called from within the `drive_fun`, which runs in the
+  # Coordinator process — so the probe was mis-targeted at the Coordinator and
+  # only reached the test via the Coordinator's `halted/3 {:unit_finished}`
+  # forwarding clause. Re-targeting the probe to the real test process (#452)
+  # makes that forwarding clause genuinely dead. AC-7/D-321 assertions are
+  # unchanged.
+  defp spawn_blocking_unit(coordinator_pid, unit_id, test_pid) do
     unit_pid =
       spawn(fn ->
         receive do
@@ -161,7 +169,12 @@ defmodule Tau.Factory.KillSwitchTest do
     coord_name = unique_name(:coord_ac7)
     ks_name = unique_name(:ks_ac7)
     pubsub_name = Tau.PubSub
-    on_halted = self()
+    # Bind the real test process here, in the TEST body, so the unit's
+    # {:unit_finished} probe targets it directly (NOT the Coordinator, which is
+    # where the drive_fun closure runs). This re-target (#452) makes the
+    # Coordinator's halted/3 {:unit_finished} forwarding clause dead.
+    test_pid = self()
+    on_halted = test_pid
 
     # Counter for select_fun: returns one work item then nil.
     {:ok, counter} = Agent.start_link(fn -> 0 end)
@@ -175,7 +188,9 @@ defmodule Tau.Factory.KillSwitchTest do
     drive_fun = fn _work ->
       # Coordinator pid is looked up by registered name at drive time.
       coord_pid = Process.whereis(coord_name)
-      {unit_pid, _} = spawn_blocking_unit(coord_pid, unit_id)
+      # test_pid is closed over from the test body (the real test process), so
+      # the probe reaches the test directly rather than via the Coordinator.
+      {unit_pid, _} = spawn_blocking_unit(coord_pid, unit_id, test_pid)
       :ets.insert(unit_pids, {unit_id, unit_pid})
       :ok
     end


### PR DESCRIPTION
## P5c-5 — Coordinator escalation drain (#453) + dead-clause removal (#452)

Closes #453, Closes #452. Advances #458 (P5c) / #416 (M10). Disjoint from P5c-3a
(`coordinator.ex` + `kill_switch_test.exs`, not `worker.ex`/`unit.ex`) — runs in parallel.

### Scope (SPEC-FACTORY-CORE §5, D-320/D-321)
1. **#453 — global-escalation drain.** `coordinator.ex` `running(:info, {:escalate, {_e,
   :global}}, …)` currently zeroes `in_flight` and drains straight to `:halted`, ABANDONING
   the in-flight unit (vs SPEC §5 drain-first). Rewrite it to route through `:halting` and
   AWAIT `{:unit_terminal}` (drain the in-flight unit), mirroring the D-321 kill path — making
   the existing `halting(:internal, :drain)` non-nil branch + `halting(:info, {:unit_terminal,…})`
   load-bearing.
2. **#452 — dead-clause removal (oracle separation).** The `halted(:info, {:unit_finished,…})`
   forwarding clause is reachable ONLY because `kill_switch_test.exs` mis-targets a test-probe
   at the Coordinator (the #452 coupling). **Test-author** refactors `kill_switch_test.exs` to
   bind `test_pid` to the real test process and send `{:unit_finished}` directly to it; **then**
   the implementer deletes the now-genuinely-dead `halted/3 {:unit_finished}` clause. The mutation
   check re-runs against the corrected test.

### Acceptance criteria
- **AC (#453 / D-320):** `escalation_drain_test.exs` — a global escalation WITH an in-flight unit
  DRAINS it (the unit reaches terminal) before `:halted` (not abandoned).
- **AC (#452 / D-321):** the corrected `kill_switch_test.exs` still passes (AC-7/D-321 intact) AND
  the mutation check confirms the `halted/3 {:unit_finished}` clause is genuinely dead (deleting it
  no longer fails any test).

### Dependencies
Disjoint from P5c-3a (different files). SPEC: SPEC-FACTORY-CORE §5, D-320/D-321.

### Gating-test paths (FROZEN — implementer MUST NOT edit)
- `test/tau/factory/escalation_drain_test.exs` (NEW — #453 / D-320)
- `test/tau/factory/kill_switch_test.exs` (refactored by the test-author for #452 — probe now
  targets the real test process; AC-7/D-321 preserved; the `halted/3 {:unit_finished}` clause
  is now genuinely dead and the implementer DELETES it)

### Gate verdicts
_(filled at gate time — critic, reviewer)_

