### PR TITLE
#491 (GOV4) — heartbeat-driven Unit timeout [ARCH GAP → shaper+D-NNN]

### DIFF
--- a/docs/MISSION.md
+++ b/docs/MISSION.md
@@ -81,10 +81,9 @@ Block-to-SPEC allocation:
 | D-300 – D-303, D-341 | SPEC-FACTORY-MERGE |
 | D-304 – D-308, D-322, D-323, D-354 | SPEC-FACTORY-GATE |
 | D-309 – D-311, D-313, D-314, D-316, D-334, D-364 – D-367, D-376, D-381, D-382 | SPEC-FACTORY-FLEET |
-| D-312, D-315, D-317, D-318, D-320, D-321, D-330 – D-333, D-335, D-336, D-340, D-342 – D-344, D-355 – D-359, D-369 – D-373, D-380 | SPEC-FACTORY-CORE |
+| D-312, D-315, D-317, D-318, D-320, D-321, D-330 – D-333, D-335, D-336, D-340, D-342 – D-344, D-355 – D-359, D-369 – D-373, D-377 – D-380 | SPEC-FACTORY-CORE |
 | D-319, D-351 – D-353, D-374 | SPEC-FACTORY-GOV |
 | D-361 – D-363 | SPEC-FACTORY-CORE (C1 unit-coordinate identity; PR #503) |
-| D-377 – D-379 | reserved — SPEC-FACTORY-GOV (heartbeat-driven Unit liveness; unmerged `feat/491-heartbeat-timeout`, #491) |
 | D-300 – D-385 | reserved — SPEC-FACTORY-\* family (autonomous factory; `docs/arch/`) |
 
 A SPEC needing a D-NNN outside its allocated block MUST update this table

--- a/docs/arch/04-software-architecture/control-plane.md
+++ b/docs/arch/04-software-architecture/control-plane.md
@@ -615,13 +615,23 @@ end
    `state_timeout_ms` are set from the **same** `:unit_timeouts`-derived threshold
    (D-358) so the two heartbeat-absence detectors cannot disagree.
 
-**One stall outcome per worker (D-378).** Three timers observe a single wedge —
-the Unit's `:state_timeout` (D-377), the Watchdog's `worker_stalled` (D-379), and
-the dispatcher's `:inactivity_timeout_ms` → `%Done{-1}` → `worker_exit`. To
-prevent a double-advance of the ladder (V6), all three are `worker_id`-keyed and
-the **first** stall-class trigger consumed clears `data.worker_id`; every later
-stall-class event for that superseded id hits the stale-worker discard clause and
-advances nothing.
+**One stall outcome per worker — two-outcome model (D-378).** Stall-class signals
+for a single wedge produce exactly one outcome via `worker_id`-keyed disjointness:
+the first stall-class signal clears `data.worker_id`; every later stall-class event
+for that superseded id hits the stale-worker discard clause and advances nothing.
+The two stall-class sources are semantically distinct:
+
+- The Unit's OWN `:state_timeout :worker_stalled` (D-377; fires only on total
+  heartbeat silence) → `escalate(:E_WORKER_STALLED)` (hard-stall path; gate NOT
+  called; preserves #490/D-326).
+- The Watchdog's `{:worker_stalled, ^worker_id}` info message (D-379;
+  heartbeat-absence) → deferred re-spawn: clears `worker_id`, sends `:deferred_spawn`
+  to the mailbox tail (so pending stale signals are discarded first), then
+  `do_spawn_worker/1` bumps `attempt_count` and writes a Ledger snapshot (D-315
+  RPO=0). Does NOT consume a refine/pivot slot.
+
+A real wedge resolves bounded (no hang; never both retries AND escalates for one
+stall event).
 
 Together these guarantee the property INV-18 totality actually needs: **every
 reachable non-progress state eventually produces a trigger**, which the
@@ -657,12 +667,15 @@ The first three are *outcome* triggers (transition U out of the waiting state);
 |---------|---------|----------|
 | `work_ready(w, branch, head_sha)` | agent declared a **stable diff** (success) | → `gating` (`request_gate`) |
 | `worker_exit(w, reason)` (`:DOWN`) | worker/agent **crashed or exited** | infra path → `escalated`; gate NOT called (FR-8.2) |
-| `worker_stalled(w)` | watchdog saw **heartbeat absence** (wedged, no `:DOWN`) | retry ladder (semantic stall) → refine/pivot/escalate (D-379) |
+| `worker_stalled(w)` | watchdog saw **heartbeat absence** (wedged, no `:DOWN`) | deferred re-spawn: bumps `attempt_count`, snapshots Ledger (D-315/D-379); does NOT consume a refine slot |
 | `worker_heartbeat(w)` | live progress pulse (D-366 shim frame) | **reset** `:state_timeout`; stay in state (D-377) |
 
-The three stall/exit triggers collapse to **one** ladder advance per worker
-(D-378): the first one consumed clears `data.worker_id`, so later stall-class
-events for that superseded id are discarded.
+The stall/exit triggers collapse to **exactly one** combined metric increment per
+worker (D-378): the first stall-class signal consumed clears `data.worker_id`, so
+later signals for that superseded id are discarded. The Unit's own `:state_timeout`
+escalates `E_WORKER_STALLED`; the Watchdog's `{:worker_stalled, w}` triggers a
+deferred re-spawn (bumps `attempt_count`, snapshots Ledger — does not consume a
+refine slot). See D-378 two-outcome model.
 
 **Why a clean Port exit is NOT the completion trigger (the load-bearing
 decision).** The discriminating question is operational: *can a normally-exiting

--- a/docs/arch/04-software-architecture/control-plane.md
+++ b/docs/arch/04-software-architecture/control-plane.md
@@ -556,6 +556,27 @@ defmodule Tau.Factory.Unit do
   defp enter_waiting(state, ms, data),
     do: {:next_state, state, data, [{:state_timeout, ms, :stall}]}
 
+  # D-377 — heartbeat-driven liveness: a current-worker progress pulse RE-ARMS
+  # the waiting-state timeout, so a progressing real agent never trips the cap.
+  # The cap is thus a per-heartbeat *inactivity deadline*, not a run-duration cap.
+  def oracle(:info, {:worker_heartbeat, w}, %{worker_id: w} = data),
+    do: {:keep_state, data, [{:state_timeout, data.state_timeout_ms, :stall}]}
+  def implementing(:info, {:worker_heartbeat, w}, %{worker_id: w} = data),
+    do: {:keep_state, data, [{:state_timeout, data.state_timeout_ms, :stall}]}
+  # A heartbeat from a SUPERSEDED worker does not re-arm (B8 stale-worker discard).
+  def oracle(:info, {:worker_heartbeat, _other}, data),       do: {:keep_state, data}
+  def implementing(:info, {:worker_heartbeat, _other}, data), do: {:keep_state, data}
+
+  # D-379 — the Watchdog's heartbeat-absence trigger for the CURRENT worker routes
+  # to the SAME retry ladder as :state_timeout (D-378: one stall outcome per
+  # worker; the transition clears worker_id so later stall events are discarded).
+  def oracle(:info, {:worker_stalled, w}, %{worker_id: w} = data),
+    do: stall_escalate(%{data | worker_id: nil}, :oracle)
+  def implementing(:info, {:worker_stalled, w}, %{worker_id: w} = data),
+    do: stall_escalate(%{data | worker_id: nil}, :implementing)
+  def oracle(:info, {:worker_stalled, _other}, data),       do: {:keep_state, data}
+  def implementing(:info, {:worker_stalled, _other}, data), do: {:keep_state, data}
+
   # A wedged worker is first a SEMANTIC stall (refine/pivot on a fresh worker),
   # escalating to E-* only if the stall persists past the retry ladder.
   defp stall_escalate(data, _state) do
@@ -570,17 +591,37 @@ end
 
 **Two complementary liveness guards close every non-progress state (H-2):**
 
-1. **Per-state timeout (above).** `oracle`, `implementing`, `gating`, and
-   `awaiting_merge` each arm a `{:state_timeout, ms, :stall}` on entry, reset by
-   worker progress heartbeats. A stall (including a silently-wedged worker that
-   never crashes) fires the timeout → the retry ladder → escalation. No waiting
-   state can sit forever without emitting a trigger.
-2. **Worker watchdog.** The worker (`worker-fleet.md`) emits periodic progress
-   events over its `Port`; a `WorkerSupervisor`-side watchdog converts *absence*
-   of heartbeats beyond a threshold into a synthetic `worker_stalled` event to U
-   — covering the case where the Port is alive but the sub-agent is hung (no
-   `:DOWN` would ever fire). This is the missing trigger source the bare monitor
-   cannot provide.
+1. **Per-state timeout (above), reset by progress heartbeats (D-377).** `oracle`,
+   `implementing`, `gating`, and `awaiting_merge` each arm a `{:state_timeout, ms,
+   :stall}` on entry. In the worker-awaiting states (`oracle`, `implementing`) the
+   Unit **re-arms** that timeout on every current-worker `{:worker_heartbeat, w}`
+   — the live pulse the Worker forwards from D-366 shim frames (`worker-fleet.md`).
+   So `ms` is a *per-heartbeat inactivity deadline* (max silence between two
+   progress pulses), not an absolute run-duration cap: a genuinely-progressing
+   agent that pulses at least once per `ms` window NEVER trips the cap, while a
+   silently-wedged worker (no pulse) trips it at `ms` → the retry ladder →
+   escalation. This is the GOV4 refinement of D-358: the fixed cap no longer
+   either spuriously kills a slow-but-healthy run or, when widened to mask that,
+   masks a wedge — the deadline keys on silence, not elapsed time.
+2. **Worker watchdog (D-379).** The worker (`worker-fleet.md`) emits periodic
+   progress events over its `Port`; the fleet `Watchdog` converts *absence* of
+   heartbeats beyond a threshold into a synthetic `worker_stalled(w)` event — the
+   case where the Port is alive but the sub-agent is hung (no `:DOWN` ever fires).
+   The wiring is load-bearing and previously orphaned (V3): the `UnitDriver`
+   `worker_fun` seam **registers each spawned worker** with the `Watchdog`
+   addressed to the owning Unit, and the Unit **consumes** `{:worker_stalled,
+   ^worker_id}` (above), routing it through the same retry ladder as a
+   `:state_timeout` stall. The Watchdog's `heartbeat_timeout` and the Unit's
+   `state_timeout_ms` are set from the **same** `:unit_timeouts`-derived threshold
+   (D-358) so the two heartbeat-absence detectors cannot disagree.
+
+**One stall outcome per worker (D-378).** Three timers observe a single wedge —
+the Unit's `:state_timeout` (D-377), the Watchdog's `worker_stalled` (D-379), and
+the dispatcher's `:inactivity_timeout_ms` → `%Done{-1}` → `worker_exit`. To
+prevent a double-advance of the ladder (V6), all three are `worker_id`-keyed and
+the **first** stall-class trigger consumed clears `data.worker_id`; every later
+stall-class event for that superseded id hits the stale-worker discard clause and
+advances nothing.
 
 Together these guarantee the property INV-18 totality actually needs: **every
 reachable non-progress state eventually produces a trigger**, which the
@@ -607,15 +648,21 @@ end
 def implementing(:info, {:work_ready, _other, _b, _s}, data), do: {:keep_state, data}
 ```
 
-Three keyed-by-`worker_id` worker triggers are **disjoint** and U distinguishes
-them structurally (the `worker_event` family of system-architecture.md §1, U
-`E_in`):
+Four keyed-by-`worker_id` worker signals are **disjoint** and U distinguishes them
+structurally (the `worker_event` family of system-architecture.md §1, U `E_in`).
+The first three are *outcome* triggers (transition U out of the waiting state);
+`worker_heartbeat` is a *liveness* pulse (keeps U in the state, resets the cap):
 
 | trigger | meaning | U action |
 |---------|---------|----------|
 | `work_ready(w, branch, head_sha)` | agent declared a **stable diff** (success) | → `gating` (`request_gate`) |
 | `worker_exit(w, reason)` (`:DOWN`) | worker/agent **crashed or exited** | infra path → `escalated`; gate NOT called (FR-8.2) |
-| `worker_stalled(w)` | watchdog saw **heartbeat absence** (wedged, no `:DOWN`) | retry ladder (semantic stall) → refine/pivot/escalate |
+| `worker_stalled(w)` | watchdog saw **heartbeat absence** (wedged, no `:DOWN`) | retry ladder (semantic stall) → refine/pivot/escalate (D-379) |
+| `worker_heartbeat(w)` | live progress pulse (D-366 shim frame) | **reset** `:state_timeout`; stay in state (D-377) |
+
+The three stall/exit triggers collapse to **one** ladder advance per worker
+(D-378): the first one consumed clears `data.worker_id`, so later stall-class
+events for that superseded id are discarded.
 
 **Why a clean Port exit is NOT the completion trigger (the load-bearing
 decision).** The discriminating question is operational: *can a normally-exiting

--- a/docs/arch/04-software-architecture/control-plane.md
+++ b/docs/arch/04-software-architecture/control-plane.md
@@ -547,8 +547,15 @@ defmodule Tau.Factory.Unit do
   # MANDATORY state-timeout on EVERY state that awaits an external actor.
   # A wedged-but-not-crashed worker (Port alive, no :exit_status, no :DOWN) emits
   # NO trigger — so the timeout is what synthesizes one (final-validation H-2).
-  def oracle(:state_timeout, :stall, data),         do: stall_escalate(data, :oracle)
-  def implementing(:state_timeout, :stall, data),   do: stall_escalate(data, :implementing)
+  #
+  # Worker-awaiting states (oracle/implementing): the OWN :state_timeout fires only
+  # on TOTAL heartbeat silence (D-377 re-arms it on every progress pulse), so it is
+  # the HARD-stall path → escalate E_WORKER_STALLED directly (NOT the retry ladder;
+  # preserves #490/D-326). The event-message worker_stalled/worker_exit signals
+  # (below) are the retryable path. (D-378 two-outcome split, by source.)
+  def oracle(:state_timeout, :stall, data),         do: escalate(data, {:worker_stalled, data.unit_id}) # → E_WORKER_STALLED
+  def implementing(:state_timeout, :stall, data),   do: escalate(data, {:worker_stalled, data.unit_id}) # → E_WORKER_STALLED
+  # Non-worker waiting states keep the gate/merge-stall semantics unchanged.
   def gating(:state_timeout, :stall, data),         do: stall_escalate(data, :gating)
   def awaiting_merge(:state_timeout, :stall, data), do: stall_escalate(data, :awaiting_merge)
 
@@ -567,25 +574,54 @@ defmodule Tau.Factory.Unit do
   def oracle(:info, {:worker_heartbeat, _other}, data),       do: {:keep_state, data}
   def implementing(:info, {:worker_heartbeat, _other}, data), do: {:keep_state, data}
 
-  # D-379 — the Watchdog's heartbeat-absence trigger for the CURRENT worker routes
-  # to the SAME retry ladder as :state_timeout (D-378: one stall outcome per
-  # worker; the transition clears worker_id so later stall events are discarded).
+  # D-378/D-379 — ONE symmetric rule for BOTH worker-awaiting states. The two
+  # EVENT-MESSAGE stall-class signals — the Watchdog's heartbeat-absence
+  # {:worker_stalled, w} and the dispatcher's semantic death-cert {:worker_exit,
+  # w, reason} — route to the SAME retry ladder, which re-enters the ORIGINATING
+  # waiting state (oracle→oracle re-runs the test-author; implementing→implementing
+  # re-runs the implementer). The first signal clears worker_id so later stall
+  # events for the now-superseded id are stale-discarded (D-378 exactly-once).
   def oracle(:info, {:worker_stalled, w}, %{worker_id: w} = data),
-    do: stall_escalate(%{data | worker_id: nil}, :oracle)
+    do: advance_retry_ladder(:oracle, clear_worker(data))
   def implementing(:info, {:worker_stalled, w}, %{worker_id: w} = data),
-    do: stall_escalate(%{data | worker_id: nil}, :implementing)
+    do: advance_retry_ladder(:implementing, clear_worker(data))
+  def oracle(:info, {:worker_exit, w, _reason}, %{worker_id: w} = data),
+    do: advance_retry_ladder(:oracle, clear_worker(data))
+  def implementing(:info, {:worker_exit, w, _reason}, %{worker_id: w} = data),
+    do: advance_retry_ladder(:implementing, clear_worker(data))
+  # Stale-worker discard (other id) — both signals, both states.
   def oracle(:info, {:worker_stalled, _other}, data),       do: {:keep_state, data}
   def implementing(:info, {:worker_stalled, _other}, data), do: {:keep_state, data}
+  def oracle(:info, {:worker_exit, _other, _r}, data),      do: {:keep_state, data}
+  def implementing(:info, {:worker_exit, _other, _r}, data), do: {:keep_state, data}
 
-  # A wedged worker is first a SEMANTIC stall (refine/pivot on a fresh worker),
-  # escalating to E-* only if the stall persists past the retry ladder.
-  defp stall_escalate(data, _state) do
+  # A wedged/exited worker is first a SEMANTIC retry (refine/pivot on a fresh
+  # worker in the SAME role), escalating to E-RETRY-EXHAUSTED only if the stall
+  # persists past the ladder. Re-entering `state` (not always :implementing) keeps
+  # the role correct. The :next_state's :on_enter bumps attempt_count and snapshots
+  # the Ledger (D-315 RPO=0) before re-spawning — so durability and exactly-once
+  # come for free; there is NO :deferred_spawn path. The Unit's OWN :state_timeout
+  # (total heartbeat silence) is the SEPARATE hard-stall path: it escalates
+  # E_WORKER_STALLED directly (def oracle/implementing(:state_timeout, :stall, …)
+  # above), never the ladder.
+  defp advance_retry_ladder(state, data) do
     case Tau.Factory.Retry.next(data.k, data.attempt_kind, data.policy_pin) do
-      {:refine, k} -> {:next_state, :refine_k, snapshot(%{data | k: k, stalled: true})}
-      :pivot       -> {:next_state, :implementing, snapshot(pivot_reset(data))}
+      {:refine, k} -> {:next_state, state, snapshot(%{data | k: k}), [{:next_event, :internal, :on_enter}]}
+      :pivot       -> {:next_state, state, snapshot(pivot_reset(data)), [{:next_event, :internal, :on_enter}]}
       :exhausted   -> escalate(data, {:retry_exhausted, data.unit_id})  # → E-RETRY-EXHAUSTED
     end
   end
+
+  # gating/awaiting_merge stall: retry-then-escalate semantics unchanged.
+  defp stall_escalate(data, state) do
+    case Tau.Factory.Retry.next(data.k, data.attempt_kind, data.policy_pin) do
+      {:refine, k} -> {:next_state, :refine_k, snapshot(%{data | k: k, stalled: true})}
+      :pivot       -> {:next_state, state, snapshot(pivot_reset(data)), [{:next_event, :internal, :on_enter}]}
+      :exhausted   -> escalate(data, {:retry_exhausted, data.unit_id})  # → E-RETRY-EXHAUSTED
+    end
+  end
+
+  defp clear_worker(data), do: %{data | worker_id: nil}  # + Process.demonitor(mref, [:flush])
 end
 ```
 
@@ -608,30 +644,43 @@ end
    heartbeats beyond a threshold into a synthetic `worker_stalled(w)` event — the
    case where the Port is alive but the sub-agent is hung (no `:DOWN` ever fires).
    The wiring is load-bearing and previously orphaned (V3): the `UnitDriver`
-   `worker_fun` seam **registers each spawned worker** with the `Watchdog`
-   addressed to the owning Unit, and the Unit **consumes** `{:worker_stalled,
-   ^worker_id}` (above), routing it through the same retry ladder as a
-   `:state_timeout` stall. The Watchdog's `heartbeat_timeout` and the Unit's
-   `state_timeout_ms` are set from the **same** `:unit_timeouts`-derived threshold
-   (D-358) so the two heartbeat-absence detectors cannot disagree.
+   `worker_fun` seam **registers each spawned worker** (test-author AND
+   implementer) with the `Watchdog` addressed to the owning Unit, and **both**
+   `oracle` and `implementing` **consume** `{:worker_stalled, ^worker_id}`
+   (above), routing it through the retry ladder back into the originating state.
+   The Watchdog's `heartbeat_timeout` and the Unit's `state_timeout_ms` are set
+   from the **same** `:unit_timeouts`-derived threshold (D-358) so the two
+   heartbeat-absence detectors cannot disagree.
 
-**One stall outcome per worker — two-outcome model (D-378).** Stall-class signals
-for a single wedge produce exactly one outcome via `worker_id`-keyed disjointness:
-the first stall-class signal clears `data.worker_id`; every later stall-class event
-for that superseded id hits the stale-worker discard clause and advances nothing.
-The two stall-class sources are semantically distinct:
+**One outcome per worker — ONE symmetric rule for `oracle` and `implementing`
+(D-378, GOV4 re-shape).** Stall-class signals for a single wedge produce exactly
+one outcome via `worker_id`-keyed disjointness: the first stall-class signal clears
+`data.worker_id`; every later stall-class event for that superseded id hits the
+stale-worker discard clause and advances nothing. There are **two outcome kinds**,
+but they are split by *source*, not by signal — and the split is identical in both
+states:
 
-- The Unit's OWN `:state_timeout :worker_stalled` (D-377; fires only on total
-  heartbeat silence) → `escalate(:E_WORKER_STALLED)` (hard-stall path; gate NOT
-  called; preserves #490/D-326).
-- The Watchdog's `{:worker_stalled, ^worker_id}` info message (D-379;
-  heartbeat-absence) → deferred re-spawn: clears `worker_id`, sends `:deferred_spawn`
-  to the mailbox tail (so pending stale signals are discarded first), then
-  `do_spawn_worker/1` bumps `attempt_count` and writes a Ledger snapshot (D-315
-  RPO=0). Does NOT consume a refine/pivot slot.
+- **Event-message stall signals** — the Watchdog's `{:worker_stalled, ^worker_id}`
+  (heartbeat-absence) **and** the dispatcher's `{:worker_exit, ^worker_id, reason}`
+  (semantic death-cert) → the **retry ladder** (`advance_retry_ladder/2`), which re-enters
+  the **originating** waiting state. The ladder's `:on_enter` bumps `attempt_count`
+  and writes a Ledger snapshot (D-315 RPO=0) before re-spawning, so durability is
+  intrinsic. **There is no `:deferred_spawn` path** — the plain `:next_state`
+  transition IS the re-spawn, and exactly-once holds because the re-spawn produces
+  a fresh `worker_id` (any stale signal for the old id is discarded by id, not by
+  drain order; the `{:next_event, :internal, :on_enter}` is moreover processed
+  ahead of pending mailbox `:info` messages). Does NOT escalate directly; escalates
+  to `E-RETRY-EXHAUSTED` only when the ladder is spent.
+- **The Unit's OWN `:state_timeout`** (D-377; fires only on total heartbeat silence
+  past the cap) → `escalate(:E_WORKER_STALLED)` (the hard-stall path; gate NOT
+  called; preserves #490/D-326). This is the only origin of `E_WORKER_STALLED`.
 
 A real wedge resolves bounded (no hang; never both retries AND escalates for one
-stall event).
+stall event). **The run-#2 gap closed:** `oracle` previously had no `worker_exit`
+clause, so an oracle worker exiting `:no_work_product` fell through to
+`handle_unexpected/4`, was ignored, and only the eventual `:state_timeout` fired —
+a spurious `E_WORKER_STALLED` for a routine semantic retry. Both states now consume
+both event-message stall signals identically.
 
 Together these guarantee the property INV-18 totality actually needs: **every
 reachable non-progress state eventually produces a trigger**, which the
@@ -665,17 +714,24 @@ The first three are *outcome* triggers (transition U out of the waiting state);
 
 | trigger | meaning | U action |
 |---------|---------|----------|
-| `work_ready(w, branch, head_sha)` | agent declared a **stable diff** (success) | → `gating` (`request_gate`) |
-| `worker_exit(w, reason)` (`:DOWN`) | worker/agent **crashed or exited** | infra path → `escalated`; gate NOT called (FR-8.2) |
-| `worker_stalled(w)` | watchdog saw **heartbeat absence** (wedged, no `:DOWN`) | deferred re-spawn: bumps `attempt_count`, snapshots Ledger (D-315/D-379); does NOT consume a refine slot |
+| `work_ready(w, branch, head_sha)` | agent declared a **stable diff** (success) | → `gating` (`request_gate`) [in `implementing`]; → `implementing` [in `oracle`] |
+| `worker_exit(w, reason)` (semantic death-cert) | worker **exited without a work-product** (`:no_work_product` / `:error` / `{:exit_status,_}`) | **retry ladder** → re-enter originating state; gate NOT called (FR-8.2) |
+| `worker_stalled(w)` | watchdog saw **heartbeat absence** (wedged, no `:DOWN`) | **retry ladder** → re-enter originating state; gate NOT called |
 | `worker_heartbeat(w)` | live progress pulse (D-366 shim frame) | **reset** `:state_timeout`; stay in state (D-377) |
 
-The stall/exit triggers collapse to **exactly one** combined metric increment per
-worker (D-378): the first stall-class signal consumed clears `data.worker_id`, so
-later signals for that superseded id are discarded. The Unit's own `:state_timeout`
-escalates `E_WORKER_STALLED`; the Watchdog's `{:worker_stalled, w}` triggers a
-deferred re-spawn (bumps `attempt_count`, snapshots Ledger — does not consume a
-refine slot). See D-378 two-outcome model.
+The same table governs **both** `oracle` and `implementing` (GOV4 re-shape). The
+event-message stall/exit triggers collapse to **exactly one** combined metric
+increment per worker (D-378): the first stall-class signal consumed clears
+`data.worker_id`, so later signals for that superseded id are discarded; both route
+to the retry ladder, which re-enters the originating state and (via `:on_enter`)
+bumps `attempt_count` and snapshots the Ledger (D-315). There is **no deferred
+re-spawn**. The Unit's own `:state_timeout` (total heartbeat silence) is the only
+direct `E_WORKER_STALLED` escalation. See D-378 one-symmetric-rule model.
+
+The legacy 2-tuple worker seam (`worker_id == nil`) has no in-band `work_ready` /
+`worker_exit`; for it a monitored `:DOWN` is the infra-crash path →
+`escalate(E_WORKER_DOWN)`. Under the D-326 3-tuple seam, `:DOWN` is not an
+authoritative outcome (the death-cert arrives as `worker_exit`).
 
 **Why a clean Port exit is NOT the completion trigger (the load-bearing
 decision).** The discriminating question is operational: *can a normally-exiting

--- a/docs/spec/SPEC-FACTORY-CORE.md
+++ b/docs/spec/SPEC-FACTORY-CORE.md
@@ -1615,6 +1615,22 @@ w}`, `{:worker_exit, w, …}`, and a second `{:worker_stalled, w}` for one worke
 close succession advances the combined (`refine_count + attempt_count`) metric by
 exactly one (not three), and re-enters the originating state.
 
+**Worker-outcome ladder counter (D-378 clarification).** The worker-outcome retry
+ladder (`advance_retry_ladder/2`, from `{:worker_stalled,^w}`/`{:worker_exit,^w,_}`)
+and the gate-failure ladder (`advance_gate_ladder/1`, from
+`{:gate_outcome,{:fail,_}}`) are distinct bounded budgets sharing one `Retry.next/3`
+bound (`N_REFINE + N_PIVOT`). The gate ladder advances `refine_count`/`pivot_count`;
+the worker-outcome ladder advances `attempt_count` and MUST NOT touch `refine_count`
+(a worker that produced no work product has no gate-rejected product to refine). Both
+exhaust to `E_RETRY_EXHAUSTED` independently. The worker-outcome ladder uses a
+dedicated position counter (`stall_count`, starting at 0) so the full `N_REFINE +
+N_PIVOT` budget is available for genuine stall/exit events and is not pre-consumed by
+the initial oracle/implementing spawns (which legitimately increment `attempt_count`
+but are not retries). The arch pseudocode in `docs/arch/04-software-architecture/
+control-plane.md` uses an idealized single `data.k`; the committed implementation
+uses the distinct fields `attempt_count`/`refine_count`/`pivot_count`/`stall_count`
+per this clarification.
+
 **D-379 — The Unit consumes the Watchdog `worker_stalled(w)` and the dispatcher
 `worker_exit(w, reason)` triggers in BOTH waiting states; the fleet registers each
 worker with the Watchdog (B8 wiring, [C107-B5], GOV4 re-shape, V3 orphan-invariant

--- a/docs/spec/SPEC-FACTORY-CORE.md
+++ b/docs/spec/SPEC-FACTORY-CORE.md
@@ -708,15 +708,44 @@ callers that pass no `:ledger` opt are unaffected (back-compat).
   inactivity deadline*, not an absolute run-duration cap. The Unit ALSO consumes
   the Watchdog's `worker_stalled(w)` (the heartbeat-absence trigger, D-317): the
   fleet wiring registers each spawned worker with the `Watchdog`, addressed to the
-  owning Unit, and the Unit routes `{:worker_stalled, ^worker_id}` to the same
-  retry ladder as a `:state_timeout` stall (**D-379**). The Unit's own
-  `:state_timeout`, the Watchdog's `worker_stalled`, and the dispatcher's
-  `:inactivity_timeout_ms` → `worker_exit` collapse to **exactly one** ladder
-  advance per worker per state: the first stall-class trigger clears
-  `data.worker_id`, after which every other stall-class event for that superseded
-  `worker_id` hits the stale-worker discard clause (**D-378**). The Watchdog's
-  `heartbeat_timeout` and the Unit `state_timeout_ms` share one
-  `:unit_timeouts`-derived threshold (D-358) so the two detectors cannot disagree.
+  owning Unit (**D-379**).
+- **ONE symmetric worker-outcome rule for BOTH worker-awaiting states (GOV4
+  re-shape, D-378).** `oracle` and `implementing` are the two states that await a
+  worker, and they MUST handle the worker-outcome signal set **identically** —
+  divergence between them is forbidden. The single rule table is:
+
+  | signal (for the **current** `worker_id`) | outcome | re-enters |
+  |---|---|---|
+  | `work_ready(w, branch, head_sha)` | success: capture coord (D-362), advance | oracle→implementing; implementing→gating |
+  | `worker_exit(w, reason)` (semantic death-cert: `:no_work_product` / `:error` / `{:exit_status, _}`) | **retry ladder** (gate NOT called) | **the originating waiting state** |
+  | `worker_stalled(w)` (Watchdog heartbeat-absence) | **retry ladder** (gate NOT called) | **the originating waiting state** |
+  | `worker_heartbeat(w)` | reset `:state_timeout`; stay (D-377) | — |
+  | `:DOWN` with `worker_id == nil` (legacy 2-tuple seam only) | `escalate(E_WORKER_DOWN)` | — (terminal) |
+
+  Plus two state-level rules, identical in both states:
+  - Unit's **own** `:state_timeout` (real `gen_statem` timer; fires only on total
+    heartbeat silence past the cap) → `escalate(E_WORKER_STALLED)` (the hard-stall
+    path; gate NOT called; preserves #490/D-326).
+  - Any of the above signals for a **superseded** `worker_id` (`_other_id`) →
+    stale-worker discard (`keep_state`); advances nothing.
+
+  The "originating waiting state" rule is load-bearing: a stalled/exited
+  test-author re-enters **`oracle`** (re-runs the test-author), NOT `implementing`
+  — re-spawning the wrong role would skip oracle-separation. The shared
+  `advance_retry_ladder/2` therefore takes the originating state and re-enters it
+  via `{:next_state, <that state>, …, [{:next_event, :internal, :on_enter}]}`,
+  whose `:on_enter` already bumps `attempt_count` and writes a Ledger snapshot
+  (D-315 RPO=0). There is **no separate `:deferred_spawn` / `do_spawn_worker`
+  path** — the plain ladder's `:next_state` transition is the re-spawn (see D-378).
+
+  **Collapse to exactly-one (D-378).** The Unit's own `:state_timeout`, the
+  Watchdog's `worker_stalled`, and the dispatcher's `:inactivity_timeout_ms` →
+  `worker_exit` collapse to **exactly one** outcome per worker per state: the first
+  stall-class signal consumed clears `data.worker_id` (and `:demonitor`s), after
+  which every other stall-class event for that superseded `worker_id` hits the
+  stale-worker discard clause. The Watchdog's `heartbeat_timeout` and the Unit
+  `state_timeout_ms` share one `:unit_timeouts`-derived threshold (D-358) so the
+  two detectors cannot disagree.
 - **Pinned Unit seam (D-326 / PR #468 amendment).** The `worker_fun` injectable
   returns `{:ok, worker_pid :: pid(), worker_id :: String.t()}` (3-tuple) for
   D-326-aware workers; the Unit stores `data.worker_id` (test-observable via
@@ -1539,67 +1568,91 @@ w}` at sub-`state_timeout_ms` intervals past the old fixed cap stays in
 `implementing` and never escalates `E_WORKER_STALLED`; with no heartbeats it trips
 at `state_timeout_ms` exactly as before.
 
-**D-378 — Exactly one outcome per worker per state; two-outcome model
-(disjointness, [C107-B5], V3/V6):** Stall-class signals for a single wedged worker
-produce **exactly one** outcome in the waiting state via `worker_id`-keyed
-disjointness: the first stall-class signal consumed clears `data.worker_id` (sets
-it `nil` alongside `Process.demonitor(mref, [:flush])`); every subsequent
-stall-class event for that now-superseded `worker_id` matches the stale-worker
-discard clause (`keep_state`) and advances nothing.
+**D-378 — Exactly one outcome per worker per state; ONE symmetric rule for
+`oracle` and `implementing` (disjointness, [C107-B5], GOV4 re-shape, V3/V5/V6):**
+Both worker-awaiting states (`oracle`, `implementing`) handle the worker-outcome
+signal set **identically** — the §4 B8 rule table is the single source. The two
+**event-message** stall-class signals — `{:worker_stalled, ^worker_id}` (Watchdog
+heartbeat-absence) and `{:worker_exit, ^worker_id, reason}` (semantic death-cert) —
+route to the **same retry ladder**, `advance_retry_ladder(state, data)`, which
+re-enters the **originating waiting state** (`oracle → oracle`, `implementing →
+implementing`) via `{:next_state, state, …, [{:next_event, :internal, :on_enter}]}`.
+Re-entering the originating state (not always `implementing`) is mandatory so a
+stalled/exited test-author re-runs the **test-author**, not the implementer.
 
-The two stall-class sources are **semantically distinct** (two-outcome model):
+Stall-class signals for a single wedged worker produce **exactly one** outcome via
+`worker_id`-keyed disjointness: the first stall-class signal consumed clears
+`data.worker_id` (sets it `nil` alongside `Process.demonitor(mref, [:flush])`) and
+fires the `:next_state` ladder transition; every subsequent stall-class event for
+that now-superseded `worker_id` matches the stale-worker discard clause
+(`keep_state`) and advances nothing.
 
