### PR TITLE
fix(factory): agent-commits-aware work-product detection — HEAD-advance ∨ dirty (D-386, #525)

### DIFF
--- a/test/support/factory/committing_agent.ex
+++ b/test/support/factory/committing_agent.ex
@@ -1,0 +1,98 @@
+defmodule Tau.Factory.TestAdapters.CommittingAgent do
+  @moduledoc """
+  Test-only `Tau.CodingAgent` adapter for D-386 gating tests.
+
+  Simulates a real coding agent (e.g. ClaudeCode) that actually `git commit`s
+  its work product before emitting `%Done{exit_status: 0}`, leaving the
+  worktree with HEAD advanced and a CLEAN working tree.
+
+  This is the adapter case D-386 calls "agent commits, clean tree": HEAD ≠ base
+  at the point the shim inspects `git status --porcelain`, so the current shim's
+  dirty-tree-only detection (`git status --porcelain` → `:empty`) incorrectly
+  routes to `:no_work_product`.
+
+  NOT for use outside `test/`. No production code path reaches this module.
+  """
+
+  @behaviour Tau.CodingAgent
+
+  alias Tau.CodingAgent.Event
+
+  @impl Tau.CodingAgent
+  def capabilities do
+    %{
+      streaming: true,
+      tool_restriction: false,
+      mcp_client: false,
+      session_resume: false,
+      cost_reporting: false,
+      workspace_isolation: :cwd
+    }
+  end
+
+  @impl Tau.CodingAgent
+  def configure(opts) when is_map(opts), do: {:ok, opts}
+
+  @doc """
+  Start the committing agent stream.
+
+  Accepts `task.workspace` as the git repo root. When streamed:
+    1. Writes `agent_work.txt` into `task.workspace`.
+    2. Runs `git add -A && git commit` inside the workspace, simulating the
+       real claude subprocess committing its own work.
+    3. Emits `%Done{exit_status: 0}` — leaving HEAD advanced and tree CLEAN.
+
+  The committed SHA is NOT communicated via the event stream (real agents don't
+  do this either). The shim must detect the HEAD advance itself (D-386 contract).
+  """
+  @impl Tau.CodingAgent
+  def start(task, _ctx) when is_map(task) do
+    workspace = Map.fetch!(task, :workspace)
+
+    stream =
+      Stream.resource(
+        fn -> :pending end,
+        fn
+          :pending ->
+            # Write a file into the workspace and commit it — simulating a real
+            # coding agent that commits its own work product inside the worktree.
+            file_path = Path.join(workspace, "agent_work.txt")
+            File.write!(file_path, "work product written by CommittingAgent\n")
+
+            # git add -A
+            {_, 0} =
+              System.cmd("git", ["add", "-A"],
+                cd: workspace,
+                stderr_to_stdout: true
+              )
+
+            # git commit
+            {_, 0} =
+              System.cmd(
+                "git",
+                ["commit", "-m", "agent work product (CommittingAgent test adapter, D-386)"],
+                cd: workspace,
+                stderr_to_stdout: true
+              )
+
+            events = [
+              %Event.Start{agent: :committing_agent, version: "0.0.0-test", pid: nil},
+              %Event.AssistantText{text: "I committed my work directly.", turn: 0},
+              %Event.Cost{tokens: %{}, usd: 0.0, duration_ms: 0},
+              %Event.Done{exit_status: 0, final_message: "committed"}
+            ]
+
+            {events, :done}
+
+          :done ->
+            {:halt, :done}
+        end,
+        fn _ -> :ok end
+      )
+
+    {:ok, stream}
+  end
+
+  @impl Tau.CodingAgent
+  def cancel(_handle), do: :ok
+end

--- a/test/tau/factory/agent_commits_detection_test.exs
+++ b/test/tau/factory/agent_commits_detection_test.exs
@@ -1,0 +1,320 @@
+defmodule Tau.Factory.AgentCommitsDetectionTest do
+  @moduledoc """
+  Gating tests for PR #527 (issue #525 — D-386: agent-commits-aware work-product
+  detection).
+
+  Written BEFORE production code exists (oracle-separation, factory-loop §4b).
+
+  ## D-386 invariant
+
+  Work-product detection is `HEAD-advance ∨ dirty-tree`, NOT dirty-tree only.
+
+  The shim captures `base = git rev-parse HEAD` before draining the agent stream.
+  After `%Done{exit_status: 0}`:
+
+    * `HEAD ≠ base` (agent committed, CLEAN tree) → emit `work_ready{head_sha =
+      agent's HEAD}`; do NOT make a redundant second commit.
+    * `HEAD == base ∧ dirty` (uncommitted edits) → shim commits; emit shim's SHA
+      (back-compat, D-364).
+    * `HEAD == base ∧ clean` (nothing) → no `work_ready`; `:no_work_product`
+      (preserved, D-364).
+
+  ## Why case (a) fails before the fix
+
+  The current shim's detection path:
+
+      git status --porcelain → "" → :empty → System.halt(0) (no work_ready)
+
+  A real agent that commits its own work leaves `git status --porcelain` EMPTY
+  even though HEAD has advanced. The shim cannot see the advance because it
+  never captures the pre-drain base SHA. The `assert_receive {:work_ready, ...}`
+  in case (a) times out with the current implementation.
+
+  Cases (b) and (c) are back-compat / preserved D-364 paths that should already
+  pass.
+
+  ## AC linkage
+    - D-386 — all tests below.
+  """
+
+  use ExUnit.Case, async: false
+
+  @moduletag :capture_log
+  @moduletag :d_386
+
+  alias Tau.CodingAgent.Event
+  alias Tau.Factory.CodingAgentShim
+  alias Tau.Factory.TestAdapters.CommittingAgent
+
+  @worker_registry Tau.Factory.WorkerRegistry
+  @worker_supervisor Tau.Factory.WorkerSupervisor
+
+  # ---------------------------------------------------------------------------
+  # Hermetic git repo helpers (mirrors coding_agent_shim_bridge_test.exs idiom)
+  # ---------------------------------------------------------------------------
+
+  defp setup_git_repo(tmp_dir) do
+    repo_dir = Path.join(tmp_dir, "repo_#{System.unique_integer([:positive])}")
+    File.mkdir_p!(repo_dir)
+
+    git = fn args ->
+      System.cmd("git", args, cd: repo_dir, stderr_to_stdout: true)
+    end
+
+    {_, 0} = git.(["init", "-b", "main"])
+    {_, 0} = git.(["config", "user.email", "test@tau.test"])
+    {_, 0} = git.(["config", "user.name", "Tau Test"])
+    # CommittingAgent also needs these set inside the worktree; they are set
+    # by the shim runner, but also set here for the hermetic repo's initial
+    # commit to succeed cleanly.
+    File.write!(Path.join(repo_dir, "README"), "initial\n")
+    {_, 0} = git.(["add", "README"])
+    {_, 0} = git.(["commit", "-m", "initial commit"])
+    {sha, 0} = git.(["rev-parse", "HEAD"])
+
+    %{repo_dir: repo_dir, base_ref: String.trim(sha)}
+  end
+
+  defp mk_tmp(tag) do
+    tmp_dir =
+      Path.join(System.tmp_dir!(), "tau_#{tag}_#{System.unique_integer([:positive])}")
+
+    File.mkdir_p!(tmp_dir)
+    on_exit(fn -> File.rm_rf!(tmp_dir) end)
+    tmp_dir
+  end
+
+  defp start_fleet(tag) do
+    n = System.unique_integer([:positive])
+    registry_name = :"d386_reg_#{tag}_#{n}"
+    sup_name = :"d386_sup_#{tag}_#{n}"
+
+    {:ok, _reg} =
+      start_supervised({@worker_registry, name: registry_name}, id: :"reg_#{n}")
+
+    {:ok, sup} =
+      start_supervised(
+        {@worker_supervisor, name: sup_name, registry: registry_name},
+        id: :"sup_#{n}"
+      )
+
+    {sup, registry_name}
+  end
+
+  # A Replay fixture that edits a file (non-empty diff when committed by shim).
+  defp uncommitted_edits_fixture(ws) do
+    [
+      %Event.Start{agent: :replay, version: "0.0.0", pid: nil},
+      %Event.AssistantText{text: "I will create a file (uncommitted)", turn: 0},
+      %Event.FileEdit{path: Path.join(ws, "output.txt"), kind: :create},
+      %Event.Cost{tokens: %{}, usd: 0.0, duration_ms: 0},
+      %Event.Done{exit_status: 0, final_message: "done"}
+    ]
+  end
+
+  # A Replay fixture that produces no file edits (empty diff).
+  defp empty_diff_fixture do
+    [
+      %Event.Start{agent: :replay, version: "0.0.0", pid: nil},
+      %Event.AssistantText{text: "I did nothing", turn: 0},
+      %Event.Cost{tokens: %{}, usd: 0.0, duration_ms: 0},
+      %Event.Done{exit_status: 0, final_message: "no changes"}
+    ]
+  end
+
+  # ---------------------------------------------------------------------------
+  # D-386 case (a): agent commits its own work; tree is CLEAN; HEAD advanced.
+  #
+  # The CommittingAgent test adapter writes + git-commits a file INSIDE the
+  # worktree before emitting %Done{0}, leaving `git status --porcelain` EMPTY
+  # while HEAD ≠ base.
+  #
+  # Pre-impl failure: the current shim sees `git status --porcelain` → "" →
+  # :empty → exits 0 without emitting work_ready. The assert_receive times out.
+  #
+  # V6 strength:
+  #   (i)  head_sha == the AGENT's commit (not a shim-authored SHA).
+  #   (ii) exactly ONE new commit beyond base (no double-commit).
+  # ---------------------------------------------------------------------------
+
+  describe "D-386 agent-commits-aware detection" do
+    @tag :d_386
+    test "D-386 case (a): agent commits own work on clean tree — work_ready carries agent HEAD, no redundant shim commit" do
+      tmp_dir = mk_tmp("d386_commits")
+      %{repo_dir: repo_dir, base_ref: base_ref} = setup_git_repo(tmp_dir)
+
+      branch = "feat/d386-agent-commits"
+      n = System.unique_integer([:positive])
+      shim_bin = Path.join(tmp_dir, "shim_d386_commits_#{n}")
+
+      # Write the shim configured with the CommittingAgent adapter.
+      # CommittingAgent.start/2 writes + commits inside the workspace, then
+      # emits %Done{exit_status: 0}. The shim receives a CLEAN tree with HEAD
+      # advanced by one commit.
+      shim_bin =
+        CodingAgentShim.write(shim_bin,
+          adapter: CommittingAgent,
+          branch: branch
+        )
+
+      assert File.exists?(shim_bin),
+             "D-386: CodingAgentShim.write/2 must produce an executable shim"
+
+      {sup, registry_name} = start_fleet(:d386_commits)
+      report_to = self()
+
+      {:ok, worker_id} =
+        @worker_supervisor.spawn(sup, :implementer, "D-386 committing agent brief", base_ref,
+          repo_dir: repo_dir,
+          agent_bin: shim_bin,
+          report_to: report_to,
+          registry: registry_name
+        )
+
+      # D-386 case (a): the shim MUST detect HEAD-advance (HEAD ≠ base) even
+      # when `git status --porcelain` is empty, and emit work_ready.
+      # PRE-IMPL FAILURE: assert_receive times out because the current shim
+      # routes clean-tree → :no_work_product without checking HEAD advance.
+      assert_receive {:work_ready, ^worker_id, ^branch, head_sha},
+                     15_000,
+                     "D-386 case (a): agent committed its own work (HEAD advanced, clean tree). " <>
+                       "The shim MUST detect HEAD != base and emit work_ready. " <>
+                       "Fails pre-impl: shim's git-status-only detection sees clean tree → no work_ready."
+
+      # V6 strength (i): head_sha must be a real 40-char hex SHA.
+      assert Regex.match?(~r/\A[0-9a-fA-F]{40}\z/, head_sha),
+             "D-386: head_sha must be a 40-char commit SHA; got #{inspect(head_sha)}"
+
+      # V6 strength (ii): branch must have EXACTLY ONE new commit beyond base.
+      # Capture the current branch tip in the hermetic repo.
+      {log_out, 0} =
+        System.cmd(
+          "git",
+          ["log", "--oneline", "#{base_ref}..#{branch}"],
+          cd: repo_dir,
+          stderr_to_stdout: true
+        )
+
+      new_commits = log_out |> String.trim() |> String.split("\n") |> Enum.reject(&(&1 == ""))
+
+      assert length(new_commits) == 1,
+             "D-386: exactly 1 new commit expected beyond base (the agent's commit). " <>
+               "Got #{length(new_commits)}: #{inspect(new_commits)}. " <>
+               "A value of 2 means the shim made a redundant second commit."
+
+      # V6 strength (iii): head_sha must equal the branch tip (the agent's commit).
+      {tip_sha, 0} =
+        System.cmd("git", ["rev-parse", branch], cd: repo_dir, stderr_to_stdout: true)
+
+      assert head_sha == String.trim(tip_sha),
+             "D-386: head_sha reported in work_ready must equal the branch tip. " <>
+               "work_ready.head_sha=#{head_sha}, branch tip=#{String.trim(tip_sha)}"
+
+      # D-386: no :no_work_product when HEAD advanced.
+      refute_received {:worker_exit, ^worker_id, :no_work_product},
+                      "D-386: must NOT surface :no_work_product when HEAD advanced (agent committed)"
+
+      # D-386: single work_ready (no duplicate).
+      refute_received {:work_ready, ^worker_id, _, _},
+                      "D-386: only one work_ready must be emitted per worker"
+    end
+
+    # D-386 case (b): agent leaves uncommitted edits (HEAD == base, dirty tree).
+    # Back-compat: the shim commits and emits work_ready with the SHIM's SHA.
+    # This is the existing D-364 non-empty Replay path — preserved by D-386.
+    @tag :d_386
+    test "D-386 case (b): uncommitted edits (HEAD == base, dirty) — shim commits and emits work_ready (back-compat)" do
+      tmp_dir = mk_tmp("d386_uncommitted")
+      %{repo_dir: repo_dir, base_ref: base_ref} = setup_git_repo(tmp_dir)
+
+      branch = "feat/d386-uncommitted"
+      n = System.unique_integer([:positive])
+      shim_bin = Path.join(tmp_dir, "shim_d386_uncommitted_#{n}")
+
+      # Use the Replay adapter: Replay emits FileEdit events that the shim
+      # materializes as real files in the worktree (dirty tree, HEAD unchanged).
+      shim_bin =
+        CodingAgentShim.write(shim_bin,
+          adapter: Tau.CodingAgents.Replay,
+          replay_fixture: uncommitted_edits_fixture(""),
+          branch: branch
+        )
+
+      {sup, registry_name} = start_fleet(:d386_uncommitted)
+      report_to = self()
+
+      {:ok, worker_id} =
+        @worker_supervisor.spawn(sup, :implementer, "D-386 uncommitted edits brief", base_ref,
+          repo_dir: repo_dir,
+          agent_bin: shim_bin,
+          report_to: report_to,
+          registry: registry_name
+        )
+
+      # D-386 case (b): dirty tree, HEAD == base → shim commits and emits work_ready.
+      assert_receive {:work_ready, ^worker_id, ^branch, head_sha},
+                     10_000,
+                     "D-386 case (b): shim must commit uncommitted edits and emit work_ready (back-compat D-364)"
+
+      # head_sha must be a real 40-char SHA (the shim's commit).
+      assert Regex.match?(~r/\A[0-9a-fA-F]{40}\z/, head_sha),
+             "D-386 case (b): head_sha must be a 40-char commit SHA; got #{inspect(head_sha)}"
+
+      # Exactly one new commit beyond base.
+      {log_out, 0} =
+        System.cmd(
+          "git",
+          ["log", "--oneline", "#{base_ref}..#{branch}"],
+          cd: repo_dir,
+          stderr_to_stdout: true
+        )
+
+      new_commits = log_out |> String.trim() |> String.split("\n") |> Enum.reject(&(&1 == ""))
+
+      assert length(new_commits) == 1,
+             "D-386 case (b): exactly 1 new commit expected (the shim's commit). Got #{length(new_commits)}"
+
+      refute_received {:worker_exit, ^worker_id, :no_work_product},
+                      "D-386 case (b): must NOT surface :no_work_product when edits were committed"
+    end
+
+    # D-386 case (c): agent does nothing (HEAD == base, clean tree).
+    # Preserved D-364 / D-326 path: no work_ready, :no_work_product surfaces.
+    @tag :d_386
+    test "D-386 case (c): agent does nothing (HEAD == base, clean tree) — no work_ready, :no_work_product preserved" do
+      tmp_dir = mk_tmp("d386_nothing")
+      %{repo_dir: repo_dir, base_ref: base_ref} = setup_git_repo(tmp_dir)
+
+      branch = "feat/d386-nothing"
+      n = System.unique_integer([:positive])
+      shim_bin = Path.join(tmp_dir, "shim_d386_nothing_#{n}")
+
+      # Empty Replay fixture: no FileEdit events, HEAD stays at base, tree clean.
+      shim_bin =
+        CodingAgentShim.write(shim_bin,
+          adapter: Tau.CodingAgents.Replay,
+          replay_fixture: empty_diff_fixture(),
+          branch: branch
+        )
+
+      {sup, registry_name} = start_fleet(:d386_nothing)
+      report_to = self()
+
+      {:ok, worker_id} =
+        @worker_supervisor.spawn(sup, :implementer, "D-386 nothing brief", base_ref,
+          repo_dir: repo_dir,
+          agent_bin: shim_bin,
+          report_to: report_to,
+          registry: registry_name
+        )
+
+      # D-386 case (c): no advance, no edits → no work_ready; :no_work_product.
+      assert_receive {:worker_exit, ^worker_id, :no_work_product},
+                     10_000,
+                     "D-386 case (c): empty run must surface :no_work_product (D-326, D-364 preserved)"
+
+      refute_received {:work_ready, ^worker_id, _, _},
+                      "D-386 case (c): empty run must NOT emit work_ready"
+    end
+  end
+end


### PR DESCRIPTION
## #525 — agent-commits-aware work-product detection (D-386)

Closes #525. **ARCH GAP** (shaper): SPEC-FACTORY-FLEET D-364 / §4 B4-A1 explicitly specify uncommitted-tree detection under the FALSE premise that `ClaudeCode` "does not git commit". Run #5 proved real `claude` COMMITS its own work autonomously (`43cc281`, clean tree) → the shim's `git status --porcelain`-only detection sees `:empty` → no `work_ready` → `:no_work_product` → escalate in `oracle`. claude's correct, committed work (it even strengthened the gating test) is silently discarded. D-386 generalises D-364's detection; D-364's commit-ownership survives for the Replay (uncommitted) case.

### Design (shaper)
Detection predicate: **work_product ≡ `HEAD ≠ base` (agent committed) OR `git status --porcelain` non-empty (uncommitted)**. The shim captures `base = git rev-parse HEAD` as its FIRST git action (worktree forked at `base_ref`, agent not yet run → `HEAD == base_ref` at entry; robust vs detached-HEAD/ref-ambiguity). After `%Done{0}`:
- **committed + clean (`HEAD≠base`, real claude):** SKIP the shim commit; label the unit branch at the agent's HEAD (`git checkout -B <branch>` at HEAD / `git branch -f`); emit `work_ready{head_sha = agent's HEAD}`.
- **committed + dirty:** commit a follow-up on top of the agent's commit (agent's commit preserved as ancestor); emit new HEAD.
- **uncommitted only (`HEAD==base`, dirty — Replay):** shim `add -A && commit` as today; emit shim commit SHA. (Back-compat.)
- **nothing (`HEAD==base`, clean):** no `work_ready`; exit 0 → `:no_work_product`. (Preserved.)
Downstream D-361/D-362 already key gate/merge on the agent-asserted `head_sha` — NO `unit.ex` change.

### SPECs
SPEC-FACTORY-FLEET §4 B4-A1 + §6 amended (D-386, supersedes D-364's detection clause; D-364 commit-ownership survives for the dirty case). MISSION registry (FLEET row).

### Acceptance criteria
- **D-386** — work-product detection is `HEAD-advance ∨ dirty-tree` (agent-commits-aware), NOT uncommitted-only. The shim records `base` before draining the agent stream; after `%Done{0}`: `HEAD≠base` ⇒ emit `work_ready{head_sha = agent HEAD}` with NO redundant commit on a clean tree; `HEAD==base ∧ dirty` ⇒ shim commits + emits its SHA (Replay back-compat); `HEAD==base ∧ clean` ⇒ no `work_ready` → `:no_work_product`. The `head_sha` is the agent's actual HEAD when the agent committed.

### Scope & order
1. `lib/tau/factory/coding_agent_shim.ex` — capture `base` at Runner entry; `detect_work_product(ws, base)` → `:committed_clean | :committed_dirty | :uncommitted | :none`; branch-label-at-HEAD for committed cases; skip redundant commit on committed+clean; emit the right `head_sha`. Update the D-364 moduledoc bullet.
2. `lib/tau/factory/worker.ex` — (belt-and-suspenders, optional) inject `TAU_AGENT_BASE_SHA` alongside `TAU_AGENT_PROMPT` as a test/diagnostic override; NOT load-bearing (the shim captures base at entry regardless).
3. SPEC-FACTORY-FLEET §4 B4-A1/§6 (D-386) + MISSION — this PR.
NO real `claude` in tests. The Replay event taxonomy has no commit event, so the agent-commits case is exercised via a test-only committing adapter (preferred) OR a clearly-marked test-only shim seam.

### Dependencies
Found by run #5 (#519/D-383 + #521/D-385 merged). THE blocker before #501 capstone — everything downstream (permission, merge-isolation, cost fence) functions. Unblocks dogfood run #6.

### Gating-test paths (frozen at 4b)
- `test/tau/factory/agent_commits_detection_test.exs` — D-386 (a) agent commits clean tree → work_ready{agent HEAD}, exactly +1 commit (no redundant shim commit); (b) uncommitted → shim commits (Replay back-compat); (c) nothing → :no_work_product.
- `test/support/factory/committing_agent.ex` — test-only adapter that commits its own work (simulates real claude).
### Gate verdicts — _(filled at gate time)_