### PR TITLE
#489 (A2) — brief/issue→prompt assembler [ARCH GAP → shaper+D-NNN]

### DIFF
--- a/docs/MISSION.md
+++ b/docs/MISSION.md
@@ -81,7 +81,7 @@ Block-to-SPEC allocation:
 | D-300 – D-303, D-341 | SPEC-FACTORY-MERGE |
 | D-304 – D-308, D-322, D-323, D-354 | SPEC-FACTORY-GATE |
 | D-309 – D-311, D-313, D-314, D-316, D-334, D-364 – D-367 | SPEC-FACTORY-FLEET |
-| D-312, D-315, D-317, D-318, D-320, D-321, D-330 – D-333, D-335, D-336, D-340, D-342 – D-344, D-355 – D-359, D-369 – D-371 | SPEC-FACTORY-CORE |
+| D-312, D-315, D-317, D-318, D-320, D-321, D-330 – D-333, D-335, D-336, D-340, D-342 – D-344, D-355 – D-359, D-369 – D-373 | SPEC-FACTORY-CORE |
 | D-319, D-351 – D-353, D-374 | SPEC-FACTORY-GOV |
 | D-361 – D-363 | SPEC-FACTORY-CORE (C1 unit-coordinate identity; PR #503) |
 | D-300 – D-380 | reserved — SPEC-FACTORY-\* family (autonomous factory; `docs/arch/`) |

--- a/docs/arch/04-software-architecture/control-plane.md
+++ b/docs/arch/04-software-architecture/control-plane.md
@@ -384,6 +384,65 @@ test wired a real string-scope work-item into a real Scheduler. The elaboration
 makes `IssueSelector → Scheduler → ConflictCheck` type-correct on a real issue
 (SPEC-FACTORY-CORE [C124-B10]).
 
+### 2.7 Where the agent's prompt comes from — issue → `task.prompt` (A2; D-372/D-373)
+
+§2.6 projects the issue onto the *Scheduler's* admission predicate (a
+`ConflictCheck.scope()`). This subsection records the **disjoint, parallel
+projection** onto the *agent's* task: the issue (and its full context) → the shim's
+`Tau.CodingAgent.task.prompt :: String.t()`. It is the autonomous analogue of the
+human coordinator's draft-PR-body implementer brief (`factory-loop.md`): without
+it, a real agent (A1, `Tau.CodingAgents.ClaudeCode`) is handed an empty prompt and
+has nothing to solve. The boundary detail is SPEC-FACTORY-CORE §4 B10 (PR #508
+amendment); the D-NNN are D-372/D-373.
+
+**The gap (V3, an orphaned input).** The `work_item` already carries every input a
+brief needs — the `issue_map` (body/labels), the elaborated `declared_scope`
+(§2.6), and downstream the test-author's gating-test paths and the cited SPEC/AC/
+D-NNN. Yet `to_unit_work_item/1` sets `brief: title` and the shim hardcodes
+`task.prompt = ""`. The brief crossing **loses everything but the title**: the
+inputs exist but no component composes them into the prompt. The `BriefAssembler`
+is the intake component that consumes those inputs (V3 — every stated input is
+actually consumed; V12 — no machinery that enforces nothing).
+
+**The composition contract (D-372).** The default assembler emits a labelled,
+section-structured Markdown prompt with one section per input — issue body,
+declared scope, gating-test paths, SPEC/AC/D-NNN refs — **plus a mandatory
+arch-pointer section** carrying at least the `docs/arch/04-software-architecture/`
+root. The arch section is non-negotiable: Tau memory
+`feedback_brief_implementers_with_arch` requires pointing agents at the worked-out
+architecture, not only SPEC §-refs. Every *present* input appears, labelled; an
+*absent* optional input degrades to an explicit "(none declared)" placeholder — a
+missing input never crashes the assembler and never silently drops its section.
+
+**The discriminating question — static template vs richer assembly vs LLM, and why
+a heuristic template is the default (the cheapest-to-reverse decision, mirroring
+§2.6/D-370).** The fact that decides the mechanism is the same one that decided the
+elaborator: *who can be held to the contract on the synchronous intake path*. An
+LLM prompt author is unauditable and network-bound on a path that must be fast and
+deterministic; a static template over inputs already in the `work_item` is pure,
+testable with fixtures, and complete-over-its-inputs by construction. The heuristic
+template is therefore the default (D-372), reached through an **injected pure seam**
+`:assemble_fun :: (input -> String.t())` (D-373) — the established `*_fun` pattern —
+so a stronger, separately-verified LLM prompt author is a *substitution*, not a
+rewrite of `Supervisor`/`UnitDriver`/`Worker`, if prompt quality ever justifies the
+cost. This is the exact shape §2.6 chose for `:elaborate_fun`, applied to the
+prompt projection.
+
+**No impossibility hidden here (V1).** Unlike the elaborator — where free issue
+text cannot yield a *provably complete* impact set, forcing the over-declare bias —
+the assembler has no completeness obligation to fake: it composes the inputs it
+*has*; it does not infer inputs it lacks. Partial inputs are a *normal* state
+(early-phase issues, no gating-test paths yet), handled by graceful degradation,
+not an error. For any non-empty issue the assembler returns a non-empty prompt.
+
+**Invocation point and the unchanged downstream path.** `to_unit_work_item/1`
+(`supervisor.ex`) is the single assembly site; it swaps `brief: title` for
+`brief: BriefAssembler.assemble(%{issue: issue, declared_scope: scope, …})`. The
+assembled brief rides the *existing* `UnitDriver → WorkerSupervisor → Worker → shim`
+path unchanged — no new boundary. The A1 shim wiring (`task.prompt = brief` instead
+of `""`) is the consumer side; A2 owns the assembler and the contract that
+`task.prompt` equals the assembled brief.
+
 ---
 
 ## 3. U — Unit/PR FSM (`gen_statem` per entity)

--- a/docs/spec/SPEC-FACTORY-CORE.md
+++ b/docs/spec/SPEC-FACTORY-CORE.md
@@ -329,6 +329,25 @@ Format: `[Cn-Bm]` = constraint number + boundary. **★** marks non-obvious.
 - **[C112-B10]** The external tracker is the authority for *what to build*; L is
   the authority for *what has been done*. The reconciliation pass crosses this
   boundary read-only (the tracker is projected, never a second writer of L).
+- **★ [C131-B8] The agent's task crosses to the Worker as an assembled prompt,
+  not a bare issue title (A2, D-372/D-373).** The fact "here is the task to solve"
+  crosses from intake (the `work_item`) to the agent (the shim's
+  `Tau.CodingAgent.task.prompt`) through the Worker's `:brief`. Today the brief is
+  set to the issue *title* alone (`supervisor.ex:to_unit_work_item/1`), and the
+  scripted agent ignores it (`task.prompt = ""`). A real agent driven by the
+  A1 shim (`Tau.CodingAgents.ClaudeCode`) has nothing to solve from a title. The
+  information that MUST survive the crossing is the autonomous analogue of the
+  human coordinator's draft-PR-body implementer brief (`factory-loop.md`): the
+  **issue body**, the **linked SPEC/AC/D-NNN context**, the **declared scope**
+  (`ConflictCheck.scope()`, B10/I2), the **gating-test paths**, and the **arch
+  pointers** (`docs/arch/04-software-architecture/*` — per Tau memory
+  `feedback_brief_implementers_with_arch`, NOT only SPEC §-refs). No component
+  assembles this; the brief crossing *loses everything but the title*. The
+  `BriefAssembler` (§4 B10 amendment below, D-372) is the intake component that
+  composes the available inputs into `task.prompt`, mirroring how the
+  `:elaborate_fun` seam composes the issue into `ConflictCheck.scope()`. The
+  assembly is a pure function of inputs already present in the `work_item` plus
+  static arch pointers — no LLM call on the assembly path (D-373).
 - **★ [C113-B3]** **Resume-read routed through the writer process.** The
   resume-read op `Ledger.Reader.latest_unit_snapshots/1` is routed through
   the `Ledger.Writer` GenServer process via `GenServer.call/2` — NOT through a
@@ -776,6 +795,79 @@ the B11 supervisor/seam contract that follows.
   only populates the `issue_map`'s real fields; the `body` / `labels` keys the
   heuristic reads are already in the §4 B10 `--json` projection. No ordering
   dependency in either direction — referenced, not implemented here.
