### PR TITLE
test(factory): filter :reject telemetry handlers by unit to fix async flakiness (#524)

### DIFF
--- a/test/tau/factory/reject_durable_outcome_test.exs
+++ b/test/tau/factory/reject_durable_outcome_test.exs
@@ -249,11 +249,14 @@ defmodule Tau.Factory.RejectDurableOutcomeTest do
       # WAL-committed (WAL-before-ack) IF the producer records it — mirroring the
       # :merged proof.
       handler_id = "reject-outcome-durable-#{System.unique_integer([:positive])}"
+      this_hash = unit.hash
 
       :telemetry.attach(
         handler_id,
         [:tau, :factory, :merge, :reject],
-        fn _event, _measurements, _metadata, _config -> send(test_pid, :reject_fired) end,
+        fn _event, measurements, _metadata, _config ->
+          if measurements[:hash] == this_hash, do: send(test_pid, :reject_fired)
+        end,
         nil
       )
 
@@ -301,11 +304,14 @@ defmodule Tau.Factory.RejectDurableOutcomeTest do
         )
 
       handler_id = "reject-outcome-crash-#{System.unique_integer([:positive])}"
+      this_hash = unit.hash
 
       :telemetry.attach(
         handler_id,
         [:tau, :factory, :merge, :reject],
-        fn _event, _measurements, _metadata, _config -> send(test_pid, :reject_fired) end,
+        fn _event, measurements, _metadata, _config ->
+          if measurements[:hash] == this_hash, do: send(test_pid, :reject_fired)
+        end,
         nil
       )
 
@@ -454,12 +460,15 @@ defmodule Tau.Factory.RejectDurableOutcomeTest do
       ma = start_merge_authority(ledger, work_path, built_build_fun(tip), StaleRefCas)
 
       handler_id = "reject-outcome-requeue-#{System.unique_integer([:positive])}"
+      this_hash = unit.hash
 
       :telemetry.attach(
         handler_id,
         [:tau, :factory, :merge, :reject],
-        fn _event, _measurements, metadata, _config ->
-          send(test_pid, {:reject_fired, Map.get(metadata, :reason)})
+        fn _event, measurements, metadata, _config ->
+          if measurements[:hash] == this_hash do
+            send(test_pid, {:reject_fired, Map.get(metadata, :reason)})
+          end
         end,
         nil
       )


### PR DESCRIPTION
## Filter the factory `:reject` telemetry handlers by the test's own unit (#524)

Closes #524.

### Problem
`test/tau/factory/reject_durable_outcome_test.exs` attaches global
`[:tau, :factory, :merge, :reject]` telemetry handlers whose callback fires on
**any** reject event, with no filter on the test's own `hash`/`unit_id`. Under
`async: true`, a concurrent test that emits `:reject` (or one running inside the
~5s `assert_receive` window) trips the handler → false `:reject_fired` → flaky.
This caused an implementer to thrash (needlessly serializing unrelated tests) on
#521.

### Fix (test-only)
In each `:reject`/`:merged` handler closure in
`reject_durable_outcome_test.exs`, guard the `send(test_pid, …)` so it fires
**only** when the event's measurements/metadata match this test's own unique
unit (its `hash` measurement and/or `units` metadata — both already unique per
test via `System.unique_integer`). Keep the existing unique `handler_id` +
`on_exit` detach. No production code changes; no behavioural contract changes.

### Scope & order
1. `test/tau/factory/reject_durable_outcome_test.exs` — add per-unit filtering to
   the three `[:tau, :factory, :merge, :*]` handlers. (Sole file.)

### Acceptance criteria
_(none — test-hygiene fix; no `AC-N`/`D-NNN` claimed. Phase 4b skipped.)_

### Out of scope / follow-up
The same unfiltered-global-handler pattern also appears in
`merge_health_test.exs` and `merge_outcome_durability_test.exs`. If the
test-author finds those measurably contribute to cross-test bleed, note them for
a follow-up issue rather than expanding this PR.

### Gate verdicts
- **critic** (HEAD 05c1ffd): **PASS** — discriminator (`measurements[:hash] == this_hash`) confirmed against the real producer emission, selective in both directions; no assertion weakening; scope clean (single test file).
- **reviewer** (HEAD 05c1ffd): **PASS** — full suite 1698 tests + 208 properties, 0 failures; 6-seed cross-file stress all 0 failures; all CI jobs green.
