### PR TITLE
#486 (C1) — thread actual head_sha as the unit coordinate [C121-B11]

### DIFF
--- a/docs/MISSION.md
+++ b/docs/MISSION.md
@@ -83,7 +83,8 @@ Block-to-SPEC allocation:
 | D-309 – D-311, D-313, D-314, D-316, D-334 | SPEC-FACTORY-FLEET |
 | D-312, D-315, D-317, D-318, D-320, D-321, D-330 – D-333, D-335, D-336, D-340, D-342 – D-344, D-355 – D-359 | SPEC-FACTORY-CORE |
 | D-319, D-351 – D-353 | SPEC-FACTORY-GOV |
-| D-300 – D-360 | reserved — SPEC-FACTORY-\* family (autonomous factory; `docs/arch/`) |
+| D-361 – D-363 | SPEC-FACTORY-CORE (C1 unit-coordinate identity; PR #503) |
+| D-300 – D-380 | reserved — SPEC-FACTORY-\* family (autonomous factory; `docs/arch/`) |
 
 A SPEC needing a D-NNN outside its allocated block MUST update this table
 in the same change.

--- a/docs/arch/04-software-architecture/control-plane.md
+++ b/docs/arch/04-software-architecture/control-plane.md
@@ -753,15 +753,17 @@ pre-declared (V1) — its actual commit is then the coordinate gated and merged.
 
 ### 7.3 `gate_fun` construction (completing the §4 B11 deferral)
 
-The Unit's `:gate_fun` seam is **arity-0** (`-> :pass | {:fail, findings}`); the
-real gate is `Gate.run/1` over a `%Gate.Request{}`. The harness/supervisor builds
-the arity-0 closure that constructs the Request at drive time and folds the
-`%Verdict{}`: `workspace` = a host-isolated checkout for the engine's revert
+The Unit's `:gate_fun` seam is **arity-1** (`(coordinate :: String.t() -> :pass |
+{:fail, findings})`); the real gate is `Gate.run/1` over a `%Gate.Request{}`. The
+Unit supplies the coordinate (`data.head_sha || data.hash`) at the `gating` state
+entry (D-361 symmetric with `awaiting_merge`). The harness/supervisor builds the
+arity-1 closure that receives the coordinate, sets `Request.hash` to it, and folds
+the `%Verdict{}`: `workspace` = a host-isolated checkout for the engine's revert
 (distinct from the worker's writable worktree), `merge_base` = `git merge-base
 origin/main HEAD` in that workspace, `frozen_paths` = the declared gating-test
-path set (D-304), `unit`/`hash`/`run`/`diff`/`policy_pin`/`ledger` from the
-work-item and supervisor context. Detail and field provenance: SPEC-FACTORY-CORE
-§4 B11.
+path set (D-304), `unit`/`run`/`diff`/`policy_pin`/`ledger` from the work-item
+and supervisor context; `hash` comes from the Unit at call time (D-361/D-363).
+Detail and field provenance: SPEC-FACTORY-CORE §4 B11.
 
 ### 7.4 Sandbox + the local-origin safety guard (D-359, V1)
 

--- a/docs/arch/04-software-architecture/control-plane.md
+++ b/docs/arch/04-software-architecture/control-plane.md
@@ -738,12 +738,18 @@ fails on the reverted tree (no `answer/0`) and passes on the real tree, so the
 mutation cross-check (`gate-and-toolchain.md` §3 step 7) is satisfied by a real
 diff, not a vacuous one.
 
-**Determinism and the head-SHA coordinate.** U discards `work_ready`'s
-`head_sha` and keys `gate_fun`/`merge_fun` on the *declared* `work_item.hash`
-(SPEC-FACTORY-CORE §4 B11 [C121-B11]). The scripted agent makes the declared
-`branch`/`hash` exactly the commit it produces, so the gate and merge coordinate
-**is** the agent's real HEAD — no head-SHA threading change is needed for the
-dogfood.
+**Determinism and the head-SHA coordinate (RESOLVED — C1, PR #503).** U
+**captures** `work_ready`'s `branch`/`head_sha` (§3.2.1) and keys
+`gate_fun`/`merge_fun` on the agent-asserted `head_sha`, not the *declared*
+`work_item.hash` (SPEC-FACTORY-CORE §4 B6/B7/B8, D-361/D-362/D-363; `[C121-B11]`
+resolved). *Earlier this section stated U discards `head_sha` and keys on the
+declared hash — that was the P5c-7 deferral, now superseded; §3.2.1 always showed
+the capturing clause, and capture is the canonical contract.* For the **dogfood**
+the change is a no-op: the deterministic scripted agent makes its asserted HEAD
+exactly the declared `branch`/`hash`, so the captured and declared coordinates
+coincide and the gate/merge coordinate **is** the agent's real HEAD either way.
+The capture matters for a **non-deterministic** agent, whose real HEAD cannot be
+pre-declared (V1) — its actual commit is then the coordinate gated and merged.
 
 ### 7.3 `gate_fun` construction (completing the §4 B11 deferral)
 

--- a/docs/spec/SPEC-FACTORY-CORE.md
+++ b/docs/spec/SPEC-FACTORY-CORE.md
@@ -73,6 +73,21 @@ Appendix B adds `tau.factory.dogfood.ex`, the dogfood agent/seed helpers,
 `dogfood_e2e_test.exs`, `dogfood_guard_test.exs`. Conforms to (does not redesign)
 arch `control-plane.md`, `gate-and-toolchain.md`, `merge-and-integration.md`.
 
+**Amendment (2026-06-13, PR #503 — C1 / `[C121-B11]` resolution: unit-coordinate
+identity).** Closes the head-SHA coordinate gap recorded as `[C121-B11]`. The
+Unit now **captures** `work_ready`'s asserted `branch`/`head_sha` into its data
+at the `implementing → gating` (and `oracle → implementing`) transition, and the
+gate/merge seams key on that **actual** coordinate, not the pre-declared
+`work_item.hash`. §4 B6/B8 pin the capture and the coordinate-substitution; §6
+adds **D-361** (the coordinate-identity invariant — gate/merge key on the
+agent-asserted `head_sha`), **D-362** (capture-on-`work_ready`), and **D-363**
+(back-compat: a deterministic agent whose declared hash == produced HEAD, and the
+legacy `head_sha = nil` 2-tuple seam, both fall through unchanged). §3 Q3
+promotes `[C121-B11]` from a recorded deferral to a **resolved** constraint.
+Conforms to arch `control-plane.md` §3.2.1 (which already showed the capturing
+clause) and `merge-and-integration.md`; resolves the `control-plane.md`
+§3.2.1↔§7.2 contradiction in favour of capture.
+
 ## 0. Why this spec exists
 
 The factory's control core is the brain of an autonomous loop that takes a
@@ -232,14 +247,20 @@ Format: `[Cn-Bm]` = constraint number + boundary. **★** marks non-obvious.
   mode" true by construction, not by trust). This is **D-359**. It complements
   [C120-B11] (off-by-default): even when the operator opts the factory *on* for a
   dogfood, the blast radius is confined to a throwaway local repo.
-- **[C121-B11]** **The agent-asserted `head_sha` is not threaded into the
-  gate/merge coordinate (recorded constraint, dogfood relies on determinism).**
-  The Unit discards `work_ready`'s `branch`/`head_sha`; `gate_fun` and
-  `merge_fun(unit_id, data.hash)` key on the *pre-declared* `work_item.hash`. The
-  dogfood's **deterministic scripted agent** produces a commit whose HEAD == the
-  declared `hash`, so the coordinate is correct. A non-deterministic agent would
-  require wiring the asserted `head_sha` through `unit.ex`/`unit_driver.ex` —
-  explicitly out of P5c-7 scope (§4 B11).
+- **[C121-B11]** **The gate/merge coordinate is the agent-asserted `head_sha`,
+  not the pre-declared `work_item.hash` (RESOLVED 2026-06-13, PR #503, D-361).**
+  *Originally recorded (P5c-7) as a deliberate deferral; now resolved.* The Unit
+  **captures** `work_ready`'s asserted `branch`/`head_sha` into `data` at the
+  `oracle → implementing` and `implementing → gating` transitions, and substitutes
+  that captured `head_sha` for `work_item.hash` as the **gate-Request `hash`** and
+  the **merge-map `hash`/`branch`**. The agent is the sole authority for what it
+  produced; pre-declaring the SHA of an unauthored commit is impossible for a
+  non-deterministic agent (V1). Back-compat is total (D-363): the dogfood's
+  deterministic scripted agent asserts `head_sha == declared hash`, so the captured
+  and declared coordinates coincide and nothing observable changes; the legacy
+  2-tuple `worker_fun` seam (no `worker_id`, `head_sha = nil`) retains the
+  declared `work_item.hash` unchanged. Enforced by D-361/D-362; wiring spans
+  `unit.ex`, `unit_driver.ex`, `gate/request.ex`, and the merge map (§4 B6/B8).
 - **[C123-B8]** **`origin/<branch>` MUST exist at oracle-spawn time when
   `oracle_base_ref` is an `origin/`-qualified ref.** The oracle (test-author)
   Worker is spawned with a detached-HEAD checkout at `oracle_base_ref`; when the
@@ -462,6 +483,21 @@ callers that pass no `:ledger` opt are unaffected (back-compat).
 - `request_merge/2 :: (unit_id, hash) -> :queued` (non-blocking; the result
   `:merged`/`:rejected` arrives asynchronously via `"factory:pr:#{id}"`). A
   blocking `call` across a minutes-long merge build is forbidden (arch H-1b).
+- **The merge coordinate is the captured `head_sha`, not the declared
+  `work_item.hash` (D-361 / `[C121-B11]` resolution, PR #503).** When the Unit has
+  a captured `data.head_sha` (the agent-asserted coordinate from `work_ready`, B8),
+  `merge_fun` is invoked with that value as the `hash` argument, and `UnitDriver`
+  builds the merge map `%{id: unit_id, hash: <captured head_sha>, run, branch:
+  <captured branch>}`. The `hash` field is the **Ledger/CAS verdict coordinate**
+  `(hash, run, half)` re-read by `assert_all_verdicts_live` at commit (SPEC-FACTORY-MERGE
+  B9, `cas.ex`), NOT a content selector — the merge build already checks out
+  `unit.branch` (`merge_authority.ex` `default_build`) and lands the branch tip.
+  Coupling the verdict coordinate to the **same** `head_sha` the gate wrote its
+  verdict under (B7 / Gate.Request) is what makes the live-verdict CAS a genuine
+  guarantee about the commit actually pushed, rather than a check against a
+  fiction. **Fallback (D-363):** when `data.head_sha` is `nil` (legacy 2-tuple
+  seam or a back-compat caller), `merge_fun` receives the declared
+  `work_item.hash` unchanged — the existing behaviour.
 - M owns INV-1..4 / D-300..D-303 and the *emission* half of the result delivery
   (MERGE D-356 — broadcast to `"factory:pr:#{id}"`); U owns the *consume* half
   (**D-356**, this SPEC). U only submits and consumes the result; it never
@@ -500,6 +536,18 @@ callers that pass no `:ledger` opt are unaffected (back-compat).
 - `request_gate/4` / `gate_outcome` (`:pass` | `{:fail, findings}`). The gate is
   the only legal producer of a verdict (G appends to L per B3 / D-335). G owns
   D-304..D-308, D-322, D-323.
+- **The gate keys on the captured `head_sha` (D-361 / `[C121-B11]`, PR #503).**
+  The Unit's `:gate_fun` seam is arity-0 (§4 B11 / arch §7.3); the closure that
+  builds `%Gate.Request{}` MUST set `Request.hash` to the Unit's captured
+  `data.head_sha` (the agent-asserted coordinate, B8/D-362), NOT the declared
+  `work_item.hash`. `Request.hash` is the `(hash, run, half)` verdict coordinate
+  the gate appends to L (Gate.Request docstring; SPEC-FACTORY-GATE B1); keying it
+  on the actual commit is what makes the verdict refer to the agent's real work.
+  The gate **content** is already the branch tip (the harness builds the gate
+  workspace via `git worktree add --detach <branch>`, `dogfood/gate_fun.ex`), so
+  this change aligns the verdict *label* with the content the gate already ran on.
+  **Fallback (D-363):** when `data.head_sha` is `nil`, the closure uses the
+  declared `work_item.hash` unchanged.
 
 ### B8: Unit (C6) ↔ Worker fleet (W) — *cited, SPEC-FACTORY-FLEET*
 
@@ -524,6 +572,20 @@ callers that pass no `:ledger` opt are unaffected (back-compat).
   form is preserved for back-compat but does NOT carry a `worker_id` — the
   `data.worker_id` field is `nil` in that path and the Unit falls back to the
   `{:worker_done, ^worker_pid}` trigger.
+- **Capture the asserted coordinate on `work_ready` (D-362 / `[C121-B11]`, PR #503).**
+  On the matching `{:work_ready, ^worker_id, branch, head_sha}` transition (from
+  BOTH `oracle → implementing` and `implementing → gating`), the Unit MUST write
+  the asserted pair into its data: `%{data | branch: branch, head_sha: head_sha}`
+  (the exact clause shown in arch `control-plane.md` §3.2.1). These fields are
+  test-observable via `:sys.get_state/1`. The capture is on the **current**-worker
+  clause only; the stale-worker discard clause (`{:work_ready, _other_id, _, _}`)
+  captures nothing. `head_sha`/`branch` initialise to `nil` and are non-`nil` only
+  after a `work_ready` from the current worker. The captured `head_sha` is the
+  coordinate the gate (B7 / Gate.Request `hash`) and the merge (B6 / merge-map
+  `hash`) key on — see D-361. **Back-compat (D-363):** the legacy 2-tuple
+  `{:worker_done, ^worker_pid}` completion carries no `branch`/`head_sha`, so
+  `data.head_sha` stays `nil` and both the gate and merge seams fall back to the
+  declared `work_item.hash` exactly as before.
 - **`:janitor` threading — reclaim is the Janitor's, not the driver's
   (PR #477 amendment; PR #479 cleanup; cross-refs SPEC-FACTORY-FLEET D-313/D-314).**
   The `UnitDriver.drive/2` seam threads `:janitor` into the `worker_fun`'s opts
@@ -698,19 +760,21 @@ closes it.
   the worker. `:policy_pin` and `:ledger` are admission-/supervisor-level values.
   `:diff` is the unified diff between `:merge_base` and `:hash` in the workspace.
 
-  **Constraint surfaced — head-SHA threading (recorded, not redesigned;
-  [C121-B11]).** The Unit consumes `work_ready(worker_id, branch, head_sha)` but
-  **discards** `branch`/`head_sha` (`unit.ex` `implementing/3` pattern
-  `{:work_ready, id, _branch, _head_sha}`), and both `gate_fun` (the arity-0
-  closure above) and `merge_fun(unit_id, data.hash)` key on the unit's
-  *pre-declared* `work_item.hash`, never on the agent-asserted `head_sha`. For
-  the dogfood this is satisfied by **determinism**: the scripted agent produces a
-  commit whose branch and HEAD are exactly the work_item's declared
-  `branch`/`hash`, so the declared hash the gate and merge key on **is** the
-  agent's real HEAD. Wiring the asserted `head_sha` through into the gate/merge
-  coordinate (so a non-deterministic agent's real HEAD is gated and merged) is a
-  separate `unit.ex` / `unit_driver.ex` change, **out of P5c-7 scope**; the
-  dogfood does not require it.
+  **Constraint RESOLVED — head-SHA threading ([C121-B11], C1, PR #503; D-361,
+  D-362, D-363).** *Originally recorded (P5c-7) as out-of-scope; now resolved.*
+  The Unit consumes `work_ready(worker_id, branch, head_sha)` and now **captures**
+  `branch`/`head_sha` into its data (D-362; `unit.ex` `implementing/3` and
+  `oracle/3` current-worker clauses write `%{data | branch: branch, head_sha:
+  head_sha}`). Both `gate_fun` (the arity-0 closure above, via `Request.hash`) and
+  `merge_fun` (via the merge-map `hash`/`branch`) key on that captured
+  agent-asserted `head_sha`, not the unit's pre-declared `work_item.hash` (D-361).
+  For the dogfood the change is observably a no-op (D-363): the scripted agent's
+  asserted HEAD == the declared `hash` by construction, so the captured and
+  declared coordinates coincide. The fix is the strict refinement a
+  non-deterministic agent requires — its real HEAD (unknowable before authorship,
+  V1) is the coordinate the gate verifies and the merge CAS lands. The
+  `head_sha = nil` fallback (legacy 2-tuple seam) retains the declared
+  `work_item.hash` unchanged (D-363).
 
 **Unit timeout widening (`:unit_timeouts`, OQ-2 → D-358).** The Unit arms a
 single `:state_timeout_ms` (default `30_000`) on every external-actor-awaiting
@@ -1010,6 +1074,54 @@ force-pushing loop at a real GitHub remote. Enforced by the safety-guard unit
 test (a non-local origin → hard refusal, factory not booted) and by
 `dogfood_e2e_test.exs` driving against a local bare-repo sandbox.
 
+**D-361 — Unit-coordinate identity: the gate/merge coordinate is the
+agent-asserted `head_sha`, not the pre-declared `work_item.hash` ([C121-B11], C1,
+PR #503):** The pre-declared `work_item.hash`
+(`IssueSelector.content_hash/2 = sha256("N:title")`) is fixed **before** the agent
+runs and is therefore unrelated to the commit the agent actually authors — for a
+non-deterministic agent, no value computable before authorship can equal the
+HEAD SHA of an unauthored commit (V1: assumes an impossibility). The agent is the
+sole authority for its output, asserted in-band as `work_ready(w, branch,
+head_sha)` (B8, D-326). Therefore, when the Unit holds a captured non-`nil`
+`data.head_sha` (D-362), the **gate-Request `hash`** (B7) and the **merge-map
+`hash`** (B6) MUST both be that captured `head_sha`, and the merge-map `branch`
+MUST be the captured `branch`. The `(hash, run, half)` Ledger/CAS verdict
+coordinate (B3; `assert_all_verdicts_live`, SPEC-FACTORY-MERGE B9) is thereby
+keyed on the **same** commit the gate ran its verdict against — closing the
+two-writers/one-truth gap (V4) in which the verdict label (declared hash) and the
+landed content (branch tip) were decoupled, making the live-verdict CAS a check
+against a fiction. Production **content** was already the branch tip on both the
+gate (`git worktree add --detach <branch>`) and the merge build (`git checkout
+unit.branch`) paths; D-361 aligns the *coordinate* with that content. Enforced by
+an oracle-separated gating test asserting the gate-Request `hash` and the merge
+map `hash`/`branch` equal the asserted `work_ready` `head_sha`/`branch`, not the
+declared `work_item.hash`.
+
+**D-362 — Capture the asserted coordinate on `work_ready` (the FSM-data
+contract, PR #503):** On the matching `{:work_ready, ^worker_id, branch,
+head_sha}` transition — from BOTH `oracle → implementing` and
+`implementing → gating` — the Unit writes `%{data | branch: branch, head_sha:
+head_sha}` into its data (the exact clause arch `control-plane.md` §3.2.1 shows).
+`head_sha`/`branch` start `nil`, become non-`nil` only after a current-worker
+`work_ready`, and are test-observable via `:sys.get_state/1`. The stale-worker
+discard clause (`{:work_ready, _other_id, _, _}` → `keep_state`) captures nothing
+(B8 invariant). This is the single producer of the coordinate D-361 consumes.
+Enforced by an FSM-data assertion (`:sys.get_state` shows the captured pair after
+a current-worker `work_ready`, and `nil`/unchanged after a stale-worker one).
+
+**D-363 — Total back-compat for the declared-hash and legacy seams (PR #503):**
+When `data.head_sha` is `nil` — the legacy 2-tuple `worker_fun` seam (no
+`worker_id`, completion via `{:worker_done, ^worker_pid}`), or any caller that
+never emits `work_ready` — the gate (B7) and merge (B6) seams fall back to the
+declared `work_item.hash` and `work_item.branch` exactly as before D-361. For the
+dogfood's **deterministic scripted agent**, the asserted `head_sha` equals the
+declared `hash` by construction (arch §7.2), so the captured and declared
+coordinates coincide and the AC-12 end-to-end flow is observably unchanged. D-361
+is therefore a strict refinement: it changes the coordinate only when the agent
+asserts one that differs, which is exactly the non-deterministic-agent case.
+Enforced by the existing `dogfood_e2e_test.exs` continuing to reach `:merged`
+green, and a unit test that the `head_sha = nil` path uses the declared hash.
+
 ## 7. Acceptance criteria
 
 Each is expressed against the user-facing path with an observable signal.
@@ -1097,8 +1209,10 @@ Files that bring a PR into scope of this SPEC (`D-NNN`/`C-N` → file:symbol):
 - `lib/tau/factory/escalation.ex` (C7; D-317) — PR-CORE-3
 - `lib/tau/factory/scheduler.ex` (C4; D-312, D-320, D-343) — PR-CORE-2
 - `lib/tau/factory/conflict_check.ex` (C5; D-312, D-343) — PR-CORE-2
-- `lib/tau/factory/unit.ex` (C6; D-318, D-340, **D-356** awaiting_merge subscribe-before-request consume + unsubscribe-on-exit, plus B6/B7/B8 cited edges) — PR-CORE-3/PR #477
-- `lib/tau/factory/unit_driver.ex` (D-340, **D-356** `:janitor` threading + no driver-side merge bridge / no driver reclaim; the real `drive_fun` wiring Unit→fleet→gate→merge seams) — PR #477
+- `lib/tau/factory/unit.ex` (C6; D-318, D-340, **D-356** awaiting_merge subscribe-before-request consume + unsubscribe-on-exit, **D-362** capture `work_ready` `branch`/`head_sha` into data, **D-361** key `merge_fun` on captured `head_sha`/`branch`, plus B6/B7/B8 cited edges) — PR-CORE-3/PR #477/PR #503
+- `lib/tau/factory/unit_driver.ex` (D-340, **D-356** `:janitor` threading + no driver-side merge bridge / no driver reclaim; **D-361** build the merge map `hash`/`branch` from the captured `head_sha`; the real `drive_fun` wiring Unit→fleet→gate→merge seams) — PR #477/PR #503
+- `lib/tau/factory/gate/request.ex` (**D-361** `Request.hash` is the captured `head_sha`, not the declared `work_item.hash`; the gate-closure construction site) — PR #503
+- `lib/tau/factory/dogfood/gate_fun.ex` (**D-361/D-363** the arity-0 gate closure sets `Request.hash` from the captured `head_sha`, falling back to declared hash when `nil`) — PR #503
 - `lib/tau/factory/retry.ex` (C8; D-318) — PR-CORE-3
 - `lib/tau/factory/kill_switch.ex` (C9; D-321) — PR-CORE-4
 - `lib/tau/factory/supervisor.ex` + `lib/tau/application.ex` (tree; rest_for_one spine; **D-357** config-gated `start_link/1` assembly + seam-threading, B11; **D-358** `:unit_timeouts` thread; **gate_fun/agent_bin** thread completing the P5c-6 deferral, §4 B11) — PR-CORE-1 / PR #480 / PR #481
@@ -1130,4 +1244,5 @@ B8 → `SPEC-FACTORY-FLEET` (D-309–D-311, D-313, D-314, D-316); `E-DESTRUCTIVE
 **Catalog registration required before first implementation PR:** add
 `SPEC-FACTORY-CORE` to `.claude/rules/spec-before-code.md` (catalog) and the
 `D-NNN` block table in `docs/MISSION.md` (D-312, D-315, D-317, D-318, D-320,
-D-321, D-330–D-333, D-335, D-336, D-340, D-342–D-344, D-355–D-359 → this SPEC).
+D-321, D-330–D-333, D-335, D-336, D-340, D-342–D-344, D-355–D-359,
+D-361–D-363 → this SPEC).

