### PR TITLE
P5c-6 — production supervision: Coordinator with real seams (config-gated) + #479 janitor cleanup

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -23,6 +23,8 @@ config :tau,
     Tau.Tools.Builtin.Delegate
   ]
 
+config :tau, :factory, enabled: false
+
 config :logger, :console,
   format: "$time $metadata[$level] $message\n",
   metadata: [:session_id, :tool_call_id, :provider]

--- a/docs/MISSION.md
+++ b/docs/MISSION.md
@@ -81,7 +81,7 @@ Block-to-SPEC allocation:
 | D-300 – D-303, D-341 | SPEC-FACTORY-MERGE |
 | D-304 – D-308, D-322, D-323, D-354 | SPEC-FACTORY-GATE |
 | D-309 – D-311, D-313, D-314, D-316, D-334 | SPEC-FACTORY-FLEET |
-| D-312, D-315, D-317, D-318, D-320, D-321, D-330 – D-333, D-335, D-336, D-340, D-342 – D-344 | SPEC-FACTORY-CORE |
+| D-312, D-315, D-317, D-318, D-320, D-321, D-330 – D-333, D-335, D-336, D-340, D-342 – D-344, D-355, D-356, D-357 | SPEC-FACTORY-CORE |
 | D-319, D-351 – D-353 | SPEC-FACTORY-GOV |
 | D-300 – D-360 | reserved — SPEC-FACTORY-\* family (autonomous factory; `docs/arch/`) |
 

--- a/docs/arch/04-software-architecture/supervision-tree.md
+++ b/docs/arch/04-software-architecture/supervision-tree.md
@@ -108,6 +108,39 @@ retry, and cron-driver — it is the durable spine for *what work exists and wha
 is owed* (research OTP durability ruling: Oban-as-system-of-record, `gen_statem`
 for live reactivity). Detail in `durable-spine.md`.
 
