### PR TITLE
#490 (A3) — route semantic worker_exit to the retry ladder (D-326)

### DIFF
--- a/lib/tau/factory/unit.ex
+++ b/lib/tau/factory/unit.ex
@@ -6,9 +6,10 @@ defmodule Tau.Factory.Unit do
 
       planned → oracle → implementing → gating → awaiting_merge → merged
       gating {:fail,_} → retry ladder → implementing | escalated
+      worker_exit (semantic) → retry ladder → implementing | escalated (D-326)
       awaiting_merge :rejected → gating (re-gate, INV-2)
       any non-terminal + :state_timeout → escalated (C107)
-      worker :DOWN → escalated (B8/C105 infra path, gate never called)
+      worker :DOWN (infra, no prior semantic exit) → escalated (B8/C105)
 
   D-318: total gate invocations == 1 + N_refine + N_pivot (exactly, bounded
   retry via `Tau.Factory.Retry.next/3`). The `gating` state ALWAYS calls
@@ -367,6 +368,32 @@ defmodule Tau.Factory.Unit do
     {:keep_state, data}
   end
 
+  # D-326 [C111b-B8 / C105-B5]: semantic worker exit — route to retry ladder,
+  # NEVER gate. Covers :no_work_product (exit-0-without-work_ready),
+  # :error (agent-reported failure), {:exit_status, n} (non-zero exit code),
+  # and any other non-completion semantic reason.
+  #
+  # Race handling: Process.demonitor(mref, [:flush]) flushes any queued :DOWN
+  # from the BEAM mailbox synchronously, so a :DOWN that was already delivered
+  # before we processed this worker_exit message is discarded. A :DOWN that
+  # arrives after the demonitor+flush is suppressed by the demonitor. This
+  # provides one-exit-one-outcome disjointness (B8) regardless of ordering.
+  #
+  # The guard `not is_nil(worker_id)` ensures this clause is only active when
+  # the 3-tuple seam is in use. 2-tuple workers (nil worker_id) still rely on
+  # the legacy :DOWN handler for infra crash detection (test 4 preserved).
+  def implementing(:info, {:worker_exit, worker_id, _reason}, %{worker_id: worker_id} = data)
+      when not is_nil(worker_id) do
+    Process.demonitor(data.worker_mref, [:flush])
+    new_data = %{data | worker_pid: nil, worker_id: nil, worker_mref: nil}
+    advance_retry_ladder(new_data)
+  end
+
+  # D-326 [B8 stale-worker]: worker_exit keyed by a different worker_id — discard.
+  def implementing(:info, {:worker_exit, _other_id, _reason}, data) do
+    {:keep_state, data}
+  end
+
   def implementing(:state_timeout, :worker_stalled, data) do
     Logger.warning("[Unit #{data.unit_id}] implementing :state_timeout — worker stalled")
     demonitor_worker(data)
@@ -430,24 +457,8 @@ defmodule Tau.Factory.Unit do
 
       {:fail, findings} ->
         new_data = %{data | last_findings: findings}
-
-        case Retry.next(:gate_fail, new_data.refine_count, new_data.pivot_count) do
-          {:refine, _k} ->
-            # Bump refine_count; go back to implementing for another attempt.
-            bumped = %{new_data | refine_count: new_data.refine_count + 1}
-            {:next_state, :implementing, bumped, [{:next_event, :internal, :on_enter}]}
-
-          :pivot ->
-            # The pivot attempt: go back to implementing one more time.
-            # On that attempt's gate-fail, Retry.next(_, N_REFINE, 1) = :exhausted.
-            bumped = %{new_data | pivot_count: new_data.pivot_count + 1}
-            {:next_state, :implementing, bumped, [{:next_event, :internal, :on_enter}]}
-
-          :exhausted ->
-            # Reached after the pivot attempt's gate fails:
-            # Retry.next(_, N_REFINE, N_PIVOT) → :exhausted → terminal.
-            escalate(new_data, :E_RETRY_EXHAUSTED)
-        end
+        # D-326: shared retry-ladder path (same as semantic worker_exit).
+        advance_retry_ladder(new_data)
     end
   end
 
@@ -547,6 +558,30 @@ defmodule Tau.Factory.Unit do
   @spec escalate(map(), atom()) :: {:next_state, :escalated, map()}
   defp escalate(data, reason) do
     terminal(data, :escalated, data.last_findings, reason)
+  end
+
+  # D-326: shared retry-ladder transition used by both the gating {:fail, _}
+  # path and the semantic worker_exit path (C111b-B8 / C105-B5). Applies
+  # Retry.next/3 on the current counters and either re-enters :implementing
+  # (refine or pivot) or escalates with :E_RETRY_EXHAUSTED.
+  #
+  # This factoring ensures gating-fail and worker-exit use one code path:
+  # the ladder logic is not duplicated.
+  @spec advance_retry_ladder(map()) ::
+          {:next_state, :implementing, map()} | {:next_state, :escalated, map()}
+  defp advance_retry_ladder(data) do
+    case Retry.next(:worker_exit, data.refine_count, data.pivot_count) do
+      {:refine, _k} ->
+        bumped = %{data | refine_count: data.refine_count + 1}
+        {:next_state, :implementing, bumped, [{:next_event, :internal, :on_enter}]}
+
+      :pivot ->
+        bumped = %{data | pivot_count: data.pivot_count + 1}
+        {:next_state, :implementing, bumped, [{:next_event, :internal, :on_enter}]}
+
+      :exhausted ->
+        escalate(data, :E_RETRY_EXHAUSTED)
+    end
   end
 
   # Demonitor the current worker if a monitor ref is present.

--- a/lib/tau/factory/unit.ex
+++ b/lib/tau/factory/unit.ex
@@ -283,8 +283,12 @@ defmodule Tau.Factory.Unit do
   end
 
   # Handle monitored worker :DOWN (infra crash path, B8/C105).
+  # D-326: guard with `is_nil(data.worker_id)` — only the legacy 2-tuple seam
+  # (worker_id == nil) escalates E_WORKER_DOWN via :DOWN. For the 3-tuple path,
+  # :DOWN is not an authoritative outcome; the fleet sends worker_exit (or the
+  # state_timeout fires for vanish-without-exit → E_WORKER_STALLED).
   def oracle(:info, {:DOWN, _mref, :process, worker_pid, reason}, %{worker_pid: worker_pid} = data)
-      when not is_nil(worker_pid) do
+      when not is_nil(worker_pid) and is_nil(data.worker_id) do
     Logger.warning("[Unit #{data.unit_id}] oracle worker :DOWN: #{inspect(reason)}")
     new_data = %{data | worker_pid: nil, worker_mref: nil}
     escalate(new_data, :E_WORKER_DOWN)
@@ -401,12 +405,16 @@ defmodule Tau.Factory.Unit do
   end
 
   # Handle monitored worker :DOWN (infra crash path, B8/C105).
+  # D-326: guard with `is_nil(data.worker_id)` — only the legacy 2-tuple seam
+  # (worker_id == nil) escalates E_WORKER_DOWN via :DOWN. For the 3-tuple path,
+  # :DOWN is not an authoritative outcome; the fleet sends worker_exit (or the
+  # state_timeout fires for vanish-without-exit → E_WORKER_STALLED).
   def implementing(
         :info,
         {:DOWN, _mref, :process, worker_pid, reason},
         %{worker_pid: worker_pid} = data
       )
-      when not is_nil(worker_pid) do
+      when not is_nil(worker_pid) and is_nil(data.worker_id) do
     Logger.warning("[Unit #{data.unit_id}] implementing worker :DOWN: #{inspect(reason)}")
     new_data = %{data | worker_pid: nil, worker_mref: nil}
     # C105: infra crash — do NOT call gate_fun. Route straight to escalated.

--- a/test/tau/factory/unit_worker_exit_test.exs
+++ b/test/tau/factory/unit_worker_exit_test.exs
@@ -3,34 +3,40 @@ defmodule Tau.Factory.UnitWorkerExitTest do
   Gating tests for PR #507 (issue #490 — A3: route semantic worker_exit to the
   retry ladder).
 
-  Advances D-326 (SPEC-FACTORY-CORE §4 B8 [C111b-B8]):
+  Advances D-326 (SPEC-FACTORY-CORE §4 B8 [C111b-B8] / [C105-B5]):
+
+    * **Race oracle (NEW):** a synthetic BEAM `:DOWN` delivered to the Unit's
+      mailbox *before* `{:worker_exit, worker_id, reason}` (simulating the
+      one-hop `:DOWN` winning over the two-hop fleet signal) MUST NOT cause
+      `E_WORKER_DOWN`. For the 3-tuple path the Unit must treat `:DOWN` as a
+      non-outcome when `data.worker_id` is non-nil and route the eventual
+      `worker_exit` to the retry ladder.  This test FAILS against the current
+      impl (the `:DOWN` handler fires unconditionally and escalates
+      `E_WORKER_DOWN`).
 
     * `worker_exit(w, :no_work_product)` — exit-0-without-work_ready — is routed
       to the retry ladder, NEVER gated.
+
     * `worker_exit(w, :error)` and `worker_exit(w, {:exit_status, n})` — semantic
       agent failures — are routed to the retry ladder, NOT escalated via the :DOWN
       infra path.
+
     * Repeated semantic exits exhaust the ladder →
       `escalated(:E_RETRY_EXHAUSTED)` (D-318).
-    * A genuine infra :DOWN (no preceding semantic worker_exit) still escalates
-      `E_WORKER_DOWN` (preserved behaviour — guards against the fix over-broadening).
-    * After a semantic exit routes to retry, the consequent monitor :DOWN for the
-      same worker does NOT fire a second outcome (one exit → one outcome, B8
-      disjointness).
+
+    * A genuine infra :DOWN on a **2-tuple** (legacy `worker_id == nil`) worker
+      still escalates `E_WORKER_DOWN` (preserved behaviour — the 2-tuple seam is
+      unchanged by this PR).
+
+    * **3-tuple vanish without `worker_exit` → `E_WORKER_STALLED`, NOT
+      `E_WORKER_DOWN`:** when a 3-tuple worker process dies before sending
+      `worker_exit`, the Unit must surface this via the stall detection path
+      (`E_WORKER_STALLED`), never via `E_WORKER_DOWN`.  This FAILS against the
+      current impl (the `:DOWN` handler fires unconditionally and escalates
+      `E_WORKER_DOWN`).
+
     * A `{:worker_exit, other_worker_id, _}` not matching the current worker_id is
       discarded (stale-worker guard, B8).
-
-  ## Fail-before validity
-
-  The current `Tau.Factory.Unit` `implementing/3` has NO `{:worker_exit, ...}`
-  clause. On receiving `{:worker_exit, worker_id, reason}` the message falls
-  through to `handle_unexpected/4` which calls `{:keep_state, data}` or is dropped
-  to the info-catch-all (logging). When the process then exits via the monitor :DOWN,
-  it lands on `E_WORKER_DOWN`, NOT the retry ladder. Tests 1, 2, 3, 5, and 6 are
-  therefore RED against current code for the right reason.
-
-  Test 4 (infra :DOWN → E_WORKER_DOWN) may already be GREEN — it guards the
-  existing behaviour and must remain GREEN after the fix.
 
   ## D-326 token linkage
 
@@ -43,14 +49,13 @@ defmodule Tau.Factory.UnitWorkerExitTest do
   @moduletag :capture_log
   @moduletag :d_326
 
-  # Runtime module references — @mod.fun form (Credo strict), never apply/2,3.
   alias Tau.Factory.Retry
 
   @unit_supervisor Tau.Factory.UnitSupervisor
   @scheduler Tau.Factory.Scheduler
 
   # ---------------------------------------------------------------------------
-  # Shared helpers — mirror the idiom from unit_termination_test.exs
+  # Shared helpers
   # ---------------------------------------------------------------------------
 
   defp empty_scope do
@@ -70,12 +75,13 @@ defmodule Tau.Factory.UnitWorkerExitTest do
     )
   end
 
-  # Spawn a long-lived worker the Unit will monitor. Normal completion is via
-  # an in-band work_ready message; the test can also kill it for :DOWN tests.
+  # Spawn a long-lived stub process; the test controls its lifetime.
   defp spawn_worker do
     spawn(fn ->
       receive do
         :stop -> :ok
+      after
+        30_000 -> :ok
       end
     end)
   end