--- a/docs/spec/SPEC-FACTORY-CORE.md
+++ b/docs/spec/SPEC-FACTORY-CORE.md
@@ -57,9 +57,10 @@ hand-thread per-child opts). §6: D-357. Appendix B lists
 
 **Amendment (2026-06-13, PR #481 — P5c-7 dogfood capstone, AC-12):** Completes
 the P5c-6 §4 B11 `:gate_fun` / `:agent_bin` deferral (the #480 critic's note):
-`:agent_bin` is the D-326 `{:packet,4}` agent path; `:gate_fun` is the **arity-0**
-Unit seam wrapping `Tau.Factory.Gate.run/1` over a `%Gate.Request{}` built at
-drive time (records exactly where each Request field comes from). Adds the
+`:agent_bin` is the D-326 `{:packet,4}` agent path; `:gate_fun` is the **arity-1**
+Unit seam (D-361 — the Unit supplies the coordinate `data.head_sha || data.hash`
+at call time) wrapping `Tau.Factory.Gate.run/1` over a `%Gate.Request{}` built
+at call time (records exactly where each Request field comes from). Adds the
 `:unit_timeouts` opt (**D-358** — widen the per-state Unit `:state_timeout_ms`
 past `T_unit` so a real agent run does not spuriously escalate; OQ-2). Records the
 **dogfood harness** contract: a **deterministic scripted `agent_bin`** (the
@@ -537,17 +538,19 @@ callers that pass no `:ledger` opt are unaffected (back-compat).
   the only legal producer of a verdict (G appends to L per B3 / D-335). G owns
   D-304..D-308, D-322, D-323.
 - **The gate keys on the captured `head_sha` (D-361 / `[C121-B11]`, PR #503).**
-  The Unit's `:gate_fun` seam is arity-0 (§4 B11 / arch §7.3); the closure that
-  builds `%Gate.Request{}` MUST set `Request.hash` to the Unit's captured
-  `data.head_sha` (the agent-asserted coordinate, B8/D-362), NOT the declared
+  The Unit's `:gate_fun` seam is **arity-1**: `(coordinate :: String.t() -> :pass |
+  {:fail, findings})`. The Unit supplies the coordinate
+  (`data.head_sha || data.hash`) at the `gating` state entry, symmetric with the
+  merge coordinate in `awaiting_merge` (D-361). The closure MUST use the received
+  coordinate as `Request.hash` — the agent-asserted `head_sha`, NOT the declared
   `work_item.hash`. `Request.hash` is the `(hash, run, half)` verdict coordinate
   the gate appends to L (Gate.Request docstring; SPEC-FACTORY-GATE B1); keying it
   on the actual commit is what makes the verdict refer to the agent's real work.
   The gate **content** is already the branch tip (the harness builds the gate
   workspace via `git worktree add --detach <branch>`, `dogfood/gate_fun.ex`), so
   this change aligns the verdict *label* with the content the gate already ran on.
-  **Fallback (D-363):** when `data.head_sha` is `nil`, the closure uses the
-  declared `work_item.hash` unchanged.
+  **Fallback (D-363):** when `data.head_sha` is `nil`, the Unit passes the declared
+  `work_item.hash` as the coordinate (nil-fallback symmetric with merge).
 
 ### B8: Unit (C6) ↔ Worker fleet (W) — *cited, SPEC-FACTORY-FLEET*
 
@@ -694,11 +697,13 @@ Tau.Factory.Supervisor.start_link(opts) :: Supervisor.on_start()
     :agent_bin  — String.t();   path to the worker agent executable each Worker
                                 runs (the {:packet,4} D-326 agent). Threaded into
                                 the assembled drive_fun deps. (P5c-7, #475.)
-    :gate_fun   — (-> :pass | {:fail, [finding]}) | nil; the per-unit gate seam
-                                (arity-0, the Unit's contract — see "gate_fun
-                                completion" below). nil ⇒ no real gate wired (the
-                                P5c-6 idle path drove no unit). Threaded into the
-                                assembled drive_fun deps. (P5c-7, #475.)
+    :gate_fun   — (coordinate :: String.t() -> :pass | {:fail, [finding]}) | nil;
+                                the per-unit gate seam (arity-1; the Unit supplies
+                                the coordinate `data.head_sha || data.hash` at call
+                                time — see "gate_fun completion" below, D-361).
+                                nil ⇒ no real gate wired (the P5c-6 idle path drove
+                                no unit). Threaded into the assembled drive_fun deps.
+                                (P5c-7, #475.)
     :unit_timeouts — keyword();  per-state Unit timeout overrides threaded into
                                 every driven Unit's :timeouts opt (default
                                 [state_timeout_ms: 30_000]). Real agent runs need
@@ -721,16 +726,19 @@ closes it.
   `decode_event/1`).
 
 - **`:gate_fun` — the arity contract and how it wraps `Gate.run/1`.** The
-  **Unit's** `:gate_fun` seam is **arity-0** returning `:pass | {:fail,
-  findings}` (`unit.ex`; called as `data.gate_fun.()` in `gating/3`). The
-  **real** gate is `Tau.Factory.Gate.run/1`, which takes a fully-built
+  **Unit's** `:gate_fun` seam is **arity-1** returning `:pass | {:fail,
+  findings}` (`unit.ex`; called as `data.gate_fun.(coordinate)` in `gating/3`
+  where `coordinate = data.head_sha || data.hash`, symmetric with `awaiting_merge`,
+  D-361). The **real** gate is `Tau.Factory.Gate.run/1`, which takes a fully-built
   `%Tau.Factory.Gate.Request{}` and returns a `%Tau.Factory.Gate.Verdict{}`
   (cited B7 / SPEC-FACTORY-GATE §4 B1; `lib/tau/factory/gate.ex`). The
-  supervisor/dogfood therefore builds a **request-bearing arity-0 closure** that
-  adapts `Gate.run/1`-over-`Request` to the Unit's arity-0 seam:
+  supervisor/dogfood therefore builds a **request-bearing arity-1 closure** that
+  adapts `Gate.run/1`-over-`Request` to the Unit's arity-1 seam. The closure uses
+  the received coordinate (the captured `head_sha`, or declared `work_item.hash`
+  via nil-fallback, D-363) as `Gate.Request.hash`:
 
   ```
-  gate_fun = fn ->
+  gate_fun = fn coordinate ->
     req = %Gate.Request{
       unit:         unit_id,        # work_item.unit_id
       diff:         diff,            # merge_base..HEAD unified diff in the gate workspace
@@ -738,7 +746,7 @@ closes it.
       policy_pin:   policy_pin,       # admission-pinned policy (HR-8); in the dogfood a hermetic oracle pin
       workspace:    gate_workspace,   # a host-isolated checkout the engine reverts in (D-309)
       merge_base:   merge_base,       # `git merge-base origin/main HEAD` in the workspace
-      hash:         hash,              # the unit's content/HEAD hash (work_item.hash)
+      hash:         coordinate,        # the captured head_sha (or declared hash via fallback, D-361/D-363)
       run:          run,               # the run identifier (work_item.run)
       ledger:       ledger              # the started Ledger.Writer (WAL-before-ack, D-335)
     }
@@ -749,8 +757,9 @@ closes it.
   end
   ```
 
-  **Where each `Gate.Request` field comes from at drive time.** `:unit`, `:hash`,
-  `:run`, `:branch` are `work_item` fields (B10 IssueSelector / B6 merge-map).
+  **Where each `Gate.Request` field comes from at drive time.** `:unit`, `:run`,
+  `:branch` are `work_item` fields (B10 IssueSelector / B6 merge-map). `:hash`
+  (= `coordinate`) is the Unit-supplied runtime value (`data.head_sha || data.hash`).
   `:frozen_paths` is the declared gating-test path set frozen at scope-freeze
   (cited B7 / SPEC-FACTORY-GATE D-304). `:merge_base` is computed in the gate
   `:workspace` (`git merge-base origin/main HEAD`). `:workspace` is a
@@ -765,9 +774,11 @@ closes it.
   The Unit consumes `work_ready(worker_id, branch, head_sha)` and now **captures**
   `branch`/`head_sha` into its data (D-362; `unit.ex` `implementing/3` and
   `oracle/3` current-worker clauses write `%{data | branch: branch, head_sha:
-  head_sha}`). Both `gate_fun` (the arity-0 closure above, via `Request.hash`) and
-  `merge_fun` (via the merge-map `hash`/`branch`) key on that captured
-  agent-asserted `head_sha`, not the unit's pre-declared `work_item.hash` (D-361).
+  head_sha}`). Both `gate_fun` (the arity-1 closure above — the Unit passes
+  `data.head_sha || data.hash` as the coordinate, which the closure sets as
+  `Request.hash`) and `merge_fun` (via the merge-map `hash`/`branch`) key on that
+  captured agent-asserted `head_sha`, not the unit's pre-declared `work_item.hash`
+  (D-361).
   For the dogfood the change is observably a no-op (D-363): the scripted agent's
   asserted HEAD == the declared `hash` by construction, so the captured and
   declared coordinates coincide. The fix is the strict refinement a
@@ -1212,7 +1223,7 @@ Files that bring a PR into scope of this SPEC (`D-NNN`/`C-N` → file:symbol):
 - `lib/tau/factory/unit.ex` (C6; D-318, D-340, **D-356** awaiting_merge subscribe-before-request consume + unsubscribe-on-exit, **D-362** capture `work_ready` `branch`/`head_sha` into data, **D-361** key `merge_fun` on captured `head_sha`/`branch`, plus B6/B7/B8 cited edges) — PR-CORE-3/PR #477/PR #503
 - `lib/tau/factory/unit_driver.ex` (D-340, **D-356** `:janitor` threading + no driver-side merge bridge / no driver reclaim; **D-361** build the merge map `hash`/`branch` from the captured `head_sha`; the real `drive_fun` wiring Unit→fleet→gate→merge seams) — PR #477/PR #503
 - `lib/tau/factory/gate/request.ex` (**D-361** `Request.hash` is the captured `head_sha`, not the declared `work_item.hash`; the gate-closure construction site) — PR #503
-- `lib/tau/factory/dogfood/gate_fun.ex` (**D-361/D-363** the arity-0 gate closure sets `Request.hash` from the captured `head_sha`, falling back to declared hash when `nil`) — PR #503
+- `lib/tau/factory/dogfood/gate_fun.ex` (**D-361/D-363** the arity-1 gate closure receives the coordinate (`head_sha || declared hash`) from the Unit and sets `Request.hash` to it) — PR #503
 - `lib/tau/factory/retry.ex` (C8; D-318) — PR-CORE-3
 - `lib/tau/factory/kill_switch.ex` (C9; D-321) — PR-CORE-4
 - `lib/tau/factory/supervisor.ex` + `lib/tau/application.ex` (tree; rest_for_one spine; **D-357** config-gated `start_link/1` assembly + seam-threading, B11; **D-358** `:unit_timeouts` thread; **gate_fun/agent_bin** thread completing the P5c-6 deferral, §4 B11) — PR-CORE-1 / PR #480 / PR #481

--- a/lib/mix/tasks/tau.factory.dogfood.ex
+++ b/lib/mix/tasks/tau.factory.dogfood.ex
@@ -113,7 +113,6 @@ defmodule Mix.Tasks.Tau.Factory.Dogfood do
 
     # Step 6 — Derive the deterministic work_item coordinate (mirrors IssueSelector).
     unit_id = "unit-#{issue_number}"
-    hash = issue_hash(issue_number, Sandbox.issue_title())
     run_id = "run-1"
     frozen_paths = MapSet.new([Sandbox.gating_test_path()])
 
@@ -124,14 +123,14 @@ defmodule Mix.Tasks.Tau.Factory.Dogfood do
     sup_name = :"tau_factory_dogfood_#{:erlang.unique_integer([:positive])}"
     writer_name = :"#{sup_name}_writer"
 
-    # Step 8 — Build the arity-0 gate_fun closure.
-    # The closure captures all work_item coordinates; creates a host-isolated
-    # gate workspace at call time (after worker commits) and calls Gate.run/1.
+    # Step 8 — Build the arity-1 gate_fun closure (D-361).
+    # The closure is arity-1: the Unit supplies the coordinate (data.head_sha || data.hash)
+    # at call time. The coordinator captures all static context (repo_dir, unit_id, run,
+    # frozen_paths, ledger); the runtime coordinate comes from the Unit seam.
     gate_fun =
       GateFun.build(
         repo_dir: repo,
         unit_id: unit_id,
-        hash: hash,
         run: run_id,
         frozen_paths: frozen_paths,
         ledger: writer_name
@@ -396,13 +395,5 @@ defmodule Mix.Tasks.Tau.Factory.Dogfood do
     dir = Path.join(repo, ".tau-factory")
     File.mkdir_p!(dir)
     Path.join(dir, "ledger.db")
-  end
-
-  # Deterministic content hash for the work_item coordinate.
-  # Mirrors IssueSelector.content_hash/2 (private): sha256("N:title").
-  # SPEC-FACTORY-CORE §4 B10 / unit_id_for → "unit-N".
-  defp issue_hash(number, title) do
-    :crypto.hash(:sha256, "#{number}:#{title}")
-    |> Base.encode16(case: :lower)
   end
 end

--- a/lib/tau/factory/dogfood/gate_fun.ex
+++ b/lib/tau/factory/dogfood/gate_fun.ex
@@ -1,12 +1,12 @@
 defmodule Tau.Factory.Dogfood.GateFun do
   @moduledoc """
-  Builds the arity-0 `gate_fun` closure for the `mix tau.factory.dogfood` harness.
+  Builds the arity-1 `gate_fun` closure for the `mix tau.factory.dogfood` harness.
 
-  The Unit's `:gate_fun` seam is `(-> :pass | {:fail, [finding]})`. The real
-  gate is `Tau.Factory.Gate.run/1` over a `%Tau.Factory.Gate.Request{}`. This
-  module builds the request-bearing arity-0 closure that adapts
-  `Gate.run/1`-over-`Request` to the Unit's arity-0 seam, as specified in
-  SPEC-FACTORY-CORE §4 B11 ("gate_fun completion", P5c-7).
+  The Unit's `:gate_fun` seam is `(coordinate :: String.t() -> :pass | {:fail, [finding]})`.
+  The real gate is `Tau.Factory.Gate.run/1` over a `%Tau.Factory.Gate.Request{}`. This
+  module builds the request-bearing arity-1 closure that adapts
+  `Gate.run/1`-over-`Request` to the Unit's arity-1 seam, as specified in
+  SPEC-FACTORY-CORE §4 B11 ("gate_fun completion", P5c-7, D-361).
 
   The closure creates a **host-isolated gate workspace** (a `git worktree add`
   of `repo_dir` on the feature branch) at call time — AFTER the worker has
@@ -30,34 +30,32 @@ defmodule Tau.Factory.Dogfood.GateFun do
   require Logger
 
   @doc """
-  Build the arity-0 `gate_fun` closure for the dogfood harness.
+  Build the arity-1 `gate_fun` closure for the dogfood harness.
 
   The closure captures:
     - `repo_dir`     — the sandbox working repo (worker's parent git dir).
     - `unit_id`      — the stable unit identity string (e.g. `"unit-1"`).
-    - `hash`         — the pre-declared content hash from the work_item
-                       (used as the Ledger coordinate; [C121-B11] — not the
-                       git HEAD SHA).
     - `run`          — the run identifier string (e.g. `"run-1"`).
     - `frozen_paths` — the declared gating-test path set (D-304; a
                        `MapSet.t(String.t())`).
     - `ledger`       — the started `Tau.Factory.Ledger.Writer` name/pid
                        (WAL-before-ack, D-335).
 
-  Returns an arity-0 function `(-> :pass | {:fail, [term()]})`.
+  The returned closure is arity-1: `(coordinate :: String.t() -> :pass | {:fail, [term()]})`.
+  The Unit supplies the coordinate (`data.head_sha || data.hash`) at call time (D-361).
+  The coordinate becomes the `Gate.Request.hash` — i.e. the captured head_sha (or the
+  declared work_item.hash via nil-fallback per D-363) is used as the gate's hash key.
   """
   @spec build(
           repo_dir: String.t(),
           unit_id: String.t(),
-          hash: String.t(),
           run: String.t(),
           frozen_paths: MapSet.t(String.t()),
           ledger: GenServer.server()
-        ) :: (-> :pass | {:fail, [term()]})
+        ) :: (String.t() -> :pass | {:fail, [term()]})
   def build(params) do
     repo_dir = Keyword.fetch!(params, :repo_dir)
     unit_id = Keyword.fetch!(params, :unit_id)
-    hash = Keyword.fetch!(params, :hash)
     run = Keyword.fetch!(params, :run)
     frozen_paths = Keyword.fetch!(params, :frozen_paths)
     ledger = Keyword.fetch!(params, :ledger)
@@ -66,8 +64,8 @@ defmodule Tau.Factory.Dogfood.GateFun do
     # The mutation half is fully real (no oracle pin for :mutation).
     policy_pin = %{oracle: %{critic: :pass, reviewer: :pass}}
 
-    fn ->
-      run_gate(repo_dir, unit_id, hash, run, frozen_paths, ledger, policy_pin)
+    fn coordinate ->
+      run_gate(repo_dir, unit_id, coordinate, run, frozen_paths, ledger, policy_pin)
     end
   end
 

--- a/lib/tau/factory/unit.ex
+++ b/lib/tau/factory/unit.ex
@@ -91,7 +91,9 @@ defmodule Tau.Factory.Unit do
                          on `{:work_ready, ^worker_id, _, _}` (D-326/SPEC-FACTORY-CORE §4 B8).
                          When the 2-tuple form is returned (legacy), the Unit matches
                          `{:worker_done, ^worker_pid}` for normal completion.
-    - `:gate_fun`       — `(-> :pass | {:fail, findings :: [term()]})`.
+    - `:gate_fun`       — `(coordinate :: String.t() -> :pass | {:fail, findings :: [term()]})`.
+                         Called with `data.head_sha || data.hash` as the coordinate
+                         (D-361 symmetric with merge; nil-fallback per D-363).
     - `:merge_fun`      — `(unit_id, hash -> :queued | {:error, reason})`.
 
   Optional options:
@@ -390,8 +392,13 @@ defmodule Tau.Factory.Unit do
 
   # ---------------------------------------------------------------------------
   # State: :gating
-  # Calls gate_fun() synchronously on entry via an internal event.
+  # Calls gate_fun(coordinate) synchronously on entry via an internal event.
   # ALWAYS calls gate_fun — for refine attempts AND the pivot attempt alike.
+  #
+  # D-361: coordinate = data.head_sha || data.hash (symmetric with awaiting_merge).
+  # When head_sha was captured from work_ready (3-tuple seam), it is used as the
+  # coordinate. When not captured (legacy 2-tuple seam), falls back to the declared
+  # work_item.hash (D-363 back-compat, nil-fallback symmetric with merge).
   #
   # :pass → awaiting_merge (this is how a successful pivot reaches merge).
   # {:fail, findings} → Retry.next(:gate_fail, refine_count, pivot_count):
@@ -411,7 +418,13 @@ defmodule Tau.Factory.Unit do
   def gating(:internal, :on_enter, data) do
     data = snapshot_state(:gating, data)
 
-    case data.gate_fun.() do
+    # D-361: use the captured head_sha as the gate coordinate when present;
+    # fall back to the declared work_item.hash for the legacy 2-tuple seam
+    # (D-363 back-compat — head_sha is nil when no work_ready was received).
+    # Symmetric with the merge coordinate in awaiting_merge.
+    coordinate = data.head_sha || data.hash
+
+    case data.gate_fun.(coordinate) do
       :pass ->
         {:next_state, :awaiting_merge, data, [{:next_event, :internal, :on_enter}]}
 

--- a/lib/tau/factory/unit.ex
+++ b/lib/tau/factory/unit.ex
@@ -177,7 +177,11 @@ defmodule Tau.Factory.Unit do
       # Incremented on every snapshot_state call so backward-edge re-entries each
       # produce a distinct key, making MAX(id) in latest_unit_snapshots/1 track
       # the genuinely-latest FSM state rather than the forward-stale state.
-      entry_seq: 0
+      entry_seq: 0,
+      # D-362: captured from {:work_ready, worker_id, branch, head_sha} (3-tuple seam).
+      # Initialised to nil; stays nil when the legacy 2-tuple seam is used (D-363).
+      head_sha: nil,
+      branch: nil
     }
 
     # Transition immediately to planned state, which triggers admission.
@@ -235,10 +239,20 @@ defmodule Tau.Factory.Unit do
   end
 
   # D-326: gate on work_ready keyed by the CURRENT worker_id (3-tuple seam).
-  def oracle(:info, {:work_ready, worker_id, _branch, _head_sha}, %{worker_id: worker_id} = data)
+  # D-362: capture branch and head_sha into data on transition.
+  def oracle(:info, {:work_ready, worker_id, branch, head_sha}, %{worker_id: worker_id} = data)
       when not is_nil(worker_id) do
     Process.demonitor(data.worker_mref, [:flush])
-    new_data = %{data | worker_pid: nil, worker_id: nil, worker_mref: nil}
+
+    new_data = %{
+      data
+      | worker_pid: nil,
+        worker_id: nil,
+        worker_mref: nil,
+        branch: branch,
+        head_sha: head_sha
+    }
+
     {:next_state, :implementing, new_data, [{:next_event, :internal, :on_enter}]}
   end
 
@@ -312,14 +326,24 @@ defmodule Tau.Factory.Unit do
 
   # D-326 §4 B8: gate implementing → gating ONLY on work_ready keyed by the
   # CURRENT worker_id (the sole completion trigger — never bare exit / :worker_done).
+  # D-362: capture branch and head_sha into data on transition.
   def implementing(
         :info,
-        {:work_ready, worker_id, _branch, _head_sha},
+        {:work_ready, worker_id, branch, head_sha},
         %{worker_id: worker_id} = data
       )
       when not is_nil(worker_id) do
     Process.demonitor(data.worker_mref, [:flush])
-    new_data = %{data | worker_pid: nil, worker_id: nil, worker_mref: nil}
+
+    new_data = %{
+      data
+      | worker_pid: nil,
+        worker_id: nil,
+        worker_mref: nil,
+        branch: branch,
+        head_sha: head_sha
+    }
+
     {:next_state, :gating, new_data, [{:next_event, :internal, :on_enter}]}
   end
 
@@ -454,7 +478,11 @@ defmodule Tau.Factory.Unit do
         # no replay; ordering here is the race-freedom guarantee.
         :ok = Phoenix.PubSub.subscribe(data.pubsub, "factory:pr:#{data.unit_id}")
 
-        _result = data.merge_fun.(data.unit_id, data.hash)
+        # D-361: use the captured head_sha as the merge coordinate when present;
+        # fall back to the declared work_item.hash for the legacy 2-tuple seam
+        # (D-363 back-compat — head_sha is nil when no work_ready was received).
+        coordinate = data.head_sha || data.hash
+        _result = data.merge_fun.(data.unit_id, coordinate)
         timeout_ms = data.state_timeout_ms
         {:keep_state, data, [{:state_timeout, timeout_ms, :merge_stalled}]}
     end

--- a/lib/tau/factory/unit_driver.ex
+++ b/lib/tau/factory/unit_driver.ex
@@ -94,8 +94,10 @@ defmodule Tau.Factory.UnitDriver do
     * `:repo_dir`          — `String.t()`; the parent git repo for worker
                              worktrees.
     * `:agent_bin`         — `String.t()`; the agent executable each worker runs.
-    * `:gate_fun`          — `(-> :pass | {:fail, findings})`; injected gate
-                             seam (passed through to the Unit unchanged).
+    * `:gate_fun`          — `(coordinate :: String.t() -> :pass | {:fail, findings})`; injected
+                             gate seam (passed through to the Unit unchanged). The Unit
+                             supplies the coordinate (`data.head_sha || data.hash`) at
+                             call time (D-361 symmetric with merge).
     * `:merge_authority`   — atom/pid of a (possibly stubbed) `MergeAuthority`;
                              the `:merge_fun` calls `request_merge/2` against it.
     * `:report_to`         — pid receiving `{:unit_terminal, unit_id, outcome,

--- a/test/tau/factory/merge_outcome_durability_test.exs
+++ b/test/tau/factory/merge_outcome_durability_test.exs
@@ -382,7 +382,7 @@ defmodule Tau.Factory.MergeOutcomeDurabilityTest do
         report_to: test_pid,
         ledger: ledger,
         worker_fun: fn _role -> {:ok, spawn_worker()} end,
-        gate_fun: fn -> :pass end,
+        gate_fun: fn _coord -> :pass end,
         merge_fun: merge_fun,
         timeouts: [state_timeout_ms: 5_000]
       ]
@@ -451,7 +451,7 @@ defmodule Tau.Factory.MergeOutcomeDurabilityTest do
 
       regate_signal = test_pid
 
-      gate_fun = fn ->
+      gate_fun = fn _coord ->
         n = Agent.get_and_update(gate_calls, fn c -> {c, c + 1} end)
         # The second gate call is the re-gate after the :rejected reconcile.
         if n >= 1, do: send(regate_signal, :regated)

--- a/test/tau/factory/reject_durable_outcome_test.exs
+++ b/test/tau/factory/reject_durable_outcome_test.exs
@@ -384,7 +384,7 @@ defmodule Tau.Factory.RejectDurableOutcomeTest do
 
       regate_signal = test_pid
 
-      gate_fun = fn ->
+      gate_fun = fn _coord ->
         n = Agent.get_and_update(gate_calls, fn c -> {c, c + 1} end)
         if n >= 1, do: send(regate_signal, :regated)
         :pass

--- a/test/tau/factory/unit_coordinate_test.exs
+++ b/test/tau/factory/unit_coordinate_test.exs
@@ -19,8 +19,15 @@ defmodule Tau.Factory.UnitCoordinateTest do
 
   When `data.head_sha` is non-`nil` (captured from `work_ready`), BOTH the
   gate seam and the merge seam MUST use `data.head_sha` as the coordinate —
-  NOT the pre-declared `work_item.hash`. The merge spy's received `hash`
-  argument is the observable signal for the merge seam (B6).
+  NOT the pre-declared `work_item.hash`. Two tests exercise this:
+
+  - **Merge coordinate** (existing): the merge spy's received `hash` argument is the
+    observable signal for the merge seam (B6). PASSES — merge half already implemented.
+  - **Gate coordinate** (new): an arity-1 `gate_fun` spy records the coordinate it
+    is called with; the assert verifies it equals the captured `head_sha`, not the
+    declared hash. FAILS until the implementer makes `gating` call
+    `data.gate_fun.(coordinate)` with the same `coordinate = data.head_sha || data.hash`
+    used by `awaiting_merge`.
 
   ### D-363 — Total back-compat: legacy 2-tuple seam falls through to declared hash (§6)
 
@@ -32,26 +39,28 @@ defmodule Tau.Factory.UnitCoordinateTest do
 
   ## Fail-before validity (oracle separation, factory-loop §4b)
 
-  The current branch (`feat/486-head-sha-coordinate`) has NOT yet implemented
-  the capture/threading:
+  After the initial PR #503 commit, capture (D-362) and the merge coordinate
+  (D-361 merge half) are already implemented. The `:head_sha` key is initialised
+  to `nil` in `init/1` (D-363). As a result, D-362, D-361 (merge), and D-363
+  all PASS on the current branch.
 
-  - `oracle/3` and `implementing/3` use `_branch` / `_head_sha` (discarded).
-  - `awaiting_merge` calls `data.merge_fun.(data.unit_id, data.hash)` — always
-    the pre-declared hash, never the captured one.
-  - The `data` map initialised in `init/1` has NO `:head_sha` or `:branch` key.
+  The SOLE remaining fail-before is the gate coordinate half of D-361:
 
-  As a result:
+  - `gating/3` currently calls `data.gate_fun.()` (arity-0). The decided
+    contract requires `data.gate_fun.(coordinate)` where
+    `coordinate = data.head_sha || data.hash` (symmetric with `merge_fun`).
+  - The new "D-361 gate-coordinate" test injects an arity-1 spy
+    (`fn coord -> send(test_pid, {:gate_coord, coord}); :pass end`).
+  - Pre-implementer, calling an arity-1 function with 0 args raises
+    `BadArityError` inside the Unit gen_statem, crashing the process.
+    The test's `assert_receive {:gate_coord, ^agent_head_sha}` therefore
+    times out — the right failure for the right reason.
 
-  - D-362 test: `:sys.get_state` after work_ready finds `data` has no `:head_sha`
-    key → `Map.get(data, :head_sha, :key_missing)` returns `:key_missing`, not the
-    asserted `head_sha` string → assertion fails.
-  - D-361 test: spy `merge_fun` receives the declared `"declared-hash-XXX"`, not
-    the asserted `"agent-sha-YYY"` → assertion fails.
-  - D-363 test: `Map.has_key?(data, :head_sha)` is `false` (key absent from the
-    current data map) → assertion fails.
+  All `gate_fun` injections in this file use arity-1 (`fn _coord -> ... end`)
+  so they remain correct after the implementer lands the arity-1 contract.
 
   ## D-NNN linkage
-    - D-361 — `test "D-361: ..."`
+    - D-361 — `test "D-361: ..."` (two tests: merge coordinate + gate coordinate)
     - D-362 — `test "D-362: ..."`
     - D-363 — `test "D-363: ..."`
   """
@@ -184,7 +193,7 @@ defmodule Tau.Factory.UnitCoordinateTest do
         scheduler: sched,
         report_to: self(),
         worker_fun: worker_fun,
-        gate_fun: fn -> {:fail, [:stop_here]} end,
+        gate_fun: fn _coord -> {:fail, [:stop_here]} end,
         merge_fun: fn _uid, _hash -> :queued end,
         timeouts: [state_timeout_ms: 5_000]
       ]
@@ -281,7 +290,7 @@ defmodule Tau.Factory.UnitCoordinateTest do
         report_to: self(),
         pubsub: Tau.PubSub,
         worker_fun: worker_fun,
-        gate_fun: fn -> :pass end,
+        gate_fun: fn _coord -> :pass end,
         merge_fun: merge_fun,
         timeouts: [state_timeout_ms: 5_000]
       ]
@@ -312,6 +321,114 @@ defmodule Tau.Factory.UnitCoordinateTest do
                "Got: #{inspect(received_hash)}. " <>
                "Current code calls merge_fun(data.unit_id, data.hash) which is always the " <>
                "pre-declared hash — the captured coordinate is not yet threaded to merge_fun."
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # D-361 (gate coordinate) — gate_fun receives captured head_sha, not declared hash
+  # ---------------------------------------------------------------------------
+
+  describe "D-361 — gate_fun receives captured head_sha as the coordinate, not the declared hash" do
+    @tag :d_361
+    test "D-361: gate verdict coordinate keys on captured head_sha, not declared hash" do
+      test_pid = self()
+      unit_id = "u-gate-coord-#{System.unique_integer([:positive])}"
+      sched = unique(:sched_d361_gate)
+      sup = unique(:sup_d361_gate)
+      start_scheduler(sched)
+      start_supervised!({@unit_supervisor, name: sup}, id: sup)
+
+      # Declared hash and agent-asserted head_sha are deliberately different so
+      # the test can distinguish which value gate_fun received.
+      declared_hash = "declared-hash-gate-d361-#{System.unique_integer([:positive])}"
+      agent_head_sha = "agent-sha-gate-d361-#{System.unique_integer([:positive])}"
+      agent_branch = "feat/branch-gate-d361"
+
+      assert declared_hash != agent_head_sha,
+             "Test setup: declared_hash and agent_head_sha must differ to make D-361 gate observable"
+
+      {:ok, worker_id_store} = Agent.start_link(fn -> nil end)
+      on_exit(fn -> if Process.alive?(worker_id_store), do: Agent.stop(worker_id_store) end)
+
+      worker_fun = fn role ->
+        worker_pid = spawn_worker()
+
+        case role do
+          :test_author ->
+            {:ok, worker_pid}
+
+          :implementer ->
+            worker_id = "wid-gate-d361-#{System.unique_integer([:positive])}"
+            Agent.update(worker_id_store, fn _ -> worker_id end)
+            {:ok, worker_pid, worker_id}
+        end
+      end
+
+      # arity-1 gate_fun spy: records the coordinate it is called with, then
+      # returns :pass so the Unit can proceed (if the implementer has landed
+      # the arity-1 contract). Pre-implementer, calling this with 0 args raises
+      # BadArityError inside the Unit gen_statem — the process crashes and the
+      # assert_receive below times out, producing the right failure.
+      gate_fun = fn coord ->
+        send(test_pid, {:gate_coord, coord})
+        :pass
+      end
+
+      # merge_fun must broadcast so the Unit can reach :merged if gate passes.
+      merge_fun = fn uid, _hash ->
+        Phoenix.PubSub.broadcast(Tau.PubSub, "factory:pr:#{uid}", {:merge_result, :merged})
+        :queued
+      end
+
+      opts = [
+        unit_id: unit_id,
+        declared_scope: empty_scope(),
+        hash: declared_hash,
+        scheduler: sched,
+        report_to: self(),
+        pubsub: Tau.PubSub,
+        worker_fun: worker_fun,
+        gate_fun: gate_fun,
+        merge_fun: merge_fun,
+        timeouts: [state_timeout_ms: 5_000]
+      ]
+
+      unit_pid = @unit_supervisor.start_unit(sup, opts)
+      assert is_pid(unit_pid)
+
+      # Drive oracle through (legacy {:worker_done}).
+      advance_oracle_to_implementing_via_legacy(unit_pid)
+
+      assert wait_for_state(unit_pid, :implementing),
+             "D-361 gate: Unit must reach :implementing after oracle completes"
+
+      worker_id = Agent.get(worker_id_store, & &1)
+      refute is_nil(worker_id), "D-361 gate: worker_id must be set by 3-tuple worker_fun"
+
+      # Deliver work_ready with the agent-asserted coordinate (differs from declared hash).
+      # The Unit will transition to :gating and call gate_fun with the coordinate.
+      send(unit_pid, {:work_ready, worker_id, agent_branch, agent_head_sha})
+
+      # Assert the gate spy was called with the captured head_sha — NOT the declared hash.
+      # Pre-implementer failure: gate_fun.() is called arity-0 on an arity-1 closure,
+      # raising BadArityError in the Unit gen_statem → process crashes → assert_receive
+      # times out with no message received.
+      assert_receive {:gate_coord, received_coord},
+                     5_000,
+                     "D-361 gate: gate_fun must be called with the captured head_sha coordinate. " <>
+                       "Pre-implementer, gate_fun.() (arity-0) crashes on the arity-1 spy, so " <>
+                       "no {:gate_coord, _} is ever sent. " <>
+                       "The implementer must change gating to call data.gate_fun.(coordinate) " <>
+                       "where coordinate = data.head_sha || data.hash."
+
+      assert received_coord == agent_head_sha,
+             "D-361 gate: gate_fun must receive the captured head_sha (\"#{agent_head_sha}\"), " <>
+               "NOT the pre-declared work_item.hash (\"#{declared_hash}\"). " <>
+               "Got: #{inspect(received_coord)}."
+
+      refute received_coord == declared_hash,
+             "D-361 gate: gate_fun received the pre-declared hash instead of the captured head_sha. " <>
+               "The coordinate threading is not yet implemented in the gating state."
     end
   end
 
@@ -349,7 +466,7 @@ defmodule Tau.Factory.UnitCoordinateTest do
         report_to: self(),
         pubsub: Tau.PubSub,
         worker_fun: worker_fun,
-        gate_fun: fn -> :pass end,
+        gate_fun: fn _coord -> :pass end,
         merge_fun: merge_fun,
         timeouts: [state_timeout_ms: 5_000]
       ]

--- a/test/tau/factory/unit_coordinate_test.exs
+++ b/test/tau/factory/unit_coordinate_test.exs
@@ -1,0 +1,418 @@
+defmodule Tau.Factory.UnitCoordinateTest do
+  @moduledoc """
+  Gating tests for PR #503 (C1 — thread the worker's actual head_sha as the
+  unit coordinate). Advances D-361, D-362, D-363 (SPEC-FACTORY-CORE §6, §4 B6/B7/B8).
+
+  ## What is being enforced
+
+  ### D-362 — Capture-on-work_ready (SPEC-FACTORY-CORE §6, §4 B8)
+
+  When the Unit's `implementing` or `oracle` state receives
+  `{:work_ready, ^worker_id, branch, head_sha}` from the current worker (3-tuple
+  seam), it MUST capture `branch` and `head_sha` into `data`:
+
+      %{data | branch: branch, head_sha: head_sha}
+
+  Observable via `:sys.get_state/1` after the transition completes.
+
+  ### D-361 — Coordinate identity: gate/merge key on captured head_sha (§6, §4 B6/B7)
+
+  When `data.head_sha` is non-`nil` (captured from `work_ready`), BOTH the
+  gate seam and the merge seam MUST use `data.head_sha` as the coordinate —
+  NOT the pre-declared `work_item.hash`. The merge spy's received `hash`
+  argument is the observable signal for the merge seam (B6).
+
+  ### D-363 — Total back-compat: legacy 2-tuple seam falls through to declared hash (§6)
+
+  With the legacy 2-tuple `worker_fun` (no `worker_id`, completion via
+  `{:worker_done, ^worker_pid}`), `data.head_sha` stays `nil` and the merge seam
+  falls back to the declared `work_item.hash` unchanged. Additionally, the
+  implementation MUST initialise the `:head_sha` key in data (with value `nil`) so
+  that `Map.has_key?(data, :head_sha)` is true even when no capture has occurred.
+
+  ## Fail-before validity (oracle separation, factory-loop §4b)
+
+  The current branch (`feat/486-head-sha-coordinate`) has NOT yet implemented
+  the capture/threading:
+
+  - `oracle/3` and `implementing/3` use `_branch` / `_head_sha` (discarded).
+  - `awaiting_merge` calls `data.merge_fun.(data.unit_id, data.hash)` — always
+    the pre-declared hash, never the captured one.
+  - The `data` map initialised in `init/1` has NO `:head_sha` or `:branch` key.
+
+  As a result:
+
+  - D-362 test: `:sys.get_state` after work_ready finds `data` has no `:head_sha`
+    key → `Map.get(data, :head_sha, :key_missing)` returns `:key_missing`, not the
+    asserted `head_sha` string → assertion fails.
+  - D-361 test: spy `merge_fun` receives the declared `"declared-hash-XXX"`, not
+    the asserted `"agent-sha-YYY"` → assertion fails.
+  - D-363 test: `Map.has_key?(data, :head_sha)` is `false` (key absent from the
+    current data map) → assertion fails.
+
+  ## D-NNN linkage
+    - D-361 — `test "D-361: ..."`
+    - D-362 — `test "D-362: ..."`
+    - D-363 — `test "D-363: ..."`
+  """
+
+  use ExUnit.Case, async: true
+
+  @moduletag :capture_log
+  @moduletag :d_361
+  @moduletag :d_362
+  @moduletag :d_363
+
+  @unit_supervisor Tau.Factory.UnitSupervisor
+  @scheduler Tau.Factory.Scheduler
+
+  # ---------------------------------------------------------------------------
+  # Helpers
+  # ---------------------------------------------------------------------------
+
+  defp unique(base), do: :"#{base}_#{System.unique_integer([:positive])}"
+
+  defp empty_scope do
+    %{
+      deps: [],
+      files: MapSet.new(),
+      codepoints: MapSet.new(),
+      specs: MapSet.new(),
+      resources: MapSet.new()
+    }
+  end
+
+  defp start_scheduler(name) do
+    start_supervised!({@scheduler, name: name, w_cap: 10}, id: name)
+  end
+
+  # A long-lived worker that parks until stopped — monitorable (B8).
+  defp spawn_worker do
+    spawn(fn ->
+      receive do
+        :stop -> :ok
+      end
+    end)
+  end
+
+  # Drive the Unit from :planned through :oracle by delivering {:worker_done, pid}
+  # (legacy seam) for the oracle role, leaving it in :implementing with the
+  # 3-tuple worker running.
+  #
+  # For the 3-tuple seam under test we deliver the oracle worker via legacy
+  # {:worker_done, pid} (oracle only uses legacy for test simplicity), then the
+  # implementing worker is spawned via the 3-tuple worker_fun and we send
+  # {:work_ready, worker_id, branch, head_sha} directly.
+  defp advance_oracle_to_implementing_via_legacy(unit_pid) do
+    :timer.sleep(50)
+
+    case :sys.get_state(unit_pid) do
+      {:oracle, data} ->
+        worker_pid = Map.get(data, :worker_pid)
+        if is_pid(worker_pid), do: send(unit_pid, {:worker_done, worker_pid})
+
+      _ ->
+        :ok
+    end
+
+    :timer.sleep(100)
+  end
+
+  # Poll until the unit is in the target state (up to max_ms milliseconds).
+  defp wait_for_state(unit_pid, target_state, max_ms \\ 3_000) do
+    deadline = System.monotonic_time(:millisecond) + max_ms
+
+    Stream.repeatedly(fn ->
+      case :sys.get_state(unit_pid) do
+        {^target_state, _data} -> :reached
+        _ -> :not_yet
+      end
+    end)
+    |> Enum.find_value(fn
+      :reached ->
+        true
+
+      :not_yet ->
+        if System.monotonic_time(:millisecond) < deadline do
+          :timer.sleep(20)
+          nil
+        else
+          false
+        end
+    end)
+  end
+
+  # ---------------------------------------------------------------------------
+  # D-362 — Capture-on-work_ready: Unit captures branch/head_sha into data
+  # ---------------------------------------------------------------------------
+
+  describe "D-362 — Unit captures branch and head_sha from work_ready into data" do
+    @tag :d_362
+    test "D-362: after {:work_ready, worker_id, branch, head_sha}, data.head_sha and data.branch are set" do
+      unit_id = "u-capture-#{System.unique_integer([:positive])}"
+      sched = unique(:sched_d362)
+      sup = unique(:sup_d362)
+      start_scheduler(sched)
+      start_supervised!({@unit_supervisor, name: sup}, id: sup)
+
+      asserted_branch = "feat/test-branch-d362"
+      asserted_head_sha = "d362sha_#{System.unique_integer([:positive])}"
+
+      # The 3-tuple worker_fun stores the worker_id so we can send work_ready.
+      {:ok, worker_id_store} = Agent.start_link(fn -> nil end)
+      on_exit(fn -> if Process.alive?(worker_id_store), do: Agent.stop(worker_id_store) end)
+
+      worker_fun = fn role ->
+        worker_pid = spawn_worker()
+
+        case role do
+          :test_author ->
+            # oracle uses legacy seam; worker_id not stored for oracle
+            {:ok, worker_pid}
+
+          :implementer ->
+            worker_id = "wid-#{System.unique_integer([:positive])}"
+            Agent.update(worker_id_store, fn _ -> worker_id end)
+            {:ok, worker_pid, worker_id}
+        end
+      end
+
+      opts = [
+        unit_id: unit_id,
+        declared_scope: empty_scope(),
+        hash: "declared-hash-#{unit_id}",
+        scheduler: sched,
+        report_to: self(),
+        worker_fun: worker_fun,
+        gate_fun: fn -> {:fail, [:stop_here]} end,
+        merge_fun: fn _uid, _hash -> :queued end,
+        timeouts: [state_timeout_ms: 5_000]
+      ]
+
+      unit_pid = @unit_supervisor.start_unit(sup, opts)
+      assert is_pid(unit_pid)
+
+      # Drive oracle through (legacy {:worker_done}).
+      advance_oracle_to_implementing_via_legacy(unit_pid)
+
+      # Wait for implementing state, then send work_ready with the asserted coordinate.
+      assert wait_for_state(unit_pid, :implementing),
+             "D-362: Unit must reach :implementing after oracle completes"
+
+      worker_id = Agent.get(worker_id_store, & &1)
+      refute is_nil(worker_id), "D-362: worker_id must be set by the 3-tuple worker_fun"
+
+      send(unit_pid, {:work_ready, worker_id, asserted_branch, asserted_head_sha})
+
+      # Wait for gating (work_ready → gating transition).
+      :timer.sleep(150)
+
+      # Read the FSM data AFTER the transition. In :gating, we capture gate_fun's
+      # immediate fail result and bounce back to implementing, but we need to observe
+      # the data AS SOON AS possible. Use :sys.get_state regardless of current state —
+      # the captured data should persist through gating into the next implementing entry.
+      {_state, data} = :sys.get_state(unit_pid)
+
+      assert Map.get(data, :head_sha, :key_missing) == asserted_head_sha,
+             "D-362: after {:work_ready, worker_id, branch, head_sha}, data.head_sha " <>
+               "must equal the asserted head_sha. Got: #{inspect(Map.get(data, :head_sha, :key_missing))}. " <>
+               "Current code discards head_sha in work_ready handlers (uses _head_sha); " <>
+               "the capture `%{data | head_sha: head_sha}` is not yet implemented."
+
+      assert Map.get(data, :branch, :key_missing) == asserted_branch,
+             "D-362: after {:work_ready, worker_id, branch, head_sha}, data.branch " <>
+               "must equal the asserted branch. Got: #{inspect(Map.get(data, :branch, :key_missing))}. " <>
+               "Current code discards branch in work_ready handlers (uses _branch)."
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # D-361 — Gate/merge coordinate is the captured head_sha, not the declared hash
+  # ---------------------------------------------------------------------------
+
+  describe "D-361 — merge_fun receives captured head_sha as the coordinate, not the declared hash" do
+    @tag :d_361
+    test "D-361: when captured head_sha != declared hash, merge_fun receives captured head_sha" do
+      test_pid = self()
+      unit_id = "u-coordinate-#{System.unique_integer([:positive])}"
+      sched = unique(:sched_d361)
+      sup = unique(:sup_d361)
+      start_scheduler(sched)
+      start_supervised!({@unit_supervisor, name: sup}, id: sup)
+
+      # Declared hash and agent-asserted head_sha are deliberately different.
+      declared_hash = "declared-hash-d361-#{System.unique_integer([:positive])}"
+      agent_head_sha = "agent-sha-d361-#{System.unique_integer([:positive])}"
+      agent_branch = "feat/branch-d361"
+
+      assert declared_hash != agent_head_sha,
+             "Test setup: declared_hash and agent_head_sha must differ to make D-361 observable"
+
+      {:ok, worker_id_store} = Agent.start_link(fn -> nil end)
+      on_exit(fn -> if Process.alive?(worker_id_store), do: Agent.stop(worker_id_store) end)
+
+      worker_fun = fn role ->
+        worker_pid = spawn_worker()
+
+        case role do
+          :test_author ->
+            {:ok, worker_pid}
+
+          :implementer ->
+            worker_id = "wid-d361-#{System.unique_integer([:positive])}"
+            Agent.update(worker_id_store, fn _ -> worker_id end)
+            {:ok, worker_pid, worker_id}
+        end
+      end
+
+      # merge_fun spy: captures the hash it receives and broadcasts :merged so the
+      # Unit can reach terminal :merged.
+      merge_fun = fn uid, received_hash ->
+        send(test_pid, {:merge_called, uid, received_hash})
+        :ok = Phoenix.PubSub.broadcast(Tau.PubSub, "factory:pr:#{uid}", {:merge_result, :merged})
+        :queued
+      end
+
+      opts = [
+        unit_id: unit_id,
+        declared_scope: empty_scope(),
+        hash: declared_hash,
+        scheduler: sched,
+        report_to: self(),
+        pubsub: Tau.PubSub,
+        worker_fun: worker_fun,
+        gate_fun: fn -> :pass end,
+        merge_fun: merge_fun,
+        timeouts: [state_timeout_ms: 5_000]
+      ]
+
+      unit_pid = @unit_supervisor.start_unit(sup, opts)
+      assert is_pid(unit_pid)
+
+      # Drive oracle through (legacy {:worker_done}).
+      advance_oracle_to_implementing_via_legacy(unit_pid)
+
+      assert wait_for_state(unit_pid, :implementing),
+             "D-361: Unit must reach :implementing"
+
+      worker_id = Agent.get(worker_id_store, & &1)
+      refute is_nil(worker_id), "D-361: worker_id must be set by 3-tuple worker_fun"
+
+      # Deliver work_ready with the agent-asserted coordinate (differs from declared hash).
+      send(unit_pid, {:work_ready, worker_id, agent_branch, agent_head_sha})
+
+      # merge_fun will be called in awaiting_merge; we capture the hash it receives.
+      assert_receive {:merge_called, ^unit_id, received_hash},
+                     5_000,
+                     "D-361: merge_fun must be called after gate :pass"
+
+      assert received_hash == agent_head_sha,
+             "D-361: merge_fun must receive the captured head_sha (\"#{agent_head_sha}\"), " <>
+               "NOT the pre-declared work_item.hash (\"#{declared_hash}\"). " <>
+               "Got: #{inspect(received_hash)}. " <>
+               "Current code calls merge_fun(data.unit_id, data.hash) which is always the " <>
+               "pre-declared hash — the captured coordinate is not yet threaded to merge_fun."
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # D-363 — Back-compat: legacy 2-tuple seam stays on declared hash; head_sha nil
+  # ---------------------------------------------------------------------------
+
+  describe "D-363 — legacy 2-tuple worker_fun: head_sha stays nil, merge receives declared hash" do
+    @tag :d_363
+    test "D-363: with legacy {:worker_done, pid} seam, data.head_sha is nil and merge gets declared hash" do
+      test_pid = self()
+      unit_id = "u-backcompat-#{System.unique_integer([:positive])}"
+      sched = unique(:sched_d363)
+      sup = unique(:sup_d363)
+      start_scheduler(sched)
+      start_supervised!({@unit_supervisor, name: sup}, id: sup)
+
+      declared_hash = "declared-hash-d363-#{System.unique_integer([:positive])}"
+
+      # Legacy 2-tuple worker_fun: no worker_id, no work_ready, completed via
+      # {:worker_done, worker_pid}. The Unit should NOT capture any head_sha.
+      worker_fun = fn _role -> {:ok, spawn_worker()} end
+
+      merge_fun = fn uid, received_hash ->
+        send(test_pid, {:merge_called, uid, received_hash})
+        :ok = Phoenix.PubSub.broadcast(Tau.PubSub, "factory:pr:#{uid}", {:merge_result, :merged})
+        :queued
+      end
+
+      opts = [
+        unit_id: unit_id,
+        declared_scope: empty_scope(),
+        hash: declared_hash,
+        scheduler: sched,
+        report_to: self(),
+        pubsub: Tau.PubSub,
+        worker_fun: worker_fun,
+        gate_fun: fn -> :pass end,
+        merge_fun: merge_fun,
+        timeouts: [state_timeout_ms: 5_000]
+      ]
+
+      unit_pid = @unit_supervisor.start_unit(sup, opts)
+      assert is_pid(unit_pid)
+
+      # Drive oracle via legacy {:worker_done}.
+      :timer.sleep(50)
+
+      case :sys.get_state(unit_pid) do
+        {:oracle, data} ->
+          worker_pid = Map.get(data, :worker_pid)
+          if is_pid(worker_pid), do: send(unit_pid, {:worker_done, worker_pid})
+
+        _ ->
+          :ok
+      end
+
+      :timer.sleep(100)
+
+      assert wait_for_state(unit_pid, :implementing),
+             "D-363: Unit must reach :implementing via legacy oracle path"
+
+      # Drive implementing via legacy {:worker_done}.
+      :timer.sleep(50)
+
+      case :sys.get_state(unit_pid) do
+        {:implementing, data} ->
+          worker_pid = Map.get(data, :worker_pid)
+          if is_pid(worker_pid), do: send(unit_pid, {:worker_done, worker_pid})
+
+        _ ->
+          :ok
+      end
+
+      # After implementing completes via legacy seam, check FSM data for :head_sha key.
+      # The implementation MUST initialise data.head_sha = nil so that Map.has_key?
+      # returns true even when no capture has occurred. Current code has NO :head_sha
+      # key in data at all, so this assertion FAILS now and will PASS after D-363 lands.
+      :timer.sleep(100)
+      {_state, data_after} = :sys.get_state(unit_pid)
+
+      assert Map.has_key?(data_after, :head_sha),
+             "D-363: data MUST have a :head_sha key (initialised to nil) even when the " <>
+               "legacy 2-tuple seam is used and no capture has occurred. " <>
+               "Current code's data map has no :head_sha key at all. " <>
+               "Got data keys: #{inspect(Map.keys(data_after))}."
+
+      assert Map.get(data_after, :head_sha) == nil,
+             "D-363: data.head_sha MUST be nil when the legacy 2-tuple seam is used " <>
+               "(no work_ready, no capture). " <>
+               "Got: #{inspect(Map.get(data_after, :head_sha))}."
+
+      # Wait for merge_fun to be called and verify it receives the declared hash.
+      assert_receive {:merge_called, ^unit_id, received_hash},
+                     5_000,
+                     "D-363: merge_fun must be called after gate :pass"
+
+      assert received_hash == declared_hash,
+             "D-363: with legacy 2-tuple seam (head_sha = nil), merge_fun MUST receive " <>
+               "the declared work_item.hash (\"#{declared_hash}\"), not nil and not something else. " <>
+               "Got: #{inspect(received_hash)}."
+    end
+  end
+end

--- a/test/tau/factory/unit_driver_test.exs
+++ b/test/tau/factory/unit_driver_test.exs
@@ -283,8 +283,12 @@ defmodule Tau.Factory.UnitDriverTest do
       assert merge_map.id == unit_id,
              "D-340: merge map :id must be the unit_id; got #{inspect(merge_map)}"
 
-      assert merge_map.hash == "hash-#{unit_id}",
-             "D-340: merge map :hash must be the work_item hash; got #{inspect(merge_map)}"
+      # D-361: merge coordinate is the captured head_sha (from {:work_ready, id, branch, sha}),
+      # NOT the pre-declared work_item.hash. The work_ready_agent_bin emits head_sha as the
+      # coordinate, which the Unit captures and threads to merge_fun (D-362).
+      assert merge_map.hash == head_sha,
+             "D-361: merge map :hash must be the captured head_sha (#{inspect(head_sha)}), " <>
+               "not the pre-declared work_item hash; got #{inspect(merge_map)}"
 
       assert merge_map.branch == branch,
              "D-340: merge map :branch must be the work_item branch; got #{inspect(merge_map)}"

--- a/test/tau/factory/unit_driver_test.exs
+++ b/test/tau/factory/unit_driver_test.exs
@@ -266,7 +266,7 @@ defmodule Tau.Factory.UnitDriverTest do
         brief: "implement the thing"
       }
 
