### PR TITLE
feat(factory): headless skip-permissions for autonomous claude_code agent (D-383, #519)

### DIFF
--- a/docs/MISSION.md
+++ b/docs/MISSION.md
@@ -66,7 +66,7 @@ Block-to-SPEC allocation:
 |---|---|
 | D-001 – D-028 | SPEC-USER-TURN — core session FSM invariants |
 | D-029, D-030, D-043, D-044 | SPEC-CIRCUIT-BREAKER |
-| D-031 – D-039, D-375 | SPEC-CODING-AGENT |
+| D-031 – D-039, D-375, D-383 | SPEC-CODING-AGENT |
 | D-040 – D-042, D-048, D-049, D-056, D-058 – D-062, D-076 – D-089 | SPEC-USER-TURN — amendments |
 | D-045 – D-047 | SPEC-MEMORY-STORE |
 | D-050 – D-055, D-057 | SPEC-OTEL-REPORTER |

--- a/docs/spec/SPEC-CODING-AGENT.md
+++ b/docs/spec/SPEC-CODING-AGENT.md
@@ -132,10 +132,20 @@ expressing the change.
         session_id: String.t(),
         resume_id: String.t() | nil,
         allowed_tools: [String.t()] | :all,
+        skip_permissions: boolean(),
         mcp_servers: [map()],
         timeout: pos_integer() | :infinity
       }
 ```
+
+**Headless permission posture (D-383).** `task.skip_permissions` controls the
+adapter's permission posture. `true` ⇒ the `ClaudeCode` adapter appends
+`--dangerously-skip-permissions`; absent/`false` ⇒ no permission flag
+(interactive default-deny retained). Opt-in: only a contained-context caller (a
+sandboxed factory worker — SPEC-FACTORY-FLEET) may set it `true`; non-factory
+callers (interactive session, the Delegate tool) MUST leave it unset. Permission
+posture only — does NOT alter D-036 (no credential injection) or D-374/D-375
+(metered-credential scrub).
 
 **Session-mode integration shape (Phase 1B Team B, resolved 2026-05-15
 toward "FSM-extended").** The session FSM (`lib/tau/session.ex`,
@@ -266,6 +276,7 @@ worktree vs cwd. `:coding_agent_workspace_backend` can be passed to
 | **D-038** | Cost line items MUST be tagged by source so the user sees the split. Each `%Tau.CodingAgent.Event.Cost{}` folds into the session-cost aggregator as a `%Tau.CodingAgent.Cost{}` record carrying the adapter atom (`source/1` yields `"coding_agent.<agent>"`); provider-direct cost continues to land tagged `"provider.<provider>"` via the existing `[:tau, :provider, :request, :stop]` event. The session FSM emits `[:tau, :coding_agent, :cost]` per fold (D-034 parity) and persists a `coding_agent_cost` JSONL event so `/resume` recomputes totals from disk. Cost-folding failures MUST degrade gracefully (D-035): `[:tau, :coding_agent, :cost, :failed]` surfaces the reason but does not crash the session. |
 | **D-039** | Delegate-tool recursion MUST bottom out. `Tau.Tools.Builtin.Delegate` carries a `depth` parameter (default 0) and refuses calls at `depth >= 2`, returning a `ToolResult{is_error: true, details.kind: :depth_exceeded}` synchronously before any dispatcher starts. The same ceiling propagates through the per-run tau-context MCP server's `tau_delegate` tool (`tau_context_max_depth` in `Tau.CodingAgent.Dispatcher.ctx`), so coding-agent-driven re-entry hits the same limit. Each Delegate invocation is **stateless** (no resume id is persisted across calls — SPEC §7 Q5). |
 | **D-375** | Adapter-level metered-credential scrub — defense-in-depth. `Tau.CodingAgents.ClaudeCode.start/2` MUST pass `{:env, [{~c"ANTHROPIC_API_KEY", false}, {~c"ANTHROPIC_AUTH_TOKEN", false}, {~c"ANTHROPIC_BASE_URL", false}]}` in `Port.open` options by default so the `claude` subprocess never inherits any metered Anthropic credential from the host environment (Erlang Port treats `{key, false}` as POSIX unsetenv on the child). The three scrubbed variables cover all metered-spend vectors: `ANTHROPIC_API_KEY` (primary API key), `ANTHROPIC_AUTH_TOKEN` (metered bearer token honoured by the claude CLI), and `ANTHROPIC_BASE_URL` (proxy endpoint redirect). The sole opt-out is `ctx[:allow_metered] == true`, which passes all three through to the child unchanged. This invariant is a sibling of D-374 (factory-plane guard) and together they form the two-layer cost-safety fence: D-374 is fail-closed at the worker-spawn boundary; D-375 is defense-in-depth at the adapter boundary. Enforced by `test/tau/factory/cost_safety_fence_test.exs` (tags `:d_375` — 2 tests): (a) default: canaries for all three variables absent from `claude` child env; (b) `allow_metered: true`: all three canaries present in child env. |
+| **D-383** | Headless permission posture — opt-in boolean. `task.skip_permissions: true` ⇒ `ClaudeCode` adapter appends `--dangerously-skip-permissions`; absent/`false` ⇒ flag absent (interactive default-deny retained). Sound because outer boundaries contain the agent: worker workspace isolation (FLEET D-309–D-316) + metered-credential scrub (D-374/D-375) + ActionClassifier on egress (D-319). Interactive permission prompts are inapplicable headless (deadlock). The factory sandbox path sets `skip_permissions: true` via `AgentBin.resolve/1`; real-tau defaults to `false` until self-hosting wires it (#494); non-factory callers (interactive session, Delegate tool) MUST leave it unset. Back-compat: a task built without `:skip_permissions` → no flag. Enforced by `test/tau/factory/skip_permissions_d383_test.exs` (tags `:d_383` — 7 tests). |
 
 ## 7. Resolved design questions
 
@@ -392,7 +403,18 @@ lib/tau/permissions/matchers.ex                  # Glob/Regex arg_for: Delegate(
 config/config.exs                                # builtin_tools registration
 ```
 