@@ -94,21 +100,6 @@ defmodule Tau.Factory.UnitWorkerExitTest do
     ]
 
     Keyword.merge(defaults, overrides)
-  end
-
-  # Advance through the oracle state by delivering work_ready keyed by the Unit's
-  # current worker_id. The Unit exposes data.worker_id via :sys.get_state/1.
-  defp drive_oracle_to_implementing(unit_pid, worker_id) do
-    :timer.sleep(50)
-
-    case :sys.get_state(unit_pid) do
-      {:oracle, data} ->
-        wid = Map.get(data, :worker_id, worker_id)
-        send(unit_pid, {:work_ready, wid, "feat/x", "deadbeef"})
-
-      _ ->
-        :ok
-    end
   end
 
   # Wait until the Unit is in :implementing; return the current {state, data}.
@@ -135,22 +126,64 @@ defmodule Tau.Factory.UnitWorkerExitTest do
     end
   end
 
+  # Advance the Unit past the oracle state by sending work_ready for the
+  # oracle worker.  Polls :sys.get_state/1 until oracle state is observed,
+  # then delivers work_ready.
+  defp advance_past_oracle(unit_pid, oracle_worker_id, deadline_ms \\ 2_000) do
+    deadline = System.monotonic_time(:millisecond) + deadline_ms
+    do_advance_oracle(unit_pid, oracle_worker_id, deadline)
+  end
+
+  defp do_advance_oracle(unit_pid, oracle_worker_id, deadline) do
+    case :sys.get_state(unit_pid) do
+      {:oracle, _data} ->
+        send(unit_pid, {:work_ready, oracle_worker_id, "feat/x", "deadbeef"})
+        :ok
+
+      {:planned, _} ->
+        if System.monotonic_time(:millisecond) >= deadline do
+          {:timeout, :planned}
+        else
+          Process.sleep(20)
+          do_advance_oracle(unit_pid, oracle_worker_id, deadline)
+        end
+
+      {:implementing, _} ->
+        # Already transitioned — oracle was advanced before we polled.
+        :ok
+
+      {other, _} ->
+        {:unexpected, other}
+    end
+  end
+
   # ---------------------------------------------------------------------------
-  # Test 1 — D-326: :no_work_product → retry ladder, not :gating, not E_WORKER_DOWN
+  # RACE TEST (NEW, key oracle) — D-326
+  #
+  # Delivers a synthetic BEAM :DOWN to the Unit's mailbox BEFORE the semantic
+  # worker_exit, simulating the one-hop :DOWN arriving ahead of the two-hop
+  # fleet signal.
+  #
+  # Fail-before: the current implementing/3 :DOWN clause matches on worker_pid
+  # unconditionally (no worker_id guard), so the :DOWN fires first and
+  # escalates E_WORKER_DOWN — directly contradicting [C111b-B8].
+  #
+  # Pass-after (no-self-monitor design): the :DOWN clause MUST be suppressed for
+  # 3-tuple workers (worker_id non-nil). The Unit only acts on the subsequent
+  # {:worker_exit, worker_id, reason} which routes to the retry ladder.
   # ---------------------------------------------------------------------------
 
-  describe "D-326 [C111b-B8] — worker_exit :no_work_product routes to retry ladder" do
+  describe "D-326 [C111b-B8] race: 3-tuple :DOWN before worker_exit" do
     @tag :d_326
-    test "D-326: {:worker_exit, worker_id, :no_work_product} routes to retry ladder — Unit re-enters :implementing, NOT :gating and NOT :escalated" do
+    test "D-326 race: :DOWN before worker_exit — Unit routes to retry, NEVER E_WORKER_DOWN" do
       test_pid = self()
-      unit_id = "u-noprod-retry-#{System.unique_integer([:positive])}"
-      scheduler_name = :"sched_noprod_#{System.unique_integer([:positive])}"
-      sup_name = :"sup_noprod_#{System.unique_integer([:positive])}"
+      unit_id = "u-race-down-#{System.unique_integer([:positive])}"
+      scheduler_name = :"sched_race_#{System.unique_integer([:positive])}"
+      sup_name = :"sup_race_#{System.unique_integer([:positive])}"
 
       start_scheduler(scheduler_name)
       start_supervised!({@unit_supervisor, name: sup_name}, id: sup_name)
 
-      # gate_fun sentinel: if called, the Unit incorrectly gated a :no_work_product exit.
       gate_called_ref = :counters.new(1, [:atomics])
 
       gate_fun = fn _coord ->
@@ -158,12 +191,30 @@ defmodule Tau.Factory.UnitWorkerExitTest do
         :pass
       end
 