-      deps = deps_for(sub, fn -> :pass end, merge_authority, test_pid)
+      deps = deps_for(sub, fn _coord -> :pass end, merge_authority, test_pid)
 
       unit_pid = @unit_driver.drive(work_item, deps)
 
@@ -362,7 +362,7 @@ defmodule Tau.Factory.UnitDriverTest do
         brief: "implement the thing"
       }
 
-      deps = deps_for(sub, fn -> {:fail, [:always_fails]} end, merge_authority, test_pid)
+      deps = deps_for(sub, fn _coord -> {:fail, [:always_fails]} end, merge_authority, test_pid)
 
       unit_pid = @unit_driver.drive(work_item, deps)
       assert is_pid(unit_pid), "D-340: drive/2 must return the Unit pid"
@@ -427,7 +427,7 @@ defmodule Tau.Factory.UnitDriverTest do
         brief: "implement the thing"
       }
 
-      deps = deps_for(sub, fn -> :pass end, merge_authority, test_pid)
+      deps = deps_for(sub, fn _coord -> :pass end, merge_authority, test_pid)
 
       unit_pid = @unit_driver.drive(work_item, deps)
       assert is_pid(unit_pid), "D-340: drive/2 must return the Unit pid"

--- a/test/tau/factory/unit_merge_result_test.exs
+++ b/test/tau/factory/unit_merge_result_test.exs
@@ -146,7 +146,7 @@ defmodule Tau.Factory.UnitMergeResultTest do
       end
 
       opts =