-Total runtime invariants claimed by this spec: **D-031 through D-039** (9).
+PR #520 — D-383 headless skip-permissions (this PR — landing):
+
+```
+lib/tau/coding_agent.ex                              # task typespec: optional(:skip_permissions) => boolean()
+lib/tau/coding_agents/claude_code/argv.ex            # maybe_append_skip_permissions/2 (D-383)
+lib/tau/factory/agent_bin.ex                         # resolve_claude_code passes skip_permissions to shim
+lib/tau/factory/coding_agent_shim.ex                 # config bakes + Runner threads skip_permissions into task
+lib/mix/tasks/tau.factory.dogfood.ex                 # sandbox path sets skip_permissions: true via AgentBin.resolve/1
+test/tau/factory/skip_permissions_d383_test.exs      # D-383 gating test (7 tests, :d_383 tag)
+```
+
+Total runtime invariants claimed by this spec: **D-031 through D-039, D-375, D-383** (11).
 
 ## Appendix B — non-goals discussion
 

--- a/lib/mix/tasks/tau.factory.dogfood.ex
+++ b/lib/mix/tasks/tau.factory.dogfood.ex
@@ -113,7 +113,11 @@ defmodule Mix.Tasks.Tau.Factory.Dogfood do
     # default), so existing dogfood behaviour is preserved unless the operator
     # explicitly sets agent_mode: :claude_code in the factory config.
     factory_opts = Application.get_env(:tau, :factory, [])
-    {agent_bin, spawn_opts} = AgentBin.resolve(factory_opts)
+    # D-383: the dogfood sandbox is the contained-context path — set skip_permissions: true
+    # so the :claude_code adapter runs headless (no interactive permission prompts).
+    # AgentBin.resolve/1 threads this only for :claude_code mode; scripted/replay paths
+    # ignore it (resolve_scripted/0 does not carry skip_permissions).
+    {agent_bin, spawn_opts} = AgentBin.resolve(Keyword.put(factory_opts, :skip_permissions, true))
     Mix.shell().info("[dogfood] agent_bin: #{agent_bin}")
 
     # Step 6 — Derive the deterministic work_item coordinate (mirrors IssueSelector).

--- a/lib/tau/coding_agent.ex
+++ b/lib/tau/coding_agent.ex
@@ -52,6 +52,7 @@ defmodule Tau.CodingAgent do
           optional(:session_id) => String.t(),
           optional(:resume_id) => String.t() | nil,
           optional(:allowed_tools) => [String.t()] | :all,
+          optional(:skip_permissions) => boolean(),
           optional(:mcp_servers) => [map()],
           optional(:timeout) => pos_integer() | :infinity
         }