+
+**Amendment (PR #508 / B10, A2 — brief/issue → prompt assembler; D-372, D-373).**
+The B10 amendment above turns the issue into a *declared scope*; this amendment
+turns the issue (and its full context) into the *agent's prompt*. The two are
+disjoint intake projections of the same `work_item`: the elaborator feeds the
+Scheduler's admission predicate (a `ConflictCheck.scope()`); the assembler feeds
+the agent's task (a `task.prompt :: String.t()`). This sub-section pins the
+assembler contract.
+
+- **The gap being closed.** `to_unit_work_item/1` (`lib/tau/factory/supervisor.ex`)
+  sets `brief: title` — the brief carried to the Worker is only the issue title;
+  the shim's `task.prompt` is the hardcoded empty string
+  (`coding_agent_shim.ex` Runner: `task = %{prompt: "", workspace: ws, …}`). The
+  scripted Replay agent ignores the prompt, so the dogfood "works" only because no
+  real agent is in the loop. A real agent (A1, `Tau.CodingAgents.ClaudeCode`) needs
+  a real prompt. **[C131-B8]**
+
+- **The assembler component (the seam).** `Tau.Factory.BriefAssembler` is a plain
+  pure functional module (no GenServer — OTP non-negotiable §3). It exposes the
+  assembly through an injected, **pure** seam mirroring `:gh_fun` / `:elaborate_fun`:
+
+  ```
+  Tau.Factory.BriefAssembler.assemble(input :: map(), opts :: keyword()) :: String.t()
+
+  input :: %{
+    required(:issue)            => map(),                  # issue_map: "number","title","body","labels"
+    required(:declared_scope)   => ConflictCheck.scope(),  # the B10/I2 elaborated scope
+    optional(:gating_test_paths)=> [String.t()],           # test-author's declared paths (factory-loop 4b)
+    optional(:spec_refs)        => [String.t()],           # cited SPEC ids / AC-N / D-NNN tokens
+    optional(:arch_pointers)    => [String.t()]            # docs/arch/04-software-architecture/* paths
+  }
+
+  opts:
+    :assemble_fun — ((input) -> String.t())   # default: the heuristic template assembler (D-372)
+  ```
+
+  The injected `:assemble_fun` (D-373) follows the established `*_fun` pattern so a
+  stronger, LLM-assisted prompt author is a *substitution*, not a rewrite — exactly
+  as `:elaborate_fun` (D-370) makes the scope elaborator swappable. The default
+  assembler is pure and network-free: it composes a labelled, section-structured
+  Markdown prompt from the inputs already in the `work_item` plus the static arch
+  pointers; it does NOT call an LLM on the assembly path.
+
+- **Invocation point.** `Tau.Factory.Supervisor.to_unit_work_item/1` is the single
+  assembly site: it already receives `{issue, scope, hash, branch}` from
+  `IssueSelector` and constructs the `work_item` map. It replaces `brief: title`
+  with `brief: BriefAssembler.assemble(%{issue: issue, declared_scope: scope, …})`.
+  The assembled brief then rides the *existing* path unchanged — `UnitDriver.drive/2`
+  → `WorkerSupervisor.spawn/5` → `Worker.init/1` → the shim — so no new boundary is
+  introduced. The shim contract is extended (A1 wiring, not A2) so the Runner sets
+  `task.prompt = brief` instead of `""`; A2 owns the assembler and the contract that
+  `task.prompt` equals the assembled brief; the transport of the brief into the
+  shim's baked config is the A1 implementer's wiring, deliberately not over-pinned
+  here.
+
+- **Composition contract (D-372).** Every input field present in `input` is
+  consumed — appears, labelled, in the assembled prompt (V3: no machinery that
+  enforces nothing; no stated input silently dropped). The issue body, the declared
+  scope, the gating-test paths, the SPEC/AC/D-NNN refs, and the arch pointers each
+  occupy a distinct labelled section. The arch-pointer section is mandatory and
+  non-empty (it carries at least the `docs/arch/04-software-architecture/` root),
+  discharging `feedback_brief_implementers_with_arch`.
+
+- **Graceful-degradation / failure posture (D-373).** The assembler does NOT assume
+  the issue text is complete (V1 — there is no impossibility hidden here: it
+  composes the inputs it *has*, it does not infer the inputs it lacks). An absent
+  optional input degrades to an explicit "(none declared)" marker in its section,
+  never a crash and never a silently-omitted section. For any non-empty issue (a
+  `"number"` and a `"title"`) the assembler returns a non-empty `String.t()`; it
+  never raises on partial input and never returns `""`. Pre: `input` carries at
+  least `:issue` (with `"number"`/`"title"`) and `:declared_scope`. Post: a
+  non-empty prompt whose section set is a superset of `{issue, scope, arch}` and
+  includes every *present* optional input.
 
 ### B11: `Tau.Factory.Supervisor` ↔ {`Tau.Application`, tests} — config-gated assembly + seam-threading (P5c-6, #474; D-357)
 
@@ -1295,6 +1387,31 @@ no post-hoc actual-path check). Enforced by `issue_elaboration_test.exs` (an
 empty-signal issue's scope clears against an empty `F` but defers against any
 non-empty `F`).
 
+**D-372 — Brief assembly is complete over its declared inputs (A2, [C131-B8]):**
+`Tau.Factory.BriefAssembler.assemble/2` composes `task.prompt` from the
+`work_item`'s inputs (issue body, declared `ConflictCheck.scope()`, gating-test
+paths, SPEC/AC/D-NNN refs) **plus** the static `docs/arch/04-software-architecture`
+pointers, and **every input present in `input` appears, labelled, in the assembled
+prompt** — no stated input is silently dropped (V3) and the arch-pointer section is
+mandatory and non-empty (`feedback_brief_implementers_with_arch`). Enforced by
+`brief_assembler_test.exs` (an `input` carrying each field yields a prompt
+containing each field's content under its labelled section, and the arch section is
+present even when no other optional input is supplied).
+
+**D-373 — Assembly is an injected pure seam that degrades, never crashes (A2,
+[C131-B8]):** the issue→prompt mapping is the injected `:assemble_fun ::
+(input -> String.t())` (defaulting to the D-372 heuristic template), following the
+codebase's `*_fun` injection pattern, so (a) a stronger LLM-assisted prompt author
+is a *substitution*, not a rewrite of `Supervisor`/`UnitDriver`/`Worker`, and (b)
+the default is pure and network-free — no LLM call on the assembly path. The
+assembler does not assume the issue text is complete: an absent optional input
+degrades to an explicit placeholder in its section, and for any non-empty issue
+(carrying `"number"`/`"title"`) the assembler returns a non-empty `String.t()`,
+never raising on partial input and never returning `""`. Enforced by
+`brief_assembler_test.exs` (a stub `assemble_fun` is honoured; the default is pure;
+partial input degrades to placeholders without raising; output is always
+non-empty).
+
 ## 7. Acceptance criteria
 
 Each is expressed against the user-facing path with an observable signal.
@@ -1386,6 +1503,8 @@ Files that bring a PR into scope of this SPEC (`D-NNN`/`C-N` → file:symbol):
 - `lib/tau/factory/unit_driver.ex` (D-340, **D-356** `:janitor` threading + no driver-side merge bridge / no driver reclaim; **D-361** build the merge map `hash`/`branch` from the captured `head_sha`; the real `drive_fun` wiring Unit→fleet→gate→merge seams) — PR #477/PR #503
 - `lib/tau/factory/gate/request.ex` (**D-361** `Request.hash` is the captured `head_sha`, not the declared `work_item.hash`; the gate-closure construction site) — PR #503
 - `lib/tau/factory/dogfood/gate_fun.ex` (**D-361/D-363** the arity-1 gate closure receives the coordinate (`head_sha || declared hash`) from the Unit and sets `Request.hash` to it) — PR #503
+- `lib/tau/factory/brief_assembler.ex` (B10/A2; **D-372** complete-over-inputs composition, **D-373** injected `:assemble_fun` pure seam + graceful degradation; the issue→`task.prompt` intake projection, invoked at `supervisor.ex:to_unit_work_item/1`) — PR #508
+- `lib/tau/factory/supervisor.ex` (**D-372** `to_unit_work_item/1` sets `brief:` via `BriefAssembler.assemble/2` instead of `brief: title`) — PR #508
 - `lib/tau/factory/retry.ex` (C8; D-318) — PR-CORE-3
 - `lib/tau/factory/kill_switch.ex` (C9; D-321) — PR-CORE-4
 - `lib/tau/factory/supervisor.ex` + `lib/tau/application.ex` (tree; rest_for_one spine; **D-357** config-gated `start_link/1` assembly + seam-threading, B11; **D-358** `:unit_timeouts` thread; **gate_fun/agent_bin** thread completing the P5c-6 deferral, §4 B11) — PR-CORE-1 / PR #480 / PR #481
@@ -1395,6 +1514,7 @@ Files that bring a PR into scope of this SPEC (`D-NNN`/`C-N` → file:symbol):
 - `test/tau/factory/ledger_durability_test.exs` (D-315) — PR-CORE-1
 - `test/tau/factory/conflict_check_property_test.exs` (D-312, D-343) — PR-CORE-2
 - `test/tau/factory/budget_admission_test.exs` (D-320, D-332) — PR-CORE-2
+- `test/tau/factory/brief_assembler_test.exs` (**D-372** complete-over-inputs composition; **D-373** injected `:assemble_fun` seam, pure default, graceful degradation, non-empty output) — PR #508
 - `test/tau/factory/retry_property_test.exs` (D-318) — PR-CORE-3
 - `test/tau/factory/escalation_property_test.exs` + `unit_timeout_test.exs` (D-317) — PR-CORE-3
 - `test/tau/factory/kill_switch_test.exs` (D-321) — PR-CORE-4