-        base_unit_opts(unit_id, merge_fun, fn -> :pass end)
+        base_unit_opts(unit_id, merge_fun, fn _coord -> :pass end)
         |> Keyword.put(:scheduler, sched)
 
       unit_pid = @unit_supervisor.start_unit(sup, opts)
@@ -200,7 +200,7 @@ defmodule Tau.Factory.UnitMergeResultTest do
       end
 
       opts =
-        base_unit_opts(unit_id, merge_fun, fn -> :pass end)
+        base_unit_opts(unit_id, merge_fun, fn _coord -> :pass end)
         |> Keyword.put(:scheduler, sched)
 
       unit_pid = @unit_supervisor.start_unit(sup, opts)
@@ -243,7 +243,7 @@ defmodule Tau.Factory.UnitMergeResultTest do
       end
 
       opts =
-        base_unit_opts(unit_id, merge_fun, fn -> :pass end)
+        base_unit_opts(unit_id, merge_fun, fn _coord -> :pass end)
         |> Keyword.put(:scheduler, sched)
 
       unit_pid = @unit_supervisor.start_unit(sup, opts)
@@ -300,7 +300,7 @@ defmodule Tau.Factory.UnitMergeResultTest do
       end
 
       opts =
-        base_unit_opts(unit_id, merge_fun, fn -> :pass end)
+        base_unit_opts(unit_id, merge_fun, fn _coord -> :pass end)
         |> Keyword.put(:scheduler, sched)
 
       unit_pid = @unit_supervisor.start_unit(sup, opts)