-      # worker_id surfaces as the 3-tuple seam so the Unit keys events by it.
-      worker_id = "w-noprod-#{System.unique_integer([:positive])}"
+      oracle_worker_id = "w-race-oracle-#{System.unique_integer([:positive])}"
+      impl_worker_id = "w-race-impl-#{System.unique_integer([:positive])}"
+
+      # The oracle call returns a 3-tuple so the oracle uses work_ready keying.
+      # The implementing call also returns a 3-tuple with a DIFFERENT worker_id.
+      call_count = :counters.new(1, [:atomics])
+
+      worker_fun = fn _role ->
+        n = :counters.get(call_count, 1)
+        :counters.add(call_count, 1, 1)
+        pid = spawn_worker()
+
+        if n == 0 do
+          # First call: oracle phase worker.
+          {:ok, pid, oracle_worker_id}
+        else
+          # Subsequent calls: implementing phase worker.
+          {:ok, pid, impl_worker_id}
+        end
+      end
 
       opts =
         base_unit_opts(unit_id, scheduler_name, test_pid,
-          worker_fun: fn _role -> {:ok, spawn_worker(), worker_id} end,
+          worker_fun: worker_fun,
           gate_fun: gate_fun,
           merge_fun: fn _uid, _hash -> :queued end,
           timeouts: [state_timeout_ms: 5_000]
@@ -173,8 +224,192 @@ defmodule Tau.Factory.UnitWorkerExitTest do
       assert is_pid(unit_pid), "start_unit must return a pid"
 
       # Advance oracle → implementing.
-      drive_oracle_to_implementing(unit_pid, worker_id)
+      advance_past_oracle(unit_pid, oracle_worker_id)
+      result = wait_for_implementing(unit_pid)
 
+      assert match?({:implementing, _}, result),
+             "D-326 race: Unit must reach :implementing; got #{inspect(result)}"
+
+      {:implementing, impl_data} = result
+      worker_pid = Map.get(impl_data, :worker_pid)
+
+      assert is_pid(worker_pid),
+             "D-326 race: Unit must expose :worker_pid in implementing state data; got #{inspect(impl_data)}"
+
+      refine_before = Map.get(impl_data, :refine_count, 0)
+      attempt_before = Map.get(impl_data, :attempt_count, 0)
+
+      # STEP 1: Deliver a synthetic :DOWN FIRST — simulating the one-hop BEAM
+      # monitor winning the race against the two-hop fleet worker_exit signal.
+      # The no-self-monitor design requires this to be ignored for 3-tuple workers.
+      send(unit_pid, {:DOWN, make_ref(), :process, worker_pid, {:shutdown, :no_work_product}})
+
+      # STEP 2: Deliver the semantic worker_exit SECOND — this is the fleet's
+      # authoritative outcome signal for the 3-tuple path.
+      send(unit_pid, {:worker_exit, impl_worker_id, :no_work_product})
+
+      # Allow the FSM to process both messages.
+      Process.sleep(250)
+
+      {state_after, data_after} = :sys.get_state(unit_pid)
+
+      assert state_after == :implementing,
+             "D-326 [C111b-B8] RACE: Unit must ignore the synthetic :DOWN and route " <>
+               "{:worker_exit, worker_id, :no_work_product} to the retry ladder, " <>
+               "re-entering :implementing. Got state=#{inspect(state_after)}. " <>
+               "FAIL-BEFORE: the current impl's :DOWN handler matches worker_pid unconditionally " <>
+               "(no worker_id guard), so the one-hop :DOWN fires FIRST and escalates " <>
+               "E_WORKER_DOWN before worker_exit is ever processed. " <>
+               "FIX REQUIRED: guard the :DOWN handler with `when is_nil(worker_id)` so it " <>
+               "only fires for the legacy 2-tuple path."
+
+      refine_after = Map.get(data_after, :refine_count, 0)
+      attempt_after = Map.get(data_after, :attempt_count, 0)
+
+      assert refine_after > refine_before or attempt_after > attempt_before,
+             "D-326 race: after routing through the retry ladder, refine_count or " <>
+               "attempt_count must have incremented; " <>
+               "refine #{refine_before}→#{refine_after}, attempt #{attempt_before}→#{attempt_after}"
+
+      gate_calls = :counters.get(gate_called_ref, 1)
+
+      assert gate_calls == 0,
+             "D-326 [C111b-B8] race: gate_fun must NOT be called for :no_work_product " <>
+               "routed via the retry ladder; called #{gate_calls} times"
+
+      refute_received {:unit_terminal, ^unit_id, _outcome, _prov},
+                      "D-326 race: a single :no_work_product exit must route to retry, not terminate"
+    end
+
+    @tag :d_326
+    test "D-326 race worker_exit-first: worker_exit before :DOWN also routes to retry" do
+      test_pid = self()
+      unit_id = "u-race-wef-#{System.unique_integer([:positive])}"
+      scheduler_name = :"sched_race_wef_#{System.unique_integer([:positive])}"
+      sup_name = :"sup_race_wef_#{System.unique_integer([:positive])}"
+
+      start_scheduler(scheduler_name)
+      start_supervised!({@unit_supervisor, name: sup_name}, id: sup_name)
+
+      gate_called_ref = :counters.new(1, [:atomics])
+
+      gate_fun = fn _coord ->
+        :counters.add(gate_called_ref, 1, 1)
+        :pass
+      end
+
+      oracle_worker_id = "w-wef-oracle-#{System.unique_integer([:positive])}"
+      impl_worker_id = "w-wef-impl-#{System.unique_integer([:positive])}"
+      call_count = :counters.new(1, [:atomics])
+
+      worker_fun = fn _role ->
+        n = :counters.get(call_count, 1)
+        :counters.add(call_count, 1, 1)
+        pid = spawn_worker()
+
+        if n == 0 do
+          {:ok, pid, oracle_worker_id}
+        else
+          {:ok, pid, impl_worker_id}
+        end
+      end
+
+      opts =
+        base_unit_opts(unit_id, scheduler_name, test_pid,
+          worker_fun: worker_fun,
+          gate_fun: gate_fun,
+          merge_fun: fn _uid, _hash -> :queued end,
+          timeouts: [state_timeout_ms: 5_000]
+        )
+
+      unit_pid = @unit_supervisor.start_unit(sup_name, opts)
+      assert is_pid(unit_pid), "start_unit must return a pid"
+
+      advance_past_oracle(unit_pid, oracle_worker_id)
+      result = wait_for_implementing(unit_pid)
+
+      assert match?({:implementing, _}, result),
+             "D-326 race/wef: Unit must reach :implementing; got #{inspect(result)}"
+
+      {:implementing, impl_data} = result
+      worker_pid = Map.get(impl_data, :worker_pid)
+      refine_before = Map.get(impl_data, :refine_count, 0)
+      attempt_before = Map.get(impl_data, :attempt_count, 0)
+
+      # worker_exit FIRST, then the :DOWN that follows in the normal sequence.
+      send(unit_pid, {:worker_exit, impl_worker_id, :no_work_product})
+      send(unit_pid, {:DOWN, make_ref(), :process, worker_pid, {:shutdown, :no_work_product}})
+
+      Process.sleep(250)
+
+      {state_after, data_after} = :sys.get_state(unit_pid)
+
+      assert state_after == :implementing,
+             "D-326 [C111b-B8] race/wef: worker_exit-first must route to retry ladder; " <>
+               "got state=#{inspect(state_after)}"
+
+      refine_after = Map.get(data_after, :refine_count, 0)
+      attempt_after = Map.get(data_after, :attempt_count, 0)
+
+      assert refine_after > refine_before or attempt_after > attempt_before,
+             "D-326 race/wef: ladder must have progressed; " <>
+               "refine #{refine_before}→#{refine_after}, attempt #{attempt_before}→#{attempt_after}"
+
+      gate_calls = :counters.get(gate_called_ref, 1)
+
+      assert gate_calls == 0,
+             "D-326 race/wef: gate_fun must NOT be called; called #{gate_calls} times"
+
+      refute_received {:unit_terminal, ^unit_id, _outcome, _prov},
+                      "D-326 race/wef: retry must not terminate the Unit"
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Semantic worker_exit → retry ladder (3-tuple path)
+  # ---------------------------------------------------------------------------
+
+  describe "D-326 [C111b-B8] — worker_exit :no_work_product routes to retry ladder" do
+    @tag :d_326
+    test "D-326: {:worker_exit, worker_id, :no_work_product} routes to retry ladder — NOT :gating, NOT :escalated" do
+      test_pid = self()
+      unit_id = "u-noprod-retry-#{System.unique_integer([:positive])}"
+      scheduler_name = :"sched_noprod_#{System.unique_integer([:positive])}"
+      sup_name = :"sup_noprod_#{System.unique_integer([:positive])}"
+
+      start_scheduler(scheduler_name)
+      start_supervised!({@unit_supervisor, name: sup_name}, id: sup_name)
+
+      gate_called_ref = :counters.new(1, [:atomics])
+
+      gate_fun = fn _coord ->
+        :counters.add(gate_called_ref, 1, 1)
+        :pass
+      end
+
+      oracle_worker_id = "w-noprod-oracle-#{System.unique_integer([:positive])}"
+      impl_worker_id = "w-noprod-impl-#{System.unique_integer([:positive])}"
+      call_count = :counters.new(1, [:atomics])
+
+      worker_fun = fn _role ->
+        n = :counters.get(call_count, 1)
+        :counters.add(call_count, 1, 1)
+        pid = spawn_worker()
+        if n == 0, do: {:ok, pid, oracle_worker_id}, else: {:ok, pid, impl_worker_id}
+      end
+
+      opts =
+        base_unit_opts(unit_id, scheduler_name, test_pid,
+          worker_fun: worker_fun,
+          gate_fun: gate_fun,
+          merge_fun: fn _uid, _hash -> :queued end,
+          timeouts: [state_timeout_ms: 5_000]
+        )
+
+      unit_pid = @unit_supervisor.start_unit(sup_name, opts)
+      assert is_pid(unit_pid), "start_unit must return a pid"
+
+      advance_past_oracle(unit_pid, oracle_worker_id)
       result = wait_for_implementing(unit_pid)
 
       assert match?({:implementing, _}, result),
@@ -184,44 +419,37 @@ defmodule Tau.Factory.UnitWorkerExitTest do
       attempt_before = Map.get(data_before, :attempt_count, 0)
       refine_before = Map.get(data_before, :refine_count, 0)
 
-      # Send the semantic non-completion — exit-0-without-work_ready.
-      send(unit_pid, {:worker_exit, worker_id, :no_work_product})
+      send(unit_pid, {:worker_exit, impl_worker_id, :no_work_product})
 
-      # Allow FSM to process and re-enter :implementing via the retry ladder.
-      :timer.sleep(200)
+      Process.sleep(200)
 
       {state_after, data_after} = :sys.get_state(unit_pid)
 
       assert state_after == :implementing,
              "D-326 [C111b-B8]: {:worker_exit, id, :no_work_product} must route to the retry " <>
-               "ladder and re-enter :implementing; got state=#{inspect(state_after)}. " <>
-               "On current code (no worker_exit handler) the message is ignored and the Unit " <>
-               "stays stuck — or the subsequent :DOWN escalates to E_WORKER_DOWN."
+               "ladder and re-enter :implementing; got state=#{inspect(state_after)}"
 
       refine_after = Map.get(data_after, :refine_count, 0)
       attempt_after = Map.get(data_after, :attempt_count, 0)
 
       assert refine_after > refine_before or attempt_after > attempt_before,
              "D-326: after routing through the retry ladder, refine_count or attempt_count " <>
-               "must have incremented (ladder progressed); refine_before=#{refine_before} " <>
-               "refine_after=#{refine_after}, attempt_before=#{attempt_before} " <>
-               "attempt_after=#{attempt_after}"
+               "must have incremented; refine #{refine_before}→#{refine_after}, " <>
+               "attempt #{attempt_before}→#{attempt_after}"
 
-      # Gate must NOT have been called — :no_work_product is retry, never gated.
       gate_calls = :counters.get(gate_called_ref, 1)
 
       assert gate_calls == 0,
              "D-326 [C111b-B8]: gate_fun must NOT be called for a semantic :no_work_product " <>
                "exit (retry ladder, never gated); called #{gate_calls} times"
 
-      # No terminal report should have arrived yet.
       refute_received {:unit_terminal, ^unit_id, _outcome, _prov},
                       "D-326: a single :no_work_product exit must route to retry, not terminate"
     end
   end
 
   # ---------------------------------------------------------------------------
-  # Test 2 — D-326: :error and {:exit_status, n} → retry ladder, not escalate
+  # Semantic worker_exit :error and {:exit_status, n} → retry ladder
   # ---------------------------------------------------------------------------
 
   describe "D-326 [C105-B5] — worker_exit :error and {:exit_status,n} route to retry ladder" do
@@ -242,11 +470,20 @@ defmodule Tau.Factory.UnitWorkerExitTest do
         :pass
       end
 
-      worker_id = "w-err-#{System.unique_integer([:positive])}"
+      oracle_worker_id = "w-err-oracle-#{System.unique_integer([:positive])}"
+      impl_worker_id = "w-err-impl-#{System.unique_integer([:positive])}"
+      call_count = :counters.new(1, [:atomics])
+
+      worker_fun = fn _role ->
+        n = :counters.get(call_count, 1)
+        :counters.add(call_count, 1, 1)
+        pid = spawn_worker()
+        if n == 0, do: {:ok, pid, oracle_worker_id}, else: {:ok, pid, impl_worker_id}
+      end
 
       opts =
         base_unit_opts(unit_id, scheduler_name, test_pid,
-          worker_fun: fn _role -> {:ok, spawn_worker(), worker_id} end,
+          worker_fun: worker_fun,
           gate_fun: gate_fun,
           merge_fun: fn _uid, _hash -> :queued end,
           timeouts: [state_timeout_ms: 5_000]
@@ -255,7 +492,7 @@ defmodule Tau.Factory.UnitWorkerExitTest do
       unit_pid = @unit_supervisor.start_unit(sup_name, opts)
       assert is_pid(unit_pid), "start_unit must return a pid"
 
-      drive_oracle_to_implementing(unit_pid, worker_id)
+      advance_past_oracle(unit_pid, oracle_worker_id)
       result = wait_for_implementing(unit_pid)
 
       assert match?({:implementing, _}, result),
@@ -265,18 +502,15 @@ defmodule Tau.Factory.UnitWorkerExitTest do
       refine_before = Map.get(data_before, :refine_count, 0)
       attempt_before = Map.get(data_before, :attempt_count, 0)
 
-      # Semantic agent failure: the agent itself reported an error (not an infra crash).
-      send(unit_pid, {:worker_exit, worker_id, :error})
+      send(unit_pid, {:worker_exit, impl_worker_id, :error})
 
-      :timer.sleep(200)
+      Process.sleep(200)
 
       {state_after, data_after} = :sys.get_state(unit_pid)
 
       assert state_after == :implementing,
              "D-326 [C105-B5]: {:worker_exit, id, :error} must route to the retry ladder and " <>
-               "re-enter :implementing; got state=#{inspect(state_after)}. " <>
-               "On current code (no worker_exit clause) this is ignored; the :DOWN that follows " <>
-               "escalates to E_WORKER_DOWN instead of entering the retry ladder."
+               "re-enter :implementing; got state=#{inspect(state_after)}"
 
       refine_after = Map.get(data_after, :refine_count, 0)
       attempt_after = Map.get(data_after, :attempt_count, 0)
@@ -288,8 +522,8 @@ defmodule Tau.Factory.UnitWorkerExitTest do
       gate_calls = :counters.get(gate_called_ref, 1)
 
       assert gate_calls == 0,
-             "D-326 [C105-B5]: gate_fun must NOT be called on a semantic :error exit " <>
-               "(retry ladder, not a gate outcome); called #{gate_calls} times"
+             "D-326 [C105-B5]: gate_fun must NOT be called on a semantic :error exit; " <>
+               "called #{gate_calls} times"
 
       refute_received {:unit_terminal, ^unit_id, _outcome, _prov},
                       "D-326: a single :error worker_exit must route to retry, not terminate"
@@ -312,11 +546,20 @@ defmodule Tau.Factory.UnitWorkerExitTest do
         :pass
       end
 
-      worker_id = "w-exst-#{System.unique_integer([:positive])}"
+      oracle_worker_id = "w-exst-oracle-#{System.unique_integer([:positive])}"
+      impl_worker_id = "w-exst-impl-#{System.unique_integer([:positive])}"
+      call_count = :counters.new(1, [:atomics])
+
+      worker_fun = fn _role ->
+        n = :counters.get(call_count, 1)
+        :counters.add(call_count, 1, 1)
+        pid = spawn_worker()
+        if n == 0, do: {:ok, pid, oracle_worker_id}, else: {:ok, pid, impl_worker_id}
+      end
 
       opts =
         base_unit_opts(unit_id, scheduler_name, test_pid,
-          worker_fun: fn _role -> {:ok, spawn_worker(), worker_id} end,
+          worker_fun: worker_fun,
           gate_fun: gate_fun,
           merge_fun: fn _uid, _hash -> :queued end,
           timeouts: [state_timeout_ms: 5_000]
@@ -325,7 +568,7 @@ defmodule Tau.Factory.UnitWorkerExitTest do
       unit_pid = @unit_supervisor.start_unit(sup_name, opts)
       assert is_pid(unit_pid), "start_unit must return a pid"
 
-      drive_oracle_to_implementing(unit_pid, worker_id)
+      advance_past_oracle(unit_pid, oracle_worker_id)
       result = wait_for_implementing(unit_pid)
 
       assert match?({:implementing, _}, result),
@@ -335,16 +578,15 @@ defmodule Tau.Factory.UnitWorkerExitTest do
       refine_before = Map.get(data_before, :refine_count, 0)
       attempt_before = Map.get(data_before, :attempt_count, 0)
 
-      # Non-zero exit code surfaces as {:exit_status, 1} — a semantic failure.
-      send(unit_pid, {:worker_exit, worker_id, {:exit_status, 1}})
+      send(unit_pid, {:worker_exit, impl_worker_id, {:exit_status, 1}})
 
-      :timer.sleep(200)
+      Process.sleep(200)
 
       {state_after, data_after} = :sys.get_state(unit_pid)
 
       assert state_after == :implementing,
              "D-326 [C105-B5]: {:worker_exit, id, {:exit_status,1}} must route to the retry " <>
-               "ladder and re-enter :implementing; got state=#{inspect(state_after)}."
+               "ladder and re-enter :implementing; got state=#{inspect(state_after)}"
 
       refine_after = Map.get(data_after, :refine_count, 0)
       attempt_after = Map.get(data_after, :attempt_count, 0)
@@ -365,7 +607,7 @@ defmodule Tau.Factory.UnitWorkerExitTest do
   end
 
   # ---------------------------------------------------------------------------
-  # Test 3 — D-326 / D-318: repeated semantic exits exhaust ladder → E_RETRY_EXHAUSTED
+  # D-326 / D-318: repeated semantic exits exhaust ladder → E_RETRY_EXHAUSTED
   # ---------------------------------------------------------------------------
 
   describe "D-326 / D-318 — repeated semantic worker_exits exhaust the retry ladder" do
@@ -382,13 +624,6 @@ defmodule Tau.Factory.UnitWorkerExitTest do
 
       n_refine = Retry.n_refine()
       n_pivot = Retry.n_pivot()
-
-      # We need to exhaust the full retry ladder via semantic exits only.
-      # Ladder (D-318): N_REFINE refines + N_PIVOT pivot = N_REFINE + N_PIVOT total
-      # non-terminal outcomes before :exhausted. Each semantic worker_exit consumes
-      # one ladder step without a gate call. After N_REFINE + N_PIVOT steps the next
-      # worker_exit (or gate-fail if gating is ever reached) yields :exhausted.
-      # We deliver N_REFINE + N_PIVOT + 1 semantic exits total.
       total_exits = n_refine + n_pivot + 1
 
       gate_called_ref = :counters.new(1, [:atomics])
@@ -398,20 +633,14 @@ defmodule Tau.Factory.UnitWorkerExitTest do
         :pass
       end
 
-      # We need fresh worker pids per implementing cycle. Use a counter to hand out
-      # sequential worker_ids so the Unit correctly keys each cycle.
-      exit_count_ref = :counters.new(1, [:atomics])
-      # Store pid→worker_id so we can drive work_ready in oracle correctly.
-      ets = :ets.new(:wpid_exhaust, [:set, :public])
+      # Each implementing cycle gets a fresh 3-tuple worker_id.
+      call_count_ref = :counters.new(1, [:atomics])
 
       worker_fun = fn _role ->
-        idx =
-          :counters.add(exit_count_ref, 1, 1) |> then(fn _ -> :counters.get(exit_count_ref, 1) end)
-
-        wid = "w-exhaust-#{unit_id}-#{idx}"
+        idx = :counters.get(call_count_ref, 1)
+        :counters.add(call_count_ref, 1, 1)
         pid = spawn_worker()
-        :ets.insert(ets, {idx, pid, wid})
-        {:ok, pid, wid}
+        {:ok, pid, "w-exhaust-#{unit_id}-#{idx}"}
       end
 
       opts =
@@ -425,33 +654,34 @@ defmodule Tau.Factory.UnitWorkerExitTest do
       unit_pid = @unit_supervisor.start_unit(sup_name, opts)
       assert is_pid(unit_pid), "start_unit must return a pid"
 
-      # Advance oracle (drives worker_fun call #1 which is for :test_author role).
-      # Find the worker_id for the oracle worker and deliver work_ready.
-      :timer.sleep(50)
+      # Advance oracle: poll for :oracle state, get oracle worker_id from data,
+      # deliver work_ready.
+      oracle_worker_id =
+        Enum.reduce_while(1..100, nil, fn _, _ ->
+          Process.sleep(20)
 
-      case :sys.get_state(unit_pid) do
-        {:oracle, data} ->
-          oracle_wid = Map.get(data, :worker_id)
-          send(unit_pid, {:work_ready, oracle_wid, "feat/oracle", "aabb0011"})
+          case :sys.get_state(unit_pid) do
+            {:oracle, data} -> {:halt, Map.get(data, :worker_id)}
+            _ -> {:cont, nil}
+          end
+        end)
 
-        {state, _} ->
-          flunk("D-326: expected :oracle after start; got #{inspect(state)}")
-      end
+      assert is_binary(oracle_worker_id),
+             "D-326/D-318: oracle must expose :worker_id in state data; got #{inspect(oracle_worker_id)}"
 
-      # Drive total_exits semantic worker_exit cycles through :implementing.
+      send(unit_pid, {:work_ready, oracle_worker_id, "feat/oracle", "aabb0011"})
+
+      # Drive total_exits semantic worker_exit cycles.
       for _i <- 1..total_exits do
-        # Wait until we are in :implementing.
         result = wait_for_implementing(unit_pid, 3_000)
 
         case result do
           {:implementing, data} ->
             wid = Map.get(data, :worker_id)
             send(unit_pid, {:worker_exit, wid, :no_work_product})
-            # Allow FSM to process the exit and re-enter the next state.
-            :timer.sleep(150)
+            Process.sleep(150)
 
-          {state, _} when state in [:escalated] ->
-            # Already exhausted — stop driving.
+          {:escalated, _} ->
             :ok
 
           {state, _} ->
@@ -459,47 +689,43 @@ defmodule Tau.Factory.UnitWorkerExitTest do
         end
       end
 
-      # All ladder steps consumed. The Unit must now be terminal :escalated.
       assert_receive {:unit_terminal, ^unit_id, :escalated, provenance},
                      10_000,
-                     "D-326/D-318: after #{total_exits} semantic worker_exits (#{n_refine} refines + " <>
-                       "#{n_pivot} pivot exhausted), the Unit must reach :escalated. " <>
-                       "On current code the message is ignored → the Unit is stuck, never exhausted."
+                     "D-326/D-318: after #{total_exits} semantic worker_exits " <>
+                       "(#{n_refine} refines + #{n_pivot} pivot exhausted), " <>
+                       "the Unit must reach :escalated"
 
       reason = Map.get(provenance, :reason)
 
       assert reason == :E_RETRY_EXHAUSTED,
              "D-318: exhausted escalation must carry :E_RETRY_EXHAUSTED; got #{inspect(reason)}"
 
-      # gate_fun must NEVER have been called — semantic exits skip the gate.
       gate_calls = :counters.get(gate_called_ref, 1)
 
       assert gate_calls == 0,
              "D-326 [C111b-B8]: gate_fun must NEVER be called for semantic worker_exit " <>
-               "exhaustion (retry ladder, never gated); called #{gate_calls} times"
+               "exhaustion; called #{gate_calls} times"
 
       in_flight = @scheduler.in_flight(scheduler_name)
 
       refute Map.has_key?(in_flight, unit_id),
              "D-326/D-318: after :escalated, unit must be released from Scheduler in_flight"
-
-      :ets.delete(ets)
     end
   end
 
   # ---------------------------------------------------------------------------
-  # Test 4 — D-326: genuine infra :DOWN (no prior semantic exit) → E_WORKER_DOWN
+  # Legacy 2-tuple seam: :DOWN on worker_id == nil → E_WORKER_DOWN (preserved)
   # ---------------------------------------------------------------------------
 
-  describe "D-326 [B8/C105] — genuine infra :DOWN (no prior semantic exit) escalates E_WORKER_DOWN" do
+  describe "D-326 [B8/C105] — 2-tuple legacy seam: genuine infra :DOWN (worker_id nil) escalates E_WORKER_DOWN" do
     @tag :d_326
     @tag :b8
     @tag :c105
-    test "D-326/B8/C105: a :DOWN with NO preceding semantic worker_exit escalates :E_WORKER_DOWN (preserved behaviour)" do
+    test "D-326/B8/C105 [2-tuple seam]: Process.exit(:kill) on 2-tuple worker (worker_id nil) escalates :E_WORKER_DOWN — legacy path preserved" do
       test_pid = self()
-      unit_id = "u-infradown-#{System.unique_integer([:positive])}"
-      scheduler_name = :"sched_infradown_#{System.unique_integer([:positive])}"
-      sup_name = :"sup_infradown_#{System.unique_integer([:positive])}"
+      unit_id = "u-2tuple-down-#{System.unique_integer([:positive])}"
+      scheduler_name = :"sched_2tuple_#{System.unique_integer([:positive])}"
+      sup_name = :"sup_2tuple_#{System.unique_integer([:positive])}"
 
       start_scheduler(scheduler_name)
       start_supervised!({@unit_supervisor, name: sup_name}, id: sup_name)
@@ -511,12 +737,17 @@ defmodule Tau.Factory.UnitWorkerExitTest do
         :pass
       end
 
-      # Capture worker pids so we can kill the implementing-phase worker directly.
-      ets = :ets.new(:wpid_infradown, [:set, :public])
+      # 2-tuple seam: worker_fun returns {:ok, pid} with NO worker_id.
+      # Unit stores worker_id = nil and uses :worker_done / :DOWN for completion.
+      worker_pids_ref = :counters.new(1, [:atomics])
+      ets = :ets.new(:wpid_2tuple, [:set, :public])
 
       worker_fun = fn role ->
+        idx = :counters.get(worker_pids_ref, 1)
+        :counters.add(worker_pids_ref, 1, 1)
         pid = spawn_worker()
-        :ets.insert(ets, {role, pid})
+        :ets.insert(ets, {idx, role, pid})
+        # 2-tuple: no worker_id — legacy seam.
         {:ok, pid}
       end
 
@@ -531,43 +762,51 @@ defmodule Tau.Factory.UnitWorkerExitTest do
       unit_pid = @unit_supervisor.start_unit(sup_name, opts)
       assert is_pid(unit_pid), "start_unit must return a pid"
 
-      # Advance oracle (2-tuple seam: {:worker_done, pid}).
-      :timer.sleep(50)
-
+      # Advance oracle via :worker_done (2-tuple oracle path).
+      # Poll until we are in :oracle state and get the worker_pid from data.
       oracle_pid =
-        case :ets.lookup(ets, :test_author) do
-          [{_, p}] -> p
-          _ -> nil
-        end
+        Enum.reduce_while(1..100, nil, fn _, _ ->
+          Process.sleep(20)
 
-      if is_pid(oracle_pid), do: send(unit_pid, {:worker_done, oracle_pid})
-      :timer.sleep(80)
+          case :sys.get_state(unit_pid) do
+            {:oracle, data} -> {:halt, Map.get(data, :worker_pid)}
+            _ -> {:cont, nil}
+          end
+        end)
 
-      # Confirm we are in :implementing.
-      {impl_state, impl_data} = :sys.get_state(unit_pid)
+      assert is_pid(oracle_pid),
+             "D-326/2-tuple: oracle must expose :worker_pid in state data"
 
-      assert impl_state == :implementing,
-             "D-326: Unit must be in :implementing; got #{inspect(impl_state)}"
+      send(unit_pid, {:worker_done, oracle_pid})
 
+      # Wait until :implementing.
+      impl_result = wait_for_implementing(unit_pid, 2_000)
+
+      assert match?({:implementing, _}, impl_result),
+             "D-326/2-tuple: Unit must reach :implementing; got #{inspect(impl_result)}"
+
+      {:implementing, impl_data} = impl_result
       implementing_pid = Map.get(impl_data, :worker_pid)
 
-      assert is_pid(implementing_pid),
-             "B8: Unit must expose :worker_pid in state data (real pid); " <>
-               "got #{inspect(impl_data)}"
+      assert is_nil(Map.get(impl_data, :worker_id)),
+             "D-326/2-tuple: 2-tuple seam must have worker_id = nil in state data"
 
-      # Kill the worker abnormally — pure infra crash, NO preceding semantic exit.
-      # The Unit's Process.monitor/1 delivers {:DOWN, _, :process, pid, :killed}.
+      assert is_pid(implementing_pid),
+             "B8: Unit must expose :worker_pid in state data; got #{inspect(impl_data)}"
+
+      # Kill the 2-tuple worker — pure infra crash, no prior semantic exit.
+      # For the 2-tuple seam (worker_id nil) this must STILL escalate E_WORKER_DOWN.
       Process.exit(implementing_pid, :kill)
 
       assert_receive {:unit_terminal, ^unit_id, :escalated, provenance},
                      5_000,
-                     "D-326/B8/C105: a pure infra :DOWN (kill, no semantic exit) must escalate " <>
-                       "E_WORKER_DOWN; not received within 5s."
+                     "D-326/B8/C105 [2-tuple]: a pure infra :DOWN (kill) on a 2-tuple worker " <>
+                       "(worker_id nil) must escalate E_WORKER_DOWN; not received within 5s"
 
       reason = Map.get(provenance, :reason)
 
       assert reason == :E_WORKER_DOWN,
-             "B8/C105: infra :DOWN must escalate :E_WORKER_DOWN, not #{inspect(reason)}"
+             "B8/C105 [2-tuple]: infra :DOWN must escalate :E_WORKER_DOWN, not #{inspect(reason)}"
 
       gate_calls = :counters.get(gate_called_ref, 1)
 
@@ -579,103 +818,108 @@ defmodule Tau.Factory.UnitWorkerExitTest do
   end
 
   # ---------------------------------------------------------------------------
-  # Test 5 — D-326: consequent monitor :DOWN after semantic exit does NOT re-fire
+  # 3-tuple vanish without worker_exit → E_WORKER_STALLED (NOT E_WORKER_DOWN)
+  #
+  # For the 3-tuple path, a worker that vanishes without sending worker_exit
+  # MUST surface via the stall detection path (E_WORKER_STALLED), never via
+  # E_WORKER_DOWN.
+  #
+  # Fail-before: the current :DOWN handler in implementing/3 does NOT check
+  # worker_id; it fires for 3-tuple workers too, escalating E_WORKER_DOWN.
+  # Pass-after: the :DOWN handler is guarded with `when is_nil(worker_id)` so
+  # it only fires for the 2-tuple legacy path. 3-tuple vanish is detected by
+  # the state_timeout watchdog → E_WORKER_STALLED.
   # ---------------------------------------------------------------------------
 
-  describe "D-326 [B8 disjointness] — monitor :DOWN after semantic worker_exit does not fire a second outcome" do
+  describe "D-326 [B8] — 3-tuple vanish without worker_exit → E_WORKER_STALLED, never E_WORKER_DOWN" do
     @tag :d_326
     @tag :b8
-    test "D-326/B8: after semantic worker_exit routes to retry, the subsequent monitor :DOWN is suppressed — one exit, one outcome" do
+    test "D-326/B8: 3-tuple worker process killed without worker_exit escalates :E_WORKER_STALLED, NOT :E_WORKER_DOWN" do
       test_pid = self()
-      unit_id = "u-nodup-#{System.unique_integer([:positive])}"
-      scheduler_name = :"sched_nodup_#{System.unique_integer([:positive])}"
-      sup_name = :"sup_nodup_#{System.unique_integer([:positive])}"
+      unit_id = "u-3tuple-vanish-#{System.unique_integer([:positive])}"
+      scheduler_name = :"sched_3tv_#{System.unique_integer([:positive])}"
+      sup_name = :"sup_3tv_#{System.unique_integer([:positive])}"
 
       start_scheduler(scheduler_name)
       start_supervised!({@unit_supervisor, name: sup_name}, id: sup_name)
 
-      # gate_fun always fails so we do not proceed past gating (keeps state stable).
       gate_called_ref = :counters.new(1, [:atomics])
 
       gate_fun = fn _coord ->
         :counters.add(gate_called_ref, 1, 1)
-        {:fail, [:stop_here]}
+        :pass
       end
 
-      worker_id = "w-nodup-#{System.unique_integer([:positive])}"
-
-      # The Unit must demonitor the previous worker before spawning the next one
-      # so that the prior worker's :DOWN does not fire a second escalation.
-      # Use a real, killable process.
-      worker_pid_ref = make_ref()
-      # We need to capture the implementing-phase worker pid BEFORE sending exit.
-      ets = :ets.new(:wpid_nodup, [:set, :public])
+      oracle_worker_id = "w-3tv-oracle-#{System.unique_integer([:positive])}"
+      impl_worker_id = "w-3tv-impl-#{System.unique_integer([:positive])}"
+      call_count = :counters.new(1, [:atomics])
 
       worker_fun = fn _role ->
+        n = :counters.get(call_count, 1)
+        :counters.add(call_count, 1, 1)
         pid = spawn_worker()
-        :ets.insert(ets, {worker_pid_ref, pid})
-        {:ok, pid, worker_id}
+        if n == 0, do: {:ok, pid, oracle_worker_id}, else: {:ok, pid, impl_worker_id}
       end
 
+      # Use a very short state_timeout so the stall watchdog fires quickly.
       opts =
         base_unit_opts(unit_id, scheduler_name, test_pid,
           worker_fun: worker_fun,
           gate_fun: gate_fun,
           merge_fun: fn _uid, _hash -> :queued end,
-          timeouts: [state_timeout_ms: 5_000]
+          timeouts: [state_timeout_ms: 200]
         )
 
       unit_pid = @unit_supervisor.start_unit(sup_name, opts)
       assert is_pid(unit_pid), "start_unit must return a pid"
 
-      # Advance oracle → implementing via work_ready.
-      drive_oracle_to_implementing(unit_pid, worker_id)
-
+      advance_past_oracle(unit_pid, oracle_worker_id)
       result = wait_for_implementing(unit_pid)
 
       assert match?({:implementing, _}, result),
-             "D-326: Unit must reach :implementing; got #{inspect(result)}"
+             "D-326/3-tuple vanish: Unit must reach :implementing; got #{inspect(result)}"
 
       {:implementing, impl_data} = result
-      current_impl_pid = Map.get(impl_data, :worker_pid)
+      worker_pid = Map.get(impl_data, :worker_pid)
 
-      assert is_pid(current_impl_pid),
-             "B8: Unit must expose :worker_pid in state data; got #{inspect(impl_data)}"
+      assert is_pid(worker_pid),
+             "B8: Unit must expose :worker_pid in implementing state data"
 
-      # Send the semantic exit — the Unit should demonitor and route to retry.
-      send(unit_pid, {:worker_exit, worker_id, :no_work_product})
+      assert impl_worker_id == Map.get(impl_data, :worker_id),
+             "D-326/3-tuple: worker_id must be set in state data for 3-tuple worker"
 
-      # Allow FSM to process the exit, demonitor the old worker, enter retry.
-      :timer.sleep(200)
+      # Kill the 3-tuple worker WITHOUT sending worker_exit.
+      # In the no-self-monitor design the Unit must NOT see E_WORKER_DOWN —
+      # the only detection path for vanish-without-exit is the stall watchdog
+      # (state_timeout → E_WORKER_STALLED).
+      Process.exit(worker_pid, :kill)
 
-      # Now kill the old worker — if the Unit did NOT demonitor it, the :DOWN fires
-      # and (before this PR's fix) would escalate E_WORKER_DOWN as a SECOND outcome.
-      Process.exit(current_impl_pid, :kill)
+      # Wait for the terminal report — must be E_WORKER_STALLED, not E_WORKER_DOWN.
+      assert_receive {:unit_terminal, ^unit_id, :escalated, provenance},
+                     3_000,
+                     "D-326 [B8]: 3-tuple worker killed without worker_exit must escalate " <>
+                       "(via stall watchdog or :DOWN-converted-to-stall); not received within 3s. " <>
+                       "FAIL-BEFORE: current impl's :DOWN handler fires unconditionally and " <>
+                       "escalates E_WORKER_DOWN instead of E_WORKER_STALLED."
 
-      # Allow time for any spurious :DOWN to reach the Unit mailbox.
-      :timer.sleep(200)
+      reason = Map.get(provenance, :reason)
 
-      # The Unit must be back in :implementing (retry ladder re-entry), NOT escalated.
-      {state_now, _} = :sys.get_state(unit_pid)
+      assert reason == :E_WORKER_STALLED,
+             "D-326 [B8]: 3-tuple vanish-without-exit must escalate :E_WORKER_STALLED, " <>
+               "not #{inspect(reason)}. " <>
+               "FAIL-BEFORE: current impl escalates :E_WORKER_DOWN because the :DOWN handler " <>
+               "does not check worker_id."
 
-      assert state_now == :implementing,
-             "D-326 [B8 disjointness]: after semantic worker_exit routed to retry, the " <>
-               "subsequent :DOWN for the same worker must NOT fire a second escalation. " <>
-               "Unit must be in :implementing; got #{inspect(state_now)}. " <>
-               "On current code: no semantic exit handler → :DOWN hits the implementing " <>
-               ":DOWN clause → E_WORKER_DOWN (the very scenario this fix prevents)."
+      gate_calls = :counters.get(gate_called_ref, 1)
 
-      # No terminal report should have arrived (single retry step, not exhausted).
-      refute_received {:unit_terminal, ^unit_id, :escalated, _},
-                      "D-326 [B8 disjointness]: the :DOWN for the prior worker must not " <>
-                        "generate a second :escalated outcome after the semantic exit already routed to retry"
-
-      :ets.delete(ets)
+      assert gate_calls == 0,
+             "D-326: gate_fun must NOT be called for a vanished 3-tuple worker; " <>
+               "called #{gate_calls} times"
     end
   end
 
   # ---------------------------------------------------------------------------
-  # Test 6 — D-326: stale worker_id → discarded, no retry, no escalate
+  # Stale worker_exit (other worker_id) → discarded
   # ---------------------------------------------------------------------------
 
   describe "D-326 [B8 stale-worker] — worker_exit from a stale worker_id is discarded" do
@@ -697,11 +941,20 @@ defmodule Tau.Factory.UnitWorkerExitTest do
         :pass
       end
 
-      current_worker_id = "w-current-#{System.unique_integer([:positive])}"
+      oracle_worker_id = "w-stale-oracle-#{System.unique_integer([:positive])}"
+      current_worker_id = "w-stale-current-#{System.unique_integer([:positive])}"
+      call_count = :counters.new(1, [:atomics])
+
+      worker_fun = fn _role ->
+        n = :counters.get(call_count, 1)
+        :counters.add(call_count, 1, 1)
+        pid = spawn_worker()
+        if n == 0, do: {:ok, pid, oracle_worker_id}, else: {:ok, pid, current_worker_id}
+      end
 
       opts =
         base_unit_opts(unit_id, scheduler_name, test_pid,
-          worker_fun: fn _role -> {:ok, spawn_worker(), current_worker_id} end,
+          worker_fun: worker_fun,
           gate_fun: gate_fun,
           merge_fun: fn _uid, _hash -> :queued end,
           timeouts: [state_timeout_ms: 5_000]
@@ -710,9 +963,7 @@ defmodule Tau.Factory.UnitWorkerExitTest do
       unit_pid = @unit_supervisor.start_unit(sup_name, opts)
       assert is_pid(unit_pid), "start_unit must return a pid"
 
-      # Advance oracle → implementing.
-      drive_oracle_to_implementing(unit_pid, current_worker_id)
-
+      advance_past_oracle(unit_pid, oracle_worker_id)
       result = wait_for_implementing(unit_pid)
 
       assert match?({:implementing, _}, result),
@@ -722,11 +973,10 @@ defmodule Tau.Factory.UnitWorkerExitTest do
       refine_before = Map.get(data_before, :refine_count, 0)
       attempt_before = Map.get(data_before, :attempt_count, 0)
 
-      # Send worker_exit keyed by a STALE / DIFFERENT worker_id — must be discarded.
       stale_worker_id = "w-stale-#{System.unique_integer([:positive])}"
       send(unit_pid, {:worker_exit, stale_worker_id, :no_work_product})
 
-      :timer.sleep(200)
+      Process.sleep(200)
 
       {state_after, data_after} = :sys.get_state(unit_pid)
 

--- a/test/tau/factory/unit_worker_exit_test.exs
+++ b/test/tau/factory/unit_worker_exit_test.exs
@@ -1,0 +1,753 @@
+defmodule Tau.Factory.UnitWorkerExitTest do
+  @moduledoc """
+  Gating tests for PR #507 (issue #490 — A3: route semantic worker_exit to the
+  retry ladder).
+
+  Advances D-326 (SPEC-FACTORY-CORE §4 B8 [C111b-B8]):
+
+    * `worker_exit(w, :no_work_product)` — exit-0-without-work_ready — is routed
+      to the retry ladder, NEVER gated.
+    * `worker_exit(w, :error)` and `worker_exit(w, {:exit_status, n})` — semantic
+      agent failures — are routed to the retry ladder, NOT escalated via the :DOWN
+      infra path.
+    * Repeated semantic exits exhaust the ladder →
+      `escalated(:E_RETRY_EXHAUSTED)` (D-318).
+    * A genuine infra :DOWN (no preceding semantic worker_exit) still escalates
+      `E_WORKER_DOWN` (preserved behaviour — guards against the fix over-broadening).
+    * After a semantic exit routes to retry, the consequent monitor :DOWN for the
+      same worker does NOT fire a second outcome (one exit → one outcome, B8
+      disjointness).
+    * A `{:worker_exit, other_worker_id, _}` not matching the current worker_id is
+      discarded (stale-worker guard, B8).
+
+  ## Fail-before validity
+
+  The current `Tau.Factory.Unit` `implementing/3` has NO `{:worker_exit, ...}`
+  clause. On receiving `{:worker_exit, worker_id, reason}` the message falls
+  through to `handle_unexpected/4` which calls `{:keep_state, data}` or is dropped
+  to the info-catch-all (logging). When the process then exits via the monitor :DOWN,
+  it lands on `E_WORKER_DOWN`, NOT the retry ladder. Tests 1, 2, 3, 5, and 6 are
+  therefore RED against current code for the right reason.
+
+  Test 4 (infra :DOWN → E_WORKER_DOWN) may already be GREEN — it guards the
+  existing behaviour and must remain GREEN after the fix.
+
+  ## D-326 token linkage
+
+  Every test in this file carries the D-326 token (in its name and/or @tag) as
+  required by factory-loop §4b gate 5.1.
+  """
+
+  use ExUnit.Case, async: true
+
+  @moduletag :capture_log
+  @moduletag :d_326
+
+  # Runtime module references — @mod.fun form (Credo strict), never apply/2,3.
+  alias Tau.Factory.Retry
+
+  @unit_supervisor Tau.Factory.UnitSupervisor
+  @scheduler Tau.Factory.Scheduler
+
+  # ---------------------------------------------------------------------------
+  # Shared helpers — mirror the idiom from unit_termination_test.exs
+  # ---------------------------------------------------------------------------
+
+  defp empty_scope do
+    %{
+      deps: [],
+      files: MapSet.new(),
+      codepoints: MapSet.new(),
+      specs: MapSet.new(),
+      resources: MapSet.new()
+    }
+  end
+
+  defp start_scheduler(name) do
+    start_supervised!(
+      {@scheduler, name: name, w_cap: 10},
+      id: name
+    )
+  end
+
+  # Spawn a long-lived worker the Unit will monitor. Normal completion is via
+  # an in-band work_ready message; the test can also kill it for :DOWN tests.
+  defp spawn_worker do
+    spawn(fn ->
+      receive do
+        :stop -> :ok
+      end
+    end)
+  end
+
+  defp base_unit_opts(unit_id, scheduler_name, report_to, overrides) do
+    defaults = [
+      unit_id: unit_id,
+      declared_scope: empty_scope(),
+      hash: "hash-#{unit_id}",
+      scheduler: scheduler_name,
+      report_to: report_to,
+      worker_fun: fn _role -> {:ok, spawn_worker()} end,
+      gate_fun: fn _coord -> :pass end,
+      merge_fun: fn _uid, _hash -> :queued end,
+      timeouts: [state_timeout_ms: 5_000]
+    ]
+
+    Keyword.merge(defaults, overrides)
+  end
+
+  # Advance through the oracle state by delivering work_ready keyed by the Unit's
+  # current worker_id. The Unit exposes data.worker_id via :sys.get_state/1.
+  defp drive_oracle_to_implementing(unit_pid, worker_id) do
+    :timer.sleep(50)
+
+    case :sys.get_state(unit_pid) do
+      {:oracle, data} ->
+        wid = Map.get(data, :worker_id, worker_id)
+        send(unit_pid, {:work_ready, wid, "feat/x", "deadbeef"})
+
+      _ ->
+        :ok
+    end
+  end
+
+  # Wait until the Unit is in :implementing; return the current {state, data}.
+  defp wait_for_implementing(unit_pid, deadline_ms \\ 2_000) do
+    deadline = System.monotonic_time(:millisecond) + deadline_ms
+    do_wait_implementing(unit_pid, deadline)
+  end
+
+  defp do_wait_implementing(unit_pid, deadline) do
+    case :sys.get_state(unit_pid) do
+      {:implementing, data} ->
+        {:implementing, data}
+
+      {state, _data} when state in [:planned, :oracle] ->
+        if System.monotonic_time(:millisecond) >= deadline do
+          {:timeout, state}
+        else
+          Process.sleep(20)
+          do_wait_implementing(unit_pid, deadline)
+        end
+
+      {state, data} ->
+        {state, data}
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Test 1 — D-326: :no_work_product → retry ladder, not :gating, not E_WORKER_DOWN
+  # ---------------------------------------------------------------------------
+
+  describe "D-326 [C111b-B8] — worker_exit :no_work_product routes to retry ladder" do
+    @tag :d_326
+    test "D-326: {:worker_exit, worker_id, :no_work_product} routes to retry ladder — Unit re-enters :implementing, NOT :gating and NOT :escalated" do
+      test_pid = self()
+      unit_id = "u-noprod-retry-#{System.unique_integer([:positive])}"
+      scheduler_name = :"sched_noprod_#{System.unique_integer([:positive])}"
+      sup_name = :"sup_noprod_#{System.unique_integer([:positive])}"
+
+      start_scheduler(scheduler_name)
+      start_supervised!({@unit_supervisor, name: sup_name}, id: sup_name)
+
+      # gate_fun sentinel: if called, the Unit incorrectly gated a :no_work_product exit.
+      gate_called_ref = :counters.new(1, [:atomics])
+
+      gate_fun = fn _coord ->
+        :counters.add(gate_called_ref, 1, 1)
+        :pass
+      end
+
+      # worker_id surfaces as the 3-tuple seam so the Unit keys events by it.
+      worker_id = "w-noprod-#{System.unique_integer([:positive])}"
+
+      opts =
+        base_unit_opts(unit_id, scheduler_name, test_pid,
+          worker_fun: fn _role -> {:ok, spawn_worker(), worker_id} end,
+          gate_fun: gate_fun,
+          merge_fun: fn _uid, _hash -> :queued end,
+          timeouts: [state_timeout_ms: 5_000]
+        )
+
+      unit_pid = @unit_supervisor.start_unit(sup_name, opts)
+      assert is_pid(unit_pid), "start_unit must return a pid"
+
+      # Advance oracle → implementing.
+      drive_oracle_to_implementing(unit_pid, worker_id)
+
+      result = wait_for_implementing(unit_pid)
+
+      assert match?({:implementing, _}, result),
+             "D-326: Unit must reach :implementing; got #{inspect(result)}"
+
+      {:implementing, data_before} = result
+      attempt_before = Map.get(data_before, :attempt_count, 0)
+      refine_before = Map.get(data_before, :refine_count, 0)
+
+      # Send the semantic non-completion — exit-0-without-work_ready.
+      send(unit_pid, {:worker_exit, worker_id, :no_work_product})
+
+      # Allow FSM to process and re-enter :implementing via the retry ladder.
+      :timer.sleep(200)
+
+      {state_after, data_after} = :sys.get_state(unit_pid)
+
+      assert state_after == :implementing,
+             "D-326 [C111b-B8]: {:worker_exit, id, :no_work_product} must route to the retry " <>
+               "ladder and re-enter :implementing; got state=#{inspect(state_after)}. " <>
+               "On current code (no worker_exit handler) the message is ignored and the Unit " <>
+               "stays stuck — or the subsequent :DOWN escalates to E_WORKER_DOWN."
+
+      refine_after = Map.get(data_after, :refine_count, 0)
+      attempt_after = Map.get(data_after, :attempt_count, 0)
+
+      assert refine_after > refine_before or attempt_after > attempt_before,
+             "D-326: after routing through the retry ladder, refine_count or attempt_count " <>
+               "must have incremented (ladder progressed); refine_before=#{refine_before} " <>
+               "refine_after=#{refine_after}, attempt_before=#{attempt_before} " <>
+               "attempt_after=#{attempt_after}"
+
+      # Gate must NOT have been called — :no_work_product is retry, never gated.
+      gate_calls = :counters.get(gate_called_ref, 1)
+
+      assert gate_calls == 0,
+             "D-326 [C111b-B8]: gate_fun must NOT be called for a semantic :no_work_product " <>
+               "exit (retry ladder, never gated); called #{gate_calls} times"
+
+      # No terminal report should have arrived yet.
+      refute_received {:unit_terminal, ^unit_id, _outcome, _prov},
+                      "D-326: a single :no_work_product exit must route to retry, not terminate"
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Test 2 — D-326: :error and {:exit_status, n} → retry ladder, not escalate
+  # ---------------------------------------------------------------------------
+
+  describe "D-326 [C105-B5] — worker_exit :error and {:exit_status,n} route to retry ladder" do
+    @tag :d_326
+    test "D-326 :error: {:worker_exit, worker_id, :error} routes to retry ladder, NOT E_WORKER_DOWN" do
+      test_pid = self()
+      unit_id = "u-err-retry-#{System.unique_integer([:positive])}"
+      scheduler_name = :"sched_err_#{System.unique_integer([:positive])}"
+      sup_name = :"sup_err_#{System.unique_integer([:positive])}"
+
+      start_scheduler(scheduler_name)
+      start_supervised!({@unit_supervisor, name: sup_name}, id: sup_name)
+
+      gate_called_ref = :counters.new(1, [:atomics])
+
+      gate_fun = fn _coord ->
+        :counters.add(gate_called_ref, 1, 1)
+        :pass
+      end
+
+      worker_id = "w-err-#{System.unique_integer([:positive])}"
+
+      opts =
+        base_unit_opts(unit_id, scheduler_name, test_pid,
+          worker_fun: fn _role -> {:ok, spawn_worker(), worker_id} end,
+          gate_fun: gate_fun,
+          merge_fun: fn _uid, _hash -> :queued end,
+          timeouts: [state_timeout_ms: 5_000]
+        )
+
+      unit_pid = @unit_supervisor.start_unit(sup_name, opts)
+      assert is_pid(unit_pid), "start_unit must return a pid"
+
+      drive_oracle_to_implementing(unit_pid, worker_id)
+      result = wait_for_implementing(unit_pid)
+
+      assert match?({:implementing, _}, result),
+             "D-326: Unit must reach :implementing; got #{inspect(result)}"
+
+      {:implementing, data_before} = result
+      refine_before = Map.get(data_before, :refine_count, 0)
+      attempt_before = Map.get(data_before, :attempt_count, 0)
+
+      # Semantic agent failure: the agent itself reported an error (not an infra crash).
+      send(unit_pid, {:worker_exit, worker_id, :error})
+
+      :timer.sleep(200)
+
+      {state_after, data_after} = :sys.get_state(unit_pid)
+
+      assert state_after == :implementing,
+             "D-326 [C105-B5]: {:worker_exit, id, :error} must route to the retry ladder and " <>
+               "re-enter :implementing; got state=#{inspect(state_after)}. " <>
+               "On current code (no worker_exit clause) this is ignored; the :DOWN that follows " <>
+               "escalates to E_WORKER_DOWN instead of entering the retry ladder."
+
+      refine_after = Map.get(data_after, :refine_count, 0)
+      attempt_after = Map.get(data_after, :attempt_count, 0)
+
+      assert refine_after > refine_before or attempt_after > attempt_before,
+             "D-326: ladder must have progressed; refine #{refine_before}→#{refine_after}, " <>
+               "attempt #{attempt_before}→#{attempt_after}"
+
+      gate_calls = :counters.get(gate_called_ref, 1)
+
+      assert gate_calls == 0,
+             "D-326 [C105-B5]: gate_fun must NOT be called on a semantic :error exit " <>
+               "(retry ladder, not a gate outcome); called #{gate_calls} times"
+
+      refute_received {:unit_terminal, ^unit_id, _outcome, _prov},
+                      "D-326: a single :error worker_exit must route to retry, not terminate"
+    end
+
+    @tag :d_326
+    test "D-326 exit_status: {:worker_exit, worker_id, {:exit_status,1}} routes to retry ladder, NOT E_WORKER_DOWN" do
+      test_pid = self()
+      unit_id = "u-exitstatus-retry-#{System.unique_integer([:positive])}"
+      scheduler_name = :"sched_exst_#{System.unique_integer([:positive])}"
+      sup_name = :"sup_exst_#{System.unique_integer([:positive])}"
+
+      start_scheduler(scheduler_name)
+      start_supervised!({@unit_supervisor, name: sup_name}, id: sup_name)
+
+      gate_called_ref = :counters.new(1, [:atomics])
+
+      gate_fun = fn _coord ->
+        :counters.add(gate_called_ref, 1, 1)
+        :pass
+      end
+
+      worker_id = "w-exst-#{System.unique_integer([:positive])}"
+
+      opts =
+        base_unit_opts(unit_id, scheduler_name, test_pid,
+          worker_fun: fn _role -> {:ok, spawn_worker(), worker_id} end,
+          gate_fun: gate_fun,
+          merge_fun: fn _uid, _hash -> :queued end,
+          timeouts: [state_timeout_ms: 5_000]
+        )
+
+      unit_pid = @unit_supervisor.start_unit(sup_name, opts)
+      assert is_pid(unit_pid), "start_unit must return a pid"
+
+      drive_oracle_to_implementing(unit_pid, worker_id)
+      result = wait_for_implementing(unit_pid)
+
+      assert match?({:implementing, _}, result),
+             "D-326: Unit must reach :implementing; got #{inspect(result)}"
+
+      {:implementing, data_before} = result
+      refine_before = Map.get(data_before, :refine_count, 0)
+      attempt_before = Map.get(data_before, :attempt_count, 0)
+
+      # Non-zero exit code surfaces as {:exit_status, 1} — a semantic failure.
+      send(unit_pid, {:worker_exit, worker_id, {:exit_status, 1}})
+
+      :timer.sleep(200)
+
+      {state_after, data_after} = :sys.get_state(unit_pid)
+
+      assert state_after == :implementing,
+             "D-326 [C105-B5]: {:worker_exit, id, {:exit_status,1}} must route to the retry " <>
+               "ladder and re-enter :implementing; got state=#{inspect(state_after)}."
+
+      refine_after = Map.get(data_after, :refine_count, 0)
+      attempt_after = Map.get(data_after, :attempt_count, 0)
+
+      assert refine_after > refine_before or attempt_after > attempt_before,
+             "D-326: ladder must have progressed; refine #{refine_before}→#{refine_after}, " <>
+               "attempt #{attempt_before}→#{attempt_after}"
+
+      gate_calls = :counters.get(gate_called_ref, 1)
+
+      assert gate_calls == 0,
+             "D-326 [C105-B5]: gate_fun must NOT be called on a {:exit_status,1} worker_exit; " <>
+               "called #{gate_calls} times"
+
+      refute_received {:unit_terminal, ^unit_id, _outcome, _prov},
+                      "D-326: a single {:exit_status,1} worker_exit must route to retry, not terminate"
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Test 3 — D-326 / D-318: repeated semantic exits exhaust ladder → E_RETRY_EXHAUSTED
+  # ---------------------------------------------------------------------------
+
+  describe "D-326 / D-318 — repeated semantic worker_exits exhaust the retry ladder" do
+    @tag :d_326
+    @tag :d_318
+    test "D-326/D-318: enough semantic :no_work_product exits exhaust the retry ladder → :escalated :E_RETRY_EXHAUSTED" do
+      test_pid = self()
+      unit_id = "u-exhaust-#{System.unique_integer([:positive])}"
+      scheduler_name = :"sched_exhaust_#{System.unique_integer([:positive])}"
+      sup_name = :"sup_exhaust_#{System.unique_integer([:positive])}"
+
+      start_scheduler(scheduler_name)
+      start_supervised!({@unit_supervisor, name: sup_name}, id: sup_name)
+
+      n_refine = Retry.n_refine()
+      n_pivot = Retry.n_pivot()
+
+      # We need to exhaust the full retry ladder via semantic exits only.
+      # Ladder (D-318): N_REFINE refines + N_PIVOT pivot = N_REFINE + N_PIVOT total
+      # non-terminal outcomes before :exhausted. Each semantic worker_exit consumes
+      # one ladder step without a gate call. After N_REFINE + N_PIVOT steps the next
+      # worker_exit (or gate-fail if gating is ever reached) yields :exhausted.
+      # We deliver N_REFINE + N_PIVOT + 1 semantic exits total.
+      total_exits = n_refine + n_pivot + 1
+
+      gate_called_ref = :counters.new(1, [:atomics])
+
+      gate_fun = fn _coord ->
+        :counters.add(gate_called_ref, 1, 1)
+        :pass
+      end
+
+      # We need fresh worker pids per implementing cycle. Use a counter to hand out
+      # sequential worker_ids so the Unit correctly keys each cycle.
+      exit_count_ref = :counters.new(1, [:atomics])
+      # Store pid→worker_id so we can drive work_ready in oracle correctly.
+      ets = :ets.new(:wpid_exhaust, [:set, :public])
+
+      worker_fun = fn _role ->
+        idx =
+          :counters.add(exit_count_ref, 1, 1) |> then(fn _ -> :counters.get(exit_count_ref, 1) end)
+
+        wid = "w-exhaust-#{unit_id}-#{idx}"
+        pid = spawn_worker()
+        :ets.insert(ets, {idx, pid, wid})
+        {:ok, pid, wid}
+      end
+
+      opts =
+        base_unit_opts(unit_id, scheduler_name, test_pid,
+          worker_fun: worker_fun,
+          gate_fun: gate_fun,
+          merge_fun: fn _uid, _hash -> :queued end,
+          timeouts: [state_timeout_ms: 5_000]
+        )
+
+      unit_pid = @unit_supervisor.start_unit(sup_name, opts)
+      assert is_pid(unit_pid), "start_unit must return a pid"
+
+      # Advance oracle (drives worker_fun call #1 which is for :test_author role).
+      # Find the worker_id for the oracle worker and deliver work_ready.
+      :timer.sleep(50)
+
+      case :sys.get_state(unit_pid) do
+        {:oracle, data} ->
+          oracle_wid = Map.get(data, :worker_id)
+          send(unit_pid, {:work_ready, oracle_wid, "feat/oracle", "aabb0011"})
+
+        {state, _} ->
+          flunk("D-326: expected :oracle after start; got #{inspect(state)}")
+      end
+
+      # Drive total_exits semantic worker_exit cycles through :implementing.
+      for _i <- 1..total_exits do
+        # Wait until we are in :implementing.
+        result = wait_for_implementing(unit_pid, 3_000)
+
+        case result do
+          {:implementing, data} ->
+            wid = Map.get(data, :worker_id)
+            send(unit_pid, {:worker_exit, wid, :no_work_product})
+            # Allow FSM to process the exit and re-enter the next state.
+            :timer.sleep(150)
+
+          {state, _} when state in [:escalated] ->
+            # Already exhausted — stop driving.
+            :ok
+
+          {state, _} ->
+            flunk("D-326/D-318: unexpected state #{inspect(state)} mid-exhaustion loop")
+        end
+      end
+
+      # All ladder steps consumed. The Unit must now be terminal :escalated.
+      assert_receive {:unit_terminal, ^unit_id, :escalated, provenance},
+                     10_000,
+                     "D-326/D-318: after #{total_exits} semantic worker_exits (#{n_refine} refines + " <>
+                       "#{n_pivot} pivot exhausted), the Unit must reach :escalated. " <>
+                       "On current code the message is ignored → the Unit is stuck, never exhausted."
+
+      reason = Map.get(provenance, :reason)
+
+      assert reason == :E_RETRY_EXHAUSTED,
+             "D-318: exhausted escalation must carry :E_RETRY_EXHAUSTED; got #{inspect(reason)}"
+
+      # gate_fun must NEVER have been called — semantic exits skip the gate.
+      gate_calls = :counters.get(gate_called_ref, 1)
+
+      assert gate_calls == 0,
+             "D-326 [C111b-B8]: gate_fun must NEVER be called for semantic worker_exit " <>
+               "exhaustion (retry ladder, never gated); called #{gate_calls} times"
+
+      in_flight = @scheduler.in_flight(scheduler_name)
+
+      refute Map.has_key?(in_flight, unit_id),
+             "D-326/D-318: after :escalated, unit must be released from Scheduler in_flight"
+
+      :ets.delete(ets)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Test 4 — D-326: genuine infra :DOWN (no prior semantic exit) → E_WORKER_DOWN
+  # ---------------------------------------------------------------------------
+
+  describe "D-326 [B8/C105] — genuine infra :DOWN (no prior semantic exit) escalates E_WORKER_DOWN" do
+    @tag :d_326
+    @tag :b8
+    @tag :c105
+    test "D-326/B8/C105: a :DOWN with NO preceding semantic worker_exit escalates :E_WORKER_DOWN (preserved behaviour)" do
+      test_pid = self()
+      unit_id = "u-infradown-#{System.unique_integer([:positive])}"
+      scheduler_name = :"sched_infradown_#{System.unique_integer([:positive])}"
+      sup_name = :"sup_infradown_#{System.unique_integer([:positive])}"
+
+      start_scheduler(scheduler_name)
+      start_supervised!({@unit_supervisor, name: sup_name}, id: sup_name)
+
+      gate_called_ref = :counters.new(1, [:atomics])
+
+      gate_fun = fn _coord ->
+        :counters.add(gate_called_ref, 1, 1)
+        :pass
+      end
+
+      # Capture worker pids so we can kill the implementing-phase worker directly.
+      ets = :ets.new(:wpid_infradown, [:set, :public])
+
+      worker_fun = fn role ->
+        pid = spawn_worker()
+        :ets.insert(ets, {role, pid})
+        {:ok, pid}
+      end
+
+      opts =
+        base_unit_opts(unit_id, scheduler_name, test_pid,
+          worker_fun: worker_fun,
+          gate_fun: gate_fun,
+          merge_fun: fn _uid, _hash -> :queued end,
+          timeouts: [state_timeout_ms: 5_000]
+        )
+
+      unit_pid = @unit_supervisor.start_unit(sup_name, opts)
+      assert is_pid(unit_pid), "start_unit must return a pid"
+
+      # Advance oracle (2-tuple seam: {:worker_done, pid}).
+      :timer.sleep(50)
+
+      oracle_pid =
+        case :ets.lookup(ets, :test_author) do
+          [{_, p}] -> p
+          _ -> nil
+        end
+
+      if is_pid(oracle_pid), do: send(unit_pid, {:worker_done, oracle_pid})
+      :timer.sleep(80)
+
+      # Confirm we are in :implementing.
+      {impl_state, impl_data} = :sys.get_state(unit_pid)
+
+      assert impl_state == :implementing,
+             "D-326: Unit must be in :implementing; got #{inspect(impl_state)}"
+
+      implementing_pid = Map.get(impl_data, :worker_pid)
+
+      assert is_pid(implementing_pid),
+             "B8: Unit must expose :worker_pid in state data (real pid); " <>
+               "got #{inspect(impl_data)}"
+
+      # Kill the worker abnormally — pure infra crash, NO preceding semantic exit.
+      # The Unit's Process.monitor/1 delivers {:DOWN, _, :process, pid, :killed}.
+      Process.exit(implementing_pid, :kill)
+
+      assert_receive {:unit_terminal, ^unit_id, :escalated, provenance},
+                     5_000,
+                     "D-326/B8/C105: a pure infra :DOWN (kill, no semantic exit) must escalate " <>
+                       "E_WORKER_DOWN; not received within 5s."
+
+      reason = Map.get(provenance, :reason)
+
+      assert reason == :E_WORKER_DOWN,
+             "B8/C105: infra :DOWN must escalate :E_WORKER_DOWN, not #{inspect(reason)}"
+
+      gate_calls = :counters.get(gate_called_ref, 1)
+
+      assert gate_calls == 0,
+             "C105: gate_fun must NOT be called for a pure infra :DOWN; called #{gate_calls} times"
+
+      :ets.delete(ets)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Test 5 — D-326: consequent monitor :DOWN after semantic exit does NOT re-fire
+  # ---------------------------------------------------------------------------
+
+  describe "D-326 [B8 disjointness] — monitor :DOWN after semantic worker_exit does not fire a second outcome" do
+    @tag :d_326
+    @tag :b8
+    test "D-326/B8: after semantic worker_exit routes to retry, the subsequent monitor :DOWN is suppressed — one exit, one outcome" do
+      test_pid = self()
+      unit_id = "u-nodup-#{System.unique_integer([:positive])}"
+      scheduler_name = :"sched_nodup_#{System.unique_integer([:positive])}"
+      sup_name = :"sup_nodup_#{System.unique_integer([:positive])}"
+
+      start_scheduler(scheduler_name)
+      start_supervised!({@unit_supervisor, name: sup_name}, id: sup_name)
+
+      # gate_fun always fails so we do not proceed past gating (keeps state stable).
+      gate_called_ref = :counters.new(1, [:atomics])
+
+      gate_fun = fn _coord ->
+        :counters.add(gate_called_ref, 1, 1)
+        {:fail, [:stop_here]}
+      end
+
+      worker_id = "w-nodup-#{System.unique_integer([:positive])}"
+
+      # The Unit must demonitor the previous worker before spawning the next one
+      # so that the prior worker's :DOWN does not fire a second escalation.
+      # Use a real, killable process.
+      worker_pid_ref = make_ref()
+      # We need to capture the implementing-phase worker pid BEFORE sending exit.
+      ets = :ets.new(:wpid_nodup, [:set, :public])
+
+      worker_fun = fn _role ->
+        pid = spawn_worker()
+        :ets.insert(ets, {worker_pid_ref, pid})
+        {:ok, pid, worker_id}
+      end
+
+      opts =
+        base_unit_opts(unit_id, scheduler_name, test_pid,
+          worker_fun: worker_fun,
+          gate_fun: gate_fun,
+          merge_fun: fn _uid, _hash -> :queued end,
+          timeouts: [state_timeout_ms: 5_000]
+        )
+
+      unit_pid = @unit_supervisor.start_unit(sup_name, opts)
+      assert is_pid(unit_pid), "start_unit must return a pid"
+
+      # Advance oracle → implementing via work_ready.
+      drive_oracle_to_implementing(unit_pid, worker_id)
+
+      result = wait_for_implementing(unit_pid)
+
+      assert match?({:implementing, _}, result),
+             "D-326: Unit must reach :implementing; got #{inspect(result)}"
+
+      {:implementing, impl_data} = result
+      current_impl_pid = Map.get(impl_data, :worker_pid)
+
+      assert is_pid(current_impl_pid),
+             "B8: Unit must expose :worker_pid in state data; got #{inspect(impl_data)}"
+
+      # Send the semantic exit — the Unit should demonitor and route to retry.
+      send(unit_pid, {:worker_exit, worker_id, :no_work_product})
+
+      # Allow FSM to process the exit, demonitor the old worker, enter retry.
+      :timer.sleep(200)
+
+      # Now kill the old worker — if the Unit did NOT demonitor it, the :DOWN fires
+      # and (before this PR's fix) would escalate E_WORKER_DOWN as a SECOND outcome.
+      Process.exit(current_impl_pid, :kill)
+
+      # Allow time for any spurious :DOWN to reach the Unit mailbox.
+      :timer.sleep(200)
+
+      # The Unit must be back in :implementing (retry ladder re-entry), NOT escalated.
+      {state_now, _} = :sys.get_state(unit_pid)
+
+      assert state_now == :implementing,
+             "D-326 [B8 disjointness]: after semantic worker_exit routed to retry, the " <>
+               "subsequent :DOWN for the same worker must NOT fire a second escalation. " <>
+               "Unit must be in :implementing; got #{inspect(state_now)}. " <>
+               "On current code: no semantic exit handler → :DOWN hits the implementing " <>
+               ":DOWN clause → E_WORKER_DOWN (the very scenario this fix prevents)."
+
+      # No terminal report should have arrived (single retry step, not exhausted).
+      refute_received {:unit_terminal, ^unit_id, :escalated, _},
+                      "D-326 [B8 disjointness]: the :DOWN for the prior worker must not " <>
+                        "generate a second :escalated outcome after the semantic exit already routed to retry"
+
+      :ets.delete(ets)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Test 6 — D-326: stale worker_id → discarded, no retry, no escalate
+  # ---------------------------------------------------------------------------
+
+  describe "D-326 [B8 stale-worker] — worker_exit from a stale worker_id is discarded" do
+    @tag :d_326
+    @tag :b8
+    test "D-326/B8: {:worker_exit, other_worker_id, :no_work_product} does NOT trigger retry or escalate" do
+      test_pid = self()
+      unit_id = "u-stale-exit-#{System.unique_integer([:positive])}"
+      scheduler_name = :"sched_stale_exit_#{System.unique_integer([:positive])}"
+      sup_name = :"sup_stale_exit_#{System.unique_integer([:positive])}"
+
+      start_scheduler(scheduler_name)
+      start_supervised!({@unit_supervisor, name: sup_name}, id: sup_name)
+
+      gate_called_ref = :counters.new(1, [:atomics])
+
+      gate_fun = fn _coord ->
+        :counters.add(gate_called_ref, 1, 1)
+        :pass
+      end
+
+      current_worker_id = "w-current-#{System.unique_integer([:positive])}"
+
+      opts =
+        base_unit_opts(unit_id, scheduler_name, test_pid,
+          worker_fun: fn _role -> {:ok, spawn_worker(), current_worker_id} end,
+          gate_fun: gate_fun,
+          merge_fun: fn _uid, _hash -> :queued end,
+          timeouts: [state_timeout_ms: 5_000]
+        )
+
+      unit_pid = @unit_supervisor.start_unit(sup_name, opts)
+      assert is_pid(unit_pid), "start_unit must return a pid"
+
+      # Advance oracle → implementing.
+      drive_oracle_to_implementing(unit_pid, current_worker_id)
+
+      result = wait_for_implementing(unit_pid)
+
+      assert match?({:implementing, _}, result),
+             "D-326: Unit must reach :implementing; got #{inspect(result)}"
+
+      {:implementing, data_before} = result
+      refine_before = Map.get(data_before, :refine_count, 0)
+      attempt_before = Map.get(data_before, :attempt_count, 0)
+
+      # Send worker_exit keyed by a STALE / DIFFERENT worker_id — must be discarded.
+      stale_worker_id = "w-stale-#{System.unique_integer([:positive])}"
+      send(unit_pid, {:worker_exit, stale_worker_id, :no_work_product})
+
+      :timer.sleep(200)
+
+      {state_after, data_after} = :sys.get_state(unit_pid)
+
+      assert state_after == :implementing,
+             "D-326 [B8 stale-worker]: worker_exit from a stale worker_id must be discarded — " <>
+               "Unit remains in :implementing, not #{inspect(state_after)}"
+
+      refine_after = Map.get(data_after, :refine_count, 0)
+      attempt_after = Map.get(data_after, :attempt_count, 0)
+
+      assert refine_before == refine_after and attempt_before == attempt_after,
+             "D-326 [B8 stale-worker]: stale worker_exit must not advance the ladder; " <>
+               "refine #{refine_before}→#{refine_after}, attempt #{attempt_before}→#{attempt_after}"
+
+      gate_calls = :counters.get(gate_called_ref, 1)
+
+      assert gate_calls == 0,
+             "D-326: stale worker_exit must not call gate_fun; called #{gate_calls} times"
+
+      refute_received {:unit_terminal, ^unit_id, _outcome, _prov},
+                      "D-326 [B8 stale-worker]: stale worker_exit must not produce any terminal report"
+    end
+  end
+end


### PR DESCRIPTION
## #490 (A3) — non-deterministic `work_ready`/diff: route semantic `worker_exit` to the retry ladder

Closes #490. **Not an ARCH GAP** — the contract is already pinned in SPEC-FACTORY-CORE §3 [C111b-B8] (L319-326) and [C105-B5]: the three worker-outcome events (`work_ready` / `worker_exit` / `worker_stalled`) are disjoint, keyed by `worker_id`; exit-0-without-`work_ready` crosses as `worker_exit(w, :no_work_product)` and is "**routed to the retry ladder, never gated**" (D-326). A worktree-add or agent failure surfaces as `worker_exit(w, :error)` and "**enters the retry ladder**" (L274). This PR makes `Tau.Factory.Unit` honour that already-specified routing.

### Problem
A real agent's output is non-deterministic: empty diff, partial fix, multi-file change, or failure. #486 (C1) + #487 (A1) landed the producer side (real `head_sha`, the shim's `:no_work_product`/non-zero-exit mapping in `worker.ex`). But the **Unit consumer** has no `{:worker_exit, worker_id, reason}` handler in `implementing/3`: a semantic non-completion (empty diff → `:no_work_product`; agent failure → `:error`/`{:exit_status,n}`) currently trips the Unit's OWN `Process.monitor` `:DOWN` clause → `escalate(:E_WORKER_DOWN)`, conflating "agent ran but produced nothing/failed" (which MUST refine) with a genuine infra crash (which escalates). Empty/partial/multi-file/fail are not handled distinctly.

### Scope & order
1. Add `implementing(:info, {:worker_exit, ^worker_id, reason}, ...)` handlers keyed by the current `worker_id`:
   - semantic reasons (`:no_work_product`, `:error`, `{:exit_status, _}`) → **retry ladder** (the same `Tau.Factory.Retry.next/3` path `gating {:fail,_}` uses: bump `refine_count` → `:implementing`; bounded → `:pivot` → `:exhausted` → `escalate(:E_RETRY_EXHAUSTED)`).
   - demonitor the Unit's own monitor so the consequent `:DOWN` does NOT also escalate (disjointness — one worker exit, one outcome).
   - stale-worker `{:worker_exit, _other, _}` → discard (keyed by `worker_id`, B8).
2. Preserve the genuine-infra-crash path: a `:DOWN` with NO preceding semantic `worker_exit` → `E_WORKER_DOWN` (unchanged).
3. Verify the four non-deterministic cases end-to-end: empty→retry, failure→retry, non-empty(real head_sha, incl. multi-file/partial)→gate, infra-crash→escalate.

### Dependencies
Blocked-by: #486 (C1, merged), #487 (A1, merged). Both landed. Blocks the capstone #501's robustness.

### SPECs
SPEC-FACTORY-CORE — conforms to §3 [C111b-B8]/[C105-B5]/L274 (D-326 worker-outcome routing); advances **D-326** (the `worker_exit → retry ladder` clause). No new D-NNN; whether a §4 B8 contract clarification is needed surfaces during impl.

### Acceptance criteria
- **D-326** — the Unit routes `worker_exit(worker_id, :no_work_product)` and `worker_exit(worker_id, :error | {:exit_status, n})` (current-worker-keyed) into the retry ladder (refine → pivot → exhausted), NEVER to the gate and NEVER directly to `E_WORKER_DOWN`; a genuine infra `:DOWN` (no preceding semantic `worker_exit`) still escalates `E_WORKER_DOWN`; `work_ready` / `worker_exit` / `worker_stalled` remain disjoint and `worker_id`-keyed; a stale-worker `worker_exit` is discarded.

### Gating-test paths (frozen at 4b)
- `test/tau/factory/unit_worker_exit_test.exs` — D-326: `:no_work_product`→retry, `:error`/`{:exit_status,n}`→retry, bounded→`E_RETRY_EXHAUSTED`, genuine `:DOWN`→`E_WORKER_DOWN` (regression guard), consequent-`:DOWN`-suppressed (disjointness), stale-worker discarded.
### Gate verdicts
**Attempt 1 — RED (refine).**
- **critic: FAIL** — V1/temporal race: the Unit `Process.monitor`s the 3-tuple worker AND receives `worker_exit` from the worker's independent death monitor (two senders, no mailbox ordering). `demonitor([:flush])` only suppresses `:DOWN` if `worker_exit` is processed FIRST; the one-hop BEAM `:DOWN` likely beats the two-hop `worker_exit` → the `:DOWN` clause escalates `E_WORKER_DOWN`, falsifying D-326 ("worker_exit → retry ladder, never E_WORKER_DOWN"). Also: the gating tests keep the worker ALIVE and hand-send `worker_exit`, so no competing `:DOWN` is produced — they never exercise the production race. (D-318 shared-helper refactor itself is sound — preserved exactly.)
- reviewer: (interrupted; critic FAIL is decisive — gate RED.)

**Refine plan:** the Unit MUST NOT self-monitor the 3-tuple (`worker_id`-keyed) worker for outcome determination — rely on `worker_exit` (authoritative single-writer death-cert, C202) + `worker_stalled` (liveness) so the raw BEAM `:DOWN` cannot pre-empt the semantic outcome. Keep the `:DOWN`→`E_WORKER_DOWN` path for the legacy 2-tuple seam (`worker_id == nil`) only. Test-author: add a gating test that exercises the REAL race (actually exit/kill the worker so a genuine `:DOWN` competes with `worker_exit`), not a hand-sent message to a live worker.

**Attempt 1 re-gate — GREEN (merge).** critic PASS (race closed via `is_nil(worker_id)` guard on both `:DOWN` clauses; D-318 `advance_retry_ladder` unchanged) + reviewer PASS (9/9 gating, 1625/0 suite, CI green all variants, mutation-probe confirms the guard load-bearing; the earlier '3 failures' did not reproduce locally or in CI).