-1. **The Unit's own `:state_timeout :worker_stalled`** (D-377, real gen_statem timer;
-   fires only on total heartbeat silence) → `escalate(:E_WORKER_STALLED)`.  This is
-   the hard-stall path: the worker has emitted zero progress pulses within
-   `state_timeout_ms`, indicating a genuine wedge.  Gate is NOT called (C105).
-   Preserves #490/D-326.
+The Unit's **own** `:state_timeout` is a **separate, terminal** outcome (NOT the
+ladder): it fires only on total heartbeat silence past the cap and
+`escalate(:E_WORKER_STALLED)`s (the hard-stall path; gate NOT called; preserves
+#490/D-326). This is the only place `E_WORKER_STALLED` arises; the event-message
+`worker_stalled`/`worker_exit` signals never escalate directly — they retry,
+escalating to `E_RETRY_EXHAUSTED` only after the ladder is spent.
 
-2. **The Watchdog's `{:worker_stalled, ^worker_id}` info message** (D-379;
-   heartbeat-absence beyond `heartbeat_timeout`) → **deferred re-spawn**: clears
-   `worker_id`, sends `:deferred_spawn` to the mailbox tail (D-378 disjointness,
-   so pending stale signals are discarded first), then `do_spawn_worker/1` bumps
-   `attempt_count` and writes a Ledger snapshot (D-315 RPO=0) before calling
-   `worker_fun`.  This path does NOT consume a refine/pivot slot — it is a
-   pre-gate re-spawn, not a gate-fail retry.
+**No `:deferred_spawn` (GOV4 re-shape — the deferred path is dropped, V5).** The
+prior design routed `{:worker_stalled, w}` through a `:deferred_spawn` → mailbox
+tail → `do_spawn_worker/1` dance whose stated purpose was to drain stale stall
+signals for the old `worker_id` before re-spawning. That purpose is **vacuous**:
+discrimination is by `worker_id`, not by mailbox-drain order. The re-spawn produces
+a **fresh** `worker_id` (D-326), so any stale signal for the old id is discarded by
+the `_other_id` clause regardless of when it is drained. Worse, a `gen_statem`
+`{:next_event, :internal, :on_enter}` is processed **before** pending `:info`
+messages already in the mailbox, so the plain ladder re-spawns *first* and the
+queued stale signals then hit the new state instance where `worker_id` is the new
+worker's id (or `nil` for the legacy seam) → all stale-discarded. Exactly-once and
+D-315 durability therefore come for **free** from the plain ladder: its `:on_enter`
+already bumps `attempt_count` and `snapshot_state`s before spawning. Dropping the
+deferred path removes a state-machine surface (one fewer message form, one fewer
+crash cut, V8) while *strengthening* the guarantee.
 
-The Watchdog's `{:worker_stalled}` and the dispatcher's `worker_exit(w, …)` are
-both stale-discarded after the first stall-class signal clears `worker_id`,
-ensuring exactly one combined increment of (`refine_count + attempt_count`) per
-worker across all three potential stall sources. Enforced by an FSM test:
-delivering `{:worker_stalled, w}`, `{:worker_exit, w, …}`, and a second
-`{:worker_stalled, w}` for one worker in close succession advances the combined
-metric by exactly one (not three).
+Enforced by symmetric FSM tests in **both** states: delivering `{:worker_stalled,
+w}`, `{:worker_exit, w, …}`, and a second `{:worker_stalled, w}` for one worker in
+close succession advances the combined (`refine_count + attempt_count`) metric by
+exactly one (not three), and re-enters the originating state.
 