--- a/test/tau/factory/unit_snapshot_durability_test.exs
+++ b/test/tau/factory/unit_snapshot_durability_test.exs
@@ -129,7 +129,7 @@ defmodule Tau.Factory.UnitSnapshotDurabilityTest do
       report_to: report_to,
       ledger: ledger,
       worker_fun: fn _role -> {:ok, spawn_worker()} end,
-      gate_fun: fn -> :pass end,
+      gate_fun: fn _coord -> :pass end,
       merge_fun: fn _uid, _hash -> :queued end,
       timeouts: [state_timeout_ms: 5_000]
     ]
@@ -173,7 +173,7 @@ defmodule Tau.Factory.UnitSnapshotDurabilityTest do
 
       opts =
         base_unit_opts(unit_id, sched, test_pid, ledger,
-          gate_fun: fn -> :pass end,
+          gate_fun: fn _coord -> :pass end,
           merge_fun: fn _uid, _hash -> :queued end
         )
 
@@ -222,7 +222,7 @@ defmodule Tau.Factory.UnitSnapshotDurabilityTest do
       start_supervised!({@unit_supervisor, name: sup}, id: sup)
 
       # gate always fails → ladder exhausts → :escalated.
-      gate_fun = fn -> {:fail, ["always-fail"]} end
+      gate_fun = fn _coord -> {:fail, ["always-fail"]} end
 
       opts =
         base_unit_opts(unit_id, sched, test_pid, ledger,
@@ -281,7 +281,7 @@ defmodule Tau.Factory.UnitSnapshotDurabilityTest do
       # never reaches a terminal sink. We signal entry to gating, then block.
       gate_entered = self()
 
-      gate_fun = fn ->
+      gate_fun = fn _coord ->
         send(gate_entered, :gate_entered)
 
         receive do
@@ -364,7 +364,7 @@ defmodule Tau.Factory.UnitSnapshotDurabilityTest do
 
       opts =
         base_unit_opts(unit_id, sched, test_pid, ledger,
-          gate_fun: fn -> :pass end,
+          gate_fun: fn _coord -> :pass end,
           merge_fun: fn _uid, _hash -> :queued end
         )
 
@@ -432,7 +432,7 @@ defmodule Tau.Factory.UnitSnapshotDurabilityTest do
       gate_calls = :counters.new(1, [])
       regate_entered = self()
 
-      gate_fun = fn ->
+      gate_fun = fn _coord ->
         n = :counters.get(gate_calls, 1)
         :counters.add(gate_calls, 1, 1)
 
@@ -547,7 +547,7 @@ defmodule Tau.Factory.UnitSnapshotDurabilityTest do
       # waiting on its worker rather than looping further through the retry ladder.
       gate_calls = :counters.new(1, [])
 
-      gate_fun = fn ->
+      gate_fun = fn _coord ->
         n = :counters.get(gate_calls, 1)
         :counters.add(gate_calls, 1, 1)
 

--- a/test/tau/factory/unit_termination_test.exs
+++ b/test/tau/factory/unit_termination_test.exs
@@ -172,7 +172,7 @@ defmodule Tau.Factory.UnitTerminationTest do
       # Default seams (overridden per test).
       # worker_fun returns a real monitorable pid (B8 contract).
       worker_fun: fn _role -> {:ok, spawn_worker()} end,
-      gate_fun: fn -> :pass end,
+      gate_fun: fn _coord -> :pass end,
       merge_fun: fn _uid, _hash -> :queued end,
       timeouts: [state_timeout_ms: 5_000]
     ]