@@ -1418,4 +1538,4 @@ B8 → `SPEC-FACTORY-FLEET` (D-309–D-311, D-313, D-314, D-316); `E-DESTRUCTIVE
 `SPEC-FACTORY-CORE` to `.claude/rules/spec-before-code.md` (catalog) and the
 `D-NNN` block table in `docs/MISSION.md` (D-312, D-315, D-317, D-318, D-320,
 D-321, D-330–D-333, D-335, D-336, D-340, D-342–D-344, D-355–D-359,
-D-361–D-363 → this SPEC).
+D-361–D-363, D-369–D-373 → this SPEC).

--- a/lib/tau/factory/brief_assembler.ex
+++ b/lib/tau/factory/brief_assembler.ex
@@ -191,8 +191,31 @@ defmodule Tau.Factory.BriefAssembler do
     if MapSet.size(set) == 0 do
       "(none declared)"
     else
-      set |> MapSet.to_list() |> Enum.sort() |> Enum.join(", ")
+      set
+      |> MapSet.to_list()
+      |> Enum.sort()
+      |> Enum.map_join(", ", &render_set_member/1)
     end
+  end
+
+  # String members (e.g. :files, :specs, :resources) pass through unchanged.
+  defp render_set_member(member) when is_binary(member), do: member
+
+  # Codepoint tuples {path, :"line_NN"} — produced by IssueSelector for any
+  # "file:line" citation — are rendered as "path:line_number" (e.g. "lib/x.ex:42").
+  # Calling Enum.join on the raw tuples would trigger Protocol.UndefinedError
+  # (String.Chars not implemented for tuples), crashing assemble/2 (D-373).
+  defp render_set_member({path, line_atom})
+       when is_binary(path) and is_atom(line_atom) do
+    line_str = Atom.to_string(line_atom)
+
+    line_number =
+      case String.split(line_str, "line_", parts: 2) do
+        [_, n] -> n
+        _ -> line_str
+      end
+
+    "#{path}:#{line_number}"
   end
 
   defp render_list_or_none([]), do: "(none declared)"

--- a/lib/tau/factory/brief_assembler.ex
+++ b/lib/tau/factory/brief_assembler.ex
@@ -1,0 +1,203 @@
+defmodule Tau.Factory.BriefAssembler do
+  @moduledoc """
+  Pure, network-free assembler that projects a brief/issue map into a
+  `task.prompt` string delivered to the implementer worker.
+
+  ## Contract (D-372 / D-373, SPEC-FACTORY-CORE §4 B10 amendment)
+
+  ### D-372 — Assembly completeness
+
+  `assemble/2` composes a `task.prompt` from all present input fields, each
+  under a distinct labelled section:
+
+    - **Issue** — issue number, title, and body.
+    - **Declared scope** — the `ConflictCheck.scope()` map (files, codepoints,
+      SPEC references, resource locks, deps).
+    - **Gating-test paths** — the frozen gating-test file paths for this PR.
+    - **SPEC / AC / D-NNN references** — acceptance criteria and invariant tokens.
+    - **Architecture pointers** — `docs/arch/04-software-architecture/` links
+      (the pointer section is MANDATORY — present even when no `arch_pointers`
+      key is supplied; carries at minimum the root pointer to discharge
+      `feedback_brief_implementers_with_arch`).
+
+  ### D-373 — Injected pure seam that degrades, never crashes
+
+  The `:assemble_fun` option (signature: `(input :: map()) -> String.t()`)
+  mirrors the `:elaborate_fun` seam on `IssueSelector`. When supplied the
+  injected function's output is returned as-is; the default heuristic
+  assembler is bypassed. The default is pure, deterministic, and network-free.
+
+  Absent optional keys (`gating_test_paths`, `spec_refs`, `arch_pointers`)
+  degrade to `(none declared)` placeholder sections — never a crash, never a
+  silently-omitted section.
+
+  Output is always a non-empty `String.t()` for any non-empty issue map
+  carrying `"number"` and `"title"`.
+
+  ## API
+
+      Tau.Factory.BriefAssembler.assemble(input, [])
+      Tau.Factory.BriefAssembler.assemble(input, assemble_fun: fn input -> "custom" end)
+
+  `input` keys (atoms):
+    - `:issue`             — required; `%{"number" => integer, "title" => string, "body" => string}`
+    - `:declared_scope`    — required; a `ConflictCheck.scope()` map
+    - `:gating_test_paths` — optional; `[String.t()]`
+    - `:spec_refs`         — optional; `[String.t()]`
+    - `:arch_pointers`     — optional; `[String.t()]`
+  """
+
+  @default_arch_root "docs/arch/04-software-architecture"
+
+  @doc """
+  Assemble a `task.prompt` string from the given `input` map.
+
+  Returns a non-empty `String.t()`. Never raises on partial input.
+  When `:assemble_fun` is supplied in `opts`, delegates to it entirely.
+  """
+  @spec assemble(map(), keyword()) :: String.t()
+  def assemble(input, opts) do
+    assemble_fun = Keyword.get(opts, :assemble_fun)
+
+    if assemble_fun do
+      assemble_fun.(input)
+    else
+      default_assemble(input)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Default heuristic assembler (D-372 template, pure and deterministic)
+  # ---------------------------------------------------------------------------
+
+  defp default_assemble(input) do
+    issue = Map.fetch!(input, :issue)
+    declared_scope = Map.fetch!(input, :declared_scope)
+    gating_test_paths = Map.get(input, :gating_test_paths)
+    spec_refs = Map.get(input, :spec_refs)
+    arch_pointers = Map.get(input, :arch_pointers)
+
+    sections = [
+      issue_section(issue),
+      scope_section(declared_scope),
+      gating_tests_section(gating_test_paths),
+      spec_refs_section(spec_refs),
+      arch_pointers_section(arch_pointers)
+    ]
+
+    Enum.join(sections, "\n\n")
+  end
+
+  defp issue_section(issue) do
+    number = Map.get(issue, "number", "?")
+    title = Map.get(issue, "title", "")
+    body = Map.get(issue, "body", "")
+
+    body_text =
+      case body do
+        nil -> "(none declared)"
+        "" -> "(none declared)"
+        b -> b
+      end
+
+    """
+    ## Issue ##{number}: #{title}
+
+    #{body_text}
+    """
+    |> String.trim_trailing()
+  end
+
+  defp scope_section(scope) do
+    files = Map.get(scope, :files, MapSet.new())
+    codepoints = Map.get(scope, :codepoints, MapSet.new())
+    specs = Map.get(scope, :specs, MapSet.new())
+    resources = Map.get(scope, :resources, MapSet.new())
+    deps = Map.get(scope, :deps, [])
+
+    files_text = render_set_or_none(files)
+    codepoints_text = render_set_or_none(codepoints)
+    specs_text = render_set_or_none(specs)
+    resources_text = render_set_or_none(resources)
+    deps_text = render_list_or_none(deps)
+
+    """
+    ## Declared Scope
+
+    **Files:** #{files_text}
+    **Codepoints:** #{codepoints_text}
+    **SPEC references:** #{specs_text}
+    **Resources:** #{resources_text}
+    **Dependencies:** #{deps_text}
+    """
+    |> String.trim_trailing()
+  end
+
+  defp gating_tests_section(nil), do: gating_tests_section([])
+
+  defp gating_tests_section(paths) do
+    content = render_list_or_none(paths)
+
+    """
+    ## Gating-Test Paths
+
+    #{content}
+    """
+    |> String.trim_trailing()
+  end
+
+  defp spec_refs_section(nil), do: spec_refs_section([])
+
+  defp spec_refs_section(refs) do
+    content = render_list_or_none(refs)
+
+    """
+    ## SPEC / AC / D-NNN References
+
+    #{content}
+    """
+    |> String.trim_trailing()
+  end
+
+  defp arch_pointers_section(nil), do: arch_pointers_section([])
+
+  defp arch_pointers_section([]) do
+    # D-372: arch-pointer section is mandatory; when no pointers supplied,
+    # include the root pointer to discharge feedback_brief_implementers_with_arch.
+    """
+    ## Architecture Pointers
+
+    - #{@default_arch_root}/
+    """
+    |> String.trim_trailing()
+  end
+
+  defp arch_pointers_section(pointers) do
+    content = Enum.map_join(pointers, "\n", fn p -> "- #{p}" end)
+
+    """
+    ## Architecture Pointers
+
+    #{content}
+    """
+    |> String.trim_trailing()
+  end
+
+  # ---------------------------------------------------------------------------
+  # Helpers
+  # ---------------------------------------------------------------------------
+
+  defp render_set_or_none(set) when is_struct(set, MapSet) do
+    if MapSet.size(set) == 0 do
+      "(none declared)"
+    else
+      set |> MapSet.to_list() |> Enum.sort() |> Enum.join(", ")
+    end
+  end
+
+  defp render_list_or_none([]), do: "(none declared)"
+
+  defp render_list_or_none(list) when is_list(list) do
+    Enum.join(list, ", ")
+  end
+end

--- a/lib/tau/factory/brief_assembler.ex
+++ b/lib/tau/factory/brief_assembler.ex
@@ -198,7 +198,7 @@ defmodule Tau.Factory.BriefAssembler do
     end
   end
 
-  # String members (e.g. :files, :specs, :resources) pass through unchanged.
+  # String members (e.g. :files) pass through unchanged.
   defp render_set_member(member) when is_binary(member), do: member
 
   # Codepoint tuples {path, :"line_NN"} — produced by IssueSelector for any
@@ -217,6 +217,15 @@ defmodule Tau.Factory.BriefAssembler do
 
     "#{path}:#{line_number}"
   end
+
+  # Atom members (e.g. :spec_FACTORY_CORE from extract_specs/1, :resource_gh_api
+  # from label-derived resources) — render as their string name so spec identifiers
+  # remain legible in the assembled brief (D-373 totality over real scope types).
+  defp render_set_member(member) when is_atom(member), do: Atom.to_string(member)
+
+  # Catch-all: any unforeseen member shape falls back to inspect/1 so the renderer
+  # can never raise on an unexpected type (D-373 "never raises" is absolute).
+  defp render_set_member(other), do: inspect(other)
 
   defp render_list_or_none([]), do: "(none declared)"
 

--- a/lib/tau/factory/supervisor.ex
+++ b/lib/tau/factory/supervisor.ex
@@ -40,6 +40,7 @@ defmodule Tau.Factory.Supervisor do
 
   use Supervisor
 
+  alias Tau.Factory.BriefAssembler
   alias Tau.Factory.Budget.Owner, as: BudgetOwner
   alias Tau.Factory.Fleet.Watchdog
   alias Tau.Factory.KillSwitch
@@ -310,7 +311,9 @@ defmodule Tau.Factory.Supervisor do
 
   defp to_unit_work_item({issue, _scope, hash, branch}) do
     number = Map.get(issue, "number", 0)
-    title = Map.get(issue, "title", "")
+
+    brief =
+      BriefAssembler.assemble(%{issue: issue, declared_scope: @empty_scope}, [])
 
     %{
       unit_id: "unit-#{number}",
@@ -325,7 +328,7 @@ defmodule Tau.Factory.Supervisor do
       # after the oracle emits work_ready, without waiting for the oracle's
       # worktree to be reclaimed (D-358 / SPEC-FACTORY-CORE §4 B11).
       oracle_base_ref: "origin/#{branch}",
-      brief: title
+      brief: brief
     }
   end
 

--- a/lib/tau/factory/supervisor.ex
+++ b/lib/tau/factory/supervisor.ex
@@ -299,8 +299,8 @@ defmodule Tau.Factory.Supervisor do
   #   unit_id   — "unit-<number>" (B10 / D-331 / [C112-B10])
   #   run       — "run-1" (initial run identifier)
   #   base_ref  — branch (the feature branch the worker checks out)
-  #   brief     — issue title (or empty string)
-  #   declared_scope — empty scope (dogfood uses a single-unit run)
+  #   brief     — assembled prompt from BriefAssembler.assemble/2 (D-372)
+  #   declared_scope — the real elaborated scope threaded from the 4-tuple
   @empty_scope %{
     deps: [],
     files: MapSet.new(),

--- a/lib/tau/factory/supervisor.ex
+++ b/lib/tau/factory/supervisor.ex
@@ -309,15 +309,15 @@ defmodule Tau.Factory.Supervisor do
     resources: MapSet.new()
   }
 
-  defp to_unit_work_item({issue, _scope, hash, branch}) do
+  defp to_unit_work_item({issue, scope, hash, branch}) do
     number = Map.get(issue, "number", 0)
 
     brief =
-      BriefAssembler.assemble(%{issue: issue, declared_scope: @empty_scope}, [])
+      BriefAssembler.assemble(%{issue: issue, declared_scope: scope}, [])
 
     %{
       unit_id: "unit-#{number}",
-      declared_scope: @empty_scope,
+      declared_scope: scope,
       hash: hash,
       branch: branch,
       run: "run-1",

--- a/test/tau/factory/brief_assembler_test.exs
+++ b/test/tau/factory/brief_assembler_test.exs
@@ -456,4 +456,163 @@ defmodule Tau.Factory.BriefAssemblerTest do
                "input=#{inspect(input)}"
     end
   end
+
+  # ---------------------------------------------------------------------------
+  # D-373(e): non-empty codepoints must render readably — no Protocol.UndefinedError
+  #
+  # The bug: render_set_or_none/1 calls Enum.join/2 on the codepoints MapSet.
+  # When codepoints contains {path, :"line_NN"} tuples (the shape produced by
+  # IssueSelector for any "file:line" citation, e.g. "lib/x.ex:42"), Enum.join
+  # invokes String.Chars on each tuple element → Protocol.UndefinedError → crash.
+  # All earlier D-373 tests use empty_scope() (codepoints: MapSet.new()), so
+  # they never exercise this path. D-373 says assemble/2 "never raises"; a crash
+  # on the IssueSelector's native codepoints shape falsifies that invariant.
+  #
+  # Expected human-readable form: "lib/x.ex:42" (path + ":" + line number),
+  # NOT the raw Elixir tuple inspect "{\"lib/x.ex\", :line_42}".
+  #
+  # PRE-IMPL FAILURE: Protocol.UndefinedError (String.Chars not implemented for
+  # tuples) raised inside assemble/2 when codepoints is non-empty.
+  # ---------------------------------------------------------------------------
+  @tag :d_373
+  test "D-373(e): assemble/2 with non-empty codepoints ({path, :line_NN} tuples) must not raise and must render each codepoint readably" do
+    # This is the exact shape IssueSelector.elaborate_scope/1 produces for any
+    # "file:line" citation (line 192 of issue_selector.ex):
+    #   MapSet.new(file_line_pairs, fn {path, line} -> {path, :"line_#{line}"} end)
+    codepoints =
+      MapSet.new([
+        {"lib/x.ex", :line_42},
+        {"lib/y.ex", :line_7}
+      ])
+
+    input = %{
+      issue: issue(489, "D-373(e) non-empty codepoints", body: "Touches lib/x.ex:42."),
+      declared_scope: %{
+        deps: [],
+        files: MapSet.new(),
+        codepoints: codepoints,
+        specs: MapSet.new(),
+        resources: MapSet.new()
+      }
+    }
+
+    # Must not raise — Protocol.UndefinedError is the pre-fix failure mode.
+    result =
+      try do
+        BriefAssembler.assemble(input, [])
+      rescue
+        err ->
+          flunk(
+            "D-373(e): assemble/2 must NOT raise when codepoints is non-empty; " <>
+              "the IssueSelector produces {path, :line_NN} tuples for any file:line " <>
+              "citation, and render_set_or_none/1 called Enum.join on them which " <>
+              "crashes with Protocol.UndefinedError (String.Chars not impl for tuple). " <>
+              "Got exception: #{inspect(err)}"
+          )
+      end
+
+    assert is_binary(result),
+           "D-373(e): assemble/2 must return a String.t() when codepoints is non-empty; " <>
+             "got: #{inspect(result)}"
+
+    assert result != "",
+           "D-373(e): assemble/2 must return a non-empty String.t() when codepoints is non-empty"
+
+    # Each codepoint must appear in a human-readable form containing both the
+    # path and the line number. The canonical human form is "lib/x.ex:42".
+    # Asserting path + ":" + line number as the essential facts; exact separator
+    # style is the implementation's choice as long as both parts are present and
+    # readable (not a raw tuple inspect like "{\"lib/x.ex\", :line_42}").
+    assert result =~ "lib/x.ex",
+           "D-373(e): path 'lib/x.ex' must appear in the assembled prompt; " <>
+             "got: #{inspect(result)}"
+
+    assert result =~ "42",
+           "D-373(e): line number '42' must appear in the assembled prompt for " <>
+             "codepoint {\"lib/x.ex\", :line_42}; got: #{inspect(result)}"
+
+    assert result =~ "lib/y.ex",
+           "D-373(e): path 'lib/y.ex' must appear in the assembled prompt; " <>
+             "got: #{inspect(result)}"
+
+    assert result =~ "7",
+           "D-373(e): line number '7' must appear in the assembled prompt for " <>
+             "codepoint {\"lib/y.ex\", :line_7}; got: #{inspect(result)}"
+
+    # Must NOT contain raw tuple inspect — that would be an unreadable brief.
+    refute result =~ ~s({"lib/x.ex", :line_42}),
+           "D-373(e): assembled prompt must NOT contain raw tuple inspect form " <>
+             ~s({"lib/x.ex", :line_42}; ) <>
+             "render each codepoint as a human-readable string (e.g. 'lib/x.ex:42'); " <>
+             "got: #{inspect(result)}"
+  end
+
+  # ---------------------------------------------------------------------------
+  # D-373(f): D-373 never-raises guarantee is exercised against the crashing input
+  #           (non-empty codepoints in scope — the realistic IssueSelector shape)
+  #
+  # This extends D-373(d)'s "never raises / always non-empty String" invariant to
+  # the realistic codepoints shape. D-373(d) only iterates over scopes where
+  # codepoints is MapSet.new() (empty), so the never-raises claim was never
+  # exercised against the input that actually crashes the production path.
+  #
+  # PRE-IMPL FAILURE: Protocol.UndefinedError raised in assemble/2 for the
+  # non-empty-codepoints input shape.
+  # ---------------------------------------------------------------------------
+  @tag :d_373
+  test "D-373(f): D-373 never-raises guarantee holds for scopes with non-empty codepoints — the realistic IssueSelector output shape" do
+    # Multiple representative inputs: one codepoint, multiple codepoints, large
+    # line numbers — all valid IssueSelector output shapes.
+    realistic_inputs = [
+      %{
+        issue: issue(489, "Single codepoint"),
+        declared_scope: %{
+          deps: [],
+          files: MapSet.new(),
+          codepoints: MapSet.new([{"lib/tau/factory/brief_assembler.ex", :line_59}]),
+          specs: MapSet.new(),
+          resources: MapSet.new()
+        }
+      },
+      %{
+        issue: issue(489, "Multiple codepoints with files"),
+        declared_scope: %{
+          deps: [],
+          files: MapSet.new(["lib/tau/factory/supervisor.ex"]),
+          codepoints:
+            MapSet.new([
+              {"lib/tau/factory/brief_assembler.ex", :line_73},
+              {"lib/tau/factory/issue_selector.ex", :line_192},
+              {"test/tau/factory/brief_assembler_test.exs", :line_1}
+            ]),
+          specs: MapSet.new(["SPEC-FACTORY-CORE"]),
+          resources: MapSet.new()
+        },
+        gating_test_paths: ["test/tau/factory/brief_assembler_test.exs"],
+        spec_refs: ["D-372", "D-373"]
+      }
+    ]
+
+    for input <- realistic_inputs do
+      result =
+        try do
+          BriefAssembler.assemble(input, [])
+        rescue
+          err ->
+            flunk(
+              "D-373(f): assemble/2 must not raise for realistic codepoints input " <>
+                "#{inspect(input)}; Protocol.UndefinedError on tuple codepoints is the " <>
+                "known crash. Got: #{inspect(err)}"
+            )
+        end
+
+      assert is_binary(result),
+             "D-373(f): assemble/2 must return a String.t() for realistic codepoints " <>
+               "input #{inspect(input)}; got: #{inspect(result)}"
+
+      assert result != "",
+             "D-373(f): assemble/2 must never return an empty string for realistic " <>
+               "codepoints input #{inspect(input)}"
+    end
+  end
 end

--- a/test/tau/factory/brief_assembler_test.exs
+++ b/test/tau/factory/brief_assembler_test.exs
@@ -151,7 +151,8 @@ defmodule Tau.Factory.BriefAssemblerTest do
   end
 
   # ---------------------------------------------------------------------------
-  # D-372(c): Supervisor.to_unit_work_item/1 sets :brief to the assembled prompt
+  # D-372(c): Supervisor.to_unit_work_item/1 sets :brief to the assembled prompt,
+  #           AND projects the real declared_scope (not @empty_scope) into it.
   #
   # SPEC: "Tau.Factory.Supervisor.to_unit_work_item/1 is the single assembly
   # site: it replaces `brief: title` with
@@ -160,19 +161,42 @@ defmodule Tau.Factory.BriefAssemblerTest do
   #
   # The invocation point is exercised via the REAL public path:
   # Supervisor.start_link/1 (enabled: true) wraps to_unit_work_item/1 inside
-  # wrapped_drive_fun, so we inject a sentinel drive_fun that captures the
-  # work_item it receives, deliver one open issue via gh_fun, and inspect :brief.
+  # wrapped_drive_fun, so we inject a sentinel drive_fun that receives the
+  # assembled work_item and sends it to the test process for inspection.
   #
-  # PRE-IMPL FAILURE: the current wrapped_drive_fun calls to_unit_work_item/1
-  # which sets `brief: title` (the bare issue title). This test asserts that
-  # :brief != the bare title and contains the mandatory arch pointer. When
-  # BriefAssembler does not exist the Supervisor fails to start (or compile),
-  # so the start_supervised! call itself fails before the drive_fun is reached.
-  # Either way the test fails — compile error or assertion failure.
+  # Synchronization: the sentinel sends {:d372c_drive_called, work_item} to
+  # the test pid. assert_receive with a 5 000 ms deadline is deterministic
+  # under full-suite load (replaces the flaky Process.sleep/1 that caused
+  # intermittent failures at seed values where 112 async cases starve the
+  # Coordinator's first loop iteration past the 300 ms window).
+  #
+  # Scope assertion (D-372 declared_scope projection):
+  # The issue body mentions `lib/tau/factory/d372_scope_sentinel.ex` (no
+  # line citation), which the default IssueSelector elaborator places into
+  # the scope's :files set. to_unit_work_item/1 MUST pass that scope to
+  # BriefAssembler.assemble/2 rather than the hard-wired @empty_scope.
+  # The assembled :brief must therefore contain the sentinel filename.
+  # This assertion FAILS against the current impl that discards `_scope`
+  # and always passes @empty_scope — the brief will say "(none declared)"
+  # for the Declared Scope section instead of the sentinel filename.
+  #
+  # PRE-IMPL FAILURE (scope): assertion failure — brief contains
+  # "(none declared)" instead of the sentinel file.
+  # PRE-IMPL FAILURE (compile): if BriefAssembler does not exist, the
+  # Supervisor fails to compile and start_supervised! raises.
   # ---------------------------------------------------------------------------
+
+  # Sentinel file that must appear in the assembled brief when scope is
+  # threaded correctly. Must not match any real file to avoid false positives.
+  @d372c_scope_sentinel "lib/tau/factory/d372_scope_sentinel.ex"
+
   @tag :d_372
   @tag :capture_log
-  test "D-372(c): Supervisor.to_unit_work_item/1 sets :brief to the assembled prompt, not the bare title" do
+  test "D-372(c): Supervisor.to_unit_work_item/1 sets :brief to the assembled prompt, not the bare title, and projects the real declared_scope" do
+    # Capture test pid BEFORE start_supervised! so the sentinel closure
+    # can send to it deterministically.
+    test_pid = self()
+
     # Throwaway git repo (mirrors merge_result_pubsub_test.exs pattern).
     repo_dir = Briefly.create!(type: :directory)
     git = fn args -> System.cmd("git", args, cd: repo_dir, stderr_to_stdout: true) end
@@ -186,23 +210,26 @@ defmodule Tau.Factory.BriefAssemblerTest do
     db_path = Briefly.create!(extname: ".db")
     sup_name = :"brief_asm_d372c_#{System.unique_integer([:positive])}"
 
-    # Shared cell to capture the work_item passed to our sentinel drive_fun.
-    capture = :ets.new(:d372c_capture, [:public, :set])
-
-    # An open issue with a known title and body.
+    # Issue body references @d372c_scope_sentinel (no line number), so the
+    # default IssueSelector elaborator puts it into the scope's :files set.
+    # to_unit_work_item/1 must thread this scope through to BriefAssembler.
     bare_title = "A2: brief/issue→prompt assembler"
 
     issue_map =
-      issue(489, bare_title, body: "Build BriefAssembler for real agents. References D-372.")
+      issue(489, bare_title,
+        body:
+          "Build BriefAssembler for real agents. References D-372.\n" <>
+            "Touches #{@d372c_scope_sentinel}."
+      )
 
     gh_fun = fn _milestone -> {:ok, [issue_map]} end
 
-    # Sentinel drive_fun: captures the work_item then returns :ok to satisfy
-    # the Coordinator's drive_fun contract (§4 B10).
+    # Sentinel drive_fun: sends the work_item to the test process and returns
+    # a stub pid to satisfy the Coordinator's drive_fun arity-2 contract.
+    # Uses send/2 rather than ETS so synchronization is a single assert_receive
+    # with no polling loop and no fixed sleep.
     sentinel_drive_fun = fn work_item, _deps ->
-      :ets.insert(capture, {:work_item, work_item})
-      # Prevent the Coordinator from trying to start a real Unit (no agent_bin
-      # in this test scope — just return a stub pid-ish value).
+      send(test_pid, {:d372c_drive_called, work_item})
       spawn(fn -> :ok end)
     end
 
@@ -222,24 +249,22 @@ defmodule Tau.Factory.BriefAssemblerTest do
         id: sup_name
       )
 
-    # Give the Coordinator one cycle to call select_fun → drive_fun.
-    Process.sleep(300)
+    # Deterministic synchronization: wait for the Coordinator to call drive_fun.
+    # 5 000 ms is generous; a loaded CI machine typically reaches drive_fun in
+    # < 100 ms. assert_receive fails immediately on timeout rather than silently
+    # succeeding when the sleep outlasts the coordinator's first iteration.
+    assert_receive {:d372c_drive_called, work_item},
+                   5_000,
+                   "D-372(c): timed out waiting for drive_fun to be called — " <>
+                     "the Coordinator did not reach drive_fun within 5 s. " <>
+                     "Likely BriefAssembler is missing (compile error) or the " <>
+                     "supervisor did not select the injected issue."
 
-    brief =
-      case :ets.lookup(capture, :work_item) do
-        [{:work_item, work_item}] ->
-          Map.get(work_item, :brief, :__missing__)
-
-        [] ->
-          :not_captured
-      end
+    brief = Map.get(work_item, :brief, :__missing__)
 
     assert is_binary(brief),
            "D-372(c): the work_item :brief delivered to drive_fun must be a String.t(); " <>
-             "got: #{inspect(brief)}. " <>
-             "If :not_captured, the Coordinator did not call drive_fun — " <>
-             "likely BriefAssembler is missing (compile error) or the supervisor " <>
-             "does not select the injected issue."
+             "got: #{inspect(brief)}"
 
     # The brief must not be the bare title — it must be the assembled prompt.
     refute brief == bare_title,
@@ -251,6 +276,29 @@ defmodule Tau.Factory.BriefAssemblerTest do
     assert brief =~ "docs/arch/04-software-architecture",
            "D-372(c): the assembled brief must include the docs/arch/04-software-architecture " <>
              "pointer section (D-372 arch-mandatory); got brief: #{inspect(brief)}"
+
+    # D-372 declared_scope projection: the sentinel file placed in the scope's
+    # :files set by the elaborator MUST appear under the "Declared Scope" /
+    # "**Files:**" label in the assembled brief. Asserting the labelled form
+    # "**Files:** <sentinel>" avoids a false positive — the sentinel also appears
+    # in the issue-body section of the brief, so a bare `=~` match on the
+    # filename alone would succeed even when scope is discarded.
+    #
+    # FAILS against the current impl where to_unit_work_item/1 discards the real
+    # scope and passes @empty_scope to BriefAssembler, producing:
+    #   **Files:** (none declared)
+    # instead of:
+    #   **Files:** lib/tau/factory/d372_scope_sentinel.ex
+    scope_files_line = "**Files:** #{@d372c_scope_sentinel}"
+
+    assert brief =~ scope_files_line,
+           "D-372(c): the assembled brief must contain \"#{scope_files_line}\" " <>
+             "in the Declared Scope section — the IssueSelector elaborator " <>
+             "extracted #{inspect(@d372c_scope_sentinel)} from the issue body into " <>
+             "scope.files, and to_unit_work_item/1 must thread that scope through " <>
+             "to BriefAssembler.assemble/2 rather than substituting @empty_scope. " <>
+             "Current impl produces \"**Files:** (none declared)\" instead. " <>
+             "Got brief: #{inspect(brief)}"
   end
 
   # ---------------------------------------------------------------------------

--- a/test/tau/factory/brief_assembler_test.exs
+++ b/test/tau/factory/brief_assembler_test.exs
@@ -1,0 +1,411 @@
+defmodule Tau.Factory.BriefAssemblerTest do
+  @moduledoc """
+  Gating tests for D-372 / D-373 — brief/issue → prompt assembler
+  (SPEC-FACTORY-CORE §6 / §4 B10 amendment, PR #508, issue #489).
+
+  ## What these tests enforce
+
+  **D-372 — Brief assembly is complete over its declared inputs.**
+  `Tau.Factory.BriefAssembler.assemble/2` composes `task.prompt` from all
+  present input fields (issue body, declared `ConflictCheck.scope()`,
+  gating-test paths, SPEC/AC/D-NNN refs), each appearing under a distinct
+  labelled section. The `docs/arch/04-software-architecture` pointer section
+  is mandatory and non-empty — present even when no optional input is supplied.
+  `Tau.Factory.Supervisor.to_unit_work_item/1` sets `:brief` to the assembled
+  prompt, not the bare issue title.
+
+  **D-373 — Assembly is an injected pure seam that degrades, never crashes.**
+  The injected `:assemble_fun :: (input -> String.t())` (defaulting to the D-372
+  heuristic template) is honoured when supplied. The default assembler is pure
+  and network-free. Absent optional keys degrade to explicit `(none declared)`
+  placeholders without raising; output is always a non-empty `String.t()`.
+
+  Each test exercises the REAL `Tau.Factory.BriefAssembler.assemble/2` API or
+  the REAL `Tau.Factory.Supervisor.to_unit_work_item/1` invocation path — no
+  hand-built bypasses. Tests MUST FAIL against the pre-D-372 implementation
+  (module does not exist → `UndefinedFunctionError`; supervisor still uses bare
+  title → assertion failure).
+  """
+
+  use ExUnit.Case, async: true
+
+  alias Tau.Factory.BriefAssembler
+  alias Tau.Factory.IssueSelector
+  alias Tau.Factory.Supervisor, as: FactorySupervisor
+
+  # ---------------------------------------------------------------------------
+  # Helpers
+  # ---------------------------------------------------------------------------
+
+  # Minimal valid issue_map (the keys the §4 B10 --json projection supplies).
+  defp issue(number, title, opts \\ []) do
+    %{
+      "number" => number,
+      "title" => title,
+      "body" => Keyword.get(opts, :body, ""),
+      "labels" => Keyword.get(opts, :labels, [])
+    }
+  end
+
+  # Minimal valid declared_scope (a ConflictCheck.scope() map).
+  defp empty_scope do
+    %{
+      deps: [],
+      files: MapSet.new(),
+      codepoints: MapSet.new(),
+      specs: MapSet.new(),
+      resources: MapSet.new()
+    }
+  end
+
+  # ---------------------------------------------------------------------------
+  # D-372(a): full input → every field appears labelled in the prompt
+  #
+  # SPEC: "every input field present in `input` is consumed — appears, labelled,
+  # in the assembled prompt ... the issue body, the declared scope, the
+  # gating-test paths, the SPEC/AC/D-NNN refs, and the arch pointers each
+  # occupy a distinct labelled section." (§4 B10 / D-372)
+  #
+  # PRE-IMPL FAILURE: BriefAssembler does not exist → UndefinedFunctionError.
+  # ---------------------------------------------------------------------------
+  @tag :d_372
+  test "D-372(a): assemble/2 with all fields present returns a prompt containing each under its labelled section" do
+    input = %{
+      issue:
+        issue(489, "A2: brief/issue→prompt assembler",
+          body: "Implement the assembler for real agents."
+        ),
+      declared_scope: %{
+        deps: [],
+        files: MapSet.new(["lib/tau/factory/brief_assembler.ex"]),
+        codepoints: MapSet.new(),
+        specs: MapSet.new(["SPEC-FACTORY-CORE"]),
+        resources: MapSet.new()
+      },
+      gating_test_paths: ["test/tau/factory/brief_assembler_test.exs"],
+      spec_refs: ["SPEC-FACTORY-CORE", "AC-14", "D-372", "D-373"],
+      arch_pointers: ["docs/arch/04-software-architecture/control-plane.md"]
+    }
+
+    result = BriefAssembler.assemble(input, [])
+
+    assert is_binary(result),
+           "D-372(a): assemble/2 must return a String.t(); got: #{inspect(result)}"
+
+    assert result != "",
+           "D-372(a): assemble/2 must return a non-empty String.t()"
+
+    # Issue body must appear under a labelled section.
+    assert result =~ "Implement the assembler for real agents.",
+           "D-372(a): the issue body must appear in the assembled prompt"
+
+    # Declared scope must appear under its own labelled section (at minimum the
+    # file cited in the scope should surface).
+    assert result =~ "lib/tau/factory/brief_assembler.ex",
+           "D-372(a): declared scope content must appear in the assembled prompt"
+
+    # Gating-test paths must appear under their labelled section.
+    assert result =~ "test/tau/factory/brief_assembler_test.exs",
+           "D-372(a): gating_test_paths must appear in the assembled prompt"
+
+    # SPEC/AC/D-NNN refs must appear under their labelled section.
+    assert result =~ "D-372",
+           "D-372(a): spec_refs (D-372) must appear in the assembled prompt"
+
+    # Arch pointers must appear under their labelled section.
+    assert result =~ "docs/arch/04-software-architecture/control-plane.md",
+           "D-372(a): arch_pointers must appear in the assembled prompt"
+  end
+
+  # ---------------------------------------------------------------------------
+  # D-372(b): arch-pointer section is mandatory — present even with only required keys
+  #
+  # SPEC: "The arch-pointer section is mandatory and non-empty (it carries at
+  # least the `docs/arch/04-software-architecture/` root), discharging
+  # `feedback_brief_implementers_with_arch`." (§4 B10 / D-372)
+  #
+  # PRE-IMPL FAILURE: BriefAssembler does not exist → UndefinedFunctionError.
+  # ---------------------------------------------------------------------------
+  @tag :d_372
+  test "D-372(b): assemble/2 with only required keys still includes the docs/arch/04-software-architecture pointer section" do
+    # Supply only the two required keys — no optional keys.
+    input = %{
+      issue: issue(489, "Minimal required-only issue"),
+      declared_scope: empty_scope()
+    }
+
+    result = BriefAssembler.assemble(input, [])
+
+    assert is_binary(result),
+           "D-372(b): assemble/2 must return a String.t(); got: #{inspect(result)}"
+
+    assert result != "",
+           "D-372(b): assemble/2 must return a non-empty String.t() even with only required keys"
+
+    # The arch-pointer section is MANDATORY even when no arch_pointers key is
+    # supplied in input.
+    assert result =~ "docs/arch/04-software-architecture",
+           "D-372(b): the assembled prompt MUST include a docs/arch/04-software-architecture " <>
+             "pointer section even when no optional inputs are supplied; " <>
+             "got prompt: #{inspect(result)}"
+  end
+
+  # ---------------------------------------------------------------------------
+  # D-372(c): Supervisor.to_unit_work_item/1 sets :brief to the assembled prompt
+  #
+  # SPEC: "Tau.Factory.Supervisor.to_unit_work_item/1 is the single assembly
+  # site: it replaces `brief: title` with
+  # `brief: BriefAssembler.assemble(%{issue: issue, declared_scope: scope, …})`."
+  # (§4 B10 / D-372 invocation point)
+  #
+  # The invocation point is exercised via the REAL public path:
+  # Supervisor.start_link/1 (enabled: true) wraps to_unit_work_item/1 inside
+  # wrapped_drive_fun, so we inject a sentinel drive_fun that captures the
+  # work_item it receives, deliver one open issue via gh_fun, and inspect :brief.
+  #
+  # PRE-IMPL FAILURE: the current wrapped_drive_fun calls to_unit_work_item/1
+  # which sets `brief: title` (the bare issue title). This test asserts that
+  # :brief != the bare title and contains the mandatory arch pointer. When
+  # BriefAssembler does not exist the Supervisor fails to start (or compile),
+  # so the start_supervised! call itself fails before the drive_fun is reached.
+  # Either way the test fails — compile error or assertion failure.
+  # ---------------------------------------------------------------------------
+  @tag :d_372
+  @tag :capture_log
+  test "D-372(c): Supervisor.to_unit_work_item/1 sets :brief to the assembled prompt, not the bare title" do
+    # Throwaway git repo (mirrors merge_result_pubsub_test.exs pattern).
+    repo_dir = Briefly.create!(type: :directory)
+    git = fn args -> System.cmd("git", args, cd: repo_dir, stderr_to_stdout: true) end
+    {_, 0} = git.(["init", "-b", "main"])
+    {_, 0} = git.(["config", "user.email", "test@tau.test"])
+    {_, 0} = git.(["config", "user.name", "Tau Test"])
+    File.write!(Path.join(repo_dir, "README"), "initial\n")
+    {_, 0} = git.(["add", "README"])
+    {_, 0} = git.(["commit", "-m", "initial commit"])
+
+    db_path = Briefly.create!(extname: ".db")
+    sup_name = :"brief_asm_d372c_#{System.unique_integer([:positive])}"
+
+    # Shared cell to capture the work_item passed to our sentinel drive_fun.
+    capture = :ets.new(:d372c_capture, [:public, :set])
+
+    # An open issue with a known title and body.
+    bare_title = "A2: brief/issue→prompt assembler"
+
+    issue_map =
+      issue(489, bare_title, body: "Build BriefAssembler for real agents. References D-372.")
+
+    gh_fun = fn _milestone -> {:ok, [issue_map]} end
+
+    # Sentinel drive_fun: captures the work_item then returns :ok to satisfy
+    # the Coordinator's drive_fun contract (§4 B10).
+    sentinel_drive_fun = fn work_item, _deps ->
+      :ets.insert(capture, {:work_item, work_item})
+      # Prevent the Coordinator from trying to start a real Unit (no agent_bin
+      # in this test scope — just return a stub pid-ish value).
+      spawn(fn -> :ok end)
+    end
+
+    _sup_pid =
+      start_supervised!(
+        {
+          FactorySupervisor,
+          enabled: true,
+          db_path: db_path,
+          name: sup_name,
+          repo_dir: repo_dir,
+          milestone: "m-d372c",
+          gh_fun: gh_fun,
+          select_fun: &IssueSelector.select/1,
+          drive_fun: sentinel_drive_fun
+        },
+        id: sup_name
+      )
+
+    # Give the Coordinator one cycle to call select_fun → drive_fun.
+    Process.sleep(300)
+
+    brief =
+      case :ets.lookup(capture, :work_item) do
+        [{:work_item, work_item}] ->
+          Map.get(work_item, :brief, :__missing__)
+
+        [] ->
+          :not_captured
+      end
+
+    assert is_binary(brief),
+           "D-372(c): the work_item :brief delivered to drive_fun must be a String.t(); " <>
+             "got: #{inspect(brief)}. " <>
+             "If :not_captured, the Coordinator did not call drive_fun — " <>
+             "likely BriefAssembler is missing (compile error) or the supervisor " <>
+             "does not select the injected issue."
+
+    # The brief must not be the bare title — it must be the assembled prompt.
+    refute brief == bare_title,
+           "D-372(c): :brief delivered to drive_fun must be the assembled prompt, " <>
+             "not the bare issue title #{inspect(bare_title)}; " <>
+             "D-372 requires BriefAssembler.assemble/2 be called in to_unit_work_item/1"
+
+    # The assembled prompt must carry the mandatory arch pointer section.
+    assert brief =~ "docs/arch/04-software-architecture",
+           "D-372(c): the assembled brief must include the docs/arch/04-software-architecture " <>
+             "pointer section (D-372 arch-mandatory); got brief: #{inspect(brief)}"
+  end
+
+  # ---------------------------------------------------------------------------
+  # D-373(a): injected :assemble_fun stub is honoured
+  #
+  # SPEC: "The injected `:assemble_fun` (D-373) follows the established `*_fun`
+  # pattern so a stronger, LLM-assisted prompt author is a *substitution*, not
+  # a rewrite ... a stub `:assemble_fun` is honoured." (§4 B10 / D-373)
+  #
+  # PRE-IMPL FAILURE: BriefAssembler does not exist → UndefinedFunctionError.
+  # ---------------------------------------------------------------------------
+  @tag :d_373
+  test "D-373(a): a stub :assemble_fun injected via opts is honoured — its output becomes the assembled brief" do
+    # A sentinel string that cannot be produced by the default heuristic assembler.
+    sentinel_output = "SENTINEL_BRIEF_#{System.unique_integer([:positive])}"
+    stub_assemble_fun = fn _input -> sentinel_output end
+
+    input = %{
+      issue: issue(489, "D-373 stub test"),
+      declared_scope: empty_scope()
+    }
+
+    result = BriefAssembler.assemble(input, assemble_fun: stub_assemble_fun)
+
+    assert result == sentinel_output,
+           "D-373(a): injected :assemble_fun stub output must be returned by assemble/2; " <>
+             "expected #{inspect(sentinel_output)}, got: #{inspect(result)}"
+  end
+
+  # ---------------------------------------------------------------------------
+  # D-373(b): default assembler is pure and deterministic — same input → same output
+  #
+  # SPEC: "the default is pure and network-free — no LLM call on the assembly
+  # path ... assert determinism: same issue → same output." (§4 B10 / D-373)
+  #
+  # PRE-IMPL FAILURE: BriefAssembler does not exist → UndefinedFunctionError.
+  # ---------------------------------------------------------------------------
+  @tag :d_373
+  test "D-373(b): default assembler is deterministic — identical inputs produce identical output" do
+    input = %{
+      issue: issue(489, "D-373 determinism check", body: "References D-373."),
+      declared_scope: %{
+        deps: [],
+        files: MapSet.new(["lib/tau/factory/brief_assembler.ex"]),
+        codepoints: MapSet.new(),
+        specs: MapSet.new(),
+        resources: MapSet.new()
+      },
+      gating_test_paths: ["test/tau/factory/brief_assembler_test.exs"],
+      spec_refs: ["D-373"]
+    }
+
+    result_1 = BriefAssembler.assemble(input, [])
+    result_2 = BriefAssembler.assemble(input, [])
+
+    assert is_binary(result_1),
+           "D-373(b): assemble/2 must return a String.t()"
+
+    assert result_1 == result_2,
+           "D-373(b): default assembler must be deterministic — same input must produce " <>
+             "identical output on repeated calls; " <>
+             "first=#{inspect(result_1)}, second=#{inspect(result_2)}"
+  end
+
+  # ---------------------------------------------------------------------------
+  # D-373(c): partial input (missing optional keys) degrades gracefully — no raise,
+  #           "(none declared)" placeholders in place of missing sections
+  #
+  # SPEC: "An absent optional input degrades to an explicit '(none declared)'
+  # marker in its section, never a crash and never a silently-omitted section."
+  # (§4 B10 / D-373)
+  #
+  # PRE-IMPL FAILURE: BriefAssembler does not exist → UndefinedFunctionError.
+  # ---------------------------------------------------------------------------
+  @tag :d_373
+  test "D-373(c): assemble/2 with only required keys degrades missing optional fields to (none declared) placeholders without raising" do
+    # Only the two required keys — no gating_test_paths, spec_refs, arch_pointers.
+    input = %{
+      issue: issue(489, "Partial input degradation test"),
+      declared_scope: empty_scope()
+    }
+
+    # Must not raise.
+    result =
+      try do
+        BriefAssembler.assemble(input, [])
+      rescue
+        err ->
+          flunk(
+            "D-373(c): assemble/2 must NOT raise on partial input; " <>
+              "got exception: #{inspect(err)}"
+          )
+      end
+
+    assert is_binary(result),
+           "D-373(c): assemble/2 must return a String.t() on partial input; got: #{inspect(result)}"
+
+    # The "(none declared)" marker must appear — indicating graceful degradation
+    # rather than silent omission of expected sections.
+    assert result =~ "(none declared)",
+           "D-373(c): absent optional fields must degrade to '(none declared)' placeholder " <>
+             "sections in the assembled prompt; got prompt: #{inspect(result)}"
+  end
+
+  # ---------------------------------------------------------------------------
+  # D-373(d): output is always a non-empty String.t()
+  #
+  # SPEC: "for any non-empty issue (carrying 'number'/'title') the assembler
+  # returns a non-empty String.t(), never raising on partial input and never
+  # returning ''." (§4 B10 / D-373)
+  #
+  # PRE-IMPL FAILURE: BriefAssembler does not exist → UndefinedFunctionError.
+  # ---------------------------------------------------------------------------
+  @tag :d_373
+  test "D-373(d): assemble/2 always returns a non-empty String.t() for any non-empty issue — never raises, never returns empty string" do
+    minimal_inputs = [
+      # Required-only
+      %{
+        issue: issue(1, "Minimal issue"),
+        declared_scope: empty_scope()
+      },
+      # Empty body
+      %{
+        issue: issue(2, "Empty body issue", body: ""),
+        declared_scope: empty_scope()
+      },
+      # All optional keys explicitly empty
+      %{
+        issue: issue(3, "All optional empty"),
+        declared_scope: empty_scope(),
+        gating_test_paths: [],
+        spec_refs: [],
+        arch_pointers: []
+      }
+    ]
+
+    for input <- minimal_inputs do
+      result =
+        try do
+          BriefAssembler.assemble(input, [])
+        rescue
+          err ->
+            flunk(
+              "D-373(d): assemble/2 must not raise for input=#{inspect(input)}; " <>
+                "got: #{inspect(err)}"
+            )
+        end
+
+      assert is_binary(result),
+             "D-373(d): assemble/2 must return a String.t() for input=#{inspect(input)}; " <>
+               "got: #{inspect(result)}"
+
+      assert result != "",
+             "D-373(d): assemble/2 must never return an empty string; " <>
+               "input=#{inspect(input)}"
+    end
+  end
+end

--- a/test/tau/factory/brief_assembler_test.exs
+++ b/test/tau/factory/brief_assembler_test.exs
@@ -615,4 +615,188 @@ defmodule Tau.Factory.BriefAssemblerTest do
                "codepoints input #{inspect(input)}"
     end
   end
+
+  # ---------------------------------------------------------------------------
+  # D-373(g): non-empty :specs (atoms) must render readably — no FunctionClauseError
+  #
+  # The bug: render_set_member/1 has a clause for binary strings and a clause for
+  # {path, :line_NN} codepoint tuples, but NO clause for bare atoms.
+  # IssueSelector.extract_specs/1 always produces atoms — e.g.
+  # "SPEC-FACTORY-CORE.md" → :"spec_FACTORY_CORE" (line 242-248 of issue_selector.ex,
+  # using String.replace("-","_") |> String.upcase() |> then(&:"spec_#{&1}")).
+  # When render_set_or_none/1 calls render_set_member/1 on a bare atom, no clause
+  # matches → FunctionClauseError → assemble/2 crashes (falsifies D-373).
+  # All earlier tests use MapSet.new([]) or MapSet.new(["SPEC-FACTORY-CORE"])
+  # (string) for :specs, so the atom path was never gated.
+  #
+  # Expected behaviour: each atom spec rendered as a human-readable string
+  # (e.g. "spec_FACTORY_CORE" or "SPEC-FACTORY-CORE" or the atom-name verbatim),
+  # present in the assembled prompt, NOT a crash.
+  #
+  # PRE-IMPL FAILURE: FunctionClauseError — no clause in render_set_member/1
+  # matches a bare atom like :spec_FACTORY_CORE.
+  # ---------------------------------------------------------------------------
+  @tag :d_373
+  test "D-373(g): assemble/2 with non-empty :specs (atoms — the real IssueSelector output) must not raise and must render each spec readably" do
+    # These are the EXACT atoms IssueSelector.extract_specs/1 emits:
+    #   "SPEC-FACTORY-CORE.md"  → :"spec_FACTORY_CORE"
+    #   "SPEC-FACTORY-GATE.md"  → :"spec_FACTORY_GATE"
+    # Derivation (issue_selector.ex lines 242-248):
+    #   captured name "FACTORY-CORE"
+    #   |> String.replace("-", "_")  → "FACTORY_CORE"
+    #   |> String.upcase()           → "FACTORY_CORE"
+    #   |> then(&:"spec_#{&1}")      → :spec_FACTORY_CORE
+    atom_specs = MapSet.new([:spec_FACTORY_CORE, :spec_FACTORY_GATE])
+
+    input = %{
+      issue:
+        issue(489, "D-373(g) atom specs",
+          body:
+            "Touches SPEC-FACTORY-CORE.md and SPEC-FACTORY-GATE.md. " <>
+              "References D-373."
+        ),
+      declared_scope: %{
+        deps: [],
+        files: MapSet.new(["lib/tau/factory/brief_assembler.ex"]),
+        codepoints: MapSet.new(),
+        specs: atom_specs,
+        resources: MapSet.new()
+      },
+      gating_test_paths: ["test/tau/factory/brief_assembler_test.exs"],
+      spec_refs: ["D-372", "D-373"]
+    }
+
+    # Must not raise — FunctionClauseError on bare atom is the pre-fix failure mode.
+    result =
+      try do
+        BriefAssembler.assemble(input, [])
+      rescue
+        err ->
+          flunk(
+            "D-373(g): assemble/2 must NOT raise when :specs contains atoms; " <>
+              "IssueSelector.extract_specs/1 always emits atoms like :spec_FACTORY_CORE. " <>
+              "render_set_member/1 has no atom clause → FunctionClauseError. " <>
+              "Got exception: #{inspect(err)}"
+          )
+      end
+
+    assert is_binary(result),
+           "D-373(g): assemble/2 must return a String.t() when :specs contains atoms; " <>
+             "got: #{inspect(result)}"
+
+    assert result != "",
+           "D-373(g): assemble/2 must return a non-empty String.t() when :specs contains atoms"
+
+    # Each spec atom must appear in the assembled prompt in a human-readable form.
+    # The render must include the substantive content of each atom name so the
+    # implementer can identify which SPECs are in scope. Checking for the
+    # distinguishing substrings "FACTORY_CORE" and "FACTORY_GATE" (present in the
+    # atom names :spec_FACTORY_CORE and :spec_FACTORY_GATE respectively).
+    assert result =~ "FACTORY_CORE",
+           "D-373(g): the atom :spec_FACTORY_CORE must render with its name in the " <>
+             "assembled prompt; got: #{inspect(result)}"
+
+    assert result =~ "FACTORY_GATE",
+           "D-373(g): the atom :spec_FACTORY_GATE must render with its name in the " <>
+             "assembled prompt; got: #{inspect(result)}"
+  end
+
+  # ---------------------------------------------------------------------------
+  # D-373(h): full realistic IssueSelector scope shape (files + codepoints +
+  #           atom specs + atom resources, all non-empty) must not raise and
+  #           must render all members readably (D-373 totality over real types)
+  #
+  # This exercises the COMPLETE production scope shape from elaborate_issue/1:
+  #   :files      → MapSet.t(String.t())     (file paths as strings)
+  #   :codepoints → MapSet.t({String.t(), atom()})  ({path, :"line_NN"} tuples)
+  #   :specs      → MapSet.t(atom())         (e.g. :spec_FACTORY_CORE)
+  #   :resources  → MapSet.t(atom())         (reserved; currently label-derived atoms)
+  #   :deps       → [String.t()]             (e.g. ["unit-42"])
+  #
+  # Prior D-373 tests left :resources always MapSet.new() (empty) because the
+  # elaborator currently emits MapSet.new() for resources (label-derived, not yet
+  # wired). However, the type contract is MapSet.t(atom()) — assemble/2 MUST
+  # handle non-empty :resources with atom members without crashing, because
+  # the elaborator may emit them as soon as label-derived resources land.
+  # Gate this now so the implementer must handle atom resources.
+  #
+  # PRE-IMPL FAILURE: FunctionClauseError — render_set_member/1 has no atom
+  # clause, so any non-empty :specs OR :resources with atom members crashes.
+  # ---------------------------------------------------------------------------
+  @tag :d_373
+  test "D-373(h): D-373 never-raises holds for the FULL realistic IssueSelector scope shape — files+codepoints+atom specs+atom resources all non-empty" do
+    # Full realistic scope with production types for every field.
+    # :specs → atoms (IssueSelector.extract_specs/1 output)
+    # :resources → atoms (type contract; label-derived atoms are reserved)
+    full_scope = %{
+      deps: ["unit-42"],
+      files: MapSet.new(["lib/tau/factory/brief_assembler.ex", "lib/tau/factory/supervisor.ex"]),
+      codepoints:
+        MapSet.new([
+          {"lib/tau/factory/brief_assembler.ex", :line_59},
+          {"lib/tau/factory/issue_selector.ex", :line_192}
+        ]),
+      specs: MapSet.new([:spec_FACTORY_CORE, :spec_FACTORY_GATE]),
+      resources: MapSet.new([:resource_gh_api])
+    }
+
+    input = %{
+      issue:
+        issue(489, "D-373(h) full realistic scope",
+          body:
+            "All scope fields non-empty with production types. " <>
+              "Touches lib/tau/factory/brief_assembler.ex:59 and SPEC-FACTORY-CORE.md."
+        ),
+      declared_scope: full_scope,
+      gating_test_paths: ["test/tau/factory/brief_assembler_test.exs"],
+      spec_refs: ["D-372", "D-373"]
+    }
+
+    # Must not raise.
+    result =
+      try do
+        BriefAssembler.assemble(input, [])
+      rescue
+        err ->
+          flunk(
+            "D-373(h): assemble/2 must NOT raise for the full realistic IssueSelector " <>
+              "scope shape (files+codepoints+atom specs+atom resources all non-empty). " <>
+              "FunctionClauseError on atom specs/resources is the known crash path — " <>
+              "render_set_member/1 handles only String.t() and {path, :line_NN} tuples, " <>
+              "not bare atoms. Got exception: #{inspect(err)}"
+          )
+      end
+
+    assert is_binary(result),
+           "D-373(h): assemble/2 must return a String.t() for full realistic scope; " <>
+             "got: #{inspect(result)}"
+
+    assert result != "",
+           "D-373(h): assemble/2 must return a non-empty String.t() for full realistic scope"
+
+    # Files must appear.
+    assert result =~ "lib/tau/factory/brief_assembler.ex",
+           "D-373(h): file 'lib/tau/factory/brief_assembler.ex' must appear in the " <>
+             "assembled prompt; got: #{inspect(result)}"
+
+    # Codepoints must appear (path + line number).
+    assert result =~ "lib/tau/factory/issue_selector.ex",
+           "D-373(h): codepoint path 'lib/tau/factory/issue_selector.ex' must appear; " <>
+             "got: #{inspect(result)}"
+
+    assert result =~ "192",
+           "D-373(h): line number '192' must appear for codepoint issue_selector.ex:192; " <>
+             "got: #{inspect(result)}"
+
+    # Atom specs must render with their names present.
+    assert result =~ "FACTORY_CORE",
+           "D-373(h): atom :spec_FACTORY_CORE must render readably in the assembled " <>
+             "prompt; got: #{inspect(result)}"
+
+    # Atom resources must render with their names present.
+    assert result =~ "gh_api",
+           "D-373(h): atom :resource_gh_api must render readably in the assembled " <>
+             "prompt — a bare atom must not crash render_set_member/1; " <>
+             "got: #{inspect(result)}"
+  end
 end


### PR DESCRIPTION
## #489 (A2) — brief / issue→prompt assembler

Closes #489. **ARCH GAP RESOLVED** — shaper pass landed (`de6196a`): SPEC-FACTORY-CORE §3/§4/§6 + control-plane.md + MISSION.md amended; verified-free **D-372/D-373** allocated.

### Problem
The Worker is spawned with a `:brief` string that the scripted agent ignores. A real coding agent (the #487 `CodingAgentShim` → `Tau.CodingAgents.ClaudeCode`) needs the **issue body + linked SPEC/AC/D-NNN context + declared scope (#488) + gating-test paths + arch pointers** assembled into `task.prompt` of a `Tau.CodingAgent.task`. No component mechanically performs this assembly — it is the autonomous analogue of the human coordinator's implementer brief (the factory-loop draft-PR body). Per `feedback_brief_implementers_with_arch`, the prompt MUST point the agent at `docs/arch`, not just SPEC §-refs.

### Plan (this PR)
1. **Shaper pass** (solution-shaping; design-reasoning) → the brief→prompt assembler contract: inputs (issue, SPEC/AC/D-NNN, `ConflictCheck.scope()` from #488, gating-test paths, arch pointers), the assembly seam (where it lives in the `UnitDriver.drive/2 → WorkerSupervisor.spawn/5 → Worker → CodingAgentShim task.prompt` flow), an injected/pure seam analogous to #488's `:elaborate_fun`, and the failure posture. Arch (`control-plane.md` U / intake) + SPEC amendment + verified-free **D-NNN (D-372+)**. Commit as `spec(factory): …`.
2. test-author → implementer → critic + reviewer.

### Dependencies
Blocked-by: #487 (A1 — the prompt's consumer, **merged**), #488 (I2 — declared scope for the prompt's scope portion, **merged**). Both landed → unblocked. Blocks the capstone #501 (a real agent needs a real prompt). Runs in parallel with #490 (disjoint: `unit.ex` worker_exit vs the brief→prompt plumbing; #490 amends no SPEC).

### SPECs
SPEC-FACTORY-CORE §3/§4/§6 amended in `de6196a` (Appendix-B source-map: `lib/tau/factory/brief_assembler.ex` + `lib/tau/factory/supervisor.ex` `to_unit_work_item/1`; gating test `test/tau/factory/brief_assembler_test.exs`). Advances **D-372/D-373**.

### Acceptance criteria
- **D-372** — assembly completeness: `Tau.Factory.BriefAssembler.assemble/2` projects the work inputs (issue body, declared `ConflictCheck.scope()`, gating-test paths, SPEC/AC/D-NNN refs) into `task.prompt`, EACH under its labelled section, and ALWAYS includes a `docs/arch/04-software-architecture` pointer section (even when no optional input is supplied); invoked at `Supervisor.to_unit_work_item/1` (replacing `brief: title`).
- **D-373** — injected pure seam + graceful degradation: the assembler is the injected `:assemble_fun :: (input -> String.t())` (default = the D-372 heuristic), pure and network-free; a stub is honoured; partial input degrades to `(none declared)` placeholders without raising; output is always a non-empty `String.t()`.

### Gating-test paths (frozen at 4b)
- `test/tau/factory/brief_assembler_test.exs` — D-372 (assembly completeness: labelled sections + mandatory arch pointer; Supervisor invocation), D-373 (injected `:assemble_fun` seam; pure/deterministic/network-free; partial-input degradation; non-empty String).
### Gate verdicts
**Attempt 1 — RED (refine).**
- **critic: FAIL** — `brief_assembler.ex` `render_set_or_none` `Enum.join`s the `:codepoints` set whose members are `{path, :"line_NN"}` TUPLES (the #488 elaborator produces these for any `file:line` citation) → `Protocol.UndefinedError` → the default `assemble/2` CRASHES on realistic input, crashing the Coordinator drive_fun → falsifies D-373 ("never raises / non-empty String"). The gating suite MASKS it (every test uses empty `:codepoints`). Scope-threading (refine a) + default-purity confirmed correct.
- **reviewer: PASS** — but only because the tests use empty codepoints (the masking the critic caught); full suite/CI green otherwise. One WARNING: stale `supervisor.ex:302-303` comment.

**Refine plan:**
- *Test-author:* add a gating case exercising NON-EMPTY `:codepoints` (`{"lib/x.ex", :"line_42"}`) through `assemble/2` and `to_unit_work_item/1` — assert it does NOT raise and renders the codepoint readably (e.g. `lib/x.ex:42`); include non-empty codepoints in the D-373 "never raises" case. Fails against current crash.
- *Implementer:* render codepoint tuples explicitly (not via `String.Chars`); fix the stale `supervisor.ex:302-303` comment.

**Attempt 1 re-gate — RED (refine #2).** critic FAIL — same crash CLASS recurred: `render_set_member/1` not total (no atom clause); real `:specs`/`:resources` are `MapSet.t(atom())` (`IssueSelector` emits `:spec_*`), so any SPEC-citing issue → `FunctionClauseError`. Tests masked it with string specs. → Refine #2: test-author rebuilt fixtures to real elaborator shapes (atom specs/resources, tuple codepoints); implementer made `render_set_member/1` total (string | `{path,atom}` | atom→`Atom.to_string` | catch-all `inspect/1`).

**Re-gate #2 — GREEN (merge).** critic PASS — `render_set_member/1` definitively total (4 clauses + fallback; non-atom 2-tuple falls safely to fallback; no raising input exists; D-373 never-raises absolute; real scope threaded). reviewer PASS — 11/11 gating; 1641/0 at seed 0 AND 42; CI all green; totality mutation-probe (remove atom+fallback → D-373(g)/(h) FAIL) confirms load-bearing.