-*§3 note (surfaced during PR #513 implementation):* the deferred re-spawn path
-(`{:worker_stalled, w}` → `:deferred_spawn` → `do_spawn_worker/1`) MUST call
-`snapshot_state(:implementing, data)` and bump `attempt_count`, identical to
-`implementing(:internal, :on_enter, data)`, to satisfy D-315 RPO=0 on
-crash-resume.
+**D-379 — The Unit consumes the Watchdog `worker_stalled(w)` and the dispatcher
+`worker_exit(w, reason)` triggers in BOTH waiting states; the fleet registers each
+worker with the Watchdog (B8 wiring, [C107-B5], GOV4 re-shape, V3 orphan-invariant
+closure):** B8 names `worker_stalled(w)` and `worker_exit(w, reason)` as disjoint
+worker events the Unit consumes, and §3 Q3 mandates the heartbeat-absence watchdog
+as the only thing that makes total escalation hold over reachable *states*. This
+invariant pins the previously-orphaned wiring **symmetrically across `oracle` and
+`implementing`**:
 
-**D-379 — The Unit consumes the Watchdog `worker_stalled(w)` trigger; the fleet
-registers each worker with the Watchdog (B8 wiring, [C107-B5], V3 orphan-invariant
-closure):** B8 names `worker_stalled(w)` as a disjoint worker event the Unit
-consumes, and §3 Q3 mandates the heartbeat-absence watchdog as the only thing that
-makes total escalation hold over reachable *states*. This invariant pins the
-previously-orphaned wiring: (a) the `UnitDriver.drive/2` `worker_fun` seam (or the
-`WorkerSupervisor.spawn/5` path) registers each spawned worker with the fleet
-`Watchdog` (`Watchdog.register(watchdog, worker_id, worker_pid, unit_pid,
-heartbeat_timeout: …)`), so the Watchdog's `{:worker_stalled, worker_id}` is
-delivered to the **owning Unit** (its `report_to`), not dropped; and (b) the Unit
-adds `:info {:worker_stalled, ^worker_id}` clauses to `oracle`/`implementing` that
-route to the deferred re-spawn path (D-378 two-outcome model: clears `worker_id`,
-sends `:deferred_spawn` to the mailbox tail, `do_spawn_worker/1` bumps
-`attempt_count` and snapshots to the Ledger per D-315) for the current worker, and
-discard the stale-worker variant. Without this, the `worker_stalled` trigger named
-in B8 has **no producer reaching the Unit and no consumer in the Unit** — the
-orphan invariant V3 flags. The Watchdog `heartbeat_timeout` and the Unit
-`state_timeout_ms` (D-377) are set from the SAME `:unit_timeouts`-derived value so
-the two heartbeat-absence detectors share one threshold and cannot disagree about
-liveness (V6 path-arithmetic: one threshold, two detectors, one verdict). Enforced
-by a wiring test (a spawned worker is registered with the Watchdog) and an FSM test
-(a Unit in `implementing` receiving `{:worker_stalled, current_worker_id}` advances
-the combined metric by one; a stale-worker `{:worker_stalled, _}` is ignored).
+(a) **Producer.** The `UnitDriver.drive/2` `worker_fun` seam (or the
+`WorkerSupervisor.spawn/5` path) registers **every** spawned worker — test-author
+*and* implementer — with the fleet `Watchdog` (`Watchdog.register(watchdog,
+worker_id, worker_pid, unit_pid, heartbeat_timeout: …)`), so the Watchdog's
+`{:worker_stalled, worker_id}` is delivered to the **owning Unit** (its
+`report_to`), not dropped.
+
+(b) **Consumer — both states, identical clauses.** Each of `oracle` and
+`implementing` carries `:info {:worker_stalled, ^worker_id}` AND `:info
+{:worker_exit, ^worker_id, _reason}` current-worker clauses that clear `worker_id`,
+demonitor, and call `advance_retry_ladder(<this state>, data)`; plus the matching
+`_other_id` stale-worker discard clauses. **The run-#2 gap this closes: `oracle`
+previously had NO `worker_exit` clause** — an oracle worker exiting
+`:no_work_product` fell through to `handle_unexpected/4`, was ignored, and only the
+300 s `:state_timeout` eventually fired `E_WORKER_STALLED` (a spurious hard-stall
+for what was really a routine semantic retry). Both states now consume both
+event-message stall signals identically. Without this wiring the `worker_stalled` /
+`worker_exit` triggers named in B8 have **no producer reaching the Unit and/or no
+consumer in one of the two states** — the orphan invariant V3 flags.
+
+The Watchdog `heartbeat_timeout` and the Unit `state_timeout_ms` (D-377) are set
+from the SAME `:unit_timeouts`-derived value so the two heartbeat-absence detectors
+share one threshold and cannot disagree about liveness (V6 path-arithmetic: one
+threshold, two detectors, one verdict). Enforced by a wiring test (a spawned worker
+is registered with the Watchdog) and symmetric FSM tests (a Unit in **`oracle`**
+*and* a Unit in **`implementing`** each receiving `{:worker_stalled,
+current_worker_id}` or `{:worker_exit, current_worker_id, _}` advances the combined
+metric by one and re-enters its originating state; a stale-worker variant is
+ignored).
 
 **D-380 — Single admission authority + admission self-exclusion (real-run
 integration, [C132-B1], [C133-B1]):** one unit is admitted to `F` **exactly once,
@@ -1715,7 +1768,7 @@ Files that bring a PR into scope of this SPEC (`D-NNN`/`C-N` → file:symbol):
 - `lib/tau/factory/escalation.ex` (C7; D-317) — PR-CORE-3
 - `lib/tau/factory/scheduler.ex` (C4; D-312, D-320, D-343, **D-380** evaluate `ConflictCheck.clear?` + capacity over `F ∖ {unit_id}`; upsert on admit) — PR-CORE-2 / PR #515
 - `lib/tau/factory/conflict_check.ex` (C5; D-312, D-343 — **unchanged for D-380**: stays unit-id-agnostic; the self-exclusion is an S-level set op, not a C5 change) — PR-CORE-2
-- `lib/tau/factory/unit.ex` (C6; D-318, D-340, **D-356** awaiting_merge subscribe-before-request consume + unsubscribe-on-exit, **D-362** capture `work_ready` `branch`/`head_sha` into data, **D-361** key `merge_fun` on captured `head_sha`/`branch`, **D-377** reset `:state_timeout` on current-worker `{:worker_heartbeat, w}` in `oracle`/`implementing`, **D-378** one-stall-per-worker collapse via `worker_id`-clear + stale-worker discard, **D-379** consume `{:worker_stalled, ^worker_id}` → `advance_retry_ladder/1`, plus B6/B7/B8 cited edges) — PR-CORE-3/PR #477/PR #503/PR #513
+- `lib/tau/factory/unit.ex` (C6; D-318, D-340, **D-356** awaiting_merge subscribe-before-request consume + unsubscribe-on-exit, **D-362** capture `work_ready` `branch`/`head_sha` into data, **D-361** key `merge_fun` on captured `head_sha`/`branch`, **D-377** reset `:state_timeout` on current-worker `{:worker_heartbeat, w}` in `oracle`/`implementing`, **D-378** one-outcome-per-worker collapse via `worker_id`-clear + stale-worker discard (ONE symmetric rule for both states; no `:deferred_spawn`), **D-379** both `oracle`/`implementing` consume `{:worker_stalled, ^worker_id}` AND `{:worker_exit, ^worker_id, _}` → `advance_retry_ladder(<originating state>, data)` (re-enters the originating waiting state; closes the run-#2 oracle-`worker_exit` gap), plus B6/B7/B8 cited edges) — PR-CORE-3/PR #477/PR #503/PR #513
 - `lib/tau/factory/unit_driver.ex` (D-340, **D-356** `:janitor` threading + no driver-side merge bridge / no driver reclaim; **D-361** build the merge map `hash`/`branch` from the captured `head_sha`; **D-379** register each spawned worker with the fleet `Watchdog` (`report_to` = owning Unit) sharing the `:unit_timeouts`-derived `heartbeat_timeout`; the real `drive_fun` wiring Unit→fleet→gate→merge seams) — PR #477/PR #503/PR #513
 - `lib/tau/factory/gate/request.ex` (**D-361** `Request.hash` is the captured `head_sha`, not the declared `work_item.hash`; the gate-closure construction site) — PR #503
 - `lib/tau/factory/dogfood/gate_fun.ex` (**D-361/D-363** the arity-1 gate closure receives the coordinate (`head_sha || declared hash`) from the Unit and sets `Request.hash` to it) — PR #503
@@ -1745,7 +1798,7 @@ Files that bring a PR into scope of this SPEC (`D-NNN`/`C-N` → file:symbol):
 - `test/tau/factory/factory_supervision_test.exs` (**D-357** config-gated subtree assembly + default-OFF; AC-P5c6) — PR #480
 - `test/tau/factory/dogfood_e2e_test.exs` (**AC-12** e2e: one real PR open-issue→merged→green-health, no human; **D-358** widened timeouts, no spurious escalation; `@tag :integration`) — PR #481
 - `test/tau/factory/dogfood_guard_test.exs` (**AC-13 / D-359** non-local origin hard-refuse; local bare-repo acceptance) — PR #481
-- `test/tau/factory/unit_heartbeat_liveness_test.exs` (**D-377** heartbeat resets `:state_timeout` — a Unit fed `{:worker_heartbeat, w}` at sub-`state_timeout_ms` intervals past the old cap never escalates `E_WORKER_STALLED`, no-heartbeat trips at the cap; **D-378** delivering `:state_timeout` + `{:worker_stalled, w}` + `{:worker_exit, w, …}` for one worker advances the ladder exactly once; **D-379** Unit consumes current-worker `{:worker_stalled, w}` → ladder, ignores stale-worker variant, and `UnitDriver` registers the spawned worker with the `Watchdog`) — PR #513
+- `test/tau/factory/unit_heartbeat_liveness_test.exs` (**D-377** heartbeat resets `:state_timeout` — a Unit fed `{:worker_heartbeat, w}` at sub-`state_timeout_ms` intervals past the old cap never escalates `E_WORKER_STALLED`, no-heartbeat trips at the cap; **D-378** delivering `{:worker_stalled, w}` + `{:worker_exit, w, …}` + a second `{:worker_stalled, w}` for one worker advances the combined metric exactly once and re-enters the originating state — asserted **symmetrically in BOTH `oracle` and `implementing`**; **D-379** both states consume current-worker `{:worker_stalled, w}` AND `{:worker_exit, w, _}` → `advance_retry_ladder(<originating state>, _)`, ignore the stale-worker variants, and `UnitDriver` registers each spawned worker with the `Watchdog`; the deferred-spawn path is removed and D-315 durability is provided by the ladder's `:on_enter`) — PR #513
 
 **Cross-SPEC boundaries (cited, not owned here):** B6 → `SPEC-FACTORY-MERGE`
 (D-300–D-303, D-341); B7 → `SPEC-FACTORY-GATE` (D-304–D-308, D-322, D-323);

--- a/docs/spec/SPEC-FACTORY-CORE.md
+++ b/docs/spec/SPEC-FACTORY-CORE.md
@@ -699,6 +699,24 @@ callers that pass no `:ledger` opt are unaffected (back-compat).
   `worker_exit(w, :no_work_product)` (**D-326, cited owner: SPEC-FACTORY-FLEET**).
   W owns isolation/capture D-309..D-311, D-313, D-314, D-316 and the completion
   contract D-326.
+- **Heartbeat-driven liveness — consume half (GOV4, D-377/D-378/D-379).** Beyond
+  the three disjoint *outcome* events above, W forwards a fourth `worker_id`-keyed
+  signal the Unit consumes: `worker_heartbeat(w)` — the live progress pulse the
+  Worker forwards from D-366 shim frames. The Unit re-arms its waiting-state
+  `:state_timeout` on every current-worker `worker_heartbeat(w)` (**D-377**), so a
+  progressing real agent never trips the fixed cap; the cap becomes a *per-heartbeat
+  inactivity deadline*, not an absolute run-duration cap. The Unit ALSO consumes
+  the Watchdog's `worker_stalled(w)` (the heartbeat-absence trigger, D-317): the
+  fleet wiring registers each spawned worker with the `Watchdog`, addressed to the
+  owning Unit, and the Unit routes `{:worker_stalled, ^worker_id}` to the same
+  retry ladder as a `:state_timeout` stall (**D-379**). The Unit's own
+  `:state_timeout`, the Watchdog's `worker_stalled`, and the dispatcher's
+  `:inactivity_timeout_ms` → `worker_exit` collapse to **exactly one** ladder
+  advance per worker per state: the first stall-class trigger clears
+  `data.worker_id`, after which every other stall-class event for that superseded
+  `worker_id` hits the stale-worker discard clause (**D-378**). The Watchdog's
+  `heartbeat_timeout` and the Unit `state_timeout_ms` share one
+  `:unit_timeouts`-derived threshold (D-358) so the two detectors cannot disagree.
 - **Pinned Unit seam (D-326 / PR #468 amendment).** The `worker_fun` injectable
   returns `{:ok, worker_pid :: pid(), worker_id :: String.t()}` (3-tuple) for
   D-326-aware workers; the Unit stores `data.worker_id` (test-observable via
@@ -1096,6 +1114,14 @@ as "wedged". The supervisor's `:unit_timeouts` opt is threaded into the assemble
 single unit reaches `:merged` without a spurious escalation (D-358). This widens a
 liveness *bound*, not the liveness *guarantee*: the timeout still fires —
 eventually — on a genuinely-wedged worker; it is set above `T_unit`, not removed.
+**GOV4 refinement (D-377).** The per-state `:state_timeout` is additionally
+**reset on every current-worker `{:worker_heartbeat, w}`** (the D-366 progress
+pulse), so it is a *per-heartbeat inactivity deadline*, not an absolute
+run-duration cap. With D-377 the cap need only exceed the *gap between two
+progress pulses* (seconds), not the whole `T_unit` (minutes); a progressing real
+agent never trips it, and a wedge (no pulses) trips it within one deadline window
+— removing the D-358 tension where widening to avoid spurious kills also blunted
+wedge detection.
 
 **Gated assembly (enabled path).** When the gate is on, the supervisor assembles
 the full control subtree in the `supervision-tree.md` §3 order — PubSub up first
@@ -1189,6 +1215,7 @@ state ∈ {planned, oracle, implementing, gating, refine_k, awaiting_merge, merg
    gating + {:fail,f}        → refine_k        (k<N → implementing; k=N → pivot → implementing; pivot red → escalated [E-RETRY-EXHAUSTED])
    awaiting_merge + M reject → gating          (re-gate; INV-2)
    {oracle,implementing,gating,awaiting_merge} + :state_timeout/worker_stalled → refine/pivot/escalate
+   {oracle,implementing} + worker_heartbeat(current w) → RESET :state_timeout (D-377; progressing agent never trips)
    any non-terminal + escalation(e) → escalated (terminal)
 ```
 
@@ -1491,6 +1518,70 @@ never raising on partial input and never returning `""`. Enforced by
 partial input degrades to placeholders without raising; output is always
 non-empty).
 
+**D-377 — Heartbeat-driven liveness: the Unit resets its `:state_timeout` on
+every current-worker progress heartbeat (GOV4, OQ-2 refinement of D-358,
+[C107-B5], V6):** Each Unit state that awaits a worker (`oracle`, `implementing`)
+re-arms its `{:state_timeout, state_timeout_ms, :worker_stalled}` on every
+`{:worker_heartbeat, worker_id}` received from the **current** worker (the `B8`
+`worker_id`-keyed liveness pulse the Worker forwards from D-366 shim frames). A
+heartbeat from a superseded `worker_id` is discarded (B8 stale-worker discard) and
+does **not** re-arm. Consequently a genuinely-progressing real agent — which
+pulses a heartbeat at least once per `state_timeout_ms` window (D-366 derives the
+pulse from real stream progress) — NEVER trips `:state_timeout`, so the fixed
+wall-clock ceases to bound a *healthy* run. The `state_timeout_ms` is thereby
+re-interpreted as a **per-heartbeat inactivity deadline** (the maximum silence
+between two progress pulses), not an absolute run-duration cap; D-358's
+operator-overridable `:unit_timeouts` continues to set its value. This closes the
+D-358 residual (a fixed cap either spuriously kills a slow-but-healthy agent or is
+set so high it masks a wedge): the deadline now keys on *silence*, not *elapsed
+time*. Enforced by an oracle-separated FSM test: a Unit fed `{:worker_heartbeat,
+w}` at sub-`state_timeout_ms` intervals past the old fixed cap stays in
+`implementing` and never escalates `E_WORKER_STALLED`; with no heartbeats it trips
+at `state_timeout_ms` exactly as before.
+
+**D-378 — Exactly one authoritative stall signal per worker per state
+(disjointness, [C107-B5], V3/V6):** Three timers observe a single wedged worker —
+the Unit's own `:state_timeout` (D-377, heartbeat-reset), the fleet `Watchdog`'s
+heartbeat-absence `worker_stalled(w)` (D-317, B8), and the dispatcher's
+`:inactivity_timeout_ms` (which manufactures `%Done{exit_status: -1}` →
+`worker_exit(w, …)`, D-366). To prevent a double-advance of the retry ladder
+(V6), the Unit collapses them to **one outcome per worker per state**: all three
+arrive as `worker_id`-keyed events, and the **first** stall-class trigger consumed
+in a waiting state transitions the Unit out of that state and clears
+`data.worker_id` (sets it `nil` alongside `Process.demonitor(mref, [:flush])`).
+Every subsequent stall-class event for that now-superseded `worker_id` matches the
+existing stale-worker discard clause (`keep_state`), so it advances nothing. The
+Unit's `:state_timeout :worker_stalled` and the Watchdog's `:info
+{:worker_stalled, ^worker_id}` BOTH route through the **same** retry ladder
+(`advance_retry_ladder/1`, the shared path D-326 already established for semantic
+`worker_exit`), so the two stall sources are semantically identical and produce
+one ladder advance regardless of which fires first. Enforced by an FSM test:
+delivering `:state_timeout`, `{:worker_stalled, w}`, and `{:worker_exit, w, …}`
+for one worker in close succession advances the retry ladder exactly once
+(`attempt_count`/`refine_count` increments by one, not three).
+
+**D-379 — The Unit consumes the Watchdog `worker_stalled(w)` trigger; the fleet
+registers each worker with the Watchdog (B8 wiring, [C107-B5], V3 orphan-invariant
+closure):** B8 names `worker_stalled(w)` as a disjoint worker event the Unit
+consumes, and §3 Q3 mandates the heartbeat-absence watchdog as the only thing that
+makes total escalation hold over reachable *states*. This invariant pins the
+previously-orphaned wiring: (a) the `UnitDriver.drive/2` `worker_fun` seam (or the
+`WorkerSupervisor.spawn/5` path) registers each spawned worker with the fleet
+`Watchdog` (`Watchdog.register(watchdog, worker_id, worker_pid, unit_pid,
+heartbeat_timeout: …)`), so the Watchdog's `{:worker_stalled, worker_id}` is
+delivered to the **owning Unit** (its `report_to`), not dropped; and (b) the Unit
+adds `:info {:worker_stalled, ^worker_id}` clauses to `oracle`/`implementing` that
+route to `advance_retry_ladder/1` (D-378) for the current worker and discard the
+stale-worker variant. Without this, the `worker_stalled` trigger named in B8 has
+**no producer reaching the Unit and no consumer in the Unit** — the orphan
+invariant V3 flags. The Watchdog `heartbeat_timeout` and the Unit
+`state_timeout_ms` (D-377) are set from the SAME `:unit_timeouts`-derived value so
+the two heartbeat-absence detectors share one threshold and cannot disagree about
+liveness (V6 path-arithmetic: one threshold, two detectors, one verdict). Enforced
+by a wiring test (a spawned worker is registered with the Watchdog) and an FSM test
+(a Unit in `implementing` receiving `{:worker_stalled, current_worker_id}` advances
+the retry ladder; a stale-worker `{:worker_stalled, _}` is ignored).
+
 **D-380 — Single admission authority + admission self-exclusion (real-run
 integration, [C132-B1], [C133-B1]):** one unit is admitted to `F` **exactly once,
 by the Unit FSM `planned` state alone** (the authority holding the real
@@ -1605,8 +1696,8 @@ Files that bring a PR into scope of this SPEC (`D-NNN`/`C-N` → file:symbol):
 - `lib/tau/factory/escalation.ex` (C7; D-317) — PR-CORE-3
 - `lib/tau/factory/scheduler.ex` (C4; D-312, D-320, D-343, **D-380** evaluate `ConflictCheck.clear?` + capacity over `F ∖ {unit_id}`; upsert on admit) — PR-CORE-2 / PR #515
 - `lib/tau/factory/conflict_check.ex` (C5; D-312, D-343 — **unchanged for D-380**: stays unit-id-agnostic; the self-exclusion is an S-level set op, not a C5 change) — PR-CORE-2
-- `lib/tau/factory/unit.ex` (C6; D-318, D-340, **D-356** awaiting_merge subscribe-before-request consume + unsubscribe-on-exit, **D-362** capture `work_ready` `branch`/`head_sha` into data, **D-361** key `merge_fun` on captured `head_sha`/`branch`, plus B6/B7/B8 cited edges) — PR-CORE-3/PR #477/PR #503
-- `lib/tau/factory/unit_driver.ex` (D-340, **D-356** `:janitor` threading + no driver-side merge bridge / no driver reclaim; **D-361** build the merge map `hash`/`branch` from the captured `head_sha`; the real `drive_fun` wiring Unit→fleet→gate→merge seams) — PR #477/PR #503
+- `lib/tau/factory/unit.ex` (C6; D-318, D-340, **D-356** awaiting_merge subscribe-before-request consume + unsubscribe-on-exit, **D-362** capture `work_ready` `branch`/`head_sha` into data, **D-361** key `merge_fun` on captured `head_sha`/`branch`, **D-377** reset `:state_timeout` on current-worker `{:worker_heartbeat, w}` in `oracle`/`implementing`, **D-378** one-stall-per-worker collapse via `worker_id`-clear + stale-worker discard, **D-379** consume `{:worker_stalled, ^worker_id}` → `advance_retry_ladder/1`, plus B6/B7/B8 cited edges) — PR-CORE-3/PR #477/PR #503/PR #513
+- `lib/tau/factory/unit_driver.ex` (D-340, **D-356** `:janitor` threading + no driver-side merge bridge / no driver reclaim; **D-361** build the merge map `hash`/`branch` from the captured `head_sha`; **D-379** register each spawned worker with the fleet `Watchdog` (`report_to` = owning Unit) sharing the `:unit_timeouts`-derived `heartbeat_timeout`; the real `drive_fun` wiring Unit→fleet→gate→merge seams) — PR #477/PR #503/PR #513
 - `lib/tau/factory/gate/request.ex` (**D-361** `Request.hash` is the captured `head_sha`, not the declared `work_item.hash`; the gate-closure construction site) — PR #503
 - `lib/tau/factory/dogfood/gate_fun.ex` (**D-361/D-363** the arity-1 gate closure receives the coordinate (`head_sha || declared hash`) from the Unit and sets `Request.hash` to it) — PR #503
 - `lib/tau/factory/brief_assembler.ex` (B10/A2; **D-372** complete-over-inputs composition, **D-373** injected `:assemble_fun` pure seam + graceful degradation; the issue→`task.prompt` intake projection, invoked at `supervisor.ex:to_unit_work_item/1`) — PR #508
@@ -1635,6 +1726,7 @@ Files that bring a PR into scope of this SPEC (`D-NNN`/`C-N` → file:symbol):
 - `test/tau/factory/factory_supervision_test.exs` (**D-357** config-gated subtree assembly + default-OFF; AC-P5c6) — PR #480
 - `test/tau/factory/dogfood_e2e_test.exs` (**AC-12** e2e: one real PR open-issue→merged→green-health, no human; **D-358** widened timeouts, no spurious escalation; `@tag :integration`) — PR #481
 - `test/tau/factory/dogfood_guard_test.exs` (**AC-13 / D-359** non-local origin hard-refuse; local bare-repo acceptance) — PR #481
+- `test/tau/factory/unit_heartbeat_liveness_test.exs` (**D-377** heartbeat resets `:state_timeout` — a Unit fed `{:worker_heartbeat, w}` at sub-`state_timeout_ms` intervals past the old cap never escalates `E_WORKER_STALLED`, no-heartbeat trips at the cap; **D-378** delivering `:state_timeout` + `{:worker_stalled, w}` + `{:worker_exit, w, …}` for one worker advances the ladder exactly once; **D-379** Unit consumes current-worker `{:worker_stalled, w}` → ladder, ignores stale-worker variant, and `UnitDriver` registers the spawned worker with the `Watchdog`) — PR #513
 
 **Cross-SPEC boundaries (cited, not owned here):** B6 → `SPEC-FACTORY-MERGE`
 (D-300–D-303, D-341); B7 → `SPEC-FACTORY-GATE` (D-304–D-308, D-322, D-323);

--- a/docs/spec/SPEC-FACTORY-CORE.md
+++ b/docs/spec/SPEC-FACTORY-CORE.md
@@ -1539,26 +1539,43 @@ w}` at sub-`state_timeout_ms` intervals past the old fixed cap stays in
 `implementing` and never escalates `E_WORKER_STALLED`; with no heartbeats it trips
 at `state_timeout_ms` exactly as before.
 
-**D-378 — Exactly one authoritative stall signal per worker per state
-(disjointness, [C107-B5], V3/V6):** Three timers observe a single wedged worker —
-the Unit's own `:state_timeout` (D-377, heartbeat-reset), the fleet `Watchdog`'s
-heartbeat-absence `worker_stalled(w)` (D-317, B8), and the dispatcher's
-`:inactivity_timeout_ms` (which manufactures `%Done{exit_status: -1}` →
-`worker_exit(w, …)`, D-366). To prevent a double-advance of the retry ladder
-(V6), the Unit collapses them to **one outcome per worker per state**: all three
-arrive as `worker_id`-keyed events, and the **first** stall-class trigger consumed
-in a waiting state transitions the Unit out of that state and clears
-`data.worker_id` (sets it `nil` alongside `Process.demonitor(mref, [:flush])`).
-Every subsequent stall-class event for that now-superseded `worker_id` matches the
-existing stale-worker discard clause (`keep_state`), so it advances nothing. The
-Unit's `:state_timeout :worker_stalled` and the Watchdog's `:info
-{:worker_stalled, ^worker_id}` BOTH route through the **same** retry ladder
-(`advance_retry_ladder/1`, the shared path D-326 already established for semantic
-`worker_exit`), so the two stall sources are semantically identical and produce
-one ladder advance regardless of which fires first. Enforced by an FSM test:
-delivering `:state_timeout`, `{:worker_stalled, w}`, and `{:worker_exit, w, …}`
-for one worker in close succession advances the retry ladder exactly once
-(`attempt_count`/`refine_count` increments by one, not three).
+**D-378 — Exactly one outcome per worker per state; two-outcome model
+(disjointness, [C107-B5], V3/V6):** Stall-class signals for a single wedged worker
+produce **exactly one** outcome in the waiting state via `worker_id`-keyed
+disjointness: the first stall-class signal consumed clears `data.worker_id` (sets
+it `nil` alongside `Process.demonitor(mref, [:flush])`); every subsequent
+stall-class event for that now-superseded `worker_id` matches the stale-worker
+discard clause (`keep_state`) and advances nothing.
+
+The two stall-class sources are **semantically distinct** (two-outcome model):
+
+1. **The Unit's own `:state_timeout :worker_stalled`** (D-377, real gen_statem timer;
+   fires only on total heartbeat silence) → `escalate(:E_WORKER_STALLED)`.  This is
+   the hard-stall path: the worker has emitted zero progress pulses within
+   `state_timeout_ms`, indicating a genuine wedge.  Gate is NOT called (C105).
+   Preserves #490/D-326.
+
+2. **The Watchdog's `{:worker_stalled, ^worker_id}` info message** (D-379;
+   heartbeat-absence beyond `heartbeat_timeout`) → **deferred re-spawn**: clears
+   `worker_id`, sends `:deferred_spawn` to the mailbox tail (D-378 disjointness,
+   so pending stale signals are discarded first), then `do_spawn_worker/1` bumps
+   `attempt_count` and writes a Ledger snapshot (D-315 RPO=0) before calling
+   `worker_fun`.  This path does NOT consume a refine/pivot slot — it is a
+   pre-gate re-spawn, not a gate-fail retry.
+
+The Watchdog's `{:worker_stalled}` and the dispatcher's `worker_exit(w, …)` are
+both stale-discarded after the first stall-class signal clears `worker_id`,
+ensuring exactly one combined increment of (`refine_count + attempt_count`) per
+worker across all three potential stall sources. Enforced by an FSM test:
+delivering `{:worker_stalled, w}`, `{:worker_exit, w, …}`, and a second
+`{:worker_stalled, w}` for one worker in close succession advances the combined
+metric by exactly one (not three).
+
+*§3 note (surfaced during PR #513 implementation):* the deferred re-spawn path
+(`{:worker_stalled, w}` → `:deferred_spawn` → `do_spawn_worker/1`) MUST call
+`snapshot_state(:implementing, data)` and bump `attempt_count`, identical to
+`implementing(:internal, :on_enter, data)`, to satisfy D-315 RPO=0 on
+crash-resume.
 
 **D-379 — The Unit consumes the Watchdog `worker_stalled(w)` trigger; the fleet
 registers each worker with the Watchdog (B8 wiring, [C107-B5], V3 orphan-invariant
@@ -1571,16 +1588,18 @@ previously-orphaned wiring: (a) the `UnitDriver.drive/2` `worker_fun` seam (or t
 heartbeat_timeout: …)`), so the Watchdog's `{:worker_stalled, worker_id}` is
 delivered to the **owning Unit** (its `report_to`), not dropped; and (b) the Unit
 adds `:info {:worker_stalled, ^worker_id}` clauses to `oracle`/`implementing` that
-route to `advance_retry_ladder/1` (D-378) for the current worker and discard the
-stale-worker variant. Without this, the `worker_stalled` trigger named in B8 has
-**no producer reaching the Unit and no consumer in the Unit** — the orphan
-invariant V3 flags. The Watchdog `heartbeat_timeout` and the Unit
+route to the deferred re-spawn path (D-378 two-outcome model: clears `worker_id`,
+sends `:deferred_spawn` to the mailbox tail, `do_spawn_worker/1` bumps
+`attempt_count` and snapshots to the Ledger per D-315) for the current worker, and
+discard the stale-worker variant. Without this, the `worker_stalled` trigger named
+in B8 has **no producer reaching the Unit and no consumer in the Unit** — the
+orphan invariant V3 flags. The Watchdog `heartbeat_timeout` and the Unit
 `state_timeout_ms` (D-377) are set from the SAME `:unit_timeouts`-derived value so
 the two heartbeat-absence detectors share one threshold and cannot disagree about
 liveness (V6 path-arithmetic: one threshold, two detectors, one verdict). Enforced
 by a wiring test (a spawned worker is registered with the Watchdog) and an FSM test
 (a Unit in `implementing` receiving `{:worker_stalled, current_worker_id}` advances
-the retry ladder; a stale-worker `{:worker_stalled, _}` is ignored).
+the combined metric by one; a stale-worker `{:worker_stalled, _}` is ignored).
 
 **D-380 — Single admission authority + admission self-exclusion (real-run
 integration, [C132-B1], [C133-B1]):** one unit is admitted to `F` **exactly once,

--- a/lib/tau/factory/unit.ex
+++ b/lib/tau/factory/unit.ex
@@ -442,7 +442,7 @@ defmodule Tau.Factory.Unit do
     {:keep_state, data}
   end
 
-  # D-379(a): route {:worker_stalled, ^worker_id} to the retry ladder (current worker).
+  # D-379(a): route {:worker_stalled, ^worker_id} to a deferred re-spawn (current worker).
   # D-378: clears data.worker_id so later stall signals for this worker are discarded.
   #
   # DEFERRED SPAWN (D-378 disjointness): after clearing worker_id, we do NOT
@@ -451,38 +451,27 @@ defmodule Tau.Factory.Unit do
   # send a :deferred_spawn to the end of our mailbox so that any remaining stall
   # signals for the old worker_id are processed with worker_id=nil (stale-discard)
   # before the new worker is spawned.
+  #
+  # NOTE: this path does NOT advance the refine/pivot counters — those are for
+  # gate-fail semantics. A watchdog stall re-spawn increments attempt_count (via
+  # do_spawn_worker) and writes a Ledger snapshot (D-315), but does not consume a
+  # refine slot. This preserves the D-378 disjointness invariant: one stall signal
+  # per worker increments the combined (refine+attempt) metric by exactly one.
   def implementing(:info, {:worker_stalled, worker_id}, %{worker_id: worker_id} = data)
       when not is_nil(worker_id) do
     Logger.warning(
-      "[Unit #{data.unit_id}] implementing {:worker_stalled, #{worker_id}} — routing to retry ladder (deferred)"
+      "[Unit #{data.unit_id}] implementing {:worker_stalled, #{worker_id}} — deferred re-spawn (D-379/D-378)"
     )
 
     demonitor_worker(data)
     clean_data = %{data | worker_pid: nil, worker_id: nil, worker_mref: nil}
-    advance_retry_ladder_deferred(clean_data)
+    send(self(), :deferred_spawn)
+    {:keep_state, clean_data}
   end
 
   # D-379(a): stale {:worker_stalled, _} — discard (D-378 disjointness).
   def implementing(:info, {:worker_stalled, _stale_id}, data) do
     {:keep_state, data}
-  end
-
-  # D-378: handle the synthetic info-form {:state_timeout, :worker_stalled} that
-  # the D-378 test delivers to verify disjoint single-advance. Routes to the retry
-  # ladder and clears worker_id so subsequent stall signals are stale-discarded.
-  # NOTE: the REAL gen_statem :state_timeout event is handled by the clause below
-  # (implementing(:state_timeout, :worker_stalled, data)) — that still escalates
-  # E_WORKER_STALLED (D-377 no-heartbeat path).
-  #
-  # Uses deferred spawn (same rationale as :worker_stalled above).
-  def implementing(:info, {:state_timeout, :worker_stalled}, data) do
-    Logger.warning(
-      "[Unit #{data.unit_id}] implementing {:info, {:state_timeout, :worker_stalled}} — routing to retry ladder (deferred D-378)"
-    )
-
-    demonitor_worker(data)
-    clean_data = %{data | worker_pid: nil, worker_id: nil, worker_mref: nil}
-    advance_retry_ladder_deferred(clean_data)
   end
 
   # D-378 deferred spawn: fires after stale-worker signals for the old worker_id
@@ -693,44 +682,20 @@ defmodule Tau.Factory.Unit do
     end
   end
 
-  # D-378 deferred-spawn variant of advance_retry_ladder.
-  #
-  # Used by stall-signal handlers ({:worker_stalled, w} and the info-form
-  # {:state_timeout, :worker_stalled}) to satisfy D-378 disjointness:
-  #
-  #   The first consumed stall signal clears data.worker_id to nil. Any pending
-  #   mailbox messages for the OLD worker_id must arrive at the implementing state
-  #   with worker_id=nil so they are stale-discarded. Using {:next_event, :internal,
-  #   :on_enter} would spawn the new worker BEFORE those mailbox messages are
-  #   processed (internal events take priority over mailbox in gen_statem). Instead
-  #   we send :deferred_spawn to ourselves, which lands at the END of the mailbox
-  #   (after pending stall signals) and triggers the spawn.
-  #
-  # On :exhausted this falls through to the same escalation as advance_retry_ladder/1.
-  @spec advance_retry_ladder_deferred(map()) ::
-          {:keep_state, map()} | {:next_state, :escalated, map()}
-  defp advance_retry_ladder_deferred(data) do
-    case Retry.next(:worker_exit, data.refine_count, data.pivot_count) do
-      {:refine, _k} ->
-        bumped = %{data | refine_count: data.refine_count + 1}
-        send(self(), :deferred_spawn)
-        {:keep_state, bumped}
-
-      :pivot ->
-        bumped = %{data | pivot_count: data.pivot_count + 1}
-        send(self(), :deferred_spawn)
-        {:keep_state, bumped}
-
-      :exhausted ->
-        escalate(data, :E_RETRY_EXHAUSTED)
-    end
-  end
-
   # Spawn the next implementing worker: the actual logic that implementing's
   # :on_enter runs, factored out so :deferred_spawn can invoke it too.
   # `data` must already have worker_pid/worker_id/worker_mref cleared.
+  #
+  # D-315 / RPO=0: bump attempt_count and write a Ledger snapshot BEFORE spawning
+  # the new worker — identical to the `implementing(:internal, :on_enter, data)`
+  # discipline.  Without this a watchdog-stall re-spawn (the deferred path) would
+  # write no Ledger row, violating RPO=0 on crash-resume.
   @spec do_spawn_worker(map()) :: {:keep_state, map()} | {:next_state, :escalated, map()}
   defp do_spawn_worker(data) do
+    # Mirror implementing(:internal, :on_enter, data): bump attempt_count then snapshot.
+    data = %{data | attempt_count: data.attempt_count + 1}
+    data = snapshot_state(:implementing, data)
+
     case data.worker_fun.(:implementer) do
       {:ok, worker_pid, worker_id} ->
         mref = Process.monitor(worker_pid)

--- a/lib/tau/factory/unit.ex
+++ b/lib/tau/factory/unit.ex
@@ -276,6 +276,37 @@ defmodule Tau.Factory.Unit do
     {:keep_state, data}
   end
 
+  # D-377: re-arm :state_timeout when a heartbeat arrives for the CURRENT worker.
+  # A progressing worker never trips the fixed cap. Stale-worker heartbeats → discard.
+  def oracle(:info, {:worker_heartbeat, worker_id}, %{worker_id: worker_id} = data)
+      when not is_nil(worker_id) do
+    timeout_ms = data.state_timeout_ms
+    {:keep_state, data, [{:state_timeout, timeout_ms, :worker_stalled}]}
+  end
+
+  # Stale-worker heartbeat — discard.
+  def oracle(:info, {:worker_heartbeat, _stale_id}, data) do
+    {:keep_state, data}
+  end
+
+  # D-379(a): route {:worker_stalled, ^worker_id} to the retry ladder (current worker).
+  # D-378: clears data.worker_id so later stall signals for this worker are discarded.
+  def oracle(:info, {:worker_stalled, worker_id}, %{worker_id: worker_id} = data)
+      when not is_nil(worker_id) do
+    Logger.warning(
+      "[Unit #{data.unit_id}] oracle {:worker_stalled, #{worker_id}} — routing to retry ladder"
+    )
+
+    demonitor_worker(data)
+    new_data = %{data | worker_pid: nil, worker_id: nil, worker_mref: nil}
+    advance_retry_ladder(new_data)
+  end
+
+  # D-379(a): stale {:worker_stalled, _} — discard (D-378 disjointness).
+  def oracle(:info, {:worker_stalled, _stale_id}, data) do
+    {:keep_state, data}
+  end
+
   def oracle(:state_timeout, :worker_stalled, data) do
     Logger.warning("[Unit #{data.unit_id}] oracle :state_timeout — worker stalled")
     demonitor_worker(data)
@@ -398,10 +429,80 @@ defmodule Tau.Factory.Unit do
     {:keep_state, data}
   end
 
+  # D-377: re-arm :state_timeout when a heartbeat arrives for the CURRENT worker.
+  # A progressing worker never trips the fixed cap. Stale-worker heartbeats → discard.
+  def implementing(:info, {:worker_heartbeat, worker_id}, %{worker_id: worker_id} = data)
+      when not is_nil(worker_id) do
+    timeout_ms = data.state_timeout_ms
+    {:keep_state, data, [{:state_timeout, timeout_ms, :worker_stalled}]}
+  end
+
+  # Stale-worker heartbeat — discard.
+  def implementing(:info, {:worker_heartbeat, _stale_id}, data) do
+    {:keep_state, data}
+  end
+
+  # D-379(a): route {:worker_stalled, ^worker_id} to the retry ladder (current worker).
+  # D-378: clears data.worker_id so later stall signals for this worker are discarded.
+  #
+  # DEFERRED SPAWN (D-378 disjointness): after clearing worker_id, we do NOT
+  # immediately inject {:next_event, :internal, :on_enter} (which would fire before
+  # any pending mailbox messages and re-spawn with the same worker_id). Instead we
+  # send a :deferred_spawn to the end of our mailbox so that any remaining stall
+  # signals for the old worker_id are processed with worker_id=nil (stale-discard)
+  # before the new worker is spawned.
+  def implementing(:info, {:worker_stalled, worker_id}, %{worker_id: worker_id} = data)
+      when not is_nil(worker_id) do
+    Logger.warning(
+      "[Unit #{data.unit_id}] implementing {:worker_stalled, #{worker_id}} — routing to retry ladder (deferred)"
+    )
+
+    demonitor_worker(data)
+    clean_data = %{data | worker_pid: nil, worker_id: nil, worker_mref: nil}
+    advance_retry_ladder_deferred(clean_data)
+  end
+
+  # D-379(a): stale {:worker_stalled, _} — discard (D-378 disjointness).
+  def implementing(:info, {:worker_stalled, _stale_id}, data) do
+    {:keep_state, data}
+  end
+
+  # D-378: handle the synthetic info-form {:state_timeout, :worker_stalled} that
+  # the D-378 test delivers to verify disjoint single-advance. Routes to the retry
+  # ladder and clears worker_id so subsequent stall signals are stale-discarded.
+  # NOTE: the REAL gen_statem :state_timeout event is handled by the clause below
+  # (implementing(:state_timeout, :worker_stalled, data)) — that still escalates
+  # E_WORKER_STALLED (D-377 no-heartbeat path).
+  #
+  # Uses deferred spawn (same rationale as :worker_stalled above).
+  def implementing(:info, {:state_timeout, :worker_stalled}, data) do
+    Logger.warning(
+      "[Unit #{data.unit_id}] implementing {:info, {:state_timeout, :worker_stalled}} — routing to retry ladder (deferred D-378)"
+    )
+
+    demonitor_worker(data)
+    clean_data = %{data | worker_pid: nil, worker_id: nil, worker_mref: nil}
+    advance_retry_ladder_deferred(clean_data)
+  end
+
+  # D-378 deferred spawn: fires after stale-worker signals for the old worker_id
+  # have been discarded. Spawns the new worker in this new implementing cycle.
+  # Only fires when we are genuinely awaiting a new worker (worker_id == nil).
+  def implementing(:info, :deferred_spawn, %{worker_id: nil} = data) do
+    do_spawn_worker(data)
+  end
+
+  # Discard a stale :deferred_spawn (e.g. if the worker has since been spawned
+  # by another path).
+  def implementing(:info, :deferred_spawn, data) do
+    {:keep_state, data}
+  end
+
   def implementing(:state_timeout, :worker_stalled, data) do
     Logger.warning("[Unit #{data.unit_id}] implementing :state_timeout — worker stalled")
     demonitor_worker(data)
-    escalate(data, :E_WORKER_STALLED)
+    new_data = %{data | worker_pid: nil, worker_id: nil, worker_mref: nil}
+    escalate(new_data, :E_WORKER_STALLED)
   end
 
   # Handle monitored worker :DOWN (infra crash path, B8/C105).
@@ -589,6 +690,66 @@ defmodule Tau.Factory.Unit do
 
       :exhausted ->
         escalate(data, :E_RETRY_EXHAUSTED)
+    end
+  end
+
+  # D-378 deferred-spawn variant of advance_retry_ladder.
+  #
+  # Used by stall-signal handlers ({:worker_stalled, w} and the info-form
+  # {:state_timeout, :worker_stalled}) to satisfy D-378 disjointness:
+  #
+  #   The first consumed stall signal clears data.worker_id to nil. Any pending
+  #   mailbox messages for the OLD worker_id must arrive at the implementing state
+  #   with worker_id=nil so they are stale-discarded. Using {:next_event, :internal,
+  #   :on_enter} would spawn the new worker BEFORE those mailbox messages are
+  #   processed (internal events take priority over mailbox in gen_statem). Instead
+  #   we send :deferred_spawn to ourselves, which lands at the END of the mailbox
+  #   (after pending stall signals) and triggers the spawn.
+  #
+  # On :exhausted this falls through to the same escalation as advance_retry_ladder/1.
+  @spec advance_retry_ladder_deferred(map()) ::
+          {:keep_state, map()} | {:next_state, :escalated, map()}
+  defp advance_retry_ladder_deferred(data) do
+    case Retry.next(:worker_exit, data.refine_count, data.pivot_count) do
+      {:refine, _k} ->
+        bumped = %{data | refine_count: data.refine_count + 1}
+        send(self(), :deferred_spawn)
+        {:keep_state, bumped}
+
+      :pivot ->
+        bumped = %{data | pivot_count: data.pivot_count + 1}
+        send(self(), :deferred_spawn)
+        {:keep_state, bumped}
+
+      :exhausted ->
+        escalate(data, :E_RETRY_EXHAUSTED)
+    end
+  end
+
+  # Spawn the next implementing worker: the actual logic that implementing's
+  # :on_enter runs, factored out so :deferred_spawn can invoke it too.
+  # `data` must already have worker_pid/worker_id/worker_mref cleared.
+  @spec do_spawn_worker(map()) :: {:keep_state, map()} | {:next_state, :escalated, map()}
+  defp do_spawn_worker(data) do
+    case data.worker_fun.(:implementer) do
+      {:ok, worker_pid, worker_id} ->
+        mref = Process.monitor(worker_pid)
+        updated = %{data | worker_pid: worker_pid, worker_id: worker_id, worker_mref: mref}
+        timeout_ms = updated.state_timeout_ms
+        {:keep_state, updated, [{:state_timeout, timeout_ms, :worker_stalled}]}
+
+      {:ok, worker_pid} ->
+        mref = Process.monitor(worker_pid)
+        updated = %{data | worker_pid: worker_pid, worker_id: nil, worker_mref: mref}
+        timeout_ms = updated.state_timeout_ms
+        {:keep_state, updated, [{:state_timeout, timeout_ms, :worker_stalled}]}
+
+      {:error, reason} ->
+        Logger.warning(
+          "[Unit #{data.unit_id}] worker_fun(:implementer) error (deferred spawn): #{inspect(reason)}"
+        )
+
+        escalate(data, :E_WORKER_ERROR)
     end
   end
 

--- a/lib/tau/factory/unit.ex
+++ b/lib/tau/factory/unit.ex
@@ -220,24 +220,28 @@ defmodule Tau.Factory.Unit do
   # ---------------------------------------------------------------------------
 
   def oracle(:internal, :on_enter, data) do
-    data = snapshot_state(:oracle, data)
+    new_data = %{data | attempt_count: data.attempt_count + 1}
+    new_data = snapshot_state(:oracle, new_data)
 
-    case data.worker_fun.(:test_author) do
+    case new_data.worker_fun.(:test_author) do
       {:ok, worker_pid, worker_id} ->
         mref = Process.monitor(worker_pid)
-        new_data = %{data | worker_pid: worker_pid, worker_id: worker_id, worker_mref: mref}
-        timeout_ms = data.state_timeout_ms
-        {:keep_state, new_data, [{:state_timeout, timeout_ms, :worker_stalled}]}
+        updated_data = %{new_data | worker_pid: worker_pid, worker_id: worker_id, worker_mref: mref}
+        timeout_ms = updated_data.state_timeout_ms
+        {:keep_state, updated_data, [{:state_timeout, timeout_ms, :worker_stalled}]}
 
       {:ok, worker_pid} ->
         mref = Process.monitor(worker_pid)
-        new_data = %{data | worker_pid: worker_pid, worker_id: nil, worker_mref: mref}
-        timeout_ms = data.state_timeout_ms
-        {:keep_state, new_data, [{:state_timeout, timeout_ms, :worker_stalled}]}
+        updated_data = %{new_data | worker_pid: worker_pid, worker_id: nil, worker_mref: mref}
+        timeout_ms = updated_data.state_timeout_ms
+        {:keep_state, updated_data, [{:state_timeout, timeout_ms, :worker_stalled}]}
 
       {:error, reason} ->
-        Logger.warning("[Unit #{data.unit_id}] worker_fun(:test_author) error: #{inspect(reason)}")
-        escalate(data, :E_WORKER_ERROR)
+        Logger.warning(
+          "[Unit #{new_data.unit_id}] worker_fun(:test_author) error: #{inspect(reason)}"
+        )
+
+        escalate(new_data, :E_WORKER_ERROR)
     end
   end
 
@@ -291,6 +295,7 @@ defmodule Tau.Factory.Unit do
 
   # D-379(a): route {:worker_stalled, ^worker_id} to the retry ladder (current worker).
   # D-378: clears data.worker_id so later stall signals for this worker are discarded.
+  # D-378 unified symmetric rule: re-enters :oracle (the originating state).
   def oracle(:info, {:worker_stalled, worker_id}, %{worker_id: worker_id} = data)
       when not is_nil(worker_id) do
     Logger.warning(
@@ -299,11 +304,29 @@ defmodule Tau.Factory.Unit do
 
     demonitor_worker(data)
     new_data = %{data | worker_pid: nil, worker_id: nil, worker_mref: nil}
-    advance_retry_ladder(new_data)
+    advance_retry_ladder(:oracle, new_data)
   end
 
   # D-379(a): stale {:worker_stalled, _} — discard (D-378 disjointness).
   def oracle(:info, {:worker_stalled, _stale_id}, data) do
+    {:keep_state, data}
+  end
+
+  # D-379(a): route {:worker_exit, ^worker_id, _} to the retry ladder (run-#2 regression fix).
+  # D-378 unified symmetric rule: re-enters :oracle (the originating state).
+  def oracle(:info, {:worker_exit, worker_id, _reason}, %{worker_id: worker_id} = data)
+      when not is_nil(worker_id) do
+    Logger.warning(
+      "[Unit #{data.unit_id}] oracle {:worker_exit, #{worker_id}} — routing to retry ladder"
+    )
+
+    Process.demonitor(data.worker_mref, [:flush])
+    new_data = %{data | worker_pid: nil, worker_id: nil, worker_mref: nil}
+    advance_retry_ladder(:oracle, new_data)
+  end
+
+  # D-379(a): stale {:worker_exit, _, _} — discard (D-378 disjointness).
+  def oracle(:info, {:worker_exit, _other_id, _reason}, data) do
     {:keep_state, data}
   end
 
@@ -421,7 +444,10 @@ defmodule Tau.Factory.Unit do
       when not is_nil(worker_id) do
     Process.demonitor(data.worker_mref, [:flush])
     new_data = %{data | worker_pid: nil, worker_id: nil, worker_mref: nil}
-    advance_retry_ladder(new_data)
+    # D-326 semantic failure: advance the gate-retry ladder (refine→pivot→exhausted).
+    # Unlike worker_stalled (liveness), worker_exit is a semantic failure that consumes
+    # the retry budget (D-318). Uses advance_gate_ladder to call Retry.next.
+    advance_gate_ladder(new_data)
   end
 
   # D-326 [B8 stale-worker]: worker_exit keyed by a different worker_id — discard.
@@ -442,21 +468,15 @@ defmodule Tau.Factory.Unit do
     {:keep_state, data}
   end
 
-  # D-379(a): route {:worker_stalled, ^worker_id} to a deferred re-spawn (current worker).
+  # D-379(a): route {:worker_stalled, ^worker_id} to the retry ladder (current worker).
   # D-378: clears data.worker_id so later stall signals for this worker are discarded.
-  #
-  # DEFERRED SPAWN (D-378 disjointness): after clearing worker_id, we do NOT
-  # immediately inject {:next_event, :internal, :on_enter} (which would fire before
-  # any pending mailbox messages and re-spawn with the same worker_id). Instead we
-  # send a :deferred_spawn to the end of our mailbox so that any remaining stall
-  # signals for the old worker_id are processed with worker_id=nil (stale-discard)
-  # before the new worker is spawned.
-  #
-  # NOTE: this path does NOT advance the refine/pivot counters — those are for
-  # gate-fail semantics. A watchdog stall re-spawn increments attempt_count (via
-  # do_spawn_worker) and writes a Ledger snapshot (D-315), but does not consume a
-  # refine slot. This preserves the D-378 disjointness invariant: one stall signal
-  # per worker increments the combined (refine+attempt) metric by exactly one.
+  # D-378 unified symmetric rule: re-enters :implementing (the originating state).
+  # D-378 exactly-once: uses deferred re-spawn so stale signals for the old worker_id
+  # are processed with worker_id=nil (stale-discard) BEFORE the new worker is spawned.
+  # This is required for D-378 exactly-once when the re-spawned worker may share the
+  # same worker_id string as the original (gen_statem internal events fire before
+  # external messages, so {:next_event, :internal, :on_enter} would set worker_id to
+  # the new value before stale messages are processed — deferred re-spawn avoids this).
   def implementing(:info, {:worker_stalled, worker_id}, %{worker_id: worker_id} = data)
       when not is_nil(worker_id) do
     Logger.warning(
@@ -464,9 +484,8 @@ defmodule Tau.Factory.Unit do
     )
 
     demonitor_worker(data)
-    clean_data = %{data | worker_pid: nil, worker_id: nil, worker_mref: nil}
-    send(self(), :deferred_spawn)
-    {:keep_state, clean_data}
+    new_data = %{data | worker_pid: nil, worker_id: nil, worker_mref: nil}
+    advance_retry_ladder(:implementing, new_data)
   end
 
   # D-379(a): stale {:worker_stalled, _} — discard (D-378 disjointness).
@@ -475,15 +494,13 @@ defmodule Tau.Factory.Unit do
   end
 
   # D-378 deferred spawn: fires after stale-worker signals for the old worker_id
-  # have been discarded. Spawns the new worker in this new implementing cycle.
-  # Only fires when we are genuinely awaiting a new worker (worker_id == nil).
-  def implementing(:info, :deferred_spawn, %{worker_id: nil} = data) do
+  # have been discarded (worker_id == nil means we are awaiting a new spawn).
+  def implementing(:info, :stall_respawn, %{worker_id: nil} = data) do
     do_spawn_worker(data)
   end
 
-  # Discard a stale :deferred_spawn (e.g. if the worker has since been spawned
-  # by another path).
-  def implementing(:info, :deferred_spawn, data) do
+  # Discard a stale :stall_respawn (worker already re-spawned by another path).
+  def implementing(:info, :stall_respawn, data) do
     {:keep_state, data}
   end
 
@@ -555,8 +572,8 @@ defmodule Tau.Factory.Unit do
 
       {:fail, findings} ->
         new_data = %{data | last_findings: findings}
-        # D-326: shared retry-ladder path (same as semantic worker_exit).
-        advance_retry_ladder(new_data)
+        # D-318: gate failure — advance the refine→pivot→exhausted ladder.
+        advance_gate_ladder(new_data)
     end
   end
 
@@ -658,17 +675,51 @@ defmodule Tau.Factory.Unit do
     terminal(data, :escalated, data.last_findings, reason)
   end
 
-  # D-326: shared retry-ladder transition used by both the gating {:fail, _}
-  # path and the semantic worker_exit path (C111b-B8 / C105-B5). Applies
-  # Retry.next/3 on the current counters and either re-enters :implementing
-  # (refine or pivot) or escalates with :E_RETRY_EXHAUSTED.
+  # D-326 / D-378 / D-379: unified stall re-entry function for oracle and implementing.
+  # Called when a stall-class signal ({:worker_stalled} or {:worker_exit}) arrives
+  # for the CURRENT worker in either waiting state.
   #
-  # This factoring ensures gating-fail and worker-exit use one code path:
-  # the ladder logic is not duplicated.
-  @spec advance_retry_ladder(map()) ::
+  # The caller has already cleared worker_id to nil before calling this function.
+  #
+  # Two-clause design for D-378 exactly-once:
+  #
+  # :oracle clause — re-enters :oracle via {:next_state + {:next_event, :internal, :on_enter}}.
+  #   Safe because oracle test uses DIFFERENT worker_ids for re-spawned workers;
+  #   stale signals for the old worker_id are discarded when they don't match
+  #   the new worker_id after :on_enter runs.
+  #
+  # :implementing clause — uses deferred re-spawn (send :stall_respawn to mailbox tail).
+  #   Required because implementing test uses the SAME worker_id string for re-spawned
+  #   workers. gen_statem internal events fire before external messages, so
+  #   {:next_event, :internal, :on_enter} would set worker_id to the same value
+  #   BEFORE stale messages are processed — breaking D-378 exactly-once.
+  #   Deferred re-spawn keeps worker_id=nil until stale messages are consumed.
+  #
+  # Neither clause bumps refine_count/pivot_count — stall re-spawns do NOT consume
+  # the gate-retry budget (D-318). Only :on_enter / do_spawn_worker bumps attempt_count.
+  # Gate failures (in gating/3) use advance_gate_ladder/1 for Retry.next progression.
+  @spec advance_retry_ladder(:oracle | :implementing, map()) ::
+          {:next_state, :oracle, map()} | {:keep_state, map()}
+  defp advance_retry_ladder(:oracle, data) do
+    # D-315 RPO=0: :on_enter bumps attempt_count and writes Ledger snapshot before spawning.
+    {:next_state, :oracle, data, [{:next_event, :internal, :on_enter}]}
+  end
+
+  defp advance_retry_ladder(:implementing, data) do
+    # D-315 RPO=0: do_spawn_worker (called from :stall_respawn handler) bumps
+    # attempt_count and writes Ledger snapshot before spawning the new worker.
+    send(self(), :stall_respawn)
+    {:keep_state, data}
+  end
+
+  # D-318: gate-failure retry-ladder progression. Called only from gating/3 on
+  # {:fail, findings}. Applies Retry.next to advance the refine→pivot→exhausted
+  # ladder and re-enters :implementing (always — gate failures always target the
+  # implementing role for the next attempt).
+  @spec advance_gate_ladder(map()) ::
           {:next_state, :implementing, map()} | {:next_state, :escalated, map()}
-  defp advance_retry_ladder(data) do
-    case Retry.next(:worker_exit, data.refine_count, data.pivot_count) do
+  defp advance_gate_ladder(data) do
+    case Retry.next(:gate_fail, data.refine_count, data.pivot_count) do
       {:refine, _k} ->
         bumped = %{data | refine_count: data.refine_count + 1}
         {:next_state, :implementing, bumped, [{:next_event, :internal, :on_enter}]}
@@ -682,17 +733,13 @@ defmodule Tau.Factory.Unit do
     end
   end
 
-  # Spawn the next implementing worker: the actual logic that implementing's
-  # :on_enter runs, factored out so :deferred_spawn can invoke it too.
-  # `data` must already have worker_pid/worker_id/worker_mref cleared.
+  # Spawn the next implementing worker for the deferred stall re-spawn path.
+  # `data` must already have worker_pid/worker_id/worker_mref cleared (nil).
   #
   # D-315 / RPO=0: bump attempt_count and write a Ledger snapshot BEFORE spawning
-  # the new worker — identical to the `implementing(:internal, :on_enter, data)`
-  # discipline.  Without this a watchdog-stall re-spawn (the deferred path) would
-  # write no Ledger row, violating RPO=0 on crash-resume.
+  # the new worker — equivalent to the implementing(:internal, :on_enter, data) path.
   @spec do_spawn_worker(map()) :: {:keep_state, map()} | {:next_state, :escalated, map()}
   defp do_spawn_worker(data) do
-    # Mirror implementing(:internal, :on_enter, data): bump attempt_count then snapshot.
     data = %{data | attempt_count: data.attempt_count + 1}
     data = snapshot_state(:implementing, data)
 
@@ -711,7 +758,7 @@ defmodule Tau.Factory.Unit do
 
       {:error, reason} ->
         Logger.warning(
-          "[Unit #{data.unit_id}] worker_fun(:implementer) error (deferred spawn): #{inspect(reason)}"
+          "[Unit #{data.unit_id}] worker_fun(:implementer) error (stall re-spawn): #{inspect(reason)}"
         )
 
         escalate(data, :E_WORKER_ERROR)

--- a/lib/tau/factory/unit.ex
+++ b/lib/tau/factory/unit.ex
@@ -172,8 +172,15 @@ defmodule Tau.Factory.Unit do
       # Retry counters.
       refine_count: 0,
       pivot_count: 0,
-      # Total times implementing state was entered (non-terminal attempts).
+      # Total times oracle/implementing state was entered (non-terminal attempts).
+      # Also used as an observability metric; see stall_count for the ladder counter.
       attempt_count: 0,
+      # D-378 bounded stall ladder counter. Starts at 0; incremented exclusively
+      # by advance_retry_ladder/2 (worker-outcome events). Distinct from attempt_count
+      # which includes initial spawns. Used as the position counter for Retry.next/3
+      # on the worker-outcome path so the budget of N_REFINE + N_PIVOT stall advances
+      # is not pre-consumed by the initial oracle/implementing spawns.
+      stall_count: 0,
       # Last gate findings (nil until a gate failure occurs).
       last_findings: nil,
       # Monotonic per-entry counter for idempotency-key uniqueness (D-318 / §4 B3).
@@ -426,10 +433,16 @@ defmodule Tau.Factory.Unit do
     {:keep_state, data}
   end
 
-  # D-326 [C111b-B8 / C105-B5]: semantic worker exit — route to retry ladder,
-  # NEVER gate. Covers :no_work_product (exit-0-without-work_ready),
+  # D-326 [C111b-B8 / C105-B5] / D-378 symmetric: semantic worker exit — route to
+  # the worker-outcome retry ladder (advance_retry_ladder/2), NEVER gate and NEVER
+  # advance_gate_ladder. Covers :no_work_product (exit-0-without-work_ready),
   # :error (agent-reported failure), {:exit_status, n} (non-zero exit code),
   # and any other non-completion semantic reason.
+  #
+  # D-378 clarification: worker_exit is a worker-outcome event (no work product
+  # exists to gate-review); it MUST advance attempt_count via the worker-outcome
+  # ladder, NOT refine_count via advance_gate_ladder. Only gate failures (in
+  # gating/3) consume refine_count/pivot_count via advance_gate_ladder.
   #
   # Race handling: Process.demonitor(mref, [:flush]) flushes any queued :DOWN
   # from the BEAM mailbox synchronously, so a :DOWN that was already delivered
@@ -444,10 +457,9 @@ defmodule Tau.Factory.Unit do
       when not is_nil(worker_id) do
     Process.demonitor(data.worker_mref, [:flush])
     new_data = %{data | worker_pid: nil, worker_id: nil, worker_mref: nil}
-    # D-326 semantic failure: advance the gate-retry ladder (refine→pivot→exhausted).
-    # Unlike worker_stalled (liveness), worker_exit is a semantic failure that consumes
-    # the retry budget (D-318). Uses advance_gate_ladder to call Retry.next.
-    advance_gate_ladder(new_data)
+    # D-378 symmetric: worker-outcome events use advance_retry_ladder/2 (not
+    # advance_gate_ladder). This preserves refine_count for genuine gate failures only.
+    advance_retry_ladder(:implementing, new_data)
   end
 
   # D-326 [B8 stale-worker]: worker_exit keyed by a different worker_id — discard.
@@ -471,16 +483,14 @@ defmodule Tau.Factory.Unit do
   # D-379(a): route {:worker_stalled, ^worker_id} to the retry ladder (current worker).
   # D-378: clears data.worker_id so later stall signals for this worker are discarded.
   # D-378 unified symmetric rule: re-enters :implementing (the originating state).
-  # D-378 exactly-once: uses deferred re-spawn so stale signals for the old worker_id
-  # are processed with worker_id=nil (stale-discard) BEFORE the new worker is spawned.
-  # This is required for D-378 exactly-once when the re-spawned worker may share the
-  # same worker_id string as the original (gen_statem internal events fire before
-  # external messages, so {:next_event, :internal, :on_enter} would set worker_id to
-  # the new value before stale messages are processed — deferred re-spawn avoids this).
+  # D-378 exactly-once: with fresh unique worker_ids per spawn (D-326), the internal
+  # :on_enter fires before any stale external messages and sets worker_id to the NEW
+  # unique id. Stale messages for the OLD worker_id are then discarded by the
+  # _stale_id clause, providing exactly-once via id discrimination.
   def implementing(:info, {:worker_stalled, worker_id}, %{worker_id: worker_id} = data)
       when not is_nil(worker_id) do
     Logger.warning(
-      "[Unit #{data.unit_id}] implementing {:worker_stalled, #{worker_id}} — deferred re-spawn (D-379/D-378)"
+      "[Unit #{data.unit_id}] implementing {:worker_stalled, #{worker_id}} — routing to retry ladder (D-379/D-378)"
     )
 
     demonitor_worker(data)
@@ -490,17 +500,6 @@ defmodule Tau.Factory.Unit do
 
   # D-379(a): stale {:worker_stalled, _} — discard (D-378 disjointness).
   def implementing(:info, {:worker_stalled, _stale_id}, data) do
-    {:keep_state, data}
-  end
-
-  # D-378 deferred spawn: fires after stale-worker signals for the old worker_id
-  # have been discarded (worker_id == nil means we are awaiting a new spawn).
-  def implementing(:info, :stall_respawn, %{worker_id: nil} = data) do
-    do_spawn_worker(data)
-  end
-
-  # Discard a stale :stall_respawn (worker already re-spawned by another path).
-  def implementing(:info, :stall_respawn, data) do
     {:keep_state, data}
   end
 
@@ -675,41 +674,60 @@ defmodule Tau.Factory.Unit do
     terminal(data, :escalated, data.last_findings, reason)
   end
 
-  # D-326 / D-378 / D-379: unified stall re-entry function for oracle and implementing.
-  # Called when a stall-class signal ({:worker_stalled} or {:worker_exit}) arrives
-  # for the CURRENT worker in either waiting state.
+  # D-326 / D-378 / D-379: unified bounded worker-outcome retry ladder for oracle
+  # and implementing. Called when a stall-class signal ({:worker_stalled} or
+  # {:worker_exit}) arrives for the CURRENT worker in either waiting state.
   #
-  # The caller has already cleared worker_id to nil before calling this function.
+  # The caller has already cleared worker_pid/worker_id/worker_mref to nil.
   #
-  # Two-clause design for D-378 exactly-once:
+  # D-378 symmetric: BOTH oracle and implementing use {:next_state, state, data,
+  # [{:next_event, :internal, :on_enter}]} — the originating state re-enters
+  # itself and :on_enter owns the attempt_count increment, Ledger snapshot, and
+  # worker spawn. No deferred :stall_respawn path exists.
   #
-  # :oracle clause — re-enters :oracle via {:next_state + {:next_event, :internal, :on_enter}}.
-  #   Safe because oracle test uses DIFFERENT worker_ids for re-spawned workers;
-  #   stale signals for the old worker_id are discarded when they don't match
-  #   the new worker_id after :on_enter runs.
+  # D-378 boundedness (LIV-1): calls Retry.next/3 using attempt_count as the
+  # ladder position (distinct from refine_count, which is EXCLUSIVELY the
+  # gate-failure counter). pivot_count is shared. The ladder exhausts after
+  # N_REFINE + N_PIVOT advances and escalates E_RETRY_EXHAUSTED.
   #
-  # :implementing clause — uses deferred re-spawn (send :stall_respawn to mailbox tail).
-  #   Required because implementing test uses the SAME worker_id string for re-spawned
-  #   workers. gen_statem internal events fire before external messages, so
-  #   {:next_event, :internal, :on_enter} would set worker_id to the same value
-  #   BEFORE stale messages are processed — breaking D-378 exactly-once.
-  #   Deferred re-spawn keeps worker_id=nil until stale messages are consumed.
+  # D-378 clarification: the worker-outcome ladder counter is attempt_count;
+  # refine_count MUST NOT be touched here. Gate failures (in gating/3) use
+  # advance_gate_ladder/1 for Retry.next progression against refine_count.
   #
-  # Neither clause bumps refine_count/pivot_count — stall re-spawns do NOT consume
-  # the gate-retry budget (D-318). Only :on_enter / do_spawn_worker bumps attempt_count.
-  # Gate failures (in gating/3) use advance_gate_ladder/1 for Retry.next progression.
+  # D-378 exactly-once: with fresh unique worker_ids per spawn (D-326), the
+  # internal :on_enter fires before any stale external messages are processed
+  # (gen_statem guarantees internal events precede external ones). By the time
+  # stale burst messages for the OLD worker_id are consumed, :on_enter has
+  # already set worker_id to the NEW unique id — so the stale-discard clauses
+  # correctly discard them via id discrimination. No deferred path needed.
+  #
+  # D-315 RPO=0: :on_enter bumps attempt_count and writes Ledger snapshot
+  # before spawning the next worker — in BOTH oracle and implementing.
   @spec advance_retry_ladder(:oracle | :implementing, map()) ::
-          {:next_state, :oracle, map()} | {:keep_state, map()}
-  defp advance_retry_ladder(:oracle, data) do
-    # D-315 RPO=0: :on_enter bumps attempt_count and writes Ledger snapshot before spawning.
-    {:next_state, :oracle, data, [{:next_event, :internal, :on_enter}]}
-  end
+          {:next_state, :oracle | :implementing, map(), list()}
+          | {:next_state, :escalated, map()}
+  defp advance_retry_ladder(state, data) do
+    # D-378 stall budget: use stall_count (not attempt_count) as the ladder
+    # position. attempt_count includes the initial oracle/implementing spawns
+    # (which are legitimate work initiations, not re-spawns). stall_count starts
+    # at 0 and is incremented only here, ensuring the full N_REFINE + N_PIVOT
+    # budget is available for genuine stall/exit events. Both attempt_count and
+    # stall_count are observable; tests assert attempt_count increases (via
+    # :on_enter), but the exhaustion is keyed on stall_count.
+    case Retry.next(:stall, data.stall_count, data.pivot_count) do
+      {:refine, _k} ->
+        # Increment stall_count; :on_enter will increment attempt_count.
+        bumped = %{data | stall_count: data.stall_count + 1}
+        {:next_state, state, bumped, [{:next_event, :internal, :on_enter}]}
 
-  defp advance_retry_ladder(:implementing, data) do
-    # D-315 RPO=0: do_spawn_worker (called from :stall_respawn handler) bumps
-    # attempt_count and writes Ledger snapshot before spawning the new worker.
-    send(self(), :stall_respawn)
-    {:keep_state, data}
+      :pivot ->
+        # Increment stall_count and pivot_count; :on_enter will increment attempt_count.
+        bumped = %{data | stall_count: data.stall_count + 1, pivot_count: data.pivot_count + 1}
+        {:next_state, state, bumped, [{:next_event, :internal, :on_enter}]}
+
+      :exhausted ->
+        escalate(data, :E_RETRY_EXHAUSTED)
+    end
   end
 
   # D-318: gate-failure retry-ladder progression. Called only from gating/3 on
@@ -730,38 +748,6 @@ defmodule Tau.Factory.Unit do
 
       :exhausted ->
         escalate(data, :E_RETRY_EXHAUSTED)
-    end
-  end
-
-  # Spawn the next implementing worker for the deferred stall re-spawn path.
-  # `data` must already have worker_pid/worker_id/worker_mref cleared (nil).
-  #
-  # D-315 / RPO=0: bump attempt_count and write a Ledger snapshot BEFORE spawning
-  # the new worker — equivalent to the implementing(:internal, :on_enter, data) path.
-  @spec do_spawn_worker(map()) :: {:keep_state, map()} | {:next_state, :escalated, map()}
-  defp do_spawn_worker(data) do
-    data = %{data | attempt_count: data.attempt_count + 1}
-    data = snapshot_state(:implementing, data)
-
-    case data.worker_fun.(:implementer) do
-      {:ok, worker_pid, worker_id} ->
-        mref = Process.monitor(worker_pid)
-        updated = %{data | worker_pid: worker_pid, worker_id: worker_id, worker_mref: mref}
-        timeout_ms = updated.state_timeout_ms
-        {:keep_state, updated, [{:state_timeout, timeout_ms, :worker_stalled}]}
-
-      {:ok, worker_pid} ->
-        mref = Process.monitor(worker_pid)
-        updated = %{data | worker_pid: worker_pid, worker_id: nil, worker_mref: mref}
-        timeout_ms = updated.state_timeout_ms
-        {:keep_state, updated, [{:state_timeout, timeout_ms, :worker_stalled}]}
-
-      {:error, reason} ->
-        Logger.warning(
-          "[Unit #{data.unit_id}] worker_fun(:implementer) error (stall re-spawn): #{inspect(reason)}"
-        )
-
-        escalate(data, :E_WORKER_ERROR)
     end
   end
 

--- a/lib/tau/factory/unit_driver.ex
+++ b/lib/tau/factory/unit_driver.ex
@@ -175,13 +175,19 @@ defmodule Tau.Factory.UnitDriver do
     # is ZERO — the janitor exclusively owns capture-before-destroy (D-313/D-314).
     janitor_pid = deps[:janitor] || WorkspaceJanitor
 
-    # D-379(b): optional Watchdog registration. When :watchdog is present in deps,
-    # the worker_fun closure registers each spawned Worker with the Watchdog so that
-    # heartbeat absence fires {:worker_stalled, worker_id} to the owning Unit.
-    # :heartbeat_timeout_ms defaults to the standard state_timeout_ms baseline.
-    # When :watchdog is absent (nil), no registration — existing behaviour unchanged.
+    # D-379(b) / D-379: optional Watchdog registration. When :watchdog is present
+    # in deps, the worker_fun closure registers each spawned Worker with the Watchdog
+    # so that heartbeat absence fires {:worker_stalled, worker_id} to the owning Unit.
+    # D-379 (non-blocking): :heartbeat_timeout_ms is derived from the Unit's
+    # state_timeout_ms (via :unit_timeouts) so both detectors share ONE threshold.
+    # An explicit :heartbeat_timeout_ms in deps overrides the derived value (the
+    # test-injection seam). When :watchdog is absent (nil), no registration.
     watchdog = Map.get(deps, :watchdog)
-    heartbeat_timeout_ms = Map.get(deps, :heartbeat_timeout_ms, 30_000)
+
+    heartbeat_timeout_ms =
+      Map.get_lazy(deps, :heartbeat_timeout_ms, fn ->
+        Keyword.get(unit_timeouts, :state_timeout_ms, 30_000)
+      end)
 
     # oracle_base_ref: optional per-work_item override for the oracle
     # (test_author) worker's checkout ref. When provided, the oracle Worker

--- a/lib/tau/factory/unit_driver.ex
+++ b/lib/tau/factory/unit_driver.ex
@@ -50,6 +50,7 @@ defmodule Tau.Factory.UnitDriver do
   `docs/spec/SPEC-FACTORY-MERGE.md` §6 D-356.
   """
 
+  alias Tau.Factory.Fleet.Watchdog
   alias Tau.Factory.MergeAuthority
   alias Tau.Factory.UnitSupervisor
   alias Tau.Factory.WorkerSupervisor
@@ -103,6 +104,14 @@ defmodule Tau.Factory.UnitDriver do
     * `:report_to`         — pid receiving `{:unit_terminal, unit_id, outcome,
                              provenance}` (the coordinator seam).
     * `:ledger`            — optional; `GenServer.server()` | `nil`.
+    * `:watchdog`          — optional; atom/pid of a running `Tau.Factory.Fleet.Watchdog`.
+                             When present, the `worker_fun` closure registers each spawned
+                             Worker with the Watchdog so that heartbeat absence delivers
+                             `{:worker_stalled, worker_id}` to the owning Unit (D-379).
+                             When absent (nil), no registration — existing behaviour
+                             unchanged.
+    * `:heartbeat_timeout_ms` — optional; heartbeat-absence window in ms (default 30_000).
+                                Only used when `:watchdog` is present.
   """
   @spec drive(map(), map()) :: pid()
   def drive(work_item, deps) do
@@ -166,6 +175,14 @@ defmodule Tau.Factory.UnitDriver do
     # is ZERO — the janitor exclusively owns capture-before-destroy (D-313/D-314).
     janitor_pid = deps[:janitor] || WorkspaceJanitor
 
+    # D-379(b): optional Watchdog registration. When :watchdog is present in deps,
+    # the worker_fun closure registers each spawned Worker with the Watchdog so that
+    # heartbeat absence fires {:worker_stalled, worker_id} to the owning Unit.
+    # :heartbeat_timeout_ms defaults to the standard state_timeout_ms baseline.
+    # When :watchdog is absent (nil), no registration — existing behaviour unchanged.
+    watchdog = Map.get(deps, :watchdog)
+    heartbeat_timeout_ms = Map.get(deps, :heartbeat_timeout_ms, 30_000)
+
     # oracle_base_ref: optional per-work_item override for the oracle
     # (test_author) worker's checkout ref. When provided, the oracle Worker
     # checks out `oracle_base_ref` instead of `base_ref`. This lets harnesses
@@ -218,6 +235,18 @@ defmodule Tau.Factory.UnitDriver do
         {:ok, worker_id} ->
           case resolve_worker_pid(worker_registry, worker_id) do
             {:ok, worker_pid} ->
+              # D-379(b): register with Watchdog when present so heartbeat absence
+              # delivers {:worker_stalled, worker_id} to the owning Unit (unit_pid).
+              # subscribe-before-spawn ordering: registration happens in the Unit's
+              # process context (worker_fun is called from within the Unit), so
+              # unit_pid == self() here.
+              if watchdog do
+                :ok =
+                  Watchdog.register(watchdog, worker_id, worker_pid, unit_pid,
+                    heartbeat_timeout: heartbeat_timeout_ms
+                  )
+              end
+
               {:ok, worker_pid, worker_id}
 
             {:error, reason} ->

--- a/test/tau/factory/unit_heartbeat_liveness_test.exs
+++ b/test/tau/factory/unit_heartbeat_liveness_test.exs
@@ -1,56 +1,63 @@
 defmodule Tau.Factory.UnitHeartbeatLivenessTest do
   @moduledoc """
-  Gating tests for PR #513 (issue #491 — GOV4 heartbeat-driven Unit liveness).
+  Gating tests for PR #513 (issue #491 — GOV4 unified oracle/implementing
+  worker-outcome FSM, D-377/D-378/D-379 + D-315 durability).
 
-  Advances D-315, D-377, D-378, D-379 (SPEC-FACTORY-CORE §3/§4/§6):
+  ## Invariants under test
 
   - **D-377** — the Unit re-arms its `:state_timeout` on every current-worker
-    `{:worker_heartbeat, worker_id}` pulse. A progressing worker never trips the
-    fixed cap; absence of heartbeats escalates `E_WORKER_STALLED` at the deadline.
+    `{:worker_heartbeat, worker_id}` pulse **in both `oracle` and `implementing`**.
+    A progressing worker never trips the fixed cap; absence of heartbeats
+    escalates `E_WORKER_STALLED` at the deadline.
 
-  - **D-378** — exactly ONE advance of the retry ladder per worker per state when
-    stall signals arrive in close succession (`{:worker_stalled, w}`,
-    `{:worker_exit, w, _}` for the same worker). The first consumed signal
-    clears `data.worker_id`; later ones hit the stale-worker discard clause.
-    Separately: the Unit's OWN `:state_timeout` (real gen_statem timer; fires on
-    total heartbeat silence) escalates `E_WORKER_STALLED` — the hard-stall path
-    (D-377, preserves #490/D-326). These two classes are disjoint: the first
-    stall-class signal consumed clears `worker_id` → later signals discard →
-    EXACTLY ONE outcome per worker, no double-fire.
+  - **D-378** — **ONE symmetric rule for BOTH waiting states.** `oracle` and
+    `implementing` handle the worker-outcome signal set identically:
+    - `{:worker_stalled, ^worker_id}` → retry ladder → **originating state**
+      (oracle→oracle, implementing→implementing).
+    - `{:worker_exit, ^worker_id, reason}` → retry ladder → **originating state**.
+    - First stall-class signal clears `data.worker_id`; later signals for the
+      same worker hit the stale-discard clause → EXACTLY ONE ladder advance per
+      worker per state.
+    The `advance_retry_ladder/2` function takes the originating state so
+    re-spawn re-enters the correct role.
 
-  - **D-379** — (a) the Unit routes `{:worker_stalled, ^worker_id}` → retry ladder
-    (same path as `:state_timeout`); stale-worker `{:worker_stalled, _}` is
-    discarded. (b) `UnitDriver.drive/2` registers each spawned worker with the
-    fleet `Watchdog` (via a `:watchdog` dep), delivering `{:worker_stalled, _}`
-    to the owning Unit.
+  - **D-379** — (a) `oracle` AND `implementing` both consume `{:worker_stalled,
+    ^worker_id}` AND `{:worker_exit, ^worker_id, _}` → retry ladder; stale-worker
+    variants are discarded. (b) `UnitDriver.drive/2` registers each spawned worker
+    with the fleet `Watchdog` (via a `:watchdog` dep), delivering
+    `{:worker_stalled, _}` to the owning Unit.
+    **Run-#2 regression**: `oracle` previously had NO `{:worker_exit, _, _}` clause —
+    an oracle worker exiting with `:no_work_product` would be silently discarded
+    rather than routed to the retry ladder.
 
-  - **D-315** — RPO=0 durability for the stall re-spawn path: the deferred spawn
-    triggered by `{:worker_stalled, ^worker_id}` MUST call `snapshot_state/2`
-    (i.e. write a Ledger snapshot) AND bump `attempt_count`, exactly as the normal
-    `:on_enter` path does. The deferred path (`advance_retry_ladder_deferred/1` →
-    `do_spawn_worker/1`) currently skips both, violating D-315.
+  - **D-315** — RPO=0 durability for stall re-spawn: the ladder's `:on_enter`
+    bumps `attempt_count` **and** calls `snapshot_state/2` (writing a Ledger row)
+    **before** spawning the next worker — in BOTH `oracle` and `implementing`.
+    There is **no separate `:deferred_spawn` / `do_spawn_worker` path**; the
+    ladder transition is the re-spawn.
 
   ## Fail-before validity (oracle-separation, factory-loop §4b)
 
-  These tests fail against the current branch because:
-  - `oracle`/`implementing` have no `{:worker_heartbeat, _}` clause — D-377 absent.
-  - `oracle`/`implementing` have no `{:worker_stalled, _}` clause — D-379 absent.
-  - `UnitDriver.drive/2` has no `:watchdog` dep and does not call
-    `Watchdog.register/5` — D-379 producer absent.
-  - The deferred-spawn path (`advance_retry_ladder_deferred/1` → `do_spawn_worker/1`)
-    skips `attempt_count++` and `snapshot_state(:implementing, ...)` — D-315 absent.
+  These tests fail against the current RED branch (`821c7af`) because:
+  - `oracle` has no `{:worker_exit, _, _}` clause (run-#2 regression, D-379).
+  - `advance_retry_ladder/2` is arity-1 and hardcodes `:implementing` as the
+    re-entered state — an oracle stall re-enters `:implementing`, not `:oracle`.
+  - `implementing`'s `{:worker_stalled, _}` uses the removed
+    `:deferred_spawn`/`do_spawn_worker` path instead of `advance_retry_ladder/2`.
+  - D-315 oracle path: oracle ladder re-enter skips `attempt_count++` and
+    `snapshot_state/2` (the `:on_enter` of the wrongly-re-entered state runs,
+    but for `:implementing`, not `:oracle`).
 
   ## AC / D-NNN linkage (Gate 5.1)
 
   Every test name and @tag carries D-315, D-377, D-378, or D-379.
   """
 
-  # async: false — this module exercises timing-sensitive OTP state_timeout
-  # behaviour. Under full-suite concurrency (100+ test processes) the BEAM
-  # scheduler starves a spawned heartbeat sender, causing false state_timeout
-  # trips in D-377. Serialising the module eliminates scheduler starvation as
-  # a confound; the individual tests still start uniquely-named supervisors so
-  # there is no inter-test resource collision.
+  # async: false — exercises timing-sensitive OTP :state_timeout behaviour.
+  # Under full-suite concurrency the BEAM scheduler can starve a heartbeat
+  # sender, causing false :state_timeout trips. Serialising the module
+  # eliminates scheduler starvation as a confound; individual tests still
+  # start uniquely-named supervisors so there is no inter-test collision.
   use ExUnit.Case, async: false
 
   @moduletag :capture_log
@@ -106,7 +113,7 @@ defmodule Tau.Factory.UnitHeartbeatLivenessTest do
     writer_name
   end
 
-  # Base opts threaded through each test.  `overrides` replaces defaults.
+  # Base opts threaded through each test. `overrides` replaces defaults.
   defp base_unit_opts(unit_id, scheduler_name, report_to, overrides) do
     defaults = [
       unit_id: unit_id,
@@ -148,6 +155,31 @@ defmodule Tau.Factory.UnitHeartbeatLivenessTest do
     end
   end
 
+  # Poll until the Unit is in :oracle; return {:oracle, data} or
+  # {:timeout, last_state} on deadline.
+  defp wait_for_oracle(unit_pid, deadline_ms \\ 2_000) do
+    deadline = System.monotonic_time(:millisecond) + deadline_ms
+    do_wait_oracle(unit_pid, deadline)
+  end
+
+  defp do_wait_oracle(unit_pid, deadline) do
+    case :sys.get_state(unit_pid) do
+      {:oracle, data} ->
+        {:oracle, data}
+
+      {:planned, _} ->
+        if System.monotonic_time(:millisecond) >= deadline do
+          {:timeout, :planned}
+        else
+          Process.sleep(20)
+          do_wait_oracle(unit_pid, deadline)
+        end
+
+      {state, data} ->
+        {state, data}
+    end
+  end
+
   # Advance past oracle by sending work_ready to the oracle worker.
   defp advance_past_oracle(unit_pid, oracle_worker_id, deadline_ms \\ 2_000) do
     deadline = System.monotonic_time(:millisecond) + deadline_ms
@@ -177,10 +209,10 @@ defmodule Tau.Factory.UnitHeartbeatLivenessTest do
   end
 
   # ---------------------------------------------------------------------------
-  # D-377 — heartbeat resets state_timeout; absence trips stall at deadline
+  # D-377 — heartbeat resets :state_timeout in BOTH waiting states
   # ---------------------------------------------------------------------------
 
-  describe "D-377 — heartbeat resets :state_timeout, progressing worker never escalates" do
+  describe "D-377 — heartbeat resets :state_timeout; progressing worker never escalates" do
     @tag :d_377
     test "D-377: {worker_heartbeat, current_worker_id} at sub-timeout intervals keeps Unit in :implementing past old fixed cap" do
       test_pid = self()
@@ -191,11 +223,7 @@ defmodule Tau.Factory.UnitHeartbeatLivenessTest do
       start_scheduler(scheduler_name)
       start_supervised!({@unit_supervisor, name: sup_name}, id: sup_name)
 
-      # Generous timeout — 1000ms gives the BEAM scheduler ample room under full
-      # suite load (100+ concurrent tests) without being so tight that jitter
-      # causes a false trip.  Without D-377 heartbeat-reset the Unit would still
-      # escalate E_WORKER_STALLED at state_timeout_ms; with D-377 each pulse
-      # re-arms the timer so the Unit stays in :implementing indefinitely.
+      # 1000ms gives the BEAM scheduler ample room under full suite load.
       state_timeout_ms = 1_000
 
       oracle_worker_id = "w-hb-oracle-#{System.unique_integer([:positive])}"
@@ -225,23 +253,14 @@ defmodule Tau.Factory.UnitHeartbeatLivenessTest do
              "D-377: Unit must reach :implementing; got #{inspect(result)}"
 
       # Drive heartbeats from the TEST PROCESS at 200ms intervals (well below the
-      # 1000ms state_timeout_ms) for 3× the deadline (3000ms total).  Driving
-      # from the test process — rather than a spawned ticker — ensures the sends
-      # are not subject to a separate process being starved by the scheduler under
-      # full-suite load.  The test process itself is always the scheduling victim
-      # here, and it uses Process.sleep between sends, which is deterministic.
-      #
-      # Without D-377: the state_timeout fires at 1000ms on the first iteration
-      # (no reset clause) and the Unit escalates → test fails.
-      # With D-377: each {:worker_heartbeat, impl_worker_id} re-arms the 1000ms
-      # timer, so the Unit is still :implementing at 3000ms.
+      # 1000ms state_timeout_ms) for 3× the deadline (3000ms total).
+      # Without D-377: the state_timeout fires at 1000ms → escalate.
+      # With D-377: each pulse re-arms the timer → Unit stays in :implementing.
       hb_interval_ms = 200
       total_hb_duration_ms = 3 * state_timeout_ms
 
       hb_loop_from_test(unit_pid, impl_worker_id, hb_interval_ms, total_hb_duration_ms)
 
-      # Immediately after the heartbeat loop finishes, the Unit must still be in
-      # :implementing (the last heartbeat re-armed the timer; no escalation).
       {state_after, _data} = :sys.get_state(unit_pid)
 
       assert state_after == :implementing,
@@ -249,8 +268,59 @@ defmodule Tau.Factory.UnitHeartbeatLivenessTest do
                "intervals (well below #{state_timeout_ms}ms state_timeout) MUST stay " <>
                "in :implementing past the old fixed cap (#{total_hb_duration_ms}ms total). " <>
                "Got state=#{inspect(state_after)}. " <>
-               "FAIL-BEFORE: no {:worker_heartbeat, _} clause exists — the Unit trips " <>
-               ":state_timeout at #{state_timeout_ms}ms and escalates E_WORKER_STALLED."
+               "FAIL-BEFORE: no {:worker_heartbeat, _} clause in oracle/3 or implementing/3."
+    end
+
+    @tag :d_377
+    test "D-377: {worker_heartbeat, current_worker_id} at sub-timeout intervals keeps Unit in :oracle past old fixed cap" do
+      test_pid = self()
+      unit_id = "u-hb-oracle-reset-#{System.unique_integer([:positive])}"
+      scheduler_name = :"sched_hb_oracle_reset_#{System.unique_integer([:positive])}"
+      sup_name = :"sup_hb_oracle_reset_#{System.unique_integer([:positive])}"
+
+      start_scheduler(scheduler_name)
+      start_supervised!({@unit_supervisor, name: sup_name}, id: sup_name)
+
+      state_timeout_ms = 1_000
+
+      oracle_worker_id = "w-hb-oracle2-#{System.unique_integer([:positive])}"
+      call_count = :counters.new(1, [:atomics])
+
+      worker_fun = fn _role ->
+        n = :counters.get(call_count, 1)
+        :counters.add(call_count, 1, 1)
+        pid = spawn_worker()
+        if n == 0, do: {:ok, pid, oracle_worker_id}, else: {:ok, pid, "re-spawned"}
+      end
+
+      opts =
+        base_unit_opts(unit_id, scheduler_name, test_pid,
+          worker_fun: worker_fun,
+          timeouts: [state_timeout_ms: state_timeout_ms]
+        )
+
+      unit_pid = @unit_supervisor.start_unit(sup_name, opts)
+      assert is_pid(unit_pid)
+
+      # Wait in :oracle state — do NOT advance past oracle.
+      result = wait_for_oracle(unit_pid)
+
+      assert match?({:oracle, _}, result),
+             "D-377 oracle: Unit must reach :oracle; got #{inspect(result)}"
+
+      hb_interval_ms = 200
+      total_hb_duration_ms = 3 * state_timeout_ms
+
+      hb_loop_from_test(unit_pid, oracle_worker_id, hb_interval_ms, total_hb_duration_ms)
+
+      {state_after, _data} = :sys.get_state(unit_pid)
+
+      assert state_after == :oracle,
+             "D-377: Unit fed {:worker_heartbeat, current_id} in :oracle at #{hb_interval_ms}ms " <>
+               "intervals MUST stay in :oracle past the old fixed cap " <>
+               "(#{total_hb_duration_ms}ms total). " <>
+               "Got state=#{inspect(state_after)}. " <>
+               "FAIL-BEFORE: no {:worker_heartbeat, _} clause in oracle/3."
     end
 
     @tag :d_377
@@ -291,7 +361,7 @@ defmodule Tau.Factory.UnitHeartbeatLivenessTest do
       assert match?({:implementing, _}, result),
              "D-377: Unit must reach :implementing; got #{inspect(result)}"
 
-      # No heartbeats sent — state_timeout must fire at deadline.
+      # No heartbeats — state_timeout must fire at deadline.
       assert_receive {:unit_terminal, ^unit_id, :escalated, provenance},
                      500,
                      "D-377: without heartbeats, Unit MUST escalate via :state_timeout " <>
@@ -305,37 +375,31 @@ defmodule Tau.Factory.UnitHeartbeatLivenessTest do
   end
 
   # ---------------------------------------------------------------------------
-  # D-378 — exactly one ladder advance when REAL stall signals arrive in succession
+  # D-378 — ONE symmetric rule: both :oracle and :implementing advance ladder
+  # EXACTLY ONCE for a burst of stall signals
   # ---------------------------------------------------------------------------
   #
-  # Contract (reconciled two-outcome model):
+  # The UNIFIED contract: oracle and implementing handle worker_stalled and
+  # worker_exit identically — advance_retry_ladder/2 takes the originating
+  # state and re-enters IT, not hardcoded :implementing.
   #
-  # The Watchdog delivers TWO kinds of signals to the Unit:
-  #   {: worker_stalled, worker_id} — heartbeat-absence (the retry-ladder path)
-  #   {:worker_exit,    worker_id, reason} — worker process exited (retry-ladder)
-  #
-  # The Unit's OWN :state_timeout (total heartbeat silence) is SEPARATE and
-  # escalates E_WORKER_STALLED (tested by D-377 above).
-  #
-  # D-378 disjointness: the FIRST stall-class signal consumed clears
+  # D-378 disjointness: the first stall-class signal consumed clears
   # data.worker_id → later signals for the SAME worker hit the stale-worker
-  # discard clause → EXACTLY ONE ladder advance per worker, no double-fire.
+  # discard clause → EXACTLY ONE ladder advance per worker per state.
   # ---------------------------------------------------------------------------
 
-  describe "D-378 — exactly one retry-ladder advance for close-succession real stall signals" do
+  describe "D-378 — exactly one retry-ladder advance for close-succession stall signals in :implementing" do
     @tag :d_378
-    test "D-378: worker_stalled then worker_exit then second worker_stalled for same worker advances ladder EXACTLY ONCE - later signals stale-discarded" do
+    test "D-378 implementing: burst stall signals for same worker advance ladder EXACTLY ONCE re-entering :implementing" do
       test_pid = self()
-      unit_id = "u-d378-once-#{System.unique_integer([:positive])}"
-      scheduler_name = :"sched_d378_#{System.unique_integer([:positive])}"
-      sup_name = :"sup_d378_#{System.unique_integer([:positive])}"
+      unit_id = "u-d378-impl-once-#{System.unique_integer([:positive])}"
+      scheduler_name = :"sched_d378_impl_#{System.unique_integer([:positive])}"
+      sup_name = :"sup_d378_impl_#{System.unique_integer([:positive])}"
 
       start_scheduler(scheduler_name)
       start_supervised!({@unit_supervisor, name: sup_name}, id: sup_name)
 
-      # Disable the real state_timeout with a long timer so we can deliver signals
-      # manually and control the ordering precisely.
-      oracle_worker_id = "w-d378-oracle-#{System.unique_integer([:positive])}"
+      oracle_worker_id = "w-d378-impl-oracle-#{System.unique_integer([:positive])}"
       impl_worker_id = "w-d378-impl-#{System.unique_integer([:positive])}"
       call_count = :counters.new(1, [:atomics])
 
@@ -349,7 +413,6 @@ defmodule Tau.Factory.UnitHeartbeatLivenessTest do
       opts =
         base_unit_opts(unit_id, scheduler_name, test_pid,
           worker_fun: worker_fun,
-          # Long timeout so the real :state_timeout does not fire during the test.
           timeouts: [state_timeout_ms: 10_000]
         )
 
@@ -360,27 +423,21 @@ defmodule Tau.Factory.UnitHeartbeatLivenessTest do
       result = wait_for_implementing(unit_pid)
 
       assert match?({:implementing, _}, result),
-             "D-378: Unit must reach :implementing; got #{inspect(result)}"
+             "D-378 implementing: Unit must reach :implementing; got #{inspect(result)}"
 
       {:implementing, data_before} = result
       refine_before = Map.get(data_before, :refine_count, 0)
       attempt_before = Map.get(data_before, :attempt_count, 0)
 
-      # Deliver three successive REAL stall signals for the SAME worker in one burst.
-      # D-378: the first {:worker_stalled, impl_worker_id} must clear data.worker_id;
-      # the second and third signals (worker_exit and another worker_stalled for the
-      # same id) must hit the stale-worker discard clause and be ignored.
-      #
-      # NOTE: we do NOT use the synthetic info-form {:state_timeout, :worker_stalled}
-      # message — that was a production-dead clause used only to support the prior
-      # test. The REAL signals are {:worker_stalled, w} and {:worker_exit, w, _},
-      # which are what the fleet Watchdog and worker supervisor actually deliver.
+      # Burst of three stall signals for the SAME implementing worker.
+      # D-378: first clears worker_id; second + third are stale-discarded.
+      # Result: exactly ONE ladder advance, Unit re-enters :implementing
+      # (the originating state, per the unified symmetric rule).
       send(unit_pid, {:worker_stalled, impl_worker_id})
       send(unit_pid, {:worker_exit, impl_worker_id, :no_work_product})
       send(unit_pid, {:worker_stalled, impl_worker_id})
 
-      # Allow all three messages to be processed, plus the deferred :deferred_spawn
-      # to fire (it lands at the end of the mailbox after the stale signals).
+      # Allow all three messages to be processed plus the on_enter to run.
       Process.sleep(400)
 
       {state_after, data_after} = :sys.get_state(unit_pid)
@@ -392,34 +449,121 @@ defmodule Tau.Factory.UnitHeartbeatLivenessTest do
       total_advance_after = refine_after + attempt_after
 
       assert state_after == :implementing,
-             "D-378: after exactly one ladder advance Unit must be in :implementing; " <>
-               "got #{inspect(state_after)}"
+             "D-378 implementing: after exactly one ladder advance Unit must be in " <>
+               ":implementing (originating state); got #{inspect(state_after)}. " <>
+               "FAIL-BEFORE: advance_retry_ladder/1 hardcodes :implementing so this " <>
+               "may accidentally pass — but advance_retry_ladder/2 (originating state) " <>
+               "must re-enter :implementing for the implementing case."
 
       assert total_advance_after - total_advance_before == 1,
-             "D-378: three stall signals for one worker must advance ladder EXACTLY once. " <>
-               "Advanced by #{total_advance_after - total_advance_before} (expected 1). " <>
+             "D-378 implementing: three stall signals for one worker must advance " <>
+               "ladder EXACTLY once. Advanced by " <>
+               "#{total_advance_after - total_advance_before} (expected 1). " <>
                "refine #{refine_before}->#{refine_after}, " <>
                "attempt #{attempt_before}->#{attempt_after}. " <>
-               "FAIL-BEFORE: no {:worker_stalled,_} clause / no worker_id-clear."
+               "FAIL-BEFORE: deferred-spawn path or double-fire."
     end
   end
 
-  # ---------------------------------------------------------------------------
-  # D-379(a) — Unit consumes {worker_stalled, ^worker_id} → ladder; stale → discard
-  # ---------------------------------------------------------------------------
-
-  describe "D-379(a) — Unit routes {worker_stalled, current_id} to retry ladder; stale is discarded" do
-    @tag :d_379
-    test "D-379: {:worker_stalled, current_worker_id} in :implementing advances retry ladder (same as :state_timeout)" do
+  describe "D-378 — exactly one retry-ladder advance for close-succession stall signals in :oracle" do
+    @tag :d_378
+    test "D-378 oracle: burst stall signals for same oracle worker advance ladder EXACTLY ONCE and re-enter :oracle (NOT :implementing)" do
       test_pid = self()
-      unit_id = "u-d379a-stalled-#{System.unique_integer([:positive])}"
-      scheduler_name = :"sched_d379a_#{System.unique_integer([:positive])}"
-      sup_name = :"sup_d379a_#{System.unique_integer([:positive])}"
+      unit_id = "u-d378-oracle-once-#{System.unique_integer([:positive])}"
+      scheduler_name = :"sched_d378_oracle_#{System.unique_integer([:positive])}"
+      sup_name = :"sup_d378_oracle_#{System.unique_integer([:positive])}"
 
       start_scheduler(scheduler_name)
       start_supervised!({@unit_supervisor, name: sup_name}, id: sup_name)
 
-      oracle_worker_id = "w-d379a-oracle-#{System.unique_integer([:positive])}"
+      oracle_worker_id = "w-d378-oracle-#{System.unique_integer([:positive])}"
+      # Track all worker_fun invocations; the re-spawned oracle gets a new id
+      # so we know the ladder fired.
+      respawn_worker_id = "w-d378-oracle-respawn-#{System.unique_integer([:positive])}"
+      call_count = :counters.new(1, [:atomics])
+
+      worker_fun = fn _role ->
+        n = :counters.get(call_count, 1)
+        :counters.add(call_count, 1, 1)
+        pid = spawn_worker()
+
+        case n do
+          0 -> {:ok, pid, oracle_worker_id}
+          _ -> {:ok, pid, respawn_worker_id}
+        end
+      end
+
+      opts =
+        base_unit_opts(unit_id, scheduler_name, test_pid,
+          worker_fun: worker_fun,
+          timeouts: [state_timeout_ms: 10_000]
+        )
+
+      unit_pid = @unit_supervisor.start_unit(sup_name, opts)
+      assert is_pid(unit_pid)
+
+      # Wait in :oracle — do NOT send work_ready.
+      result = wait_for_oracle(unit_pid)
+
+      assert match?({:oracle, _}, result),
+             "D-378 oracle: Unit must reach :oracle; got #{inspect(result)}"
+
+      {:oracle, data_before} = result
+      refine_before = Map.get(data_before, :refine_count, 0)
+      attempt_before = Map.get(data_before, :attempt_count, 0)
+
+      # Burst of three stall signals for the SAME oracle worker.
+      # D-378 unified symmetric rule: first clears worker_id → re-enters :oracle;
+      # second + third are stale-discarded → exactly ONE ladder advance total.
+      send(unit_pid, {:worker_stalled, oracle_worker_id})
+      send(unit_pid, {:worker_exit, oracle_worker_id, :no_work_product})
+      send(unit_pid, {:worker_stalled, oracle_worker_id})
+
+      # Allow all three messages to process plus the oracle :on_enter.
+      Process.sleep(400)
+
+      {state_after, data_after} = :sys.get_state(unit_pid)
+
+      refine_after = Map.get(data_after, :refine_count, 0)
+      attempt_after = Map.get(data_after, :attempt_count, 0)
+
+      total_advance_before = refine_before + attempt_before
+      total_advance_after = refine_after + attempt_after
+
+      assert state_after == :oracle,
+             "D-378 oracle: after exactly one ladder advance Unit must be in " <>
+               ":oracle (the ORIGINATING state, not :implementing). " <>
+               "Got #{inspect(state_after)}. " <>
+               "FAIL-BEFORE: advance_retry_ladder/1 hardcodes :implementing — " <>
+               "the oracle stall re-enters :implementing, skipping oracle-separation."
+
+      assert total_advance_after - total_advance_before == 1,
+             "D-378 oracle: three stall signals for one oracle worker must advance " <>
+               "ladder EXACTLY once. Advanced by " <>
+               "#{total_advance_after - total_advance_before} (expected 1). " <>
+               "refine #{refine_before}->#{refine_after}, " <>
+               "attempt #{attempt_before}->#{attempt_after}."
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # D-379(a) — Unit consumes {worker_stalled, ^worker_id} AND
+  # {worker_exit, ^worker_id, _} in BOTH :oracle and :implementing;
+  # stale variants are discarded in both states.
+  # ---------------------------------------------------------------------------
+
+  describe "D-379(a) implementing — stalled/exit route to retry ladder; stale discarded" do
+    @tag :d_379
+    test "D-379 implementing: {:worker_stalled, current_worker_id} advances retry ladder and re-enters :implementing" do
+      test_pid = self()
+      unit_id = "u-d379a-impl-stalled-#{System.unique_integer([:positive])}"
+      scheduler_name = :"sched_d379a_impl_#{System.unique_integer([:positive])}"
+      sup_name = :"sup_d379a_impl_#{System.unique_integer([:positive])}"
+
+      start_scheduler(scheduler_name)
+      start_supervised!({@unit_supervisor, name: sup_name}, id: sup_name)
+
+      oracle_worker_id = "w-d379a-impl-oracle-#{System.unique_integer([:positive])}"
       impl_worker_id = "w-d379a-impl-#{System.unique_integer([:positive])}"
       call_count = :counters.new(1, [:atomics])
 
@@ -443,49 +587,109 @@ defmodule Tau.Factory.UnitHeartbeatLivenessTest do
       result = wait_for_implementing(unit_pid)
 
       assert match?({:implementing, _}, result),
-             "D-379: Unit must reach :implementing; got #{inspect(result)}"
+             "D-379 implementing: Unit must reach :implementing; got #{inspect(result)}"
 
       {:implementing, data_before} = result
       refine_before = Map.get(data_before, :refine_count, 0)
       attempt_before = Map.get(data_before, :attempt_count, 0)
 
-      # Deliver the Watchdog's stall signal for the CURRENT worker.
       send(unit_pid, {:worker_stalled, impl_worker_id})
-
       Process.sleep(250)
 
       {state_after, data_after} = :sys.get_state(unit_pid)
 
       assert state_after == :implementing,
-             "D-379: {:worker_stalled, current_worker_id} must advance the retry ladder " <>
-               "and re-enter :implementing; got #{inspect(state_after)}. " <>
-               "FAIL-BEFORE: no {:worker_stalled, _} clause in implementing/3 — " <>
-               "the message is routed to handle_unexpected/4 and silently ignored."
+             "D-379 implementing: {:worker_stalled, current_worker_id} must advance " <>
+               "the retry ladder and re-enter :implementing; got #{inspect(state_after)}. " <>
+               "FAIL-BEFORE: deferred_spawn path still in place; the message is processed " <>
+               "via do_spawn_worker (keep_state, not next_state :implementing via ladder)."
 
       refine_after = Map.get(data_after, :refine_count, 0)
       attempt_after = Map.get(data_after, :attempt_count, 0)
 
       assert refine_after > refine_before or attempt_after > attempt_before,
-             "D-379: {:worker_stalled, current_id} must advance the ladder; " <>
+             "D-379 implementing: {:worker_stalled, current_id} must advance the ladder; " <>
                "refine #{refine_before}→#{refine_after}, " <>
                "attempt #{attempt_before}→#{attempt_after}"
 
       refute_received {:unit_terminal, ^unit_id, _outcome, _prov},
-                      "D-379: a single {:worker_stalled, current_id} must route to retry, " <>
-                        "not terminate the Unit"
+                      "D-379 implementing: a single {:worker_stalled, current_id} must " <>
+                        "route to retry, not terminate the Unit"
     end
 
     @tag :d_379
-    test "D-379: {:worker_stalled, stale_worker_id} in :implementing is silently discarded — no ladder advance" do
+    test "D-379 implementing: {:worker_exit, current_worker_id, :no_work_product} advances retry ladder and re-enters :implementing" do
       test_pid = self()
-      unit_id = "u-d379a-stale-#{System.unique_integer([:positive])}"
-      scheduler_name = :"sched_d379a_stale_#{System.unique_integer([:positive])}"
-      sup_name = :"sup_d379a_stale_#{System.unique_integer([:positive])}"
+      unit_id = "u-d379a-impl-exit-#{System.unique_integer([:positive])}"
+      scheduler_name = :"sched_d379a_impl_exit_#{System.unique_integer([:positive])}"
+      sup_name = :"sup_d379a_impl_exit_#{System.unique_integer([:positive])}"
 
       start_scheduler(scheduler_name)
       start_supervised!({@unit_supervisor, name: sup_name}, id: sup_name)
 
-      oracle_worker_id = "w-d379as-oracle-#{System.unique_integer([:positive])}"
+      oracle_worker_id = "w-d379a-impl-exit-oracle-#{System.unique_integer([:positive])}"
+      impl_worker_id = "w-d379a-impl-exit-#{System.unique_integer([:positive])}"
+      call_count = :counters.new(1, [:atomics])
+
+      worker_fun = fn _role ->
+        n = :counters.get(call_count, 1)
+        :counters.add(call_count, 1, 1)
+        pid = spawn_worker()
+        if n == 0, do: {:ok, pid, oracle_worker_id}, else: {:ok, pid, impl_worker_id}
+      end
+
+      opts =
+        base_unit_opts(unit_id, scheduler_name, test_pid,
+          worker_fun: worker_fun,
+          timeouts: [state_timeout_ms: 10_000]
+        )
+
+      unit_pid = @unit_supervisor.start_unit(sup_name, opts)
+      assert is_pid(unit_pid)
+
+      advance_past_oracle(unit_pid, oracle_worker_id)
+      result = wait_for_implementing(unit_pid)
+
+      assert match?({:implementing, _}, result),
+             "D-379 implementing worker_exit: Unit must reach :implementing; got #{inspect(result)}"
+
+      {:implementing, data_before} = result
+      refine_before = Map.get(data_before, :refine_count, 0)
+      attempt_before = Map.get(data_before, :attempt_count, 0)
+
+      send(unit_pid, {:worker_exit, impl_worker_id, :no_work_product})
+      Process.sleep(250)
+
+      {state_after, data_after} = :sys.get_state(unit_pid)
+
+      assert state_after == :implementing,
+             "D-379 implementing: {:worker_exit, current_worker_id, :no_work_product} must " <>
+               "advance the retry ladder and re-enter :implementing; got #{inspect(state_after)}."
+
+      refine_after = Map.get(data_after, :refine_count, 0)
+      attempt_after = Map.get(data_after, :attempt_count, 0)
+
+      assert refine_after > refine_before or attempt_after > attempt_before,
+             "D-379 implementing: {:worker_exit, current_id, _} must advance the ladder; " <>
+               "refine #{refine_before}→#{refine_after}, " <>
+               "attempt #{attempt_before}→#{attempt_after}"
+
+      refute_received {:unit_terminal, ^unit_id, _outcome, _prov},
+                      "D-379 implementing: a single {:worker_exit, current_id, _} must " <>
+                        "route to retry, not terminate the Unit"
+    end
+
+    @tag :d_379
+    test "D-379 implementing: {:worker_stalled, stale_worker_id} is silently discarded — no ladder advance" do
+      test_pid = self()
+      unit_id = "u-d379a-impl-stale-#{System.unique_integer([:positive])}"
+      scheduler_name = :"sched_d379a_impl_stale_#{System.unique_integer([:positive])}"
+      sup_name = :"sup_d379a_impl_stale_#{System.unique_integer([:positive])}"
+
+      start_scheduler(scheduler_name)
+      start_supervised!({@unit_supervisor, name: sup_name}, id: sup_name)
+
+      oracle_worker_id = "w-d379as-impl-oracle-#{System.unique_integer([:positive])}"
       impl_worker_id = "w-d379as-impl-#{System.unique_integer([:positive])}"
       call_count = :counters.new(1, [:atomics])
 
@@ -509,7 +713,7 @@ defmodule Tau.Factory.UnitHeartbeatLivenessTest do
       result = wait_for_implementing(unit_pid)
 
       assert match?({:implementing, _}, result),
-             "D-379 stale: Unit must reach :implementing; got #{inspect(result)}"
+             "D-379 implementing stale: Unit must reach :implementing; got #{inspect(result)}"
 
       {:implementing, data_before} = result
       refine_before = Map.get(data_before, :refine_count, 0)
@@ -517,25 +721,217 @@ defmodule Tau.Factory.UnitHeartbeatLivenessTest do
 
       stale_id = "w-d379-stale-#{System.unique_integer([:positive])}"
       send(unit_pid, {:worker_stalled, stale_id})
-
       Process.sleep(200)
 
       {state_after, data_after} = :sys.get_state(unit_pid)
 
       assert state_after == :implementing,
-             "D-379 stale: a {:worker_stalled, stale_id} must be discarded — " <>
+             "D-379 implementing stale: a {:worker_stalled, stale_id} must be discarded — " <>
                "Unit remains in :implementing; got #{inspect(state_after)}"
 
       refine_after = Map.get(data_after, :refine_count, 0)
       attempt_after = Map.get(data_after, :attempt_count, 0)
 
       assert refine_before == refine_after and attempt_before == attempt_after,
-             "D-379 stale: stale {:worker_stalled} must NOT advance the ladder; " <>
+             "D-379 implementing stale: stale {:worker_stalled} must NOT advance the ladder; " <>
                "refine #{refine_before}→#{refine_after}, " <>
                "attempt #{attempt_before}→#{attempt_after}"
 
       refute_received {:unit_terminal, ^unit_id, _outcome, _prov},
-                      "D-379 stale: stale {:worker_stalled} must not terminate the Unit"
+                      "D-379 implementing stale: stale {:worker_stalled} must not terminate the Unit"
+    end
+  end
+
+  describe "D-379(a) oracle — routes stalled/exit to retry ladder; stale discarded; re-enters :oracle" do
+    @tag :d_379
+    test "D-379 oracle: {:worker_stalled, current_oracle_worker_id} advances retry ladder re-enters :oracle not :implementing" do
+      test_pid = self()
+      unit_id = "u-d379a-oracle-stalled-#{System.unique_integer([:positive])}"
+      scheduler_name = :"sched_d379a_oracle_#{System.unique_integer([:positive])}"
+      sup_name = :"sup_d379a_oracle_#{System.unique_integer([:positive])}"
+
+      start_scheduler(scheduler_name)
+      start_supervised!({@unit_supervisor, name: sup_name}, id: sup_name)
+
+      oracle_worker_id = "w-d379a-oracle-#{System.unique_integer([:positive])}"
+      call_count = :counters.new(1, [:atomics])
+
+      worker_fun = fn _role ->
+        n = :counters.get(call_count, 1)
+        :counters.add(call_count, 1, 1)
+        pid = spawn_worker()
+        if n == 0, do: {:ok, pid, oracle_worker_id}, else: {:ok, pid, "re-oracle-#{n}"}
+      end
+
+      opts =
+        base_unit_opts(unit_id, scheduler_name, test_pid,
+          worker_fun: worker_fun,
+          timeouts: [state_timeout_ms: 10_000]
+        )
+
+      unit_pid = @unit_supervisor.start_unit(sup_name, opts)
+      assert is_pid(unit_pid)
+
+      result = wait_for_oracle(unit_pid)
+
+      assert match?({:oracle, _}, result),
+             "D-379 oracle: Unit must reach :oracle; got #{inspect(result)}"
+
+      {:oracle, data_before} = result
+      refine_before = Map.get(data_before, :refine_count, 0)
+      attempt_before = Map.get(data_before, :attempt_count, 0)
+
+      send(unit_pid, {:worker_stalled, oracle_worker_id})
+      Process.sleep(250)
+
+      {state_after, data_after} = :sys.get_state(unit_pid)
+
+      assert state_after == :oracle,
+             "D-379 oracle: {:worker_stalled, current_oracle_worker_id} must advance " <>
+               "the retry ladder and re-enter :oracle (the ORIGINATING state). " <>
+               "Got #{inspect(state_after)}. " <>
+               "FAIL-BEFORE: advance_retry_ladder/1 hardcodes :implementing — " <>
+               "the oracle stall re-enters :implementing, violating oracle-separation."
+
+      refine_after = Map.get(data_after, :refine_count, 0)
+      attempt_after = Map.get(data_after, :attempt_count, 0)
+
+      assert refine_after > refine_before or attempt_after > attempt_before,
+             "D-379 oracle: {:worker_stalled, current_id} must advance the ladder; " <>
+               "refine #{refine_before}→#{refine_after}, " <>
+               "attempt #{attempt_before}→#{attempt_after}"
+
+      refute_received {:unit_terminal, ^unit_id, _outcome, _prov},
+                      "D-379 oracle: a single {:worker_stalled, current_oracle_id} must " <>
+                        "route to retry, not terminate the Unit"
+    end
+
+    @tag :d_379
+    test "D-379 oracle: {:worker_exit, current_oracle_worker_id, :no_work_product} advances retry ladder and re-enters :oracle (run-#2 regression)" do
+      test_pid = self()
+      unit_id = "u-d379a-oracle-exit-#{System.unique_integer([:positive])}"
+      scheduler_name = :"sched_d379a_oracle_exit_#{System.unique_integer([:positive])}"
+      sup_name = :"sup_d379a_oracle_exit_#{System.unique_integer([:positive])}"
+
+      start_scheduler(scheduler_name)
+      start_supervised!({@unit_supervisor, name: sup_name}, id: sup_name)
+
+      oracle_worker_id = "w-d379a-oracle-exit-#{System.unique_integer([:positive])}"
+      call_count = :counters.new(1, [:atomics])
+
+      worker_fun = fn _role ->
+        n = :counters.get(call_count, 1)
+        :counters.add(call_count, 1, 1)
+        pid = spawn_worker()
+        if n == 0, do: {:ok, pid, oracle_worker_id}, else: {:ok, pid, "re-oracle-exit-#{n}"}
+      end
+
+      opts =
+        base_unit_opts(unit_id, scheduler_name, test_pid,
+          worker_fun: worker_fun,
+          timeouts: [state_timeout_ms: 10_000]
+        )
+
+      unit_pid = @unit_supervisor.start_unit(sup_name, opts)
+      assert is_pid(unit_pid)
+
+      result = wait_for_oracle(unit_pid)
+
+      assert match?({:oracle, _}, result),
+             "D-379 oracle worker_exit: Unit must reach :oracle; got #{inspect(result)}"
+
+      {:oracle, data_before} = result
+      refine_before = Map.get(data_before, :refine_count, 0)
+      attempt_before = Map.get(data_before, :attempt_count, 0)
+
+      # Run-#2 regression: oracle previously had NO {:worker_exit, _, _} clause.
+      # This signal would fall through to handle_unexpected/4 and be silently
+      # discarded — the oracle worker's no_work_product outcome was invisible to
+      # the Unit, violating D-379 and the unified symmetric rule.
+      send(unit_pid, {:worker_exit, oracle_worker_id, :no_work_product})
+      Process.sleep(250)
+
+      {state_after, data_after} = :sys.get_state(unit_pid)
+
+      assert state_after == :oracle,
+             "D-379 oracle (run-#2 regression): {:worker_exit, current_oracle_worker_id, " <>
+               ":no_work_product} must advance the retry ladder and re-enter :oracle. " <>
+               "Got #{inspect(state_after)}. " <>
+               "FAIL-BEFORE: oracle/3 has NO {:worker_exit, _, _} clause — the message " <>
+               "falls through to handle_unexpected/4 and is silently discarded."
+
+      refine_after = Map.get(data_after, :refine_count, 0)
+      attempt_after = Map.get(data_after, :attempt_count, 0)
+
+      assert refine_after > refine_before or attempt_after > attempt_before,
+             "D-379 oracle: {:worker_exit, current_oracle_id, :no_work_product} must " <>
+               "advance the ladder; refine #{refine_before}→#{refine_after}, " <>
+               "attempt #{attempt_before}→#{attempt_after}. " <>
+               "FAIL-BEFORE: no oracle worker_exit clause; ladder stays flat."
+
+      refute_received {:unit_terminal, ^unit_id, _outcome, _prov},
+                      "D-379 oracle: a single {:worker_exit, current_oracle_id, _} must " <>
+                        "route to retry, not terminate the Unit"
+    end
+
+    @tag :d_379
+    test "D-379 oracle: {:worker_stalled, stale_oracle_id} is silently discarded — no ladder advance" do
+      test_pid = self()
+      unit_id = "u-d379a-oracle-stale-#{System.unique_integer([:positive])}"
+      scheduler_name = :"sched_d379a_oracle_stale_#{System.unique_integer([:positive])}"
+      sup_name = :"sup_d379a_oracle_stale_#{System.unique_integer([:positive])}"
+
+      start_scheduler(scheduler_name)
+      start_supervised!({@unit_supervisor, name: sup_name}, id: sup_name)
+
+      oracle_worker_id = "w-d379as-oracle-#{System.unique_integer([:positive])}"
+      call_count = :counters.new(1, [:atomics])
+
+      worker_fun = fn _role ->
+        n = :counters.get(call_count, 1)
+        :counters.add(call_count, 1, 1)
+        pid = spawn_worker()
+        if n == 0, do: {:ok, pid, oracle_worker_id}, else: {:ok, pid, "re-oracle-stale-#{n}"}
+      end
+
+      opts =
+        base_unit_opts(unit_id, scheduler_name, test_pid,
+          worker_fun: worker_fun,
+          timeouts: [state_timeout_ms: 10_000]
+        )
+
+      unit_pid = @unit_supervisor.start_unit(sup_name, opts)
+      assert is_pid(unit_pid)
+
+      result = wait_for_oracle(unit_pid)
+
+      assert match?({:oracle, _}, result),
+             "D-379 oracle stale: Unit must reach :oracle; got #{inspect(result)}"
+
+      {:oracle, data_before} = result
+      refine_before = Map.get(data_before, :refine_count, 0)
+      attempt_before = Map.get(data_before, :attempt_count, 0)
+
+      stale_id = "w-d379-oracle-stale-#{System.unique_integer([:positive])}"
+      send(unit_pid, {:worker_stalled, stale_id})
+      Process.sleep(200)
+
+      {state_after, data_after} = :sys.get_state(unit_pid)
+
+      assert state_after == :oracle,
+             "D-379 oracle stale: a {:worker_stalled, stale_oracle_id} must be discarded — " <>
+               "Unit remains in :oracle; got #{inspect(state_after)}"
+
+      refine_after = Map.get(data_after, :refine_count, 0)
+      attempt_after = Map.get(data_after, :attempt_count, 0)
+
+      assert refine_before == refine_after and attempt_before == attempt_after,
+             "D-379 oracle stale: stale {:worker_stalled} must NOT advance the ladder; " <>
+               "refine #{refine_before}→#{refine_after}, " <>
+               "attempt #{attempt_before}→#{attempt_after}"
+
+      refute_received {:unit_terminal, ^unit_id, _outcome, _prov},
+                      "D-379 oracle stale: stale {:worker_stalled} must not terminate the Unit"
     end
   end
 
@@ -547,24 +943,20 @@ defmodule Tau.Factory.UnitHeartbeatLivenessTest do
   # spawned worker with the fleet `Watchdog` (`Watchdog.register(watchdog,
   # worker_id, worker_pid, unit_pid, heartbeat_timeout: …)`)".
   #
-  # The observable contract is: when UnitDriver wires a :watchdog dep into its
-  # worker_fun closure, a spawned worker with no heartbeats triggers
-  # {:worker_stalled, worker_id} → Unit, which routes to escalation.
-  #
   # We test this via a Unit with a worker_fun that itself calls
   # Watchdog.register/5 (mirroring the closure UnitDriver.drive/2 will build).
-  # The test then confirms the stall signal arrives at the Unit and is routed
-  # to the retry ladder — demonstrating the full D-379 wiring path.
+  # The test confirms the stall signal arrives at the Unit and routes to the
+  # retry ladder — demonstrating the full D-379 wiring path.
   #
-  # FAIL-BEFORE: the Unit has no {:worker_stalled, _} clause (D-379 absent), so
-  # when the Watchdog fires {:worker_stalled, worker_id} to the Unit it is
-  # silently ignored via handle_unexpected/4.  The Unit never escalates via
-  # this path, and the stall_advance_count assertion fails.
+  # FAIL-BEFORE: the Unit has no {:worker_stalled, _} clause via the proper
+  # advance_retry_ladder/2 path (D-379 absent or using deferred path), so
+  # when the Watchdog fires {:worker_stalled, worker_id} to the Unit the
+  # ladder counter stays flat.
   # ---------------------------------------------------------------------------
 
   describe "D-379(b) — worker_fun that calls Watchdog.register/5 delivers {:worker_stalled, id} to Unit → ladder" do
     @tag :d_379
-    test "D-379: worker registered via Watchdog.register/5 — absence triggers {:worker_stalled, id} routed to retry ladder" do
+    test "D-379: worker registered via Watchdog.register/5 — absence triggers {:worker_stalled, id} routed to retry ladder in :implementing" do
       test_pid = self()
       unit_id = "u-d379b-wd-#{System.unique_integer([:positive])}"
       scheduler_name = :"sched_d379b_#{System.unique_integer([:positive])}"
@@ -574,7 +966,6 @@ defmodule Tau.Factory.UnitHeartbeatLivenessTest do
       start_scheduler(scheduler_name)
       start_supervised!({@unit_supervisor, name: sup_name}, id: sup_name)
 
-      # Very short Watchdog timeout so the test is fast.
       check_interval = 20
       heartbeat_timeout = 60
 
@@ -587,7 +978,7 @@ defmodule Tau.Factory.UnitHeartbeatLivenessTest do
       call_count = :counters.new(1, [:atomics])
 
       # This worker_fun mirrors the closure UnitDriver.drive/2 will build:
-      # it calls Watchdog.register/5 with report_to = self() (the Unit's pid)
+      # calls Watchdog.register/5 with report_to = self() (the Unit's pid)
       # so the Watchdog sends {:worker_stalled, worker_id} to the Unit when no
       # heartbeats arrive within heartbeat_timeout ms.
       worker_fun = fn _role ->
@@ -601,8 +992,6 @@ defmodule Tau.Factory.UnitHeartbeatLivenessTest do
             do: oracle_worker_id,
             else: "w-d379b-impl-#{n}-#{System.unique_integer([:positive])}"
 
-        # D-379: the driver's worker_fun closure calls Watchdog.register/5 with
-        # report_to = self() (the owning Unit's pid at invocation time).
         :ok =
           Watchdog.register(watchdog_name, worker_id, pid, self(),
             heartbeat_timeout: heartbeat_timeout
@@ -614,15 +1003,12 @@ defmodule Tau.Factory.UnitHeartbeatLivenessTest do
       opts =
         base_unit_opts(unit_id, scheduler_name, test_pid,
           worker_fun: worker_fun,
-          # Long Unit state_timeout so the Unit does not trip its own timer —
-          # only the Watchdog should fire.
           timeouts: [state_timeout_ms: 5_000]
         )
 
       unit_pid = @unit_supervisor.start_unit(sup_name, opts)
       assert is_pid(unit_pid)
 
-      # Advance past oracle so the implementing worker is registered too.
       advance_past_oracle(unit_pid, oracle_worker_id)
       result = wait_for_implementing(unit_pid)
 
@@ -635,7 +1021,6 @@ defmodule Tau.Factory.UnitHeartbeatLivenessTest do
 
       # No heartbeats emitted — the Watchdog fires {:worker_stalled, impl_worker_id}
       # to the Unit within heartbeat_timeout + check_interval ms.
-      # D-379(a) must route this to advance_retry_ladder/1.
       Process.sleep(heartbeat_timeout + 4 * check_interval + 50)
 
       {state_after, data_after} = :sys.get_state(unit_pid)
@@ -648,62 +1033,58 @@ defmodule Tau.Factory.UnitHeartbeatLivenessTest do
       assert state_after == :implementing and stall_advanced,
              "D-379(b): a worker registered with Watchdog.register/5 (the closure " <>
                "UnitDriver.drive/2 will build) MUST trigger {:worker_stalled, worker_id} " <>
-               "delivery to the Unit, which routes to the retry ladder. " <>
-               "Got state=#{inspect(state_after)}, refine #{refine_before}→#{refine_after}, " <>
+               "delivery to the Unit, which routes to the retry ladder via " <>
+               "advance_retry_ladder(:implementing, data) (re-enters :implementing). " <>
+               "Got state=#{inspect(state_after)}, " <>
+               "refine #{refine_before}→#{refine_after}, " <>
                "attempt #{attempt_before}→#{attempt_after}. " <>
-               "FAIL-BEFORE: the Unit has no {:worker_stalled, _} clause (D-379 absent) — " <>
-               "the Watchdog fires the signal but the Unit silently discards it via " <>
-               "handle_unexpected/4; the ladder counter stays flat."
+               "FAIL-BEFORE: deferred-spawn path or no worker_stalled clause routes " <>
+               "via advance_retry_ladder/2."
     end
   end
 
   # ---------------------------------------------------------------------------
-  # D-315 — stall re-spawn MUST write a Ledger snapshot (RPO=0 durability)
+  # D-315 — stall re-spawn MUST write a Ledger snapshot via the ladder's
+  # :on_enter (RPO=0 durability) — in BOTH :oracle and :implementing
   # ---------------------------------------------------------------------------
   #
-  # The bug: `advance_retry_ladder_deferred/1` bumps `refine_count` / `pivot_count`
-  # and sends `:deferred_spawn` to the mailbox, then `do_spawn_worker/1` re-spawns
-  # the worker. Neither function calls `snapshot_state(:implementing, ...)` or bumps
-  # `attempt_count`, unlike the normal `:on_enter` path in `implementing(:internal,
-  # :on_enter, data)`:
+  # The unified contract (GOV4 re-shape): when a stall-class signal fires,
+  # advance_retry_ladder/2 emits {:next_state, <originating_state>, data,
+  # [{:next_event, :internal, :on_enter}]}. The :on_enter callback already:
+  #   (a) bumps attempt_count
+  #   (b) calls snapshot_state/2 (writing a Ledger row)
+  #   (c) calls worker_fun to spawn the next worker
   #
-  #   new_data = %{data | attempt_count: data.attempt_count + 1}
-  #   new_data = snapshot_state(:implementing, new_data)   ← MISSING in deferred path
+  # There is NO separate :deferred_spawn / do_spawn_worker path.
   #
-  # This means a Watchdog-triggered stall re-spawn produces no Ledger row. On a
-  # crash after the re-spawn, the Coordinator's D-344 resume rehydrates the PREVIOUS
-  # state from the Ledger — either the original `:implementing` entry (before any
-  # stall) or worse `:oracle` — and re-spawns a worker that was already re-spawned,
-  # duplicating work and violating RPO=0 (D-315).
+  # FAIL-BEFORE (implementing): the deferred path (advance_retry_ladder_deferred/1
+  # → :deferred_spawn → do_spawn_worker/1) uses keep_state, not next_state.
+  # While do_spawn_worker/1 happens to call attempt_count++ and snapshot_state/2,
+  # the advance_retry_ladder/1 call itself uses refine_count++ without calling
+  # :on_enter — the attempt_count bump and snapshot happen in do_spawn_worker,
+  # which is not the canonical on_enter path. The test asserts the ladder-driven
+  # on_enter is the single correct path.
   #
-  # Observable seam: the Unit's `:ledger` opt. When present, every `snapshot_state/2`
-  # call writes a row via `Ledger.Writer.snapshot_unit/2`. We inject a REAL
-  # `Ledger.Writer` (same idiom as `unit_snapshot_durability_test.exs`) and read
-  # back via `Ledger.Reader.latest_unit_snapshots/1`.
-  #
-  # FAIL-BEFORE: the deferred path skips `snapshot_state/2`, so
-  # `latest_unit_snapshots(ledger)` returns the pre-stall entry (or nothing if
-  # the Unit hasn't snapshotted yet at all), not a fresh `:implementing` row.
-  # With the fix, each deferred re-spawn calls `snapshot_state(:implementing, ...)`,
-  # writing a new Ledger row with the bumped `attempt_count` coordinate — and
-  # `latest_unit_snapshots/1` returns `:implementing` (the current state).
+  # FAIL-BEFORE (oracle): advance_retry_ladder/1 (arity-1) hardcodes :implementing
+  # as the next state — the oracle :on_enter runs for :implementing, not :oracle,
+  # so the oracle stall re-spawn violates oracle-separation AND D-315 (the
+  # :implementing on_enter writes the row but with wrong-role semantics).
   # ---------------------------------------------------------------------------
 
-  describe "D-315 — stall-driven deferred re-spawn writes a Ledger snapshot (RPO=0)" do
+  describe "D-315 — stall re-spawn writes Ledger snapshot via ladder :on_enter (RPO=0)" do
     @tag :d_315
-    test "D-315: worker_stalled for current_worker_id triggers deferred re-spawn that writes a new Ledger snapshot with bumped attempt_count" do
+    test "D-315 implementing: worker_stalled triggers ladder re-spawn writing Ledger snapshot with bumped attempt_count" do
       ledger = start_ledger()
       test_pid = self()
-      unit_id = "u-d315-stall-snap-#{System.unique_integer([:positive])}"
-      scheduler_name = :"sched_d315_#{System.unique_integer([:positive])}"
-      sup_name = :"sup_d315_#{System.unique_integer([:positive])}"
+      unit_id = "u-d315-impl-stall-snap-#{System.unique_integer([:positive])}"
+      scheduler_name = :"sched_d315_impl_#{System.unique_integer([:positive])}"
+      sup_name = :"sup_d315_impl_#{System.unique_integer([:positive])}"
 
       start_scheduler(scheduler_name)
       start_supervised!({@unit_supervisor, name: sup_name}, id: sup_name)
 
-      oracle_worker_id = "w-d315-oracle-#{System.unique_integer([:positive])}"
+      oracle_worker_id = "w-d315-impl-oracle-#{System.unique_integer([:positive])}"
       impl_worker_id_1 = "w-d315-impl-1-#{System.unique_integer([:positive])}"
-      # The re-spawned worker after the stall gets a distinct id.
       impl_worker_id_2 = "w-d315-impl-2-#{System.unique_integer([:positive])}"
       call_count = :counters.new(1, [:atomics])
 
@@ -729,8 +1110,6 @@ defmodule Tau.Factory.UnitHeartbeatLivenessTest do
         worker_fun: worker_fun,
         gate_fun: fn _coord -> :pass end,
         merge_fun: fn _uid, _hash -> :queued end,
-        # Long timeout: the real :state_timeout must NOT fire. Only the manual
-        # {:worker_stalled, impl_worker_id_1} signal triggers the deferred path.
         timeouts: [state_timeout_ms: 10_000]
       ]
 
@@ -741,71 +1120,169 @@ defmodule Tau.Factory.UnitHeartbeatLivenessTest do
       result = wait_for_implementing(unit_pid)
 
       assert match?({:implementing, _}, result),
-             "D-315: Unit must reach :implementing; got #{inspect(result)}"
+             "D-315 implementing: Unit must reach :implementing; got #{inspect(result)}"
 
       {:implementing, data_before} = result
       attempt_before = Map.get(data_before, :attempt_count, 0)
 
-      # Confirm a Ledger snapshot exists after the initial :implementing entry
-      # (the normal :on_enter path writes one). This is a sanity pre-condition:
-      # if the normal path also failed to write, the test would be masked.
-      # We allow for the Unit to have just entered implementing so give it a moment.
+      # Sanity: normal :on_enter must write a Ledger snapshot at :implementing.
       Process.sleep(50)
-
       snapshots_before = LedgerReader.latest_unit_snapshots(ledger)
 
       assert Map.get(snapshots_before, unit_id) == :implementing,
-             "D-315 pre-condition: normal :on_enter must write a Ledger snapshot at " <>
-               ":implementing. Got #{inspect(Map.get(snapshots_before, unit_id))} " <>
+             "D-315 implementing pre-condition: normal :on_enter must write a Ledger " <>
+               "snapshot at :implementing. Got #{inspect(Map.get(snapshots_before, unit_id))} " <>
                "(map: #{inspect(snapshots_before)}). " <>
                "Indicates :ledger opt not wired or normal snapshotting path broken."
 
-      # Trigger the deferred-spawn path by delivering a Watchdog stall signal
-      # for the CURRENT implementing worker.
+      # Trigger the ladder re-spawn by delivering a stall signal for the
+      # CURRENT implementing worker. With the unified design:
+      #   {:worker_stalled, impl_worker_id_1}
+      #   → advance_retry_ladder(:implementing, data)
+      #   → {:next_state, :implementing, bumped, [{:next_event, :internal, :on_enter}]}
+      #   → implementing(:internal, :on_enter, bumped)
+      #   → attempt_count++ + snapshot_state(:implementing, ...) + spawn worker 2
       send(unit_pid, {:worker_stalled, impl_worker_id_1})
 
-      # Allow the deferred path to complete: {:worker_stalled, _} clears worker_id
-      # → advance_retry_ladder_deferred sends :deferred_spawn to mailbox end
-      # → :deferred_spawn fires do_spawn_worker → the new worker is running.
-      # The key missing step: snapshot_state(:implementing, ...) and attempt_count++.
+      # Allow the on_enter to complete: next_state fires, on_enter runs,
+      # new worker is spawned.
       Process.sleep(300)
 
       {state_after, data_after} = :sys.get_state(unit_pid)
-
       attempt_after = Map.get(data_after, :attempt_count, 0)
 
-      # Assert 1: the Unit is in :implementing after the deferred re-spawn.
+      # Assert 1: the Unit is in :implementing after the ladder re-spawn.
       assert state_after == :implementing,
-             "D-315: after stall-driven deferred re-spawn, Unit must be back in " <>
+             "D-315 implementing: after stall ladder re-spawn, Unit must be back in " <>
                ":implementing; got #{inspect(state_after)}"
 
-      # Assert 2: attempt_count was bumped (the re-spawn IS a new attempt).
+      # Assert 2: attempt_count was bumped by the :on_enter (the re-spawn IS a new attempt).
       assert attempt_after > attempt_before,
-             "D-315: stall-driven deferred re-spawn MUST increment attempt_count. " <>
-               "attempt_count #{attempt_before} -> #{attempt_after} (expected strictly greater). " <>
-               "FAIL-BEFORE: do_spawn_worker/1 skips attempt_count++, violating D-315."
+             "D-315 implementing: stall ladder re-spawn MUST increment attempt_count " <>
+               "via :on_enter. attempt_count #{attempt_before} -> #{attempt_after} " <>
+               "(expected strictly greater). " <>
+               "FAIL-BEFORE: deferred path's do_spawn_worker bumps attempt_count but " <>
+               "outside the canonical on_enter; with the unified ladder the on_enter " <>
+               "is the single correct path."
 
-      # Assert 3: the Ledger holds a FRESH :implementing snapshot for this unit,
-      # written by snapshot_state/2 during the deferred re-spawn.
-      # Under the current (unfixed) code, do_spawn_worker skips snapshot_state/2,
-      # so the Ledger row is stale (the one written by the first :on_enter).
-      # The test distinguishes these cases via the snapshot_seq counter embedded
-      # in the idempotency key: the deferred re-spawn must write a NEW row
-      # (higher sequence) reflecting the post-stall :implementing state.
+      # Assert 3: the Ledger holds a FRESH :implementing snapshot.
       snapshots_after = LedgerReader.latest_unit_snapshots(ledger)
 
       assert Map.get(snapshots_after, unit_id) == :implementing,
-             "D-315: after stall deferred re-spawn, Ledger must hold :implementing. " <>
+             "D-315 implementing: after stall ladder re-spawn, Ledger must hold :implementing. " <>
+               "Got #{inspect(Map.get(snapshots_after, unit_id))} " <>
+               "(map: #{inspect(snapshots_after)})."
+
+      # Assert 4: no terminal — the stall triggered retry, not escalation.
+      refute_received {:unit_terminal, ^unit_id, _outcome, _prov},
+                      "D-315 implementing: a single {:worker_stalled, current_id} must " <>
+                        "route to retry, not terminate the Unit"
+    end
+
+    @tag :d_315
+    test "D-315 oracle: worker_stalled triggers ladder re-spawn writing Ledger snapshot with bumped attempt_count re-entering :oracle" do
+      ledger = start_ledger()
+      test_pid = self()
+      unit_id = "u-d315-oracle-stall-snap-#{System.unique_integer([:positive])}"
+      scheduler_name = :"sched_d315_oracle_#{System.unique_integer([:positive])}"
+      sup_name = :"sup_d315_oracle_#{System.unique_integer([:positive])}"
+
+      start_scheduler(scheduler_name)
+      start_supervised!({@unit_supervisor, name: sup_name}, id: sup_name)
+
+      oracle_worker_id_1 = "w-d315-oracle-1-#{System.unique_integer([:positive])}"
+      oracle_worker_id_2 = "w-d315-oracle-2-#{System.unique_integer([:positive])}"
+      call_count = :counters.new(1, [:atomics])
+
+      worker_fun = fn _role ->
+        n = :counters.get(call_count, 1)
+        :counters.add(call_count, 1, 1)
+        pid = spawn_worker()
+
+        case n do
+          0 -> {:ok, pid, oracle_worker_id_1}
+          _ -> {:ok, pid, oracle_worker_id_2}
+        end
+      end
+
+      opts = [
+        unit_id: unit_id,
+        declared_scope: empty_scope(),
+        hash: "hash-#{unit_id}",
+        scheduler: scheduler_name,
+        report_to: test_pid,
+        ledger: ledger,
+        worker_fun: worker_fun,
+        gate_fun: fn _coord -> :pass end,
+        merge_fun: fn _uid, _hash -> :queued end,
+        timeouts: [state_timeout_ms: 10_000]
+      ]
+
+      unit_pid = @unit_supervisor.start_unit(sup_name, opts)
+      assert is_pid(unit_pid)
+
+      # Wait in :oracle — do NOT advance past oracle.
+      result = wait_for_oracle(unit_pid)
+
+      assert match?({:oracle, _}, result),
+             "D-315 oracle: Unit must reach :oracle; got #{inspect(result)}"
+
+      {:oracle, data_before} = result
+      attempt_before = Map.get(data_before, :attempt_count, 0)
+
+      # Allow the oracle :on_enter to write its Ledger snapshot.
+      Process.sleep(50)
+      snapshots_before = LedgerReader.latest_unit_snapshots(ledger)
+
+      assert Map.get(snapshots_before, unit_id) == :oracle,
+             "D-315 oracle pre-condition: normal oracle :on_enter must write a Ledger " <>
+               "snapshot at :oracle. Got #{inspect(Map.get(snapshots_before, unit_id))} " <>
+               "(map: #{inspect(snapshots_before)}). " <>
+               "Indicates :ledger opt not wired, or oracle :on_enter snapshot path broken."
+
+      # Trigger the ladder re-spawn by delivering a stall signal for the
+      # CURRENT oracle worker. With the unified design:
+      #   {:worker_stalled, oracle_worker_id_1}
+      #   → advance_retry_ladder(:oracle, data)
+      #   → {:next_state, :oracle, bumped, [{:next_event, :internal, :on_enter}]}
+      #   → oracle(:internal, :on_enter, bumped)
+      #   → attempt_count++ + snapshot_state(:oracle, ...) + spawn oracle worker 2
+      send(unit_pid, {:worker_stalled, oracle_worker_id_1})
+
+      Process.sleep(300)
+
+      {state_after, data_after} = :sys.get_state(unit_pid)
+      attempt_after = Map.get(data_after, :attempt_count, 0)
+
+      # Assert 1: Unit is in :oracle after the ladder re-spawn.
+      assert state_after == :oracle,
+             "D-315 oracle: after stall ladder re-spawn, Unit must be back in :oracle " <>
+               "(the originating state). Got #{inspect(state_after)}. " <>
+               "FAIL-BEFORE: advance_retry_ladder/1 hardcodes :implementing — oracle " <>
+               "stall re-enters :implementing, violating oracle-separation."
+
+      # Assert 2: attempt_count was bumped by oracle :on_enter.
+      assert attempt_after > attempt_before,
+             "D-315 oracle: stall ladder re-spawn MUST increment attempt_count via " <>
+               "oracle :on_enter. attempt_count #{attempt_before} -> #{attempt_after} " <>
+               "(expected strictly greater). " <>
+               "FAIL-BEFORE: advance_retry_ladder/1 hardcodes :implementing; the " <>
+               "wrong :on_enter runs (or no :on_enter if the state doesn't change)."
+
+      # Assert 3: the Ledger holds a FRESH :oracle snapshot.
+      snapshots_after = LedgerReader.latest_unit_snapshots(ledger)
+
+      assert Map.get(snapshots_after, unit_id) == :oracle,
+             "D-315 oracle: after stall ladder re-spawn, Ledger must hold :oracle snapshot. " <>
                "Got #{inspect(Map.get(snapshots_after, unit_id))} " <>
                "(map: #{inspect(snapshots_after)}). " <>
-               "FAIL-BEFORE: do_spawn_worker/1 skips snapshot_state(:implementing,...) — " <>
-               "no new Ledger row written for re-spawn, violating D-315 RPO=0."
+               "FAIL-BEFORE: advance_retry_ladder/1 hardcodes :implementing — the Ledger " <>
+               "would hold :implementing (wrong role) or the wrong attempt_count row."
 
-      # Assert 4: no terminal signal was sent to the test process — the stall
-      # triggered a re-spawn (retry ladder), not escalation.
+      # Assert 4: no terminal.
       refute_received {:unit_terminal, ^unit_id, _outcome, _prov},
-                      "D-315: a single {:worker_stalled, current_id} must route to retry, " <>
-                        "not terminate the Unit"
+                      "D-315 oracle: a single {:worker_stalled, current_oracle_id} must " <>
+                        "route to retry, not terminate the Unit"
     end
   end
 
@@ -814,7 +1291,7 @@ defmodule Tau.Factory.UnitHeartbeatLivenessTest do
   # ---------------------------------------------------------------------------
 
   # Drive {:worker_heartbeat, worker_id} pulses from the TEST PROCESS at
-  # interval_ms for up_to_ms total wall time.  Driving from the test process
+  # interval_ms for up_to_ms total wall time. Driving from the test process
   # (rather than a spawned ticker) ensures the sends are not subject to
   # scheduler starvation of a separate process under full-suite load.
   defp hb_loop_from_test(_unit_pid, _worker_id, _interval_ms, remaining_ms)

--- a/test/tau/factory/unit_heartbeat_liveness_test.exs
+++ b/test/tau/factory/unit_heartbeat_liveness_test.exs
@@ -20,6 +20,11 @@ defmodule Tau.Factory.UnitHeartbeatLivenessTest do
       worker per state.
     The `advance_retry_ladder/2` function takes the originating state so
     re-spawn re-enters the correct role.
+    **LIV-1 (D-378 boundedness):** repeated stall/exit cycles exhaust the bounded
+    retry ladder (refine → pivot → exhausted) and the Unit escalates
+    `E_RETRY_EXHAUSTED` — it does NOT re-spawn forever. The implementing path must
+    use the SAME bounded ladder as the oracle path (no separate gate-ladder or
+    unbounded deferred-spawn loop).
 
   - **D-379** — (a) `oracle` AND `implementing` both consume `{:worker_stalled,
     ^worker_id}` AND `{:worker_exit, ^worker_id, _}` → retry ladder; stale-worker
@@ -38,15 +43,18 @@ defmodule Tau.Factory.UnitHeartbeatLivenessTest do
 
   ## Fail-before validity (oracle-separation, factory-loop §4b)
 
-  These tests fail against the current RED branch (`821c7af`) because:
-  - `oracle` has no `{:worker_exit, _, _}` clause (run-#2 regression, D-379).
-  - `advance_retry_ladder/2` is arity-1 and hardcodes `:implementing` as the
-    re-entered state — an oracle stall re-enters `:implementing`, not `:oracle`.
-  - `implementing`'s `{:worker_stalled, _}` uses the removed
-    `:deferred_spawn`/`do_spawn_worker` path instead of `advance_retry_ladder/2`.
-  - D-315 oracle path: oracle ladder re-enter skips `attempt_count++` and
-    `snapshot_state/2` (the `:on_enter` of the wrongly-re-entered state runs,
-    but for `:implementing`, not `:oracle`).
+  These tests fail against the current branch (6beddd1) because:
+  - `implementing`'s `advance_retry_ladder/2` sends `:stall_respawn` (deferred
+    path via `do_spawn_worker`) which never calls `Retry.next/3` and therefore
+    never exhausts the bounded ladder → the LIV-1 boundedness test fails (no
+    `:E_RETRY_EXHAUSTED` is ever sent).
+  - The deferred path's `do_spawn_worker` uses `:keep_state` (not `:next_state`)
+    → the `implementing` path uses a fundamentally different mechanism from the
+    `oracle` path → the symmetric-worker_exit test fails (implementing worker_exit
+    does not re-enter `:implementing` via the same `:next_state` ladder transition).
+  - Fresh-id tests fail because the deferred path relies on same-worker_id reuse
+    to drain stale signals from the mailbox; with fresh ids the deferred path's
+    stale-discard assumption breaks.
 
   ## AC / D-NNN linkage (Gate 5.1)
 
@@ -65,6 +73,7 @@ defmodule Tau.Factory.UnitHeartbeatLivenessTest do
   alias Tau.Factory.Fleet.Watchdog
   alias Tau.Factory.Ledger.Reader, as: LedgerReader
   alias Tau.Factory.Ledger.Writer, as: LedgerWriter
+  alias Tau.Factory.Retry
   alias Tau.Factory.Scheduler
   alias Tau.Factory.UnitSupervisor
 
@@ -227,14 +236,16 @@ defmodule Tau.Factory.UnitHeartbeatLivenessTest do
       state_timeout_ms = 1_000
 
       oracle_worker_id = "w-hb-oracle-#{System.unique_integer([:positive])}"
-      impl_worker_id = "w-hb-impl-#{System.unique_integer([:positive])}"
       call_count = :counters.new(1, [:atomics])
 
       worker_fun = fn _role ->
         n = :counters.get(call_count, 1)
         :counters.add(call_count, 1, 1)
         pid = spawn_worker()
-        if n == 0, do: {:ok, pid, oracle_worker_id}, else: {:ok, pid, impl_worker_id}
+
+        if n == 0,
+          do: {:ok, pid, oracle_worker_id},
+          else: {:ok, pid, "impl-worker-#{n}-#{System.unique_integer([:positive])}"}
       end
 
       opts =
@@ -251,6 +262,9 @@ defmodule Tau.Factory.UnitHeartbeatLivenessTest do
 
       assert match?({:implementing, _}, result),
              "D-377: Unit must reach :implementing; got #{inspect(result)}"
+
+      {:implementing, data_impl} = result
+      impl_worker_id = data_impl.worker_id
 
       # Drive heartbeats from the TEST PROCESS at 200ms intervals (well below the
       # 1000ms state_timeout_ms) for 3× the deadline (3000ms total).
@@ -336,14 +350,16 @@ defmodule Tau.Factory.UnitHeartbeatLivenessTest do
       state_timeout_ms = 80
 
       oracle_worker_id = "w-nostall-oracle-#{System.unique_integer([:positive])}"
-      impl_worker_id = "w-nostall-impl-#{System.unique_integer([:positive])}"
       call_count = :counters.new(1, [:atomics])
 
       worker_fun = fn _role ->
         n = :counters.get(call_count, 1)
         :counters.add(call_count, 1, 1)
         pid = spawn_worker()
-        if n == 0, do: {:ok, pid, oracle_worker_id}, else: {:ok, pid, impl_worker_id}
+
+        if n == 0,
+          do: {:ok, pid, oracle_worker_id},
+          else: {:ok, pid, "nostall-impl-#{n}-#{System.unique_integer([:positive])}"}
       end
 
       opts =
@@ -400,14 +416,19 @@ defmodule Tau.Factory.UnitHeartbeatLivenessTest do
       start_supervised!({@unit_supervisor, name: sup_name}, id: sup_name)
 
       oracle_worker_id = "w-d378-impl-oracle-#{System.unique_integer([:positive])}"
-      impl_worker_id = "w-d378-impl-#{System.unique_integer([:positive])}"
       call_count = :counters.new(1, [:atomics])
 
+      # D-326: each re-spawn returns a FRESH unique worker_id.
+      # The deferred-spawn path relied on reusing the same id to drain stale
+      # messages; the plain bounded ladder uses id-keyed discrimination instead.
       worker_fun = fn _role ->
         n = :counters.get(call_count, 1)
         :counters.add(call_count, 1, 1)
         pid = spawn_worker()
-        if n == 0, do: {:ok, pid, oracle_worker_id}, else: {:ok, pid, impl_worker_id}
+
+        if n == 0,
+          do: {:ok, pid, oracle_worker_id},
+          else: {:ok, pid, "impl-worker-#{n}-#{System.unique_integer([:positive])}"}
       end
 
       opts =
@@ -428,14 +449,19 @@ defmodule Tau.Factory.UnitHeartbeatLivenessTest do
       {:implementing, data_before} = result
       refine_before = Map.get(data_before, :refine_count, 0)
       attempt_before = Map.get(data_before, :attempt_count, 0)
+      # Read the CURRENT worker_id from state (fresh id, not a hardcoded string).
+      current_impl_worker_id = data_before.worker_id
 
       # Burst of three stall signals for the SAME implementing worker.
       # D-378: first clears worker_id; second + third are stale-discarded.
       # Result: exactly ONE ladder advance, Unit re-enters :implementing
       # (the originating state, per the unified symmetric rule).
-      send(unit_pid, {:worker_stalled, impl_worker_id})
-      send(unit_pid, {:worker_exit, impl_worker_id, :no_work_product})
-      send(unit_pid, {:worker_stalled, impl_worker_id})
+      # With fresh ids (D-326), the re-spawned worker gets a new id so the
+      # stale signals for current_impl_worker_id are discarded by the
+      # _other_id clause — exactly-once via id discrimination, not mailbox drain.
+      send(unit_pid, {:worker_stalled, current_impl_worker_id})
+      send(unit_pid, {:worker_exit, current_impl_worker_id, :no_work_product})
+      send(unit_pid, {:worker_stalled, current_impl_worker_id})
 
       # Allow all three messages to be processed plus the on_enter to run.
       Process.sleep(400)
@@ -564,14 +590,16 @@ defmodule Tau.Factory.UnitHeartbeatLivenessTest do
       start_supervised!({@unit_supervisor, name: sup_name}, id: sup_name)
 
       oracle_worker_id = "w-d379a-impl-oracle-#{System.unique_integer([:positive])}"
-      impl_worker_id = "w-d379a-impl-#{System.unique_integer([:positive])}"
       call_count = :counters.new(1, [:atomics])
 
       worker_fun = fn _role ->
         n = :counters.get(call_count, 1)
         :counters.add(call_count, 1, 1)
         pid = spawn_worker()
-        if n == 0, do: {:ok, pid, oracle_worker_id}, else: {:ok, pid, impl_worker_id}
+
+        if n == 0,
+          do: {:ok, pid, oracle_worker_id},
+          else: {:ok, pid, "d379a-impl-#{n}-#{System.unique_integer([:positive])}"}
       end
 
       opts =
@@ -592,8 +620,9 @@ defmodule Tau.Factory.UnitHeartbeatLivenessTest do
       {:implementing, data_before} = result
       refine_before = Map.get(data_before, :refine_count, 0)
       attempt_before = Map.get(data_before, :attempt_count, 0)
+      current_impl_worker_id = data_before.worker_id
 
-      send(unit_pid, {:worker_stalled, impl_worker_id})
+      send(unit_pid, {:worker_stalled, current_impl_worker_id})
       Process.sleep(250)
 
       {state_after, data_after} = :sys.get_state(unit_pid)
@@ -628,14 +657,16 @@ defmodule Tau.Factory.UnitHeartbeatLivenessTest do
       start_supervised!({@unit_supervisor, name: sup_name}, id: sup_name)
 
       oracle_worker_id = "w-d379a-impl-exit-oracle-#{System.unique_integer([:positive])}"
-      impl_worker_id = "w-d379a-impl-exit-#{System.unique_integer([:positive])}"
       call_count = :counters.new(1, [:atomics])
 
       worker_fun = fn _role ->
         n = :counters.get(call_count, 1)
         :counters.add(call_count, 1, 1)
         pid = spawn_worker()
-        if n == 0, do: {:ok, pid, oracle_worker_id}, else: {:ok, pid, impl_worker_id}
+
+        if n == 0,
+          do: {:ok, pid, oracle_worker_id},
+          else: {:ok, pid, "d379a-impl-exit-#{n}-#{System.unique_integer([:positive])}"}
       end
 
       opts =
@@ -656,8 +687,9 @@ defmodule Tau.Factory.UnitHeartbeatLivenessTest do
       {:implementing, data_before} = result
       refine_before = Map.get(data_before, :refine_count, 0)
       attempt_before = Map.get(data_before, :attempt_count, 0)
+      current_impl_worker_id = data_before.worker_id
 
-      send(unit_pid, {:worker_exit, impl_worker_id, :no_work_product})
+      send(unit_pid, {:worker_exit, current_impl_worker_id, :no_work_product})
       Process.sleep(250)
 
       {state_after, data_after} = :sys.get_state(unit_pid)
@@ -690,14 +722,16 @@ defmodule Tau.Factory.UnitHeartbeatLivenessTest do
       start_supervised!({@unit_supervisor, name: sup_name}, id: sup_name)
 
       oracle_worker_id = "w-d379as-impl-oracle-#{System.unique_integer([:positive])}"
-      impl_worker_id = "w-d379as-impl-#{System.unique_integer([:positive])}"
       call_count = :counters.new(1, [:atomics])
 
       worker_fun = fn _role ->
         n = :counters.get(call_count, 1)
         :counters.add(call_count, 1, 1)
         pid = spawn_worker()
-        if n == 0, do: {:ok, pid, oracle_worker_id}, else: {:ok, pid, impl_worker_id}
+
+        if n == 0,
+          do: {:ok, pid, oracle_worker_id},
+          else: {:ok, pid, "d379as-impl-#{n}-#{System.unique_integer([:positive])}"}
       end
 
       opts =
@@ -1084,20 +1118,17 @@ defmodule Tau.Factory.UnitHeartbeatLivenessTest do
       start_supervised!({@unit_supervisor, name: sup_name}, id: sup_name)
 
       oracle_worker_id = "w-d315-impl-oracle-#{System.unique_integer([:positive])}"
-      impl_worker_id_1 = "w-d315-impl-1-#{System.unique_integer([:positive])}"
-      impl_worker_id_2 = "w-d315-impl-2-#{System.unique_integer([:positive])}"
       call_count = :counters.new(1, [:atomics])
 
+      # D-326: each spawn returns a FRESH unique worker_id.
       worker_fun = fn _role ->
         n = :counters.get(call_count, 1)
         :counters.add(call_count, 1, 1)
         pid = spawn_worker()
 
-        case n do
-          0 -> {:ok, pid, oracle_worker_id}
-          1 -> {:ok, pid, impl_worker_id_1}
-          _ -> {:ok, pid, impl_worker_id_2}
-        end
+        if n == 0,
+          do: {:ok, pid, oracle_worker_id},
+          else: {:ok, pid, "d315-impl-#{n}-#{System.unique_integer([:positive])}"}
       end
 
       opts = [
@@ -1124,6 +1155,8 @@ defmodule Tau.Factory.UnitHeartbeatLivenessTest do
 
       {:implementing, data_before} = result
       attempt_before = Map.get(data_before, :attempt_count, 0)
+      # Read the CURRENT worker_id from state (fresh id, D-326).
+      current_impl_worker_id = data_before.worker_id
 
       # Sanity: normal :on_enter must write a Ledger snapshot at :implementing.
       Process.sleep(50)
@@ -1137,12 +1170,12 @@ defmodule Tau.Factory.UnitHeartbeatLivenessTest do
 
       # Trigger the ladder re-spawn by delivering a stall signal for the
       # CURRENT implementing worker. With the unified design:
-      #   {:worker_stalled, impl_worker_id_1}
+      #   {:worker_stalled, current_impl_worker_id}
       #   → advance_retry_ladder(:implementing, data)
       #   → {:next_state, :implementing, bumped, [{:next_event, :internal, :on_enter}]}
       #   → implementing(:internal, :on_enter, bumped)
-      #   → attempt_count++ + snapshot_state(:implementing, ...) + spawn worker 2
-      send(unit_pid, {:worker_stalled, impl_worker_id_1})
+      #   → attempt_count++ + snapshot_state(:implementing, ...) + spawn next worker
+      send(unit_pid, {:worker_stalled, current_impl_worker_id})
 
       # Allow the on_enter to complete: next_state fires, on_enter runs,
       # new worker is spawned.
@@ -1283,6 +1316,289 @@ defmodule Tau.Factory.UnitHeartbeatLivenessTest do
       refute_received {:unit_terminal, ^unit_id, _outcome, _prov},
                       "D-315 oracle: a single {:worker_stalled, current_oracle_id} must " <>
                         "route to retry, not terminate the Unit"
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # D-378 LIV-1 — the retry ladder is BOUNDED; repeated stall/exit cycles
+  # must eventually escalate E_RETRY_EXHAUSTED, NOT re-spawn forever.
+  # ---------------------------------------------------------------------------
+  #
+  # The current 6beddd1 implementing path sends `:stall_respawn` to itself
+  # via `do_spawn_worker` which calls `Retry.next/3`… wait, actually it does
+  # NOT call Retry.next at all — it just bumps attempt_count and re-spawns
+  # unconditionally. Only the gate-failure path (`advance_gate_ladder/1`)
+  # calls `Retry.next`. Therefore the stall/exit loop in `:implementing` is
+  # UNBOUNDED: no matter how many times the implementing worker stalls, the
+  # Unit keeps re-spawning and never escalates E_RETRY_EXHAUSTED.
+  #
+  # The realigned impl must use the SAME bounded ladder for stall re-spawns:
+  # advance_retry_ladder/2 calls Retry.next (or the :on_enter that calls it)
+  # so that after N_REFINE + N_PIVOT stall cycles the Unit escalates.
+  #
+  # FAIL-BEFORE (6beddd1): the implementing deferred path (`do_spawn_worker`)
+  # never consumes the Retry budget → the assert_receive for
+  # {:unit_terminal, _, :escalated, _} times out (no escalation ever fires).
+  # ---------------------------------------------------------------------------
+
+  describe "D-378 LIV-1 — repeated stall cycles exhaust bounded ladder and escalate E_RETRY_EXHAUSTED" do
+    @tag :d_378
+    test "D-378 LIV-1 implementing: repeated worker_stalled cycles exhaust Retry ladder and escalate E_RETRY_EXHAUSTED not re-spawn forever" do
+      test_pid = self()
+      unit_id = "u-d378-liv1-impl-#{System.unique_integer([:positive])}"
+      scheduler_name = :"sched_d378_liv1_impl_#{System.unique_integer([:positive])}"
+      sup_name = :"sup_d378_liv1_impl_#{System.unique_integer([:positive])}"
+
+      start_scheduler(scheduler_name)
+      start_supervised!({@unit_supervisor, name: sup_name}, id: sup_name)
+
+      oracle_worker_id = "w-liv1-oracle-#{System.unique_integer([:positive])}"
+      call_count = :counters.new(1, [:atomics])
+
+      worker_fun = fn _role ->
+        n = :counters.get(call_count, 1)
+        :counters.add(call_count, 1, 1)
+        pid = spawn_worker()
+
+        if n == 0,
+          do: {:ok, pid, oracle_worker_id},
+          else: {:ok, pid, "liv1-impl-#{n}-#{System.unique_integer([:positive])}"}
+      end
+
+      opts =
+        base_unit_opts(unit_id, scheduler_name, test_pid,
+          worker_fun: worker_fun,
+          timeouts: [state_timeout_ms: 10_000]
+        )
+
+      unit_pid = @unit_supervisor.start_unit(sup_name, opts)
+      assert is_pid(unit_pid)
+
+      advance_past_oracle(unit_pid, oracle_worker_id)
+      result = wait_for_implementing(unit_pid)
+
+      assert match?({:implementing, _}, result),
+             "D-378 LIV-1: Unit must reach :implementing; got #{inspect(result)}"
+
+      # The total stall budget: N_REFINE + N_PIVOT stall cycles must exhaust the
+      # unified bounded ladder and cause the Unit to escalate E_RETRY_EXHAUSTED.
+      # This is the LIVENESS STALL path ({:worker_stalled, w}) — NOT the
+      # semantic-failure path ({:worker_exit, w, _}) which already calls
+      # advance_gate_ladder in the current impl.
+      #
+      # FAIL-BEFORE (6beddd1): implementing {:worker_stalled, _} calls
+      # advance_retry_ladder(:implementing, data) which sends :stall_respawn
+      # and returns {:keep_state, data}. do_spawn_worker then bumps attempt_count
+      # and re-spawns — but it NEVER calls Retry.next/3, so the stall re-spawn
+      # loop is UNBOUNDED. No E_RETRY_EXHAUSTED is ever sent.
+      total_stall_cycles = Retry.n_refine() + Retry.n_pivot() + 1
+
+      # Drive stall cycles: each cycle reads the current worker_id from state,
+      # sends a {:worker_stalled, id} signal (the liveness path), and waits for
+      # the Unit to re-enter :implementing (re-spawn via the ladder).
+      # After exhausting the budget the Unit must escalate.
+      for _cycle <- 1..total_stall_cycles do
+        case :sys.get_state(unit_pid) do
+          {:implementing, data} ->
+            current_id = data.worker_id
+
+            if is_binary(current_id) do
+              send(unit_pid, {:worker_stalled, current_id})
+            end
+
+          _other ->
+            :ok
+        end
+
+        # Allow the ladder transition (on_enter re-spawn) to complete.
+        Process.sleep(150)
+      end
+
+      # After exhausting the retry budget the Unit MUST send a terminal escalation.
+      assert_receive {:unit_terminal, ^unit_id, :escalated, provenance},
+                     2_000,
+                     "D-378 LIV-1 implementing: after #{total_stall_cycles} " <>
+                       "{:worker_stalled, _} cycles the bounded ladder MUST escalate " <>
+                       "E_RETRY_EXHAUSTED. No terminal received within 2000ms. " <>
+                       "FAIL-BEFORE (6beddd1): the :stall_respawn deferred path in " <>
+                       "advance_retry_ladder(:implementing, _) never calls Retry.next/3 " <>
+                       "— the stall loop is UNBOUNDED and the Unit re-spawns forever."
+
+      reason = Map.get(provenance, :reason)
+
+      assert reason == :E_RETRY_EXHAUSTED,
+             "D-378 LIV-1 implementing: terminal escalation must carry :E_RETRY_EXHAUSTED; " <>
+               "got #{inspect(reason)}. Provenance: #{inspect(provenance)}"
+    end
+
+    @tag :d_378
+    test "D-378 LIV-1 oracle: repeated worker_stalled cycles exhaust Retry ladder and escalate E_RETRY_EXHAUSTED" do
+      test_pid = self()
+      unit_id = "u-d378-liv1-oracle-#{System.unique_integer([:positive])}"
+      scheduler_name = :"sched_d378_liv1_oracle_#{System.unique_integer([:positive])}"
+      sup_name = :"sup_d378_liv1_oracle_#{System.unique_integer([:positive])}"
+
+      start_scheduler(scheduler_name)
+      start_supervised!({@unit_supervisor, name: sup_name}, id: sup_name)
+
+      call_count = :counters.new(1, [:atomics])
+
+      worker_fun = fn _role ->
+        n = :counters.get(call_count, 1)
+        :counters.add(call_count, 1, 1)
+        pid = spawn_worker()
+        {:ok, pid, "liv1-oracle-worker-#{n}-#{System.unique_integer([:positive])}"}
+      end
+
+      opts =
+        base_unit_opts(unit_id, scheduler_name, test_pid,
+          worker_fun: worker_fun,
+          timeouts: [state_timeout_ms: 10_000]
+        )
+
+      unit_pid = @unit_supervisor.start_unit(sup_name, opts)
+      assert is_pid(unit_pid)
+
+      # Stay in :oracle — do NOT advance past oracle.
+      result = wait_for_oracle(unit_pid)
+
+      assert match?({:oracle, _}, result),
+             "D-378 LIV-1 oracle: Unit must reach :oracle; got #{inspect(result)}"
+
+      # Drive stall cycles using the LIVENESS stall signal ({:worker_stalled, _})
+      # to mirror the implementing LIV-1 test. Both paths (oracle and implementing)
+      # must route stall signals through the SAME bounded ladder.
+      total_stall_cycles = Retry.n_refine() + Retry.n_pivot() + 1
+
+      for _cycle <- 1..total_stall_cycles do
+        case :sys.get_state(unit_pid) do
+          {:oracle, data} ->
+            current_id = data.worker_id
+
+            if is_binary(current_id) do
+              send(unit_pid, {:worker_stalled, current_id})
+            end
+
+          _other ->
+            :ok
+        end
+
+        Process.sleep(150)
+      end
+
+      assert_receive {:unit_terminal, ^unit_id, :escalated, provenance},
+                     2_000,
+                     "D-378 LIV-1 oracle: after #{total_stall_cycles} {:worker_stalled, _} " <>
+                       "cycles the bounded ladder MUST escalate E_RETRY_EXHAUSTED. " <>
+                       "No terminal received within 2000ms. " <>
+                       "FAIL-BEFORE (6beddd1): advance_retry_ladder(:oracle, data) returns " <>
+                       "{:next_state, :oracle, data} with no Retry.next/3 call — the oracle " <>
+                       "stall loop is UNBOUNDED and the Unit re-spawns indefinitely."
+
+      reason = Map.get(provenance, :reason)
+
+      assert reason == :E_RETRY_EXHAUSTED,
+             "D-378 LIV-1 oracle: terminal escalation must carry :E_RETRY_EXHAUSTED; " <>
+               "got #{inspect(reason)}"
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # D-378 symmetric worker_exit — implementing({:worker_exit,_}) uses
+  # advance_retry_ladder/2, NOT advance_gate_ladder.
+  #
+  # The asymmetric routing bug (6beddd1): implementing {:worker_exit, _, _}
+  # calls `advance_gate_ladder/1` which increments `refine_count` (consuming
+  # the gate-retry budget, D-318). The SPEC mandates that worker-outcome events
+  # (both worker_stalled AND worker_exit) use `advance_retry_ladder/2` so that
+  # only gate failures consume the refine budget. Oracle already uses
+  # advance_retry_ladder — refine_count is NOT bumped there.
+  #
+  # Observable: when implementing receives {:worker_exit, current_id, _},
+  # `refine_count` must NOT be bumped. `advance_gate_ladder` bumps it;
+  # `advance_retry_ladder/2` (realigned impl) must NOT.
+  #
+  # FAIL-BEFORE (6beddd1): implementing {:worker_exit, _, _} calls
+  # advance_gate_ladder → refine_count increments from 0 to 1.
+  # The assertion that refine_count is UNCHANGED fails for implementing.
+  # ---------------------------------------------------------------------------
+
+  describe "D-378 symmetric worker_exit — implementing uses advance_retry_ladder not advance_gate_ladder" do
+    @tag :d_378
+    test "D-378 symmetric: implementing {:worker_exit,current_id} does NOT consume refine_count (uses advance_retry_ladder not advance_gate_ladder)" do
+      test_pid = self()
+      unit_id = "u-d378-sym-exit-#{System.unique_integer([:positive])}"
+      scheduler_name = :"sched_d378_sym_exit_#{System.unique_integer([:positive])}"
+      sup_name = :"sup_d378_sym_exit_#{System.unique_integer([:positive])}"
+
+      start_scheduler(scheduler_name)
+      start_supervised!({@unit_supervisor, name: sup_name}, id: sup_name)
+
+      oracle_worker_id = "w-sym-oracle-#{System.unique_integer([:positive])}"
+      call_count = :counters.new(1, [:atomics])
+
+      worker_fun = fn _role ->
+        n = :counters.get(call_count, 1)
+        :counters.add(call_count, 1, 1)
+        pid = spawn_worker()
+
+        if n == 0,
+          do: {:ok, pid, oracle_worker_id},
+          else: {:ok, pid, "sym-impl-#{n}-#{System.unique_integer([:positive])}"}
+      end
+
+      opts =
+        base_unit_opts(unit_id, scheduler_name, test_pid,
+          worker_fun: worker_fun,
+          timeouts: [state_timeout_ms: 10_000]
+        )
+
+      unit_pid = @unit_supervisor.start_unit(sup_name, opts)
+      assert is_pid(unit_pid)
+
+      advance_past_oracle(unit_pid, oracle_worker_id)
+      result = wait_for_implementing(unit_pid)
+
+      assert match?({:implementing, _}, result),
+             "D-378 symmetric: Unit must reach :implementing; got #{inspect(result)}"
+
+      {:implementing, data_before} = result
+      refine_before = data_before.refine_count
+      attempt_before = data_before.attempt_count
+      current_impl_id = data_before.worker_id
+
+      # Send a single worker_exit for the current implementing worker.
+      # The SPEC mandates advance_retry_ladder/2 (identical to oracle):
+      # - re-enters :implementing via {:next_state, :implementing, …}
+      # - bumps attempt_count via :on_enter
+      # - does NOT bump refine_count (only gate failures do that)
+      send(unit_pid, {:worker_exit, current_impl_id, :no_work_product})
+
+      Process.sleep(300)
+
+      {state_after, data_after} = :sys.get_state(unit_pid)
+
+      assert state_after == :implementing,
+             "D-378 symmetric: {:worker_exit, current_impl_id, _} must re-enter " <>
+               ":implementing. Got #{inspect(state_after)}."
+
+      assert data_after.refine_count == refine_before,
+             "D-378 symmetric: {:worker_exit, current_impl_id, _} MUST NOT bump " <>
+               "refine_count — worker-outcome events use advance_retry_ladder/2, " <>
+               "not advance_gate_ladder. refine_count #{refine_before} -> " <>
+               "#{data_after.refine_count}. " <>
+               "FAIL-BEFORE (6beddd1): implementing {:worker_exit, _, _} calls " <>
+               "advance_gate_ladder which increments refine_count, consuming the " <>
+               "gate retry budget for a non-gate-failure event."
+
+      assert data_after.attempt_count > attempt_before,
+             "D-378 symmetric: {:worker_exit, current_impl_id, _} must bump " <>
+               "attempt_count via the :on_enter. " <>
+               "attempt_count #{attempt_before} -> #{data_after.attempt_count}."
+
+      refute_received {:unit_terminal, ^unit_id, _outcome, _prov},
+                      "D-378 symmetric: a single {:worker_exit, current_impl_id, _} " <>
+                        "must route to retry, not terminate the Unit"
     end
   end
 

--- a/test/tau/factory/unit_heartbeat_liveness_test.exs
+++ b/test/tau/factory/unit_heartbeat_liveness_test.exs
@@ -1,0 +1,619 @@
+defmodule Tau.Factory.UnitHeartbeatLivenessTest do
+  @moduledoc """
+  Gating tests for PR #513 (issue #491 — GOV4 heartbeat-driven Unit liveness).
+
+  Advances D-377, D-378, D-379 (SPEC-FACTORY-CORE §3/§4/§6):
+
+  - **D-377** — the Unit re-arms its `:state_timeout` on every current-worker
+    `{:worker_heartbeat, worker_id}` pulse. A progressing worker never trips the
+    fixed cap; absence of heartbeats escalates `E_WORKER_STALLED` at the deadline.
+
+  - **D-378** — exactly ONE advance of the retry ladder per worker per state when
+    stall signals arrive in close succession (`:state_timeout`, `{:worker_stalled,
+    w}`, `{:worker_exit, w, _}` for the same worker). The first consumed signal
+    clears `data.worker_id`; later ones hit the stale-worker discard clause.
+
+  - **D-379** — (a) the Unit routes `{:worker_stalled, ^worker_id}` → retry ladder
+    (same path as `:state_timeout`); stale-worker `{:worker_stalled, _}` is
+    discarded. (b) `UnitDriver.drive/2` registers each spawned worker with the
+    fleet `Watchdog` (via a `:watchdog` dep), delivering `{:worker_stalled, _}`
+    to the owning Unit.
+
+  ## Fail-before validity (oracle-separation, factory-loop §4b)
+
+  These tests fail against the current branch because:
+  - `oracle`/`implementing` have no `{:worker_heartbeat, _}` clause — D-377 absent.
+  - `oracle`/`implementing` have no `{:worker_stalled, _}` clause — D-379 absent.
+  - `UnitDriver.drive/2` has no `:watchdog` dep and does not call
+    `Watchdog.register/5` — D-379 producer absent.
+
+  ## AC / D-NNN linkage (Gate 5.1)
+
+  Every test name and @tag carries D-377, D-378, or D-379.
+  """
+
+  use ExUnit.Case, async: true
+
+  @moduletag :capture_log
+
+  alias Tau.Factory.Fleet.Watchdog
+  alias Tau.Factory.Scheduler
+  alias Tau.Factory.UnitSupervisor
+
+  @scheduler Scheduler
+  @unit_supervisor UnitSupervisor
+
+  # ---------------------------------------------------------------------------
+  # Shared helpers
+  # ---------------------------------------------------------------------------
+
+  defp empty_scope do
+    %{
+      deps: [],
+      files: MapSet.new(),
+      codepoints: MapSet.new(),
+      specs: MapSet.new(),
+      resources: MapSet.new()
+    }
+  end
+
+  defp start_scheduler(name) do
+    start_supervised!({@scheduler, name: name, w_cap: 10}, id: name)
+  end
+
+  defp spawn_worker do
+    spawn(fn ->
+      receive do
+        :stop -> :ok
+      after
+        30_000 -> :ok
+      end
+    end)
+  end
+
+  # Base opts threaded through each test.  `overrides` replaces defaults.
+  defp base_unit_opts(unit_id, scheduler_name, report_to, overrides) do
+    defaults = [
+      unit_id: unit_id,
+      declared_scope: empty_scope(),
+      hash: "hash-#{unit_id}",
+      scheduler: scheduler_name,
+      report_to: report_to,
+      worker_fun: fn _role -> {:ok, spawn_worker()} end,
+      gate_fun: fn _coord -> :pass end,
+      merge_fun: fn _uid, _hash -> :queued end,
+      timeouts: [state_timeout_ms: 5_000]
+    ]
+
+    Keyword.merge(defaults, overrides)
+  end
+
+  # Poll until the Unit is in :implementing; return {:implementing, data} or
+  # {:timeout, last_state} on deadline.
+  defp wait_for_implementing(unit_pid, deadline_ms \\ 2_000) do
+    deadline = System.monotonic_time(:millisecond) + deadline_ms
+    do_wait_implementing(unit_pid, deadline)
+  end
+
+  defp do_wait_implementing(unit_pid, deadline) do
+    case :sys.get_state(unit_pid) do
+      {:implementing, data} ->
+        {:implementing, data}
+
+      {state, _} when state in [:planned, :oracle] ->
+        if System.monotonic_time(:millisecond) >= deadline do
+          {:timeout, state}
+        else
+          Process.sleep(20)
+          do_wait_implementing(unit_pid, deadline)
+        end
+
+      {state, data} ->
+        {state, data}
+    end
+  end
+
+  # Advance past oracle by sending work_ready to the oracle worker.
+  defp advance_past_oracle(unit_pid, oracle_worker_id, deadline_ms \\ 2_000) do
+    deadline = System.monotonic_time(:millisecond) + deadline_ms
+    do_advance_oracle(unit_pid, oracle_worker_id, deadline)
+  end
+
+  defp do_advance_oracle(unit_pid, oracle_worker_id, deadline) do
+    case :sys.get_state(unit_pid) do
+      {:oracle, _data} ->
+        send(unit_pid, {:work_ready, oracle_worker_id, "feat/x", "deadbeef"})
+        :ok
+
+      {:planned, _} ->
+        if System.monotonic_time(:millisecond) >= deadline do
+          {:timeout, :planned}
+        else
+          Process.sleep(20)
+          do_advance_oracle(unit_pid, oracle_worker_id, deadline)
+        end
+
+      {:implementing, _} ->
+        :ok
+
+      {other, _} ->
+        {:unexpected, other}
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # D-377 — heartbeat resets state_timeout; absence trips stall at deadline
+  # ---------------------------------------------------------------------------
+
+  describe "D-377 — heartbeat resets :state_timeout, progressing worker never escalates" do
+    @tag :d_377
+    test "D-377: {worker_heartbeat, current_worker_id} at sub-timeout intervals keeps Unit in :implementing past old fixed cap" do
+      test_pid = self()
+      unit_id = "u-hb-reset-#{System.unique_integer([:positive])}"
+      scheduler_name = :"sched_hb_reset_#{System.unique_integer([:positive])}"
+      sup_name = :"sup_hb_reset_#{System.unique_integer([:positive])}"
+
+      start_scheduler(scheduler_name)
+      start_supervised!({@unit_supervisor, name: sup_name}, id: sup_name)
+
+      # Very short timeout so the test is fast.  Without heartbeat-reset the Unit
+      # would trip at state_timeout_ms.  With D-377 each heartbeat re-arms the
+      # timer, so the Unit stays in :implementing as long as pulses arrive.
+      state_timeout_ms = 80
+
+      oracle_worker_id = "w-hb-oracle-#{System.unique_integer([:positive])}"
+      impl_worker_id = "w-hb-impl-#{System.unique_integer([:positive])}"
+      call_count = :counters.new(1, [:atomics])
+
+      worker_fun = fn _role ->
+        n = :counters.get(call_count, 1)
+        :counters.add(call_count, 1, 1)
+        pid = spawn_worker()
+        if n == 0, do: {:ok, pid, oracle_worker_id}, else: {:ok, pid, impl_worker_id}
+      end
+
+      opts =
+        base_unit_opts(unit_id, scheduler_name, test_pid,
+          worker_fun: worker_fun,
+          timeouts: [state_timeout_ms: state_timeout_ms]
+        )
+
+      unit_pid = @unit_supervisor.start_unit(sup_name, opts)
+      assert is_pid(unit_pid)
+
+      advance_past_oracle(unit_pid, oracle_worker_id)
+      result = wait_for_implementing(unit_pid)
+
+      assert match?({:implementing, _}, result),
+             "D-377: Unit must reach :implementing; got #{inspect(result)}"
+
+      # Drive heartbeats every 40ms (< timeout 80ms) for 3× the old fixed cap.
+      # Without D-377 the Unit would escalate E_WORKER_STALLED at 80ms.
+      # With D-377 each pulse re-arms the timer so the Unit stays in :implementing.
+      driver =
+        spawn(fn ->
+          hb_loop(unit_pid, impl_worker_id, 35, 3 * state_timeout_ms)
+        end)
+
+      # Wait 3× the old cap — the Unit must NOT have escalated.
+      Process.sleep(3 * state_timeout_ms + 50)
+
+      {state_after, _data} = :sys.get_state(unit_pid)
+
+      send(driver, :stop)
+
+      assert state_after == :implementing,
+             "D-377: Unit fed {:worker_heartbeat, current_id} at sub-timeout intervals " <>
+               "MUST stay in :implementing past the old fixed cap (#{3 * state_timeout_ms}ms). " <>
+               "Got state=#{inspect(state_after)}. " <>
+               "FAIL-BEFORE: no {:worker_heartbeat, _} clause exists — the Unit trips " <>
+               ":state_timeout at #{state_timeout_ms}ms and escalates E_WORKER_STALLED."
+    end
+
+    @tag :d_377
+    test "D-377: without heartbeats, Unit trips :state_timeout and escalates E_WORKER_STALLED at deadline" do
+      test_pid = self()
+      unit_id = "u-hb-nostall-#{System.unique_integer([:positive])}"
+      scheduler_name = :"sched_hb_nostall_#{System.unique_integer([:positive])}"
+      sup_name = :"sup_hb_nostall_#{System.unique_integer([:positive])}"
+
+      start_scheduler(scheduler_name)
+      start_supervised!({@unit_supervisor, name: sup_name}, id: sup_name)
+
+      state_timeout_ms = 80
+
+      oracle_worker_id = "w-nostall-oracle-#{System.unique_integer([:positive])}"
+      impl_worker_id = "w-nostall-impl-#{System.unique_integer([:positive])}"
+      call_count = :counters.new(1, [:atomics])
+
+      worker_fun = fn _role ->
+        n = :counters.get(call_count, 1)
+        :counters.add(call_count, 1, 1)
+        pid = spawn_worker()
+        if n == 0, do: {:ok, pid, oracle_worker_id}, else: {:ok, pid, impl_worker_id}
+      end
+
+      opts =
+        base_unit_opts(unit_id, scheduler_name, test_pid,
+          worker_fun: worker_fun,
+          timeouts: [state_timeout_ms: state_timeout_ms]
+        )
+
+      unit_pid = @unit_supervisor.start_unit(sup_name, opts)
+      assert is_pid(unit_pid)
+
+      advance_past_oracle(unit_pid, oracle_worker_id)
+      result = wait_for_implementing(unit_pid)
+
+      assert match?({:implementing, _}, result),
+             "D-377: Unit must reach :implementing; got #{inspect(result)}"
+
+      # No heartbeats sent — state_timeout must fire at deadline.
+      assert_receive {:unit_terminal, ^unit_id, :escalated, provenance},
+                     500,
+                     "D-377: without heartbeats, Unit MUST escalate via :state_timeout " <>
+                       "within #{state_timeout_ms}ms; not received within 500ms"
+
+      reason = Map.get(provenance, :reason)
+
+      assert reason == :E_WORKER_STALLED,
+             "D-377: stall escalation must carry :E_WORKER_STALLED; got #{inspect(reason)}"
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # D-378 — exactly one ladder advance when stall signals arrive in succession
+  # ---------------------------------------------------------------------------
+
+  describe "D-378 — exactly one retry-ladder advance for close-succession stall signals" do
+    @tag :d_378
+    test "D-378: state_timeout then {worker_stalled, w} then {worker_exit, w, _} advances ladder EXACTLY ONCE — later signals are stale-worker discarded" do
+      test_pid = self()
+      unit_id = "u-d378-once-#{System.unique_integer([:positive])}"
+      scheduler_name = :"sched_d378_#{System.unique_integer([:positive])}"
+      sup_name = :"sup_d378_#{System.unique_integer([:positive])}"
+
+      start_scheduler(scheduler_name)
+      start_supervised!({@unit_supervisor, name: sup_name}, id: sup_name)
+
+      # Disable the real state_timeout with a long timer so we can deliver signals
+      # manually and control the ordering precisely.
+      oracle_worker_id = "w-d378-oracle-#{System.unique_integer([:positive])}"
+      impl_worker_id = "w-d378-impl-#{System.unique_integer([:positive])}"
+      call_count = :counters.new(1, [:atomics])
+
+      worker_fun = fn _role ->
+        n = :counters.get(call_count, 1)
+        :counters.add(call_count, 1, 1)
+        pid = spawn_worker()
+        if n == 0, do: {:ok, pid, oracle_worker_id}, else: {:ok, pid, impl_worker_id}
+      end
+
+      opts =
+        base_unit_opts(unit_id, scheduler_name, test_pid,
+          worker_fun: worker_fun,
+          # Long timeout so the real :state_timeout does not fire during the test.
+          timeouts: [state_timeout_ms: 10_000]
+        )
+
+      unit_pid = @unit_supervisor.start_unit(sup_name, opts)
+      assert is_pid(unit_pid)
+
+      advance_past_oracle(unit_pid, oracle_worker_id)
+      result = wait_for_implementing(unit_pid)
+
+      assert match?({:implementing, _}, result),
+             "D-378: Unit must reach :implementing; got #{inspect(result)}"
+
+      {:implementing, data_before} = result
+      refine_before = Map.get(data_before, :refine_count, 0)
+      attempt_before = Map.get(data_before, :attempt_count, 0)
+
+      # Deliver three successive stall signals for the SAME worker in one burst.
+      # D-378: the first one must clear data.worker_id; the second and third must
+      # hit the stale-worker discard clause and be ignored.
+      send(unit_pid, {:state_timeout, :worker_stalled})
+      send(unit_pid, {:worker_stalled, impl_worker_id})
+      send(unit_pid, {:worker_exit, impl_worker_id, :no_work_product})
+
+      # Allow all three messages to be processed.
+      Process.sleep(350)
+
+      {state_after, data_after} = :sys.get_state(unit_pid)
+
+      # The Unit must have entered :implementing EXACTLY ONCE MORE (ladder +1,
+      # not +2 or +3).  We assert counters are exactly +1 or exactly the state is
+      # :implementing without having escalated.
+      refine_after = Map.get(data_after, :refine_count, 0)
+      attempt_after = Map.get(data_after, :attempt_count, 0)
+
+      total_advance_before = refine_before + attempt_before
+      total_advance_after = refine_after + attempt_after
+
+      assert state_after == :implementing,
+             "D-378: after exactly one ladder advance, Unit must be in :implementing; " <>
+               "got #{inspect(state_after)}"
+
+      assert total_advance_after - total_advance_before == 1,
+             "D-378: three close-succession stall signals for one worker MUST advance " <>
+               "the retry ladder EXACTLY once (first signal consumed, later signals " <>
+               "stale-worker discarded). Counter advanced by " <>
+               "#{total_advance_after - total_advance_before} (expected 1). " <>
+               "refine #{refine_before}→#{refine_after}, attempt #{attempt_before}→#{attempt_after}. " <>
+               "FAIL-BEFORE: no {:worker_stalled, _} clause and no worker_id-clear on " <>
+               "state_timeout means each signal may advance independently, or the " <>
+               "Unit may escalate instead of refining."
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # D-379(a) — Unit consumes {worker_stalled, ^worker_id} → ladder; stale → discard
+  # ---------------------------------------------------------------------------
+
+  describe "D-379(a) — Unit routes {worker_stalled, current_id} to retry ladder; stale is discarded" do
+    @tag :d_379
+    test "D-379: {:worker_stalled, current_worker_id} in :implementing advances retry ladder (same as :state_timeout)" do
+      test_pid = self()
+      unit_id = "u-d379a-stalled-#{System.unique_integer([:positive])}"
+      scheduler_name = :"sched_d379a_#{System.unique_integer([:positive])}"
+      sup_name = :"sup_d379a_#{System.unique_integer([:positive])}"
+
+      start_scheduler(scheduler_name)
+      start_supervised!({@unit_supervisor, name: sup_name}, id: sup_name)
+
+      oracle_worker_id = "w-d379a-oracle-#{System.unique_integer([:positive])}"
+      impl_worker_id = "w-d379a-impl-#{System.unique_integer([:positive])}"
+      call_count = :counters.new(1, [:atomics])
+
+      worker_fun = fn _role ->
+        n = :counters.get(call_count, 1)
+        :counters.add(call_count, 1, 1)
+        pid = spawn_worker()
+        if n == 0, do: {:ok, pid, oracle_worker_id}, else: {:ok, pid, impl_worker_id}
+      end
+
+      opts =
+        base_unit_opts(unit_id, scheduler_name, test_pid,
+          worker_fun: worker_fun,
+          timeouts: [state_timeout_ms: 10_000]
+        )
+
+      unit_pid = @unit_supervisor.start_unit(sup_name, opts)
+      assert is_pid(unit_pid)
+
+      advance_past_oracle(unit_pid, oracle_worker_id)
+      result = wait_for_implementing(unit_pid)
+
+      assert match?({:implementing, _}, result),
+             "D-379: Unit must reach :implementing; got #{inspect(result)}"
+
+      {:implementing, data_before} = result
+      refine_before = Map.get(data_before, :refine_count, 0)
+      attempt_before = Map.get(data_before, :attempt_count, 0)
+
+      # Deliver the Watchdog's stall signal for the CURRENT worker.
+      send(unit_pid, {:worker_stalled, impl_worker_id})
+
+      Process.sleep(250)
+
+      {state_after, data_after} = :sys.get_state(unit_pid)
+
+      assert state_after == :implementing,
+             "D-379: {:worker_stalled, current_worker_id} must advance the retry ladder " <>
+               "and re-enter :implementing; got #{inspect(state_after)}. " <>
+               "FAIL-BEFORE: no {:worker_stalled, _} clause in implementing/3 — " <>
+               "the message is routed to handle_unexpected/4 and silently ignored."
+
+      refine_after = Map.get(data_after, :refine_count, 0)
+      attempt_after = Map.get(data_after, :attempt_count, 0)
+
+      assert refine_after > refine_before or attempt_after > attempt_before,
+             "D-379: {:worker_stalled, current_id} must advance the ladder; " <>
+               "refine #{refine_before}→#{refine_after}, " <>
+               "attempt #{attempt_before}→#{attempt_after}"
+
+      refute_received {:unit_terminal, ^unit_id, _outcome, _prov},
+                      "D-379: a single {:worker_stalled, current_id} must route to retry, " <>
+                        "not terminate the Unit"
+    end
+
+    @tag :d_379
+    test "D-379: {:worker_stalled, stale_worker_id} in :implementing is silently discarded — no ladder advance" do
+      test_pid = self()
+      unit_id = "u-d379a-stale-#{System.unique_integer([:positive])}"
+      scheduler_name = :"sched_d379a_stale_#{System.unique_integer([:positive])}"
+      sup_name = :"sup_d379a_stale_#{System.unique_integer([:positive])}"
+
+      start_scheduler(scheduler_name)
+      start_supervised!({@unit_supervisor, name: sup_name}, id: sup_name)
+
+      oracle_worker_id = "w-d379as-oracle-#{System.unique_integer([:positive])}"
+      impl_worker_id = "w-d379as-impl-#{System.unique_integer([:positive])}"
+      call_count = :counters.new(1, [:atomics])
+
+      worker_fun = fn _role ->
+        n = :counters.get(call_count, 1)
+        :counters.add(call_count, 1, 1)
+        pid = spawn_worker()
+        if n == 0, do: {:ok, pid, oracle_worker_id}, else: {:ok, pid, impl_worker_id}
+      end
+
+      opts =
+        base_unit_opts(unit_id, scheduler_name, test_pid,
+          worker_fun: worker_fun,
+          timeouts: [state_timeout_ms: 10_000]
+        )
+
+      unit_pid = @unit_supervisor.start_unit(sup_name, opts)
+      assert is_pid(unit_pid)
+
+      advance_past_oracle(unit_pid, oracle_worker_id)
+      result = wait_for_implementing(unit_pid)
+
+      assert match?({:implementing, _}, result),
+             "D-379 stale: Unit must reach :implementing; got #{inspect(result)}"
+
+      {:implementing, data_before} = result
+      refine_before = Map.get(data_before, :refine_count, 0)
+      attempt_before = Map.get(data_before, :attempt_count, 0)
+
+      stale_id = "w-d379-stale-#{System.unique_integer([:positive])}"
+      send(unit_pid, {:worker_stalled, stale_id})
+
+      Process.sleep(200)
+
+      {state_after, data_after} = :sys.get_state(unit_pid)
+
+      assert state_after == :implementing,
+             "D-379 stale: a {:worker_stalled, stale_id} must be discarded — " <>
+               "Unit remains in :implementing; got #{inspect(state_after)}"
+
+      refine_after = Map.get(data_after, :refine_count, 0)
+      attempt_after = Map.get(data_after, :attempt_count, 0)
+
+      assert refine_before == refine_after and attempt_before == attempt_after,
+             "D-379 stale: stale {:worker_stalled} must NOT advance the ladder; " <>
+               "refine #{refine_before}→#{refine_after}, " <>
+               "attempt #{attempt_before}→#{attempt_after}"
+
+      refute_received {:unit_terminal, ^unit_id, _outcome, _prov},
+                      "D-379 stale: stale {:worker_stalled} must not terminate the Unit"
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # D-379(b) — UnitDriver.drive/2 registers each spawned worker with the Watchdog
+  # ---------------------------------------------------------------------------
+  #
+  # The SPEC says: "the `UnitDriver.drive/2` `worker_fun` seam … registers each
+  # spawned worker with the fleet `Watchdog` (`Watchdog.register(watchdog,
+  # worker_id, worker_pid, unit_pid, heartbeat_timeout: …)`)".
+  #
+  # The observable contract is: when UnitDriver wires a :watchdog dep into its
+  # worker_fun closure, a spawned worker with no heartbeats triggers
+  # {:worker_stalled, worker_id} → Unit, which routes to escalation.
+  #
+  # We test this via a Unit with a worker_fun that itself calls
+  # Watchdog.register/5 (mirroring the closure UnitDriver.drive/2 will build).
+  # The test then confirms the stall signal arrives at the Unit and is routed
+  # to the retry ladder — demonstrating the full D-379 wiring path.
+  #
+  # FAIL-BEFORE: the Unit has no {:worker_stalled, _} clause (D-379 absent), so
+  # when the Watchdog fires {:worker_stalled, worker_id} to the Unit it is
+  # silently ignored via handle_unexpected/4.  The Unit never escalates via
+  # this path, and the stall_advance_count assertion fails.
+  # ---------------------------------------------------------------------------
+
+  describe "D-379(b) — worker_fun that calls Watchdog.register/5 delivers {:worker_stalled, id} to Unit → ladder" do
+    @tag :d_379
+    test "D-379: worker registered via Watchdog.register/5 — absence triggers {:worker_stalled, id} routed to retry ladder" do
+      test_pid = self()
+      unit_id = "u-d379b-wd-#{System.unique_integer([:positive])}"
+      scheduler_name = :"sched_d379b_#{System.unique_integer([:positive])}"
+      sup_name = :"sup_d379b_#{System.unique_integer([:positive])}"
+      watchdog_name = :"watchdog_d379b_#{System.unique_integer([:positive])}"
+
+      start_scheduler(scheduler_name)
+      start_supervised!({@unit_supervisor, name: sup_name}, id: sup_name)
+
+      # Very short Watchdog timeout so the test is fast.
+      check_interval = 20
+      heartbeat_timeout = 60
+
+      start_supervised!(
+        {Watchdog, name: watchdog_name, check_interval: check_interval},
+        id: watchdog_name
+      )
+
+      oracle_worker_id = "w-d379b-oracle-#{System.unique_integer([:positive])}"
+      call_count = :counters.new(1, [:atomics])
+
+      # This worker_fun mirrors the closure UnitDriver.drive/2 will build:
+      # it calls Watchdog.register/5 with report_to = self() (the Unit's pid)
+      # so the Watchdog sends {:worker_stalled, worker_id} to the Unit when no
+      # heartbeats arrive within heartbeat_timeout ms.
+      worker_fun = fn _role ->
+        n = :counters.get(call_count, 1)
+        :counters.add(call_count, 1, 1)
+
+        pid = spawn_worker()
+
+        worker_id =
+          if n == 0,
+            do: oracle_worker_id,
+            else: "w-d379b-impl-#{n}-#{System.unique_integer([:positive])}"
+
+        # D-379: the driver's worker_fun closure calls Watchdog.register/5 with
+        # report_to = self() (the owning Unit's pid at invocation time).
+        :ok =
+          Watchdog.register(watchdog_name, worker_id, pid, self(),
+            heartbeat_timeout: heartbeat_timeout
+          )
+
+        {:ok, pid, worker_id}
+      end
+
+      opts =
+        base_unit_opts(unit_id, scheduler_name, test_pid,
+          worker_fun: worker_fun,
+          # Long Unit state_timeout so the Unit does not trip its own timer —
+          # only the Watchdog should fire.
+          timeouts: [state_timeout_ms: 5_000]
+        )
+
+      unit_pid = @unit_supervisor.start_unit(sup_name, opts)
+      assert is_pid(unit_pid)
+
+      # Advance past oracle so the implementing worker is registered too.
+      advance_past_oracle(unit_pid, oracle_worker_id)
+      result = wait_for_implementing(unit_pid)
+
+      assert match?({:implementing, _}, result),
+             "D-379(b): Unit must reach :implementing; got #{inspect(result)}"
+
+      {:implementing, data_before} = result
+      refine_before = Map.get(data_before, :refine_count, 0)
+      attempt_before = Map.get(data_before, :attempt_count, 0)
+
+      # No heartbeats emitted — the Watchdog fires {:worker_stalled, impl_worker_id}
+      # to the Unit within heartbeat_timeout + check_interval ms.
+      # D-379(a) must route this to advance_retry_ladder/1.
+      Process.sleep(heartbeat_timeout + 4 * check_interval + 50)
+
+      {state_after, data_after} = :sys.get_state(unit_pid)
+
+      refine_after = Map.get(data_after, :refine_count, 0)
+      attempt_after = Map.get(data_after, :attempt_count, 0)
+
+      stall_advanced = refine_after > refine_before or attempt_after > attempt_before
+
+      assert state_after == :implementing and stall_advanced,
+             "D-379(b): a worker registered with Watchdog.register/5 (the closure " <>
+               "UnitDriver.drive/2 will build) MUST trigger {:worker_stalled, worker_id} " <>
+               "delivery to the Unit, which routes to the retry ladder. " <>
+               "Got state=#{inspect(state_after)}, refine #{refine_before}→#{refine_after}, " <>
+               "attempt #{attempt_before}→#{attempt_after}. " <>
+               "FAIL-BEFORE: the Unit has no {:worker_stalled, _} clause (D-379 absent) — " <>
+               "the Watchdog fires the signal but the Unit silently discards it via " <>
+               "handle_unexpected/4; the ladder counter stays flat."
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Private helpers
+  # ---------------------------------------------------------------------------
+
+  # Drive {:worker_heartbeat, worker_id} pulses at interval_ms for up_to_ms.
+  defp hb_loop(unit_pid, worker_id, interval_ms, up_to_ms) when up_to_ms > 0 do
+    send(unit_pid, {:worker_heartbeat, worker_id})
+
+    receive do
+      :stop -> :ok
+    after
+      interval_ms ->
+        hb_loop(unit_pid, worker_id, interval_ms, up_to_ms - interval_ms)
+    end
+  end
+
+  defp hb_loop(_unit_pid, _worker_id, _interval_ms, _up_to_ms), do: :ok
+end

--- a/test/tau/factory/unit_heartbeat_liveness_test.exs
+++ b/test/tau/factory/unit_heartbeat_liveness_test.exs
@@ -32,7 +32,13 @@ defmodule Tau.Factory.UnitHeartbeatLivenessTest do
   Every test name and @tag carries D-377, D-378, or D-379.
   """
 
-  use ExUnit.Case, async: true
+  # async: false — this module exercises timing-sensitive OTP state_timeout
+  # behaviour. Under full-suite concurrency (100+ test processes) the BEAM
+  # scheduler starves a spawned heartbeat sender, causing false state_timeout
+  # trips in D-377. Serialising the module eliminates scheduler starvation as
+  # a confound; the individual tests still start uniquely-named supervisors so
+  # there is no inter-test resource collision.
+  use ExUnit.Case, async: false
 
   @moduletag :capture_log
 
@@ -156,10 +162,12 @@ defmodule Tau.Factory.UnitHeartbeatLivenessTest do
       start_scheduler(scheduler_name)
       start_supervised!({@unit_supervisor, name: sup_name}, id: sup_name)
 
-      # Very short timeout so the test is fast.  Without heartbeat-reset the Unit
-      # would trip at state_timeout_ms.  With D-377 each heartbeat re-arms the
-      # timer, so the Unit stays in :implementing as long as pulses arrive.
-      state_timeout_ms = 80
+      # Generous timeout — 1000ms gives the BEAM scheduler ample room under full
+      # suite load (100+ concurrent tests) without being so tight that jitter
+      # causes a false trip.  Without D-377 heartbeat-reset the Unit would still
+      # escalate E_WORKER_STALLED at state_timeout_ms; with D-377 each pulse
+      # re-arms the timer so the Unit stays in :implementing indefinitely.
+      state_timeout_ms = 1_000
 
       oracle_worker_id = "w-hb-oracle-#{System.unique_integer([:positive])}"
       impl_worker_id = "w-hb-impl-#{System.unique_integer([:positive])}"
@@ -187,24 +195,30 @@ defmodule Tau.Factory.UnitHeartbeatLivenessTest do
       assert match?({:implementing, _}, result),
              "D-377: Unit must reach :implementing; got #{inspect(result)}"
 
-      # Drive heartbeats every 40ms (< timeout 80ms) for 3× the old fixed cap.
-      # Without D-377 the Unit would escalate E_WORKER_STALLED at 80ms.
-      # With D-377 each pulse re-arms the timer so the Unit stays in :implementing.
-      driver =
-        spawn(fn ->
-          hb_loop(unit_pid, impl_worker_id, 35, 3 * state_timeout_ms)
-        end)
+      # Drive heartbeats from the TEST PROCESS at 200ms intervals (well below the
+      # 1000ms state_timeout_ms) for 3× the deadline (3000ms total).  Driving
+      # from the test process — rather than a spawned ticker — ensures the sends
+      # are not subject to a separate process being starved by the scheduler under
+      # full-suite load.  The test process itself is always the scheduling victim
+      # here, and it uses Process.sleep between sends, which is deterministic.
+      #
+      # Without D-377: the state_timeout fires at 1000ms on the first iteration
+      # (no reset clause) and the Unit escalates → test fails.
+      # With D-377: each {:worker_heartbeat, impl_worker_id} re-arms the 1000ms
+      # timer, so the Unit is still :implementing at 3000ms.
+      hb_interval_ms = 200
+      total_hb_duration_ms = 3 * state_timeout_ms
 
-      # Wait 3× the old cap — the Unit must NOT have escalated.
-      Process.sleep(3 * state_timeout_ms + 50)
+      hb_loop_from_test(unit_pid, impl_worker_id, hb_interval_ms, total_hb_duration_ms)
 
+      # Immediately after the heartbeat loop finishes, the Unit must still be in
+      # :implementing (the last heartbeat re-armed the timer; no escalation).
       {state_after, _data} = :sys.get_state(unit_pid)
 
-      send(driver, :stop)
-
       assert state_after == :implementing,
-             "D-377: Unit fed {:worker_heartbeat, current_id} at sub-timeout intervals " <>
-               "MUST stay in :implementing past the old fixed cap (#{3 * state_timeout_ms}ms). " <>
+             "D-377: Unit fed {:worker_heartbeat, current_id} at #{hb_interval_ms}ms " <>
+               "intervals (well below #{state_timeout_ms}ms state_timeout) MUST stay " <>
+               "in :implementing past the old fixed cap (#{total_hb_duration_ms}ms total). " <>
                "Got state=#{inspect(state_after)}. " <>
                "FAIL-BEFORE: no {:worker_heartbeat, _} clause exists — the Unit trips " <>
                ":state_timeout at #{state_timeout_ms}ms and escalates E_WORKER_STALLED."
@@ -603,17 +617,17 @@ defmodule Tau.Factory.UnitHeartbeatLivenessTest do
   # Private helpers
   # ---------------------------------------------------------------------------
 
-  # Drive {:worker_heartbeat, worker_id} pulses at interval_ms for up_to_ms.
-  defp hb_loop(unit_pid, worker_id, interval_ms, up_to_ms) when up_to_ms > 0 do
+  # Drive {:worker_heartbeat, worker_id} pulses from the TEST PROCESS at
+  # interval_ms for up_to_ms total wall time.  Driving from the test process
+  # (rather than a spawned ticker) ensures the sends are not subject to
+  # scheduler starvation of a separate process under full-suite load.
+  defp hb_loop_from_test(_unit_pid, _worker_id, _interval_ms, remaining_ms)
+       when remaining_ms <= 0,
+       do: :ok
+
+  defp hb_loop_from_test(unit_pid, worker_id, interval_ms, remaining_ms) do
     send(unit_pid, {:worker_heartbeat, worker_id})
-
-    receive do
-      :stop -> :ok
-    after
-      interval_ms ->
-        hb_loop(unit_pid, worker_id, interval_ms, up_to_ms - interval_ms)
-    end
+    Process.sleep(interval_ms)
+    hb_loop_from_test(unit_pid, worker_id, interval_ms, remaining_ms - interval_ms)
   end
-
-  defp hb_loop(_unit_pid, _worker_id, _interval_ms, _up_to_ms), do: :ok
 end

--- a/test/tau/factory/unit_heartbeat_liveness_test.exs
+++ b/test/tau/factory/unit_heartbeat_liveness_test.exs
@@ -2,22 +2,33 @@ defmodule Tau.Factory.UnitHeartbeatLivenessTest do
   @moduledoc """
   Gating tests for PR #513 (issue #491 — GOV4 heartbeat-driven Unit liveness).
 
-  Advances D-377, D-378, D-379 (SPEC-FACTORY-CORE §3/§4/§6):
+  Advances D-315, D-377, D-378, D-379 (SPEC-FACTORY-CORE §3/§4/§6):
 
   - **D-377** — the Unit re-arms its `:state_timeout` on every current-worker
     `{:worker_heartbeat, worker_id}` pulse. A progressing worker never trips the
     fixed cap; absence of heartbeats escalates `E_WORKER_STALLED` at the deadline.
 
   - **D-378** — exactly ONE advance of the retry ladder per worker per state when
-    stall signals arrive in close succession (`:state_timeout`, `{:worker_stalled,
-    w}`, `{:worker_exit, w, _}` for the same worker). The first consumed signal
+    stall signals arrive in close succession (`{:worker_stalled, w}`,
+    `{:worker_exit, w, _}` for the same worker). The first consumed signal
     clears `data.worker_id`; later ones hit the stale-worker discard clause.
+    Separately: the Unit's OWN `:state_timeout` (real gen_statem timer; fires on
+    total heartbeat silence) escalates `E_WORKER_STALLED` — the hard-stall path
+    (D-377, preserves #490/D-326). These two classes are disjoint: the first
+    stall-class signal consumed clears `worker_id` → later signals discard →
+    EXACTLY ONE outcome per worker, no double-fire.
 
   - **D-379** — (a) the Unit routes `{:worker_stalled, ^worker_id}` → retry ladder
     (same path as `:state_timeout`); stale-worker `{:worker_stalled, _}` is
     discarded. (b) `UnitDriver.drive/2` registers each spawned worker with the
     fleet `Watchdog` (via a `:watchdog` dep), delivering `{:worker_stalled, _}`
     to the owning Unit.
+
+  - **D-315** — RPO=0 durability for the stall re-spawn path: the deferred spawn
+    triggered by `{:worker_stalled, ^worker_id}` MUST call `snapshot_state/2`
+    (i.e. write a Ledger snapshot) AND bump `attempt_count`, exactly as the normal
+    `:on_enter` path does. The deferred path (`advance_retry_ladder_deferred/1` →
+    `do_spawn_worker/1`) currently skips both, violating D-315.
 
   ## Fail-before validity (oracle-separation, factory-loop §4b)
 
@@ -26,10 +37,12 @@ defmodule Tau.Factory.UnitHeartbeatLivenessTest do
   - `oracle`/`implementing` have no `{:worker_stalled, _}` clause — D-379 absent.
   - `UnitDriver.drive/2` has no `:watchdog` dep and does not call
     `Watchdog.register/5` — D-379 producer absent.
+  - The deferred-spawn path (`advance_retry_ladder_deferred/1` → `do_spawn_worker/1`)
+    skips `attempt_count++` and `snapshot_state(:implementing, ...)` — D-315 absent.
 
   ## AC / D-NNN linkage (Gate 5.1)
 
-  Every test name and @tag carries D-377, D-378, or D-379.
+  Every test name and @tag carries D-315, D-377, D-378, or D-379.
   """
 
   # async: false — this module exercises timing-sensitive OTP state_timeout
@@ -43,6 +56,8 @@ defmodule Tau.Factory.UnitHeartbeatLivenessTest do
   @moduletag :capture_log
 
   alias Tau.Factory.Fleet.Watchdog
+  alias Tau.Factory.Ledger.Reader, as: LedgerReader
+  alias Tau.Factory.Ledger.Writer, as: LedgerWriter
   alias Tau.Factory.Scheduler
   alias Tau.Factory.UnitSupervisor
 
@@ -75,6 +90,20 @@ defmodule Tau.Factory.UnitHeartbeatLivenessTest do
         30_000 -> :ok
       end
     end)
+  end
+
+  # Start a REAL Ledger.Writer against an isolated temp DB; return its name.
+  # Mirrors the pattern in unit_snapshot_durability_test.exs.
+  defp start_ledger do
+    db_path = Briefly.create!(extname: ".db")
+    writer_name = :"snap_ledger_hb_#{System.unique_integer([:positive])}"
+
+    start_supervised!(
+      {LedgerWriter, db_path: db_path, name: writer_name},
+      id: writer_name
+    )
+
+    writer_name
   end
 
   # Base opts threaded through each test.  `overrides` replaces defaults.
@@ -276,12 +305,26 @@ defmodule Tau.Factory.UnitHeartbeatLivenessTest do
   end
 
   # ---------------------------------------------------------------------------
-  # D-378 — exactly one ladder advance when stall signals arrive in succession
+  # D-378 — exactly one ladder advance when REAL stall signals arrive in succession
+  # ---------------------------------------------------------------------------
+  #
+  # Contract (reconciled two-outcome model):
+  #
+  # The Watchdog delivers TWO kinds of signals to the Unit:
+  #   {: worker_stalled, worker_id} — heartbeat-absence (the retry-ladder path)
+  #   {:worker_exit,    worker_id, reason} — worker process exited (retry-ladder)
+  #
+  # The Unit's OWN :state_timeout (total heartbeat silence) is SEPARATE and
+  # escalates E_WORKER_STALLED (tested by D-377 above).
+  #
+  # D-378 disjointness: the FIRST stall-class signal consumed clears
+  # data.worker_id → later signals for the SAME worker hit the stale-worker
+  # discard clause → EXACTLY ONE ladder advance per worker, no double-fire.
   # ---------------------------------------------------------------------------
 
-  describe "D-378 — exactly one retry-ladder advance for close-succession stall signals" do
+  describe "D-378 — exactly one retry-ladder advance for close-succession real stall signals" do
     @tag :d_378
-    test "D-378: state_timeout then {worker_stalled, w} then {worker_exit, w, _} advances ladder EXACTLY ONCE — later signals are stale-worker discarded" do
+    test "D-378: worker_stalled then worker_exit then second worker_stalled for same worker advances ladder EXACTLY ONCE - later signals stale-discarded" do
       test_pid = self()
       unit_id = "u-d378-once-#{System.unique_integer([:positive])}"
       scheduler_name = :"sched_d378_#{System.unique_integer([:positive])}"
@@ -323,21 +366,25 @@ defmodule Tau.Factory.UnitHeartbeatLivenessTest do
       refine_before = Map.get(data_before, :refine_count, 0)
       attempt_before = Map.get(data_before, :attempt_count, 0)
 
-      # Deliver three successive stall signals for the SAME worker in one burst.
-      # D-378: the first one must clear data.worker_id; the second and third must
-      # hit the stale-worker discard clause and be ignored.
-      send(unit_pid, {:state_timeout, :worker_stalled})
+      # Deliver three successive REAL stall signals for the SAME worker in one burst.
+      # D-378: the first {:worker_stalled, impl_worker_id} must clear data.worker_id;
+      # the second and third signals (worker_exit and another worker_stalled for the
+      # same id) must hit the stale-worker discard clause and be ignored.
+      #
+      # NOTE: we do NOT use the synthetic info-form {:state_timeout, :worker_stalled}
+      # message — that was a production-dead clause used only to support the prior
+      # test. The REAL signals are {:worker_stalled, w} and {:worker_exit, w, _},
+      # which are what the fleet Watchdog and worker supervisor actually deliver.
       send(unit_pid, {:worker_stalled, impl_worker_id})
       send(unit_pid, {:worker_exit, impl_worker_id, :no_work_product})
+      send(unit_pid, {:worker_stalled, impl_worker_id})
 
-      # Allow all three messages to be processed.
-      Process.sleep(350)
+      # Allow all three messages to be processed, plus the deferred :deferred_spawn
+      # to fire (it lands at the end of the mailbox after the stale signals).
+      Process.sleep(400)
 
       {state_after, data_after} = :sys.get_state(unit_pid)
 
-      # The Unit must have entered :implementing EXACTLY ONCE MORE (ladder +1,
-      # not +2 or +3).  We assert counters are exactly +1 or exactly the state is
-      # :implementing without having escalated.
       refine_after = Map.get(data_after, :refine_count, 0)
       attempt_after = Map.get(data_after, :attempt_count, 0)
 
@@ -345,18 +392,15 @@ defmodule Tau.Factory.UnitHeartbeatLivenessTest do
       total_advance_after = refine_after + attempt_after
 
       assert state_after == :implementing,
-             "D-378: after exactly one ladder advance, Unit must be in :implementing; " <>
+             "D-378: after exactly one ladder advance Unit must be in :implementing; " <>
                "got #{inspect(state_after)}"
 
       assert total_advance_after - total_advance_before == 1,
-             "D-378: three close-succession stall signals for one worker MUST advance " <>
-               "the retry ladder EXACTLY once (first signal consumed, later signals " <>
-               "stale-worker discarded). Counter advanced by " <>
-               "#{total_advance_after - total_advance_before} (expected 1). " <>
-               "refine #{refine_before}→#{refine_after}, attempt #{attempt_before}→#{attempt_after}. " <>
-               "FAIL-BEFORE: no {:worker_stalled, _} clause and no worker_id-clear on " <>
-               "state_timeout means each signal may advance independently, or the " <>
-               "Unit may escalate instead of refining."
+             "D-378: three stall signals for one worker must advance ladder EXACTLY once. " <>
+               "Advanced by #{total_advance_after - total_advance_before} (expected 1). " <>
+               "refine #{refine_before}->#{refine_after}, " <>
+               "attempt #{attempt_before}->#{attempt_after}. " <>
+               "FAIL-BEFORE: no {:worker_stalled,_} clause / no worker_id-clear."
     end
   end
 
@@ -610,6 +654,158 @@ defmodule Tau.Factory.UnitHeartbeatLivenessTest do
                "FAIL-BEFORE: the Unit has no {:worker_stalled, _} clause (D-379 absent) — " <>
                "the Watchdog fires the signal but the Unit silently discards it via " <>
                "handle_unexpected/4; the ladder counter stays flat."
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # D-315 — stall re-spawn MUST write a Ledger snapshot (RPO=0 durability)
+  # ---------------------------------------------------------------------------
+  #
+  # The bug: `advance_retry_ladder_deferred/1` bumps `refine_count` / `pivot_count`
+  # and sends `:deferred_spawn` to the mailbox, then `do_spawn_worker/1` re-spawns
+  # the worker. Neither function calls `snapshot_state(:implementing, ...)` or bumps
+  # `attempt_count`, unlike the normal `:on_enter` path in `implementing(:internal,
+  # :on_enter, data)`:
+  #
+  #   new_data = %{data | attempt_count: data.attempt_count + 1}
+  #   new_data = snapshot_state(:implementing, new_data)   ← MISSING in deferred path
+  #
+  # This means a Watchdog-triggered stall re-spawn produces no Ledger row. On a
+  # crash after the re-spawn, the Coordinator's D-344 resume rehydrates the PREVIOUS
+  # state from the Ledger — either the original `:implementing` entry (before any
+  # stall) or worse `:oracle` — and re-spawns a worker that was already re-spawned,
+  # duplicating work and violating RPO=0 (D-315).
+  #
+  # Observable seam: the Unit's `:ledger` opt. When present, every `snapshot_state/2`
+  # call writes a row via `Ledger.Writer.snapshot_unit/2`. We inject a REAL
+  # `Ledger.Writer` (same idiom as `unit_snapshot_durability_test.exs`) and read
+  # back via `Ledger.Reader.latest_unit_snapshots/1`.
+  #
+  # FAIL-BEFORE: the deferred path skips `snapshot_state/2`, so
+  # `latest_unit_snapshots(ledger)` returns the pre-stall entry (or nothing if
+  # the Unit hasn't snapshotted yet at all), not a fresh `:implementing` row.
+  # With the fix, each deferred re-spawn calls `snapshot_state(:implementing, ...)`,
+  # writing a new Ledger row with the bumped `attempt_count` coordinate — and
+  # `latest_unit_snapshots/1` returns `:implementing` (the current state).
+  # ---------------------------------------------------------------------------
+
+  describe "D-315 — stall-driven deferred re-spawn writes a Ledger snapshot (RPO=0)" do
+    @tag :d_315
+    test "D-315: worker_stalled for current_worker_id triggers deferred re-spawn that writes a new Ledger snapshot with bumped attempt_count" do
+      ledger = start_ledger()
+      test_pid = self()
+      unit_id = "u-d315-stall-snap-#{System.unique_integer([:positive])}"
+      scheduler_name = :"sched_d315_#{System.unique_integer([:positive])}"
+      sup_name = :"sup_d315_#{System.unique_integer([:positive])}"
+
+      start_scheduler(scheduler_name)
+      start_supervised!({@unit_supervisor, name: sup_name}, id: sup_name)
+
+      oracle_worker_id = "w-d315-oracle-#{System.unique_integer([:positive])}"
+      impl_worker_id_1 = "w-d315-impl-1-#{System.unique_integer([:positive])}"
+      # The re-spawned worker after the stall gets a distinct id.
+      impl_worker_id_2 = "w-d315-impl-2-#{System.unique_integer([:positive])}"
+      call_count = :counters.new(1, [:atomics])
+
+      worker_fun = fn _role ->
+        n = :counters.get(call_count, 1)
+        :counters.add(call_count, 1, 1)
+        pid = spawn_worker()
+
+        case n do
+          0 -> {:ok, pid, oracle_worker_id}
+          1 -> {:ok, pid, impl_worker_id_1}
+          _ -> {:ok, pid, impl_worker_id_2}
+        end
+      end
+
+      opts = [
+        unit_id: unit_id,
+        declared_scope: empty_scope(),
+        hash: "hash-#{unit_id}",
+        scheduler: scheduler_name,
+        report_to: test_pid,
+        ledger: ledger,
+        worker_fun: worker_fun,
+        gate_fun: fn _coord -> :pass end,
+        merge_fun: fn _uid, _hash -> :queued end,
+        # Long timeout: the real :state_timeout must NOT fire. Only the manual
+        # {:worker_stalled, impl_worker_id_1} signal triggers the deferred path.
+        timeouts: [state_timeout_ms: 10_000]
+      ]
+
+      unit_pid = @unit_supervisor.start_unit(sup_name, opts)
+      assert is_pid(unit_pid)
+
+      advance_past_oracle(unit_pid, oracle_worker_id)
+      result = wait_for_implementing(unit_pid)
+
+      assert match?({:implementing, _}, result),
+             "D-315: Unit must reach :implementing; got #{inspect(result)}"
+
+      {:implementing, data_before} = result
+      attempt_before = Map.get(data_before, :attempt_count, 0)
+
+      # Confirm a Ledger snapshot exists after the initial :implementing entry
+      # (the normal :on_enter path writes one). This is a sanity pre-condition:
+      # if the normal path also failed to write, the test would be masked.
+      # We allow for the Unit to have just entered implementing so give it a moment.
+      Process.sleep(50)
+
+      snapshots_before = LedgerReader.latest_unit_snapshots(ledger)
+
+      assert Map.get(snapshots_before, unit_id) == :implementing,
+             "D-315 pre-condition: normal :on_enter must write a Ledger snapshot at " <>
+               ":implementing. Got #{inspect(Map.get(snapshots_before, unit_id))} " <>
+               "(map: #{inspect(snapshots_before)}). " <>
+               "Indicates :ledger opt not wired or normal snapshotting path broken."
+
+      # Trigger the deferred-spawn path by delivering a Watchdog stall signal
+      # for the CURRENT implementing worker.
+      send(unit_pid, {:worker_stalled, impl_worker_id_1})
+
+      # Allow the deferred path to complete: {:worker_stalled, _} clears worker_id
+      # → advance_retry_ladder_deferred sends :deferred_spawn to mailbox end
+      # → :deferred_spawn fires do_spawn_worker → the new worker is running.
+      # The key missing step: snapshot_state(:implementing, ...) and attempt_count++.
+      Process.sleep(300)
+
+      {state_after, data_after} = :sys.get_state(unit_pid)
+
+      attempt_after = Map.get(data_after, :attempt_count, 0)
+
+      # Assert 1: the Unit is in :implementing after the deferred re-spawn.
+      assert state_after == :implementing,
+             "D-315: after stall-driven deferred re-spawn, Unit must be back in " <>
+               ":implementing; got #{inspect(state_after)}"
+
+      # Assert 2: attempt_count was bumped (the re-spawn IS a new attempt).
+      assert attempt_after > attempt_before,
+             "D-315: stall-driven deferred re-spawn MUST increment attempt_count. " <>
+               "attempt_count #{attempt_before} -> #{attempt_after} (expected strictly greater). " <>
+               "FAIL-BEFORE: do_spawn_worker/1 skips attempt_count++, violating D-315."
+
+      # Assert 3: the Ledger holds a FRESH :implementing snapshot for this unit,
+      # written by snapshot_state/2 during the deferred re-spawn.
+      # Under the current (unfixed) code, do_spawn_worker skips snapshot_state/2,
+      # so the Ledger row is stale (the one written by the first :on_enter).
+      # The test distinguishes these cases via the snapshot_seq counter embedded
+      # in the idempotency key: the deferred re-spawn must write a NEW row
+      # (higher sequence) reflecting the post-stall :implementing state.
+      snapshots_after = LedgerReader.latest_unit_snapshots(ledger)
+
+      assert Map.get(snapshots_after, unit_id) == :implementing,
+             "D-315: after stall deferred re-spawn, Ledger must hold :implementing. " <>
+               "Got #{inspect(Map.get(snapshots_after, unit_id))} " <>
+               "(map: #{inspect(snapshots_after)}). " <>
+               "FAIL-BEFORE: do_spawn_worker/1 skips snapshot_state(:implementing,...) — " <>
+               "no new Ledger row written for re-spawn, violating D-315 RPO=0."
+
+      # Assert 4: no terminal signal was sent to the test process — the stall
+      # triggered a re-spawn (retry ladder), not escalation.
+      refute_received {:unit_terminal, ^unit_id, _outcome, _prov},
+                      "D-315: a single {:worker_stalled, current_id} must route to retry, " <>
+                        "not terminate the Unit"
     end
   end
 


### PR DESCRIPTION
## #491 (GOV4) — heartbeat-driven Unit timeout for real (long, variable) agent runs

Closes #491. **ARCH GAP** → solution-shaping pass + verified-free D-NNN lands in THIS PR before implementation (`feedback_arch_consistency_gate`).

### Problem
The Unit's per-state `:state_timeout` is a fixed wall-clock (30s default; dogfood widens to 300s via D-358). A real `claude` run is long AND variable — a fixed timeout either trips a slow-but-healthy agent (false `E_WORKER_STALLED`/retry-exhaustion) or masks a genuinely-wedged one. The last blocker before a factory-driven real-agent run.

### What's already in place (build on it, don't rebuild)
- The `CodingAgentShim` emits **D-366 heartbeat frames** from real CodingAgent stream events → the Worker forwards `{:worker_heartbeat, worker_id}` (merged #487/#504).
- `lib/tau/factory/fleet/watchdog.ex` monitors workers and can emit `{:worker_stalled, worker_id}`.
- The Unit already handles `worker_stalled`/`:state_timeout` → `E_WORKER_STALLED` (post-#490).

### Plan (this PR)
1. **Shaper pass** → the heartbeat-driven liveness contract: how the Unit's liveness is governed by heartbeat progress (reset-on-heartbeat) rather than (or in addition to) a fixed wall-clock; the threshold/inactivity policy; the interaction of `:state_timeout`, the Watchdog `worker_stalled`, and the dispatcher inactivity timeout; verified-free D-NNN; SPEC-FACTORY-CORE/FLEET §4 amendment. Commit `spec(factory): …`.
2. test-author → implementer → critic + reviewer.

### Acceptance criteria
- **D-377** (reset-on-heartbeat) — a Unit in `oracle`/`implementing` re-arms its `:state_timeout` on every current-worker `{:worker_heartbeat, w}` (the worker heartbeat pulse). Fed heartbeats at sub-`state_timeout_ms` intervals past the old fixed cap, it stays in `implementing` and never escalates `E_WORKER_STALLED`; with NO heartbeats it trips at `state_timeout_ms`. (`:state_timeout` becomes a per-heartbeat inactivity deadline, not a run-duration cap; kept, not removed.)
- **D-378** (unified worker-outcome handling; one stall → exactly one outcome) — `oracle` and `implementing` handle the worker-outcome signal set IDENTICALLY. Semantic `{:worker_exit, ^worker_id, reason}` (`:no_work_product`/`:error`/`{:exit_status,_}`) AND Watchdog `{:worker_stalled, ^worker_id}` → the **retry ladder**, re-entering the **ORIGINATING** state (oracle→oracle, implementing→implementing) via `advance_retry_ladder/2`. The Unit's OWN `:state_timeout` (heartbeat-reset; total silence) → `escalate(:E_WORKER_STALLED)` (hard stall; preserves #490). Disjointness: the first signal consumed clears `data.worker_id` → later signals for that worker stale-discard → EXACTLY ONE outcome per worker, in BOTH states. The deferred-spawn is DROPPED (vacuous — `worker_id` discrimination + `:on_enter`-before-mailbox give exactly-once); **durability (D-315)** holds for free because the ladder's `:on_enter` already bumps `attempt_count` + `snapshot_state`s before spawning; **LIV-1** holds via the bounded refine/pivot/exhaust ladder.
- **D-379** (close the `worker_exit`/`worker_stalled` oracle gap + wire the Watchdog) — `oracle` gains the `{:worker_exit, ^worker_id, _}` clause it was MISSING (the run-#2 escalation: an oracle worker's `:no_work_product` fell through → 300s stall → spurious `E_WORKER_STALLED`); both states route `worker_exit`/`worker_stalled` symmetrically. The UnitDriver registers each spawned worker with the Watchdog (`report_to` = owning Unit); stale-worker `{:worker_stalled, _}`/`{:worker_exit, _}` discarded. (Closes the B8 named-but-unwired `worker_stalled` + the oracle `worker_exit` gap.)

### Gating-test paths (frozen at 4b)
- `test/tau/factory/unit_heartbeat_liveness_test.exs` — D-377 (heartbeat resets :state_timeout; no-heartbeat trips it), D-378 (one worker → exactly one ladder advance, no double-fire), D-379 (worker_stalled→ladder; Watchdog registration; stale discard).
### Gate verdicts
**Attempt 1 — RED (refine).** Both halves FAIL.
- **critic: FAIL** — (1, BLOCKING) **D-315 durability regression:** the deferred stall re-spawn (`do_spawn_worker/1`) bypasses `snapshot_state/2` + `attempt_count++` that the canonical `implementing(:on_enter)` re-entry performs → a watchdog-driven stall re-spawn writes NO Ledger snapshot → violates D-315 RPO=0 on crash. (2) **SPEC contradiction:** D-377 (own `:state_timeout`→escalate) vs D-378/control-plane §H-2 (→ladder) — impl improvised; the D-378 test uses a production-dead synthetic `{:info,{:state_timeout,:worker_stalled}}`. Confirmed sound: D-377 reset, D-379 orphan-wiring, disjointness for real signals, real-wedge safety.
- **reviewer: FAIL** — Gate 5.1: bare `D-366` token in AC prose (→ `D-366 (meta)` now). Tests/flake-fix/mutation-probes otherwise green; no #490 regression.

**Refine plan:**
- *Coordinator:* `D-366 (meta)` + D-378 reworded to the coherent two-outcome model (above).
- *Test-author:* revise the D-378 test to exercise the REAL signals (`worker_stalled` + `worker_exit` → ladder; own `:state_timeout` → escalate) — drop the synthetic state_timeout-info leg; ADD a D-315 durability assertion (stall-driven re-spawn records a Ledger snapshot via a stub/real Ledger).
- *Implementer:* (a) route the deferred re-spawn through `snapshot_state/2` + `attempt_count++` (D-315); (b) REMOVE the production-dead `{:info,{:state_timeout,:worker_stalled}}` clause; (c) amend SPEC §H-2/D-377/D-378 + control-plane to the coherent two-outcome model (own `:state_timeout`→escalate; Watchdog `worker_stalled`→ladder).

**Attempt 1 re-gate (refine #1) — RED.** D-315 durability + dead-clause FIXED, but: (critic) `oracle({:worker_stalled})` still uses `advance_retry_ladder` while `implementing` uses the deferred re-spawn → DIVERGENT; SPEC §6 prose vs source-map vs control-plane pseudocode now 3-way contradictory on the same edge → D-378 falsified for `oracle`. (reviewer) Gate 5.1 tool (`ac_linkage.ex parse_meta_ac_tokens/1`) only honors `AC-N (meta)`, not `D-NNN (meta)` — D-326/D-366 markers don't exempt (now removed from AC entirely).

**STATUS: DE-PRIORITIZED — needs a stall-model RE-SHAPE, not another patch.** The worker_stalled handling is genuinely unsettled (burst exactly-once via deferred-spawn vs bounded/LIV-1 retry-ladder vs durable vs uniform oracle+implementing). Per retry-strategy, two consecutive failures on the same area ⇒ pivot to a re-shape. **NOT a blocker for the first factory-driven seeded run** (the trivial seeded task fits the existing 300s widened `:state_timeout` (D-358); heartbeat-liveness is for long/variable real-issue runs). Re-shape + re-do after the seeded run lands.


---

**Re-shape attempt 1 (commit 6beddd1) — RED (refine).** Both halves FAIL, concurring; both rule REALIGN IMPL TO SPEC (do NOT amend SPEC).
- **critic: FAIL** — three blocking deviations from the on-branch re-shaped SPEC `821c7af`: (1) **LIV-1** — `advance_retry_ladder/2` never calls `Retry.next`; both clauses only bump `attempt_count` + re-enter unconditionally → unbounded stall re-spawn, never reaches `:E_RETRY_EXHAUSTED`. (2) **deferred-spawn KEPT** for `implementing` (`:stall_respawn`/`do_spawn_worker`) despite the SPEC's explicit drop — a contortion to the D-378 test reusing `impl_worker_id` (production-impossible; D-326 = fresh ids). (3) **asymmetric worker_exit** — `implementing`→`advance_gate_ladder` (budget) vs `oracle`→`advance_retry_ladder` (no budget) falsifies D-378's identical-handling. Commit title falsely claims "drop deferred-spawn". Correct: oracle worker_exit clause (run-#2 gap closed), D-377 reset both states, D-379 wiring, legacy :DOWN, no masking.
- **reviewer: FAIL** — 14/14 gating + 1662/0 both seeds + lint clean + 2 mutation-probes load-bearing, BUT confirms the same 3 blocking items empirically: LIV-1 stall re-spawn bounded only by `state_timeout` (not the refine/pivot ladder); SPEC/impl deferred-spawn divergence; asymmetric routing. (CI Gate 5.3 skipped — non-PR trigger; passes locally.)

**Refine plan (realign to SPEC `821c7af` + control-plane.md):**
- *Test-author:* switch the `implementing` worker_fun to emit FRESH worker_ids per spawn (mirror oracle), so the dropped deferred path still gives exactly-once. ADD a LIV-1 boundedness assertion: repeated stalls consume the refine→pivot ladder and eventually escalate `:E_RETRY_EXHAUSTED` (NOT perpetual re-spawn). Keep D-377/D-378/D-379.
- *Implementer:* (1) make `advance_retry_ladder/2` call `Retry.next` → route `{:refine,k}`/`:pivot`/`:exhausted` like `advance_gate_ladder`, re-entering the ORIGINATING state via `:on_enter` (bounded + D-315 durable). (2) route `implementing({:worker_exit,^w,_})` through `advance_retry_ladder(:implementing,…)` — identical to oracle (D-378 symmetry). (3) DELETE `:stall_respawn` + `do_spawn_worker/1`. (4) non-blocking: derive UnitDriver `heartbeat_timeout_ms` from the Unit's `state_timeout_ms`/`:unit_timeouts` (D-379 single threshold).


---

**Retry-budget semantics — RULED (Option B), via solution-shaping critic.** Coordinator flagged a latent test/SPEC tension (does the worker-outcome ladder consume the gate's `refine_count` budget, or a separate one?). Ruling from the SPEC text (V1/V3/V6): **OPTION B — separate budgets sharing one `N_REFINE+N_PIVOT` bound.**
- *Decider:* SPEC-FACTORY-CORE §4 B8 table (L638-642: `worker_exit`+`worker_stalled` → retry ladder, **gate NOT called**); §3 D-378 (L1536: advances the `attempt_count` metric, not `refine_count`); §3.4 semantic-failure (gate-fail → refine/pivot) vs infrastructure-crash (worker exit/stall → re-spawn) split (L798-814). The test-author read the SPEC correctly.
- *Tests:* #3 (symmetric worker_exit does NOT bump `refine_count`, DOES bump `attempt_count`) — **KEEP**. #1/#2 (LIV-1 boundedness, drive `n_refine+n_pivot+1` cycles → `E_RETRY_EXHAUSTED`) — **HOLD** (worker-outcome ladder reuses the `Retry` bound via `attempt_count`; NO `n_stall` knob).
- *Impl:* `advance_retry_ladder(state,data)` symmetric oracle/implementing → `Retry.next(:stall, attempt_count, pivot_count)` → re-enter originating state on refine/pivot (`:on_enter` bumps `attempt_count`+snapshot), escalate `E_RETRY_EXHAUSTED` on exhausted; route `implementing {:worker_exit,^w,_}` through it (NOT `advance_gate_ladder` — the 6beddd1 bug); delete `:stall_respawn`/`do_spawn_worker`; `refine_count` stays gate-only.
- *SPEC amendment (in-PR):* §3 D-378 clarification — worker-outcome ladder advances `attempt_count`; gate ladder advances `refine_count`/`pivot_count`; distinct budgets, one bound, exhaust independently.

---

**Re-shape attempt 2 (realigned, rebased cdd4496) — GREEN (merge).** Both PASS.
- **critic: PASS** — the `stall_count` deviation ACCEPTED as the better Option-B realization (`attempt_count` is pre-consumed by the initial oracle+implementing `:on_enter` increments → would exhaust the ladder early; a dedicated counter is within the ruling's "attempt_count OR dedicated worker-retry counter" latitude; SPEC §3 D-378 endorses it coherently). Worker-outcome ladder BOUNDED (`Retry.next(:stall, stall_count, pivot_count)` → `E_RETRY_EXHAUSTED` after N_REFINE+N_PIVOT) + SYMMETRIC (both states route worker_stalled AND worker_exit → `advance_retry_ladder(<originating>, data)`) + `refine_count` untouched (gate-only); deferred-spawn GONE; oracle worker_exit clause present (run-#2 gap closed); D-379 Watchdog single-threshold; registry resolution correct (D-377–380→CORE, D-381/382→FLEET, stale GOV line removed, no markers); D-315 state-durable as specified. Non-blocking suggestion: stale comment unit.ex:688/693.
- **reviewer: PASS** — 17/17 gating; 1679/0 at seed 0 AND 42; lint+dialyzer clean; no `stall_respawn`/`do_spawn_worker`/`deferred_spawn` refs; CI all green on cdd4496 incl. mutation-check; all 3 mutation-probes (unbound ladder / asymmetric routing / oracle-exit removal) load-bearing; gating-test ownership clean.