@@ -214,7 +214,7 @@ defmodule Tau.Factory.UnitTerminationTest do
       start_scheduler(scheduler_name)
       start_supervised!({@unit_supervisor, name: sup_name}, id: sup_name)
 
-      gate_fun = fn -> :pass end
+      gate_fun = fn _coord -> :pass end
       merge_fun = fn _uid, _hash -> :queued end
 
       opts =
@@ -289,7 +289,7 @@ defmodule Tau.Factory.UnitTerminationTest do
 
       gate_count_ref = :counters.new(1, [:atomics])
 
-      gate_fun = fn ->
+      gate_fun = fn _coord ->
         :counters.add(gate_count_ref, 1, 1)
         {:fail, ["finding-#{:counters.get(gate_count_ref, 1)}"]}
       end
@@ -385,7 +385,7 @@ defmodule Tau.Factory.UnitTerminationTest do
       gate_count_ref = :counters.new(1, [:atomics])
 
       # Script: first (1 + n_refine) calls → {:fail,_}; the pivot call → :pass.
-      gate_fun = fn ->
+      gate_fun = fn _coord ->
         call_n =
           :counters.add(gate_count_ref, 1, 1) |> then(fn _ -> :counters.get(gate_count_ref, 1) end)
 
@@ -466,7 +466,7 @@ defmodule Tau.Factory.UnitTerminationTest do
       # Unit must arm :state_timeout and escalate on expiry.
       worker_fun = fn _role -> {:ok, spawn_worker()} end
 