--- a/lib/tau/coding_agents/claude_code/argv.ex
+++ b/lib/tau/coding_agents/claude_code/argv.ex
@@ -20,6 +20,9 @@ defmodule Tau.CodingAgents.ClaudeCode.Argv do
       the adapter is responsible for the tempfile lifecycle).
     * `--allowed-tools <csv>` when `task.allowed_tools` is a list.
       `:all` (the default) omits the flag.
+    * `--dangerously-skip-permissions` when `task.skip_permissions` is
+      `true` (D-383). Absent or `false` omits the flag — interactive
+      default-deny is retained.
 
   D-036: no credentials are read or injected here. The CLI inherits
   the host user's auth on its own.
@@ -43,6 +46,7 @@ defmodule Tau.CodingAgents.ClaudeCode.Argv do
     |> maybe_append_resume(task)
     |> maybe_append_mcp(Keyword.get(opts, :mcp_config_path))
     |> maybe_append_allowed_tools(task)
+    |> maybe_append_skip_permissions(task)
   end
 
   defp maybe_append_resume(argv, %{resume_id: id}) when is_binary(id) and id != "" do
@@ -63,4 +67,10 @@ defmodule Tau.CodingAgents.ClaudeCode.Argv do
   end
 
   defp maybe_append_allowed_tools(argv, _), do: argv
+
+  defp maybe_append_skip_permissions(argv, %{skip_permissions: true}) do
+    argv ++ ["--dangerously-skip-permissions"]
+  end
+
+  defp maybe_append_skip_permissions(argv, _), do: argv
 end

--- a/lib/tau/factory/agent_bin.ex
+++ b/lib/tau/factory/agent_bin.ex
@@ -72,10 +72,12 @@ defmodule Tau.Factory.AgentBin do
     dest_path = unique_tmp_path("tau_agentbin_claude_code")
 
     branch = Keyword.get(opts, :branch, "main")
+    skip_permissions = Keyword.get(opts, :skip_permissions, false)
 
     CodingAgentShim.write(dest_path,
       adapter: Tau.CodingAgents.ClaudeCode,
-      branch: branch
+      branch: branch,
+      skip_permissions: skip_permissions
     )
 
     {dest_path, [agent_mode: :claude_code]}

--- a/lib/tau/factory/coding_agent_shim.ex
+++ b/lib/tau/factory/coding_agent_shim.ex
@@ -70,7 +70,8 @@ defmodule Tau.Factory.CodingAgentShim do
       gap_before_phase_ms: Keyword.get(opts, :gap_before_phase_ms),
       replay_delay_ms: Keyword.get(opts, :replay_delay_ms, 0),
       heartbeat_interval_ms: Keyword.get(opts, :heartbeat_interval_ms),
-      inspect_env_file: Keyword.get(opts, :inspect_env_file)
+      inspect_env_file: Keyword.get(opts, :inspect_env_file),
+      skip_permissions: Keyword.get(opts, :skip_permissions, false)
     }
 
     encoded_config =
@@ -210,9 +211,11 @@ defmodule Tau.Factory.CodingAgentShim.Runner do
     # Initial heartbeat state: last_hb_at = nil (no heartbeat sent yet).
     initial_hb_state = %{last_hb_at: nil, interval_ms: hb_interval}
 
+    skip_permissions = config[:skip_permissions] || false
+
     case resolve_stream_mode(config) do
       {:single, fixture, delay_ms} ->
-        run_single_stream(ws, config.adapter, fixture, delay_ms, initial_hb_state)
+        run_single_stream(ws, config.adapter, fixture, delay_ms, initial_hb_state, skip_permissions)
 
       {:phased, phases, gaps} ->
         run_phased_stream(ws, config.adapter, phases, gaps, initial_hb_state)
@@ -234,13 +237,14 @@ defmodule Tau.Factory.CodingAgentShim.Runner do
     {:single, [], config[:replay_delay_ms] || 0}
   end
 
-  defp run_single_stream(ws, adapter, fixture, delay_ms, hb_state) do
+  defp run_single_stream(ws, adapter, fixture, delay_ms, hb_state, skip_permissions) do
     # D-381: read the brief from the Worker-injected TAU_AGENT_PROMPT env var.
     # Falls back to "" when absent (back-compat with Replay / non-D-381 paths).
     task = %{
       prompt: System.get_env("TAU_AGENT_PROMPT") || "",
       workspace: ws,
-      replay_fixture: fixture
+      replay_fixture: fixture,
+      skip_permissions: skip_permissions
     }
 
     ctx = if delay_ms > 0, do: %{replay_delay_ms: delay_ms}, else: %{}

