### PR TITLE
#515 — real-run integration: admission self-exclusion (D-380) + per-unit prompt delivery (D-381)

### DIFF
--- a/docs/MISSION.md
+++ b/docs/MISSION.md
@@ -80,11 +80,12 @@ Block-to-SPEC allocation:
 | D-180 – D-189 | SPEC-WEB-DASHBOARD |
 | D-300 – D-303, D-341 | SPEC-FACTORY-MERGE |
 | D-304 – D-308, D-322, D-323, D-354 | SPEC-FACTORY-GATE |
-| D-309 – D-311, D-313, D-314, D-316, D-334, D-364 – D-367, D-376 | SPEC-FACTORY-FLEET |
-| D-312, D-315, D-317, D-318, D-320, D-321, D-330 – D-333, D-335, D-336, D-340, D-342 – D-344, D-355 – D-359, D-369 – D-373 | SPEC-FACTORY-CORE |
+| D-309 – D-311, D-313, D-314, D-316, D-334, D-364 – D-367, D-376, D-381 | SPEC-FACTORY-FLEET |
+| D-312, D-315, D-317, D-318, D-320, D-321, D-330 – D-333, D-335, D-336, D-340, D-342 – D-344, D-355 – D-359, D-369 – D-373, D-380 | SPEC-FACTORY-CORE |
 | D-319, D-351 – D-353, D-374 | SPEC-FACTORY-GOV |
 | D-361 – D-363 | SPEC-FACTORY-CORE (C1 unit-coordinate identity; PR #503) |
-| D-300 – D-380 | reserved — SPEC-FACTORY-\* family (autonomous factory; `docs/arch/`) |
+| D-377 – D-379 | reserved — SPEC-FACTORY-GOV (heartbeat-driven Unit liveness; unmerged `feat/491-heartbeat-timeout`, #491) |
+| D-300 – D-385 | reserved — SPEC-FACTORY-\* family (autonomous factory; `docs/arch/`) |
 
 A SPEC needing a D-NNN outside its allocated block MUST update this table
 in the same change.

--- a/docs/arch/04-software-architecture/control-plane.md
+++ b/docs/arch/04-software-architecture/control-plane.md
@@ -229,10 +229,29 @@ S.state = %{
 (system-architecture.md §1 S.δ):
 
 ```
-admit(u) ⟺  ConflictCheck.clear?(declared(u), F)            # five clauses, HR-4
+admit(u) ⟺  ConflictCheck.clear?(declared(u), F ∖ {u})      # five clauses, HR-4; SELF-EXCLUDED (D-380)
         ∧  budget_precheck(u) = :ok                          # INV-21, ETS snapshot
-        ∧  fleet_headroom?(W_cap)                            # |F| < W_cap (§2.5)
+        ∧  fleet_headroom?(|F ∖ {u}| < W_cap)                # capacity over F∖{u} (§2.5)
 ```
+
+**Self-exclusion (D-380, #515).** The conflict and capacity checks evaluate over
+`F ∖ {unit_id}`, never the raw `F` — a unit can never conflict with its own
+in-flight entry. This is the structural reason (a) a single unscopable unit
+(the `universal_conflict` sentinel, §2.6.D-371) admits against its excluded-empty
+`F'` instead of self-conflicting, and (b) the §2.4 scope-amendment re-admit of an
+already-present unit is **idempotent** (returns `:admit`, replaces the scope). The
+exclusion is an **S-level set operation** keyed by `unit_id`; `ConflictCheck` (C5)
+stays unit-id-agnostic and keeps P-CC-2 (a non-trivial *scope* self-conflicts).
+
+**Single admission authority (D-380, #515).** `admit/3` has **exactly one** caller
+— the Unit FSM `planned` state, which holds the real `declared_scope`. K
+**selects and drives** but MUST NOT admit. An early implementation had K admit with
+an `@empty_scope` placeholder *and* the Unit admit with the real scope — a
+**double admission of one unit against one Scheduler**: the empty-scope `F` entry
+both blinded other units' conflict checks (a soundness hole, the dual of the
+under-declaration in §2.6) and made the Unit's real-scope admit self-conflict via
+the sentinel (the first-real-run wedge). One unit, one admit, by the authority
+that holds the real scope.
 
 `W_cap` is **not** the naïve `W*`. It is derived from measured gate-stage
 utilization `ρ_g < 1 − margin` with `T_unit(W)` modeled *endogenously*
@@ -307,7 +326,11 @@ is *not* a silent in-flight mutation — U emits a `scope_amendment`, the unit i
 re-runs `ConflictCheck` against the *current* `F`. Re-admission is a fresh,
 monotone decision; there is no in-flight scope drift, and INV-13 holds against
 the *amended* declaration. This is the structural reading of `factory-loop.md`'s
-"scope growth becomes a separate PR or a deliberate, logged re-plan".
+"scope growth becomes a separate PR or a deliberate, logged re-plan". The
+re-admit is **idempotent** by §2.2's self-exclusion (D-380): because the check
+runs over `F ∖ {unit_id}`, a re-submitted unit never conflicts with its *own*
+prior `F` entry — even if the withdraw step has not yet landed — so the amended
+admit is decided purely against the *other* in-flight units.
 
 ### 2.5 Budget pre-check (INV-21) and monotone admission (LIV-4)
 
@@ -439,9 +462,25 @@ not an error. For any non-empty issue the assembler returns a non-empty prompt.
 (`supervisor.ex`) is the single assembly site; it swaps `brief: title` for
 `brief: BriefAssembler.assemble(%{issue: issue, declared_scope: scope, …})`. The
 assembled brief rides the *existing* `UnitDriver → WorkerSupervisor → Worker → shim`
-path unchanged — no new boundary. The A1 shim wiring (`task.prompt = brief` instead
-of `""`) is the consumer side; A2 owns the assembler and the contract that
+path unchanged — no new boundary. A2 owns the assembler and the contract that
 `task.prompt` equals the assembled brief.
+
+**The consumer side — delivery across the Worker↔shim Port (D-381, #515).** A2
+gets the brief as far as the Worker's `:brief`, but the **first real-`claude` run
+showed the brief stops there**: the shim baked only adapter+branch (`agent_bin` is
+resolved **once** at supervisor setup, `AgentBin.resolve/1`, D-376) and hardcoded
+`task.prompt = ""`, so the real agent ran `claude -p ""`. The per-unit prompt
+therefore cannot be a shim-write-time bake; it must cross the *existing* B4 `Port`
+boundary at *spawn* time. The cheapest-to-reverse seam (V3, mirroring why A1 chose
+the Port-shim over an in-process drive) is an **environment variable**:
+the Worker — which is per-unit and already builds a per-spawn `:env` list — sets
+`TAU_AGENT_PROMPT = brief` at `Port.open`, and the shim's `Runner.main/1` reads it
+into `task.prompt`. Rejected: baking the brief per-unit by moving `AgentBin.resolve/1`
+to unit-spawn time (a per-unit shim rewrite; re-homes the one-time `agent_bin`
+construction). The delivery is **orthogonal to the #509/D-374 metered-spend scrub**
+— that scrub removes only the three `ANTHROPIC_*` keys; `TAU_AGENT_PROMPT` is task
+data, never a credential, and is never scrubbed. The boundary detail is
+SPEC-FACTORY-FLEET §4 B4-A1 ("Prompt delivery"); the invariant is D-381.
 
 ---
 

--- a/docs/spec/SPEC-FACTORY-CORE.md
+++ b/docs/spec/SPEC-FACTORY-CORE.md
@@ -89,6 +89,31 @@ Conforms to arch `control-plane.md` §3.2.1 (which already showed the capturing
 clause) and `merge-and-integration.md`; resolves the `control-plane.md`
 §3.2.1↔§7.2 contradiction in favour of capture.
 
+**Amendment (2026-06-14, PR #515 — real-run integration: admission
+self-exclusion + single admission authority; D-380).** The first
+factory-driven *real-`claude`* run surfaced a coordination defect: `unit-N` is
+admitted **twice** against the **one** Scheduler — once by the Coordinator's
+`drive_unit/3` with an `@empty_scope` (`coordinator.ex`), then again by the Unit
+FSM `planned` state with the **real** `declared_scope` (`unit.ex`). For an
+unscopable seed issue (the D-371 `universal_conflict` sentinel), the Unit's
+second admit runs `ConflictCheck.clear?/2` against an `F` that already holds the
+unit's **own** first entry → the sentinel branch fires `{:conflict,
+:no_dependency}` → `escalate(:E_SCHEDULER_DEFER)`. The unit self-conflicts and
+the loop wedges before any work. There are **two** distinct defects: (1) a
+**double admission** of one unit against one authority (the contract assumes one
+admit per unit — §3 Q2 `admit→withdraw→re-admit` is forbidden absent a
+`release`), and (2) a **soundness** bug — the Coordinator's `@empty_scope` admit
+records the unit in `F` with an *empty* scope, blinding every *other* unit's
+conflict check to the unit's real files. The fix pins **single admission
+authority at the Unit FSM** (which holds the real `declared_scope`) and adds
+**self-exclusion** in the Scheduler as the structural guarantee that a unit can
+never conflict with its own `F` entry. §3 Q1/Q2/Q6 record the constraint; §4
+B1 pins single-authority + the `admit/3` self-exclusion post-condition; §4 B2
+pins that `ConflictCheck` stays unit-id-agnostic (P-CC-2 self-conflict on scope
+is preserved — the exclusion lives in S, not C5); §6 adds **D-380**. Conforms
+to arch `control-plane.md` §2.2 (the admission predicate) and §2.4
+(scope-amendment re-admission, which now relies on self-exclusion to be idempotent).
+
 ## 0. Why this spec exists
 
 The factory's control core is the brain of an autonomous loop that takes a
@@ -180,6 +205,32 @@ Format: `[Cn-Bm]` = constraint number + boundary. **★** marks non-obvious.
 - **[C102-B1]** The in-flight set `F` is written only by the Scheduler (C4) on
   admit/terminal. The Coordinator and Units *read* admission results; they never
   mutate `F`.
+- **★ [C132-B1] One unit is admitted exactly once, by exactly one authority — the
+  Unit FSM `planned` state — and the authority that admits is the one holding the
+  unit's *real* `declared_scope` (D-380, V3).** The Coordinator (K) **selects and
+  drives**; it MUST NOT call `Scheduler.admit/3`. An admit by K is unsound *and*
+  redundant: K does not hold the real scope (it would admit with an `@empty_scope`
+  placeholder), so the unit's `F` entry would carry an **empty** scope, blinding
+  every *other* unit's `ConflictCheck` to the unit's real files (a missed-conflict
+  corruption, the dual of [C130-B10] under-declaration). It is also a **second
+  admit of the same `unit_id` against the same Scheduler**, which Q2's
+  no-`admit→withdraw→re-admit` ordering forbids absent a prior `release`. Single
+  authority = the Unit FSM, which holds `data.declared_scope` (the real elaborated
+  scope, D-369..D-371). K's `drive_fun` invokes the unit driver directly; the
+  admission gate lives once, in U's `planned → oracle` transition (§5 FSM; §4 B1).
+- **★ [C133-B1] A unit can never conflict with its own in-flight entry — the
+  Scheduler self-excludes the candidate from `F` before the conflict check (D-380,
+  V3).** `Scheduler.admit(unit_id, scope)` MUST evaluate `ConflictCheck.clear?`
+  over `F ∖ {unit_id}`, never over the raw `F`. Self-exclusion is the structural
+  guarantee that makes admission **idempotent for a unit already in `F`** (a re-admit
+  on the scope-amendment path, §4 B2 / arch §2.4, returns `:admit` against the
+  unit's own prior entry rather than self-conflicting) and is the **sole** reason
+  the D-371 `universal_conflict` sentinel does not make a single unscopable unit
+  conflict with itself. The exclusion lives in **S** (which holds `F` keyed by
+  `unit_id` and receives the candidate's `unit_id`), **not** in `ConflictCheck`
+  (C5) — C5 stays unit-id-agnostic and keeps P-CC-2 (a non-trivial *scope* still
+  self-conflicts when handed to itself; §4 B2, §6 D-312). One invariant
+  ("no unit self-conflicts via its own `F` membership"), one enforcer (S).
 
 ### Q2: What ordering assumptions are implicit?
 
@@ -400,11 +451,25 @@ Format: `[Cn-Bm]` = constraint number + boundary. **★** marks non-obvious.
 
 ### B1: Coordinator (C3) ↔ Scheduler (C4)
 
-- `admit/2 :: (unit_id, declared_scope) -> :admit | {:defer, reason}` (`call`).
+- `admit/2 :: (unit_id, declared_scope) -> :admit | {:defer, reason}` (`call`;
+  the implementation arity is `admit/3` — `(server, unit_id, declared_scope)`).
 - Pre: Scheduler running; `Ledger.Writer` running.
-- Post: `:admit` ⟺ `ConflictCheck.clear?(declared_scope, F)` ∧
-  `budget_precheck(unit) == :ok` ∧ `|F| < W_cap`; on `:admit`, `unit_id` is added
-  to `F` before the reply (single-writer of `F`).
+- Post: `:admit` ⟺ `ConflictCheck.clear?(declared_scope, F ∖ {unit_id})` ∧
+  `budget_precheck(unit) == :ok` ∧ `|F ∖ {unit_id}| < W_cap`; on `:admit`,
+  `unit_id ↦ declared_scope` is **upserted** into `F` before the reply
+  (single-writer of `F`).
+- **Self-exclusion (D-380, [C133-B1]):** the conflict check and capacity check are
+  evaluated over `F ∖ {unit_id}`, never the raw `F`. A unit therefore never
+  conflicts with its own in-flight entry, and a re-admit of an already-present
+  `unit_id` (the scope-amendment path, B2 / arch §2.4) is **idempotent** —
+  it returns `:admit` and replaces the unit's scope, never `{:conflict, _}` against
+  itself. The exclusion is by `unit_id` (S holds `F` keyed by it); `ConflictCheck`
+  (C5) never sees the candidate's id (B2).
+- **Single admission authority (D-380, [C132-B1]):** the **only** caller of
+  `admit/3` is the Unit FSM `planned` state (§5), which holds the real
+  `declared_scope`. The Coordinator (K) selects and drives but MUST NOT admit
+  (an empty-scope K-admit is unsound — it blinds other units' checks — and is a
+  forbidden double-admit of one unit against one Scheduler).
 - Invariant (**D-343, monotone**): a `{:defer, _}` never demotes a unit's queue
   position; deferred units are served in arrival order with aging.
 
@@ -417,12 +482,26 @@ Format: `[Cn-Bm]` = constraint number + boundary. **★** marks non-obvious.
   resource-isolatable.
 - Invariants (properties, §6 D-312): symmetry; non-trivial self-conflict;
   monotone-in-`F`; each clause necessary; gating-path collision blocks.
+- **Unit-id-agnostic (D-380, [C133-B1]):** `clear?/2` receives only `(scope, F')`
+  where the **Scheduler** has already excluded the candidate (`F' = F ∖ {unit_id}`).
+  C5 has **no** knowledge of the candidate's id, so the self-exclusion fix MUST
+  NOT be placed here. P-CC-2 (a non-trivial *scope* never clears against an equal
+  *scope*) is **preserved unchanged** — it is a property of the pure predicate over
+  *scopes*, not over *unit identities*. The "a unit never self-conflicts via its
+  own `F` membership" guarantee is an S-level set operation (`F ∖ {unit_id}`),
+  not a C5 change. The D-371 `universal_conflict` sentinel branch below operates
+  over the already-excluded `F'`, so a single unscopable unit (its own entry
+  excluded) sees an *empty* `F'` and clears.
 - `scope()` type: `%{deps: [unit_id], files: MapSet.t(String.t()),
   codepoints: MapSet.t({String.t(), atom()}), specs: MapSet.t(atom()),
   resources: MapSet.t(atom()), optional(:universal_conflict) => boolean()}` —
   the `universal_conflict: true` sentinel (D-371) causes `clear?/2` to return
-  `{:conflict, :no_dependency}` against any non-empty `F`, regardless of
-  whether the sentinel is the candidate or an in-flight member (symmetric).
+  `{:conflict, :no_dependency}` against any non-empty argument set, regardless of
+  whether the sentinel is the candidate or an in-flight member (symmetric). Note
+  the argument set `clear?/2` receives is the Scheduler's already-excluded
+  `F ∖ {unit_id}` (D-380, [C133-B1]): a **single** unscopable unit sees an empty
+  argument set and clears; the sentinel still serializes it against every *other*
+  in-flight member.
 
 ### B3: {Coordinator, Unit} ↔ Ledger.Writer (C1)
 
@@ -1412,6 +1491,27 @@ never raising on partial input and never returning `""`. Enforced by
 partial input degrades to placeholders without raising; output is always
 non-empty).
 
+**D-380 — Single admission authority + admission self-exclusion (real-run
+integration, [C132-B1], [C133-B1]):** one unit is admitted to `F` **exactly once,
+by the Unit FSM `planned` state alone** (the authority holding the real
+`declared_scope`); the Coordinator selects and drives but **never** calls
+`Scheduler.admit/3`. The Scheduler evaluates `ConflictCheck.clear?` and the
+capacity check over `F ∖ {unit_id}` — a unit **never** conflicts with its own
+in-flight entry, so (a) a single unscopable unit (D-371 `universal_conflict`)
+admits against its excluded-empty `F'` instead of self-conflicting, and (b)
+re-admit of an already-present `unit_id` (the scope-amendment path) is idempotent
+(returns `:admit`, replaces the scope). The exclusion is by `unit_id` in the
+Scheduler; `ConflictCheck` (C5) stays unit-id-agnostic and P-CC-2 (scope
+self-conflict) is preserved. Two defects are jointly closed: the
+**double-admission self-conflict** (`unit.ex` admit sees the Coordinator's prior
+empty-scope `F` entry → `escalate(:E_SCHEDULER_DEFER)`) and the **soundness** hole
+(an empty-scope `F` entry blinds other units' conflict checks). Enforced by
+`scheduler_self_exclusion_test.exs` (admit `unit-1` with a sentinel/non-trivial
+scope; re-admit the **same** `unit_id` against an `F` already holding it →
+`:admit`, not `{:conflict, _}`; and a single sentinel unit admits into the
+excluded-empty `F'`) and by an integration assertion that the Coordinator's
+`drive_unit` performs **no** `Scheduler.admit` call.
+
 ## 7. Acceptance criteria
 
 Each is expressed against the user-facing path with an observable signal.
@@ -1487,6 +1587,12 @@ PR groupings are indicative.
   (`select_fun → nil`, no in-flight unit, no `Unit` spawned); and on a default
   boot (factory disabled) no `Tau.Factory.Coordinator` exists. Signal: both Test A
   (enabled assembly + idle) and Test B (default-OFF) assert it.
+- **AC-D380 (PR #515, D-380):** `mix test test/tau/factory/scheduler_self_exclusion_test.exs`
+  passes — re-admitting the **same** `unit_id` against an `F` already holding it
+  returns `:admit` (not `{:conflict, _}`), a single `universal_conflict` unit
+  admits into its excluded-empty `F'`, and the Coordinator's `drive_unit` issues
+  **no** `Scheduler.admit` call (single authority = the Unit FSM). Signal: the
+  test asserts the self-exclusion verdict and the absence of the K-side admit.
 
 ## Appendix B — Source map
 
@@ -1495,10 +1601,10 @@ Files that bring a PR into scope of this SPEC (`D-NNN`/`C-N` → file:symbol):
 - `lib/tau/factory/ledger/writer.ex` (C1; D-315, D-330–D-333, D-335, D-336) — PR-CORE-1/5
 - `lib/tau/factory/ledger/schema/*.ex` + `lib/tau/factory/ledger/migrations.ex` (Exqlite schema; D-335 partial unique index) — PR-CORE-1/5
 - `lib/tau/factory/budget/owner.ex` (C2; D-320, D-332) — PR-CORE-2
-- `lib/tau/factory/coordinator.ex` (C3; D-317, D-321, D-342, D-344) — PR-CORE-3/4
+- `lib/tau/factory/coordinator.ex` (C3; D-317, D-321, D-342, D-344, **D-380** `drive_unit/3` MUST NOT call `Scheduler.admit`; drop the `@empty_scope` admit — single admission authority is the Unit FSM) — PR-CORE-3/4 / PR #515
 - `lib/tau/factory/escalation.ex` (C7; D-317) — PR-CORE-3
-- `lib/tau/factory/scheduler.ex` (C4; D-312, D-320, D-343) — PR-CORE-2
-- `lib/tau/factory/conflict_check.ex` (C5; D-312, D-343) — PR-CORE-2
+- `lib/tau/factory/scheduler.ex` (C4; D-312, D-320, D-343, **D-380** evaluate `ConflictCheck.clear?` + capacity over `F ∖ {unit_id}`; upsert on admit) — PR-CORE-2 / PR #515
+- `lib/tau/factory/conflict_check.ex` (C5; D-312, D-343 — **unchanged for D-380**: stays unit-id-agnostic; the self-exclusion is an S-level set op, not a C5 change) — PR-CORE-2
 - `lib/tau/factory/unit.ex` (C6; D-318, D-340, **D-356** awaiting_merge subscribe-before-request consume + unsubscribe-on-exit, **D-362** capture `work_ready` `branch`/`head_sha` into data, **D-361** key `merge_fun` on captured `head_sha`/`branch`, plus B6/B7/B8 cited edges) — PR-CORE-3/PR #477/PR #503
 - `lib/tau/factory/unit_driver.ex` (D-340, **D-356** `:janitor` threading + no driver-side merge bridge / no driver reclaim; **D-361** build the merge map `hash`/`branch` from the captured `head_sha`; the real `drive_fun` wiring Unit→fleet→gate→merge seams) — PR #477/PR #503
 - `lib/tau/factory/gate/request.ex` (**D-361** `Request.hash` is the captured `head_sha`, not the declared `work_item.hash`; the gate-closure construction site) — PR #503
@@ -1513,6 +1619,7 @@ Files that bring a PR into scope of this SPEC (`D-NNN`/`C-N` → file:symbol):
 - `lib/tau/factory/dogfood/` (the scripted deterministic `agent_bin` and sandbox-seeding helpers — the seeded issue + its real gating test; emits the D-326 `work_ready` frame) — PR #481
 - `test/tau/factory/ledger_durability_test.exs` (D-315) — PR-CORE-1
 - `test/tau/factory/conflict_check_property_test.exs` (D-312, D-343) — PR-CORE-2
+- `test/tau/factory/scheduler_self_exclusion_test.exs` (**D-380** self-exclusion + idempotent re-admit + Coordinator issues no admit — single authority) — PR #515
 - `test/tau/factory/budget_admission_test.exs` (D-320, D-332) — PR-CORE-2
 - `test/tau/factory/brief_assembler_test.exs` (**D-372** complete-over-inputs composition; **D-373** injected `:assemble_fun` seam, pure default, graceful degradation, non-empty output) — PR #508
 - `test/tau/factory/retry_property_test.exs` (D-318) — PR-CORE-3

--- a/docs/spec/SPEC-FACTORY-FLEET.md
+++ b/docs/spec/SPEC-FACTORY-FLEET.md
@@ -849,18 +849,21 @@ bridge):** the per-unit brief (`work_item.brief`, composed by CORE D-372)
 reaches the per-unit shim's `Tau.CodingAgent.task.prompt`. Because `agent_bin` is
 resolved **once** at supervisor setup (D-376), the per-unit prompt cannot be baked
 at shim-write time; it crosses the existing B4 `Port` boundary as an **environment
-variable**. The Worker sets `{"TAU_AGENT_PROMPT", brief}` in the `Port.open`
-`:env` list (per-spawn, alongside `ns`/`extra_env`/the D-374 scrub); the shim's
-`Runner.main/1` reads `System.get_env("TAU_AGENT_PROMPT")` and sets
-`task.prompt = it || ""`. Holds for every agent_mode (Replay ignores it; benign).
-`□( brief ≠ "" ⇒ shim builds task.prompt == brief ) ∧ □( real :claude_code run ⇒
-claude argv contains "-p", brief, NOT "-p", "" )`. **Orthogonality (D-374):** the
-metered-spend scrub touches only the three `ANTHROPIC_*` keys;
-`TAU_AGENT_PROMPT` is task data and MUST NOT be added to the scrub. Detection:
-`coding_agent_shim_prompt_test.exs` — a Worker spawned with a non-empty `:brief`
-and `agent_mode: :claude_code` (with `claude` stubbed by a Replay/fixture source)
-produces an argv carrying the brief as `-p <brief>`; a `""` brief yields `-p ""`;
-the `ANTHROPIC_*` scrub is unaffected.
+variable**. Injection is **omit-on-empty**: when `brief` is non-empty the Worker
+appends `{"TAU_AGENT_PROMPT", brief}` to the `Port.open` `:env` list
+(per-spawn, alongside `ns`/`extra_env`/the D-374 scrub); when `brief == ""`
+the key is **omitted entirely** — no `:os.putenv`/`:os.unsetenv` global-env
+mutation (unsafe under concurrent `Worker.init` calls). The shim's
+`Runner.main/1` reads `System.get_env("TAU_AGENT_PROMPT") || ""` — absent is
+equivalent to `""` — and sets `task.prompt = it`. Holds for every agent_mode
+(Replay ignores it; benign). `□( brief ≠ "" ⇒ shim builds task.prompt == brief )
+∧ □( real :claude_code run ⇒ claude argv contains "-p", brief, NOT "-p", "" )`.
+**Orthogonality (D-374):** the metered-spend scrub touches only the three
+`ANTHROPIC_*` keys; `TAU_AGENT_PROMPT` is task data and MUST NOT be added to
+the scrub. Detection: `coding_agent_shim_prompt_test.exs` — a Worker spawned
+with a non-empty `:brief` and `agent_mode: :claude_code` (with `claude` stubbed
+by a Replay/fixture source) produces an argv carrying the brief as `-p <brief>`;
+a `""` brief yields `-p ""`; the `ANTHROPIC_*` scrub is unaffected.
 
 ## 7. Acceptance criteria
 

--- a/docs/spec/SPEC-FACTORY-FLEET.md
+++ b/docs/spec/SPEC-FACTORY-FLEET.md
@@ -31,6 +31,14 @@ not owned here.
 B4-A1 extension, §6, Appendix B). Wires `mix tau.factory.dogfood` to use
 `AgentBin.resolve/1`; default mode stays scripted so existing dogfood gates are
 unaffected.
+#515 amendment (real-run integration) — adds **D-381**: per-unit **prompt
+delivery** across the Worker↔shim `Port` (§4 B4-A1, §6, Appendix B). A2/#488
+(CORE D-372) *composes* the brief and threads it to the Worker's `:brief`, but the
+brief stopped at the Worker state and never reached the shim — the real `claude`
+ran as `claude -p ""`. D-381 pins the delivery seam: the Worker sets a
+`TAU_AGENT_PROMPT` env var at `Port.open` and the shim reads it into
+`task.prompt`. Orthogonal to the #509/D-374 metered-spend scrub (the prompt is
+task data, never a credential).
 
 ## 0. Why this spec exists
 
@@ -417,8 +425,41 @@ passes its environment through (D-365).
   `claude` subprocess's stdout/stderr go to *its* stderr / a log, never the
   Worker's `{:packet,4}` stdout — mirroring the dogfood script's stderr discipline
   and `ClaudeCode`'s "stderr NOT redirected to stdout").
+- **Prompt delivery — the per-unit brief reaches the per-unit shim's `task.prompt`
+  (the load-bearing new logic — D-381).** A2/#488 (SPEC-FACTORY-CORE D-372)
+  *composes* the brief and threads it as `work_item.brief` → `WorkerSupervisor.spawn/5`
+  → the Worker's `:brief`. But the brief **stops at the Worker GenServer state**: it
+  is never delivered to the shim subprocess, so the shim builds `task.prompt = ""`
+  and the real `claude` runs as `claude -p ""` (the issue surfaced on the first
+  real run). The structural cause is that `agent_bin` is **resolved once** at
+  supervisor setup (`AgentBin.resolve/1`, D-376) — adapter + a static `branch`
+  are baked into the shim before any unit exists, so the *per-unit* prompt cannot
+  be a write-time bake. **Decision (cheapest-to-reverse, V3):** the **per-unit
+  brief crosses the existing Worker↔shim `Port` boundary (B4) as an environment
+  variable**, `TAU_AGENT_PROMPT`, set by the Worker at `Port.open` time (the Worker
+  *is* per-unit; the env list it already builds is per-spawn) and read by the
+  shim's `Runner.main/1` into `task.prompt`. Rejected alternative (b) — bake the
+  brief into the shim per-unit by moving `AgentBin.resolve/1` to unit-spawn time —
+  is a heavier change (a fresh shim executable written per unit) and re-homes the
+  one-time `agent_bin` construction; reversing a wrong (b) guess touches the
+  supervisor/UnitDriver wiring, whereas (a) is one env key added at one site and
+  one `System.get_env` read. **(a) is selected.** Contract:
+    - The Worker appends `{"TAU_AGENT_PROMPT", brief}` to the `Port.open` `:env`
+      list (alongside `ns`, `extra_env`, and the D-374 metered-scrub). It is set
+      for **every** agent_mode (Replay and `:claude_code`); the Replay shim
+      ignores `task.prompt`, so the key is benign there.
+    - The shim's `Runner.main/1` reads `System.get_env("TAU_AGENT_PROMPT")` and
+      builds `task.prompt = it || ""`. Absent var → `""` (back-compat: existing
+      Replay/dogfood paths that set no prompt are unchanged).
+    - **#509 (D-374/D-375) interaction (pinned).** The metered-spend env scrub
+      removes **only** `ANTHROPIC_API_KEY` / `ANTHROPIC_AUTH_TOKEN` /
+      `ANTHROPIC_BASE_URL`. `TAU_AGENT_PROMPT` is **not** a metered key and MUST
+      NOT be added to the scrub list — the fence and the prompt-delivery channel
+      are orthogonal. The prompt is task data, never a credential.
 - **Drive.** The shim builds a `Tau.CodingAgent.task` (`%{prompt, workspace: ws,
-  …}`) — the issue→prompt assembly is **A2 (#488), cited not owned here** — then
+  …}`) — the issue→prompt **composition** is **A2 (#488)/D-372, cited not owned
+  here**; the brief→`task.prompt` **delivery** across the Port is **D-381, owned
+  here** (see "Prompt delivery" above) — then
   calls `adapter.start(task, ctx)` to obtain a lazy `Enumerable.t()` of
   `%Tau.CodingAgent.Event{}` and **consumes it lazily, event by event**. Each
   consumed event that carries progress information (`AssistantText`, `ToolUse`,
@@ -507,7 +548,8 @@ that coordinate is **discarded by the Unit FSM today** (`unit.ex` matches
 `data.hash`). Threading the real `head_sha` through gate+merge is **#486 (C1)** —
 a separate ARCH GAP with its own D-NNN. Without #486 the shim's real `head_sha`
 lands but is ignored, so a useful real-dogfood smoke needs **A1 ∧ #486** (and a
-real prompt from **A2/#488**). This contract therefore *produces* the coordinate
+real prompt *composed* by **A2/#488/D-372** and *delivered* to the shim by
+**D-381**, this contract). This contract therefore *produces* the coordinate
 and *names its consumer*; it does not implement the consumption. (V2-clean: the
 shape solves exactly A1 — replace the canned agent — and explicitly defers C1/A2.)
 
@@ -802,6 +844,24 @@ not silent-hang ) ∧ □( crashes(shim) ⇒ blast_radius ⊆ {worker} )`. Detec
 shim emits a non-recoverable terminal event and exits non-zero (Worker observes a
 death-cert), and a sibling worker is unaffected.
 
+**D-381 — Per-unit prompt delivery across the Worker↔shim Port (#515, A1/A2
+bridge):** the per-unit brief (`work_item.brief`, composed by CORE D-372)
+reaches the per-unit shim's `Tau.CodingAgent.task.prompt`. Because `agent_bin` is
+resolved **once** at supervisor setup (D-376), the per-unit prompt cannot be baked
+at shim-write time; it crosses the existing B4 `Port` boundary as an **environment
+variable**. The Worker sets `{"TAU_AGENT_PROMPT", brief}` in the `Port.open`
+`:env` list (per-spawn, alongside `ns`/`extra_env`/the D-374 scrub); the shim's
+`Runner.main/1` reads `System.get_env("TAU_AGENT_PROMPT")` and sets
+`task.prompt = it || ""`. Holds for every agent_mode (Replay ignores it; benign).
+`□( brief ≠ "" ⇒ shim builds task.prompt == brief ) ∧ □( real :claude_code run ⇒
+claude argv contains "-p", brief, NOT "-p", "" )`. **Orthogonality (D-374):** the
+metered-spend scrub touches only the three `ANTHROPIC_*` keys;
+`TAU_AGENT_PROMPT` is task data and MUST NOT be added to the scrub. Detection:
+`coding_agent_shim_prompt_test.exs` — a Worker spawned with a non-empty `:brief`
+and `agent_mode: :claude_code` (with `claude` stubbed by a Replay/fixture source)
+produces an argv carrying the brief as `-p <brief>`; a `""` brief yields `-p ""`;
+the `ANTHROPIC_*` scrub is unaffected.
+
 ## 7. Acceptance criteria
 
 Each is expressed against the user-facing path with an observable signal. PR
@@ -873,13 +933,20 @@ groupings are indicative.
   no-completion/retry outcomes (D-364); the shim+sub-agent stay inside `ws` and
   the namespace (D-365); heartbeats track stream progress not a clock (D-366);
   a `claude`/dispatcher crash surfaces as a terminal event, not a hang (D-367).
+- **AC-D381 (PR #515, D-381 — per-unit prompt delivery):** a Worker spawned with
+  a non-empty `:brief` and `agent_mode: :claude_code` delivers that brief to the
+  shim's `task.prompt`, so the resulting `claude` argv carries `-p <brief>` (not
+  `-p ""`). Signal: `mix test test/tau/factory/coding_agent_shim_prompt_test.exs`
+  passes — with `claude` stubbed by a fixture source, the captured argv contains
+  the brief; a `""` brief yields `-p ""`; the `ANTHROPIC_*` metered scrub
+  (D-374) is unaffected.
 
 ## Appendix B — Source map
 
 Files that bring a PR into scope of this SPEC (`D-NNN`/`C-N` → file:symbol):
 
 - `lib/tau/factory/worker_supervisor.ex` (C1; D-316, death-certificate) — PR-FLEET-1
-- `lib/tau/factory/worker.ex` (C2; D-309, D-310, D-311, D-316 + heartbeat emission; D-326 `work_ready` decode/forward in `handle_info({port,{:data,_}},…)`) — PR-FLEET-1/2; D-326 wiring is P5c-3
+- `lib/tau/factory/worker.ex` (C2; D-309, D-310, D-311, D-316 + heartbeat emission; D-326 `work_ready` decode/forward in `handle_info({port,{:data,_}},…)`; **D-381** append `{"TAU_AGENT_PROMPT", brief}` to the `Port.open` `:env` list in `open_port_final/5`) — PR-FLEET-1/2; D-326 wiring is P5c-3; D-381 is PR #515
 - `lib/tau/factory/worker_registry.ex` (C3; key-not-pid identity) — PR-FLEET-1
 - `lib/tau/factory/worker/isolation.ex` (C5; D-309, D-311 — pure namespace/verify helpers) — PR-FLEET-2
 - `lib/tau/factory/workspace_janitor.ex` (C4; D-313, D-314, D-334 — `:DOWN` monitor) — PR-FLEET-3
@@ -896,7 +963,7 @@ Files that bring a PR into scope of this SPEC (`D-NNN`/`C-N` → file:symbol):
 - `test/tau/factory/worker_stalled_test.exs` (watchdog; feeds CORE D-317) — PR-FLEET-4
 - `test/tau/factory/worker_completion_event_test.exs` (D-326 — `work_ready` vs exit-0 no-op vs stale `worker_id`) — P5c-3
 - `test/tau/factory/oracle_spawn_order_test.exs` (D-304 mechanism, cited) — PR-FLEET-4
-- `lib/tau/factory/coding_agent_shim.ex` (B4-A1; D-364..D-367 — drives `Tau.CodingAgent`, owns branch+commit, emits `work_ready`/heartbeat frames) — PR-A1 (#487)
+- `lib/tau/factory/coding_agent_shim.ex` (B4-A1; D-364..D-367 — drives `Tau.CodingAgent`, owns branch+commit, emits `work_ready`/heartbeat frames; **D-381** `Runner.main/1` reads `System.get_env("TAU_AGENT_PROMPT")` into `task.prompt` in `run_single_stream`/`run_phased_stream`) — PR-A1 (#487); D-381 is PR #515
 - `lib/tau/factory/dogfood/agent.ex` (the canned script the shim replaces as the real-dogfood `agent_bin`; D-358 retained for the orchestration smoke) — PR-A1 (#487)
 - `lib/tau/factory/agent_bin.ex` (D-376 — `AgentBin.resolve/1`; config-gated selector mapping `:agent_mode` → `{agent_bin_path, spawn_opts}`) — PR #512 (#511)
 - `lib/mix/tasks/tau.factory.dogfood.ex` (D-376 — wired to `AgentBin.resolve/1`; default mode stays scripted/replay; existing dogfood gates unaffected) — PR #512 (#511)
@@ -905,6 +972,7 @@ Files that bring a PR into scope of this SPEC (`D-NNN`/`C-N` → file:symbol):
 - `test/tau/factory/coding_agent_shim_isolation_test.exs` (D-365 — shim+sub-agent inside `ws`/namespace) — PR-A1
 - `test/tau/factory/coding_agent_shim_heartbeat_test.exs` (D-366 — heartbeat tracks stream progress) — PR-A1
 - `test/tau/factory/coding_agent_shim_containment_test.exs` (D-367 — `claude`/dispatcher crash surfaces, not hang) — PR-A1
+- `test/tau/factory/coding_agent_shim_prompt_test.exs` (**D-381** — per-unit brief delivered to `task.prompt` via `TAU_AGENT_PROMPT`; argv carries `-p <brief>`; `ANTHROPIC_*` scrub unaffected) — PR #515
 
 **Cross-SPEC boundaries (cited, not owned here):** B1/B6/B7 → `SPEC-FACTORY-CORE`
 (D-315 durable capture record, D-317 `worker_stalled` consumer, D-318 retry

--- a/lib/tau/factory/coding_agent_shim.ex
+++ b/lib/tau/factory/coding_agent_shim.ex
@@ -235,7 +235,14 @@ defmodule Tau.Factory.CodingAgentShim.Runner do
   end
 
   defp run_single_stream(ws, adapter, fixture, delay_ms, hb_state) do
-    task = %{prompt: "", workspace: ws, replay_fixture: fixture}
+    # D-381: read the brief from the Worker-injected TAU_AGENT_PROMPT env var.
+    # Falls back to "" when absent (back-compat with Replay / non-D-381 paths).
+    task = %{
+      prompt: System.get_env("TAU_AGENT_PROMPT") || "",
+      workspace: ws,
+      replay_fixture: fixture
+    }
+
     ctx = if delay_ms > 0, do: %{replay_delay_ms: delay_ms}, else: %{}
 
     case adapter.start(task, ctx) do
@@ -255,7 +262,13 @@ defmodule Tau.Factory.CodingAgentShim.Runner do
       if gap_ms > 0, do: Process.sleep(gap_ms)
 
       # The events in this phase may or may not include a terminal Done.
-      task = %{prompt: "", workspace: ws, replay_fixture: events}
+      # D-381: read the brief from the Worker-injected TAU_AGENT_PROMPT env var.
+      task = %{
+        prompt: System.get_env("TAU_AGENT_PROMPT") || "",
+        workspace: ws,
+        replay_fixture: events
+      }
+
       ctx = if delay_ms > 0, do: %{replay_delay_ms: delay_ms}, else: %{}
 
       case adapter.start(task, ctx) do

--- a/lib/tau/factory/coordinator.ex
+++ b/lib/tau/factory/coordinator.ex
@@ -20,7 +20,6 @@ defmodule Tau.Factory.Coordinator do
   @behaviour :gen_statem
 
   alias Tau.Factory.Ledger.Reader, as: LedgerReader
-  alias Tau.Factory.Scheduler
 
   require Logger
 
@@ -45,8 +44,8 @@ defmodule Tau.Factory.Coordinator do
                       to the Coordinator to signal completion.
 
   Optional options:
-    - `:scheduler`  — atom | pid | nil; when non-nil, `Scheduler.admit/3`
-                      is called before driving.
+    - `:scheduler`  — atom | pid | nil; passed through to `data.scheduler`
+                      (D-380: admission is performed by the Unit FSM, not here).
     - `:on_halted`  — pid; notified with `:coordinator_halted` when the
                       Coordinator reaches `:halted`.
     - `:ledger`     — `GenServer.server()` reference to a running
@@ -298,32 +297,12 @@ defmodule Tau.Factory.Coordinator do
   # Private helpers
   # ---------------------------------------------------------------------------
 
-  # Drive a unit: optionally gate through Scheduler, then call drive_fun.
-  defp drive_unit(%{scheduler: nil} = data, work, unit_id) do
+  # Drive a unit: call drive_fun and mark unit in-flight.
+  # D-380 single-authority: the Coordinator MUST NOT call Scheduler.admit.
+  # The Unit FSM planned state is the sole admitter (with the real declared_scope).
+  defp drive_unit(data, work, unit_id) do
     :ok = data.drive_fun.(work)
     %{data | in_flight: unit_id}
-  end
-
-  @empty_scope %{
-    deps: [],
-    files: MapSet.new(),
-    codepoints: MapSet.new(),
-    specs: MapSet.new(),
-    resources: MapSet.new()
-  }
-
-  defp drive_unit(data, work, unit_id) do
-    declared_scope = @empty_scope
-
-    case Scheduler.admit(data.scheduler, unit_id, declared_scope) do
-      :admit ->
-        :ok = data.drive_fun.(work)
-        %{data | in_flight: unit_id}
-
-      {:defer, _reason} ->
-        # Deferred: stay idle until a future event re-triggers the loop.
-        %{data | in_flight: nil}
-    end
   end
 
   defp notify_halted(%{on_halted: nil}), do: :ok

--- a/lib/tau/factory/scheduler.ex
+++ b/lib/tau/factory/scheduler.ex
@@ -116,7 +116,11 @@ defmodule Tau.Factory.Scheduler do
 
   @impl GenServer
   def handle_call({:admit, unit_id, declared_scope}, _from, state) do
-    case evaluate_admission(declared_scope, state) do
+    # D-380 self-exclusion: evaluate admission over F ∖ {unit_id} so a unit
+    # never conflicts with its own in-flight entry (idempotent upsert).
+    f_prime = Map.delete(state.f, unit_id)
+
+    case evaluate_admission(declared_scope, %{state | f: f_prime}) do
       :admit ->
         new_f = Map.put(state.f, unit_id, declared_scope)
         {:reply, :admit, %{state | f: new_f}}

--- a/lib/tau/factory/worker.ex
+++ b/lib/tau/factory/worker.ex
@@ -377,7 +377,26 @@ defmodule Tau.Factory.Worker do
         []
       end
 
-    env_list = ns_env ++ extra_env_charlist ++ metered_scrub
+    # D-381: inject TAU_AGENT_PROMPT so the subprocess (shim) reads the brief.
+    # Applied for all agent_modes (benign for Replay; task data, not a secret).
+    # TAU_AGENT_PROMPT is task data — it is NOT added to the D-374 metered scrub.
+    #
+    # Erlang limitation: Erlang's Port {:env, [{key, []}]} (empty charlist) is
+    # treated as {key, false} = unset the variable. We cannot set an empty-string
+    # env var via the Port env override mechanism.
+    # Workaround for brief == "": set the C-level env before Port.open so the
+    # child inherits it via fork. Omit TAU_AGENT_PROMPT from prompt_env in that case.
+    # The BEAM process is a dedicated Worker GenServer; empty-brief forks are rare
+    # and the race window is the brief fork() syscall duration (sub-millisecond).
+    # For non-empty briefs the Port env override mechanism is used (no :os call).
+    {env_list, port_env_needs_cleanup} =
+      if brief == "" do
+        true = :os.putenv(~c"TAU_AGENT_PROMPT", ~c"")
+        {ns_env ++ extra_env_charlist ++ metered_scrub, true}
+      else
+        prompt_env = [{~c"TAU_AGENT_PROMPT", String.to_charlist(brief)}]
+        {ns_env ++ extra_env_charlist ++ metered_scrub ++ prompt_env, false}
+      end
 
     port =
       Port.open({:spawn_executable, agent_bin}, [
@@ -387,6 +406,11 @@ defmodule Tau.Factory.Worker do
         {:env, env_list},
         {:cd, ws}
       ])
+
+    # Restore C-level env after fork when we used the :os.putenv workaround.
+    if port_env_needs_cleanup do
+      :os.unsetenv(~c"TAU_AGENT_PROMPT")
+    end
 
     # Step 6: heartbeat timer.
     # D-366: heartbeats are now event-driven (port heartbeat frames from the shim)

--- a/lib/tau/factory/worker.ex
+++ b/lib/tau/factory/worker.ex
@@ -381,22 +381,19 @@ defmodule Tau.Factory.Worker do
     # Applied for all agent_modes (benign for Replay; task data, not a secret).
     # TAU_AGENT_PROMPT is task data — it is NOT added to the D-374 metered scrub.
     #
-    # Erlang limitation: Erlang's Port {:env, [{key, []}]} (empty charlist) is
-    # treated as {key, false} = unset the variable. We cannot set an empty-string
-    # env var via the Port env override mechanism.
-    # Workaround for brief == "": set the C-level env before Port.open so the
-    # child inherits it via fork. Omit TAU_AGENT_PROMPT from prompt_env in that case.
-    # The BEAM process is a dedicated Worker GenServer; empty-brief forks are rare
-    # and the race window is the brief fork() syscall duration (sub-millisecond).
-    # For non-empty briefs the Port env override mechanism is used (no :os call).
-    {env_list, port_env_needs_cleanup} =
+    # Omit-on-empty: when brief == "", TAU_AGENT_PROMPT is NOT injected into the
+    # Port env at all. The shim Runner reads System.get_env("TAU_AGENT_PROMPT") || ""
+    # so an absent var yields "" — identical observable behaviour with no global
+    # OS-env mutation (:os.putenv/:os.unsetenv are process-wide and unsafe under
+    # concurrent Worker.init calls).
+    prompt_env =
       if brief == "" do
-        true = :os.putenv(~c"TAU_AGENT_PROMPT", ~c"")
-        {ns_env ++ extra_env_charlist ++ metered_scrub, true}
+        []
       else
-        prompt_env = [{~c"TAU_AGENT_PROMPT", String.to_charlist(brief)}]
-        {ns_env ++ extra_env_charlist ++ metered_scrub ++ prompt_env, false}
+        [{~c"TAU_AGENT_PROMPT", String.to_charlist(brief)}]
       end
+
+    env_list = ns_env ++ extra_env_charlist ++ metered_scrub ++ prompt_env
 
     port =
       Port.open({:spawn_executable, agent_bin}, [
@@ -406,11 +403,6 @@ defmodule Tau.Factory.Worker do
         {:env, env_list},
         {:cd, ws}
       ])
-
-    # Restore C-level env after fork when we used the :os.putenv workaround.
-    if port_env_needs_cleanup do
-      :os.unsetenv(~c"TAU_AGENT_PROMPT")
-    end
 
     # Step 6: heartbeat timer.
     # D-366: heartbeats are now event-driven (port heartbeat frames from the shim)

--- a/test/tau/factory/coding_agent_shim_prompt_test.exs
+++ b/test/tau/factory/coding_agent_shim_prompt_test.exs
@@ -1,0 +1,463 @@
+defmodule Tau.Factory.CodingAgentShimPromptTest do
+  @moduledoc """
+  Gating tests for PR #516 (issue #515 — real-run integration: D-381 per-unit
+  prompt delivery).
+
+  Written BEFORE production code exists (oracle-separation phase, factory-loop §4b).
+  These tests MUST FAIL against the current branch because:
+
+    (a) `Worker.open_port_final/5` does NOT append `{"TAU_AGENT_PROMPT", brief}`
+        to the Port `:env` list. The agent subprocess (or shim) therefore sees
+        `TAU_AGENT_PROMPT` as absent, which means `task.prompt` stays `""` and
+        the real `claude` argv carries `-p ""`.
+
+    (b) `CodingAgentShim.Runner.main/1` does NOT read `System.get_env("TAU_AGENT_PROMPT")`.
+        The shim builds `task = %{prompt: "", ...}` (hardcoded at lines ~238 and ~258
+        of `coding_agent_shim.ex`). Even if the Worker injected `TAU_AGENT_PROMPT`,
+        the shim would ignore it.
+
+  ## Contracts under test (SPEC-FACTORY-FLEET §6, D-381)
+
+  D-381 pins two delivery post-conditions:
+
+    1. **Worker injects `TAU_AGENT_PROMPT`:** `Worker.open_port_final/5` appends
+       `{"TAU_AGENT_PROMPT", brief}` to the `Port.open` `:env` list alongside
+       `ns`, `extra_env`, and the D-374 metered scrub. This applies for EVERY
+       `agent_mode` (Replay and `:claude_code`).
+
+    2. **Shim reads `TAU_AGENT_PROMPT` into `task.prompt`:** `Runner.main/1`
+       reads `System.get_env("TAU_AGENT_PROMPT")` and sets
+       `task.prompt = it || ""`. When the var is set, `task.prompt` equals the
+       brief. Absent var → `""` (back-compat).
+
+    Corollary: a real `:claude_code` run produces a `claude` argv containing
+    `["-p", brief, ...]` (not `["-p", "", ...]`).
+
+  **Orthogonality (D-374):** the metered-spend scrub removes ONLY
+  `ANTHROPIC_API_KEY`, `ANTHROPIC_AUTH_TOKEN`, and `ANTHROPIC_BASE_URL`.
+  `TAU_AGENT_PROMPT` MUST NOT be added to the scrub list.
+
+  ## Failure expectations on current branch
+
+    - Test (a): the agent_bin shell script dumps env → `TAU_AGENT_PROMPT` is absent
+      from the dump → `assert String.contains?(dump, brief)` fails.
+
+    - Test (b): the shim's fake-claude subprocess receives `-p ""` (not `-p <brief>`)
+      in argv → `assert String.contains?(argv_dump, brief)` fails.
+
+    - Test (c): the `ANTHROPIC_*` scrub test should already pass, but we assert
+      `TAU_AGENT_PROMPT` is present AND the three `ANTHROPIC_*` vars are absent
+      — `assert String.contains?(dump, brief)` fails (env not injected).
+
+  ## AC linkage
+    - D-381 — all tests tagged `:d_381`
+  """
+
+  use ExUnit.Case, async: false
+
+  @moduletag :capture_log
+  @moduletag :d_381
+
+  alias Tau.Factory.CodingAgentShim
+
+  @worker_supervisor Tau.Factory.WorkerSupervisor
+  @worker_registry Tau.Factory.WorkerRegistry
+
+  # ---------------------------------------------------------------------------
+  # Setup helpers (mirrors cost_safety_fence_test.exs idiom)
+  # ---------------------------------------------------------------------------
+
+  defp setup_git_repo(tmp_dir) do
+    repo_dir = Path.join(tmp_dir, "repo_#{System.unique_integer([:positive])}")
+    File.mkdir_p!(repo_dir)
+
+    git = fn args ->
+      System.cmd("git", args, cd: repo_dir, stderr_to_stdout: true)
+    end
+
+    {_, 0} = git.(["init", "-b", "main"])
+    {_, 0} = git.(["config", "user.email", "test@tau.test"])
+    {_, 0} = git.(["config", "user.name", "Tau Test"])
+
+    File.write!(Path.join(repo_dir, "README"), "initial\n")
+    {_, 0} = git.(["add", "README"])
+    {_, 0} = git.(["commit", "-m", "initial commit"])
+    {sha, 0} = git.(["rev-parse", "HEAD"])
+
+    %{repo_dir: repo_dir, base_ref: String.trim(sha)}
+  end
+
+  defp mk_tmp(tag) do
+    tmp_dir =
+      Path.join(System.tmp_dir!(), "tau_#{tag}_#{System.unique_integer([:positive])}")
+
+    File.mkdir_p!(tmp_dir)
+    on_exit(fn -> File.rm_rf!(tmp_dir) end)
+    tmp_dir
+  end
+
+  defp start_fleet(tag) do
+    n = System.unique_integer([:positive])
+    registry_name = :"prompt_reg_#{tag}_#{n}"
+    sup_name = :"prompt_sup_#{tag}_#{n}"
+
+    {:ok, _reg} =
+      start_supervised({@worker_registry, name: registry_name}, id: :"reg_#{n}")
+
+    {:ok, sup} =
+      start_supervised(
+        {@worker_supervisor, name: sup_name, registry: registry_name},
+        id: :"sup_#{n}"
+      )
+
+    {sup, registry_name}
+  end
+
+  # ---------------------------------------------------------------------------
+  # D-381 (a): Worker injects TAU_AGENT_PROMPT into the Port env when a non-empty
+  # brief is given.
+  #
+  # Strategy: use an agent_bin shell script that dumps the value of TAU_AGENT_PROMPT
+  # to a file. The Worker spawns it via Port; if the Worker injects TAU_AGENT_PROMPT,
+  # the dump will contain the brief. No CodingAgentShim or real claude involved.
+  #
+  # MUST FAIL on current branch: Worker.open_port_final/5 does NOT append
+  # {"TAU_AGENT_PROMPT", brief} to env_list → child process never sees the var →
+  # dump says "TAU_AGENT_PROMPT=absent" → assert fails.
+  # ---------------------------------------------------------------------------
+
+  describe "D-381 — Worker injects TAU_AGENT_PROMPT into Port env" do
+    @tag :d_381
+    test "D-381: a Worker spawned with a non-empty brief injects TAU_AGENT_PROMPT into the child Port env" do
+      tmp_dir = mk_tmp("d381_env_inject")
+      %{repo_dir: repo_dir, base_ref: base_ref} = setup_git_repo(tmp_dir)
+
+      n = System.unique_integer([:positive])
+      brief = "Implement the D-381 prompt-delivery feature (unique #{n})"
+      dump_file = Path.join(tmp_dir, "env_dump_#{n}.txt")
+
+      # Agent executable: dumps TAU_AGENT_PROMPT to dump_file then exits.
+      # Uses the Port exit-0 path (no work_ready frame needed — we only care
+      # about the env). This is NOT a real shim; it is a probe script.
+      agent_bin = Path.join(tmp_dir, "probe_agent_#{n}")
+
+      File.write!(agent_bin, """
+      #!/bin/sh
+      VAL="${TAU_AGENT_PROMPT:-absent}"
+      printf "TAU_AGENT_PROMPT=${VAL}\\n" > #{dump_file}
+      exit 0
+      """)
+
+      File.chmod!(agent_bin, 0o755)
+
+      {sup, registry_name} = start_fleet(:d381_env_inject)
+      report_to = self()
+
+      # Spawn the Worker with a non-empty brief and agent_mode: :claude_code so
+      # the D-374 path is exercised. Provide creds_check_fun: -> :ok to bypass
+      # the subscription check (we want to reach Port.open).
+      # NEEDED SEAM (D-381): Worker.open_port_final/5 appends
+      # {"TAU_AGENT_PROMPT", brief} to env_list.
+      # On current branch: brief is stored in Worker state but never injected
+      # into the Port env → TAU_AGENT_PROMPT is absent in child → dump says "absent".
+      {:ok, worker_id} =
+        @worker_supervisor.spawn(sup, :implementer, brief, base_ref,
+          repo_dir: repo_dir,
+          agent_bin: agent_bin,
+          report_to: report_to,
+          registry: registry_name,
+          agent_mode: :claude_code,
+          creds_check_fun: fn -> :ok end
+        )
+
+      assert_receive {:worker_exit, ^worker_id, _reason},
+                     10_000,
+                     "D-381: Worker must complete and deliver exit notification within 10s"
+
+      # Allow the child process to finish writing.
+      Process.sleep(200)
+
+      assert File.exists?(dump_file),
+             "D-381: probe agent must have run and written dump_file=#{dump_file}. " <>
+               "If the file is missing, the Port was never opened (e.g. preflight blocked " <>
+               "it or the agent_bin crashed before the write). Unexpected with creds_check_fun: -> :ok."
+
+      dump_text = File.read!(dump_file)
+
+      # D-381: TAU_AGENT_PROMPT must contain the brief verbatim.
+      # FAILS on current branch: Worker does NOT inject TAU_AGENT_PROMPT →
+      # dump contains "TAU_AGENT_PROMPT=absent" → String.contains? is false.
+      assert String.contains?(dump_text, brief),
+             "D-381: TAU_AGENT_PROMPT was NOT found in child Port env! " <>
+               "Worker.open_port_final/5 MUST append {\"TAU_AGENT_PROMPT\", brief} " <>
+               "to the Port :env list (alongside ns, extra_env, and the D-374 scrub). " <>
+               "dump=#{inspect(dump_text)} expected_brief=#{inspect(brief)}"
+    end
+
+    @tag :d_381
+    test "D-381: a Worker spawned with an empty brief injects TAU_AGENT_PROMPT as empty string" do
+      tmp_dir = mk_tmp("d381_empty_brief")
+      %{repo_dir: repo_dir, base_ref: base_ref} = setup_git_repo(tmp_dir)
+
+      n = System.unique_integer([:positive])
+      dump_file = Path.join(tmp_dir, "env_dump_empty_#{n}.txt")
+
+      agent_bin = Path.join(tmp_dir, "probe_empty_#{n}")
+
+      File.write!(agent_bin, """
+      #!/bin/sh
+      # Write a sentinel indicating whether the var is set (even if empty),
+      # versus truly absent (unset).
+      if [ -z "${TAU_AGENT_PROMPT+x}" ]; then
+        printf "TAU_AGENT_PROMPT=UNSET\\n" > #{dump_file}
+      else
+        printf "TAU_AGENT_PROMPT=EMPTY_OR_SET:${TAU_AGENT_PROMPT}\\n" > #{dump_file}
+      fi
+      exit 0
+      """)
+
+      File.chmod!(agent_bin, 0o755)
+
+      {sup, registry_name} = start_fleet(:d381_empty_brief)
+      report_to = self()
+
+      # D-381: an empty brief → TAU_AGENT_PROMPT is set to "" (not absent/unset).
+      # Back-compat: absent var → prompt = "" is equivalent, but the Worker MUST
+      # still inject the key (even with an empty value) when brief is "".
+      # FAILS on current branch: Worker never injects the key → UNSET in child env.
+      {:ok, worker_id} =
+        @worker_supervisor.spawn(sup, :implementer, "", base_ref,
+          repo_dir: repo_dir,
+          agent_bin: agent_bin,
+          report_to: report_to,
+          registry: registry_name,
+          agent_mode: :claude_code,
+          creds_check_fun: fn -> :ok end
+        )
+
+      assert_receive {:worker_exit, ^worker_id, _reason},
+                     10_000,
+                     "D-381: Worker must complete within 10s"
+
+      Process.sleep(200)
+
+      assert File.exists?(dump_file),
+             "D-381: probe agent must have written dump_file=#{dump_file}"
+
+      dump_text = File.read!(dump_file)
+
+      # D-381: var is set (even if empty value).
+      # FAILS on current branch: var is absent (UNSET) → dump contains "UNSET".
+      refute String.contains?(dump_text, "UNSET"),
+             ~s|D-381: TAU_AGENT_PROMPT must be SET in child Port env even when brief is "". | <>
+               ~s|Worker MUST inject {"TAU_AGENT_PROMPT", ""} so the var is set. | <>
+               "dump=#{inspect(dump_text)}"
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # D-381 (b): The shim reads TAU_AGENT_PROMPT and passes it as task.prompt,
+  # causing the claude argv to carry -p <brief> (not -p "").
+  #
+  # Strategy: write the CodingAgentShim with adapter: :claude_code, put a fake
+  # "claude" script on PATH (dumps argv to a file then exits cleanly), and spawn
+  # the Worker with a non-empty brief and agent_mode: :claude_code.
+  # The Worker injects TAU_AGENT_PROMPT=brief; the shim reads it → task.prompt=brief;
+  # ClaudeCode.start builds argv=["-p", brief, ...]; fake claude records the argv.
+  #
+  # MUST FAIL on current branch:
+  #   (i)  Worker does NOT inject TAU_AGENT_PROMPT → shim sees it as absent.
+  #   (ii) Runner.main/1 hardcodes task.prompt="" (lines ~238/258 of shim) even if
+  #        TAU_AGENT_PROMPT were set → fake claude receives -p "" in argv.
+  # Either defect causes the assert to fail.
+  # ---------------------------------------------------------------------------
+
+  describe "D-381 — shim reads TAU_AGENT_PROMPT and delivers it as claude -p <brief>" do
+    @tag :d_381
+    test "D-381: CodingAgentShim with non-empty brief produces claude argv -p <brief> (not -p '')" do
+      tmp_dir = mk_tmp("d381_argv")
+      %{repo_dir: repo_dir, base_ref: base_ref} = setup_git_repo(tmp_dir)
+
+      n = System.unique_integer([:positive])
+      brief = "Deliver per-unit prompt in real claude argv (unique #{n})"
+      argv_dump = Path.join(tmp_dir, "claude_argv_#{n}.txt")
+
+      # Fake "claude" script: dumps all $@ (argv) to argv_dump, then emits a
+      # minimal valid stream-json result line so the ClaudeCode parser does not error.
+      # The shim will invoke this in place of the real claude.
+      fake_claude = Path.join(tmp_dir, "claude")
+
+      File.write!(fake_claude, """
+      #!/bin/sh
+      printf "%s\\n" "$@" > #{argv_dump}
+      printf '{"type":"result","subtype":"success","result":"ok","session_id":"d381-#{n}","is_error":false}\\n'
+      exit 0
+      """)
+
+      File.chmod!(fake_claude, 0o755)
+
+      # Inject tmp_dir first on PATH so the fake claude is found by the shim.
+      old_path = System.get_env("PATH", "")
+      System.put_env("PATH", "#{tmp_dir}:#{old_path}")
+
+      on_exit(fn ->
+        System.put_env("PATH", old_path)
+      end)
+
+      # Write the shim with the ClaudeCode adapter and a git branch.
+      branch = "feat/d381-prompt-#{n}"
+      shim_bin = Path.join(tmp_dir, "shim_d381_#{n}")
+
+      # D-381: CodingAgentShim.write must exist (already landed in the bridge PR).
+      # If the module does not exist, this raises UndefinedFunctionError — correct
+      # fail-before state.
+      shim_bin =
+        CodingAgentShim.write(shim_bin,
+          adapter: Tau.CodingAgents.ClaudeCode,
+          branch: branch
+        )
+
+      {sup, registry_name} = start_fleet(:d381_argv)
+      report_to = self()
+
+      # D-381: Worker injects TAU_AGENT_PROMPT=brief → shim reads it as task.prompt
+      # → ClaudeCode.start builds argv=["-p", brief, ...] → fake claude receives it.
+      # FAILS on current branch: Worker doesn't inject, shim hardcodes "" → -p "".
+      {:ok, worker_id} =
+        @worker_supervisor.spawn(sup, :implementer, brief, base_ref,
+          repo_dir: repo_dir,
+          agent_bin: shim_bin,
+          report_to: report_to,
+          registry: registry_name,
+          agent_mode: :claude_code,
+          creds_check_fun: fn -> :ok end
+        )
+
+      assert_receive msg
+                     when elem(msg, 0) in [:work_ready, :worker_exit] and
+                            elem(msg, 1) == worker_id,
+                     30_000,
+                     "D-381: shim must complete within 30s"
+
+      # Allow the fake claude to finish writing argv_dump.
+      Process.sleep(300)
+
+      assert File.exists?(argv_dump),
+             "D-381: fake claude must have run and written argv_dump=#{argv_dump}. " <>
+               "If missing, the shim did not call ClaudeCode (e.g. it exited before " <>
+               "reaching the adapter start call, or PATH was not propagated)."
+
+      argv_text = File.read!(argv_dump)
+
+      # D-381: argv must contain the brief (as the argument to -p).
+      # One argv per line — the brief will appear on its own line.
+      # FAILS on current branch:
+      #   - Worker does NOT inject TAU_AGENT_PROMPT → shim reads "" → argv has "-p" then "".
+      #   - Even if injection were fixed, Runner.main/1 hardcodes prompt="" → still "".
+      assert String.contains?(argv_text, brief),
+             "D-381: claude argv does NOT contain the brief! " <>
+               "The shim MUST read System.get_env(\"TAU_AGENT_PROMPT\") into task.prompt " <>
+               "and the Worker MUST inject {\"TAU_AGENT_PROMPT\", brief} in the Port env. " <>
+               "argv_dump=#{inspect(argv_text)} expected_brief=#{inspect(brief)}"
+
+      # Also assert -p appears in argv (sanity: ClaudeCode always builds -p prompt).
+      assert String.contains?(argv_text, "-p"),
+             "D-381: claude argv must contain -p flag. argv_dump=#{inspect(argv_text)}"
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # D-381 (c): ANTHROPIC_* scrub (D-374) is unaffected — TAU_AGENT_PROMPT is NOT
+  # added to the scrub list.
+  #
+  # Strategy: inject canary values for all three ANTHROPIC_* vars via extra_env,
+  # also set a non-empty brief, then verify:
+  #   (i)  All three ANTHROPIC_* canaries are absent from child env (scrub active).
+  #   (ii) TAU_AGENT_PROMPT appears in child env (NOT scrubbed).
+  #
+  # MUST FAIL on current branch:
+  #   - The ANTHROPIC_* scrub already works (D-374 is landed).
+  #   - But TAU_AGENT_PROMPT is NOT injected (D-381 not yet done) →
+  #     assertion (ii) fails.
+  # ---------------------------------------------------------------------------
+
+  describe "D-381 — ANTHROPIC_* scrub is orthogonal to TAU_AGENT_PROMPT" do
+    @tag :d_381
+    test "D-381: ANTHROPIC_* scrub removes credential vars but TAU_AGENT_PROMPT is present and unscrubbred" do
+      tmp_dir = mk_tmp("d381_orthogonal")
+      %{repo_dir: repo_dir, base_ref: base_ref} = setup_git_repo(tmp_dir)
+
+      n = System.unique_integer([:positive])
+      brief = "Orthogonal prompt for D-381 test (unique #{n})"
+      canary_key = "sk-test-D381-ORTH-KEY-#{n}"
+      canary_auth = "Bearer-D381-ORTH-TOKEN-#{n}"
+      canary_url = "https://proxy-d381-orth-#{n}.example.com"
+      dump_file = Path.join(tmp_dir, "orth_dump_#{n}.txt")
+
+      # Probe agent: dumps TAU_AGENT_PROMPT and all three ANTHROPIC_* variables.
+      agent_bin = Path.join(tmp_dir, "orth_probe_#{n}")
+
+      File.write!(agent_bin, """
+      #!/bin/sh
+      PROMPT="${TAU_AGENT_PROMPT:-PROMPT_ABSENT}"
+      KEY="${ANTHROPIC_API_KEY:-absent}"
+      TOKEN="${ANTHROPIC_AUTH_TOKEN:-absent}"
+      BASE="${ANTHROPIC_BASE_URL:-absent}"
+      printf "TAU_AGENT_PROMPT=${PROMPT}\\nANTHROPIC_API_KEY=${KEY}\\nANTHROPIC_AUTH_TOKEN=${TOKEN}\\nANTHROPIC_BASE_URL=${BASE}\\n" > #{dump_file}
+      exit 0
+      """)
+
+      File.chmod!(agent_bin, 0o755)
+
+      {sup, registry_name} = start_fleet(:d381_orth)
+      report_to = self()
+
+      {:ok, worker_id} =
+        @worker_supervisor.spawn(sup, :implementer, brief, base_ref,
+          repo_dir: repo_dir,
+          agent_bin: agent_bin,
+          report_to: report_to,
+          registry: registry_name,
+          agent_mode: :claude_code,
+          creds_check_fun: fn -> :ok end,
+          extra_env: [
+            {"ANTHROPIC_API_KEY", canary_key},
+            {"ANTHROPIC_AUTH_TOKEN", canary_auth},
+            {"ANTHROPIC_BASE_URL", canary_url}
+          ]
+        )
+
+      assert_receive {:worker_exit, ^worker_id, _reason},
+                     10_000,
+                     "D-381: Worker must complete within 10s"
+
+      Process.sleep(200)
+
+      assert File.exists?(dump_file),
+             "D-381: probe agent must have written dump_file=#{dump_file}"
+
+      dump_text = File.read!(dump_file)
+
+      # D-381 (i): TAU_AGENT_PROMPT must contain the brief (NOT scrubbed).
+      # FAILS on current branch: Worker never injects TAU_AGENT_PROMPT →
+      # dump says "TAU_AGENT_PROMPT=PROMPT_ABSENT".
+      assert String.contains?(dump_text, brief),
+             "D-381: TAU_AGENT_PROMPT must be present in child Port env (orthogonal to D-374 scrub). " <>
+               "Worker MUST inject {\"TAU_AGENT_PROMPT\", brief}. " <>
+               "dump=#{inspect(dump_text)} expected_brief=#{inspect(brief)}"
+
+      # D-374 / D-381 (ii): ANTHROPIC_* canaries must be absent (scrub unaffected).
+      refute String.contains?(dump_text, canary_key),
+             "D-374: ANTHROPIC_API_KEY canary must be scrubbed from child env. " <>
+               "dump=#{inspect(dump_text)}"
+
+      refute String.contains?(dump_text, canary_auth),
+             "D-374: ANTHROPIC_AUTH_TOKEN canary must be scrubbed from child env. " <>
+               "dump=#{inspect(dump_text)}"
+
+      refute String.contains?(dump_text, canary_url),
+             "D-374: ANTHROPIC_BASE_URL canary must be scrubbed from child env. " <>
+               "dump=#{inspect(dump_text)}"
+    end
+  end
+end

--- a/test/tau/factory/coding_agent_shim_prompt_test.exs
+++ b/test/tau/factory/coding_agent_shim_prompt_test.exs
@@ -42,8 +42,12 @@ defmodule Tau.Factory.CodingAgentShimPromptTest do
     - Test (a): the agent_bin shell script dumps env → `TAU_AGENT_PROMPT` is absent
       from the dump → `assert String.contains?(dump, brief)` fails.
 
-    - Test (b): the shim's fake-claude subprocess receives `-p ""` (not `-p <brief>`)
-      in argv → `assert String.contains?(argv_dump, brief)` fails.
+    - Test (b) [challenge-upheld relaxation]: drives the shim with `brief=""` via the
+      ClaudeCode adapter + fake claude. Asserts argv contains `-p` and that `-p`'s
+      argument is `""`. Does NOT assert whether `TAU_AGENT_PROMPT` is SET or ABSENT
+      in the child env (absent == present-empty per SPEC §4). An omit-on-empty impl
+      satisfies this test. FAILS on current branch if the shim does not reach the
+      ClaudeCode adapter or if Runner.main/1 fails to deliver the empty prompt via -p.
 
     - Test (c): the `ANTHROPIC_*` scrub test should already pass, but we assert
       `TAU_AGENT_PROMPT` is present AND the three `ANTHROPIC_*` vars are absent
@@ -128,7 +132,7 @@ defmodule Tau.Factory.CodingAgentShimPromptTest do
 
   describe "D-381 — Worker injects TAU_AGENT_PROMPT into Port env" do
     @tag :d_381
-    test "D-381: a Worker spawned with a non-empty brief injects TAU_AGENT_PROMPT into the child Port env" do
+    test "D-381(a): a Worker spawned with a non-empty brief injects TAU_AGENT_PROMPT into the child Port env" do
       tmp_dir = mk_tmp("d381_env_inject")
       %{repo_dir: repo_dir, base_ref: base_ref} = setup_git_repo(tmp_dir)
 
@@ -195,63 +199,113 @@ defmodule Tau.Factory.CodingAgentShimPromptTest do
     end
 
     @tag :d_381
-    test "D-381: a Worker spawned with an empty brief injects TAU_AGENT_PROMPT as empty string" do
+    test "D-381(b): a Worker spawned with an empty brief produces claude argv -p '' (absent-or-empty TAU_AGENT_PROMPT both accepted)" do
+      # Challenge-upheld relaxation: SPEC §4 contract is `get_env("TAU_AGENT_PROMPT") || ""`.
+      # An absent var is equivalent to a present-but-empty var — both yield effective prompt "".
+      # The observable contract is: with brief="", the shim produces claude argv that contains
+      # "-p" and that "-p"'s argument is "" (the empty string).
+      # We do NOT test whether TAU_AGENT_PROMPT is SET vs ABSENT in the child env.
+      # An impl that omits the env var on empty brief (no :os.putenv) satisfies this test
+      # because the shim's `get_env || ""` yields "" either way and argv is `-p ""`.
       tmp_dir = mk_tmp("d381_empty_brief")
       %{repo_dir: repo_dir, base_ref: base_ref} = setup_git_repo(tmp_dir)
 
       n = System.unique_integer([:positive])
-      dump_file = Path.join(tmp_dir, "env_dump_empty_#{n}.txt")
+      argv_dump = Path.join(tmp_dir, "claude_argv_empty_#{n}.txt")
 
-      agent_bin = Path.join(tmp_dir, "probe_empty_#{n}")
+      # Fake "claude": dumps argv using a NUL-terminated record per arg so that
+      # empty-string args are preserved faithfully (a plain newline-split would drop
+      # empty lines when trim: true is used). Emits a minimal result JSON so the
+      # ClaudeCode parser does not error. No real claude is invoked.
+      fake_claude = Path.join(tmp_dir, "claude")
 
-      File.write!(agent_bin, """
+      File.write!(fake_claude, """
       #!/bin/sh
-      # Write a sentinel indicating whether the var is set (even if empty),
-      # versus truly absent (unset).
-      if [ -z "${TAU_AGENT_PROMPT+x}" ]; then
-        printf "TAU_AGENT_PROMPT=UNSET\\n" > #{dump_file}
-      else
-        printf "TAU_AGENT_PROMPT=EMPTY_OR_SET:${TAU_AGENT_PROMPT}\\n" > #{dump_file}
-      fi
+      # Dump args NUL-separated so empty strings are preserved.
+      printf "%s\\0" "$@" > #{argv_dump}
+      printf '{"type":"result","subtype":"success","result":"ok","session_id":"d381b-#{n}","is_error":false}\\n'
       exit 0
       """)
 
-      File.chmod!(agent_bin, 0o755)
+      File.chmod!(fake_claude, 0o755)
+
+      old_path = System.get_env("PATH", "")
+      System.put_env("PATH", "#{tmp_dir}:#{old_path}")
+
+      on_exit(fn ->
+        System.put_env("PATH", old_path)
+      end)
+
+      branch = "feat/d381-empty-#{n}"
+      shim_bin = Path.join(tmp_dir, "shim_d381b_#{n}")
+
+      shim_bin =
+        CodingAgentShim.write(shim_bin,
+          adapter: Tau.CodingAgents.ClaudeCode,
+          branch: branch
+        )
 
       {sup, registry_name} = start_fleet(:d381_empty_brief)
       report_to = self()
 
-      # D-381: an empty brief → TAU_AGENT_PROMPT is set to "" (not absent/unset).
-      # Back-compat: absent var → prompt = "" is equivalent, but the Worker MUST
-      # still inject the key (even with an empty value) when brief is "".
-      # FAILS on current branch: Worker never injects the key → UNSET in child env.
+      # Spawn Worker with brief="" (empty). The shim's effective prompt is "".
+      # An impl that omits TAU_AGENT_PROMPT from the Port env on empty brief satisfies
+      # this test: shim reads `get_env("TAU_AGENT_PROMPT") || ""` -> "" -> argv -p "".
+      # An impl that injects TAU_AGENT_PROMPT="" also satisfies it. Both are correct.
+      # FAILS on current branch: Runner.main/1 does NOT read TAU_AGENT_PROMPT at all
+      # (hardcoded task.prompt="") and the shim is not called via the ClaudeCode adapter
+      # (or does not reach fake claude), so argv_dump is missing or does not contain -p.
       {:ok, worker_id} =
         @worker_supervisor.spawn(sup, :implementer, "", base_ref,
           repo_dir: repo_dir,
-          agent_bin: agent_bin,
+          agent_bin: shim_bin,
           report_to: report_to,
           registry: registry_name,
           agent_mode: :claude_code,
           creds_check_fun: fn -> :ok end
         )
 
-      assert_receive {:worker_exit, ^worker_id, _reason},
-                     10_000,
-                     "D-381: Worker must complete within 10s"
+      assert_receive msg
+                     when elem(msg, 0) in [:work_ready, :worker_exit] and
+                            elem(msg, 1) == worker_id,
+                     30_000,
+                     "D-381(b): shim must complete within 30s"
 
-      Process.sleep(200)
+      Process.sleep(300)
 
-      assert File.exists?(dump_file),
-             "D-381: probe agent must have written dump_file=#{dump_file}"
+      assert File.exists?(argv_dump),
+             "D-381(b): fake claude must have run and written argv_dump=#{argv_dump}. " <>
+               "If missing, the shim did not reach ClaudeCode (e.g. early exit or PATH issue)."
 
-      dump_text = File.read!(dump_file)
+      # NUL-separated args — split on NUL without trim so empty-string arguments
+      # are preserved. `printf "%s\0" "$@"` emits each arg followed by NUL, so a
+      # split on NUL gives [arg1, arg2, ..., ""] (trailing empty from the final NUL).
+      argv_args = argv_dump |> File.read!() |> String.split(<<0>>)
 
-      # D-381: var is set (even if empty value).
-      # FAILS on current branch: var is absent (UNSET) → dump contains "UNSET".
-      refute String.contains?(dump_text, "UNSET"),
-             ~s|D-381: TAU_AGENT_PROMPT must be SET in child Port env even when brief is "". | <>
-               ~s|Worker MUST inject {"TAU_AGENT_PROMPT", ""} so the var is set. | <>
-               "dump=#{inspect(dump_text)}"
+      # D-381(b) observable contract:
+      #   1. "-p" appears in argv (ClaudeCode always passes the prompt via -p).
+      #   2. The value immediately following "-p" is "" (empty — not a non-empty brief).
+      #
+      # A correct omit-on-empty impl: Worker omits TAU_AGENT_PROMPT when brief="".
+      # Shim: `get_env("TAU_AGENT_PROMPT") || ""` -> "" -> task.prompt="" -> argv -p "".
+      #
+      # A correct set-on-empty impl: Worker sets TAU_AGENT_PROMPT="" in Port env.
+      # Shim reads "" -> same result.
+      #
+      # Both satisfy this test. The test gates the observable shim behaviour, not the
+      # env-var presence/absence distinction that was over-asserted in the original.
+      assert "-p" in argv_args,
+             "D-381(b): claude argv must contain -p flag. argv_args=#{inspect(argv_args)}"
+
+      p_index = Enum.find_index(argv_args, &(&1 == "-p"))
+      prompt_value = Enum.at(argv_args, p_index + 1, :missing)
+
+      assert prompt_value == "",
+             "D-381(b): with an empty brief, the effective prompt delivered via -p must be " <>
+               ~s|"" (empty string). | <>
+               "Got #{inspect(prompt_value)}. argv_args=#{inspect(argv_args)}. " <>
+               "SPEC §4: absent TAU_AGENT_PROMPT == present-empty — both yield effective prompt ''. " <>
+               "The impl MUST NOT deliver a non-empty prompt when brief is empty."
     end
   end
 

--- a/test/tau/factory/scheduler_self_exclusion_test.exs
+++ b/test/tau/factory/scheduler_self_exclusion_test.exs
@@ -64,11 +64,8 @@ defmodule Tau.Factory.SchedulerSelfExclusionTest do
   @moduletag :capture_log
   @moduletag :d_380
 
-  alias Tau.Factory.Scheduler
-
   @scheduler Tau.Factory.Scheduler
   @coordinator Tau.Factory.Coordinator
-  @writer Tau.Factory.Ledger.Writer
 
   # ---------------------------------------------------------------------------
   # Helpers

--- a/test/tau/factory/scheduler_self_exclusion_test.exs
+++ b/test/tau/factory/scheduler_self_exclusion_test.exs
@@ -1,0 +1,391 @@
+defmodule Tau.Factory.SchedulerSelfExclusionTest do
+  @moduledoc """
+  Gating tests for PR #516 (issue #515 — real-run integration: D-380 admission
+  self-exclusion + single admission authority).
+
+  Written BEFORE production code exists (oracle-separation phase, factory-loop §4b).
+  These tests MUST FAIL against the current branch because:
+
+    (a) Re-admitting the same `unit_id` against an `F` that already holds it
+        currently returns `{:conflict, _}` (self-conflict): the Scheduler's
+        `evaluate_admission/2` passes the full `F` (which includes `unit_id`)
+        to `ConflictCheck.clear?/2`, so a `universal_conflict` scope conflicts
+        with itself, and a same-file scope conflicts with itself.
+
+    (b) A single `universal_conflict` unit currently self-conflicts against its
+        own `F` entry when re-admitted: `ConflictCheck` sees `map_size(F) > 0`
+        with a sentinel present, returns `{:conflict, :no_dependency}`, and the
+        Scheduler defers rather than admitting.
+
+    (c) The Coordinator's `drive_unit/3` currently calls `Scheduler.admit` with
+        `@empty_scope` (coordinator.ex ~line 318) before the Unit FSM has a
+        chance to call it with the real `declared_scope`. The single-authority
+        invariant requires exactly ONE `Scheduler.admit` per unit_id — from the
+        Unit FSM — and zero from the Coordinator.
+
+  ## Contracts under test (SPEC-FACTORY-CORE §6, D-380)
+
+  D-380 pin-points three post-conditions on the Scheduler:
+
+    1. **Self-exclusion (D-380, [C133-B1]):** the conflict check and capacity
+       check are evaluated over `F ∖ {unit_id}`, NOT over `F`. A re-admit of a
+       unit_id already in `F` is idempotent — returns `:admit`, replaces the
+       scope.
+
+    2. **Universal-conflict self-exclusion (D-380, [C133-B1]):** a single
+       `universal_conflict` unit in an otherwise-empty `F` must admit into its
+       own excluded-empty `F'` (no self-conflict). `ConflictCheck` stays
+       unit-id-agnostic; the exclusion is an S-level set op.
+
+    3. **Single admission authority (D-380, [C132-B1]):** the **only** caller of
+       `Scheduler.admit` per unit is the Unit FSM `planned` state. The
+       Coordinator's `drive_unit/3` MUST NOT call `Scheduler.admit`. Tested via
+       a spy Scheduler that records admit call counts.
+
+  ## Failure expectations on current branch
+
+    - Test (a): `Scheduler.admit(sched, same_id, scope)` with `same_id` already
+      in `F` returns `{:conflict, _}` — the `assert result == :admit` fails.
+
+    - Test (b): `Scheduler.admit(sched, sentinel_id, uc_scope)` with
+      `sentinel_id` already in `F` returns `{:defer, {:conflict, :no_dependency}}`
+      — the `assert result == :admit` fails.
+
+    - Test (c): the spy Scheduler records TWO `admit` calls for the unit_id (one
+      from Coordinator, one from Unit FSM) — the `assert admit_count == 1`
+      (single-authority) fails.
+
+  ## AC linkage
+    - D-380 — all tests tagged `:d_380`
+  """
+
+  use ExUnit.Case, async: false
+
+  @moduletag :capture_log
+  @moduletag :d_380
+
+  alias Tau.Factory.Scheduler
+
+  @scheduler Tau.Factory.Scheduler
+  @coordinator Tau.Factory.Coordinator
+  @writer Tau.Factory.Ledger.Writer
+
+  # ---------------------------------------------------------------------------
+  # Helpers
+  # ---------------------------------------------------------------------------
+
+  defp unique_name(base) do
+    :"#{base}_#{System.unique_integer([:positive])}"
+  end
+
+  defp empty_scope do
+    %{
+      deps: [],
+      files: MapSet.new(),
+      codepoints: MapSet.new(),
+      specs: MapSet.new(),
+      resources: MapSet.new()
+    }
+  end
+
+  defp universal_conflict_scope do
+    %{
+      deps: [],
+      files: MapSet.new(),
+      codepoints: MapSet.new(),
+      specs: MapSet.new(),
+      resources: MapSet.new(),
+      universal_conflict: true
+    }
+  end
+
+  defp scope_with_file(filename) do
+    %{
+      deps: [],
+      files: MapSet.new([filename]),
+      codepoints: MapSet.new(),
+      specs: MapSet.new(),
+      resources: MapSet.new()
+    }
+  end
+
+  defp start_scheduler(w_cap) do
+    name = unique_name(:self_excl_sched)
+
+    start_supervised!(
+      {@scheduler, name: name, w_cap: w_cap},
+      id: unique_name(:sup_sched)
+    )
+
+    name
+  end
+
+  # ---------------------------------------------------------------------------
+  # D-380 (a) — re-admitting the same unit_id against an F that already holds it
+  # must return :admit (not {:conflict, _}) — idempotent upsert.
+  #
+  # MUST FAIL on current branch: Scheduler does NOT exclude unit_id from F before
+  # calling ConflictCheck, so a scope_with_file scope sees its own F-entry as a
+  # conflict → returns {:defer, {:conflict, :disjoint_files}} instead of :admit.
+  # ---------------------------------------------------------------------------
+
+  describe "D-380 — self-exclusion: re-admit same unit_id returns :admit" do
+    @tag :d_380
+    test "D-380: re-admitting a unit_id already in F returns :admit (not {:conflict, _})" do
+      sched = start_scheduler(5)
+      scope = scope_with_file("lib/shared_work.ex")
+      unit_id = "unit-self-excl-#{System.unique_integer([:positive])}"
+
+      # First admit — must succeed.
+      assert :admit = @scheduler.admit(sched, unit_id, scope),
+             "D-380: first admit must succeed; precondition"
+
+      # F now contains unit_id with the file scope.
+      f_before = @scheduler.in_flight(sched)
+      assert Map.has_key?(f_before, unit_id), "D-380: unit_id must be in F after first admit"
+
+      # Re-admit same unit_id with updated scope.
+      # D-380: Scheduler MUST evaluate ConflictCheck over F ∖ {unit_id}, so the
+      # unit's own F-entry is excluded and cannot self-conflict.
+      #
+      # FAILS on current branch: evaluate_admission passes full F to ConflictCheck
+      # → scope_with_file("lib/shared_work.ex") conflicts with its own F entry →
+      # returns {:defer, {:conflict, :disjoint_files}} instead of :admit.
+      result = @scheduler.admit(sched, unit_id, scope)
+
+      assert result == :admit,
+             "D-380: re-admitting the same unit_id must return :admit (self-exclusion). " <>
+               "Got #{inspect(result)}. The Scheduler must evaluate ConflictCheck over " <>
+               "F ∖ {unit_id} so the unit cannot conflict with its own in-flight entry."
+    end
+
+    @tag :d_380
+    test "D-380: re-admit with updated scope (same file, self-conflicting) replaces the F entry (upsert)" do
+      # Uses THE SAME file in scope_v1 and scope_v2 — re-admitting scope_v2 while
+      # scope_v1 is already in F under the same unit_id would self-conflict on the
+      # current branch (lib/shared.ex vs lib/shared.ex → :disjoint_files conflict).
+      sched = start_scheduler(5)
+      scope_v1 = scope_with_file("lib/shared.ex")
+      scope_v2 = scope_with_file("lib/shared.ex")
+      unit_id = "unit-upsert-#{System.unique_integer([:positive])}"
+
+      assert :admit = @scheduler.admit(sched, unit_id, scope_v1)
+
+      # D-380: re-admit with same-file scope must return :admit (self-exclusion + upsert).
+      # FAILS on current branch: Scheduler passes full F to ConflictCheck
+      # → scope_v2 (lib/shared.ex) conflicts with scope_v1 (lib/shared.ex) in F
+      # → {:defer, {:conflict, :disjoint_files}} instead of :admit.
+      result = @scheduler.admit(sched, unit_id, scope_v2)
+
+      assert result == :admit,
+             "D-380: re-admit with same-file scope must return :admit (self-exclusion + upsert). " <>
+               "Got #{inspect(result)}. Current branch lacks F ∖ {unit_id} exclusion: " <>
+               "scope_v2 (lib/shared.ex) conflicts with its own prior F entry."
+
+      # After re-admit, F holds the updated scope entry.
+      f_after = @scheduler.in_flight(sched)
+      assert Map.has_key?(f_after, unit_id)
+
+      assert Map.fetch!(f_after, unit_id) == scope_v2,
+             "D-380: upsert must replace the old scope with scope_v2"
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # D-380 (b) — a single universal_conflict unit admits into its own
+  # excluded-empty F' (no self-conflict via D-371 sentinel path).
+  #
+  # MUST FAIL on current branch: ConflictCheck sees map_size(F) > 0 with the
+  # sentinel present for the re-admit, returns {:conflict, :no_dependency}.
+  # ---------------------------------------------------------------------------
+
+  describe "D-380 — universal_conflict unit does not self-conflict" do
+    @tag :d_380
+    test "D-380: a single universal_conflict unit in F re-admits without self-conflicting" do
+      sched = start_scheduler(5)
+      uc_scope = universal_conflict_scope()
+      unit_id = "unit-uc-#{System.unique_integer([:positive])}"
+
+      # First admit with a universal_conflict scope — must succeed (F is empty).
+      assert :admit = @scheduler.admit(sched, unit_id, uc_scope),
+             "D-380: first admit of universal_conflict unit must succeed into empty F"
+
+      # F holds the sentinel unit — an empty-scope second unit would be deferred.
+      other_id = "unit-other-#{System.unique_integer([:positive])}"
+      result_other = @scheduler.admit(sched, other_id, empty_scope())
+
+      assert {:defer, _} = result_other,
+             "D-380: a distinct unit must be deferred by the universal_conflict sentinel in F. " <>
+               "Got #{inspect(result_other)}."
+
+      # Re-admit the sentinel unit itself — must return :admit (not {:conflict, _}).
+      # D-380: Scheduler excludes unit_id from F before ConflictCheck, so F' is
+      # empty → universal_conflict with empty F' → :clear → :admit.
+      #
+      # FAILS on current branch: Scheduler passes full F to ConflictCheck
+      # → F contains the sentinel with map_size(F) > 0
+      # → ConflictCheck returns {:conflict, :no_dependency}
+      # → Scheduler returns {:defer, {:conflict, :no_dependency}}.
+      result = @scheduler.admit(sched, unit_id, uc_scope)
+
+      assert result == :admit,
+             "D-380: a universal_conflict unit re-admitting against an F containing only " <>
+               "itself must return :admit. The Scheduler must exclude unit_id from F " <>
+               "(F' is empty) before the ConflictCheck, so the sentinel sees map_size(F') == 0. " <>
+               "Got #{inspect(result)}.  FAILS on current branch (no self-exclusion)."
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # D-380 (c) — single admission authority: the Coordinator's drive_unit/3 MUST
+  # NOT call Scheduler.admit; only the Unit FSM planned state may call it.
+  #
+  # Strategy: use a spy GenServer as the Scheduler that records admit call counts.
+  # Wire the Coordinator with this spy scheduler and a drive_fun that bypasses the
+  # real Unit FSM (to isolate the K-side admit). Assert admit_count == 0 from the
+  # Coordinator side (the drive_fun below models what happens at the K→U boundary).
+  #
+  # The test directly checks that Coordinator.drive_unit does not call
+  # Scheduler.admit by starting a Coordinator with a spy scheduler and a
+  # synchronous drive_fun that returns immediately, then asserting the spy
+  # recorded exactly zero admits from the Coordinator's drive_unit path.
+  #
+  # MUST FAIL on current branch: Coordinator.drive_unit/3 (~line 318) calls
+  # Scheduler.admit(data.scheduler, unit_id, @empty_scope) before calling
+  # drive_fun — the spy records at least one admit → assert spy_admit_count == 0
+  # fails.
+  # ---------------------------------------------------------------------------
+
+  describe "D-380 — single admission authority: Coordinator calls no Scheduler.admit" do
+    @tag :d_380
+    test "D-380: Coordinator.drive_unit issues no Scheduler.admit call (Unit FSM is the sole admitter)" do
+      # Spy Scheduler: records every admit call (count) and always returns :admit.
+      # Implemented as a simple Agent holding a counter.
+      {:ok, spy} = Agent.start_link(fn -> %{admit_count: 0} end)
+
+      # Spy module: a plain GenServer responding like a Scheduler but counting
+      # admit calls via the spy agent.
+      spy_name = unique_name(:spy_sched_d380)
+      test_pid = self()
+
+      {:ok, _spy_server} =
+        start_supervised(
+          {__MODULE__.SpyScheduler, name: spy_name, spy: spy},
+          id: unique_name(:spy_sup)
+        )
+
+      # PubSub needed by Coordinator.
+      pubsub_name = unique_name(:coord_pubsub)
+
+      start_supervised!(
+        {Phoenix.PubSub, name: pubsub_name},
+        id: unique_name(:pubsub_sup)
+      )
+
+      # A drive_fun that signals completion immediately (simulates the K→U hand-off
+      # WITHOUT spawning a real Unit FSM — the Coordinator calls drive_fun AFTER
+      # any admit it might perform; we count only the Coordinator-side calls).
+      work_item = %{unit_id: "unit-k-side-#{System.unique_integer([:positive])}"}
+
+      coordinator_name = unique_name(:coord_d380)
+
+      _coord_pid =
+        start_supervised!(
+          {
+            @coordinator,
+            name: coordinator_name,
+            pubsub: pubsub_name,
+            scheduler: spy_name,
+            select_fun: fn ->
+              # Return the work item exactly once, then nil to idle.
+              case Agent.get_and_update(spy, fn st ->
+                     Map.get_and_update(st, :selected, fn
+                       nil -> {work_item, true}
+                       true -> {nil, true}
+                     end)
+                   end) do
+                ^work_item ->
+                  # Also notify the test when we return the item
+                  send(test_pid, :work_selected)
+                  work_item
+
+                nil ->
+                  nil
+              end
+            end,
+            drive_fun: fn _work ->
+              # Notify the coordinator of immediate completion so it loops cleanly.
+              # The coordinator will call handle_info({:unit_terminal, id, :merged})
+              # after drive_fun returns, so we send it that message.
+              Process.send_after(
+                Process.whereis(coordinator_name),
+                {:unit_terminal, work_item.unit_id, :merged, %{}},
+                10
+              )
+
+              :ok
+            end
+          },
+          id: unique_name(:coord_d380_sup)
+        )
+
+      # Wait for the Coordinator to run through drive_unit for the work item.
+      assert_receive :work_selected,
+                     5_000,
+                     "D-380: Coordinator must call select_fun and pick the work item within 5s"
+
+      # Give the Coordinator enough time to call drive_unit (and any admit it would do).
+      Process.sleep(200)
+
+      # Read the admit count recorded by the spy BEFORE the Unit FSM would fire.
+      # D-380: Coordinator.drive_unit must NOT call Scheduler.admit at all.
+      # The spy counts every admit call regardless of caller.
+      # In this test there is no Unit FSM (drive_fun bypasses it), so
+      # the only source of admits is the Coordinator itself.
+      admit_count = Agent.get(spy, fn st -> st.admit_count end)
+
+      assert admit_count == 0,
+             "D-380: Coordinator.drive_unit must issue ZERO Scheduler.admit calls. " <>
+               "The spy recorded #{admit_count} call(s). " <>
+               "On current branch, drive_unit calls Scheduler.admit with @empty_scope " <>
+               "(coordinator.ex ~line 318), producing admit_count == 1 here. " <>
+               "Fix: remove the Scheduler.admit call from drive_unit; " <>
+               "the Unit FSM planned state is the sole admitter."
+    end
+  end
+end
+
+# ---------------------------------------------------------------------------
+# SpyScheduler: minimal GenServer that records admit calls and returns :admit.
+# Lives inside the test module namespace so no lib/ file is created.
+# ---------------------------------------------------------------------------
+defmodule Tau.Factory.SchedulerSelfExclusionTest.SpyScheduler do
+  @moduledoc false
+
+  use GenServer
+
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(opts) do
+    name = Keyword.fetch!(opts, :name)
+    GenServer.start_link(__MODULE__, opts, name: name)
+  end
+
+  @impl GenServer
+  def init(opts) do
+    {:ok, %{spy: Keyword.fetch!(opts, :spy)}}
+  end
+
+  @impl GenServer
+  def handle_call({:admit, _unit_id, _scope}, _from, state) do
+    Agent.update(state.spy, fn st -> Map.update!(st, :admit_count, &(&1 + 1)) end)
+    {:reply, :admit, state}
+  end
+
+  def handle_call({:release, _unit_id}, _from, state) do
+    {:reply, :ok, state}
+  end
+
+  def handle_call(:in_flight, _from, state) do
+    {:reply, %{}, state}
+  end
+end


### PR DESCRIPTION
## #515 — real-run integration: admission self-exclusion (D-380) + per-unit prompt delivery (D-381)

Closes #515. The FIRST factory-driven real-`claude` run (sandbox + seeded issue) proved cost-safety + the `:claude_code` selector, but `claude` never ran — two upstream gaps. **ARCH GAP RESOLVED** — shaper pass landed (`ea8f378`): SPEC-FACTORY-CORE + SPEC-FACTORY-FLEET + control-plane.md + MISSION amended; verified-free **D-380/D-381** allocated (D-377-379 reserved on the unmerged #491 branch — noted, no collision). Implementation follows in this PR.

### Acceptance criteria
- **D-380** (admission: single authority + self-exclusion; SPEC-FACTORY-CORE §4 B1/B2) — a unit is admitted to the Scheduler EXACTLY ONCE, by the Unit FSM `planned` state with its REAL `declared_scope`; `Coordinator.drive_unit/3` issues NO `Scheduler.admit` call. The Scheduler evaluates `ConflictCheck.clear?` + capacity over `F ∖ {unit_id}` (a unit never self-conflicts; ConflictCheck stays unit-id-agnostic). Re-admitting the same `unit_id` against an `F` already holding it returns `:admit`; a single universal-conflict-sentinel unit admits into its excluded-empty `F'`.
- **D-381** (per-unit prompt delivery; SPEC-FACTORY-FLEET §4 B4-A1) — the per-unit `work_item.brief` (assembled by the BriefAssembler) is delivered to the `:claude_code` shim at spawn time via the Worker's Port `:env` (`TAU_AGENT_PROMPT`); the shim's `Runner` reads it into `task.prompt`, so the real `claude` argv carries `-p <brief>` (not `-p ""`). Orthogonal to the #509 fence (only `ANTHROPIC_*` scrubbed; `TAU_AGENT_PROMPT` is task data, never scrubbed). An empty brief → the var is OMITTED and the shim defaults to `""` → `-p ""` (no global-env mutation).

### Scope & order
SPEC (landed `ea8f378`) → D-380: drop Coordinator `@empty_scope` admit + Scheduler `F ∖ {unit_id}` self-exclusion (`coordinator.ex`, `scheduler.ex`); D-381: Worker injects `TAU_AGENT_PROMPT` + shim Runner reads it (`worker.ex`, `coding_agent_shim.ex`). Disjoint file sets. NO real `claude` in tests.

### Dependencies
#487/#489/#509/#511 (merged). Unblocks the first SUCCESSFUL factory-driven real run.

### Gating-test paths (frozen at 4b)
- `test/tau/factory/scheduler_self_exclusion_test.exs` — D-380 (re-admit same unit_id → :admit; sentinel self-admit; Coordinator issues no admit).
- `test/tau/factory/coding_agent_shim_prompt_test.exs` — D-381 (Worker injects TAU_AGENT_PROMPT; shim argv `-p <brief>`; empty→`-p ""`; ANTHROPIC_* scrub unaffected).
### Gate verdicts
**Attempt 1 — RED (refine).** Both halves FAIL (D-380 + the D-381 non-empty path are SOUND; FAIL is solely the empty-brief handling + a token glitch).
- **critic: FAIL** — (F1, BLOCKING) `worker.ex` empty-brief path uses `:os.putenv`/`:os.unsetenv` = global OS-env mutation in concurrent `Worker.init` (OTP non-negotiable #1; glibc `setenv`/`fork` not thread-safe), **reachable in production** via the D-344 rehydrate path (`supervisor.ex:359` `brief: ""`). Fix: **omit-on-empty** (no `:os` call; the shim's `get_env || ""` makes absent==empty per SPEC §4). (F2) the D-381(b) test over-asserts present-empty ("refute UNSET") — contradicts SPEC §4 absent==empty → **upheld challenge**; relax it.
- **reviewer: FAIL** — Gate 5.1 CI: bare `D-371`/`D-372` cross-ref tokens in the AC prose (now removed). D-380/D-381 mutation-probes load-bearing; admission-path tests green; minor unused `@writer` in the scheduler test.

**Refine plan:**
- *Coordinator:* removed `D-371`/`D-372` tokens from AC (above).
- *Test-author (upheld challenge):* relax D-381(b) to accept absent-OR-empty (drop "refute UNSET"); remove the unused `@writer`.
- *Implementer:* OMIT `TAU_AGENT_PROMPT` when `brief == ""` (no `:os.putenv`/`:os.unsetenv`); keep the non-empty Port-`:env` injection. D-380 unchanged (sound).

**Attempt 1 re-gate — GREEN (merge).** Both PASS. critic — `:os.putenv` hazard GONE (omit-on-empty; behavior preserved: absent==empty → `-p ""`); D-380 self-exclusion + single-admit + D-381 non-empty + #509 fence all sound; F1/F2 resolved; Gate 5.1 clean. reviewer — 8/8 gating; 1656/0 both seeds; CI all green incl. Gate 5.1; `git grep` confirms no live `:os.*`; both mutation-probes load-bearing; no regression. (Info-only: SPEC §4 prose "every agent_mode" vs the omit-on-empty carve-out — doc tension; invariant+code agree.)