-      gate_fun = fn ->
+      gate_fun = fn _coord ->
         :counters.add(gate_called_ref, 1, 1)
         :pass
       end
@@ -525,7 +525,7 @@ defmodule Tau.Factory.UnitTerminationTest do
       start_scheduler(scheduler_name)
       start_supervised!({@unit_supervisor, name: sup_name}, id: sup_name)
 
-      gate_fun = fn -> :pass end
+      gate_fun = fn _coord -> :pass end
       merge_fun = fn _uid, _hash -> :queued end
 
       opts =
@@ -586,7 +586,7 @@ defmodule Tau.Factory.UnitTerminationTest do
 
       last_findings = ["finding-alpha", "finding-beta"]
 
-      gate_fun = fn -> {:fail, last_findings} end
+      gate_fun = fn _coord -> {:fail, last_findings} end
 
       n_refine = Retry.n_refine()
       n_pivot = Retry.n_pivot()
@@ -663,7 +663,7 @@ defmodule Tau.Factory.UnitTerminationTest do
       # semantic gate-fail path — a C105 violation.
       gate_called_ref = :counters.new(1, [:atomics])
 
-      gate_fun = fn ->
+      gate_fun = fn _coord ->
         :counters.add(gate_called_ref, 1, 1)
         :pass
       end

