### PR TITLE
fix(factory): Gate 5.1 exempts D-NNN (meta) tokens, not only AC-N (meta) (#514)

### DIFF
--- a/lib/tau/factory/gate/ac_linkage.ex
+++ b/lib/tau/factory/gate/ac_linkage.ex
@@ -94,14 +94,22 @@ defmodule Tau.Factory.Gate.AcLinkage do
   # Token parsing
   # ---------------------------------------------------------------------------
 
-  # Parse AC-N tokens marked as meta (exempt from the linkage gate).
+  # Parse AC-N and D-NNN tokens marked as meta (exempt from the linkage gate).
   defp parse_meta_ac_tokens(section_text) do
-    meta_pattern = ~r/\bAC-(\d+)\s*\(meta\)/
+    ac_meta_pattern = ~r/\bAC-(\d+)\s*\(meta\)/
+    d_meta_pattern = ~r/\bD-(\d+)\s*\(meta\)/
 
-    Regex.scan(meta_pattern, section_text, capture: :all_but_first)
-    |> List.flatten()
-    |> Enum.map(&"AC-#{&1}")
-    |> MapSet.new()
+    ac_meta =
+      Regex.scan(ac_meta_pattern, section_text, capture: :all_but_first)
+      |> List.flatten()
+      |> Enum.map(&"AC-#{&1}")
+
+    d_meta =
+      Regex.scan(d_meta_pattern, section_text, capture: :all_but_first)
+      |> List.flatten()
+      |> Enum.map(&"D-#{&1}")
+
+    MapSet.new(ac_meta ++ d_meta)
   end
 
   # Parse all AC-N and D-NNN tokens from the given text.

--- a/test/tau/factory/gate/ac_linkage_property_test.exs
+++ b/test/tau/factory/gate/ac_linkage_property_test.exs
@@ -136,7 +136,7 @@ defmodule Tau.Factory.Gate.AcLinkagePropertyTest do
 
   property "P-AC3: AC-1 — a (meta)-marked AC is never reported missing" do
     check all(meta_token <- ac_token_gen(), other_token <- any_token_gen()) do
-      # Only AC- tokens support the (meta) marker in this PR's convention.
+      # Both AC- and D-NNN tokens support the (meta) marker (D-322 extends this).
       # meta_token is present with (meta) — should be exempt.
       # other_token is a normal claimed token — we cover it.
       other_token = if other_token == meta_token, do: "D-999", else: other_token
@@ -203,5 +203,48 @@ defmodule Tau.Factory.Gate.AcLinkagePropertyTest do
 
     gating_tests = [%{name: "AC-1: present", tags: [:ac_1]}]
     assert {:pass, []} = AcLinkage.check(pr_body, gating_tests)
+  end
+
+  # ---------------------------------------------------------------------------
+  # D-322 — D-NNN (meta) exemption: a D-NNN (meta) token is NEVER reported
+  # missing. Gate 5.1's meta-exemption applies to D-NNN tokens, not only AC-N.
+  # ---------------------------------------------------------------------------
+
+  @tag :d_322
+  test "D-322: check/2 treats D-NNN (meta) token as exempt — never reported missing" do
+    # PR body with ONLY a D-NNN (meta) token in the AC section.
+    # No gating tests cover it — it must be exempt (not missing).
+    pr_body = """
+    ## Acceptance criteria
+
+    - **D-999 (meta)** verified by CI, not a unit test.
+
+    ## Test plan
+
+    See gating tests.
+    """
+
+    # Empty gating-test list — D-999 has no covering test.
+    # D-322 requires check/2 to return {:pass, []} because D-999 (meta) is exempt.
+    assert {:pass, []} = AcLinkage.check(pr_body, [])
+  end
+
+  @tag :d_322
+  test "D-322: check/2 still reports a non-meta D-NNN token missing when uncovered" do
+    # A D-NNN WITHOUT (meta) must still be reported missing when uncovered.
+    # This guards against an over-broad fix that skips all D-NNN tokens.
+    pr_body = """
+    ## Acceptance criteria
+
+    - **D-888** a normal D-NNN claim with no covering test.
+
+    ## Test plan
+
+    See gating tests.
+    """
+
+    result = AcLinkage.check(pr_body, [])
+    assert {:fail, missing} = result
+    assert "D-888" in missing, "Non-meta D-NNN must be reported missing; got #{inspect(missing)}"
   end
 end


### PR DESCRIPTION
## Gate 5.1 (ac_linkage): exempt `D-NNN (meta)` tokens, not only `AC-N (meta)` (#514)

Closes #514.

### Problem
`lib/tau/factory/gate/ac_linkage.ex` `parse_meta_ac_tokens/1` matches only
`~r/\bAC-(\d+)\s*\(meta\)/` — it exempts `AC-N (meta)` but NOT `D-NNN (meta)`.
Yet `parse_ac_tokens/1` scans BOTH `AC-N` and `D-NNN` as claims, and the module
docstring + SPEC-FACTORY-GATE §C2 (D-322) intent is "every **non-meta**
`AC-N`/`D-NNN` token" / "a `(meta)`-marked claim is never reported missing".
Result: a `D-NNN (meta)` cross-reference in the AC section is scanned as a
claim but never exempted → Gate 5.1 false-fails (observed on PR #513:
D-326/D-366 reported missing despite `(meta)` markers).

### Fix
Extend `parse_meta_ac_tokens/1` to ALSO match `~r/\bD-(\d+)\s*\(meta\)/` and
union the results, so a `D-NNN (meta)` token is exempt exactly as `AC-N (meta)`
is. Conforms to the existing D-322 / C2 intent (no new state at the SPEC'd
boundary — a parsing bug fixed to match the documented contract).

### Acceptance criteria
- **D-322** — Gate 5.1's `(meta)` exemption applies to `D-NNN (meta)` tokens,
  not only `AC-N (meta)`: a `D-NNN (meta)` token in the `## Acceptance criteria`
  section is never reported missing.

### Gating-test paths (frozen at 4b)
- `test/tau/factory/gate/ac_linkage_property_test.exs` — D-322 (`D-NNN (meta)` exempt; non-meta `D-NNN` still reported missing). Tags `:d_322`.

### Scope & order
1. `test/tau/factory/gate/ac_linkage_property_test.exs` (or a sibling) — one
   failing test asserting `D-NNN (meta)` is exempt. [4b]
2. `lib/tau/factory/gate/ac_linkage.ex` — extend `parse_meta_ac_tokens/1`. [D-322]

### SPECs
SPEC-FACTORY-GATE §C2 (D-322) already states the meta-exemption intent; this PR
conforms the implementation to it. No new constraint surfaced (no §3 amendment).

### Gate verdicts
- **critic** (HEAD 744d253): **PASS** — token-form match exact (`D-NNN` meta ↔ claim), exemption marker-specific (non-meta `D-NNN` still reported missing, proven by companion test), conforms to documented D-322/C2 intent. One non-blocking SUGGESTION (add a `D-NNN (meta)` example to SPEC §C2 prose).
- **reviewer** (HEAD 744d253): **PASS** — full suite 1700 tests + 208 properties, 0 failures; gate dir green; Gate 5.1 self-check OK; all CI jobs green.