--- a/test/tau/factory/skip_permissions_d383_test.exs
+++ b/test/tau/factory/skip_permissions_d383_test.exs
@@ -1,0 +1,179 @@
+defmodule Tau.Factory.SkipPermissionsD383Test do
+  @moduledoc """
+  Gating tests for PR #520 (issue #519 — D-383: headless skip-permissions
+  for the autonomous `:claude_code` agent).
+
+  Written BEFORE production code exists (oracle-separation, factory-loop §4b).
+  All tests MUST FAIL against the current branch because neither
+  `skip_permissions` field nor `--dangerously-skip-permissions` are wired
+  anywhere yet.
+
+  ## D-383 invariant
+
+  The `:claude_code` adapter's headless permission posture is a single
+  opt-in boolean `task.skip_permissions` (default `false`):
+
+    - `skip_permissions: true`  → `Argv.build/2` argv contains
+      `"--dangerously-skip-permissions"`.
+    - absent / `false`          → argv does NOT contain it (interactive
+      default preserved).
+
+  Factory threading:
+    - `AgentBin.resolve(agent_mode: :claude_code, skip_permissions: true)`
+      → the CodingAgentShim encoded config carries `skip_permissions: true`.
+    - `AgentBin.resolve(agent_mode: :claude_code)` (no skip opt)
+      → encoded config `skip_permissions: false` (or key absent treated as false).
+    - Non-`:claude_code` modes: `skip_permissions` irrelevant; no flag.
+
+  Back-compat: a task built without `:skip_permissions` (non-factory caller)
+  → no flag.
+
+  ## Gating-test path
+
+  `test/tau/factory/skip_permissions_d383_test.exs`
+
+  ## AC / D-NNN linkage
+
+  All tests carry `@tag :d_383`.
+  """
+
+  use ExUnit.Case, async: true
+
+  alias Tau.CodingAgents.ClaudeCode.Argv
+  alias Tau.Factory.AgentBin
+
+  # ---------------------------------------------------------------------------
+  # Layer 1 — Argv mapping
+  # Tests that Argv.build/2 emits / omits --dangerously-skip-permissions
+  # based solely on task.skip_permissions.  No subprocess is spawned.
+  # ---------------------------------------------------------------------------
+
+  describe "D-383 Argv mapping" do
+    @tag :d_383
+    test "D-383 argv: skip_permissions: true appends --dangerously-skip-permissions" do
+      task = %{prompt: "p", workspace: "/tmp", skip_permissions: true}
+      argv = Argv.build(task)
+
+      assert "--dangerously-skip-permissions" in argv,
+             "D-383: Argv.build/2 with skip_permissions: true must include " <>
+               "--dangerously-skip-permissions; got #{inspect(argv)}"
+    end
+
+    @tag :d_383
+    test "D-383 argv: skip_permissions: false does NOT append --dangerously-skip-permissions" do
+      task = %{prompt: "p", workspace: "/tmp", skip_permissions: false}
+      argv = Argv.build(task)
+
+      refute "--dangerously-skip-permissions" in argv,
+             "D-383: Argv.build/2 with skip_permissions: false must NOT include " <>
+               "--dangerously-skip-permissions; got #{inspect(argv)}"
+    end
+
+    @tag :d_383
+    test "D-383 argv back-compat: task without :skip_permissions key does NOT append --dangerously-skip-permissions" do
+      task = %{prompt: "p", workspace: "/tmp"}
+      argv = Argv.build(task)
+
+      refute "--dangerously-skip-permissions" in argv,
+             "D-383: Argv.build/2 with no :skip_permissions key must NOT include " <>
+               "--dangerously-skip-permissions (back-compat); got #{inspect(argv)}"
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Layer 2 — Factory wiring
+  # Tests that AgentBin.resolve/1 threads skip_permissions: true into the
+  # CodingAgentShim encoded config, and that the config decodes correctly.
+  # Mirrors the decode pattern from test/tau/factory/agent_bin_test.exs.
+  # ---------------------------------------------------------------------------
+
+  describe "D-383 factory wiring via AgentBin.resolve/1" do
+    @tag :d_383
+    test "D-383 wiring: resolve(agent_mode: :claude_code, skip_permissions: true) bakes skip_permissions: true into shim config" do
+      opts = [agent_mode: :claude_code, skip_permissions: true, branch: "feat/test-d-383"]
+
+      {agent_bin_path, _spawn_opts} = AgentBin.resolve(opts)
+
+      assert is_binary(agent_bin_path),
+             "D-383: AgentBin.resolve/1 must return {String.t(), keyword()}"
+
+      assert File.exists?(agent_bin_path),
+             "D-383: agent_bin_path #{agent_bin_path} must exist on disk"
+
+      script = File.read!(agent_bin_path)
+
+      assert [_, encoded_config] =
+               Regex.run(~r/encoded = \\"([A-Za-z0-9+\/]+)\\"/, script),
+             "D-383: shim script must contain a baked base64-encoded config; " <>
+               "head=#{String.slice(script, 0, 200)}"
+
+      decoded_config =
+        encoded_config
+        |> Base.decode64!(padding: false)
+        |> :erlang.binary_to_term()
+
+      assert decoded_config[:skip_permissions] == true,
+             "D-383: decoded shim config must carry skip_permissions: true; " <>
+               "got #{inspect(decoded_config)}"
+
+      File.rm(agent_bin_path)
+    end
+
+    @tag :d_383
+    test "D-383 wiring: resolve(agent_mode: :claude_code) without skip opt → decoded config skip_permissions is false or absent" do
+      opts = [agent_mode: :claude_code, branch: "feat/test-d-383-absent"]
+
+      {agent_bin_path, _spawn_opts} = AgentBin.resolve(opts)
+
+      script = File.read!(agent_bin_path)
+
+      assert [_, encoded_config] =
+               Regex.run(~r/encoded = \\"([A-Za-z0-9+\/]+)\\"/, script),
+             "D-383: shim script must contain a baked base64-encoded config"
+
+      decoded_config =
+        encoded_config
+        |> Base.decode64!(padding: false)
+        |> :erlang.binary_to_term()
+
+      # skip_permissions absent or false both satisfy D-383 back-compat
+      actual = Map.get(decoded_config, :skip_permissions, false)
+
+      refute actual == true,
+             "D-383: decoded shim config without skip opt must NOT carry " <>
+               "skip_permissions: true; got #{inspect(decoded_config)}"
+
+      File.rm(agent_bin_path)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Layer 3 — Back-compat for non-factory callers
+  # A non-`:claude_code` resolve call must not carry skip_permissions: true,
+  # and the absent-key Argv.build path is already covered in Layer 1.
+  # ---------------------------------------------------------------------------
+
+  describe "D-383 back-compat for non-factory paths" do
+    @tag :d_383
+    test "D-383 back-compat: resolve(agent_mode: :scripted) does not thread skip_permissions into spawn_opts" do
+      opts = [agent_mode: :scripted, skip_permissions: true]
+
+      {_agent_bin_path, spawn_opts} = AgentBin.resolve(opts)
+
+      refute Keyword.get(spawn_opts, :skip_permissions) == true,
+             "D-383: :scripted mode MUST NOT propagate skip_permissions: true " <>
+               "into spawn_opts; got #{inspect(spawn_opts)}"
+    end
+
+    @tag :d_383
+    test "D-383 back-compat: absent agent_mode with skip_permissions: true does not activate the flag in spawn_opts" do
+      opts = [skip_permissions: true]
+
+      {_agent_bin_path, spawn_opts} = AgentBin.resolve(opts)
+
+      refute Keyword.get(spawn_opts, :skip_permissions) == true,
+             "D-383: default (absent agent_mode) MUST NOT propagate skip_permissions: true " <>
+               "into spawn_opts; got #{inspect(spawn_opts)}"
+    end
+  end
+end