--- a/test/tau/factory/worker_completion_event_test.exs
+++ b/test/tau/factory/worker_completion_event_test.exs
@@ -255,7 +255,7 @@ defmodule Tau.Factory.WorkerCompletionEventTest do
 
       # gate_fun records that the gate WAS reached — the discriminating signal
       # that the Unit gated on work_ready rather than ignoring it.
-      gate_fun = fn ->
+      gate_fun = fn _coord ->
         send(test_pid, {:gate_called, unit_id})
         {:fail, [:stop_here]}
       end
@@ -366,7 +366,7 @@ defmodule Tau.Factory.WorkerCompletionEventTest do
       worker_id = "w-noprod-#{n}"
       worker_pid = spawn(fn -> receive do: (:stop -> :ok) end)
 
-      gate_fun = fn ->
+      gate_fun = fn _coord ->
         send(test_pid, {:gate_called, unit_id})
         :pass
       end
@@ -441,7 +441,7 @@ defmodule Tau.Factory.WorkerCompletionEventTest do
       current_worker_id = "w-current-#{n}"
       worker_pid = spawn(fn -> receive do: (:stop -> :ok) end)
 
-      gate_fun = fn ->
+      gate_fun = fn _coord ->
         send(test_pid, {:gate_called, unit_id})
         :pass
       end


### PR DESCRIPTION
## #486 (C1) — thread the worker's actual `head_sha` as the unit coordinate `[C121-B11]`

Closes #486. **ARCH GAP RESOLVED** — solution-shaping pass landed (commit `c8cd9ad1`): SPEC-FACTORY-CORE §4 (B6/B7/B8) + control-plane.md amended, verified-free **D-361/D-362/D-363** allocated. Implementation follows in this PR.

### Problem
The Unit FSM discards `work_ready`'s `branch`/`head_sha`; `gate_fun` and `merge_fun(unit_id, data.hash)` key on the PRE-DECLARED `work_item.hash`. With a real (non-deterministic) coding agent the produced HEAD is NOT known in advance, so the gate/merge would key on the wrong commit. This is the first real-world dogfooding blocker (#480/#481 critic).

### Plan (this PR)
1. ~~**Shaper pass**~~ ✅ DONE (`c8cd9ad1`): coordinate-identity contract pinned in SPEC-FACTORY-CORE §4 B6/B7/B8 + §6 D-361/D-362/D-363; control-plane.md `[C121-B11]` marked resolved.
2. test-author → implementer (`lib/tau/factory/unit.ex`, `lib/tau/factory/unit_driver.ex`, and the gate_fun & merge-map construction) → critic + reviewer.

### Acceptance criteria
- **D-361** — coordinate identity: when the Unit holds a captured `data.head_sha` (the agent-asserted coordinate from `work_ready`), BOTH the gate Request `hash` and the merge-map `hash` key on that captured `head_sha`, NOT the pre-declared `work_item.hash`. A worker whose produced HEAD differs from the declared hash is gated AND merged on its real HEAD.
- **D-362** — capture-on-`work_ready`: the Unit captures `work_ready`'s asserted `branch`/`head_sha` into its `data` at the `work_ready` transition (it no longer discards them).
- **D-363** — back-compat fallback: when `data.head_sha` is `nil` (the legacy 2-tuple `worker_fun` seam with no `worker_id`/`head_sha`), the gate/merge coordinate falls through to the declared `work_item.hash` unchanged — the deterministic scripted dogfood agent (asserting `head_sha == declared hash`) observes no change.

### Gating-test paths (frozen at 4b)
- `test/tau/factory/unit_coordinate_test.exs` — D-361 (merge_fun receives captured head_sha), D-362 (capture branch/head_sha into data), D-363 (legacy nil seam → declared hash).
### Gate verdicts
**Attempt 1 — RED (refine).**
- **critic: FAIL** — D-361 incomplete: only the merge coordinate threaded; `gate_fun` is arity-0, built before `work_ready` over `work_item.hash`, so the gate verdict is written at the declared hash while merge reads at `head_sha` → verdict-coordinate mismatch. Also: SPEC §4 B7 claims the gate closure captures `head_sha` (contradicts code) — spec/code contradiction. Under-asserting gating test (gate half untested).
- **reviewer: PASS-with-WARNINGS** — confirmed `dogfood/gate_fun.ex` still keys on `work_item.hash`; treated as deferrable (scripted agent makes `head_sha == declared hash` today). Coordinator override: deferral is forbidden — the finding falsifies named invariant D-361, and #487 (real agent) makes the gap bite.

**Refine plan (decided architecture — arity-1 gate coordinate):** make the `gate_fun` seam arity-1, symmetric with `merge_fun`. The Unit's `gating` state calls `gate_fun.(data.head_sha || data.hash)`; `unit_driver.ex`/`supervisor.ex`/`dogfood/gate_fun.ex`/`tau.factory.dogfood.ex` build arity-1 closures that set `Gate.Request.hash` to the supplied coordinate; nil-fallback to the declared hash is symmetric across gate and merge (D-363). SPEC §4 B7/B11 corrected to the coherent arity-1 contract. Gating test extended with a gate-coordinate D-361 assertion (head_sha ≠ declared hash).

**Attempt 2 — GREEN (merge).**
- **critic: PASS** — V6 path arithmetic: gate (`unit.ex:425`) and merge (`unit.ex:497`) both key on identical `data.head_sha || data.hash`; `dogfood/gate_fun.ex` sets `Request.hash`=coordinate. D-361 closed at both endpoints; D-362 capture + D-363 symmetric fallback enforced; spec/code coherent (no residual arity-0 claim); gating tests genuine; masking legitimate; OTP + scope clean.
- **reviewer: PASS** — 4 gating tests pass; full suite 1600/0; CI green (binary-qa, lint, mutation-check, both OTP versions). D-361/D-362/D-363 met.