+### Config-gating layer — the factory is OFF by default (P5c-6, #474; D-357)
+
+The composition above is the subtree that exists **only when the factory is
+enabled**. The control loop drives autonomous work that merges to `main`, so it
+must never start merely because the binary launched. A boolean config gate sits
+in front of the assembly:
+
+```
+config :tau, :factory, enabled: false   # default — opt-in is an operator action
+```
+
+`Tau.Factory.Supervisor.start_link/1` (and `Tau.Application`, which reads the
+gate at boot — mirroring the established `Tau.OtelReporter` `:enabled`
+precedent) consults this flag:
+
+- **disabled (default)** → assemble **no** Coordinator-bearing subtree (the
+  ledger-and-below children may still start for non-factory subsystems, but the
+  Coordinator, Scheduler, Merge Authority, fleet, and Unit supervisors do not).
+  `Process.whereis(Tau.Factory.Coordinator)` is `nil`; no work is driven. This is
+  the "no-uncontrolled-work-on-normal-boot" safety property (**D-357**).
+- **enabled** → assemble the full subtree in the order above, **Coordinator
+  started LAST** (it depends on every sibling — D-344 resume reads the started
+  Ledger; its seams reference the started fleet/merge/registry processes).
+
+The gate is read **once at boot** from `config` (not `Application.put_env/3`
+runtime mutation — OTP non-negotiable #1). The contract for the option surface
+and seam-threading (the supervisor *derives* every per-child opt and wraps the
+arity-1 `IssueSelector.select/1` and arity-2 `UnitDriver.drive/2` seams into the
+arity-0/arity-1 forms the Coordinator expects; the caller hand-threads none of
+the per-child opts) is recorded in `docs/spec/SPEC-FACTORY-CORE.md` §4 B11 /
+D-357. This layer **records** the gate on top of the composition above; it does
+not alter the composition or the start-order.
+
 ## Step 4 — Identity & read/write split
 
 - **Logical identity, never pid.** Units and workers are addressed by key via

--- a/docs/spec/SPEC-FACTORY-CORE.md
+++ b/docs/spec/SPEC-FACTORY-CORE.md
@@ -41,6 +41,20 @@ telemetry→Unit merge bridge (forbidden by MERGE D-356). Appendix B adds the
 gating-test paths. Resolves the merge-bridge lifecycle arch gap and the
 U-callback no-block gap; folds in #478.
 
+**Amendment (2026-06-13, PR #480 — P5c-6 production supervision):** Records
+(does not redesign) the **config-gating + seam-threading contract** for
+`Tau.Factory.Supervisor`, conforming to the assembly in
+`docs/arch/04-software-architecture/supervision-tree.md`. Introduces **D-357**
+(factory OFF by default — a normal boot starts no factory subtree and drives no
+uncontrolled work). §3 Q3: adds the `[C120-B11]` default-OFF safety constraint.
+§4: adds boundary **B11** — the `Tau.Factory.Supervisor.start_link/1` option
+surface, the `enabled`-gated full-subtree assembly (Coordinator-LAST), and the
+seam-derivation rules (the supervisor derives per-child opts and wraps the
+`select_fun`/`drive_fun` seams from its high-level opts; the caller does NOT
+hand-thread per-child opts). §6: D-357. Appendix B lists
+`factory_supervision_test.exs`. Closes the §4 gap the test-author surfaced for
+#474.
+
 ## 0. Why this spec exists
 
 The factory's control core is the brain of an autonomous loop that takes a
@@ -109,6 +123,7 @@ Boundaries (B-N attach contracts in §4):
 | B8 | C6 Unit ↔ **W** (SPEC-FACTORY-FLEET) | `spawn(role, brief, ref)` / `{:DOWN,…}` / `worker_stalled`. **Cited boundary.** |
 | B9 | C9 KillSwitch ↔ C3 Coordinator | `:halt_requested` over PubSub `"factory:control"`. |
 | B10 | C3 Coordinator ↔ external tracker | `select_next` / `reconcile` (issue source; reconciliation, CON-2). |
+| B11 | `Tau.Factory.Supervisor` ↔ {`Tau.Application`, tests} | `start_link/1` — config-gated subtree assembly + seam-threading (P5c-6, #474). |
 
 ## 3. L0 constraints
 
@@ -171,6 +186,18 @@ Format: `[Cn-Bm]` = constraint number + boundary. **★** marks non-obvious.
 - **[C109-B5]** A non-progress state with no foreseen cause MUST escalate
   `E-UNCLASSIFIED` (the catch-all), never spin. Its firing is logged as a defect
   signal.
+- **★ [C120-B11]** **The factory is OFF by default.** The control subtree
+  (Coordinator and everything that drives uncontrolled autonomous work) is gated
+  on `config :tau, :factory` `:enabled`, whose **default is `false`**. A normal
+  application boot — with no operator opt-in — MUST start **no** factory subtree:
+  no `Coordinator`, no admitted units, no driven work. This is the
+  "no-uncontrolled-work-on-normal-boot" safety property: an autonomous loop that
+  merges to `main` must never start itself merely because the binary launched.
+  The gate is read once at boot (mirroring the established
+  `Tau.OtelReporter` `:enabled` precedent in `Tau.Application`); when disabled,
+  `Tau.Factory.Supervisor` assembles only the durable-ledger-and-below children
+  it needs for non-factory subsystems, never the Coordinator-bearing subtree
+  (D-357).
 
 ### Q4: What information crosses a boundary, and what is lost?
 
@@ -494,6 +521,95 @@ implements `select_next`:
 - **L is read-only:** the selector NEVER writes L; the tracker is not a second
   writer of L (D-331 [C112-B10]).
 
+### B11: `Tau.Factory.Supervisor` ↔ {`Tau.Application`, tests} — config-gated assembly + seam-threading (P5c-6, #474; D-357)
+
+This boundary records (does **not** redesign) the assembly that
+`docs/arch/04-software-architecture/supervision-tree.md` §3 specifies; the arch
+file is authoritative on the **composition and internal start-order**, this
+contract on the **gating layer and the option surface** on top of it. The
+implementer conforms to both.
+
+**Config key + default.**
+
+```
+config :tau, :factory, enabled: false   # default; opt-in is operator action
+```
+
+The flag is read **once at boot** by `Tau.Application` (mirroring the
+established `Tau.OtelReporter` `:enabled` precedent — `otel_reporter_spec/0`),
+not per-message. Reading it from `config` (compile/runtime config, not
+`Application.put_env/3` runtime mutation) keeps it out of the
+"runtime mutable state" anti-pattern (OTP non-negotiable #1). Default `false` ⇒
+no Coordinator-bearing subtree on a normal boot (D-357, [C120-B11]).
+
+**`start_link/1` option surface.** The supervisor accepts a *high-level seam*
+option set and **derives** every per-child option from it; the caller does NOT
+hand-thread per-child opts (no `coordinator_opts:` / `budget_opts:` /
+`scheduler_opts:` from the caller for the gated full-subtree path):
+
+```
+Tau.Factory.Supervisor.start_link(opts) :: Supervisor.on_start()
+  opts (full-subtree, enabled path):
+    :enabled    — boolean();    request the gated full-subtree assembly
+                                (defaults to the config gate when absent)
+    :db_path    — String.t();   Ledger DB file (test: tmp-dir DB)
+    :name       — atom();       this supervisor's registered name (test isolation;
+                                per-supervisor child names are derived from it)
+    :repo_dir   — String.t();   the real (or throwaway, in tests) git repo —
+                                threaded to MergeAuthority and the worker fleet
+    :milestone  — String.t();   the assigned milestone (→ IssueSelector)
+    :gh_fun     — (String.t() -> {:ok, [issue_map]});  issue source, stubbable;
+                                NO network in tests (B10 IssueSelector contract)
+    :select_fun — &IssueSelector.select/1  (arity-1, opts-taking — see wrapping)
+    :drive_fun  — &UnitDriver.drive/2      (arity-2 — see wrapping)
+```
+
+**Gated assembly (enabled path).** When the gate is on, the supervisor assembles
+the full control subtree in the `supervision-tree.md` §3 order — PubSub up first
+(the shared `Tau.PubSub`, never a second instance), then
+`Ledger.Writer → Budget.Owner → Scheduler → MergeAuthority → UnitRegistry /
+UnitSupervisor → worker fleet (`WorkerSupervisor` / `WorkerRegistry` /
+`WorkspaceJanitor` / fleet `Watchdog`) → KillSwitch → **Coordinator (LAST)**`.
+The internal relative order of the spine children is the arch file's to fix; the
+**Coordinator-LAST** placement is invariant in both this contract and the arch
+(it depends on every sibling — D-344 resume reads the started Ledger; its
+seams reference the started fleet/merge/registry processes). When the gate is
+**off** (default), the supervisor assembles **no** Coordinator-bearing subtree
+(today's ledger-and-below behaviour); `Process.whereis(Tau.Factory.Coordinator)`
+is `nil` (D-357).
+
+**Seam-derivation rules (the supervisor derives; the caller does not).**
+
+- **Ledger threading (D-344).** The started `Ledger.Writer`'s (per-supervisor
+  derived) name is threaded as the Coordinator's `:ledger` so `init/1` resumes
+  from L, and into the assembled `drive_fun` deps (`:ledger`) so Units snapshot
+  durable state (D-318/D-355).
+- **`select_fun` wrapping.** The injected `&IssueSelector.select/1` is arity-1
+  over `opts`, but the Coordinator's `:select_fun` is arity-0
+  (`(-> work_item | nil)`). The supervisor wraps it into the arity-0 form,
+  binding `IssueSelector.select(ledger: <writer>, milestone: <milestone>,
+  gh_fun: <gh_fun>)` (B10 IssueSelector opts). In tests `gh_fun` returns
+  `{:ok, []}`, so the wrapped selector yields `nil` and the Coordinator **idles**
+  in `:running` — driving no uncontrolled work (D-357 idle property).
+- **`drive_fun` wrapping.** The injected `&UnitDriver.drive/2` is arity-2
+  (`work_item, deps`), but the Coordinator's `:drive_fun` is arity-1. The
+  supervisor wraps it into the arity-1 form, binding the assembled `deps` map
+  (the started `:unit_supervisor`, `:unit_registry`, `:scheduler`,
+  `:worker_supervisor`, `:worker_registry`, `:janitor`, the shared `:pubsub`,
+  `:repo_dir`, `:agent_bin`, `:gate_fun`, `:merge_authority`, `:ledger`, and
+  `:report_to` = the Coordinator) — see the UnitDriver `deps` contract (§4 B6/B8).
+- **MergeAuthority threading.** `MergeAuthority` is started against the real
+  `:repo_dir` and the shared `:pubsub` (D-356 result delivery on
+  `"factory:pr:#{id}"`).
+
+- Pre: `Tau.Settings` `data_dir/0` resolvable (the ledger DB path); the shared
+  `Tau.PubSub` running (started above this subtree in `Tau.Application`).
+- Post (enabled): the subtree is assembled in arch order; the Coordinator is a
+  child started LAST and reaches `:running`; with a no-issues `gh_fun` it idles
+  (`select_fun → nil`), holding no in-flight unit and spawning no `Unit`.
+- Post (disabled / default): no Coordinator child exists; no work is driven.
+- Invariant (**D-357**): a default boot starts no factory subtree.
+
 ## 5. State enumeration
 
 ### Coordinator (K) — `gen_statem`, `state_functions`
@@ -689,6 +805,19 @@ published immediately after — and even concurrently with — `request_merge`
 reaches U and drives it to terminal, with no `state_timeout` escalation; and U
 holds **no** subscription to the topic after leaving `awaiting_merge`.
 
+**D-357 — Factory OFF by default (no uncontrolled work on normal boot):**
+The factory control subtree is gated on `config :tau, :factory` `:enabled`
+(default `false`, read once at boot — [C120-B11]). (a) On a default boot
+`Tau.Application` starts **no** Coordinator-bearing subtree:
+`Process.whereis(Tau.Factory.Coordinator)` is `nil` and no `Unit` is admitted.
+(b) When `Tau.Factory.Supervisor.start_link/1` is invoked with the gated
+full-subtree assembly (enabled), it assembles the subtree in the
+`supervision-tree.md` §3 order with the Coordinator started LAST, threading the
+started Ledger as `:ledger` (D-344) and wrapping the `select_fun`/`drive_fun`
+seams (B11); a no-issues `gh_fun` keeps the Coordinator **idle** in `:running`
+with no in-flight unit. Enforced by `factory_supervision_test.exs` — Test A
+(enabled assembly + idle property) and Test B (default-OFF regression guard).
+
 ## 7. Acceptance criteria
 
 Each is expressed against the user-facing path with an observable signal.
@@ -728,6 +857,12 @@ PR groupings are indicative.
   dogfood proof; arch `06-roadmap/spec-factory.md` AC-10). *This AC depends on
   SPEC-FACTORY-{GATE,FLEET,MERGE} landing; it is the integration gate, not a
   CORE-only unit.*
+- **AC-P5c6 (PR #480, D-357):** `mix test test/tau/factory/factory_supervision_test.exs`
+  passes — with the factory enabled, `Tau.Factory.Supervisor` assembles the full
+  subtree and the Coordinator (started LAST) reaches `:running` and idles
+  (`select_fun → nil`, no in-flight unit, no `Unit` spawned); and on a default
+  boot (factory disabled) no `Tau.Factory.Coordinator` exists. Signal: both Test A
+  (enabled assembly + idle) and Test B (default-OFF) assert it.
 
 ## Appendix B — Source map
 
@@ -744,7 +879,8 @@ Files that bring a PR into scope of this SPEC (`D-NNN`/`C-N` → file:symbol):
 - `lib/tau/factory/unit_driver.ex` (D-340, **D-356** `:janitor` threading + no driver-side merge bridge / no driver reclaim; the real `drive_fun` wiring Unit→fleet→gate→merge seams) — PR #477
 - `lib/tau/factory/retry.ex` (C8; D-318) — PR-CORE-3
 - `lib/tau/factory/kill_switch.ex` (C9; D-321) — PR-CORE-4
-- `lib/tau/factory/supervisor.ex` + `lib/tau/application.ex` (tree; rest_for_one spine) — PR-CORE-1
+- `lib/tau/factory/supervisor.ex` + `lib/tau/application.ex` (tree; rest_for_one spine; **D-357** config-gated `start_link/1` assembly + seam-threading, B11) — PR-CORE-1 / PR #480
+- `config/config.exs` + `config/runtime.exs` (`config :tau, :factory, enabled:` gate, default `false`; **D-357**) — PR #480
 - `test/tau/factory/ledger_durability_test.exs` (D-315) — PR-CORE-1
 - `test/tau/factory/conflict_check_property_test.exs` (D-312, D-343) — PR-CORE-2
 - `test/tau/factory/budget_admission_test.exs` (D-320, D-332) — PR-CORE-2
@@ -758,6 +894,7 @@ Files that bring a PR into scope of this SPEC (`D-NNN`/`C-N` → file:symbol):
 - `test/tau/factory/unit_termination_test.exs` (D-340) + `scope_amendment_test.exs` (D-343) — PR-CORE-3/2
 - `test/tau/factory/unit_driver_test.exs` (D-340; real drive_fun gating tests) — PR #477
 - `test/tau/factory/unit_merge_result_test.exs` (**D-356** U subscribe-before-request consume + unsubscribe-on-exit) — PR #477
+- `test/tau/factory/factory_supervision_test.exs` (**D-357** config-gated subtree assembly + default-OFF; AC-P5c6) — PR #480
 
 **Cross-SPEC boundaries (cited, not owned here):** B6 → `SPEC-FACTORY-MERGE`
 (D-300–D-303, D-341); B7 → `SPEC-FACTORY-GATE` (D-304–D-308, D-322, D-323);

--- a/docs/spec/SPEC-FACTORY-CORE.md
+++ b/docs/spec/SPEC-FACTORY-CORE.md
@@ -473,12 +473,15 @@ callers that pass no `:ledger` opt are unaffected (back-compat).
   `data.worker_id` field is `nil` in that path and the Unit falls back to the
   `{:worker_done, ^worker_pid}` trigger.
 - **`:janitor` threading — reclaim is the Janitor's, not the driver's
-  (PR #477 amendment; cross-refs SPEC-FACTORY-FLEET D-313/D-314).** The
-  `UnitDriver.drive/2` seam threads `:janitor` (a running
-  `Tau.Factory.WorkspaceJanitor`) into the `worker_fun`'s opts so it reaches
-  `WorkerSupervisor.spawn/5` (the `:janitor` opt seam) and the spawned
-  `Tau.Factory.Worker`, which **registers itself** with the janitor in `init/1`
-  (passing its own `ws`, `ns_dirs`, `report_to`) before opening its Port. The
+  (PR #477 amendment; PR #479 cleanup; cross-refs SPEC-FACTORY-FLEET D-313/D-314).**
+  The `UnitDriver.drive/2` seam threads `:janitor` into the `worker_fun`'s opts
+  so it reaches `WorkerSupervisor.spawn/5` (the `:janitor` opt seam) and the
+  spawned `Tau.Factory.Worker`, which **registers itself** with the janitor in
+  `init/1` (passing its own `ws`, `ns_dirs`, `report_to`) before opening its
+  Port. The janitor is resolved as `deps[:janitor] || Tau.Factory.WorkspaceJanitor`:
+  the singleton `WorkspaceJanitor` (always registered under its module name) is
+  the production default; the `:janitor` dep key is a **test-injection seam**
+  (pass the running singleton module atom to name it explicitly in tests). The
   janitor `Process.monitor/1`s the worker (never links) and on the worker's
   `:DOWN` — for ANY exit reason — executes capture-before-destroy and reclaims
   the worktree (D-313/D-314). Consequently the UnitDriver performs **zero

--- a/lib/tau/application.ex
+++ b/lib/tau/application.ex
@@ -77,11 +77,13 @@ defmodule Tau.Application do
         # :rest_for_one a crash cascades forward — intentional; a broken
         # memory store should not allow new sessions to start.
         Tau.Memory.Supervisor,
-        # Factory ledger. Must follow Memory.Supervisor (data_dir/0 depends on
-        # Settings.Watcher, same requirement). Under :rest_for_one a crash
+        # Factory ledger / control subtree. Must follow Memory.Supervisor
+        # (data_dir/0 depends on Settings.Watcher, same requirement). Gated on
+        # config :tau, :factory, enabled (default false — D-357, [C120-B11]).
+        # Mirrors the OtelReporter :enabled precedent. Under :rest_for_one a crash
         # cascades forward — intentional; a broken ledger should not allow the
         # factory to continue operating. D-315 / SPEC-FACTORY-CORE.
-        Tau.Factory.Supervisor,
+        factory_supervisor_spec(),
         Tau.Permissions.RuleSet,
         {Finch, name: Tau.Providers.Finch},
         Tau.Providers.RateLimiter.Supervisor,
@@ -124,6 +126,17 @@ defmodule Tau.Application do
     else
       []
     end
+  end
+
+  # Returns a child spec for the Factory supervisor.
+  # When the factory is enabled (config :tau, :factory, enabled: true), the
+  # full Coordinator-bearing subtree is assembled. When disabled (the default),
+  # the supervisor starts without a Coordinator — no uncontrolled work is driven
+  # on a normal boot (D-357, [C120-B11]).
+  # Mirrors the otel_reporter_spec/0 pattern.
+  defp factory_supervisor_spec do
+    enabled = Application.get_env(:tau, :factory, []) |> Keyword.get(:enabled, false)
+    [Tau.Factory.Supervisor.child_spec(enabled: enabled)]
   end
 
   # Suppress noisy `[error]`/`[warning]` messages from the `:file_system`

--- a/lib/tau/factory/supervisor.ex
+++ b/lib/tau/factory/supervisor.ex
@@ -2,29 +2,72 @@ defmodule Tau.Factory.Supervisor do
   @moduledoc """
   Supervision subtree for the factory control components.
 
-  Hosts `Tau.Factory.Ledger.Writer` under a `one_for_one` strategy. Sits in
-  `Tau.Application`'s `:rest_for_one` child list after `Tau.Memory.Supervisor`
-  (which resolves `data_dir/0` — required before the ledger can open its DB).
+  ## Config-gated assembly (P5c-6, #474; D-357, [C120-B11])
 
-  Supports `start_link/1` with `db_path:` and `name:` options for test
-  isolation — each test can spin up an isolated supervisor against a tmp-dir DB
-  without touching the application-started instance.
+  When `enabled: false` (the default, read from `config :tau, :factory,
+  enabled: false`), the supervisor starts only the `Tau.Factory.Ledger.Writer`
+  — no Coordinator-bearing subtree is assembled. `Process.whereis(Tau.Factory.Coordinator)`
+  is `nil`; no uncontrolled work is driven on a normal boot (D-357).
 
-  See `docs/spec/SPEC-FACTORY-CORE.md`.
+  When `enabled: true`, the supervisor assembles the full control subtree in
+  the `docs/arch/04-software-architecture/supervision-tree.md` §3 order, with
+  the Coordinator started LAST (it depends on every sibling — D-344 resume
+  reads the started Ledger; its seams reference the started fleet/merge/registry
+  processes). The `:rest_for_one` strategy is used for the full spine: if
+  `Ledger.Writer` crashes, everything downstream restarts.
+
+  ## Option surface (`start_link/1`, B11)
+
+  High-level seams only. The supervisor **derives** every per-child opt; the
+  caller does NOT hand-thread per-child opts:
+
+    - `:enabled`   — boolean; request the gated full-subtree assembly (defaults
+                     to `Application.get_env(:tau, :factory, [])[:enabled]`).
+    - `:db_path`   — path to the SQLite ledger DB (test: tmp-dir DB).
+    - `:name`      — atom; this supervisor's registered name (test isolation;
+                     per-supervisor child names are derived from it).
+    - `:repo_dir`  — the real (or throwaway) git repo; threaded to
+                     MergeAuthority and the worker fleet.
+    - `:milestone` — the assigned milestone string (→ IssueSelector).
+    - `:gh_fun`    — `(String.t() -> {:ok, [issue_map()]})`; stubbable issue
+                     source (NO network in tests).
+    - `:select_fun` — `&IssueSelector.select/1`; arity-1 opts-taking seam.
+    - `:drive_fun`  — `&UnitDriver.drive/2`; arity-2 seam.
+
+  See `docs/spec/SPEC-FACTORY-CORE.md` §4 B11, D-357; and
+  `docs/arch/04-software-architecture/supervision-tree.md` §3.
   """
 
   use Supervisor
+
+  alias Tau.Factory.Budget.Owner, as: BudgetOwner
+  alias Tau.Factory.Fleet.Watchdog
+  alias Tau.Factory.KillSwitch
+  alias Tau.Factory.Ledger.Writer, as: LedgerWriter
+  alias Tau.Factory.MergeAuthority
+  alias Tau.Factory.Scheduler
+  alias Tau.Factory.UnitRegistry
+  alias Tau.Factory.UnitSupervisor
+  alias Tau.Factory.WorkerRegistry
+  alias Tau.Factory.WorkerSupervisor
+  alias Tau.Factory.WorkspaceJanitor
 
   @doc """
   Start the factory supervisor (called by `Tau.Application` or tests).
 
   Options:
-    - `:db_path` — path to the SQLite ledger DB file (required when not using
-      the application default).
-    - `:name` — registered name for this supervisor process (defaults to
-      `__MODULE__`). The `Ledger.Writer` child is registered under a derived
-      name (`{:via, name}` convention: `:"<name>_writer"`) so multiple isolated
-      supervisor instances can coexist (e.g. in tests).
+    - `:enabled`   — boolean; request the full-subtree assembly. Defaults to
+                     `Application.get_env(:tau, :factory, [])[:enabled]`.
+    - `:db_path`   — path to the SQLite ledger DB file (required when not using
+                     the application default).
+    - `:name`      — registered name for this supervisor (defaults to
+                     `__MODULE__`). Child names are derived from it.
+    - `:repo_dir`  — git repo path (full subtree only; threaded to
+                     MergeAuthority and WorkerSupervisor).
+    - `:milestone` — the assigned milestone (full subtree only).
+    - `:gh_fun`    — issue-source adapter (full subtree only; stubbable).
+    - `:select_fun` — `&IssueSelector.select/1` (full subtree only).
+    - `:drive_fun`  — `&UnitDriver.drive/2` (full subtree only).
   """
   @spec start_link(keyword()) :: Supervisor.on_start()
   def start_link(opts \\ []) do
@@ -34,6 +77,28 @@ defmodule Tau.Factory.Supervisor do
 
   @impl true
   def init(opts) do
+    # Resolve :enabled from opts, falling back to the application config gate.
+    enabled =
+      Keyword.get_lazy(opts, :enabled, fn ->
+        Application.get_env(:tau, :factory, []) |> Keyword.get(:enabled, false)
+      end)
+
+    if enabled do
+      init_full_subtree(opts)
+    else
+      init_ledger_only(opts)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Private — ledger-only path (default / disabled factory)
+  # ---------------------------------------------------------------------------
+
+  # Assembles only the Ledger.Writer (and optional existing per-test children
+  # that the legacy non-enabled tests wire via coordinator_opts / budget_opts
+  # / etc.). This preserves backward compat with existing tests that do NOT
+  # pass `enabled: true` but still hand-thread coordinator_opts etc.
+  defp init_ledger_only(opts) do
     db_path = Keyword.get(opts, :db_path, default_db_path())
     sup_name = Keyword.get(opts, :name, __MODULE__)
     repo_dir = Keyword.get(opts, :repo_dir)
@@ -44,63 +109,26 @@ defmodule Tau.Factory.Supervisor do
     kill_switch_opts = Keyword.get(opts, :kill_switch_opts)
     coordinator_opts = Keyword.get(opts, :coordinator_opts)
 
-    # Derive a per-supervisor writer name so concurrent supervisor instances
-    # (e.g. isolated test instances) do not conflict on the writer's name.
-    writer_name =
-      if sup_name == __MODULE__ do
-        Tau.Factory.Ledger.Writer
-      else
-        :"#{sup_name}_writer"
-      end
+    writer_name = derive_name(sup_name, __MODULE__, LedgerWriter)
 
-    tasks_name =
-      if sup_name == __MODULE__ do
-        Tau.Factory.MergeTasks
-      else
-        :"#{sup_name}_tasks"
-      end
+    tasks_name = derive_name(sup_name, __MODULE__, Tau.Factory.MergeTasks)
 
-    ma_name =
-      if sup_name == __MODULE__ do
-        Tau.Factory.MergeAuthority
-      else
-        :"#{sup_name}_merge_authority"
-      end
+    ma_name = derive_name(sup_name, __MODULE__, MergeAuthority)
+
+    unit_registry_name = derive_name(sup_name, __MODULE__, UnitRegistry)
+
+    unit_supervisor_name = derive_name(sup_name, __MODULE__, UnitSupervisor)
+
+    ks_name = derive_name(sup_name, __MODULE__, KillSwitch)
+
+    coord_name = derive_name(sup_name, __MODULE__, Tau.Factory.Coordinator)
 
     base_children = [
-      {Tau.Factory.Ledger.Writer, db_path: db_path, name: writer_name},
+      {LedgerWriter, db_path: db_path, name: writer_name},
       {Task.Supervisor, name: tasks_name}
     ]
 
     unit_opts = Keyword.get(opts, :unit_opts)
-
-    unit_registry_name =
-      if sup_name == __MODULE__ do
-        Tau.Factory.UnitRegistry
-      else
-        :"#{sup_name}_unit_registry"
-      end
-
-    unit_supervisor_name =
-      if sup_name == __MODULE__ do
-        Tau.Factory.UnitSupervisor
-      else
-        :"#{sup_name}_unit_supervisor"
-      end
-
-    ks_name =
-      if sup_name == __MODULE__ do
-        Tau.Factory.KillSwitch
-      else
-        :"#{sup_name}_kill_switch"
-      end
-
-    coord_name =
-      if sup_name == __MODULE__ do
-        Tau.Factory.Coordinator
-      else
-        :"#{sup_name}_coordinator"
-      end
 
     children =
       base_children
@@ -122,8 +150,139 @@ defmodule Tau.Factory.Supervisor do
   end
 
   # ---------------------------------------------------------------------------
+  # Private — full subtree assembly (enabled path, B11, D-357)
+  # ---------------------------------------------------------------------------
+
+  # Assembles the full control subtree in supervision-tree.md §3 order with
+  # :rest_for_one strategy. The Coordinator is started LAST (D-344, B11).
+  # select_fun (arity-1) and drive_fun (arity-2) are wrapped into the
+  # Coordinator's arity-0/arity-1 forms; the Ledger.Writer name is threaded as
+  # the Coordinator's :ledger (D-344).
+  defp init_full_subtree(opts) do
+    db_path = Keyword.get(opts, :db_path, default_db_path())
+    sup_name = Keyword.get(opts, :name, __MODULE__)
+    repo_dir = Keyword.fetch!(opts, :repo_dir)
+    milestone = Keyword.fetch!(opts, :milestone)
+    gh_fun = Keyword.fetch!(opts, :gh_fun)
+    select_fun = Keyword.fetch!(opts, :select_fun)
+    drive_fun = Keyword.fetch!(opts, :drive_fun)
+
+    # Derive per-supervisor child names for isolation (tests / multiple instances).
+    writer_name = derive_name(sup_name, __MODULE__, LedgerWriter)
+    budget_owner_name = derive_name(sup_name, __MODULE__, BudgetOwner)
+    scheduler_name = derive_name(sup_name, __MODULE__, Scheduler)
+    tasks_name = derive_name(sup_name, __MODULE__, Tau.Factory.MergeTasks)
+    ma_name = derive_name(sup_name, __MODULE__, MergeAuthority)
+    unit_registry_name = derive_name(sup_name, __MODULE__, UnitRegistry)
+    unit_supervisor_name = derive_name(sup_name, __MODULE__, UnitSupervisor)
+    worker_supervisor_name = derive_name(sup_name, __MODULE__, WorkerSupervisor)
+    worker_registry_name = derive_name(sup_name, __MODULE__, WorkerRegistry)
+    janitor_name = derive_name(sup_name, __MODULE__, WorkspaceJanitor)
+    watchdog_name = derive_name(sup_name, __MODULE__, Watchdog)
+    ks_name = derive_name(sup_name, __MODULE__, KillSwitch)
+    coord_name = derive_name(sup_name, __MODULE__, Tau.Factory.Coordinator)
+
+    # -------------------------------------------------------------------------
+    # Seam wrapping (B11 / supervision-tree.md §Config-gating):
+    #
+    # select_fun: &IssueSelector.select/1  (arity-1, keyword opts)
+    #   → wrapped into arity-0 (Coordinator's :select_fun contract)
+    #   binding ledger: writer_name, milestone:, gh_fun:  (B10 opts)
+    #
+    # drive_fun: &UnitDriver.drive/2  (arity-2: work_item, deps)
+    #   → wrapped into arity-1 (Coordinator's :drive_fun contract)
+    #   binding the assembled deps map (all started substrate processes).
+    #   :agent_bin and :gate_fun are nil for P5c-6 (no unit driven on idle path).
+    #
+    # Coordinator :ledger: writer_name (D-344 resume reads the started Ledger).
+    # -------------------------------------------------------------------------
+
+    wrapped_select_fun = fn ->
+      select_fun.(
+        ledger: writer_name,
+        milestone: milestone,
+        gh_fun: gh_fun
+      )
+    end
+
+    # deps is assembled from the derived child names — the names are atoms that
+    # are registered by the time the Coordinator's drive_fun is called.
+    deps = %{
+      unit_supervisor: unit_supervisor_name,
+      unit_registry: unit_registry_name,
+      scheduler: scheduler_name,
+      worker_supervisor: worker_supervisor_name,
+      worker_registry: worker_registry_name,
+      janitor: WorkspaceJanitor,
+      pubsub: Tau.PubSub,
+      repo_dir: repo_dir,
+      merge_authority: ma_name,
+      ledger: writer_name,
+      # :agent_bin and :gate_fun are nil for P5c-6 (idle path — no unit
+      # driven on boot). These will be threaded from operator opts in a
+      # subsequent PR when units are actually driven.
+      agent_bin: nil,
+      gate_fun: nil,
+      report_to: coord_name
+    }
+
+    wrapped_drive_fun = fn work_item ->
+      drive_fun.(work_item, %{deps | report_to: self()})
+    end
+
+    children = [
+      # 1. Ledger.Writer — durable-decision writer; root of all dependence.
+      {LedgerWriter, db_path: db_path, name: writer_name},
+      # 2. Budget.Owner — ETS snapshot of per-dimension budget limits.
+      {BudgetOwner, ledger: writer_name, totals: %{}, name: budget_owner_name},
+      # 3. Scheduler — admission authority.
+      {Scheduler, name: scheduler_name, w_cap: 5},
+      # 4. Task.Supervisor for MergeAuthority's async integration tasks.
+      {Task.Supervisor, name: tasks_name},
+      # 5. MergeAuthority — sole writer of origin/main; gen_statem.
+      {MergeAuthority,
+       name: ma_name,
+       ledger: writer_name,
+       repo_dir: repo_dir,
+       tasks_name: tasks_name,
+       pubsub: Tau.PubSub},
+      # 6. UnitRegistry + UnitSupervisor — per-PR FSM registry and dynamic supervisor.
+      {UnitRegistry, name: unit_registry_name},
+      {UnitSupervisor, name: unit_supervisor_name},
+      # 7. Worker fleet: WorkerSupervisor, WorkerRegistry, WorkspaceJanitor, Watchdog.
+      {WorkerSupervisor, name: worker_supervisor_name},
+      {WorkerRegistry, name: worker_registry_name},
+      {WorkspaceJanitor, ledger: writer_name, name: janitor_name},
+      {Watchdog, name: watchdog_name, check_interval: 30_000},
+      # 8. KillSwitch — sentinel-file poller; broadcasts :halt_requested.
+      {KillSwitch, name: ks_name, pubsub: Tau.PubSub},
+      # 9. Coordinator — the loop; started LAST (D-344, B11).
+      {Tau.Factory.Coordinator,
+       name: coord_name,
+       pubsub: Tau.PubSub,
+       ledger: writer_name,
+       scheduler: scheduler_name,
+       select_fun: wrapped_select_fun,
+       drive_fun: wrapped_drive_fun}
+    ]
+
+    Supervisor.init(children, strategy: :rest_for_one)
+  end
+
+  # ---------------------------------------------------------------------------
   # Private helpers
   # ---------------------------------------------------------------------------
+
+  # Derive a per-supervisor child name. When the supervisor IS the module
+  # default, use the child module itself (canonical singleton names). Otherwise
+  # prefix with the supervisor name for isolation (concurrent test instances).
+  defp derive_name(sup_name, mod_default, child_mod) do
+    if sup_name == mod_default do
+      child_mod
+    else
+      :"#{sup_name}_#{inspect(child_mod) |> String.split(".") |> List.last() |> Macro.underscore()}"
+    end
+  end
 
   # Add Budget.Owner as a child only when budget_opts are provided.
   # Requires :totals and :name in budget_opts; threads :ledger from writer_name.
@@ -134,7 +293,7 @@ defmodule Tau.Factory.Supervisor do
       budget_opts
       |> Keyword.put(:ledger, writer_name)
 
-    children ++ [{Tau.Factory.Budget.Owner, owner_opts}]
+    children ++ [{BudgetOwner, owner_opts}]
   end
 
   # Add Scheduler as a child only when scheduler_opts are provided.
@@ -159,7 +318,7 @@ defmodule Tau.Factory.Supervisor do
           end
       end
 
-    children ++ [{Tau.Factory.Scheduler, scheduler_opts}]
+    children ++ [{Scheduler, scheduler_opts}]
   end
 
   # Add MergeAuthority as a child only when repo_dir is provided.
@@ -192,7 +351,7 @@ defmodule Tau.Factory.Supervisor do
         required_halves: required_halves
       ] ++ merge_authority_opts
 
-    children ++ [{Tau.Factory.MergeAuthority, ma_opts}]
+    children ++ [{MergeAuthority, ma_opts}]
   end
 
   # Add UnitRegistry + UnitSupervisor only when unit_opts are provided.
@@ -202,8 +361,8 @@ defmodule Tau.Factory.Supervisor do
   defp maybe_add_unit_subsystem(children, _unit_opts, registry_name, sup_name) do
     children ++
       [
-        {Tau.Factory.UnitRegistry, name: registry_name},
-        {Tau.Factory.UnitSupervisor, name: sup_name}
+        {UnitRegistry, name: registry_name},
+        {UnitSupervisor, name: sup_name}
       ]
   end
 
@@ -212,7 +371,7 @@ defmodule Tau.Factory.Supervisor do
 
   defp maybe_add_kill_switch(children, kill_switch_opts, ks_name, _sup_name) do
     opts = Keyword.put_new(kill_switch_opts, :name, ks_name)
-    children ++ [{Tau.Factory.KillSwitch, opts}]
+    children ++ [{KillSwitch, opts}]
   end
 
   # Add Coordinator as a child only when coordinator_opts are provided.

--- a/lib/tau/factory/unit_driver.ex
+++ b/lib/tau/factory/unit_driver.ex
@@ -120,7 +120,6 @@ defmodule Tau.Factory.UnitDriver do
       scheduler: scheduler,
       worker_supervisor: worker_supervisor,
       worker_registry: worker_registry,
-      janitor: janitor,
       pubsub: pubsub,
       repo_dir: repo_dir,
       agent_bin: agent_bin,
@@ -148,7 +147,11 @@ defmodule Tau.Factory.UnitDriver do
     # Resolve the pid now so the Worker's GenServer.call targets a live pid
     # rather than the supervision-id atom which may differ.
     # -------------------------------------------------------------------------
-    janitor_pid = GenServer.whereis(WorkspaceJanitor) || janitor
+    # Resolve the janitor: prefer the explicit deps[:janitor] injection (the
+    # test-injection seam per B8/#479); fall back to the singleton
+    # WorkspaceJanitor (always registered under __MODULE__). Driver-side reclaim
+    # is ZERO — the janitor exclusively owns capture-before-destroy (D-313/D-314).
+    janitor_pid = deps[:janitor] || WorkspaceJanitor
 
     worker_fun = fn role ->
       unit_pid = self()

--- a/test/tau/factory/factory_supervision_test.exs
+++ b/test/tau/factory/factory_supervision_test.exs
@@ -1,0 +1,203 @@
+defmodule Tau.Factory.FactorySupervisionTest do
+  @moduledoc """
+  Gating test for PR #480 — **P5c-6 production supervision** (AC-P5c6, #474).
+
+  Pins the **config-gated full-subtree assembly**: `Tau.Factory.Supervisor`
+  starts the entire factory control subtree — Ledger → Budget.Owner →
+  Scheduler → MergeAuthority → UnitRegistry/UnitSupervisor → KillSwitch →
+  Coordinator (LAST) — wired with the REAL seams
+  (`select_fun = Tau.Factory.IssueSelector.select/1`,
+  `drive_fun = Tau.Factory.UnitDriver.drive/2`, `:ledger` = the started writer)
+  **only when the factory is enabled**, and starts NOTHING (no Coordinator,
+  no uncontrolled work) on a normal default boot.
+
+  ## The config-gating seam this test pins (drives the implementer brief)
+
+  The factory subtree is gated on `config :tau, :factory, enabled: false`
+  (the default). The testable seam is `Tau.Factory.Supervisor.start_link/1`:
+  the supervisor consults the gating decision and, **when enabled**, assembles
+  the full Coordinator-bearing subtree threading the real seams from its opts;
+  when NOT enabled (the default), it assembles no Coordinator subtree
+  (today's ledger-only behaviour).
+
+  An `enabled: true` opt to `start_link/1` requests the gated full-subtree
+  assembly for a single isolated test instance (tmp-dir DB + throwaway git
+  repo), so the assembly can be exercised without booting the whole app and
+  without touching the application-started instance. The real `select_fun`
+  is wired against a no-issues `:gh_fun` (NO network in tests) so the
+  Coordinator IDLES — `select_fun → nil` — and drives no uncontrolled work.
+
+  ## Fail-before validity (oracle separation, factory-loop §4b)
+
+  On THIS branch `Tau.Factory.Supervisor` has NO `enabled`-gated full-subtree
+  path: passing `enabled: true` (without hand-threading `coordinator_opts`)
+  starts NO Coordinator (`maybe_add_coordinator(children, nil, …)`), so
+  **Test A's** lookup of the Coordinator child fails / `:sys.get_state` cannot
+  reach `:running` via the real assembly. The config-gated subtree assembly
+  does not yet exist — Test A fails until the implementer wires it (#474).
+  **Test B** asserts the default-OFF safety property and may pass trivially
+  today (nothing starts a Coordinator on default boot); it is the regression
+  guard for "no uncontrolled work on normal boot".
+
+  ## AC / D-NNN linkage
+    - AC-P5c6 — every test in this file (config-gated subtree assembly;
+      default OFF). See #474 / SPEC-FACTORY-CORE §5 (Coordinator `running`);
+      docs/arch/04-software-architecture/supervision-tree.md (tree composition,
+      Coordinator started LAST, rest_for_one spine).
+  """
+
+  use ExUnit.Case, async: false
+
+  @moduletag :ac_p5c6
+  @moduletag :capture_log
+
+  @supervisor Tau.Factory.Supervisor
+  @coordinator Tau.Factory.Coordinator
+  @issue_selector Tau.Factory.IssueSelector
+  @unit_driver Tau.Factory.UnitDriver
+
+  # ---------------------------------------------------------------------------
+  # Throwaway git repo (mirrors merge_result_pubsub_test.exs / unit_driver_test.exs)
+  # ---------------------------------------------------------------------------
+
+  defp setup_git_repo do
+    repo_dir = Briefly.create!(type: :directory)
+
+    git = fn args -> System.cmd("git", args, cd: repo_dir, stderr_to_stdout: true) end
+
+    {_, 0} = git.(["init", "-b", "main"])
+    {_, 0} = git.(["config", "user.email", "test@tau.test"])
+    {_, 0} = git.(["config", "user.name", "Tau Test"])
+
+    File.write!(Path.join(repo_dir, "README"), "initial\n")
+    {_, 0} = git.(["add", "README"])
+    {_, 0} = git.(["commit", "-m", "initial commit"])
+
+    repo_dir
+  end
+
+  # Walk the supervisor's children for the Coordinator child (the derived name
+  # is internal; identify it by the module reported in the child spec).
+  defp coordinator_child(sup_pid) do
+    sup_pid
+    |> Supervisor.which_children()
+    |> Enum.find_value(fn
+      {_id, pid, :worker, mods} when is_pid(pid) ->
+        if @coordinator in List.wrap(mods), do: pid, else: nil
+
+      _ ->
+        nil
+    end)
+  end
+
+  defp child_pids_of(sup_pid, target_mod) do
+    sup_pid
+    |> Supervisor.which_children()
+    |> Enum.flat_map(fn
+      {_id, pid, _type, mods} when is_pid(pid) ->
+        if target_mod in List.wrap(mods), do: [pid], else: []
+
+      _ ->
+        []
+    end)
+  end
+
+  # ---------------------------------------------------------------------------
+  # AC-P5c6, Test A — ENABLED: the full subtree assembles; Coordinator reaches
+  # :running and IDLES (select_fun → nil); no Unit spawned, no merge requested.
+  # ---------------------------------------------------------------------------
+
+  describe "AC-P5c6 — config-gated factory subtree starts the Coordinator at :running and idles" do
+    @tag :ac_p5c6
+    test "AC-P5c6: with the factory enabled, the subtree assembles and the Coordinator reaches :running and idles (no uncontrolled work)" do
+      repo_dir = setup_git_repo()
+      db_path = Briefly.create!(extname: ".db")
+      sup_name = :"factory_sup_p5c6_#{System.unique_integer([:positive])}"
+
+      # The real select_fun: IssueSelector against a no-issues gh_fun so the
+      # Coordinator IDLES (select_fun → nil) without driving uncontrolled work.
+      no_issues_gh_fun = fn _milestone -> {:ok, []} end
+
+      sup_pid =
+        start_supervised!(
+          {
+            @supervisor,
+            enabled: true,
+            db_path: db_path,
+            name: sup_name,
+            repo_dir: repo_dir,
+            milestone: "p5c6-test-milestone",
+            gh_fun: no_issues_gh_fun,
+            select_fun: &@issue_selector.select/1,
+            drive_fun: &@unit_driver.drive/2
+          },
+          id: sup_name
+        )
+
+      assert is_pid(sup_pid), "AC-P5c6: Tau.Factory.Supervisor must start"
+
+      # The Coordinator is a child of the assembled subtree.
+      coord_pid = coordinator_child(sup_pid)
+
+      assert is_pid(coord_pid),
+             "AC-P5c6: with the factory enabled, Tau.Factory.Supervisor MUST assemble the " <>
+               "full subtree INCLUDING a Tau.Factory.Coordinator child (started LAST per " <>
+               "supervision-tree.md). No Coordinator child was found — the config-gated " <>
+               "full-subtree assembly is absent."
+
+      # The Coordinator reaches and holds :running (gen_statem state_functions:
+      # :sys.get_state returns {state_name, data}).
+      {state_name, _data} = :sys.get_state(coord_pid)
+
+      assert state_name == :running,
+             "AC-P5c6: the Coordinator must reach :running via the real assembly; got " <>
+               "#{inspect(state_name)}. SPEC-FACTORY-CORE §5: `running` is the loop entry " <>
+               "(start = resume from L)."
+
+      # IDLE PROPERTY: select_fun → nil (no open issues in the sandbox), so the
+      # Coordinator drives NO uncontrolled work. After the loop settles there is
+      # no in-flight unit.
+      Process.sleep(200)
+
+      {state_name_after, data_after} = :sys.get_state(coord_pid)
+
+      assert state_name_after == :running,
+             "AC-P5c6: the Coordinator must IDLE in :running when select_fun → nil; got " <>
+               "#{inspect(state_name_after)}."
+
+      assert Map.get(data_after, :in_flight) == nil,
+             "AC-P5c6: an idle Coordinator (select_fun → nil) must hold no in-flight unit; " <>
+               "in_flight = #{inspect(Map.get(data_after, :in_flight))}. A non-nil in_flight " <>
+               "means it drove uncontrolled work on boot — the safety property is violated."
+
+      # No Unit was spawned: every UnitSupervisor in the subtree has no children.
+      unit_sup_pids = child_pids_of(sup_pid, Tau.Factory.UnitSupervisor)
+
+      for unit_sup_pid <- unit_sup_pids do
+        assert DynamicSupervisor.count_children(unit_sup_pid).active == 0,
+               "AC-P5c6: an idle Coordinator must spawn NO Unit; the UnitSupervisor has " <>
+                 "active children — uncontrolled work was driven on boot."
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # AC-P5c6, Test B — DEFAULT OFF: no Coordinator on a normal boot (the safety
+  # property — no uncontrolled work on normal startup).
+  # ---------------------------------------------------------------------------
+
+  describe "AC-P5c6 — default config leaves the factory OFF (no Coordinator on normal boot)" do
+    @tag :ac_p5c6
+    test "AC-P5c6: with the default config (factory disabled), no Tau.Factory.Coordinator is started on normal boot" do
+      # The application boots with `config :tau, :factory, enabled: false`
+      # (the default). The application-started factory subtree therefore starts
+      # NO Coordinator — the safety property: no uncontrolled work on normal
+      # boot. The canonical Coordinator name is unregistered.
+      assert Process.whereis(@coordinator) == nil,
+             "AC-P5c6: on a default boot the factory MUST be OFF — no " <>
+               "Tau.Factory.Coordinator process may exist. A registered Coordinator means " <>
+               "the factory started uncontrolled on normal boot (the default-OFF safety " <>
+               "property is violated)."
+    end
+  end
+end

--- a/test/tau/factory/merge_result_pubsub_test.exs
+++ b/test/tau/factory/merge_result_pubsub_test.exs
@@ -68,6 +68,17 @@ defmodule Tau.Factory.MergeResultPubSubTest do
     def cas_push(_repo_dir, _tip, _base), do: :ok
   end
 
+  defmodule StaleRefCas do
+    @moduledoc false
+    # Verdicts live, but the CAS push reports a stale ref → :committing takes the
+    # `{:error, :stale_ref}` branch, which REQUEUES the train for a rebase + re-gate.
+    # A requeue is NOT a terminal outcome: D-356 explicitly does NOT publish a
+    # {:merge_result, _} broadcast on a mere requeue (the emission half fires only
+    # on a terminal :merged or terminal :rejected).
+    def assert_all_verdicts_live(_ledger, _units, _required_halves), do: :all_pass
+    def cas_push(_repo_dir, _tip, _base), do: {:error, :stale_ref}
+  end
+
   # ---------------------------------------------------------------------------
   # Helpers (mirror merge_outcome_durability_test.exs / merge_verdict_revoke_test.exs)
   # ---------------------------------------------------------------------------
@@ -220,6 +231,48 @@ defmodule Tau.Factory.MergeResultPubSubTest do
 
       # A terminal reject must NOT also publish :merged on the same topic.
       refute_received {:merge_result, :merged}
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # D-356 emission, REQUEUE — a mere requeue (stale-ref CAS / non-health build
+  # failure) is NOT terminal and broadcasts NOTHING on the per-PR topic. This is
+  # the negative half of the D-356 emission contract: the broadcast fires ONLY on
+  # a terminal :merged / :rejected, never on a re-gate requeue.
+  # ---------------------------------------------------------------------------
+
+  describe "D-356 — a requeued train member broadcasts NO merge-result on the per-PR topic" do
+    @tag :d_356
+    test "D-356: a stale-ref CAS requeue (re-gate, not terminal) publishes NO {:merge_result, _} on the per-PR topic" do
+      ledger = start_ledger()
+
+      unit = %{
+        id: "u-requeue-#{System.unique_integer([:positive])}",
+        hash: "hash-#{System.unique_integer([:positive])}",
+        run: "run-#{System.unique_integer([:positive])}",
+        branch: "feat/merge-result-requeue-#{System.unique_integer([:positive])}"
+      }
+
+      {work_path, tip} = setup_git_repo(unit)
+      # StaleRefCas → assert_all_verdicts_live :all_pass, then cas_push returns
+      # {:error, :stale_ref} → the train is REQUEUED for rebase + re-gate. A
+      # requeue is NOT terminal: D-356 must NOT broadcast on the per-PR topic.
+      ma = start_merge_authority(ledger, work_path, built_build_fun(tip), StaleRefCas)
+
+      :ok = Phoenix.PubSub.subscribe(Tau.PubSub, pr_topic(unit.id))
+
+      assert :queued = MergeAuthority.request_merge(ma, unit)
+
+      # The stale-ref path requeues (does not push, does not terminally reject).
+      # Across the requeue window NO merge-result broadcast may land on the topic —
+      # neither :merged nor :rejected. A spurious broadcast here would falsely
+      # signal a terminal outcome to a subscribed Unit on a mere re-gate.
+      refute_receive {:merge_result, _any},
+                     1_500,
+                     "D-356: a mere requeue (stale-ref CAS → rebase + re-gate) must broadcast " <>
+                       "NOTHING on #{pr_topic(unit.id)}. The emission half fires ONLY on a " <>
+                       "terminal :merged / :rejected; a broadcast on requeue would falsely " <>
+                       "terminate a subscribed Unit mid-re-gate."
     end
   end
 end

--- a/test/tau/factory/unit_driver_test.exs
+++ b/test/tau/factory/unit_driver_test.exs
@@ -214,7 +214,15 @@ defmodule Tau.Factory.UnitDriverTest do
       worker_supervisor: sub.worker_supervisor,
       worker_registry: sub.worker_registry,
       ledger: sub.ledger,
-      janitor: sub.janitor,
+      # #479 task 3: the WorkspaceJanitor is a singleton per node — it always
+      # registers under `Tau.Factory.WorkspaceJanitor` (`__MODULE__`) and IGNORES
+      # the `:name` opt (SPEC-FACTORY-FLEET §4 C4; worker-fleet.md). Threading the
+      # bespoke per-test name (`sub.janitor`) here was a NO-OP masked by the
+      # driver's `whereis(WorkspaceJanitor) || deps.janitor` resolution. Pass the
+      # singleton MODULE so the `:janitor` test-injection seam names the real
+      # running janitor — correct under both the current driver (`whereis || dep`)
+      # and the #479 driver change (`deps[:janitor] || WorkspaceJanitor`).
+      janitor: @janitor,
       pubsub: Tau.PubSub,
       repo_dir: sub.repo_dir,
       agent_bin: sub.agent_bin,


### PR DESCRIPTION
## P5c-6 — production supervision: start the Coordinator with real seams (config-gated) + #479 janitor cleanup

Closes #474. Closes #479 (folded in — the janitor it cleans up is the one this PR wires into the tree). Advances #458.

### Scope & order
Wire the full factory subtree into the running system, **config-gated OFF by default** (no uncontrolled work on normal boot).
1. **`lib/tau/factory/supervisor.ex` + `lib/tau/application.ex`** — config-gated (`config :tau, :factory, enabled: false` default) full-subtree assembly, conforming to the start-order in `docs/arch/04-software-architecture/supervision-tree.md`: Ledger → Budget.Owner → Scheduler → MergeAuthority (real `repo_dir`, `:pubsub`) → UnitRegistry/UnitSupervisor → WorkerSupervisor/WorkerRegistry/**WorkspaceJanitor**/Watchdog → KillSwitch → Coordinator LAST. PubSub up first. Coordinator seams: `select_fun = IssueSelector` (P5c-4), `drive_fun = UnitDriver` (P5c-3b), `:ledger` (D-344).
2. **#479 cleanup** — `UnitDriver` references the singleton `Tau.Factory.WorkspaceJanitor` cleanly (`deps[:janitor] || WorkspaceJanitor`, not `whereis || dep`); SPEC-FACTORY-CORE §4 B8 wording updated to match (`:janitor` dep = test-injection seam); the two #477 tests corrected (drop the no-op `name:` atom; add the requeue `refute_receive` negative).

### Dependencies
P5c-3b (#477 ✅ — `UnitDriver`), P5c-4 (✅ — `IssueSelector`), #472 (✅ #476 — 4-arg halting). All merged. Required before P5c-7 (dogfood).

### SPECs (in scope)
- **SPEC-FACTORY-CORE** — `supervisor.ex`/`application.ex` (Appendix B); conforms to §5 supervision order; §4 B8 wording amendment (#479). Conforms to **arch `supervision-tree.md`** (authoritative start-order). The test-author surfaced a §4 gap (the config-gating + seam-threading contract was unspecified); a spec pass recorded it (§4 B11, [C120-B11]) and allocated **D-357** (*factory OFF by default — no uncontrolled work on normal boot*; the Test-B safety property). `agent_bin`/`gate_fun` in the UnitDriver deps are `nil` on the idle path and threaded for real in P5c-7 (documented; D-357 gates production until then).

### Acceptance criteria
- **AC-P5c6** — `factory_supervision_test.exs`: under the config flag, against a tmp-dir DB + throwaway repo, the Coordinator reaches `:running` and idles (`select_fun → nil`) without driving uncontrolled work; the **default** config leaves the factory OFF (no factory subtree started).
- **D-356 (regression, #479)** — `merge_result_pubsub_test.exs` adds the requeue `refute_receive {:merge_result, _}` negative (no spurious re-gate broadcast on a requeued member).

### Gating-test paths (frozen at e12105a — implementer MUST NOT edit)
- `test/tau/factory/factory_supervision_test.exs` (AC-P5c6 — config-gated assembly; default OFF)
- `test/tau/factory/unit_driver_test.exs` (#479 — singleton janitor reference)
- `test/tau/factory/merge_result_pubsub_test.exs` (#479 / D-356 — requeue refute_receive negative)

### Gate verdicts
_(filled at gate time — critic, reviewer)_