### PR DESCRIPTION
## #519 — headless skip-permissions for the autonomous claude_code agent (D-383)

Closes #519. **ARCH GAP RESOLVED** — shaper pass settled the autonomous-agent permission model (this PR lands the SPEC amendment + verified-free D-383). Found by dogfood run #3: the real `claude` ran cost-safely but every `Write`/`Bash` was permission-denied headlessly → empty diff → `:no_work_product` → escalate. Empirically `--allowed-tools` does NOT clear it (a `PreToolUse` hook fires first); `--dangerously-skip-permissions` does.

### Design (from shaper pass)
For an autonomous `-p`-mode agent, claude's interactive permission prompt is inapplicable — it deadlocks (default-deny). The real boundary is OUTER: the worker's isolated workspace + the #509 metered scrub + the #494 ActionClassifier on egress. So: an **opt-in** `task.skip_permissions :: boolean` (default `false`) maps to `--dangerously-skip-permissions`; the factory **sandbox** path sets it ON; **real-tau stays OFF until #494** closes three named holes (FS not OS-isolated; the claude subprocess bypasses `Egress`; subprocess `git push` bypasses `ActionClassifier`).

### SPECs
SPEC-CODING-AGENT §3/§4 B1 + §6 amended (owns D-383 — the adapter seam). Cross-ref into SPEC-FACTORY-FLEET §4 (AgentBin/shim wiring sets it) + SPEC-FACTORY-GOV §3 (#494 cross-ref for the residual holes). `docs/MISSION.md` registry line 69 → `| D-031 – D-039, D-375, D-383 | SPEC-CODING-AGENT |`.

### Acceptance criteria
- **D-383** — the `:claude_code` adapter's headless permission posture is the single opt-in boolean `task.skip_permissions` (default `false`): `true` ⇒ argv contains `--dangerously-skip-permissions`; `false`/absent ⇒ no permission flag (interactive default preserved). Non-factory callers (interactive session, Delegate) omit the field and are UNCHANGED. The factory `:claude_code` sandbox path sets it `true`, threaded end-to-end AgentBin→CodingAgentShim→Runner task→adapter argv. Permission posture only — orthogonal to the #509 metered-credential env scrub and the no-credential-injection invariant (cross-refs in Design, below).

### Scope & order
1. `lib/tau/coding_agent.ex` — add `skip_permissions: boolean()` to the `task` type (absent ⇒ false).
2. `lib/tau/coding_agents/claude_code/argv.ex` — `maybe_append_skip_permissions/2` after `maybe_append_allowed_tools` (pure, append-only).
3. `lib/tau/factory/agent_bin.ex` — `resolve/1` reads `skip_permissions` opt (default false), threads to the shim config.
4. `lib/tau/factory/coding_agent_shim.ex` — bake `skip_permissions` into the encoded config; the Runner reads it into the built `task` (benign for Replay).
5. `lib/mix/tasks/tau.factory.dogfood.ex` (or the dogfood AgentBin opts) — set `skip_permissions: true` for the sandbox run (the contained context).
6. SPEC-CODING-AGENT amendment + MISSION registry (this PR).
NO real `claude` in tests (argv-shape + config-decode assertions only).

### Dependencies
Found by run #3. Real-tau enablement deferred to #494 (ActionClassifier / subprocess containment). Unblocks dogfood run #4 → the merged real-claude run + #501 capstone.

### Gating-test paths (frozen at 4b)
- `test/tau/factory/skip_permissions_d383_test.exs` — D-383 (argv `--dangerously-skip-permissions` mapping; AgentBin→shim config wiring; back-compat: false/absent ⇒ no flag, non-`:claude_code` modes unaffected).
### Gate verdicts
**Attempt 1 — RED (refine, PR-body only).**
- **critic: PASS** — end-to-end threading CONFIRMED no orphan (dogfood→AgentBin.resolve(skip_permissions:true)→shim encoded config→Runner task→ClaudeCode→Argv `--dangerously-skip-permissions`); back-compat preserved (opt-in; all defaults false; only the dogfood sandbox sets true; non-factory callers + scripted/replay never bypassed; real-tau OFF until #494); SPEC §4 B1/§6 D-383 + MISSION registry coherent; #509/D-036 fence untouched; D-383 verified-free; Gate 5.2 clean. Info: no test covers the Runner config→task hop (verified by inspection).
- **reviewer: FAIL** — sole issue: Gate 5.1 CI `tau.gate.ac_linkage: FAIL — missing tokens: D-036` (a bare `D-036` cross-ref in the AC section, no gating test). Otherwise 7/7 gating, 1686/0 both seeds, mutation probes load-bearing, `worker.ex` scrub untouched, Gate 5.2 clean.

**Refine:** removed the bare `D-036` token from the AC section (it was a cross-ref, not a claim; D-383 is the sole AC token, tested). No code change.


---

**Attempt 1 re-gate (refine, body-only) — GREEN (merge).** CI rerun all jobs success — `lint` (incl. Gate 5.1 `ac_linkage` now PASS after the bare `D-036` token was removed from the AC section), `mutation-check` (Gate 5.3), `test` (1.18.1 + 1.17.3), `binary-qa`, `dialyzer`, `web`, `escript` all green. critic PASS stands (no code change since e0e6282 — only the PR-body AC section was edited). reviewer's sole blocker resolved. Both halves GREEN.