### PR TITLE
fix(factory): bound MergeAuthority build-failure requeue (D-394, #523)

### DIFF
--- a/docs/spec/SPEC-FACTORY-MERGE.md
+++ b/docs/spec/SPEC-FACTORY-MERGE.md
@@ -42,6 +42,23 @@ Updates §5 `:committing` exit line, adds D-356 to §6, and cross-references
 SPEC-FACTORY-CORE D-356 (the U subscribe-before-request consume half). Resolves
 #478 (telemetry-vs-PubSub mismatch).
 
+**Amendment (2026-06-16, PR #534):** Introduces **D-394** (bounded, backed-off
+build-retry with per-member terminal eject). The non-health build-failure paths
+in `:integrating` (`{:build_failed, reason}` for `reason ≠ {:health_red, _}`, and
+build-`Task` `:DOWN`) requeued the train **instantly, with no attempt bound and
+no backoff** — a single deterministic `{:git_error, _}` drove ~6000
+requeue/rebuild cycles in ~5 min until the Unit's fixed 30 s `:awaiting_merge`
+state-timeout escalated `:E_MERGE_STALLED` (run #4). Adds a per-member
+`build_attempts` bound (`N_build = 3`) with a `T_backoff = 2_000 ms` non-blocking
+generic-timeout, enforced by a single head-guard clause on `start_build/1`
+(`backoff_pending`). On exhaustion the member is terminally ejected (per-member,
+never max-based) through the D-355/D-356 reject machinery
+(`reason: :build_retry_exhausted`). A **wedged** build (`:state_timeout`) is now
+terminal at B=1 (`reason: :build_wedged`), same class as health-red, never folded
+into the retry climb. Adds §3 `[C207-B2a]`, the `:build_retry` point span to §4
+B8, §5 table/prose edits, §6 D-394, §7 AC-10. `{:health_red,_}` stays terminal at
+first failure (D-303). Resolves #523.
+
 ## 0. Why this spec exists
 
 M is the **crux** of the autonomous factory: it is the one component where the
@@ -163,10 +180,29 @@ Format: `[Cn-Bm]` = constraint number + boundary. **★** marks non-obvious.
 
 - **★ [C207-B2]** A **wedged build** (the `Task` neither completes nor crashes)
   would hang M in `:integrating` forever, silently starving the whole merge
-  stage. `:integrating` MUST arm a mandatory `:state_timeout`; on expiry M
-  abandons the build (requeues the train) rather than waiting indefinitely. A
-  `Task` *crash* surfaces as `:DOWN` and is handled (requeue), but a wedge emits
-  no message — the timeout is the only signal.
+  stage. `:integrating` MUST arm a mandatory `:state_timeout`; a wedge emits no
+  message — the timeout is the only signal. On expiry M does **not** requeue: a
+  wedge is **terminal at B=1** — the member is ejected (its 30-min build budget
+  cannot fit the Unit's 30 s window, so a retry climb is pointless), same class
+  as a health-red eject (`[C207-B2a]`, D-394). A `Task` *crash* surfaces as
+  `:DOWN`; rather than an unbounded instant requeue it joins the **bounded,
+  backed-off** retry climb of `[C207-B2a]`.
+- **★ [C207-B2a] (D-394)** A **retryable** build failure (`{:build_failed, _}`
+  other than `:health_red`; or a build-`Task` `:DOWN` crash) MUST be bounded: at
+  most `N_build = 3` consecutive retries per M-lifetime, each separated from the
+  previous build launch by ≥ `T_backoff = 2_000 ms` of dwell in `:idle` with no
+  build running (a `backoff_pending` flag + a generic
+  `{:timeout, T_backoff, :build_backoff}`; the single head-guard clause on
+  `start_build/1` makes every launch path refuse while pending — INV-3 preserved,
+  a mid-backoff `request_merge` only enqueues). An unbounded zero-delay requeue
+  silently storms M and trips the Unit's 30 s `:awaiting_merge` stall timer with a
+  spurious `:E_MERGE_STALLED` (#523). On the `N_build`-th consecutive failure the
+  member is **terminally ejected** (durable `:rejected` row + telemetry +
+  `{:merge_result, :rejected}` broadcast), per-member, not `max`-based. A
+  **wedge** (`:state_timeout`) is terminal at B=1 — never folded into the climb
+  (its 30-min budget cannot fit the Unit's 30 s window). Sizing:
+  `N_build·T_build_worst + (N_build−1)·T_backoff + T_eject < 30_000 ms` MUST hold;
+  breakeven ≈ 8_600 ms/attempt.
 - **★ [C208-B5]** A buggy or adversarial Toolchain adapter MUST NOT be able to
   fake `:green`. The adapter supplies only the *recipe* (data); M **executes and
   judges** the structured artifact itself (HR-3, FC-5). The judgement is the
@@ -334,6 +370,11 @@ Format: `[Cn-Bm]` = constraint number + boundary. **★** marks non-obvious.
   falsification test for LIV-2** (an unbounded climb is starvation surfacing).
   Spans also feed the `T_int` model the §sizing rule depends on — measurement is
   a binding input, not optional instrumentation.
+- `:build_retry` (D-394) is a **point event** — a single `:telemetry.execute`
+  (like the module's existing `:reject` / `:integrating` point emissions), **not**
+  a `*.start`/`*.stop` pair, so it inherits no pairing obligation — emitted once
+  per bounded retry launch, carrying `unit_id`, `attempt_n`, `backoff_ms`. Its
+  count (= `N_build` on a deterministic failure) is the live anti-storm watch.
 
 ### B9: Merge Authority COMMIT (C1) ↔ Ledger merge-outcome write (*D-355, PR #465*)
 
@@ -360,8 +401,8 @@ Format: `[Cn-Bm]` = constraint number + boundary. **★** marks non-obvious.
 
 | State | Meaning | Entry | Exit |
 |-------|---------|-------|------|
-| `:idle` | Accept submissions; assemble the next train; handle revocation notices | start (rebuild train+queue from L); commit/requeue done | non-empty green batch → `:integrating` |
-| `:integrating` | Monitored `Task` runs `rebase → gate → health` **off the mailbox** in a **private ephemeral worktree** (`.merge-wt-<nonce>`, D-385); M still accepts submissions for the *next* train but starts no second train (INV-3) | a green batch assembled, `base` captured | `Task {:built,…}` → `:committing`; `{:build_failed, :health_red}` → `:idle` (bisect/eject); `:DOWN` → `:idle` (requeue); `:state_timeout` → `:idle` (requeue wedged build) |
+| `:idle` | Accept submissions; assemble the next train; handle revocation notices; while `backoff_pending`, a `{:timeout, :build_backoff}` defers the next build — `request_merge` during backoff only enqueues (INV-3) | start (rebuild train+queue from L); commit/requeue done | non-empty green batch → `:integrating` |
+| `:integrating` | Monitored `Task` runs `rebase → gate → health` **off the mailbox** in a **private ephemeral worktree** (`.merge-wt-<nonce>`, D-385); M still accepts submissions for the *next* train but starts no second train (INV-3) | a green batch assembled, `base` captured | `Task {:built,…}` → `:committing`; `{:build_failed, :health_red}` → `:idle` (bisect/eject); non-health `{:build_failed,_}` and `:DOWN` → `:idle` with `backoff_pending` + `{:timeout, T_backoff, :build_backoff}` (D-394 bounded retry); on the `N_build`-th failure → terminal per-member eject; `:state_timeout` (wedge) → terminal eject at B=1 (D-394) |
 | `:committing` | **Short** critical section: `assert_all_verdicts_live` (re-read latest, HR-2) then `cas_push` (`--force-with-lease`, HR-1) | `Task` returned `:built` | push `:ok` → `:idle` (commit, broadcast `:merged`); `{:error, :stale_ref}` → `:idle` (requeue all); `{:revoked, u}` → `:idle` (eject `u`, retry rest) |
 
 ```
@@ -395,12 +436,17 @@ submitted(green) ─enqueue→ wait-queue (FIFO + aging by restale_count)
   post-merge main re-check RED → E-RED-MAIN (global halt; main left red, named)
 ```
 
-On every **terminal rejection** of a train member (verdict-revoked, build-failed
-health-RED eject, task-down/wedged requeue exhausted to an eject, stale-ref) M
-likewise broadcasts `{:merge_result, :rejected}` to `"factory:pr:#{id}"` for the
-affected member(s) (D-356). A `:rejected` re-gates at U (INV-2); a member only
-*requeued* (e.g. `:stale_ref` for a later rebase attempt) is **not** a terminal
-rejection and is not yet published — U keeps awaiting. The broadcast is the
+On every **terminal rejection** of a train member M likewise broadcasts
+`{:merge_result, :rejected}` to `"factory:pr:#{id}"` for the affected member(s)
+(D-356). The terminal reasons are: verdict-revoked; build-failed health-RED
+eject; **build-retry exhausted** (`:build_retry_exhausted`, after `N_build`
+consecutive retryable failures, D-394); **wedge eject** (`:build_wedged`, B=1, a
+`:state_timeout`, D-394). A `:rejected` re-gates at U (INV-2). A member still
+**within** the D-394 bound (a retryable `{:build_failed,_}`/`:DOWN` with
+`build_attempts < N_build`) is only **requeued** — backed off, not terminally
+rejected — and is **not** published; likewise a member only *requeued* for
+`:stale_ref` (a later rebase attempt) is **not** a terminal rejection and is not
+yet published — U keeps awaiting. The broadcast is the
 authoritative async result the arch's `control-plane.md` §5 names; the
 `[:tau, :factory, :merge, …]` telemetry remains a *derived observer projection*
 (§4 B8), never the control-path delivery.
@@ -420,6 +466,11 @@ ahead of newcomers (LIV-2).
 
 `E-CONFLICT` (unresolvable rebase) is raised by U on a rejected/looping rebase,
 not by M; M's `:stale_ref` path is an ordinary requeue, not an escalation.
+
+D-394's build-retry exhaustion and wedge eject are **terminal rejections**
+(`{:merge_result, :rejected}` + durable `:rejected` row), **not** escalations —
+they yield a deterministic answer at U (re-gate, INV-2) within the Unit's stall
+budget, which is why no `:E_MERGE_STALLED` is raised.
 
 ## 6. D-NNN invariants
 
@@ -481,8 +532,11 @@ only terminal outcomes are durable. `Ledger.Reader.merge_outcome_for/2` returns
 reconcile on resume without re-submitting an already-landed or
 already-terminally-rejected merge (D-344 / PR #465, #466). Terminal rejection
 paths covered: health-red eject (`:integrating` → `{:build_failed, {:health_red,
-_}}`); verdict-revoked eject (`:committing` → `{:revoked, _}`). Owned by this
-SPEC (§4 B9); cited by SPEC-FACTORY-CORE (Unit `:awaiting_merge` reconcile,
+_}}`); verdict-revoked eject (`:committing` → `{:revoked, _}`); build-retry
+exhausted (`:integrating`, `N_build` consecutive retryable
+`{:build_failed,_}`/`:DOWN`, `reason: :build_retry_exhausted`, D-394); wedge
+eject (`:integrating` `:state_timeout`, `reason: :build_wedged`, B=1, D-394).
+Owned by this SPEC (§4 B9); cited by SPEC-FACTORY-CORE (Unit `:awaiting_merge` reconcile,
 D-344 amendment). Enforced by `merge_outcome_durability_test.exs` (`:merged`
 side, PR #465) and `reject_durable_outcome_test.exs` (`:rejected` side, PR #466;
 oracle-separated).
@@ -526,6 +580,37 @@ Enforced by `merge_build_clean_tree_test.exs` (oracle-separated gating test;
 PR #522): a concurrent worktree holding the unit branch does not cause a
 collision, the outcome is `:merged`, and `repo_dir`'s HEAD remains on `main`
 with a clean index after the build.
+
+**D-394 — Bounded, backed-off build-retry with per-member terminal eject
+(anti-storm):** A train member's *retryable* build failure (`{:build_failed, _}`
+other than `{:health_red, _}`, or a build-`Task` `:DOWN`) is retried at most
+`N_build = 3` consecutive times per M-lifetime; every retry launch is separated
+from the previous build by ≥ `T_backoff = 2_000 ms` of dwell in `:idle` with
+`backoff_pending = true`. A single head-guard clause
+`start_build(%{backoff_pending: true})` makes **every** launch path refuse while
+pending (every build funnels through `start_build/1`), so a `request_merge`
+arriving mid-backoff only enqueues and replies `:queued` (INV-3/D-302: never two
+concurrent builds); the backoff uses a **generic** `{:timeout, T_backoff,
+:build_backoff}` (not a `:state_timeout`), which survives the intervening
+`:keep_state` enqueue. On the `N_build`-th consecutive failure the member — and
+only that member (per-member, never `max`-based; forward-compatible with D-341
+batch trains) — is terminally ejected: a durable `merge_outcomes` `:rejected` row
+is written (`reason: :build_retry_exhausted`, D-355 WAL-before-ack, BEFORE the
+telemetry projection), `:reject` telemetry fires, then `{:merge_result,
+:rejected}` is broadcast to `"factory:pr:#{id}"` (D-356); the member is dropped,
+not requeued. `build_attempts` is per-M-lifetime in-memory (NOT WAL-persisted —
+D-355 forbids non-terminal durable rows; an M restart resets it, which is safe —
+re-climbing from 0 is bounded) and is reset to 0 on a member's successful merge
+and dropped on terminal eject. A **wedged** build (`:state_timeout`) is terminal
+at the first occurrence (B=1, same class as health-red, D-303): immediate
+terminal eject (`reason: :build_wedged`) with durable row + telemetry +
+broadcast, never requeued. Sizing inequality `N_build·T_build_worst +
+(N_build−1)·T_backoff + T_eject < 30_000 ms` (the Unit's `:awaiting_merge`
+budget, SPEC-FACTORY-CORE) MUST hold; breakeven ≈ 8_600 ms/attempt, so the bound
+holds even at a pessimistic 3 s/attempt. `{:health_red, _}` is exempt (terminal
+at first failure, D-303). Enforced by
+`test/tau/factory/merge_build_retry_test.exs` (oracle-separated). Owned by
+SPEC-FACTORY-MERGE (§3 `[C207-B2a]`, §6).
 
 **D-341 — Fair merge progress, no starvation (LIV-2):**
 M serves merge-ready units from a **FIFO + aging** wait-queue;
@@ -581,17 +666,32 @@ Each is expressed against an observable signal. PR groupings are indicative.
   `[:tau, :factory, :merge, :health]` span (the dogfood proof). *This AC depends
   on SPEC-FACTORY-{CORE,GATE} landing; it is the integration gate, not a
   MERGE-only unit.*
+- **AC-10 (D-394, build-retry storm bound):** `mix test
+  test/tau/factory/merge_build_retry_test.exs` passes. With a `build_fun`
+  injected to fail deterministically (`{:build_failed, {:git_error, 1, "boom"}}`),
+  a single `request_merge` is retried **exactly `N_build = 3`** times; consecutive
+  build launches are spaced **≥ `T_backoff` (2_000 ms)**; a `request_merge`
+  arriving during a backoff window replies `:queued` and launches **no** build
+  until the timer fires (INV-3); on the 3rd failure exactly **one** durable
+  `merge_outcomes` `:rejected` row (`reason: :build_retry_exhausted`) and **one**
+  `{:merge_result, :rejected}` broadcast occur; **no** `:E_MERGE_STALLED`; a
+  **wedged** build ejects terminally at B=1 (`reason: :build_wedged`) with one
+  durable row + one broadcast, never requeued. Signal: `:build_retry` point spans
+  (count = 3, `backoff_ms = 2000`), one terminal `:reject` span, one Ledger row,
+  one PubSub message.
 
 ## Appendix B — Source map
 
 Files that bring a PR into scope of this SPEC (`D-NNN`/`C-N` → file:symbol):
 
 - `lib/tau/factory/merge_authority.ex` (C1; D-300, D-301, D-302, D-303, D-341,
-  D-355, D-356, D-385 — the `gen_statem`, `:idle`/`:integrating`/`:committing`;
+  D-355, D-356, D-385, D-394 — the `gen_statem`, `:idle`/`:integrating`/`:committing`;
   D-356 PubSub broadcast of `{:merge_result, _}` to `"factory:pr:#{id}"` on every
-  terminal member outcome; D-385 private-worktree build isolation in `default_build/3`)
-  — PR-MERGE-1..5/PR#465/PR#477/PR#522
+  terminal member outcome; D-385 private-worktree build isolation in `default_build/3`;
+  D-394 bounded backed-off build retry + per-member terminal eject + wedge-at-B=1)
+  — PR-MERGE-1..5/PR#465/PR#477/PR#522/PR#534
 - `test/tau/factory/merge_build_clean_tree_test.exs` (D-385 gating test) — PR#522
+- `test/tau/factory/merge_build_retry_test.exs` (D-394 gating test) — PR #534
 - `lib/tau/factory/dogfood/sandbox.ex` (D-385 `.gitignore` hygiene in `seed/1`) — PR#522
 - `test/tau/factory/merge_result_pubsub_test.exs` (D-356 emission gating test) — PR#477
 - `lib/tau/factory/ledger/migrations.ex` (D-355 migration `20260612_010_merge_outcomes`) — PR#465

--- a/lib/tau/factory/merge_authority.ex
+++ b/lib/tau/factory/merge_authority.ex
@@ -512,8 +512,9 @@ defmodule Tau.Factory.MergeAuthority do
 
     if retryable == [] do
       # All members exhausted — eject was already terminal; transition immediately.
-      # (terminal_eject_members already cleared train/task_ref/task_pid)
-      transition_from_idle(%{data_after_eject | build_attempts: new_attempts})
+      # (terminal_eject_members already cleared train/task_ref/task_pid and dropped
+      # the ejected units from build_attempts — do NOT overwrite with new_attempts.)
+      transition_from_idle(data_after_eject)
     else
       # At least one retryable member: requeue, set backoff_pending, arm timer.
       # Emit per-retryable-member :build_retry point telemetry (D-394).

--- a/lib/tau/factory/merge_authority.ex
+++ b/lib/tau/factory/merge_authority.ex
@@ -27,6 +27,12 @@ defmodule Tau.Factory.MergeAuthority do
   # How long to wait for a build task before treating it as wedged (C207).
   @build_timeout_ms :timer.minutes(30)
 
+  # D-394: maximum consecutive retryable failures per member before terminal eject.
+  @build_retry_max 3
+
+  # D-394: dwell between retry launches (non-blocking backoff timer).
+  @build_backoff_ms 2_000
+
   # ---------------------------------------------------------------------------
   # Public API
   # ---------------------------------------------------------------------------
@@ -45,6 +51,12 @@ defmodule Tau.Factory.MergeAuthority do
     - `:cas` — the CAS module to use (default `Tau.Factory.Merge.Cas`; injectable for tests).
     - `:pubsub` — the `Phoenix.PubSub` instance to broadcast D-356 merge results on
       (default `Tau.PubSub`; injectable for tests).
+    - `:build_retry_max` — maximum consecutive retryable failures before terminal eject
+      (default #{@build_retry_max}; injectable for tests, D-394).
+    - `:build_backoff_ms` — dwell in ms between retry launches
+      (default #{@build_backoff_ms}; injectable for tests, D-394).
+    - `:build_timeout_ms` — ms before a running build task is killed as wedged
+      (default #{@build_timeout_ms}; injectable for tests, D-394).
   """
   @spec child_spec(keyword()) :: Supervisor.child_spec()
   def child_spec(opts) do
@@ -92,6 +104,11 @@ defmodule Tau.Factory.MergeAuthority do
     cas = Keyword.get(opts, :cas, Cas)
     pubsub = Keyword.get(opts, :pubsub, Tau.PubSub)
 
+    # D-394: resolve retry/backoff/timeout params from opts, falling back to module attrs.
+    build_retry_max = Keyword.get(opts, :build_retry_max, @build_retry_max)
+    build_backoff_ms = Keyword.get(opts, :build_backoff_ms, @build_backoff_ms)
+    build_timeout_ms = Keyword.get(opts, :build_timeout_ms, @build_timeout_ms)
+
     # Start the Task.Supervisor for builds if it is not already running.
     # Linking it to this process ensures it is cleaned up when MA stops.
     case Process.whereis(tasks_name) do
@@ -115,6 +132,10 @@ defmodule Tau.Factory.MergeAuthority do
       cas: cas,
       pubsub: pubsub,
       build_fun: build_fun,
+      # D-394: resolved retry parameters
+      build_retry_max: build_retry_max,
+      build_backoff_ms: build_backoff_ms,
+      build_timeout_ms: build_timeout_ms,
       # wait queue: list of units waiting to be built
       queue: [],
       # task ref for current build (nil when :idle)
@@ -122,7 +143,11 @@ defmodule Tau.Factory.MergeAuthority do
       # task pid for forwarding barrier messages (nil when :idle)
       task_pid: nil,
       # units currently in the integrating train
-      train: []
+      train: [],
+      # D-394: per-member consecutive failure counter (unit_id => non_neg_integer)
+      build_attempts: %{},
+      # D-394: true while the T_backoff timer is armed; blocks start_build
+      backoff_pending: false
     }
 
     {:ok, :idle, data}
@@ -142,6 +167,14 @@ defmodule Tau.Factory.MergeAuthority do
       {:idle, next_data} ->
         {:keep_state, next_data, [{:reply, from, :queued}]}
     end
+  end
+
+  # D-394: backoff timer expired — clear pending flag and attempt next build.
+  # In :state_functions callback mode, a generic timeout {:timeout, T, Name}
+  # arrives as idle(:timeout, Name, data) — event type is :timeout, content is Name.
+  def idle(:timeout, :build_backoff, data) do
+    next_data = %{data | backoff_pending: false}
+    transition_from_idle(next_data)
   end
 
   # Ignore stray barrier messages in idle state.
@@ -182,82 +215,80 @@ defmodule Tau.Factory.MergeAuthority do
 
     telemetry(:committing, %{hash: hd_hash(units)}, %{units: units, tip: tip})
 
-    next_data = %{data | task_ref: nil, task_pid: nil, train: []}
+    # D-394: reset build_attempts for all successfully-built members.
+    next_attempts =
+      Enum.reduce(units, data.build_attempts, fn unit, acc ->
+        Map.delete(acc, unit.id)
+      end)
+
+    next_data = %{data | task_ref: nil, task_pid: nil, train: [], build_attempts: next_attempts}
     commit_action = {:next_event, :internal, {:commit, units, base, tip}}
     {:next_state, :committing, next_data, [commit_action]}
   end
 
   # Task result: build failed — health_red means eject (D-303, B=1); other
-  # failures requeue for the next train attempt.
+  # failures enter D-394 bounded backed-off retry or terminal eject.
   def integrating(:info, {ref, {:build_failed, reason}}, %{task_ref: ref} = data) do
     Process.demonitor(ref, [:flush])
     Logger.warning("[MergeAuthority] build failed: #{inspect(reason)}")
 
     train = data.train
 
-    next_data =
-      case reason do
-        {:health_red, _report} ->
-          # Eject the train; do NOT requeue — health failure is terminal for this tip.
-          # D-355 (symmetric) / WAL-before-ack: write the durable :rejected outcome
-          # row for each ejected member BEFORE the ephemeral telemetry projection
-          # fires. Mirrors the :merged WAL-before-ack path in :committing (D-315,
-          # RPO=0). Only TERMINAL rejections are durable; requeues write nothing.
-          Enum.each(train, fn unit ->
-            LedgerWriter.record_merge_outcome(data.ledger, %{
-              unit_id: unit.id,
-              outcome: :rejected,
-              commit_sha: nil,
-              reason: :build_failed,
-              run: unit.run
-            })
-          end)
+    case reason do
+      {:health_red, _report} ->
+        # Eject the train; do NOT requeue — health failure is terminal for this tip.
+        # D-355 (symmetric) / WAL-before-ack: write the durable :rejected outcome
+        # row for each ejected member BEFORE the ephemeral telemetry projection
+        # fires. Mirrors the :merged WAL-before-ack path in :committing (D-315,
+        # RPO=0). Only TERMINAL rejections are durable; requeues write nothing.
+        Enum.each(train, fn unit ->
+          LedgerWriter.record_merge_outcome(data.ledger, %{
+            unit_id: unit.id,
+            outcome: :rejected,
+            commit_sha: nil,
+            reason: :build_failed,
+            run: unit.run
+          })
+        end)
 
-          telemetry(:reject, %{hash: hd_hash(train)}, %{reason: :build_failed, units: train})
+        telemetry(:reject, %{hash: hd_hash(train)}, %{reason: :build_failed, units: train})
 
-          # D-356: broadcast :rejected to each ejected member (terminal rejection).
-          Enum.each(train, fn unit ->
-            Phoenix.PubSub.broadcast(
-              data.pubsub,
-              "factory:pr:#{unit.id}",
-              {:merge_result, :rejected}
-            )
-          end)
+        # D-356: broadcast :rejected to each ejected member (terminal rejection).
+        Enum.each(train, fn unit ->
+          Phoenix.PubSub.broadcast(
+            data.pubsub,
+            "factory:pr:#{unit.id}",
+            {:merge_result, :rejected}
+          )
+        end)
 
-          eject_train(data)
+        next_data = eject_train(data)
+        transition_from_idle(next_data)
 
-        _other ->
-          # Non-terminal: requeue for the next train attempt; do NOT write a durable
-          # outcome row (only terminal outcomes are durable — D-355 symmetric).
-          telemetry(:reject, %{hash: hd_hash(train)}, %{reason: :build_failed, units: train})
-          requeue_train(data)
-      end
-
-    transition_from_idle(next_data)
+      _other ->
+        # D-394: non-health retryable failure — bounded retry or terminal eject.
+        bounded_retry_or_eject(data, :build_failed)
+    end
   end
 
   # Task crashed (:DOWN without a prior result message).
+  # D-394: task crash joins the bounded backed-off retry climb.
   def integrating(:info, {:DOWN, ref, :process, _pid, reason}, %{task_ref: ref} = data) do
     Logger.warning("[MergeAuthority] build task crashed: #{inspect(reason)}")
-
-    train = data.train
-    telemetry(:reject, %{hash: hd_hash(train)}, %{reason: :task_down, units: train})
-
-    next_data = requeue_train(data)
-    transition_from_idle(next_data)
+    bounded_retry_or_eject(data, :task_down)
   end
 
   # Wedged build guard: state_timeout fires if the build takes too long.
+  # D-394: wedge is terminal at B=1 — kill task, eject, never requeue.
   def integrating(:state_timeout, :build_timeout, data) do
-    Logger.warning("[MergeAuthority] build task wedged; requeuing train")
+    Logger.warning("[MergeAuthority] build task wedged; ejecting train (terminal at B=1)")
 
     if data.task_pid, do: Process.exit(data.task_pid, :kill)
     if data.task_ref, do: Process.demonitor(data.task_ref, [:flush])
 
-    train = data.train
-    telemetry(:reject, %{hash: hd_hash(train)}, %{reason: :build_timeout, units: train})
-
-    next_data = requeue_train(data)
+    # D-394: wedge is terminal at B=1 — does NOT count toward build_attempts.
+    # Write durable row + broadcast then transition.
+    next_data = terminal_eject_members(data, data.train, :build_wedged)
     transition_from_idle(next_data)
   end
 
@@ -347,7 +378,13 @@ defmodule Tau.Factory.MergeAuthority do
               )
             end)
 
-            transition_from_idle(data)
+            # D-394: reset build_attempts for successfully merged members.
+            next_attempts =
+              Enum.reduce(units, data.build_attempts, fn unit, acc ->
+                Map.delete(acc, unit.id)
+              end)
+
+            transition_from_idle(%{data | build_attempts: next_attempts})
 
           {:error, :stale_ref} ->
             Logger.info("[MergeAuthority] stale ref; requeuing train for rebase + re-gate")
@@ -386,8 +423,11 @@ defmodule Tau.Factory.MergeAuthority do
     %{data | queue: queue ++ [unit]}
   end
 
-  # Attempt to start a new build from the queue. Returns a gen_statem reply tuple.
-  # Used from `:idle` to avoid duplicating the transition logic.
+  # D-394: head guard — if a backoff timer is armed, do NOT launch a build.
+  # This is the single chokepoint: every code path that might launch funnels
+  # through start_build/1, so the guard covers all of them.
+  defp start_build(%{backoff_pending: true} = data), do: {:idle, data}
+
   defp start_build(%{queue: []} = data), do: {:idle, data}
 
   defp start_build(%{queue: [unit | rest]} = data) do
@@ -409,7 +449,8 @@ defmodule Tau.Factory.MergeAuthority do
         task_pid: task.pid
     }
 
-    timeout_action = {:state_timeout, @build_timeout_ms, :build_timeout}
+    # D-394: use the resolved build_timeout_ms from data (not the module attribute).
+    timeout_action = {:state_timeout, data.build_timeout_ms, :build_timeout}
     {:integrating, next_data, [timeout_action]}
   end
 
@@ -425,8 +466,122 @@ defmodule Tau.Factory.MergeAuthority do
     end
   end
 
-  defp requeue_train(%{train: train} = data) do
-    requeue_units(%{data | train: []}, train)
+  # D-394: bounded retry or terminal eject for retryable build failures.
+  #
+  # Increments build_attempts for each train member, then:
+  #   - Members at N_build exhaustion → terminal_eject_members (durable row + broadcast).
+  #   - Remaining retryable members → requeue with a T_backoff timer.
+  #   - If ALL exhausted → no timer, transition_from_idle immediately.
+  #   - If ANY retryable → arm {:timeout, T_backoff, :build_backoff}, set backoff_pending.
+  #
+  # Returns a gen_statem action tuple.
+  defp bounded_retry_or_eject(data, failure_reason) do
+    train = data.train
+    retry_max = data.build_retry_max
+    backoff_ms = data.build_backoff_ms
+
+    # Increment attempt counter for each current train member.
+    new_attempts =
+      Enum.reduce(train, data.build_attempts, fn unit, acc ->
+        Map.update(acc, unit.id, 1, &(&1 + 1))
+      end)
+
+    # Partition by exhaustion.
+    {exhausted, retryable} =
+      Enum.split_with(train, fn unit ->
+        Map.get(new_attempts, unit.id, 0) >= retry_max
+      end)
+
+    # Emit a non-terminal telemetry span for ALL train members first.
+    # (Terminal path emits its own telemetry inside terminal_eject_members.)
+    unless retryable == [] do
+      telemetry(:reject, %{hash: hd_hash(train)}, %{reason: failure_reason, units: train})
+    end
+
+    # Terminal eject exhausted members (writes durable rows + broadcasts).
+    data_after_eject =
+      if exhausted == [] do
+        data
+      else
+        terminal_eject_members(
+          %{data | build_attempts: new_attempts},
+          exhausted,
+          :build_retry_exhausted
+        )
+      end
+
+    if retryable == [] do
+      # All members exhausted — eject was already terminal; transition immediately.
+      # (terminal_eject_members already cleared train/task_ref/task_pid)
+      transition_from_idle(%{data_after_eject | build_attempts: new_attempts})
+    else
+      # At least one retryable member: requeue, set backoff_pending, arm timer.
+      # Emit per-retryable-member :build_retry point telemetry (D-394).
+      Enum.each(retryable, fn unit ->
+        attempt_n = Map.get(new_attempts, unit.id, 0)
+
+        :telemetry.execute(
+          [:tau, :factory, :merge, :build_retry],
+          %{},
+          %{unit_id: unit.id, attempt_n: attempt_n, backoff_ms: backoff_ms}
+        )
+      end)
+
+      next_data =
+        data_after_eject
+        |> requeue_units(retryable)
+        |> Map.put(:build_attempts, new_attempts)
+        |> Map.put(:backoff_pending, true)
+
+      {:next_state, :idle, next_data, [{:timeout, backoff_ms, :build_backoff}]}
+    end
+  end
+
+  # D-394: terminal eject for a list of units with a given reason.
+  #
+  # For each unit IN ORDER (D-355/D-356):
+  #   (a) Write durable :rejected row via LedgerWriter (WAL-before-ack).
+  #   (b) Emit :reject telemetry.
+  #   (c) Broadcast {:merge_result, :rejected} on the per-PR PubSub topic.
+  #
+  # Returns updated data with those units removed from train, task_ref/task_pid
+  # cleared, and their build_attempts entries dropped.
+  defp terminal_eject_members(data, units, reason) do
+    # (a) WAL-before-ack: write all durable rows BEFORE any telemetry or broadcast.
+    Enum.each(units, fn unit ->
+      LedgerWriter.record_merge_outcome(data.ledger, %{
+        unit_id: unit.id,
+        outcome: :rejected,
+        commit_sha: nil,
+        reason: reason,
+        run: unit.run
+      })
+    end)
+
+    # (b) Telemetry after WAL writes.
+    telemetry(:reject, %{hash: hd_hash(units)}, %{reason: reason, units: units})
+
+    # (c) D-356: broadcast :rejected per unit after telemetry.
+    Enum.each(units, fn unit ->
+      Phoenix.PubSub.broadcast(
+        data.pubsub,
+        "factory:pr:#{unit.id}",
+        {:merge_result, :rejected}
+      )
+    end)
+
+    # Drop ejected units from train and build_attempts; clear task handles.
+    ejected_ids = MapSet.new(units, & &1.id)
+
+    remaining_train =
+      Enum.reject(data.train, fn unit -> MapSet.member?(ejected_ids, unit.id) end)
+
+    next_attempts =
+      Enum.reduce(units, data.build_attempts, fn unit, acc ->
+        Map.delete(acc, unit.id)
+      end)
+
+    %{data | train: remaining_train, task_ref: nil, task_pid: nil, build_attempts: next_attempts}
   end
 
   # Eject the current train without requeuing its units. Used for D-303 health

--- a/test/tau/factory/merge_build_retry_test.exs
+++ b/test/tau/factory/merge_build_retry_test.exs
@@ -409,6 +409,141 @@ defmodule Tau.Factory.MergeBuildRetryTest do
   end
 
   # ---------------------------------------------------------------------------
+  # Test 6 — build_attempts reset on terminal eject: re-submit after exhaustion
+  # gets the FULL N_build retries (D-394, AC-10)
+  #
+  # The latent bug (pre-fix): terminal_eject_members/3 drops unit.id from
+  # build_attempts, but the all-exhausted branch at merge_authority.ex:516 then
+  # overwrites data_after_eject.build_attempts with new_attempts, which still
+  # contains unit.id => N_build. A re-submitted unit_id therefore begins its
+  # second episode with a stale attempt count and is instantly ejected after
+  # only ONE build invocation (N_build + 1 >= retry_max fires immediately).
+  #
+  # Expected (D-394 §6 — "dropped on terminal eject"): after a terminal eject,
+  # build_attempts[unit_id] MUST be absent, so a re-submitted unit_id begins
+  # fresh and receives the full N_build=3 attempts.
+  # ---------------------------------------------------------------------------
+
+  describe "D-394 / AC-10 — build_attempts reset on terminal eject: re-submit after exhaustion gets full N_build" do
+    @tag :"D-394"
+    @tag :"AC-10"
+    test "D-394 AC-10 (reset-on-eject): re-submitted unit_id after exhaustion eject gets full N_build=3 attempts, not instant re-eject" do
+      ledger = start_ledger()
+      test_pid = self()
+
+      # Episode 1 unit: a fixed id so we can re-submit it.
+      unit_id = "u-reset-eject-#{System.unique_integer([:positive])}"
+
+      unit_ep1 = %{
+        id: unit_id,
+        hash: "hash-ep1-#{System.unique_integer([:positive])}",
+        run: "run-ep1-#{System.unique_integer([:positive])}",
+        branch: "feat/reset-eject-ep1-#{System.unique_integer([:positive])}"
+      }
+
+      {work_path, _tip} = setup_git_repo(unit_ep1)
+
+      # Episode 2 unit: SAME id, fresh hash/run/branch so git setup is distinct.
+      unit_ep2 = %{
+        id: unit_id,
+        hash: "hash-ep2-#{System.unique_integer([:positive])}",
+        run: "run-ep2-#{System.unique_integer([:positive])}",
+        branch: "feat/reset-eject-ep2-#{System.unique_integer([:positive])}"
+      }
+
+      # Set up the ep2 branch in the same work_path repo so the build can fetch it.
+      git_work = fn args -> System.cmd("git", args, cd: work_path) end
+      git_work.(["checkout", "-b", unit_ep2.branch])
+      File.write!(Path.join(work_path, "feature_ep2"), "ep2 work")
+      git_work.(["add", "."])
+      git_work.(["commit", "-m", "ep2 commit"])
+      git_work.(["push", "origin", unit_ep2.branch])
+      git_work.(["checkout", "main"])
+
+      # Track which episode each invocation belongs to by counting total
+      # invocations: first N_build belong to ep1, next N_build should belong to ep2.
+      build_fun = fn _units, _base ->
+        send(test_pid, {:build_invoked, unit_id})
+        {:build_failed, {:git_error, 1, "boom"}}
+      end
+
+      ma =
+        start_merge_authority(ledger, work_path, build_fun,
+          build_retry_max: 3,
+          build_backoff_ms: 50
+        )
+
+      :ok = Phoenix.PubSub.subscribe(Tau.PubSub, pr_topic(unit_id))
+
+      # --- Episode 1: submit and drain to terminal eject ---
+      assert :queued = MergeAuthority.request_merge(ma, unit_ep1)
+
+      # Drain the 3 ep1 invocations.
+      assert_receive {:build_invoked, ^unit_id},
+                     2_000,
+                     "D-394 AC-10 (reset-on-eject): ep1 build invocation 1 never arrived"
+
+      assert_receive {:build_invoked, ^unit_id},
+                     2_000,
+                     "D-394 AC-10 (reset-on-eject): ep1 build invocation 2 never arrived"
+
+      assert_receive {:build_invoked, ^unit_id},
+                     2_000,
+                     "D-394 AC-10 (reset-on-eject): ep1 build invocation 3 never arrived"
+
+      # Wait for the terminal eject broadcast confirming ep1 is done.
+      assert_receive {:merge_result, :rejected},
+                     2_000,
+                     "D-394 AC-10 (reset-on-eject): no {:merge_result, :rejected} broadcast " <>
+                       "after N_build=3 ep1 exhaustion — ep1 terminal eject did not fire"
+
+      # Flush any additional messages that might have arrived (defensive).
+      receive do
+        {:build_invoked, _} -> flunk("unexpected build_invoked after ep1 terminal eject")
+      after
+        50 -> :ok
+      end
+
+      # --- Episode 2: re-submit the SAME unit_id ---
+      # At this point, if the bug is present, build_attempts[unit_id] == 3 (N_build).
+      # The next failure increments to 4 >= 3, firing an instant terminal eject
+      # after only 1 invocation. With the fix, build_attempts[unit_id] is absent (nil),
+      # so the counter starts from 1 and the unit gets 3 full attempts.
+
+      assert :queued = MergeAuthority.request_merge(ma, unit_ep2),
+             "D-394 AC-10 (reset-on-eject): request_merge for re-submitted unit_id must return :queued"
+
+      # Collect ep2 invocations. Assert we get 3 before any second terminal eject.
+      # With the bug, only 1 arrives before the instant eject.
+      assert_receive {:build_invoked, ^unit_id},
+                     2_000,
+                     "D-394 AC-10 (reset-on-eject): ep2 build invocation 1 never arrived — " <>
+                       "re-submitted unit_id was not scheduled for a new build episode"
+
+      assert_receive {:build_invoked, ^unit_id},
+                     2_000,
+                     "D-394 AC-10 (reset-on-eject): ep2 build invocation 2 never arrived — " <>
+                       "build_attempts was NOT reset on terminal eject: the unit was ejected " <>
+                       "after only 1 attempt (stale N_build counter from ep1 was reused). " <>
+                       "D-394 §6 requires build_attempts be dropped on terminal eject so a " <>
+                       "re-submitted unit_id receives the FULL N_build retry budget."
+
+      assert_receive {:build_invoked, ^unit_id},
+                     2_000,
+                     "D-394 AC-10 (reset-on-eject): ep2 build invocation 3 never arrived — " <>
+                       "build_attempts was NOT reset on terminal eject: the unit was ejected " <>
+                       "prematurely (only 2 ep2 attempts observed instead of 3). " <>
+                       "D-394 §6 requires the full N_build=3 budget for a fresh submission."
+
+      # The ep2 terminal eject broadcast must eventually arrive (ep2 always fails).
+      assert_receive {:merge_result, :rejected},
+                     2_000,
+                     "D-394 AC-10 (reset-on-eject): no second {:merge_result, :rejected} " <>
+                       "broadcast after ep2 N_build=3 exhaustion"
+    end
+  end
+
+  # ---------------------------------------------------------------------------
   # Test 5 — Wedge terminal at B=1 (D-394, AC-10)
   #
   # A build task that blocks past build_timeout_ms must be killed and the unit

--- a/test/tau/factory/merge_build_retry_test.exs
+++ b/test/tau/factory/merge_build_retry_test.exs
@@ -1,0 +1,481 @@
+defmodule Tau.Factory.MergeBuildRetryTest do
+  @moduledoc """
+  Gating test for PR #534 (issue #523) — D-394 bounded, backed-off
+  build-failure requeue with per-member terminal eject.
+
+  ## Background
+
+  Before D-394, `MergeAuthority` requeued any non-health-red build failure
+  (`{:build_failed, {:git_error, _}}` or a task `:DOWN`) INSTANTLY with NO
+  attempt bound. A deterministic `{:build_failed, {:git_error, 1, "boom"}}`
+  would loop ~6000× in ~5 min until the Unit's fixed 30 s `:awaiting_merge`
+  timeout fired a spurious `:E_MERGE_STALLED` (#523).
+
+  D-394 introduces:
+    - A per-member `build_attempts` counter (in-memory per M-lifetime).
+    - A `T_backoff` dwell between retries (`:idle` with `backoff_pending = true`;
+      a generic `{:timeout, T_backoff, :build_backoff}` timer).
+    - On the `N_build`-th consecutive retryable failure: terminal per-member eject
+      (durable `{:rejected, :build_retry_exhausted}` row + `{:merge_result, :rejected}`
+      broadcast).
+    - A wedged build (`:state_timeout` on the build task) is terminal at B=1
+      (`{:rejected, :build_wedged}` row + broadcast), never folded into the retry
+      climb.
+
+  ## Fail-before validity (oracle separation, factory-loop §4b)
+
+  Against the current code (no D-394 implementation):
+    - Test 1 (bounded count + throttle): the 4th `{:build_invoked}` arrives
+      immediately (unbounded requeue); `refute_receive` for the 4th invocation
+      FAILS. The backoff-gap assertion also FAILS (zero delay between invocations).
+    - Test 2 (no premature build mid-backoff): no backoff exists; a new build
+      launches immediately, producing a spurious `{:build_invoked}` before the
+      backoff window; assertion FAILS.
+    - Test 3 (terminal eject on exhaustion): no terminal eject; after the 3rd
+      failure M re-queues again; `LedgerReader.merge_outcome_for` returns `:none`,
+      no `{:merge_result, :rejected}` broadcast fires; assertions FAIL.
+    - Test 4 (transient recovers): build_fun succeeds on the 3rd attempt; the
+      result must be `:merged` not `:rejected`. Against current code this MAY pass
+      (no bound logic exists to wrongly eject a recovering member); this test
+      serves as a regression guard — a bounded implementation that resets
+      `build_attempts` on success will keep this passing.
+    - Test 5 (wedge terminal at B=1): the wedge requeue fires `transition_from_idle`
+      which immediately starts another build — the wedge loop is unbounded; no
+      durable row is written, no broadcast fires; assertions FAIL.
+
+  ## D-NNN linkage: D-394, AC-10.
+  """
+
+  use ExUnit.Case, async: false
+
+  alias Tau.Factory.Ledger.Reader, as: LedgerReader
+  alias Tau.Factory.Ledger.Writer, as: LedgerWriter
+  alias Tau.Factory.MergeAuthority
+
+  @moduletag :capture_log
+  @moduletag :"D-394"
+  @moduletag :"AC-10"
+
+  # ---------------------------------------------------------------------------
+  # Injected CAS seams
+  # ---------------------------------------------------------------------------
+
+  defmodule PassingCas do
+    @moduledoc false
+    def assert_all_verdicts_live(_ledger, _units, _required_halves), do: :all_pass
+    def cas_push(_repo_dir, _tip, _base), do: :ok
+  end
+
+  # ---------------------------------------------------------------------------
+  # Helpers — mirror reject_durable_outcome_test.exs / merge_result_pubsub_test.exs
+  # ---------------------------------------------------------------------------
+
+  defp unique(base), do: :"#{base}_#{System.unique_integer([:positive])}"
+
+  defp start_ledger do
+    db_path = Briefly.create!(extname: ".db")
+    writer_name = unique(:build_retry_ledger)
+    start_supervised!({LedgerWriter, db_path: db_path, name: writer_name}, id: writer_name)
+    writer_name
+  end
+
+  # Real git topology so MergeAuthority.start_build's fetch_main_oid succeeds.
+  defp setup_git_repo(unit) do
+    tmp_dir = Briefly.create!(type: :directory)
+    work_path = Path.join(tmp_dir, "work")
+    origin_path = Path.join(tmp_dir, "origin.git")
+
+    {_, 0} = System.cmd("git", ["init", "-b", "main", work_path])
+    git_work = fn args -> System.cmd("git", args, cd: work_path) end
+    git_work.(["config", "user.email", "test@tau.test"])
+    git_work.(["config", "user.name", "Tau Test"])
+
+    File.write!(Path.join(work_path, "README"), "initial")
+    git_work.(["add", "README"])
+    {_, 0} = git_work.(["commit", "-m", "initial commit"])
+
+    {_, 0} = System.cmd("git", ["init", "--bare", origin_path])
+    {_, 0} = System.cmd("git", ["symbolic-ref", "HEAD", "refs/heads/main"], cd: origin_path)
+    {_, 0} = git_work.(["remote", "add", "origin", origin_path])
+    {_, 0} = git_work.(["push", "-u", "origin", "main"])
+
+    feature_name = String.replace(unit.branch, "/", "_")
+    {_, 0} = git_work.(["checkout", "-b", unit.branch])
+    File.write!(Path.join(work_path, "feature_#{feature_name}"), "feature work")
+    {_, 0} = git_work.(["add", "."])
+    {_, 0} = git_work.(["commit", "-m", "feature commit for #{unit.branch}"])
+    {tip, 0} = git_work.(["rev-parse", "HEAD"])
+    tip = String.trim(tip)
+    {_, 0} = git_work.(["push", "origin", unit.branch])
+    {_, 0} = git_work.(["checkout", "main"])
+
+    {work_path, tip}
+  end
+
+  defp start_merge_authority(ledger, repo_dir, build_fun, opts \\ []) do
+    ma_name = unique(:build_retry_ma)
+    tasks_name = unique(:build_retry_tasks)
+
+    base_opts = [
+      name: ma_name,
+      ledger: ledger,
+      repo_dir: repo_dir,
+      required_halves: [:critic, :reviewer],
+      tasks_name: tasks_name,
+      cas: PassingCas,
+      build_fun: build_fun
+    ]
+
+    start_supervised!(
+      {MergeAuthority, Keyword.merge(base_opts, opts)},
+      id: ma_name
+    )
+
+    ma_name
+  end
+
+  defp pr_topic(unit_id), do: "factory:pr:#{unit_id}"
+
+  defp make_unit do
+    idx = System.unique_integer([:positive])
+
+    %{
+      id: "u-retry-#{idx}",
+      hash: "hash-retry-#{idx}",
+      run: "run-retry-#{idx}",
+      branch: "feat/build-retry-#{idx}"
+    }
+  end
+
+  # ---------------------------------------------------------------------------
+  # Test 1 — Bounded count + throttle (D-394, AC-10)
+  #
+  # Inject a build_fun that always returns a retryable failure AND records each
+  # invocation timestamp. Assert: exactly 3 invocations, NO 4th, consecutive
+  # gaps ≥ build_backoff_ms.
+  # ---------------------------------------------------------------------------
+
+  describe "D-394 / AC-10 — bounded build-failure requeue: count cap + backoff throttle" do
+    @tag :"D-394"
+    @tag :"AC-10"
+    test "D-394 AC-10: retryable build failure is retried exactly N_build=3 times with ≥T_backoff gaps between launches" do
+      ledger = start_ledger()
+      test_pid = self()
+
+      unit = make_unit()
+      {work_path, _tip} = setup_git_repo(unit)
+
+      # Build fun that always fails with a retryable git_error.
+      # Each invocation sends its monotonic timestamp to the test process so we
+      # can count invocations and measure inter-launch gaps.
+      build_fun = fn _units, _base ->
+        send(test_pid, {:build_invoked, System.monotonic_time(:millisecond)})
+        {:build_failed, {:git_error, 1, "boom"}}
+      end
+
+      _ma =
+        start_merge_authority(ledger, work_path, build_fun,
+          build_retry_max: 3,
+          build_backoff_ms: 50
+        )
+
+      :ok = Phoenix.PubSub.subscribe(Tau.PubSub, pr_topic(unit.id))
+
+      assert :queued = MergeAuthority.request_merge(_ma, unit)
+
+      # Collect the first 3 invocation timestamps. Each is separated by at least
+      # build_backoff_ms (50 ms injected). Allow generous total window: 3 attempts
+      # × (50 ms backoff + 100 ms slack) = ~450 ms plus task spin-up overhead.
+      ts1 = assert_receive({:build_invoked, _}, 2_000)
+      ts2 = assert_receive({:build_invoked, _}, 2_000)
+      ts3 = assert_receive({:build_invoked, _}, 2_000)
+
+      {_, ts1} = ts1
+      {_, ts2} = ts2
+      {_, ts3} = ts3
+
+      # After the 3rd failure the implementer applies the terminal eject. Give it
+      # time to process, then assert NO 4th invocation arrives within a window
+      # large enough that unbounded code would have already launched it (200 ms).
+      refute_receive {:build_invoked, _},
+                     200,
+                     "D-394 AC-10 (bounded count): a 4th build_fun invocation arrived after N_build=3 " <>
+                       "exhaustion — the requeue must be bounded at N_build attempts, not unbounded."
+
+      # Throttle: each consecutive gap must be ≥ build_backoff_ms (50 ms).
+      gap1 = ts2 - ts1
+      gap2 = ts3 - ts2
+
+      assert gap1 >= 50,
+             "D-394 AC-10 (throttle): gap between invocation 1 and 2 was #{gap1} ms, " <>
+               "expected ≥ 50 ms (build_backoff_ms). The D-394 T_backoff dwell between " <>
+               "retry launches is missing — invocations are not throttled."
+
+      assert gap2 >= 50,
+             "D-394 AC-10 (throttle): gap between invocation 2 and 3 was #{gap2} ms, " <>
+               "expected ≥ 50 ms (build_backoff_ms). The D-394 T_backoff dwell between " <>
+               "retry launches is missing — invocations are not throttled."
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Test 2 — No premature build mid-backoff (INV-3, D-394, AC-10)
+  #
+  # During the armed backoff window after the 1st failure, a second request_merge
+  # must return :queued WITHOUT launching a new build task (INV-3 preserved).
+  # ---------------------------------------------------------------------------
+
+  describe "D-394 / AC-10 — INV-3 preserved mid-backoff: second request_merge enqueues only" do
+    @tag :"D-394"
+    @tag :"AC-10"
+    test "D-394 AC-10 INV-3: a request_merge issued during the backoff dwell returns :queued and does NOT launch a build" do
+      ledger = start_ledger()
+      test_pid = self()
+
+      unit1 = make_unit()
+      unit2 = make_unit()
+      {work_path, _tip} = setup_git_repo(unit1)
+      setup_git_repo(unit2)
+
+      # Use a large backoff (500 ms) so we can issue a second request_merge while
+      # firmly inside the backoff window.
+      large_backoff_ms = 500
+
+      build_fun = fn _units, _base ->
+        send(test_pid, {:build_invoked, System.monotonic_time(:millisecond)})
+        {:build_failed, {:git_error, 1, "boom"}}
+      end
+
+      ma =
+        start_merge_authority(ledger, work_path, build_fun,
+          build_retry_max: 3,
+          build_backoff_ms: large_backoff_ms
+        )
+
+      # Submit unit1 and wait for the first build invocation, confirming the
+      # machine entered :integrating.
+      assert :queued = MergeAuthority.request_merge(ma, unit1)
+
+      assert_receive {:build_invoked, _},
+                     2_000,
+                     "D-394 AC-10 INV-3: first build never launched (test setup failure)"
+
+      # Now we are in the backoff window (large_backoff_ms = 500 ms). Submit
+      # unit2 — it must be enqueued (:queued) but must NOT trigger a new build
+      # launch during the backoff period.
+      assert :queued = MergeAuthority.request_merge(ma, unit2),
+             "D-394 AC-10 INV-3: request_merge during backoff must return :queued"
+
+      # Assert NO additional build_invoked arrives within the backoff window
+      # (allow 300 ms — well inside the 500 ms backoff). Against unbounded code
+      # the next build launches immediately and this assertion FAILS.
+      refute_receive {:build_invoked, _},
+                     300,
+                     "D-394 AC-10 INV-3: a build was launched during the backoff dwell window — " <>
+                       "INV-3 (no second build while backoff_pending) is violated. " <>
+                       "No build should launch until the {timeout, T_backoff, :build_backoff} fires."
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Test 3 — Terminal eject on exhaustion (D-394, AC-10, D-355, D-356)
+  #
+  # After N_build=3 consecutive retryable failures:
+  #   a) LedgerReader.merge_outcome_for returns {:rejected, :build_retry_exhausted}
+  #   b) {:merge_result, :rejected} is broadcast on the per-PR topic
+  #   c) No further build invocations (unit dropped, not requeued)
+  # ---------------------------------------------------------------------------
+
+  describe "D-394 / AC-10 — terminal eject on N_build exhaustion: durable row + broadcast" do
+    @tag :"D-394"
+    @tag :"AC-10"
+    test "D-394 AC-10: after N_build=3 retryable failures the unit is terminally ejected with {:rejected, :build_retry_exhausted} and a D-356 broadcast" do
+      ledger = start_ledger()
+      test_pid = self()
+
+      unit = make_unit()
+      {work_path, _tip} = setup_git_repo(unit)
+
+      build_fun = fn _units, _base ->
+        send(test_pid, {:build_invoked, :erlang.monotonic_time(:millisecond)})
+        {:build_failed, {:git_error, 1, "boom"}}
+      end
+
+      ma =
+        start_merge_authority(ledger, work_path, build_fun,
+          build_retry_max: 3,
+          build_backoff_ms: 50
+        )
+
+      :ok = Phoenix.PubSub.subscribe(Tau.PubSub, pr_topic(unit.id))
+
+      assert :queued = MergeAuthority.request_merge(ma, unit)
+
+      # Drain all 3 invocations.
+      assert_receive {:build_invoked, _}, 2_000
+      assert_receive {:build_invoked, _}, 2_000
+      assert_receive {:build_invoked, _}, 2_000
+
+      # The D-356 broadcast must arrive after the 3rd exhaustion.
+      assert_receive {:merge_result, :rejected},
+                     2_000,
+                     "D-394 AC-10 (broadcast): no {:merge_result, :rejected} broadcast on " <>
+                       "#{pr_topic(unit.id)} after N_build=3 exhaustion. The D-356 terminal " <>
+                       "rejection broadcast is missing — the unit was likely requeued instead " <>
+                       "of terminally ejected."
+
+      # The durable row must be present (D-355 WAL-before-ack — written before
+      # the broadcast fires).
+      assert {:rejected, :build_retry_exhausted} =
+               LedgerReader.merge_outcome_for(ledger, unit.id),
+             "D-394 AC-10 (durable row): LedgerReader.merge_outcome_for returned " <>
+               "#{inspect(LedgerReader.merge_outcome_for(ledger, unit.id))} after N_build=3 " <>
+               "exhaustion. Expected {:rejected, :build_retry_exhausted}. Either the durable " <>
+               "row was not written (non-terminal requeue) or the wrong reason was recorded."
+
+      # No further build launches: the unit must be dropped, not requeued.
+      refute_receive {:build_invoked, _},
+                     200,
+                     "D-394 AC-10 (no requeue after eject): a 4th build invocation arrived " <>
+                       "after terminal exhaustion eject — the unit must be dropped, not requeued."
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Test 4 — Transient recovers: reset guard, no false eject (D-394, AC-10)
+  #
+  # A build_fun that fails twice then succeeds must result in :merged (not
+  # :rejected). This pins the `build_attempts` reset-on-success invariant.
+  # ---------------------------------------------------------------------------
+
+  describe "D-394 / AC-10 — transient failure recovers: build_attempts reset on success" do
+    @tag :"D-394"
+    @tag :"AC-10"
+    test "D-394 AC-10 (reset guard): a build_fun that fails twice then returns {:built,_} results in :merged, not :rejected" do
+      ledger = start_ledger()
+
+      unit = make_unit()
+      {work_path, tip} = setup_git_repo(unit)
+
+      {:ok, attempt_counter} = Agent.start_link(fn -> 0 end)
+      on_exit(fn -> if Process.alive?(attempt_counter), do: Agent.stop(attempt_counter) end)
+
+      # Fail twice, succeed on the 3rd attempt.
+      build_fun = fn units, base ->
+        n = Agent.get_and_update(attempt_counter, fn c -> {c + 1, c + 1} end)
+
+        if n <= 2 do
+          {:build_failed, {:git_error, 1, "transient"}}
+        else
+          {:built, units, base, tip}
+        end
+      end
+
+      ma =
+        start_merge_authority(ledger, work_path, build_fun,
+          build_retry_max: 3,
+          build_backoff_ms: 50
+        )
+
+      :ok = Phoenix.PubSub.subscribe(Tau.PubSub, pr_topic(unit.id))
+
+      assert :queued = MergeAuthority.request_merge(ma, unit)
+
+      # Wait for the terminal outcome — either :merged (correct) or :rejected
+      # (wrong: false eject). Allow up to 3 attempts × (50 ms backoff + overhead).
+      result =
+        receive do
+          {:merge_result, outcome} -> outcome
+        after
+          5_000 ->
+            flunk(
+              "D-394 AC-10 (reset guard): no {:merge_result, _} broadcast received within 5 s. " <>
+                "The build_fun that fails twice then succeeds should eventually produce a " <>
+                "terminal outcome (either :merged on success or :rejected on premature eject)."
+            )
+        end
+
+      assert result == :merged,
+             "D-394 AC-10 (reset guard): expected {:merge_result, :merged} for a build_fun " <>
+               "that fails twice then succeeds, but got {:merge_result, #{inspect(result)}}. " <>
+               "The D-394 implementation must not prematurely eject a member that would succeed " <>
+               "within N_build attempts — or must correctly count only consecutive failures."
+
+      assert {:merged, _sha} = LedgerReader.merge_outcome_for(ledger, unit.id),
+             "D-394 AC-10 (reset guard durable): LedgerReader returned " <>
+               "#{inspect(LedgerReader.merge_outcome_for(ledger, unit.id))} — expected " <>
+               "{:merged, _} for a unit whose build recovered within N_build attempts."
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Test 5 — Wedge terminal at B=1 (D-394, AC-10)
+  #
+  # A build task that blocks past build_timeout_ms must be killed and the unit
+  # terminally ejected at B=1 (reason: :build_wedged), with a durable row and
+  # a D-356 broadcast, never requeued.
+  # ---------------------------------------------------------------------------
+
+  describe "D-394 / AC-10 — wedged build is terminal at B=1 with reason :build_wedged" do
+    @tag :"D-394"
+    @tag :"AC-10"
+    test "D-394 AC-10 (wedge): a build task that blocks past build_timeout_ms is killed and the unit ejected at B=1 with {:rejected, :build_wedged}" do
+      ledger = start_ledger()
+      test_pid = self()
+
+      unit = make_unit()
+      {work_path, _tip} = setup_git_repo(unit)
+
+      # build_timeout_ms is injected small so the test is fast.
+      wedge_timeout_ms = 150
+
+      build_fun = fn _units, _base ->
+        send(test_pid, {:build_invoked, System.monotonic_time(:millisecond)})
+        # Block indefinitely — simulates a wedged build. The gen_statem's
+        # :state_timeout (build_timeout_ms) must kill this task and eject the unit.
+        receive do
+          :never -> :ok
+        end
+      end
+
+      ma =
+        start_merge_authority(ledger, work_path, build_fun,
+          build_retry_max: 3,
+          build_backoff_ms: 50,
+          build_timeout_ms: wedge_timeout_ms
+        )
+
+      :ok = Phoenix.PubSub.subscribe(Tau.PubSub, pr_topic(unit.id))
+
+      assert :queued = MergeAuthority.request_merge(ma, unit)
+
+      # First (and only) build invocation.
+      assert_receive {:build_invoked, _},
+                     2_000,
+                     "D-394 AC-10 (wedge): the wedged build was never launched (test setup failure)"
+
+      # The D-356 broadcast must arrive after the build_timeout fires.
+      # Allow wedge_timeout_ms + generous overhead.
+      assert_receive {:merge_result, :rejected},
+                     3_000,
+                     "D-394 AC-10 (wedge broadcast): no {:merge_result, :rejected} broadcast " <>
+                       "on #{pr_topic(unit.id)} after wedge timeout (#{wedge_timeout_ms} ms). " <>
+                       "A wedged build must be terminal at B=1 per D-394 — the timeout handler " <>
+                       "must eject the unit, not requeue it."
+
+      # Durable row must record :build_wedged.
+      assert {:rejected, :build_wedged} = LedgerReader.merge_outcome_for(ledger, unit.id),
+             "D-394 AC-10 (wedge durable row): LedgerReader.merge_outcome_for returned " <>
+               "#{inspect(LedgerReader.merge_outcome_for(ledger, unit.id))} — expected " <>
+               "{:rejected, :build_wedged}. The wedge eject must write a durable row with " <>
+               "reason :build_wedged (D-394 / D-355 WAL-before-ack) before broadcasting."
+
+      # No requeue: only one build invocation must have occurred.
+      refute_receive {:build_invoked, _},
+                     200,
+                     "D-394 AC-10 (wedge no requeue): a second build invocation arrived after " <>
+                       "a wedge eject — a wedged build is terminal at B=1 and must NOT be " <>
+                       "requeued into the retry climb."
+    end
+  end
+end


### PR DESCRIPTION
## Closes

Closes #523 — factory MergeAuthority: bound the build-failure requeue (transient `git_error` → instant unbounded retry storm).

## Background

Run #4 surfaced a liveness defect in `Tau.Factory.MergeAuthority`: a single deterministic `{:build_failed, {:git_error, _}}` from the build `Task` drives `integrating/3` to `requeue_train → transition_from_idle → start_build` **instantly, with no attempt bound and no backoff** (the same instant-requeue shape on the `:DOWN` and wedge `:state_timeout` paths). The result is ~6000 requeue/rebuild cycles in ~5 min until the **Unit's** fixed 30 s `:awaiting_merge` `:state_timeout` fires a spurious `:E_MERGE_STALLED`. #521/D-385 removed the worktree-collision *cause*; any transient git error keeps this latent.

This PR introduces invariant **D-394** (verified free across the repo + git history before reservation). Design produced by the solution shaper and gated by the critic (two rounds; 5/6 v2 findings cleared, final round pinned the `build_attempts` reset sites and SPEC-edit requirements below).

## SPECs

Amends **`docs/spec/SPEC-FACTORY-MERGE.md`** (in-scope: this PR touches `lib/tau/factory/merge_authority.ex`, a §-Appendix-B source-mapped file). It **introduces D-394** and **rewrites** the now-contradicted prose:

- §3 `[C207-B2]` (line ~167) — **rewrite** "abandons the build (requeues the train)" to the bounded/terminal semantics; add `[C207-B2a]`.
- §4 B8 telemetry-span list (line ~332) — add `:build_retry` (a **point event**, like the existing `:reject`/`:integrating` single-`execute` emissions — not a `*.start`/`*.stop` pair).
- §5 state table `:integrating` exit cell (line ~364) — **rewrite** `:DOWN → :idle (requeue)` and `:state_timeout → :idle (requeue wedged build)` to bounded-retry / terminal-eject.
- §5 terminal-rejection prose (~398), §5 escalation table note (~416), D-355 covered-paths (~482), §6 (new D-394 block after D-356 ~513), §7 (AC-10), Appendix B (~589).

## Acceptance criteria

This section is the authoritative claims list for Gate 5.1. Each token must appear in a gating-test name or `@tag`.

- **AC-10** / **D-394** — Bounded, backed-off build-retry with per-member terminal eject. Driving the real `MergeAuthority` via `request_merge/2` with a `build_fun` that deterministically returns `{:build_failed, {:git_error, 1, "boom"}}`:
  1. the unit is retried **exactly `N_build = 3`** times (build launched 3×, no more);
  2. consecutive build launches are separated by **≥ `T_backoff` (2_000 ms)** — the storm is throttled, not merely capped;
  3. a `request_merge` arriving **during** a backoff window replies `:queued` and launches **no** build until the timer fires (INV-3, serialized merge: never two concurrent builds);
  4. on the 3rd failure the member is **terminally ejected**: exactly one durable `merge_outcomes` `:rejected` row (`reason: :build_retry_exhausted`, WAL-before-ack) **and** exactly one `{:merge_result, :rejected}` broadcast on `"factory:pr:#{id}"`; the member is dropped (not requeued);
  5. **no** `:E_MERGE_STALLED` escalation; the whole climb completes well under the Unit's 30 s budget;
  6. a **wedged** build (`:state_timeout`/`:build_timeout`) is terminal at the **first** occurrence (B=1, like health-red): one durable `:rejected` row (`reason: :build_wedged`) + one broadcast, never requeued;
  7. eject is **per-member** (only members whose own `build_attempts == N_build`), never `max`-based whole-train;
  8. `build_attempts` resets so a unit that fails `< N_build` times then **merges** is not falsely ejected on a later episode; AND a unit re-submitted **after** a terminal exhaustion eject again receives the full `N_build` retries (reset-on-eject, not an instant eject).

  Sizing discharged: `N_build·T_build_worst + (N_build−1)·T_backoff + T_eject < 30_000 ms`; breakeven is **8_600 ms/attempt** ((30000−4000−200)/3), so the bound holds even at a pessimistic 3 s/attempt (~17 s margin). `{:health_red, _}` stays terminal at B=1 (health-red is terminal at first failure), exempt from the bound. Counter is per-M-lifetime (in-memory; non-terminal failures write no durable row).

## Scope & order

1. **SPEC amendment** (shaper / general-purpose role) — author the D-394 amendment above. `docs/spec/**`.
2. **Gating test** (test-author, phase 4b) — `test/tau/factory/merge_build_retry_test.exs`, failing-first, tagged `D-394`/`AC-10`. `test/**`.
3. **Implementation** (implementer) — `lib/tau/factory/merge_authority.ex` only:
   - module attrs `@build_retry_max 3`, `@build_backoff_ms 2_000` (+ opt-injectable for fast tests); keep `@build_timeout_ms` (opt-injectable for the wedge test);
   - `init/1` `data`: `build_attempts: %{}`, `backoff_pending: false`;
   - **head guard clause** `defp start_build(%{backoff_pending: true} = data), do: {:idle, data}` (the single chokepoint — every launch funnels through `start_build/1`);
   - `bounded_retry_or_eject/2` for non-health `:build_failed` (~229) and `:DOWN` (~240): increment per-member `build_attempts`, partition exhausted (==`N_build`) vs retryable, terminally eject exhausted (per-member), requeue retryable with `backoff_pending: true` + `{:timeout, @build_backoff_ms, :build_backoff}` — **arm the timer only when the retryable set is non-empty**;
   - new `idle({:timeout, :build_backoff}, _, data)` clause: clear `backoff_pending`, `transition_from_idle`;
   - wedge `:state_timeout` (~251): **terminal at B=1** via shared eject (reason `:build_wedged`);
   - shared `terminal_eject_members/3`: durable D-355 `:rejected` row **→** `:reject` telemetry **→** D-356 broadcast (this exact order); drop members; **drop their `build_attempts` entries**;
   - **`build_attempts` reset** (critic f-r1): zero/drop `build_attempts[u]` on successful merge — the `:built` path (~185) **and** the `:committing` `:merged` path (~328-350) — and on terminal eject;
   - new `:build_retry` point telemetry per retryable requeue (`attempt_n`, `backoff_ms`, `unit_id`).

## Dependencies

None blocking. Forward-compatible with D-341 batch trains (per-member eject). Does **not** modify the Unit's `awaiting_merge` timer (out of scope — SPEC-FACTORY-CORE).

## Gating-test paths

Frozen at phase 4b (test-author, commit `13fccb4`):
- `test/tau/factory/merge_build_retry_test.exs`

## Gate verdicts

- **critic:** PASS — f-1 (build_attempts leak on terminal-exhaustion, prior FAIL) verified resolved (commit `26ccd7f`); guard-clause totality, terminal durability order, wedge-at-B=1, per-member eject, injectable opts, SPEC consistency all re-confirmed. One non-blocking SUGGESTION (f-2: latent mixed-partition leak on the retryable branch, unreachable until D-341 batch trains) filed as #535.
- **reviewer:** PASS — Gate 5.1 (AC-linkage) clean (AC section claims only `D-394`/`AC-10`); CI green (lint/Gate 5.3 mutation/binary-qa/dialyzer/both test matrices/web); gating test `6 tests, 0 failures`; masking clean.
- **CI (run 27616397220):** all checks pass.
