### PR TITLE
#488 (I2) — issue → declared-scope elaboration

### DIFF
--- a/docs/MISSION.md
+++ b/docs/MISSION.md
@@ -81,7 +81,7 @@ Block-to-SPEC allocation:
 | D-300 – D-303, D-341 | SPEC-FACTORY-MERGE |
 | D-304 – D-308, D-322, D-323, D-354 | SPEC-FACTORY-GATE |
 | D-309 – D-311, D-313, D-314, D-316, D-334, D-364 – D-367 | SPEC-FACTORY-FLEET |
-| D-312, D-315, D-317, D-318, D-320, D-321, D-330 – D-333, D-335, D-336, D-340, D-342 – D-344, D-355 – D-359 | SPEC-FACTORY-CORE |
+| D-312, D-315, D-317, D-318, D-320, D-321, D-330 – D-333, D-335, D-336, D-340, D-342 – D-344, D-355 – D-359, D-369 – D-371 | SPEC-FACTORY-CORE |
 | D-319, D-351 – D-353 | SPEC-FACTORY-GOV |
 | D-361 – D-363 | SPEC-FACTORY-CORE (C1 unit-coordinate identity; PR #503) |
 | D-300 – D-380 | reserved — SPEC-FACTORY-\* family (autonomous factory; `docs/arch/`) |

--- a/docs/arch/04-software-architecture/control-plane.md
+++ b/docs/arch/04-software-architecture/control-plane.md
@@ -320,6 +320,70 @@ Admission is **monotone** (LIV-4): a `{:defer, _}` never demotes a unit's
 queue position; S serves deferred units in arrival order with aging once their
 blocker clears (the fairness analogue of M's merge queue, Q-L1).
 
+### 2.6 Where the declared scope comes from — issue → `ConflictCheck.scope()` (I2; D-369/D-370/D-371)
+
+§2.3's five-clause check operates over a `declared_scope :: ConflictCheck.scope()`
+(`%{deps, files, codepoints, specs, resources}`). §2.4 assumes that scope already
+exists, *frozen, at admission time* (FR-1.3). **It does not say how a real issue's
+text becomes that map.** `IssueSelector` (B10) is the intake that closes this gap:
+it elaborates an open milestone issue into the structured scope the Scheduler
+admits on. This subsection records the elaboration contract and its soundness
+posture; the boundary detail is SPEC-FACTORY-CORE §4 B10 (PR #505 amendment).
+
+**The soundness dependency (the load-bearing fact, V3).** `ConflictCheck` is the
+*sole enforcer* of conflict-gated concurrency (INV-13), but it is a pure function
+of *what it is told*. A scope that **under-declares** — omits a file two units
+actually share — clears them as disjoint, and S admits both in parallel; they
+then corrupt the omitted shared file. So the safety of the *check* is conditional
+on the soundness of the *elaboration*, and free issue text cannot be turned into a
+provably-complete impact set (V1 — the static-impact-analysis impossibility). The
+design does not pretend otherwise. Instead it makes incompleteness *safe* by
+construction through **directional soundness**:
+
+- **Over-declare, never under-declare.** Uncertain membership → *include*. A false
+  inclusion costs only a needless `{:defer, …}` (a unit serialises that could have
+  parallelised — cheap, reversible). A false exclusion costs *correctness* (a
+  missed conflict — a corrupting defect). The asymmetry dictates the bias:
+  *serialize when unsure*.
+- **Coarsen codepoints to whole files absent a `file:line` citation.** The
+  parallel-on-disjoint-regions optimisation (§2.3 `disjoint_codepoints?`) is taken
+  **only** where the issue cites `file:line`/`file#function` (the human author
+  discharges the burden of proof). Otherwise the unit serialises against anything
+  touching the file.
+- **Serialize-on-unscopable fallback.** An issue too vague to yield any file or
+  SPEC elaborates to a *universal-conflict sentinel scope* that fails
+  `pairwise_clear?` against any non-empty in-flight member — admitted only into an
+  empty `F`, never silently disjoint-from-everything.
+
+This preserves §2.4's monotonicity (D-343): the elaborated scope is still a *fixed
+declaration*, frozen before any worker runs — no post-hoc actual-path check is
+introduced.
+
+**The discriminating question — heuristic vs LLM vs required-template — and why a
+heuristic is the default.** The fact that decides the mechanism is *who can be
+held to soundness*: an LLM elaboration is unsound by nature (it omits or
+hallucinates and cannot be audited on the synchronous admission path); a
+required issue-template scope field shifts the burden to the human author but is
+still unverifiable; a citation-driven heuristic over signals already in the
+`issue_map` (`title`/`body`/`labels`) and the in-repo SPEC source-maps is the
+**cheapest-to-reverse** shape that makes incompleteness *safe* rather than
+*trusted*. The heuristic is therefore the default elaborator (D-369). It is
+reached through an **injected pure seam** `:elaborate_fun :: (issue_map ->
+ConflictCheck.scope())` (D-370), so a stronger LLM-assisted elaborator — gated
+behind an out-of-band verification step, never trusted blindly — remains a
+*substitution*, not a rewrite of `Scheduler`/`ConflictCheck`, if scope precision
+ever justifies its cost. **Coupling to #492** (real `gh issue list`) is by
+reference only: elaboration consumes the `issue_map` regardless of source; #492
+populates real fields the `--json number,title,body,labels` projection already
+names.
+
+**Closing a latent type error.** Before this contract, `IssueSelector` emitted
+`scope` as the string `"#{number}: #{title}"`, which `ConflictCheck.clear?/2`
+would crash on (`Map.fetch!(string, :files)`). The seam was sound only because no
+test wired a real string-scope work-item into a real Scheduler. The elaboration
+makes `IssueSelector → Scheduler → ConflictCheck` type-correct on a real issue
+(SPEC-FACTORY-CORE [C124-B10]).
+
 ---
 
 ## 3. U — Unit/PR FSM (`gen_statem` per entity)

--- a/docs/spec/SPEC-FACTORY-CORE.md
+++ b/docs/spec/SPEC-FACTORY-CORE.md
@@ -272,6 +272,35 @@ Format: `[Cn-Bm]` = constraint number + boundary. **★** marks non-obvious.
   admitting the unit. Failure to satisfy this precondition causes the Worker's
   `git worktree add --detach origin/<branch>` to fail, which surfaces as
   `worker_exit(w, :error)` and enters the retry ladder.
+- **★ [C130-B10]** **The conflict check is only as sound as the declared scope it
+  is handed; an under-declared scope silently defeats it (I2; D-369/D-370/D-371).**
+  `ConflictCheck.clear?/2` (the sole enforcer of conflict-gated admission) is a
+  *pure function of declarations*. If `IssueSelector`'s elaboration of an issue
+  *omits* a file/codepoint two units actually share, the predicate clears them as
+  "disjoint" and the Scheduler admits both in parallel — they then collide on the
+  omitted file (a corrupting defect, NOT a deferred-throughput cost). The
+  soundness of the *check* is therefore conditional on the soundness of the
+  *elaboration*, and free issue text cannot be turned into a provably-complete
+  scope (the static-impact-analysis impossibility — V1). The constraint this SPEC
+  pins is **directional soundness**: the elaborator MUST be **conservative** —
+  over-declare under uncertainty, coarsen codepoints to whole files absent an
+  explicit `file:line` citation, and **fall back to a serialize-against-everything
+  sentinel scope** when it can extract no files/specs at all (admit only into an
+  empty `F`). A false *over*-declaration costs only a needless `{:defer, …}`
+  (reversible, cheap); a false *under*-declaration costs correctness (a missed
+  conflict). The asymmetry is the load-bearing fact: bias every uncertain call
+  toward *serialize*. The mechanism is the default `elaborate_fun` heuristic (§4
+  B10 amendment, D-369); its conservative posture is D-369, the seam that lets a
+  stronger elaborator be substituted without weakening the posture is D-370, and
+  the serialize-on-empty fallback is D-371. The **discriminating question** —
+  heuristic vs LLM vs required-template — is resolved by *who can be held to
+  soundness*: an LLM elaboration is unsound by nature (it omits/hallucinates and
+  cannot be audited on the admission path), a required-template field shifts the
+  burden to the human author but is still unverifiable, and the citation-driven
+  heuristic is the **cheapest-to-reverse** shape that makes incompleteness *safe*
+  rather than *trusted*. The heuristic is therefore the default; the injected seam
+  (D-370) keeps an LLM-assisted elaborator a *swap*, not a *rewrite*, if scope
+  precision ever justifies its cost and an out-of-band verification step is added.
 
 ### Q4: What information crosses a boundary, and what is lost?
 
@@ -651,6 +680,96 @@ implements `select_next`:
   when the milestone is drained or every open issue is terminal in L (D-342).
 - **L is read-only:** the selector NEVER writes L; the tracker is not a second
   writer of L (D-331 [C112-B10]).
+
+**Amendment (PR #505 / B10, I2 — issue → declared-scope elaboration; D-369, D-370, D-371).**
+The PR #470 amendment above pins `work_item.scope` as a *non-nil frozen declared
+scope string* — adequate for the stubbed-`gh_fun` idle path (P5c-6, D-357), but
+**not** a `ConflictCheck.scope()` (`%{deps, files, codepoints, specs, resources}`
+— §4 B2, `conflict_check.ex`). A real milestone issue must be *elaborated* into a
+structured declared scope before `Scheduler.admit/3` can run the five-clause
+check on it. This sub-section pins that elaboration contract; it is disjoint from
+the B11 supervisor/seam contract that follows.
+
+- **The shape gap being closed (a latent type error).** Today `IssueSelector`
+  emits `scope` as the string `"#{number}: #{title}"`. `Scheduler.admit/3` passes
+  it verbatim to `ConflictCheck.clear?/2`, whose clauses call
+  `Map.fetch!(declared_scope, :files)` etc. A string therefore **crashes** the
+  predicate — the seam is sound today only because no test wires a real
+  string-`scope` work-item into a real Scheduler. The elaboration is what makes
+  `IssueSelector → Scheduler → ConflictCheck` type-correct and admission-correct
+  on a real issue. **[C124-B10]**
+
+- **The elaboration function (the seam).** `IssueSelector` derives the structured
+  scope through an injected, **pure** seam — the established `*_fun` pattern,
+  mirroring `:gh_fun`:
+
+  ```
+  :elaborate_fun — (issue_map -> ConflictCheck.scope())   # default: the conservative heuristic below
+  ```
+
+  `select/1` builds `work_item = {issue, declared_scope, hash, branch}` where
+  `declared_scope = elaborate_fun.(issue)` is a `ConflictCheck.scope()` map (no
+  longer a string). The seam is injected so the soundness posture is testable
+  with deterministic fixtures and so a future, stronger elaborator (LLM-assisted —
+  see the discriminating question, §3 / D-370) can be swapped without touching the
+  Scheduler or the conflict-check. **[C125-B10]**
+
+- **The default elaborator is a CONSERVATIVE, citation-driven heuristic.** It
+  reads only **machine-checkable** signals already present in the `issue_map`
+  (`"title"`, `"body"`, `"labels"`) and the in-repo SPEC source-maps; it does NOT
+  call an LLM on the admission path. Concretely it harvests:
+  - **`files`** — file paths the issue body cites verbatim (paths matching a
+    repo-relative `lib/…`, `test/…`, `web/…`, `docs/…` shape) **plus** every file
+    named by the Appendix-B source-map of each SPEC the issue cites.
+  - **`specs`** — `SPEC-*.md` ids cited in body/labels; the `no-shared-SPEC`
+    clause already folds the shared-D-NNN-block check (§4 B2), so a cited SPEC
+    covers both.
+  - **`codepoints`** — `{path, region}` pairs only where the issue cites
+    `file:line` / `file#function`; absent citations contribute **no** codepoint
+    narrowing (see soundness, below).
+  - **`resources`** — declared from labels / known-resource keywords (e.g. a
+    `burrito` / `smoke` label ⇒ the shared-`$HOME` cache resource of
+    `worktree-discipline.md`).
+  - **`deps`** — in-flight unit-ids named by `blocked-by:` / `depends-on:`
+    references in the body. **[C126-B10]**
+
+- **Soundness posture — conservative over-declaration with serialize-on-uncertainty
+  (the load-bearing decision, V1/V3).** The conflict-check's safety (D-312) holds
+  **iff declared scopes are sound** — a scope that *omits* a file two units truly
+  share lets the Scheduler admit them in parallel and corrupt each other (the V3
+  orphan-invariant failure: `ConflictCheck` is the sole enforcer of conflict-gated
+  admission, but it can only enforce over what it is *told*). No mechanism can
+  derive a *provably complete* file/codepoint set from free issue text (V1 — that
+  is the static-impact-analysis impossibility in disguise). The contract therefore
+  does **not** assume completeness; it makes the *consequence of incompleteness*
+  safe:
+  - **Over-declare, never under-declare.** When the heuristic is uncertain whether
+    a file/codepoint belongs in scope, it **includes** it. A false *inclusion*
+    only costs throughput (an unnecessary `{:defer, …}` — two units serialize that
+    could have run in parallel); a false *exclusion* costs *correctness* (two
+    conflicting units run concurrently and corrupt shared files). The cost
+    asymmetry is the whole argument: **throughput is cheap and reversible; a
+    missed conflict is a corrupting, expensive defect.** **[C127-B10]**
+  - **Coarsen codepoints to whole files when uncertain.** An issue that cites a
+    file but no `file:line` yields a *whole-file* `files` entry, **not** a narrow
+    `codepoints` entry. Codepoint-level narrowing (the parallel-on-disjoint-regions
+    optimisation) is admitted **only** on explicit `file:line` citation, where the
+    burden of proof is discharged by the human author. Absent that, the unit
+    serialises against any other unit touching the file. **[C128-B10]**
+  - **Fallback-to-serialize on an empty elaboration.** If the heuristic extracts
+    **no** files and **no** specs (an issue too vague to scope), `elaborate_fun`
+    returns the **universal-conflict sentinel scope** — a scope that
+    `pairwise_clear?` rejects against *any* non-empty in-flight member — so the
+    unit is admitted **only when `F` is empty** (it runs alone). It is never
+    silently treated as disjoint-from-everything. This makes "we could not scope
+    it" resolve to *serialize*, never to *risk a collision*. **[C129-B10]**
+
+- **Coupling to #492 (real `gh issue list`).** This contract is **independent of**
+  the `gh_fun` real-network adapter (#492): elaboration consumes the `issue_map`
+  whatever its source (stub or real `gh --json number,title,body,labels`). #492
+  only populates the `issue_map`'s real fields; the `body` / `labels` keys the
+  heuristic reads are already in the §4 B10 `--json` projection. No ordering
+  dependency in either direction — referenced, not implemented here.
 
 ### B11: `Tau.Factory.Supervisor` ↔ {`Tau.Application`, tests} — config-gated assembly + seam-threading (P5c-6, #474; D-357)
 
@@ -1132,6 +1251,43 @@ is therefore a strict refinement: it changes the coordinate only when the agent
 asserts one that differs, which is exactly the non-deterministic-agent case.
 Enforced by the existing `dogfood_e2e_test.exs` continuing to reach `:merged`
 green, and a unit test that the `head_sha = nil` path uses the declared hash.
+
+**D-369 — Issue → declared-scope elaboration is conservative (I2, [C124-B10],
+[C126-B10], [C127-B10], [C130-B10], V1/V3):** `IssueSelector.select/1` produces
+`work_item.scope` as a `ConflictCheck.scope()` map (`%{deps, files, codepoints,
+specs, resources}`), **never** a string, via the `:elaborate_fun` seam (D-370).
+The default elaborator harvests scope only from machine-checkable issue signals
+(cited `lib/…`/`test/…`/`web/…`/`docs/…` paths, cited `SPEC-*.md` Appendix-B
+source-maps, `file:line`-cited codepoints, label-derived resources, `blocked-by:`
+deps) and is **directionally sound**: it over-declares under uncertainty and
+**coarsens a file-cited-but-not-line-cited reference to a whole-`files` entry**,
+never a narrow `codepoints` entry. Enforced by `issue_elaboration_test.exs`: (a)
+the returned `scope` is a map accepted by `ConflictCheck.clear?/2` without a
+crash (closes the [C124-B10] latent type error); (b) a fixture issue citing a
+file but no line yields that file in `files` and **no** narrowing
+`codepoints` entry (over-declaration); (c) two fixture issues citing a shared
+file elaborate to scopes that `ConflictCheck.pairwise_clear?/2` rejects (the V3
+soundness witness — a real shared file is never elaborated apart).
+
+**D-370 — Elaboration is an injected pure seam (I2, [C125-B10]):** the
+issue→scope mapping is the injected `:elaborate_fun :: (issue_map ->
+ConflictCheck.scope())` (defaulting to the D-369 heuristic), following the
+codebase's `*_fun` injection pattern, so (a) the soundness posture is tested with
+deterministic fixtures with no network/LLM call on the admission path, and (b) a
+stronger (LLM-assisted, separately verified) elaborator is a *substitution*, not
+a rewrite of `Scheduler`/`ConflictCheck`. Enforced by `issue_elaboration_test.exs`
+(a stub `elaborate_fun` is honoured; the default is pure and network-free).
+
+**D-371 — Serialize-on-unscopable fallback (I2, [C129-B10], [C130-B10]):** when
+the default elaborator extracts **no** files and **no** specs from an issue, it
+returns a **universal-conflict sentinel scope** that `ConflictCheck.pairwise_clear?/2`
+rejects against every non-empty in-flight member, so an unscopable unit is
+admitted **only into an empty `F`** (it runs alone) and is **never** treated as
+disjoint-from-everything. This makes "could not scope it" resolve to *serialize*,
+preserving D-312/D-343 monotonicity (the sentinel is still a fixed declaration —
+no post-hoc actual-path check). Enforced by `issue_elaboration_test.exs` (an
+empty-signal issue's scope clears against an empty `F` but defers against any
+non-empty `F`).
 
 ## 7. Acceptance criteria
 

--- a/docs/spec/SPEC-FACTORY-CORE.md
+++ b/docs/spec/SPEC-FACTORY-CORE.md
@@ -398,6 +398,12 @@ Format: `[Cn-Bm]` = constraint number + boundary. **★** marks non-obvious.
   resource-isolatable.
 - Invariants (properties, §6 D-312): symmetry; non-trivial self-conflict;
   monotone-in-`F`; each clause necessary; gating-path collision blocks.
+- `scope()` type: `%{deps: [unit_id], files: MapSet.t(String.t()),
+  codepoints: MapSet.t({String.t(), atom()}), specs: MapSet.t(atom()),
+  resources: MapSet.t(atom()), optional(:universal_conflict) => boolean()}` —
+  the `universal_conflict: true` sentinel (D-371) causes `clear?/2` to return
+  `{:conflict, :no_dependency}` against any non-empty `F`, regardless of
+  whether the sentinel is the candidate or an in-flight member (symmetric).
 
 ### B3: {Coordinator, Unit} ↔ Ledger.Writer (C1)
 

--- a/lib/tau/factory/conflict_check.ex
+++ b/lib/tau/factory/conflict_check.ex
@@ -13,11 +13,12 @@ defmodule Tau.Factory.ConflictCheck do
   @type unit_id :: String.t()
 
   @type scope :: %{
-          deps: [unit_id()],
-          files: MapSet.t(String.t()),
-          codepoints: MapSet.t({String.t(), atom()}),
-          specs: MapSet.t(atom()),
-          resources: MapSet.t(atom())
+          required(:deps) => [unit_id()],
+          required(:files) => MapSet.t(String.t()),
+          required(:codepoints) => MapSet.t({String.t(), atom()}),
+          required(:specs) => MapSet.t(atom()),
+          required(:resources) => MapSet.t(atom()),
+          optional(:universal_conflict) => boolean()
         }
 
   @type in_flight :: %{unit_id() => scope()}
@@ -40,17 +41,21 @@ defmodule Tau.Factory.ConflictCheck do
   """
   @spec clear?(scope(), in_flight()) :: :clear | {:conflict, clause()}
   def clear?(declared_scope, in_flight) do
-    in_flight_ids = MapSet.new(Map.keys(in_flight))
-    members = Map.values(in_flight)
+    if Map.get(declared_scope, :universal_conflict, false) and map_size(in_flight) > 0 do
+      {:conflict, :no_dependency}
+    else
+      in_flight_ids = MapSet.new(Map.keys(in_flight))
+      members = Map.values(in_flight)
 
-    with :ok <- check_no_dependency(declared_scope, in_flight_ids),
-         :ok <- check_disjoint_sets(members, declared_scope, :files, :disjoint_files),
-         :ok <-
-           check_disjoint_sets(members, declared_scope, :codepoints, :disjoint_codepoints),
-         :ok <- check_disjoint_sets(members, declared_scope, :specs, :no_shared_spec),
-         :ok <-
-           check_disjoint_sets(members, declared_scope, :resources, :resource_isolatable) do
-      :clear
+      with :ok <- check_no_dependency(declared_scope, in_flight_ids),
+           :ok <- check_disjoint_sets(members, declared_scope, :files, :disjoint_files),
+           :ok <-
+             check_disjoint_sets(members, declared_scope, :codepoints, :disjoint_codepoints),
+           :ok <- check_disjoint_sets(members, declared_scope, :specs, :no_shared_spec),
+           :ok <-
+             check_disjoint_sets(members, declared_scope, :resources, :resource_isolatable) do
+        :clear
+      end
     end
   end
 

--- a/lib/tau/factory/conflict_check.ex
+++ b/lib/tau/factory/conflict_check.ex
@@ -41,7 +41,12 @@ defmodule Tau.Factory.ConflictCheck do
   """
   @spec clear?(scope(), in_flight()) :: :clear | {:conflict, clause()}
   def clear?(declared_scope, in_flight) do
-    if Map.get(declared_scope, :universal_conflict, false) and map_size(in_flight) > 0 do
+    candidate_sentinel = Map.get(declared_scope, :universal_conflict, false)
+
+    in_flight_has_sentinel =
+      Enum.any?(Map.values(in_flight), &Map.get(&1, :universal_conflict, false))
+
+    if (candidate_sentinel or in_flight_has_sentinel) and map_size(in_flight) > 0 do
       {:conflict, :no_dependency}
     else
       in_flight_ids = MapSet.new(Map.keys(in_flight))

--- a/lib/tau/factory/issue_selector.ex
+++ b/lib/tau/factory/issue_selector.ex
@@ -22,58 +22,95 @@ defmodule Tau.Factory.IssueSelector do
     4. Returns a `work_item` `{issue, scope, hash, branch}`, or `nil` when no
        admittable open issue remains (D-342 — milestone termination signal).
 
-  ## Pinned contract (§4 B10 amendment, PR #470)
+  ## Pinned contract (§4 B10 amendment, PR #470, updated PR #505)
 
     - **Entry point:** `select(opts :: keyword()) :: work_item | nil`.
 
     - **opts:**
-        * `:ledger`    — `GenServer.server()` of a running `Ledger.Writer`
-                         (projection source, read-only).
-        * `:milestone` — `String.t()`; the assigned milestone title.
-        * `:gh_fun`    — `(milestone :: String.t() -> {:ok, [issue_map]})`;
-                         the stubbable read-only `gh` adapter. When absent,
-                         the real default is used. `issue_map` carries at
-                         minimum `"number"` and `"title"` keys (the `--json`
-                         projection). This seam follows the codebase's
-                         canonical `*_fun` injection pattern.
+        * `:ledger`        — `GenServer.server()` of a running `Ledger.Writer`
+                             (projection source, read-only).
+        * `:milestone`     — `String.t()`; the assigned milestone title.
+        * `:gh_fun`        — optional; `(String.t() -> {:ok, [map()]})`. Defaults to
+                             the real `gh issue list` shell adapter.
+        * `:elaborate_fun` — optional; `(issue_map -> ConflictCheck.scope())`.
+                             Defaults to the pure heuristic elaborator (D-370).
+                             The injected function is called with the raw `issue_map`
+                             and its return value becomes `work_item.scope`.
 
     - **`unit_id` derivation:** `"unit-<number>"` — a stable, issue-derived id
       so the L-projection aligns with the ids the rest of the factory snapshots
       under (D-331 §4 [C112-B10], pinned in this PR).
 
     - **Return:** `{issue, scope, hash, branch}` (4-tuple `work_item`) or `nil`.
-      `scope` is a non-nil frozen declared scope string; `hash` and `branch` are
-      non-empty strings.
+      `scope` is a `ConflictCheck.scope()` map; `hash` and `branch` are
+      non-empty strings (D-369 — closes [C124-B10] latent type error).
+
+  ## Elaboration (D-369 / D-370 / D-371)
+
+  The default elaborator (`elaborate_issue/1`) is pure and network-free on the
+  admission path. It harvests scope signals from machine-readable issue fields:
+
+  - `files`      — `lib/`, `test/`, `web/`, `docs/` path patterns cited anywhere
+                   in the issue title or body (without a `:NN` line reference).
+  - `codepoints` — `file:line` patterns where a file path is followed by `:NN`.
+                   Only explicit `file:line` citations produce codepoints; a file
+                   cited without a line produces a whole-`files` entry instead
+                   (over-declaration, [C127-B10] / [C128-B10]).
+  - `specs`      — `SPEC-<NAME>.md` citations → `:spec_<NAME>` atoms.
+  - `resources`  — reserved; label-derived resources (empty in this PR).
+  - `deps`       — `blocked-by: #NN` / `blocked by #NN` → `"unit-NN"`.
+
+  When no `files` AND no `specs` are extracted, a **universal-conflict sentinel**
+  is returned (D-371): it clears an empty in-flight set but conflicts against any
+  non-empty member, enforcing serialization of unscopable units.
 
   This module is a plain functional module — no GenServer. Pure given injected
   seams (OTP non-negotiable §3: no GenServer wrapping stateless logic).
   """
 
+  alias Tau.Factory.ConflictCheck
   alias Tau.Factory.Ledger.Reader, as: LedgerReader
 
   @terminal_states [:merged, :escalated]
 
+  # Regex for file paths: lib/, test/, web/, docs/ prefix, then the path component
+  # (letters, digits, underscores, hyphens, dots, slashes).
+  # capture: :all_but_first extracts the inner group (the path itself).
+  @file_path_re ~r/((?:lib|test|web|docs)\/[\w.\/\-]+\.\w+)/
+
+  # Regex for file:line citations (file path followed by colon + digits).
+  # Groups: [full_match, path, prefix, line_str] — use :all_but_first.
+  @file_line_re ~r/((?:lib|test|web|docs)\/[\w.\/\-]+\.\w+):(\d+)/
+
+  # Regex for SPEC-NAME.md citations — captures the NAME part.
+  @spec_re ~r/SPEC-([\w\-]+)\.md/
+
+  # Regex for "blocked-by: #N" or "blocked by #N" (case-insensitive).
+  @blocked_by_re ~r/blocked[- ]by[:\s]+#(\d+)/i
+
   @typedoc """
   The 4-tuple returned by `select/1` when an admittable issue exists.
 
-  - `issue`  — the raw `issue_map` (or normalised form) carrying at minimum
-               `"number"` and `"title"`.
-  - `scope`  — frozen declared scope string (non-nil).
+  - `issue`  — the raw `issue_map` carrying at minimum `"number"` and `"title"`.
+  - `scope`  — a `ConflictCheck.scope()` map (D-369 — never a String).
   - `hash`   — content hash string (non-empty).
   - `branch` — feature branch name string (non-empty).
   """
   @type work_item ::
-          {issue_map :: map(), scope :: String.t(), hash :: String.t(), branch :: String.t()}
+          {issue_map :: map(), scope :: ConflictCheck.scope(), hash :: String.t(),
+           branch :: String.t()}
 
   @doc """
   Select the next admittable work item from the assigned milestone.
 
   ## Options
 
-    - `:ledger`    — `GenServer.server()`; a running `Ledger.Writer`.
-    - `:milestone` — `String.t()`; the milestone title to query.
-    - `:gh_fun`    — optional; `(String.t() -> {:ok, [map()]})`. Defaults to
-                     the real `gh issue list` shell adapter.
+    - `:ledger`        — `GenServer.server()`; a running `Ledger.Writer`.
+    - `:milestone`     — `String.t()`; the milestone title to query.
+    - `:gh_fun`        — optional; `(String.t() -> {:ok, [map()]})`. Defaults to
+                         the real `gh issue list` shell adapter.
+    - `:elaborate_fun` — optional; `(map() -> ConflictCheck.scope())`. Defaults
+                         to the pure heuristic elaborator (D-370).
 
   Returns a `work_item` 4-tuple or `nil`.
   """
@@ -82,6 +119,7 @@ defmodule Tau.Factory.IssueSelector do
     ledger = Keyword.fetch!(opts, :ledger)
     milestone = Keyword.fetch!(opts, :milestone)
     gh_fun = Keyword.get(opts, :gh_fun, &default_gh_fun/1)
+    elaborate_fun = Keyword.get(opts, :elaborate_fun, &elaborate_issue/1)
 
     {:ok, issues} = gh_fun.(milestone)
 
@@ -89,7 +127,7 @@ defmodule Tau.Factory.IssueSelector do
 
     issues
     |> Enum.reject(&terminal_in_ledger?(&1, snapshots))
-    |> pick_work_item()
+    |> pick_work_item(elaborate_fun)
   end
 
   # ---------------------------------------------------------------------------
@@ -108,21 +146,131 @@ defmodule Tau.Factory.IssueSelector do
   end
 
   # Pick the smallest shippable increment: first in tracker order.
-  # Freezes a declared scope and derives a deterministic hash and branch name.
-  defp pick_work_item([]), do: nil
+  # Elaborates the declared scope and derives a deterministic hash and branch name.
+  defp pick_work_item([], _elaborate_fun), do: nil
 
-  defp pick_work_item([issue | _rest]) do
+  defp pick_work_item([issue | _rest], elaborate_fun) do
     number = Map.fetch!(issue, "number")
     title = Map.get(issue, "title", "")
 
-    scope = "#{number}: #{title}"
+    scope = elaborate_fun.(issue)
     hash = content_hash(number, title)
     branch = "unit-#{number}"
 
     {issue, scope, hash, branch}
   end
 
-  # Deterministic content hash for the scope — SHA-256 of "number:title".
+  # ---------------------------------------------------------------------------
+  # Default elaborator — D-369 / D-370 / D-371
+  # ---------------------------------------------------------------------------
+
+  @doc false
+  @spec elaborate_issue(map()) :: ConflictCheck.scope()
+  def elaborate_issue(issue_map) do
+    title = Map.get(issue_map, "title", "")
+    body = Map.get(issue_map, "body", "") || ""
+    text = title <> "\n" <> body
+
+    # Extract file:line codepoints first (these are NARROWER citations).
+    # A file:line citation goes into :codepoints ONLY, not into :files.
+    file_line_pairs = extract_file_line_pairs(text)
+    codepointed_files = MapSet.new(file_line_pairs, fn {path, _line} -> path end)
+
+    # Extract whole-file citations: files cited WITHOUT an explicit :line.
+    # Over-declaration: if any match lacks a line, put it in :files, never in
+    # :codepoints. A file cited WITH a line does NOT produce a :files entry.
+    all_files = extract_files(text)
+    whole_files = MapSet.difference(all_files, codepointed_files)
+
+    # SPEC citations → :specs atoms
+    specs = extract_specs(text)
+
+    # blocked-by deps → "unit-NN" strings
+    deps = extract_deps(text)
+
+    # Codepoints as {path, :line_NN} tuples
+    codepoints = MapSet.new(file_line_pairs, fn {path, line} -> {path, :"line_#{line}"} end)
+
+    # D-371: no files AND no specs → universal-conflict sentinel
+    if MapSet.size(whole_files) == 0 and MapSet.size(specs) == 0 and
+         MapSet.size(codepoints) == 0 do
+      sentinel_scope()
+    else
+      %{
+        deps: deps,
+        files: whole_files,
+        codepoints: codepoints,
+        specs: specs,
+        resources: MapSet.new()
+      }
+    end
+  end
+
+  # Extract all file paths (any of the recognized prefixes) from text.
+  # Returns a MapSet of path strings.
+  # Uses :all_but_first to get only the captured group (the path), not the full match.
+  defp extract_files(text) do
+    @file_path_re
+    |> Regex.scan(text, capture: :all_but_first)
+    |> Enum.map(&List.first/1)
+    |> Enum.reject(&is_nil/1)
+    |> MapSet.new()
+  end
+
+  # Extract file:line pairs from text.
+  # Returns a list of {path_string, line_integer} tuples.
+  # Groups: [path, line_str] (all_but_first drops the full match).
+  defp extract_file_line_pairs(text) do
+    @file_line_re
+    |> Regex.scan(text, capture: :all_but_first)
+    |> Enum.flat_map(fn
+      [path, line_str] ->
+        case Integer.parse(line_str) do
+          {line, ""} -> [{path, line}]
+          _ -> []
+        end
+
+      _ ->
+        []
+    end)
+  end
+
+  # Extract SPEC citations → MapSet of atoms like :spec_FACTORY_CORE
+  defp extract_specs(text) do
+    @spec_re
+    |> Regex.scan(text, capture: :all_but_first)
+    |> Enum.map(fn [name] ->
+      name
+      |> String.replace("-", "_")
+      |> String.upcase()
+      |> then(&:"spec_#{&1}")
+    end)
+    |> MapSet.new()
+  end
+
+  # Extract "blocked-by: #N" deps → list of "unit-N" strings
+  defp extract_deps(text) do
+    @blocked_by_re
+    |> Regex.scan(text, capture: :all_but_first)
+    |> Enum.map(fn [num_str] -> "unit-#{num_str}" end)
+  end
+
+  # D-371 sentinel: universal-conflict scope.
+  # Clears against empty in-flight (ConflictCheck treats it as :clear);
+  # conflicts against any non-empty in-flight (ConflictCheck.clear?/2 checks
+  # the :universal_conflict flag before any set comparison).
+  defp sentinel_scope do
+    %{
+      deps: [],
+      files: MapSet.new(),
+      codepoints: MapSet.new(),
+      specs: MapSet.new(),
+      resources: MapSet.new(),
+      universal_conflict: true
+    }
+  end
+
+  # Deterministic content hash for the work item — SHA-256 of "number:title".
   defp content_hash(number, title) do
     :crypto.hash(:sha256, "#{number}:#{title}")
     |> Base.encode16(case: :lower)

--- a/test/tau/factory/issue_elaboration_test.exs
+++ b/test/tau/factory/issue_elaboration_test.exs
@@ -1,0 +1,396 @@
+defmodule Tau.Factory.IssueElaborationTest do
+  @moduledoc """
+  Gating tests for D-369 / D-370 / D-371 — issue → declared-scope elaboration
+  (SPEC-FACTORY-CORE §6, PR #505, issue #488).
+
+  ## What these tests enforce
+
+  **D-369 — Conservative elaboration.**  `IssueSelector.select/1` MUST return
+  `work_item.scope` as a `ConflictCheck.scope()` map (never a String).  The
+  returned map must be accepted by `ConflictCheck.clear?/2` without crashing
+  (closing the [C124-B10] latent type error), must over-declare files cited
+  without a line reference (no codepoint narrowing), and must produce scopes
+  that conflict on a shared file (the V3 soundness witness).
+
+  **D-370 — Injected pure seam.**  An `:elaborate_fun` injected into
+  `IssueSelector.select/1` is honoured (its output becomes `work_item.scope`).
+  The DEFAULT elaborator is pure and deterministic — same issue → same scope —
+  and makes NO network/LLM call on the admission path.
+
+  **D-371 — Serialize-on-unscopable.**  An issue with no file paths and no SPEC
+  citations yields a sentinel scope that clears against an EMPTY in-flight set
+  `F` (admitted alone) but conflicts against ANY non-empty `F` (never
+  disjoint-from-everything).
+
+  Each test exercises the REAL `IssueSelector.select/1` and `ConflictCheck`
+  API — no hand-built scope bypasses. Tests MUST FAIL against the pre-D-369
+  implementation (where `select/1` emits a String scope and lacks
+  `:elaborate_fun`).
+  """
+
+  use ExUnit.Case, async: false
+
+  alias Tau.Factory.ConflictCheck
+  alias Tau.Factory.IssueSelector
+  alias Tau.Factory.Ledger.Writer
+
+  # ---------------------------------------------------------------------------
+  # Helpers
+  # ---------------------------------------------------------------------------
+
+  defp unique_name(base) do
+    suffix = System.unique_integer([:positive])
+    :"#{base}_#{suffix}"
+  end
+
+  defp start_ledger do
+    db_path = Briefly.create!(extname: ".db")
+    writer_name = unique_name(:elab_ledger)
+
+    start_supervised!(
+      {Writer, db_path: db_path, name: writer_name},
+      id: writer_name
+    )
+
+    writer_name
+  end
+
+  # Stub gh adapter: returns fixed issues, no network.
+  defp gh_stub(issues) do
+    fn _milestone -> {:ok, issues} end
+  end
+
+  # Build an issue_map with at least the keys the --json projection supplies.
+  defp issue(number, title, opts \\ []) do
+    %{
+      "number" => number,
+      "title" => title,
+      "body" => Keyword.get(opts, :body, ""),
+      "labels" => Keyword.get(opts, :labels, [])
+    }
+  end
+
+  # Empty ConflictCheck.scope() — no deps, files, codepoints, specs, resources.
+  defp empty_scope do
+    %{
+      deps: [],
+      files: MapSet.new(),
+      codepoints: MapSet.new(),
+      specs: MapSet.new(),
+      resources: MapSet.new()
+    }
+  end
+
+  # ---------------------------------------------------------------------------
+  # D-369(a): scope is a ConflictCheck.scope() map — not a String
+  #
+  # SPEC: "IssueSelector.select/1 produces work_item.scope as a
+  # ConflictCheck.scope() map (%{deps, files, codepoints, specs, resources}),
+  # never a string, … (closes the [C124-B10] latent type error)."
+  #
+  # PRE-IMPL FAILURE: select/1 returns scope as "#{number}: #{title}" (a
+  # String).  ConflictCheck.clear?/2 calls Map.fetch!(scope, :files) on it,
+  # which raises a KeyError/BadMapError, OR the map-shape assertion below fails.
+  # ---------------------------------------------------------------------------
+  @tag :d_369
+  test "D-369(a): select/1 scope is a ConflictCheck.scope() map accepted by clear?/2 without crashing" do
+    ledger = start_ledger()
+
+    issue_map = issue(488, "I2: issue → declared-scope elaboration")
+    gh_fun = gh_stub([issue_map])
+
+    result =
+      IssueSelector.select(
+        ledger: ledger,
+        milestone: "M10",
+        gh_fun: gh_fun
+      )
+
+    assert {_issue, scope, _hash, _branch} = result,
+           "D-369: select/1 must return a {issue, scope, hash, branch} work_item; got: #{inspect(result)}"
+
+    # scope MUST be a map with the five ConflictCheck keys — never a String.
+    assert is_map(scope),
+           "D-369: work_item.scope must be a map (ConflictCheck.scope()), not #{inspect(scope)}"
+
+    assert Map.has_key?(scope, :files),
+           "D-369: scope missing :files key; got keys: #{inspect(Map.keys(scope))}"
+
+    assert Map.has_key?(scope, :codepoints),
+           "D-369: scope missing :codepoints key"
+
+    assert Map.has_key?(scope, :specs),
+           "D-369: scope missing :specs key"
+
+    assert Map.has_key?(scope, :deps),
+           "D-369: scope missing :deps key"
+
+    assert Map.has_key?(scope, :resources),
+           "D-369: scope missing :resources key"
+
+    # The map must be accepted by ConflictCheck.clear?/2 without crashing.
+    # (Pre-impl: a String scope causes Map.fetch! to crash here.)
+    result_clear = ConflictCheck.clear?(scope, %{})
+
+    assert result_clear in [
+             :clear,
+             {:conflict, :no_dependency},
+             {:conflict, :disjoint_files},
+             {:conflict, :disjoint_codepoints},
+             {:conflict, :no_shared_spec},
+             {:conflict, :resource_isolatable}
+           ],
+           "D-369: ConflictCheck.clear?/2 returned unexpected value: #{inspect(result_clear)}"
+  end
+
+  # ---------------------------------------------------------------------------
+  # D-369(b): file-cited-but-not-line-cited → whole-files entry, no codepoints
+  #
+  # SPEC: "a fixture issue citing a file but no line yields that file in
+  # `files` and no narrowing `codepoints` entry (over-declaration)"
+  # [C127-B10] / [C128-B10].
+  #
+  # PRE-IMPL FAILURE: scope is a String — map assertions fail.
+  # ---------------------------------------------------------------------------
+  @tag :d_369
+  test "D-369(b): issue citing a file path but no line yields that file in scope.files with no codepoints entry" do
+    ledger = start_ledger()
+
+    body = """
+    Fixes a bug in lib/tau/factory/issue_selector.ex — no specific line cited.
+    """
+
+    issue_map = issue(488, "File-cited but no line", body: body)
+    gh_fun = gh_stub([issue_map])
+
+    result =
+      IssueSelector.select(
+        ledger: ledger,
+        milestone: "M10",
+        gh_fun: gh_fun
+      )
+
+    assert {_issue, scope, _hash, _branch} = result,
+           "D-369: select/1 must return a 4-tuple work_item"
+
+    assert is_map(scope),
+           "D-369(b): scope must be a ConflictCheck.scope() map, not #{inspect(scope)}"
+
+    # The file cited in the body must appear in scope.files.
+    assert MapSet.member?(scope.files, "lib/tau/factory/issue_selector.ex"),
+           "D-369(b): cited file 'lib/tau/factory/issue_selector.ex' must appear in scope.files; " <>
+             "got: #{inspect(scope.files)}"
+
+    # Over-declaration: NO codepoints entry for the cited file (no line was cited).
+    codepoint_paths = MapSet.to_list(scope.codepoints) |> Enum.map(&elem(&1, 0))
+
+    refute "lib/tau/factory/issue_selector.ex" in codepoint_paths,
+           "D-369(b): file cited without a line MUST NOT appear in scope.codepoints " <>
+             "(codepoint narrowing requires explicit file:line citation); " <>
+             "got codepoints: #{inspect(scope.codepoints)}"
+  end
+
+  # ---------------------------------------------------------------------------
+  # D-369(c): two issues citing a SHARED file → their scopes conflict
+  #
+  # SPEC: "two fixture issues citing a shared file elaborate to scopes that
+  # ConflictCheck.pairwise_clear?/2 rejects (the V3 soundness witness — a real
+  # shared file is never elaborated apart)."
+  #
+  # We assert via ConflictCheck.clear?(scope_b, %{"unit-a" => scope_a}), which
+  # is the real pairwise-conflict path through the Scheduler's admission check.
+  # A shared file must produce a {:conflict, :disjoint_files} result.
+  #
+  # PRE-IMPL FAILURE: scope is a String → ConflictCheck.clear?/2 crashes.
+  # ---------------------------------------------------------------------------
+  @tag :d_369
+  test "D-369(c): two issues citing a shared file produce scopes that conflict via ConflictCheck.clear?/2" do
+    ledger = start_ledger()
+
+    shared_file = "lib/tau/factory/issue_selector.ex"
+
+    body_a = "Modifies #{shared_file} for reason A."
+    body_b = "Also modifies #{shared_file} for reason B."
+
+    issue_a = issue(488, "Issue A — shared file", body: body_a)
+    issue_b = issue(489, "Issue B — shared file", body: body_b)
+
+    {_issue_a_raw, scope_a, _hash_a, _branch_a} =
+      IssueSelector.select(
+        ledger: ledger,
+        milestone: "M10",
+        gh_fun: gh_stub([issue_a])
+      )
+
+    {_issue_b_raw, scope_b, _hash_b, _branch_b} =
+      IssueSelector.select(
+        ledger: ledger,
+        milestone: "M10",
+        gh_fun: gh_stub([issue_b])
+      )
+
+    assert is_map(scope_a),
+           "D-369(c): scope_a must be a ConflictCheck.scope() map, not #{inspect(scope_a)}"
+
+    assert is_map(scope_b),
+           "D-369(c): scope_b must be a ConflictCheck.scope() map, not #{inspect(scope_b)}"
+
+    # Both scopes must include the shared file.
+    assert MapSet.member?(scope_a.files, shared_file),
+           "D-369(c): shared file must appear in scope_a.files; got: #{inspect(scope_a.files)}"
+
+    assert MapSet.member?(scope_b.files, shared_file),
+           "D-369(c): shared file must appear in scope_b.files; got: #{inspect(scope_b.files)}"
+
+    # Soundness witness: scope_b conflicts against scope_a via the real
+    # ConflictCheck predicate (the same path Scheduler.admit/3 uses).
+    in_flight = %{"unit-488" => scope_a}
+    check_result = ConflictCheck.clear?(scope_b, in_flight)
+
+    assert {:conflict, :disjoint_files} = check_result,
+           "D-369(c): two scopes sharing '#{shared_file}' must conflict on " <>
+             ":disjoint_files; ConflictCheck.clear?/2 returned: #{inspect(check_result)}"
+  end
+
+  # ---------------------------------------------------------------------------
+  # D-370(a): injected :elaborate_fun is honoured
+  #
+  # SPEC: "a stub elaborate_fun is honoured; the default is pure and
+  # network-free." [C125-B10].
+  #
+  # PRE-IMPL FAILURE: select/1 does not accept :elaborate_fun → KeyError or
+  # the stub output is ignored and the String scope is returned instead.
+  # ---------------------------------------------------------------------------
+  @tag :d_370
+  test "D-370(a): :elaborate_fun stub injected into select/1 is honoured as work_item.scope" do
+    ledger = start_ledger()
+
+    # A known sentinel scope that could not be produced by any real heuristic.
+    sentinel_files = MapSet.new(["lib/tau/__sentinel_test_file__.ex"])
+
+    stub_scope = %{
+      deps: [],
+      files: sentinel_files,
+      codepoints: MapSet.new(),
+      specs: MapSet.new(),
+      resources: MapSet.new()
+    }
+
+    elaborate_stub = fn _issue_map -> stub_scope end
+
+    issue_map = issue(488, "D-370 stub test")
+    gh_fun = gh_stub([issue_map])
+
+    result =
+      IssueSelector.select(
+        ledger: ledger,
+        milestone: "M10",
+        gh_fun: gh_fun,
+        elaborate_fun: elaborate_stub
+      )
+
+    assert {_issue, scope, _hash, _branch} = result,
+           "D-370: select/1 must return a 4-tuple work_item; got: #{inspect(result)}"
+
+    assert scope == stub_scope,
+           "D-370(a): injected :elaborate_fun output must become work_item.scope; " <>
+             "expected #{inspect(stub_scope)}, got #{inspect(scope)}"
+  end
+
+  # ---------------------------------------------------------------------------
+  # D-370(b): default elaborator is pure and deterministic — same issue → same scope
+  #
+  # SPEC: "the DEFAULT elaborator is pure/deterministic and makes NO network/
+  # LLM call on the admission path (assert determinism: same issue → same scope;
+  # no network)."
+  #
+  # PRE-IMPL FAILURE: scope is a String — not a scope map, but determinism
+  # comparison may coincidentally pass; the is_map/1 assertion fails.
+  # ---------------------------------------------------------------------------
+  @tag :d_370
+  test "D-370(b): default elaborator is deterministic — same issue input yields identical scope twice" do
+    ledger_1 = start_ledger()
+    ledger_2 = start_ledger()
+
+    body = "Touches lib/tau/factory/conflict_check.ex for D-370 determinism check."
+    issue_map = issue(488, "D-370 determinism", body: body)
+
+    # Select from two independent ledgers (both empty) with the same issue.
+    {_i1, scope_1, _h1, _b1} =
+      IssueSelector.select(
+        ledger: ledger_1,
+        milestone: "M10",
+        gh_fun: gh_stub([issue_map])
+      )
+
+    {_i2, scope_2, _h2, _b2} =
+      IssueSelector.select(
+        ledger: ledger_2,
+        milestone: "M10",
+        gh_fun: gh_stub([issue_map])
+      )
+
+    assert is_map(scope_1),
+           "D-370(b): scope must be a ConflictCheck.scope() map, not #{inspect(scope_1)}"
+
+    assert scope_1 == scope_2,
+           "D-370(b): default elaborator must be deterministic — same issue must " <>
+             "produce identical scope on repeated calls; got scope_1=#{inspect(scope_1)} " <>
+             "scope_2=#{inspect(scope_2)}"
+  end
+
+  # ---------------------------------------------------------------------------
+  # D-371: unscopable issue (no files, no specs) → clears empty F, defers non-empty F
+  #
+  # SPEC: "when the default elaborator extracts no files and no specs from an
+  # issue, it returns a universal-conflict sentinel scope that ConflictCheck
+  # rejects against every non-empty in-flight member, so an unscopable unit is
+  # admitted only into an empty F (it runs alone) and is never treated as
+  # disjoint-from-everything."
+  #
+  # PRE-IMPL FAILURE: scope is a String → ConflictCheck.clear?/2 crashes on both
+  # the empty-F and non-empty-F assertions.
+  # ---------------------------------------------------------------------------
+  @tag :d_371
+  test "D-371: unscopable issue scope clears an empty in-flight set but conflicts any non-empty one" do
+    ledger = start_ledger()
+
+    # Deliberately vague issue body — no file paths, no SPEC citations,
+    # no labels that map to resources.
+    vague_issue = issue(488, "Something needs fixing", body: "We should fix the thing.")
+    gh_fun = gh_stub([vague_issue])
+
+    result =
+      IssueSelector.select(
+        ledger: ledger,
+        milestone: "M10",
+        gh_fun: gh_fun
+      )
+
+    assert {_issue, scope, _hash, _branch} = result,
+           "D-371: select/1 must return a 4-tuple work_item; got: #{inspect(result)}"
+
+    assert is_map(scope),
+           "D-371: scope must be a ConflictCheck.scope() map, not #{inspect(scope)}"
+
+    # (a) Clears against an EMPTY in-flight set — admitted alone.
+    assert ConflictCheck.clear?(scope, %{}) == :clear,
+           "D-371: unscopable scope must clear an empty in-flight F; " <>
+             "ConflictCheck.clear?/2 returned: #{inspect(ConflictCheck.clear?(scope, %{}))}"
+
+    # (b) Conflicts against a non-empty in-flight set containing ANY scope.
+    # We use a minimal non-empty scope as the in-flight member.
+    other_scope = empty_scope()
+    in_flight = %{"unit-other" => other_scope}
+    conflict_result = ConflictCheck.clear?(scope, in_flight)
+
+    assert conflict_result != :clear,
+           "D-371: unscopable scope must conflict against ANY non-empty in-flight F " <>
+             "(serialize-on-unscopable); ConflictCheck.clear?/2 returned :clear " <>
+             "instead of a {:conflict, _} tuple; scope=#{inspect(scope)}"
+
+    assert match?({:conflict, _}, conflict_result),
+           "D-371: ConflictCheck.clear?/2 must return {:conflict, _} for unscopable " <>
+             "scope against non-empty F; got: #{inspect(conflict_result)}"
+  end
+end

--- a/test/tau/factory/issue_elaboration_test.exs
+++ b/test/tau/factory/issue_elaboration_test.exs
@@ -393,4 +393,83 @@ defmodule Tau.Factory.IssueElaborationTest do
            "D-371: ConflictCheck.clear?/2 must return {:conflict, _} for unscopable " <>
              "scope against non-empty F; got: #{inspect(conflict_result)}"
   end
+
+  # ---------------------------------------------------------------------------
+  # D-371 (reverse direction): sentinel ALREADY IN-FLIGHT blocks later non-sentinel
+  #
+  # SPEC: "an unscopable unit is admitted only into an empty F (it runs alone)"
+  # — equivalently, once a sentinel is in F, NO subsequent unit may join F
+  # alongside it.  The current implementation is ASYMMETRIC:
+  #   clear?(sentinel, %{"u" => other})  → conflict  ✓  (forward, tested above)
+  #   clear?(non_sentinel, %{"u" => sentinel}) → :clear  ✗  (reverse, the hole)
+  #
+  # This test asserts the REVERSE direction: when the sentinel scope is already
+  # an in-flight member, a subsequent NON-sentinel candidate must CONFLICT, not
+  # clear.
+  #
+  # PRE-IMPL FAILURE: ConflictCheck.clear?/2 only checks
+  # `declared_scope.universal_conflict` — it never checks in-flight members'
+  # `:universal_conflict` flag.  So `clear?(normal_scope, %{"unit-N" => sentinel})`
+  # falls through to the MapSet checks (all empty-vs-nonempty intersections are
+  # disjoint) and returns `:clear`, violating D-371.
+  # ---------------------------------------------------------------------------
+  @tag :d_371
+  test "D-371 (reverse): sentinel scope already in-flight causes subsequent non-sentinel candidate to conflict" do
+    ledger_sentinel = start_ledger()
+    ledger_normal = start_ledger()
+
+    # Produce the sentinel scope via the REAL elaborator (vague issue, no
+    # file paths, no SPEC citations — triggers the universal-conflict sentinel).
+    vague_issue = issue(999, "Something vague", body: "No files or specs mentioned here.")
+
+    {_i_s, sentinel_scope, _h_s, _b_s} =
+      IssueSelector.select(
+        ledger: ledger_sentinel,
+        milestone: "M10",
+        gh_fun: gh_stub([vague_issue])
+      )
+
+    assert is_map(sentinel_scope),
+           "D-371(reverse): sentinel scope must be a map; got: #{inspect(sentinel_scope)}"
+
+    assert Map.get(sentinel_scope, :universal_conflict, false),
+           "D-371(reverse): vague issue must yield a sentinel scope with universal_conflict: true; " <>
+             "got: #{inspect(sentinel_scope)}"
+
+    # Produce a normal (scopable) scope via the REAL elaborator: a regular
+    # issue citing a concrete file path — no sentinel flag.
+    normal_issue =
+      issue(488, "Normal scoped work",
+        body: "Modifies lib/tau/factory/conflict_check.ex for some reason."
+      )
+
+    {_i_n, normal_scope, _h_n, _b_n} =
+      IssueSelector.select(
+        ledger: ledger_normal,
+        milestone: "M10",
+        gh_fun: gh_stub([normal_issue])
+      )
+
+    assert is_map(normal_scope),
+           "D-371(reverse): normal scope must be a map; got: #{inspect(normal_scope)}"
+
+    refute Map.get(normal_scope, :universal_conflict, false),
+           "D-371(reverse): file-citing issue must NOT yield a sentinel scope; " <>
+             "got: #{inspect(normal_scope)}"
+
+    # The sentinel is already in-flight.  The non-sentinel candidate comes later.
+    # D-371 requires it to CONFLICT — the sentinel unit must run alone.
+    in_flight_with_sentinel = %{"unit-sentinel" => sentinel_scope}
+    reverse_result = ConflictCheck.clear?(normal_scope, in_flight_with_sentinel)
+
+    assert reverse_result != :clear,
+           "D-371(reverse): a non-sentinel candidate must CONFLICT when the in-flight " <>
+             "set already contains a sentinel (universal_conflict) scope; " <>
+             "ConflictCheck.clear?/2 returned :clear — asymmetric D-371 bug present; " <>
+             "normal_scope=#{inspect(normal_scope)}, sentinel_scope=#{inspect(sentinel_scope)}"
+
+    assert match?({:conflict, _}, reverse_result),
+           "D-371(reverse): ConflictCheck.clear?/2 must return {:conflict, _}; " <>
+             "got: #{inspect(reverse_result)}"
+  end
 end


### PR DESCRIPTION
## #488 (I2) — issue → declared-scope elaboration

Closes #488. **ARCH GAP RESOLVED** — solution-shaping pass landed (`spec(factory): issue->declared-scope elaboration contract`, rebased `9d8c193`): SPEC-FACTORY-CORE §3 [C130-B10] + §4 B10 + §6 D-369/D-370/D-371 and `control-plane.md` §2.6 amended; verified-free **D-369/D-370/D-371** allocated. Implementation follows in this PR.

### Problem
`IssueSelector` produces a work_item from a stubbed `gh_fun` (one seeded issue) and emits `scope` as a **String** that `ConflictCheck` would crash on (latent type error [C124-B10]). A real tau issue must be elaborated into a `declared_scope` (`ConflictCheck.scope()` — `%{deps, files, codepoints, specs, resources}`) so admission + the conflict check work.

### Plan (this PR)
1. ~~**Shaper pass**~~ ✅ DONE (`9d8c193`): elaboration contract pinned in SPEC-FACTORY-CORE §4 B10 + §6 D-369..D-371 + §3 [C130-B10] soundness + control-plane.md §2.6.
2. test-author → implementer → critic + reviewer.

### Acceptance criteria
- **D-369** — conservative elaboration: `IssueSelector.select/1` produces `work_item.scope` as a `ConflictCheck.scope()` **map** (never a String), via the `:elaborate_fun` seam. The default elaborator harvests scope only from machine-checkable signals (cited `lib/`/`test/`/`web/`/`docs/` paths, cited `SPEC-*.md` source-maps, `file:line` codepoints, label resources, `blocked-by:` deps) and is **directionally sound**: over-declares under uncertainty; a file cited WITHOUT a line → a whole-`files` entry, NEVER a narrowing `codepoints` entry. (Closes the [C124-B10] type error; two issues citing a shared file elaborate to scopes `ConflictCheck` rejects as conflicting.)
- **D-370** — injected pure seam: the issue→scope mapping is the injected `:elaborate_fun :: (issue_map -> ConflictCheck.scope())` (default = the D-369 heuristic), deterministic and network-free on the admission path (no LLM/network call); a stronger elaborator is a substitution, not a `Scheduler`/`ConflictCheck` rewrite.
- **D-371** — serialize-on-unscopable fallback: when the elaborator extracts NO files and NO specs, it returns a **universal-conflict sentinel scope** that conflicts with every non-empty in-flight member, so an unscopable unit is admitted ONLY into an empty `F` (runs alone) and is NEVER treated as disjoint-from-everything; preserves admission monotonicity (D-312 (meta) / D-343 (meta) — enforced by the existing `conflict_check_property_test.exs`, not this PR's gating tests).

### Gating-test paths (frozen at 4b)
- `test/tau/factory/issue_elaboration_test.exs` — D-369 (scope is a map; file-no-line→files-not-codepoints; shared file→conflict), D-370 (stub elaborate_fun honoured; default deterministic/network-free), D-371 (unscopable→clears empty F, defers non-empty F).
### Gate verdicts
**Attempt 1 — RED (refine).** Both halves FAIL.
- **critic: FAIL (substantive)** — D-371 sentinel is ASYMMETRIC: `ConflictCheck.clear?/2` checks `universal_conflict` only on the candidate, not on in-flight members (`conflict_check.ex:44`). A sentinel admitted FIRST (empty F) does not block a later non-sentinel unit from joining → the unscopable unit runs concurrently → **falsifies D-371** ("runs alone / never disjoint-from-everything"); breaks arch P-CC-1 symmetry / P-CC-2 self-conflict. The gating test only asserts `clear?(sentinel, {other})`, never the reverse `clear?(other, {sentinel})`. D-369/D-370 PASS; type-fix/seam/purity PASS.
- **reviewer: FAIL** — Gate 5.1 CI fail (AC section's bare `D-312`/`D-343` tokens had no test linkage → now marked `(meta)`); WARNING: `universal_conflict` not in SPEC §4 B2 scope-type. Mutation probes SOUND.

**Refine plan:**
- *Implementer:* make `clear?/2` symmetric — honour `universal_conflict` when it appears on the candidate OR ANY in-flight member (Option A); a sentinel anywhere in the pair → conflict (against any non-empty other). Add `optional(:universal_conflict) => boolean()` to the SPEC-FACTORY-CORE §4 B2 `scope()` type (spec-before-code).
- *Test-author:* add the reverse-direction D-371 assertion (`clear?(non_sentinel, {sentinel})` → conflict) so the asymmetry is gated.

**Attempt 1 re-gate — GREEN (merge).** Both halves PASS.
- **critic: PASS** — D-371 now ORDER-INDEPENDENT: `clear?/2` checks `universal_conflict` on candidate OR any in-flight member (`conflict_check.ex:44-50`); arch P-CC-1/P-CC-2 hold; five-clause logic intact for normal scopes; SPEC §4 B2 documents the field; D-369/370 not regressed.
- **reviewer: PASS** — all 7 gating tests pass; CI green on both OTP versions + lint + binary-qa + mutation-check (Gate 5.1 D-312/D-343 meta resolved). The "4 failures" diagnosed as pre-existing local flakes (CI is decisive). D-371 symmetry mutation-probe genuine.