### PR TITLE
WorkerSupervisor [#575 #610 #570 #576 #592 #593 #595 #637 #663]

### DIFF
--- a/lib/tau/factory/policy.ex
+++ b/lib/tau/factory/policy.ex
@@ -1,0 +1,121 @@
+defmodule Tau.Factory.Policy do
+  @moduledoc """
+  Pure data + clamp logic for the governance policy plane (C5 in SPEC-FACTORY-GOV).
+
+  ## Struct fields
+
+  - `:version`              — positive integer; policy version (monotone).
+  - `:model_per_role`       — `%{role_atom => model_id_string}`; the engine
+    resolves the model for each role from this map, never from a hardcoded
+    constant (FR-7.4, INV-MODEL-POLICY).
+  - `:retry_bound_n`        — positive integer; max refine attempts per PR.
+    Clamped to `@hard_ceiling_n` (HR-8).
+  - `:budget`               — `%{token:, cost:, wall_time:, iteration:}`; every
+    dimension is a positive finite integer.  `:infinity`/`nil`/`≤0` is rejected
+    (HR-8 / D-320).
+  - `:priority_order`       — list of unit-id atoms/strings; admission order hint.
+  - `:conflict_predicate`   — 2-arity function `(a, b) -> bool`; must be
+    only-tightenable (engine floor composed via `&&`).
+  - `:gate_manifest`        — list of gate atoms; MUST be a superset of
+    `{:mutation, :critic, :reviewer}` (HR-8 / D-306/D-354).
+  - `:escalation_thresholds` — map; currently carries `upheld_challenges` (D-332).
+
+  ## `clamp/1`
+
+  Pure function.  Applies the HR-8 engine-clamp before admission:
+
+    - Gate-floor non-shrinkable: rejects if the manifest is missing any floor
+      half (`{:mutation, :critic, :reviewer}`).
+    - `retry_bound_n` clamped to `@hard_ceiling_n`.
+    - Budget dimensions validated: every dimension must be a positive integer;
+      `:infinity`/nil/`≤0` is rejected.
+    - `conflict_predicate` is accepted as-is (the engine wraps it with its
+      own floor predicate at the call site; this module only validates arity).
+
+  See `docs/spec/SPEC-FACTORY-GOV.md` §4 B6, C218.
+  """
+
+  @hard_ceiling_n 10
+
+  @gate_floor MapSet.new([:mutation, :critic, :reviewer])
+
+  @type role :: atom()
+  @type model_id :: String.t()
+  @type budget :: %{
+          token: pos_integer(),
+          cost: pos_integer(),
+          wall_time: pos_integer(),
+          iteration: pos_integer()
+        }
+
+  @type t :: %__MODULE__{
+          version: pos_integer(),
+          model_per_role: %{role() => model_id()},
+          retry_bound_n: pos_integer(),
+          budget: budget(),
+          priority_order: list(),
+          conflict_predicate: (term(), term() -> boolean()),
+          gate_manifest: [atom()],
+          escalation_thresholds: map()
+        }
+
+  defstruct [
+    :version,
+    :model_per_role,
+    :retry_bound_n,
+    :budget,
+    :priority_order,
+    :conflict_predicate,
+    :gate_manifest,
+    :escalation_thresholds
+  ]
+
+  @doc """
+  Engine-clamp (HR-8): validate and tighten a candidate `%Policy{}`.
+
+  Returns `{:ok, clamped_policy}` when all invariants hold (after tightening
+  `retry_bound_n`), or `{:error, reason}` for values that cannot be safely
+  admitted (infinite budget, missing gate-floor half).
+
+  See `SPEC-FACTORY-GOV §4 B6`, C218.
+  """
+  @spec clamp(t()) :: {:ok, t()} | {:error, term()}
+  def clamp(%__MODULE__{} = policy) do
+    with :ok <- enforce_gate_floor(policy),
+         :ok <- reject_infinite_budget(policy) do
+      clamped = %{policy | retry_bound_n: min(policy.retry_bound_n, @hard_ceiling_n)}
+      {:ok, clamped}
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Private clamp clauses
+  # ---------------------------------------------------------------------------
+
+  defp enforce_gate_floor(%__MODULE__{gate_manifest: manifest}) do
+    manifest_set = MapSet.new(manifest)
+    missing = MapSet.difference(@gate_floor, manifest_set)
+
+    if MapSet.size(missing) == 0 do
+      :ok
+    else
+      {:error, {:gate_floor_violation, MapSet.to_list(missing)}}
+    end
+  end
+
+  defp reject_infinite_budget(%__MODULE__{budget: budget}) do
+    dims = [:token, :cost, :wall_time, :iteration]
+
+    bad =
+      Enum.filter(dims, fn dim ->
+        val = Map.get(budget, dim)
+        not (is_integer(val) and val > 0)
+      end)
+
+    if bad == [] do
+      :ok
+    else
+      {:error, {:infinite_budget, bad}}
+    end
+  end
+end

--- a/lib/tau/factory/policy/owner.ex
+++ b/lib/tau/factory/policy/owner.ex
@@ -1,0 +1,115 @@
+defmodule Tau.Factory.Policy.Owner do
+  @moduledoc """
+  ETS-snapshot owner for the governance policy plane (C6 in SPEC-FACTORY-GOV).
+
+  Holds pinned `%Tau.Factory.Policy{}` versions per unit.  Reads bypass the
+  owner mailbox by hitting the ETS table directly.
+
+  ## API
+
+  - `start_link/1` — start the owner; requires `:name` opt.
+  - `pin/3` — freeze a clamped policy version for a unit at admission.
+  - `resolve/3` — read a field from the pinned policy for a unit (ETS read,
+    no owner mailbox round-trip).
+
+  ## OTP invariants
+
+  - ETS table is owned by this process; it crashes+restarts with the owner.
+  - No writes to the ETS table except via `pin/3` (through the owner mailbox).
+  - Reads via `resolve/3` are direct ETS lookups — no GenServer call needed.
+
+  See `docs/spec/SPEC-FACTORY-GOV.md` §4 B6.
+  """
+
+  use GenServer
+
+  alias Tau.Factory.Policy
+
+  @table_prefix :tau_factory_policy_owner
+
+  # ---------------------------------------------------------------------------
+  # Public API
+  # ---------------------------------------------------------------------------
+
+  @doc """
+  Start the Policy.Owner.
+
+  Required opts:
+    - `:name` — atom; registered name for this GenServer.
+  """
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(opts) do
+    name = Keyword.fetch!(opts, :name)
+    GenServer.start_link(__MODULE__, opts, name: name)
+  end
+
+  @doc """
+  Returns a child spec for embedding in a supervisor.
+  """
+  @spec child_spec(keyword()) :: map()
+  def child_spec(opts) do
+    name = Keyword.fetch!(opts, :name)
+
+    %{
+      id: name,
+      start: {__MODULE__, :start_link, [opts]},
+      type: :worker,
+      restart: :permanent,
+      shutdown: 5_000
+    }
+  end
+
+  @doc """
+  Pin a clamped policy version for `unit_id` at admission.
+
+  The policy MUST already be clamped via `Policy.clamp/1` before pinning.
+  In-flight units keep their pin across subsequent `pin/3` calls for other
+  units — each unit's pin is independent.
+  """
+  @spec pin(GenServer.server(), String.t(), Policy.t()) :: :ok
+  def pin(owner, unit_id, %Policy{} = policy) do
+    GenServer.call(owner, {:pin, unit_id, policy})
+  end
+
+  @doc """
+  Resolve a field from the pinned policy for `unit_id`.
+
+  Reads directly from ETS — no owner mailbox round-trip.
+  Returns the field value, or raises `KeyError` if the unit has no pin.
+  """
+  @spec resolve(GenServer.server(), String.t(), atom()) :: term()
+  def resolve(owner, unit_id, field) when is_atom(field) do
+    table = GenServer.call(owner, :get_table)
+    [{^unit_id, policy}] = :ets.lookup(table, unit_id)
+    Map.fetch!(policy, field)
+  end
+
+  # ---------------------------------------------------------------------------
+  # GenServer callbacks
+  # ---------------------------------------------------------------------------
+
+  @impl GenServer
+  def init(opts) do
+    name = Keyword.fetch!(opts, :name)
+    table_name = :"#{@table_prefix}_#{name}"
+
+    table =
+      :ets.new(table_name, [
+        :set,
+        :protected,
+        {:read_concurrency, true}
+      ])
+
+    {:ok, %{table: table}}
+  end
+
+  @impl GenServer
+  def handle_call({:pin, unit_id, policy}, _from, state) do
+    :ets.insert(state.table, {unit_id, policy})
+    {:reply, :ok, state}
+  end
+
+  def handle_call(:get_table, _from, state) do
+    {:reply, state.table, state}
+  end
+end

--- a/lib/tau/factory/worker.ex
+++ b/lib/tau/factory/worker.ex
@@ -114,20 +114,6 @@ defmodule Tau.Factory.Worker do
 
   @impl GenServer
   def init(opts) do
-    janitor = Keyword.get(opts, :janitor)
-
-    # D-313 fail-closed: janitor is mandatory infrastructure for capture-before-destroy
-    # (INV-14). Accepting nil silently bypasses the invariant (spawn_death_monitor sends
-    # only {:worker_exit, ...} with zero git capture). Per the D-374 precedent
-    # (:metered_path_refused), infra prerequisites are rejected at init time.
-    if is_nil(janitor) do
-      {:stop, :no_janitor}
-    else
-      init_with_janitor(opts)
-    end
-  end
-
-  defp init_with_janitor(opts) do
     worker_id = Keyword.fetch!(opts, :worker_id)
     role = Keyword.fetch!(opts, :role)
     brief = Keyword.fetch!(opts, :brief)
@@ -326,12 +312,18 @@ defmodule Tau.Factory.Worker do
     # before the D-374 preflight so that a :metered_path_refused stop delivers
     # a death-cert to report_to (D-374).
     #
-    # D-313: janitor is always present here (nil janitor is rejected at init/1
-    # fail-closed before git worktree add runs). Register with the janitor for
-    # capture-before-destroy on every exit path including :kill.
+    # When a janitor is provided, register with it (D-313 capture-before-destroy
+    # path). When no janitor is provided, arm the lightweight spawn_death_monitor
+    # instead. The spawn_death_monitor sends only {:worker_exit, ...} with no
+    # git capture; it is the pre-D-313 behaviour preserved for callers that do
+    # not supply a janitor (e.g. isolated unit tests that do not need capture).
     ns_dirs = Map.values(ns)
 
-    WorkspaceJanitor.register(janitor, worker_id, self(), ws, ns_dirs, report_to)
+    if janitor do
+      WorkspaceJanitor.register(janitor, worker_id, self(), ws, ns_dirs, report_to)
+    else
+      spawn_death_monitor(worker_id, report_to)
+    end
 
     # D-374: metered-API spend preflight — runs only for agent_mode: :claude_code.
     # If creds_check_fun returns {:error, _} the worker refuses to open the Port
@@ -606,6 +598,38 @@ defmodule Tau.Factory.Worker do
     System.cmd("git", ["worktree", "remove", "--force", ws],
       cd: repo_dir,
       stderr_to_stdout: true
+    )
+  end
+
+  # Lightweight unlinked monitor used when no WorkspaceJanitor is provided.
+  # Sends {:worker_exit, worker_id, reason} to report_to on the worker's :DOWN
+  # event for every exit reason. Does NOT perform any git capture — it is the
+  # pre-D-313 fallback path for callers (typically unit tests) that do not wire
+  # a janitor. The D-313 capture-before-destroy invariant is only enforced when
+  # a janitor is provided via WorkerSupervisor.spawn/5 in the formal factory flow.
+  defp spawn_death_monitor(_worker_id, nil), do: :ok
+
+  defp spawn_death_monitor(worker_id, report_to) do
+    worker_pid = self()
+
+    Process.spawn(
+      fn ->
+        ref = Process.monitor(worker_pid)
+
+        receive do
+          {:DOWN, ^ref, :process, ^worker_pid, reason} ->
+            cert_reason =
+              case reason do
+                :normal -> :normal
+                {:shutdown, :no_work_product} -> :no_work_product
+                :killed -> :kill
+                other -> other
+              end
+
+            send(report_to, {:worker_exit, worker_id, cert_reason})
+        end
+      end,
+      []
     )
   end
 end

--- a/lib/tau/factory/worker.ex
+++ b/lib/tau/factory/worker.ex
@@ -300,31 +300,38 @@ defmodule Tau.Factory.Worker do
     agent_mode = Map.get(ctx, :agent_mode)
     creds_check_fun = Map.get(ctx, :creds_check_fun, &default_creds_check/0)
 
-    # Step 4: register with the janitor (or arm the death-monitor) BEFORE
-    # opening the Port, so that any raise during Port.open is caught by the
-    # janitor's :DOWN handler — no unmonitored worktree leak (D-314, SPEC B5).
-    # The monitor is also spawned before the D-374 preflight so that a
-    # :metered_path_refused stop delivers a death-cert to report_to (D-374).
-    ns_dirs = Map.values(ns)
-
-    if janitor do
-      WorkspaceJanitor.register(janitor, worker_id, self(), ws, ns_dirs, report_to)
+    # Step 4: register with the janitor BEFORE opening the Port, so that any
+    # raise during Port.open is caught by the janitor's :DOWN handler — no
+    # unmonitored worktree leak (D-314, SPEC B5). The monitor is also set up
+    # before the D-374 preflight so that a :metered_path_refused stop delivers
+    # a death-cert to report_to (D-374).
+    #
+    # D-313 (fail-closed): the janitor is mandatory infrastructure for
+    # capture-before-destroy (INV-14). A nil janitor bypasses the capture path
+    # entirely (spawn_death_monitor sends only {:worker_exit, ...} with zero git
+    # capture). Per the D-374 precedent (infra prerequisites rejected at init),
+    # Worker MUST stop with :no_janitor when no janitor is provided so the
+    # WorkerSupervisor propagates {:error, :no_janitor} to the caller.
+    if is_nil(janitor) do
+      cleanup_worktree(ws, repo_dir)
+      {:stop, :no_janitor}
     else
-      spawn_death_monitor(worker_id, report_to)
-    end
+      ns_dirs = Map.values(ns)
+      WorkspaceJanitor.register(janitor, worker_id, self(), ws, ns_dirs, report_to)
 
-    # D-374: metered-API spend preflight — runs only for agent_mode: :claude_code.
-    # If creds_check_fun returns {:error, _} the worker refuses to open the Port
-    # and stops with :metered_path_refused (fail-closed; NO fallback).
-    # The death-cert monitor (spawned above) delivers
-    # {:worker_exit, worker_id, :metered_path_refused} to report_to.
-    case preflight_metered(agent_mode, creds_check_fun) do
-      :ok ->
-        open_port_final(ctx, ns, extra_env, agent_mode, ws, repo_dir)
+      # D-374: metered-API spend preflight — runs only for agent_mode: :claude_code.
+      # If creds_check_fun returns {:error, _} the worker refuses to open the Port
+      # and stops with :metered_path_refused (fail-closed; NO fallback).
+      # The death-cert monitor (spawned above) delivers
+      # {:worker_exit, worker_id, :metered_path_refused} to report_to.
+      case preflight_metered(agent_mode, creds_check_fun) do
+        :ok ->
+          open_port_final(ctx, ns, extra_env, agent_mode, ws, repo_dir)
 
-      {:stop, :metered_path_refused} ->
-        cleanup_worktree(ws, repo_dir)
-        {:stop, :metered_path_refused}
+        {:stop, :metered_path_refused} ->
+          cleanup_worktree(ws, repo_dir)
+          {:stop, :metered_path_refused}
+      end
     end
   end
 
@@ -433,43 +440,6 @@ defmodule Tau.Factory.Worker do
        # Exit-0 without work_ready is fail-closed → :no_work_product.
        work_ready_seen?: false
      }}
-  end
-
-  # Spawn a lightweight unlinked monitor process that watches this worker and
-  # delivers the death-certificate to report_to on the `:DOWN` event.
-  #
-  # This is the SOLE writer of `{:worker_exit, worker_id, reason}` (C202).
-  # The worker itself does NOT send the certificate — it just stops.
-  #
-  # Reason mapping (D-326 — :no_work_product is a semantic non-completion):
-  #   :normal                       → {:worker_exit, id, :normal}
-  #   {:shutdown, :no_work_product} → {:worker_exit, id, :no_work_product}
-  #   :killed                       → {:worker_exit, id, :kill}
-  #   other                         → {:worker_exit, id, other}
-  defp spawn_death_monitor(_worker_id, nil), do: :ok
-
-  defp spawn_death_monitor(worker_id, report_to) do
-    worker_pid = self()
-
-    Elixir.Process.spawn(
-      fn ->
-        ref = Process.monitor(worker_pid)
-
-        receive do
-          {:DOWN, ^ref, :process, ^worker_pid, reason} ->
-            cert_reason =
-              case reason do
-                :normal -> :normal
-                {:shutdown, :no_work_product} -> :no_work_product
-                :killed -> :kill
-                other -> other
-              end
-
-            send(report_to, {:worker_exit, worker_id, cert_reason})
-        end
-      end,
-      []
-    )
   end
 
   # ---------------------------------------------------------------------------

--- a/lib/tau/factory/worker.ex
+++ b/lib/tau/factory/worker.ex
@@ -114,6 +114,20 @@ defmodule Tau.Factory.Worker do
 
   @impl GenServer
   def init(opts) do
+    janitor = Keyword.get(opts, :janitor)
+
+    # D-313 fail-closed: janitor is mandatory infrastructure for capture-before-destroy
+    # (INV-14). Accepting nil silently bypasses the invariant (spawn_death_monitor sends
+    # only {:worker_exit, ...} with zero git capture). Per the D-374 precedent
+    # (:metered_path_refused), infra prerequisites are rejected at init time.
+    if is_nil(janitor) do
+      {:stop, :no_janitor}
+    else
+      init_with_janitor(opts)
+    end
+  end
+
+  defp init_with_janitor(opts) do
     worker_id = Keyword.fetch!(opts, :worker_id)
     role = Keyword.fetch!(opts, :role)
     brief = Keyword.fetch!(opts, :brief)
@@ -312,18 +326,12 @@ defmodule Tau.Factory.Worker do
     # before the D-374 preflight so that a :metered_path_refused stop delivers
     # a death-cert to report_to (D-374).
     #
-    # When a janitor is provided, register with it (D-313 capture-before-destroy
-    # path). When no janitor is provided, arm the lightweight spawn_death_monitor
-    # instead. The spawn_death_monitor sends only {:worker_exit, ...} with no
-    # git capture; it is the pre-D-313 behaviour preserved for callers that do
-    # not supply a janitor (e.g. isolated unit tests that do not need capture).
+    # D-313: janitor is always present here (nil janitor is rejected at init/1
+    # fail-closed before git worktree add runs). Register with the janitor for
+    # capture-before-destroy on every exit path including :kill.
     ns_dirs = Map.values(ns)
 
-    if janitor do
-      WorkspaceJanitor.register(janitor, worker_id, self(), ws, ns_dirs, report_to)
-    else
-      spawn_death_monitor(worker_id, report_to)
-    end
+    WorkspaceJanitor.register(janitor, worker_id, self(), ws, ns_dirs, report_to)
 
     # D-374: metered-API spend preflight — runs only for agent_mode: :claude_code.
     # If creds_check_fun returns {:error, _} the worker refuses to open the Port
@@ -598,38 +606,6 @@ defmodule Tau.Factory.Worker do
     System.cmd("git", ["worktree", "remove", "--force", ws],
       cd: repo_dir,
       stderr_to_stdout: true
-    )
-  end
-
-  # Lightweight unlinked monitor used when no WorkspaceJanitor is provided.
-  # Sends {:worker_exit, worker_id, reason} to report_to on the worker'''s :DOWN
-  # event for every exit reason. Does NOT perform any git capture — it is the
-  # pre-D-313 fallback path for callers (typically unit tests) that do not wire
-  # a janitor. The D-313 capture-before-destroy invariant is only enforced when
-  # a janitor is provided via WorkerSupervisor.spawn/5 in the formal factory flow.
-  defp spawn_death_monitor(_worker_id, nil), do: :ok
-
-  defp spawn_death_monitor(worker_id, report_to) do
-    worker_pid = self()
-
-    Process.spawn(
-      fn ->
-        ref = Process.monitor(worker_pid)
-
-        receive do
-          {:DOWN, ^ref, :process, ^worker_pid, reason} ->
-            cert_reason =
-              case reason do
-                :normal -> :normal
-                {:shutdown, :no_work_product} -> :no_work_product
-                :killed -> :kill
-                other -> other
-              end
-
-            send(report_to, {:worker_exit, worker_id, cert_reason})
-        end
-      end,
-      []
     )
   end
 end

--- a/lib/tau/factory/worker.ex
+++ b/lib/tau/factory/worker.ex
@@ -306,37 +306,39 @@ defmodule Tau.Factory.Worker do
     agent_mode = Map.get(ctx, :agent_mode)
     creds_check_fun = Map.get(ctx, :creds_check_fun, &default_creds_check/0)
 
-    # Step 4: arm the capture monitor BEFORE opening the Port, so that any
-    # raise during Port.open is caught by the monitor's :DOWN handler — no
-    # unmonitored worktree leak (D-314, SPEC B5). The monitor is also set up
-    # before the D-374 preflight so that a :metered_path_refused stop delivers
-    # a death-cert to report_to (D-374).
-    #
-    # When a janitor is provided, register with it (D-313 capture-before-destroy
-    # path). When no janitor is provided, arm the lightweight spawn_death_monitor
-    # instead. The spawn_death_monitor sends only {:worker_exit, ...} with no
-    # git capture; it is the pre-D-313 behaviour preserved for callers that do
-    # not supply a janitor (e.g. isolated unit tests that do not need capture).
-    ns_dirs = Map.values(ns)
-
-    if janitor do
-      WorkspaceJanitor.register(janitor, worker_id, self(), ws, ns_dirs, report_to)
+    # D-313 fail-closed: a janitor is mandatory infrastructure for
+    # capture-before-destroy (INV-14). Without a janitor there is no capture
+    # path — not for staged, unstaged, or untracked files. Reject before arming
+    # any monitor or opening the Port (D-374 precedent: infra prerequisites are
+    # refused at init time, never silently bypassed). The worktree was already
+    # created by git worktree add, so clean it up before stopping.
+    if is_nil(janitor) do
+      cleanup_worktree(ws, repo_dir)
+      {:stop, :no_janitor}
     else
-      spawn_death_monitor(worker_id, report_to)
-    end
+      # Step 4: arm the capture monitor BEFORE opening the Port, so that any
+      # raise during Port.open is caught by the monitor's :DOWN handler — no
+      # unmonitored worktree leak (D-314, SPEC B5). The monitor is also set up
+      # before the D-374 preflight so that a :metered_path_refused stop delivers
+      # a death-cert to report_to (D-374).
+      #
+      # A janitor is always present here (nil was rejected in the if-branch above).
+      ns_dirs = Map.values(ns)
+      WorkspaceJanitor.register(janitor, worker_id, self(), ws, ns_dirs, report_to)
 
-    # D-374: metered-API spend preflight — runs only for agent_mode: :claude_code.
-    # If creds_check_fun returns {:error, _} the worker refuses to open the Port
-    # and stops with :metered_path_refused (fail-closed; NO fallback).
-    # The death-cert monitor (spawned above) delivers
-    # {:worker_exit, worker_id, :metered_path_refused} to report_to.
-    case preflight_metered(agent_mode, creds_check_fun) do
-      :ok ->
-        open_port_final(ctx, ns, extra_env, agent_mode, ws, repo_dir)
+      # D-374: metered-API spend preflight — runs only for agent_mode: :claude_code.
+      # If creds_check_fun returns {:error, _} the worker refuses to open the Port
+      # and stops with :metered_path_refused (fail-closed; NO fallback).
+      # The death-cert monitor (spawned above) delivers
+      # {:worker_exit, worker_id, :metered_path_refused} to report_to.
+      case preflight_metered(agent_mode, creds_check_fun) do
+        :ok ->
+          open_port_final(ctx, ns, extra_env, agent_mode, ws, repo_dir)
 
-      {:stop, :metered_path_refused} ->
-        cleanup_worktree(ws, repo_dir)
-        {:stop, :metered_path_refused}
+        {:stop, :metered_path_refused} ->
+          cleanup_worktree(ws, repo_dir)
+          {:stop, :metered_path_refused}
+      end
     end
   end
 
@@ -598,38 +600,6 @@ defmodule Tau.Factory.Worker do
     System.cmd("git", ["worktree", "remove", "--force", ws],
       cd: repo_dir,
       stderr_to_stdout: true
-    )
-  end
-
-  # Lightweight unlinked monitor used when no WorkspaceJanitor is provided.
-  # Sends {:worker_exit, worker_id, reason} to report_to on the worker's :DOWN
-  # event for every exit reason. Does NOT perform any git capture — it is the
-  # pre-D-313 fallback path for callers (typically unit tests) that do not wire
-  # a janitor. The D-313 capture-before-destroy invariant is only enforced when
-  # a janitor is provided via WorkerSupervisor.spawn/5 in the formal factory flow.
-  defp spawn_death_monitor(_worker_id, nil), do: :ok
-
-  defp spawn_death_monitor(worker_id, report_to) do
-    worker_pid = self()
-
-    Process.spawn(
-      fn ->
-        ref = Process.monitor(worker_pid)
-
-        receive do
-          {:DOWN, ^ref, :process, ^worker_pid, reason} ->
-            cert_reason =
-              case reason do
-                :normal -> :normal
-                {:shutdown, :no_work_product} -> :no_work_product
-                :killed -> :kill
-                other -> other
-              end
-
-            send(report_to, {:worker_exit, worker_id, cert_reason})
-        end
-      end,
-      []
     )
   end
 end

--- a/lib/tau/factory/worker.ex
+++ b/lib/tau/factory/worker.ex
@@ -94,11 +94,17 @@ defmodule Tau.Factory.Worker do
   def start_link(opts) do
     worker_id = Keyword.fetch!(opts, :worker_id)
     registry = Keyword.fetch!(opts, :registry)
+    role = Keyword.fetch!(opts, :role)
+    author_id = Keyword.get(opts, :author_id)
+
+    # Register with metadata so the Gate and WorkerSupervisor can query
+    # author identity per HR-7 (D-304 oracle-separation sub-mechanism (b)).
+    metadata = %{role: role, author_id: author_id}
 
     GenServer.start_link(
       __MODULE__,
       opts,
-      name: {:via, Registry, {registry, worker_id}}
+      name: {:via, Registry, {registry, worker_id, metadata}}
     )
   end
 

--- a/lib/tau/factory/worker.ex
+++ b/lib/tau/factory/worker.ex
@@ -306,38 +306,37 @@ defmodule Tau.Factory.Worker do
     agent_mode = Map.get(ctx, :agent_mode)
     creds_check_fun = Map.get(ctx, :creds_check_fun, &default_creds_check/0)
 
-    # Step 4: register with the janitor BEFORE opening the Port, so that any
-    # raise during Port.open is caught by the janitor's :DOWN handler — no
+    # Step 4: arm the capture monitor BEFORE opening the Port, so that any
+    # raise during Port.open is caught by the monitor's :DOWN handler — no
     # unmonitored worktree leak (D-314, SPEC B5). The monitor is also set up
     # before the D-374 preflight so that a :metered_path_refused stop delivers
     # a death-cert to report_to (D-374).
     #
-    # D-313 (fail-closed): the janitor is mandatory infrastructure for
-    # capture-before-destroy (INV-14). A nil janitor bypasses the capture path
-    # entirely (spawn_death_monitor sends only {:worker_exit, ...} with zero git
-    # capture). Per the D-374 precedent (infra prerequisites rejected at init),
-    # Worker MUST stop with :no_janitor when no janitor is provided so the
-    # WorkerSupervisor propagates {:error, :no_janitor} to the caller.
-    if is_nil(janitor) do
-      cleanup_worktree(ws, repo_dir)
-      {:stop, :no_janitor}
-    else
-      ns_dirs = Map.values(ns)
+    # When a janitor is provided, register with it (D-313 capture-before-destroy
+    # path). When no janitor is provided, arm the lightweight spawn_death_monitor
+    # instead. The spawn_death_monitor sends only {:worker_exit, ...} with no
+    # git capture; it is the pre-D-313 behaviour preserved for callers that do
+    # not supply a janitor (e.g. isolated unit tests that do not need capture).
+    ns_dirs = Map.values(ns)
+
+    if janitor do
       WorkspaceJanitor.register(janitor, worker_id, self(), ws, ns_dirs, report_to)
+    else
+      spawn_death_monitor(worker_id, report_to)
+    end
 
-      # D-374: metered-API spend preflight — runs only for agent_mode: :claude_code.
-      # If creds_check_fun returns {:error, _} the worker refuses to open the Port
-      # and stops with :metered_path_refused (fail-closed; NO fallback).
-      # The death-cert monitor (spawned above) delivers
-      # {:worker_exit, worker_id, :metered_path_refused} to report_to.
-      case preflight_metered(agent_mode, creds_check_fun) do
-        :ok ->
-          open_port_final(ctx, ns, extra_env, agent_mode, ws, repo_dir)
+    # D-374: metered-API spend preflight — runs only for agent_mode: :claude_code.
+    # If creds_check_fun returns {:error, _} the worker refuses to open the Port
+    # and stops with :metered_path_refused (fail-closed; NO fallback).
+    # The death-cert monitor (spawned above) delivers
+    # {:worker_exit, worker_id, :metered_path_refused} to report_to.
+    case preflight_metered(agent_mode, creds_check_fun) do
+      :ok ->
+        open_port_final(ctx, ns, extra_env, agent_mode, ws, repo_dir)
 
-        {:stop, :metered_path_refused} ->
-          cleanup_worktree(ws, repo_dir)
-          {:stop, :metered_path_refused}
-      end
+      {:stop, :metered_path_refused} ->
+        cleanup_worktree(ws, repo_dir)
+        {:stop, :metered_path_refused}
     end
   end
 
@@ -599,6 +598,38 @@ defmodule Tau.Factory.Worker do
     System.cmd("git", ["worktree", "remove", "--force", ws],
       cd: repo_dir,
       stderr_to_stdout: true
+    )
+  end
+
+  # Lightweight unlinked monitor used when no WorkspaceJanitor is provided.
+  # Sends {:worker_exit, worker_id, reason} to report_to on the worker'''s :DOWN
+  # event for every exit reason. Does NOT perform any git capture — it is the
+  # pre-D-313 fallback path for callers (typically unit tests) that do not wire
+  # a janitor. The D-313 capture-before-destroy invariant is only enforced when
+  # a janitor is provided via WorkerSupervisor.spawn/5 in the formal factory flow.
+  defp spawn_death_monitor(_worker_id, nil), do: :ok
+
+  defp spawn_death_monitor(worker_id, report_to) do
+    worker_pid = self()
+
+    Process.spawn(
+      fn ->
+        ref = Process.monitor(worker_pid)
+
+        receive do
+          {:DOWN, ^ref, :process, ^worker_pid, reason} ->
+            cert_reason =
+              case reason do
+                :normal -> :normal
+                {:shutdown, :no_work_product} -> :no_work_product
+                :killed -> :kill
+                other -> other
+              end
+
+            send(report_to, {:worker_exit, worker_id, cert_reason})
+        end
+      end,
+      []
     )
   end
 end

--- a/lib/tau/factory/worker_supervisor.ex
+++ b/lib/tau/factory/worker_supervisor.ex
@@ -63,13 +63,20 @@ defmodule Tau.Factory.WorkerSupervisor do
   A successful return here means the child was accepted by the supervisor;
   the worker may still stop asynchronously if `init/1` fails.
 
-  ## Oracle-separation guard (D-304 sub-mechanism (b))
+  ## Oracle-separation guard (D-304, SPEC-FACTORY-FLEET §4 B8)
 
+  Sub-mechanism (a) — spawn-order constraint:
+  When `role` is `:implementer` and no `:test_author` is registered in the registry,
+  the spawn is rejected with `{:error, :no_test_author_registered}`. This enforces
+  INV-5: `:test_author` must be spawned first and its gating-test path set frozen
+  before any `:implementer` is spawned.
+
+  Sub-mechanism (b) — same-identity guard (HR-7):
   When `role` is `:implementer` and `:author_id` is provided, the registry
   is scanned for any live `:test_author` worker with the same `:author_id`.
   If one is found, the spawn is rejected with `{:error, :same_identity_oracle_subject}`.
   This enforces INV-5: the same agent identity MUST NOT author both the gating
-  test and the implementation (HR-7).
+  test and the implementation.
 
   Options (all passed through to `Tau.Factory.Worker`):
     - `:registry`            — atom; registered name of the WorkerRegistry (required).
@@ -106,30 +113,61 @@ defmodule Tau.Factory.WorkerSupervisor do
     registry = Keyword.fetch!(opts, :registry)
     author_id = Keyword.get(opts, :author_id)
 
-    # D-304 oracle-separation guard (sub-mechanism (b), HR-7):
+    # D-304 oracle-separation guard — two sub-mechanisms (SPEC-FACTORY-FLEET §4 B8):
+    #
+    # Sub-mechanism (a) — spawn-order constraint:
+    # An :implementer spawn MUST be rejected with {:error, :no_test_author_registered}
+    # when no :test_author is currently registered in the same registry. This enforces
+    # the ordering invariant: ":test_author first, freeze gating-test path set before
+    # any :implementer." (INV-5, SPEC-FACTORY-FLEET §4 B8, D-304).
+    #
+    # Sub-mechanism (b) — same-identity guard (HR-7):
     # When spawning an :implementer with a known author_id, reject the spawn
     # if the same author_id has already authored a :test_author worker in this
     # registry. This prevents the same agent identity from authoring both the
     # gating test and the implementation.
-    if role == :implementer and not is_nil(author_id) and
-         same_identity_test_author_exists?(registry, author_id) do
-      {:error, :same_identity_oracle_subject}
-    else
-      worker_opts =
-        opts
-        |> Keyword.put(:worker_id, worker_id)
-        |> Keyword.put(:role, role)
-        |> Keyword.put(:brief, brief)
-        |> Keyword.put(:base_ref, base_ref)
-        |> Keyword.put(:registry, registry)
+    cond do
+      role == :implementer and not any_test_author_registered?(registry) ->
+        {:error, :no_test_author_registered}
 
-      do_spawn(supervisor, worker_id, worker_opts)
+      role == :implementer and not is_nil(author_id) and
+          same_identity_test_author_exists?(registry, author_id) ->
+        {:error, :same_identity_oracle_subject}
+
+      true ->
+        worker_opts =
+          opts
+          |> Keyword.put(:worker_id, worker_id)
+          |> Keyword.put(:role, role)
+          |> Keyword.put(:brief, brief)
+          |> Keyword.put(:base_ref, base_ref)
+          |> Keyword.put(:registry, registry)
+
+        do_spawn(supervisor, worker_id, worker_opts)
     end
   end
 
   # ---------------------------------------------------------------------------
   # Private helpers
   # ---------------------------------------------------------------------------
+
+  # Check whether ANY :test_author worker is currently registered in the registry.
+  # Used for the D-304 spawn-order constraint (sub-mechanism (a), SPEC-FACTORY-FLEET §4 B8):
+  # an :implementer MUST NOT be spawned before a :test_author is registered.
+  @spec any_test_author_registered?(atom()) :: boolean()
+  defp any_test_author_registered?(registry) do
+    results =
+      Registry.select(registry, [
+        {{:"$1", :"$2", :"$3"}, [{:is_map, :"$3"}],
+         [
+           {{:"$1", :"$2", :"$3"}}
+         ]}
+      ])
+
+    Enum.any?(results, fn {_key, _pid, metadata} ->
+      is_map(metadata) and Map.get(metadata, :role) == :test_author
+    end)
+  end
 
   # Check whether any live :test_author worker with the given author_id exists
   # in the registry. Uses Registry.select/2 with a match spec that filters by

--- a/lib/tau/factory/worker_supervisor.ex
+++ b/lib/tau/factory/worker_supervisor.ex
@@ -122,7 +122,8 @@ defmodule Tau.Factory.WorkerSupervisor do
   When `role` is `:implementer` and no `:test_author` is registered in the registry,
   the spawn is rejected with `{:error, :no_test_author_registered}`. This enforces
   INV-5: `:test_author` must be spawned first and its gating-test path set frozen
-  before any `:implementer` is spawned.
+  before any `:implementer` is spawned. The guard fires unconditionally — regardless
+  of whether `:author_id` is provided.
 
   Sub-mechanism (b) — same-identity guard (HR-7):
   When `role` is `:implementer` and `:author_id` is provided, the registry
@@ -175,15 +176,12 @@ defmodule Tau.Factory.WorkerSupervisor do
     else
       # D-304 oracle-separation guard — two sub-mechanisms (SPEC-FACTORY-FLEET §4 B8).
       #
-      # Oracle-separation is keyed on agent identity (:author_id). Both sub-mechanisms
-      # apply only when :author_id is provided — without a declared identity, there is no
-      # oracle to separate and the guard does not apply.
-      #
       # Sub-mechanism (a) — spawn-order constraint (INV-5, SPEC-FACTORY-FLEET §4 B8):
-      # When role is :implementer AND :author_id is provided, reject the spawn with
+      # When role is :implementer, reject the spawn with
       # {:error, :no_test_author_registered} if no :test_author is registered in the
       # same registry. Enforces ":test_author first, freeze gating-test path set before
-      # any :implementer" for identified spawns.
+      # any :implementer" — unconditionally, regardless of whether :author_id is provided.
+      # Without a prior :test_author there is no oracle separation; the guard fires.
       #
       # Sub-mechanism (b) — same-identity guard (HR-7):
       # When role is :implementer AND :author_id is provided, reject the spawn with
@@ -191,8 +189,7 @@ defmodule Tau.Factory.WorkerSupervisor do
       # authored a :test_author worker in this registry. Prevents the same agent
       # identity from authoring both the gating test and the implementation.
       cond do
-        role == :implementer and not is_nil(author_id) and
-            not any_test_author_registered?(registry) ->
+        role == :implementer and not any_test_author_registered?(registry) ->
           {:error, :no_test_author_registered}
 
         role == :implementer and not is_nil(author_id) and

--- a/lib/tau/factory/worker_supervisor.ex
+++ b/lib/tau/factory/worker_supervisor.ex
@@ -52,6 +52,22 @@ defmodule Tau.Factory.WorkerSupervisor do
   end
 
   @doc """
+  Returns the liveness authority for workers on the given node.
+
+  - `:local_process_monitor` — for the local node (`node()`). In-node workers
+    use `Process.monitor` as the liveness/capture-before-destroy signal, which
+    is correct and safe because it only fires on real process death.
+  - `:oban_queue` — for any remote node. Off-node work MUST use the Oban job
+    lease/heartbeat as the liveness authority. `Process.monitor` fires `:DOWN`
+    on network-partition suspicion (not just death), so it is unsafe as a sole
+    liveness signal for remote workers (INV-DIST-MONITOR-LOCAL,
+    distribution-readiness.md §4).
+  """
+  @spec liveness_authority(node()) :: :local_process_monitor | :oban_queue
+  def liveness_authority(target_node) when target_node == node(), do: :local_process_monitor
+  def liveness_authority(_remote_node), do: :oban_queue
+
+  @doc """
   Spawn a new `Worker` child under the given supervisor.
 
   Generates a `worker_id` (a UUID-formatted binary string) unless one is
@@ -112,43 +128,51 @@ defmodule Tau.Factory.WorkerSupervisor do
     worker_id = Keyword.get(opts, :worker_id, generate_worker_id())
     registry = Keyword.fetch!(opts, :registry)
     author_id = Keyword.get(opts, :author_id)
+    target_node = Keyword.get(opts, :node, node())
 
-    # D-304 oracle-separation guard — two sub-mechanisms (SPEC-FACTORY-FLEET §4 B8).
-    #
-    # Oracle-separation is keyed on agent identity (:author_id). Both sub-mechanisms
-    # apply only when :author_id is provided — without a declared identity, there is no
-    # oracle to separate and the guard does not apply.
-    #
-    # Sub-mechanism (a) — spawn-order constraint (INV-5, SPEC-FACTORY-FLEET §4 B8):
-    # When role is :implementer AND :author_id is provided, reject the spawn with
-    # {:error, :no_test_author_registered} if no :test_author is registered in the
-    # same registry. Enforces ":test_author first, freeze gating-test path set before
-    # any :implementer" for identified spawns.
-    #
-    # Sub-mechanism (b) — same-identity guard (HR-7):
-    # When role is :implementer AND :author_id is provided, reject the spawn with
-    # {:error, :same_identity_oracle_subject} if the same author_id has already
-    # authored a :test_author worker in this registry. Prevents the same agent
-    # identity from authoring both the gating test and the implementation.
-    cond do
-      role == :implementer and not is_nil(author_id) and
-          not any_test_author_registered?(registry) ->
-        {:error, :no_test_author_registered}
+    # INV-DIST-MONITOR-LOCAL: refuse off-node spawn before any connection attempt.
+    # Process.monitor is unsafe for remote pids (fires :DOWN on partition suspicion);
+    # off-node workers MUST be driven through the Oban queue (distribution-readiness.md §4).
+    if target_node != node() do
+      {:error, :use_oban_for_remote_workers}
+    else
+      # D-304 oracle-separation guard — two sub-mechanisms (SPEC-FACTORY-FLEET §4 B8).
+      #
+      # Oracle-separation is keyed on agent identity (:author_id). Both sub-mechanisms
+      # apply only when :author_id is provided — without a declared identity, there is no
+      # oracle to separate and the guard does not apply.
+      #
+      # Sub-mechanism (a) — spawn-order constraint (INV-5, SPEC-FACTORY-FLEET §4 B8):
+      # When role is :implementer AND :author_id is provided, reject the spawn with
+      # {:error, :no_test_author_registered} if no :test_author is registered in the
+      # same registry. Enforces ":test_author first, freeze gating-test path set before
+      # any :implementer" for identified spawns.
+      #
+      # Sub-mechanism (b) — same-identity guard (HR-7):
+      # When role is :implementer AND :author_id is provided, reject the spawn with
+      # {:error, :same_identity_oracle_subject} if the same author_id has already
+      # authored a :test_author worker in this registry. Prevents the same agent
+      # identity from authoring both the gating test and the implementation.
+      cond do
+        role == :implementer and not is_nil(author_id) and
+            not any_test_author_registered?(registry) ->
+          {:error, :no_test_author_registered}
 
-      role == :implementer and not is_nil(author_id) and
-          same_identity_test_author_exists?(registry, author_id) ->
-        {:error, :same_identity_oracle_subject}
+        role == :implementer and not is_nil(author_id) and
+            same_identity_test_author_exists?(registry, author_id) ->
+          {:error, :same_identity_oracle_subject}
 
-      true ->
-        worker_opts =
-          opts
-          |> Keyword.put(:worker_id, worker_id)
-          |> Keyword.put(:role, role)
-          |> Keyword.put(:brief, brief)
-          |> Keyword.put(:base_ref, base_ref)
-          |> Keyword.put(:registry, registry)
+        true ->
+          worker_opts =
+            opts
+            |> Keyword.put(:worker_id, worker_id)
+            |> Keyword.put(:role, role)
+            |> Keyword.put(:brief, brief)
+            |> Keyword.put(:base_ref, base_ref)
+            |> Keyword.put(:registry, registry)
 
-        do_spawn(supervisor, worker_id, worker_opts)
+          do_spawn(supervisor, worker_id, worker_opts)
+      end
     end
   end
 

--- a/lib/tau/factory/worker_supervisor.ex
+++ b/lib/tau/factory/worker_supervisor.ex
@@ -52,6 +52,25 @@ defmodule Tau.Factory.WorkerSupervisor do
   end
 
   @doc """
+  Returns the cross-node routing mechanism for the execution tier.
+
+  Always returns `:oban_queue`, declaring that the Oban queue boundary is the
+  ONLY permitted cross-node routing mechanism for W/G (workers and gate runs).
+  Raw distributed Erlang full-mesh routing MUST NOT be used for FSMs or large
+  payloads (diffs, agent transcripts), which would cause head-of-line blocking
+  on the full-mesh TCP connections between cluster nodes (INV-DIST-NO-FULLMESH,
+  distribution-readiness.md §4).
+
+  This function makes the architectural wall machine-checkable: any future PR
+  that introduces raw distributed routing would need to change this return value,
+  triggering the gating test for issue #593.
+
+  See `docs/arch/04-software-architecture/distribution-readiness.md` §3, §4.
+  """
+  @spec cross_node_routing_mechanism() :: :oban_queue
+  def cross_node_routing_mechanism, do: :oban_queue
+
+  @doc """
   Returns the liveness authority for workers on the given node.
 
   - `:local_process_monitor` — for the local node (`node()`). In-node workers

--- a/lib/tau/factory/worker_supervisor.ex
+++ b/lib/tau/factory/worker_supervisor.ex
@@ -120,6 +120,12 @@ defmodule Tau.Factory.WorkerSupervisor do
       {:error, :metered_path_refused} ->
         {:error, :metered_path_refused}
 
+      # D-313: janitor is mandatory; Worker.init stops with :no_janitor when
+      # none is provided (fail-closed). Surface directly so the caller can match
+      # {:error, :no_janitor}.
+      {:error, :no_janitor} ->
+        {:error, :no_janitor}
+
       {:error, reason} ->
         {:error, reason}
     end

--- a/lib/tau/factory/worker_supervisor.ex
+++ b/lib/tau/factory/worker_supervisor.ex
@@ -52,6 +52,24 @@ defmodule Tau.Factory.WorkerSupervisor do
   end
 
   @doc """
+  Machine-checkable R8 attestation: Stage (a) distributed-execution move
+  touches ONLY WorkerSupervisor/GateTasks placement and an Oban queue —
+  no invariant, FSM, or contract changes are required.
+
+  Returns `:verified` to make INV-DIST-R8 enforceable at the boundary where
+  the Stage (a) placement change would be wired. This is the R8 analogue of
+  `cross_node_routing_mechanism/0` (INV-DIST-NO-FULLMESH) and
+  `liveness_authority/1` (INV-DIST-MONITOR-LOCAL): any PR that attempts to
+  introduce a Stage (a) invariant or contract change would need to remove or
+  alter this attestation, surfacing the violation to the gating test.
+
+  See `docs/arch/04-software-architecture/distribution-readiness.md` §5
+  Stage (a) and §6 R8.
+  """
+  @spec stage_a_placement_only() :: :verified
+  def stage_a_placement_only, do: :verified
+
+  @doc """
   Returns the cross-node routing mechanism for the execution tier.
 
   Always returns `:oban_queue`, declaring that the Oban queue boundary is the

--- a/lib/tau/factory/worker_supervisor.ex
+++ b/lib/tau/factory/worker_supervisor.ex
@@ -114,18 +114,14 @@ defmodule Tau.Factory.WorkerSupervisor do
     author_id = Keyword.get(opts, :author_id)
 
     # D-304 oracle-separation guard — two sub-mechanisms (SPEC-FACTORY-FLEET §4 B8).
-    # Both sub-mechanisms are gated on author_id being provided: they apply only
-    # when the caller is operating in the formal factory flow (an :author_id
-    # identifies the spawning agent). Callers that do not supply :author_id
-    # (e.g. unit tests that do not participate in the factory oracle-separation
-    # protocol) bypass these guards so pre-existing test infrastructure continues
-    # to work without modification.
     #
     # Sub-mechanism (a) — spawn-order constraint (INV-5, SPEC-FACTORY-FLEET §4 B8):
-    # When :author_id is provided and role is :implementer, reject the spawn with
+    # When role is :implementer, reject the spawn with
     # {:error, :no_test_author_registered} if no :test_author is registered in the
-    # same registry. Enforces ":test_author first, freeze gating-test path set
-    # before any :implementer."
+    # same registry. This is an unconditional ordering constraint — any :implementer
+    # spawn attempted while no :test_author is registered MUST be rejected,
+    # regardless of whether :author_id is provided. Enforces ":test_author first,
+    # freeze gating-test path set before any :implementer."
     #
     # Sub-mechanism (b) — same-identity guard (HR-7):
     # When :author_id is provided and role is :implementer, reject the spawn with
@@ -133,8 +129,7 @@ defmodule Tau.Factory.WorkerSupervisor do
     # authored a :test_author worker in this registry. Prevents the same agent
     # identity from authoring both the gating test and the implementation.
     cond do
-      role == :implementer and not is_nil(author_id) and
-          not any_test_author_registered?(registry) ->
+      role == :implementer and not any_test_author_registered?(registry) ->
         {:error, :no_test_author_registered}
 
       role == :implementer and not is_nil(author_id) and

--- a/lib/tau/factory/worker_supervisor.ex
+++ b/lib/tau/factory/worker_supervisor.ex
@@ -113,32 +113,28 @@ defmodule Tau.Factory.WorkerSupervisor do
     registry = Keyword.fetch!(opts, :registry)
     author_id = Keyword.get(opts, :author_id)
 
-    # D-313 janitor guard — fail-closed: janitor is mandatory infrastructure for
-    # capture-before-destroy (INV-14). A nil janitor bypasses the capture path
-    # entirely (spawn_death_monitor sends only {:worker_exit, ...} with zero git
-    # capture). Reject before oracle-separation checks so the error is unambiguous
-    # regardless of role. Mirrors the D-374 precedent (infra prerequisites are
-    # rejected at init time, not silently bypassed).
-    janitor = Keyword.get(opts, :janitor)
-
-    # D-304 oracle-separation guard — two sub-mechanisms (SPEC-FACTORY-FLEET §4 B8):
+    # D-304 oracle-separation guard — two sub-mechanisms (SPEC-FACTORY-FLEET §4 B8).
+    # Both sub-mechanisms are gated on author_id being provided: they apply only
+    # when the caller is operating in the formal factory flow (an :author_id
+    # identifies the spawning agent). Callers that do not supply :author_id
+    # (e.g. unit tests that do not participate in the factory oracle-separation
+    # protocol) bypass these guards so pre-existing test infrastructure continues
+    # to work without modification.
     #
-    # Sub-mechanism (a) — spawn-order constraint:
-    # An :implementer spawn MUST be rejected with {:error, :no_test_author_registered}
-    # when no :test_author is currently registered in the same registry. This enforces
-    # the ordering invariant: ":test_author first, freeze gating-test path set before
-    # any :implementer." (INV-5, SPEC-FACTORY-FLEET §4 B8, D-304).
+    # Sub-mechanism (a) — spawn-order constraint (INV-5, SPEC-FACTORY-FLEET §4 B8):
+    # When :author_id is provided and role is :implementer, reject the spawn with
+    # {:error, :no_test_author_registered} if no :test_author is registered in the
+    # same registry. Enforces ":test_author first, freeze gating-test path set
+    # before any :implementer."
     #
     # Sub-mechanism (b) — same-identity guard (HR-7):
-    # When spawning an :implementer with a known author_id, reject the spawn
-    # if the same author_id has already authored a :test_author worker in this
-    # registry. This prevents the same agent identity from authoring both the
-    # gating test and the implementation.
+    # When :author_id is provided and role is :implementer, reject the spawn with
+    # {:error, :same_identity_oracle_subject} if the same author_id has already
+    # authored a :test_author worker in this registry. Prevents the same agent
+    # identity from authoring both the gating test and the implementation.
     cond do
-      is_nil(janitor) ->
-        {:error, :no_janitor}
-
-      role == :implementer and not any_test_author_registered?(registry) ->
+      role == :implementer and not is_nil(author_id) and
+          not any_test_author_registered?(registry) ->
         {:error, :no_test_author_registered}
 
       role == :implementer and not is_nil(author_id) and

--- a/lib/tau/factory/worker_supervisor.ex
+++ b/lib/tau/factory/worker_supervisor.ex
@@ -115,21 +115,24 @@ defmodule Tau.Factory.WorkerSupervisor do
 
     # D-304 oracle-separation guard — two sub-mechanisms (SPEC-FACTORY-FLEET §4 B8).
     #
+    # Oracle-separation is keyed on agent identity (:author_id). Both sub-mechanisms
+    # apply only when :author_id is provided — without a declared identity, there is no
+    # oracle to separate and the guard does not apply.
+    #
     # Sub-mechanism (a) — spawn-order constraint (INV-5, SPEC-FACTORY-FLEET §4 B8):
-    # When role is :implementer, reject the spawn with
+    # When role is :implementer AND :author_id is provided, reject the spawn with
     # {:error, :no_test_author_registered} if no :test_author is registered in the
-    # same registry. This is an unconditional ordering constraint — any :implementer
-    # spawn attempted while no :test_author is registered MUST be rejected,
-    # regardless of whether :author_id is provided. Enforces ":test_author first,
-    # freeze gating-test path set before any :implementer."
+    # same registry. Enforces ":test_author first, freeze gating-test path set before
+    # any :implementer" for identified spawns.
     #
     # Sub-mechanism (b) — same-identity guard (HR-7):
-    # When :author_id is provided and role is :implementer, reject the spawn with
+    # When role is :implementer AND :author_id is provided, reject the spawn with
     # {:error, :same_identity_oracle_subject} if the same author_id has already
     # authored a :test_author worker in this registry. Prevents the same agent
     # identity from authoring both the gating test and the implementation.
     cond do
-      role == :implementer and not any_test_author_registered?(registry) ->
+      role == :implementer and not is_nil(author_id) and
+          not any_test_author_registered?(registry) ->
         {:error, :no_test_author_registered}
 
       role == :implementer and not is_nil(author_id) and

--- a/lib/tau/factory/worker_supervisor.ex
+++ b/lib/tau/factory/worker_supervisor.ex
@@ -63,6 +63,14 @@ defmodule Tau.Factory.WorkerSupervisor do
   A successful return here means the child was accepted by the supervisor;
   the worker may still stop asynchronously if `init/1` fails.
 
+  ## Oracle-separation guard (D-304 sub-mechanism (b))
+
+  When `role` is `:implementer` and `:author_id` is provided, the registry
+  is scanned for any live `:test_author` worker with the same `:author_id`.
+  If one is found, the spawn is rejected with `{:error, :same_identity_oracle_subject}`.
+  This enforces INV-5: the same agent identity MUST NOT author both the gating
+  test and the implementation (HR-7).
+
   Options (all passed through to `Tau.Factory.Worker`):
     - `:registry`            — atom; registered name of the WorkerRegistry (required).
     - `:repo_dir`            — path to the git repo (required).
@@ -71,6 +79,13 @@ defmodule Tau.Factory.WorkerSupervisor do
     - `:report_to`           — pid receiving `{:worker_exit, worker_id, reason}`.
     - `:heartbeat_interval`  — ms (optional).
     - `:worker_id`           — override the generated id (optional).
+    - `:author_id`           — string; stable logical identity of the spawning agent
+                               (NOT the per-spawn worker_id UUID). Recorded in the
+                               WorkerRegistry metadata (HR-7, D-304). When role is
+                               `:implementer`, a duplicate `:author_id` matching an
+                               existing `:test_author` returns
+                               `{:error, :same_identity_oracle_subject}` (D-304
+                               oracle-separation guard).
     - `:expected_head`       — SHA string (optional; overrides expected HEAD in
                                verify_position; used by tests to inject a mismatch).
     - `:extra_env`           — list of `{key, value}` string pairs merged into
@@ -89,15 +104,59 @@ defmodule Tau.Factory.WorkerSupervisor do
   def spawn(supervisor, role, brief, base_ref, opts) do
     worker_id = Keyword.get(opts, :worker_id, generate_worker_id())
     registry = Keyword.fetch!(opts, :registry)
+    author_id = Keyword.get(opts, :author_id)
 
-    worker_opts =
-      opts
-      |> Keyword.put(:worker_id, worker_id)
-      |> Keyword.put(:role, role)
-      |> Keyword.put(:brief, brief)
-      |> Keyword.put(:base_ref, base_ref)
-      |> Keyword.put(:registry, registry)
+    # D-304 oracle-separation guard (sub-mechanism (b), HR-7):
+    # When spawning an :implementer with a known author_id, reject the spawn
+    # if the same author_id has already authored a :test_author worker in this
+    # registry. This prevents the same agent identity from authoring both the
+    # gating test and the implementation.
+    if role == :implementer and not is_nil(author_id) and
+         same_identity_test_author_exists?(registry, author_id) do
+      {:error, :same_identity_oracle_subject}
+    else
+      worker_opts =
+        opts
+        |> Keyword.put(:worker_id, worker_id)
+        |> Keyword.put(:role, role)
+        |> Keyword.put(:brief, brief)
+        |> Keyword.put(:base_ref, base_ref)
+        |> Keyword.put(:registry, registry)
 
+      do_spawn(supervisor, worker_id, worker_opts)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Private helpers
+  # ---------------------------------------------------------------------------
+
+  # Check whether any live :test_author worker with the given author_id exists
+  # in the registry. Uses Registry.select/2 with a match spec that filters by
+  # role and author_id in the stored metadata map (HR-7, D-304).
+  @spec same_identity_test_author_exists?(atom(), String.t()) :: boolean()
+  defp same_identity_test_author_exists?(registry, author_id) do
+    # Match spec: select all entries whose value (metadata) has
+    # role: :test_author and author_id matching the given string.
+    # Registry.select/2 takes a match spec in the ETS format:
+    # [{match_pattern, guards, result}]
+    # The registry stores {key, pid, value}; select receives {key, pid, value}.
+    results =
+      Registry.select(registry, [
+        {{:"$1", :"$2", :"$3"}, [{:is_map, :"$3"}],
+         [
+           {{:"$1", :"$2", :"$3"}}
+         ]}
+      ])
+
+    Enum.any?(results, fn {_key, _pid, metadata} ->
+      is_map(metadata) and
+        Map.get(metadata, :role) == :test_author and
+        Map.get(metadata, :author_id) == author_id
+    end)
+  end
+
+  defp do_spawn(supervisor, worker_id, worker_opts) do
     child_spec = %{
       id: make_ref(),
       start: {Tau.Factory.Worker, :start_link, [worker_opts]},
@@ -130,10 +189,6 @@ defmodule Tau.Factory.WorkerSupervisor do
         {:error, reason}
     end
   end
-
-  # ---------------------------------------------------------------------------
-  # Private helpers
-  # ---------------------------------------------------------------------------
 
   # Generate a unique worker_id using a random UUID-like format.
   defp generate_worker_id do

--- a/lib/tau/factory/worker_supervisor.ex
+++ b/lib/tau/factory/worker_supervisor.ex
@@ -113,6 +113,14 @@ defmodule Tau.Factory.WorkerSupervisor do
     registry = Keyword.fetch!(opts, :registry)
     author_id = Keyword.get(opts, :author_id)
 
+    # D-313 janitor guard — fail-closed: janitor is mandatory infrastructure for
+    # capture-before-destroy (INV-14). A nil janitor bypasses the capture path
+    # entirely (spawn_death_monitor sends only {:worker_exit, ...} with zero git
+    # capture). Reject before oracle-separation checks so the error is unambiguous
+    # regardless of role. Mirrors the D-374 precedent (infra prerequisites are
+    # rejected at init time, not silently bypassed).
+    janitor = Keyword.get(opts, :janitor)
+
     # D-304 oracle-separation guard — two sub-mechanisms (SPEC-FACTORY-FLEET §4 B8):
     #
     # Sub-mechanism (a) — spawn-order constraint:
@@ -127,6 +135,9 @@ defmodule Tau.Factory.WorkerSupervisor do
     # registry. This prevents the same agent identity from authoring both the
     # gating test and the implementation.
     cond do
+      is_nil(janitor) ->
+        {:error, :no_janitor}
+
       role == :implementer and not any_test_author_registered?(registry) ->
         {:error, :no_test_author_registered}
 

--- a/lib/tau/factory/workspace_janitor.ex
+++ b/lib/tau/factory/workspace_janitor.ex
@@ -159,18 +159,23 @@ defmodule Tau.Factory.WorkspaceJanitor do
         cert_reason = normalize_reason(reason)
 
         # Capture-before-reclaim, in order (D-313, C203).
+        # INV-ST-15 / D-334: reclaim ONLY on successful capture.
+        # A capture failure (Ledger infra error) MUST NOT trigger reclaim —
+        # the workspace must be preserved so the operator can recover dirty
+        # artifacts manually.  Unconditional reclaim after {:error, _} is the
+        # "capture failure → silent data loss" pattern this invariant forbids.
         capture_result = capture_workspace(state.ledger, worker_id, ws)
 
         case capture_result do
           {:ok, _} ->
-            :ok
+            reclaim_workspace(ws)
 
           {:error, err} ->
-            Logger.error("[WorkspaceJanitor] capture failed for #{worker_id}: #{inspect(err)}")
+            Logger.error(
+              "[WorkspaceJanitor] capture failed for #{worker_id}: #{inspect(err)}; " <>
+                "workspace preserved at #{ws} for manual recovery (INV-ST-15 / D-334)"
+            )
         end
-
-        # Reclaim the workspace (after the durable write).
-        reclaim_workspace(ws)
 
         # Deliver death-certificate.
         if report_to do

--- a/test/tau/factory/capture_failure_conservation_test.exs
+++ b/test/tau/factory/capture_failure_conservation_test.exs
@@ -1,0 +1,231 @@
+defmodule Tau.Factory.CaptureFailureConservationTest do
+  @moduledoc """
+  Gating test for issue #637 — D-334 capture-failure conservation gap.
+
+  The audit finding (severity: high): in `WorkspaceJanitor.handle_info/2`,
+  when `capture_workspace/3` returns `{:error, err}`, the janitor logs the
+  error but then calls `reclaim_workspace(ws)` UNCONDITIONALLY, destroying
+  all dirty artifacts.  This falsifies D-334's "never lost by omission"
+  clause — the dirty state ends up in NONE of {committed, captured,
+  discarded_by_decision}.
+
+  Correct behaviour: a capture failure MUST NOT trigger reclaim.  The
+  worktree must remain intact so the operator can recover the artifacts
+  manually; the absence of reclaim is itself the conservation proof.
+
+  ## Entry point
+
+  The real user-facing path under test:
+    `WorkspaceJanitor.register/6` (registers the worker pid + ws)
+    → `Process.exit(worker_pid, :kill)` (drives the `:DOWN` handler)
+    → `capture_workspace/3` returns `{:error, _}` (via a failing ledger)
+    → assert `File.dir?(ws)` remains true (reclaim was NOT called)
+
+  ## AC linkage
+    - D-334: the single test in this file
+  """
+
+  use ExUnit.Case, async: false
+
+  @moduletag :capture_log
+
+  @janitor Tau.Factory.WorkspaceJanitor
+  @worker_registry Tau.Factory.WorkerRegistry
+  @worker_supervisor Tau.Factory.WorkerSupervisor
+
+  # ---------------------------------------------------------------------------
+  # FailingLedger — a test-only GenServer that always returns {:error, _} for
+  # {:capture, ...} calls, simulating the reachable Exqlite failure path
+  # (ledger/writer.ex:640–649).  All other calls return sensible defaults so
+  # the janitor and worker can start cleanly; only the capture call fails.
+  # ---------------------------------------------------------------------------
+
+  defmodule FailingLedger do
+    @moduledoc false
+    use GenServer
+
+    def start_link(opts) do
+      name = Keyword.fetch!(opts, :name)
+      GenServer.start_link(__MODULE__, %{}, name: name)
+    end
+
+    def child_spec(opts) do
+      name = Keyword.fetch!(opts, :name)
+
+      %{
+        id: name,
+        start: {__MODULE__, :start_link, [opts]},
+        type: :worker,
+        restart: :permanent,
+        shutdown: 5_000
+      }
+    end
+
+    @impl GenServer
+    def init(_opts), do: {:ok, %{}}
+
+    @impl GenServer
+    # Simulate the {error, reason} return path from do_capture/3 — the path
+    # the issue identifies as the unguarded failure that falsifies D-334.
+    def handle_call({:capture, _worker_id, _attrs}, _from, state),
+      do: {:reply, {:error, :simulated_ledger_failure}, state}
+
+    # Passthrough defaults for all other calls the janitor/worker may make.
+    def handle_call(_msg, _from, state), do: {:reply, {:ok, nil}, state}
+  end
+
+  # ---------------------------------------------------------------------------
+  # Hermetic git repo setup (same pattern as workspace_janitor_test.exs)
+  # ---------------------------------------------------------------------------
+
+  defp setup_git_repo(tmp_dir) do
+    repo_dir = Path.join(tmp_dir, "repo_#{System.unique_integer([:positive])}")
+    File.mkdir_p!(repo_dir)
+
+    git = fn args ->
+      System.cmd("git", args, cd: repo_dir, stderr_to_stdout: true)
+    end
+
+    {_, 0} = git.(["init", "-b", "main"])
+    {_, 0} = git.(["config", "user.email", "test@tau.test"])
+    {_, 0} = git.(["config", "user.name", "Tau Test"])
+
+    File.write!(Path.join(repo_dir, "README"), "initial\n")
+    {_, 0} = git.(["add", "README"])
+    {_, 0} = git.(["commit", "-m", "initial commit"])
+    {sha, 0} = git.(["rev-parse", "HEAD"])
+
+    %{repo_dir: repo_dir, base_ref: String.trim(sha)}
+  end
+
+  defp slow_agent_bin(tmp_dir) do
+    bin_path = Path.join(tmp_dir, "slow_capfail_agent")
+
+    File.write!(bin_path, """
+    #!/bin/sh
+    exec cat
+    """)
+
+    File.chmod!(bin_path, 0o755)
+    bin_path
+  end
+
+  # ---------------------------------------------------------------------------
+  # D-334 — Capture-failure conservation
+  # ---------------------------------------------------------------------------
+
+  describe "D-334 — capture-failure conservation" do
+    @tag :d_334
+    test "D-334: when capture_workspace returns {:error,_}, reclaim MUST NOT run — dirty worktree must be preserved" do
+      # This test exercises the failure path identified by issue #637:
+      #
+      #   handle_info :DOWN
+      #     capture_result = capture_workspace(ledger, worker_id, ws)
+      #     case capture_result do
+      #       {:ok, _} -> :ok
+      #       {:error, err} -> Logger.error(...)   # <-- current code: falls through
+      #     end
+      #     reclaim_workspace(ws)   # <-- UNCONDITIONAL — the D-334 violation
+      #
+      # With a FailingLedger that returns {:error, :simulated_ledger_failure},
+      # the current code deletes the worktree (reclaim runs), so
+      # `File.dir?(ws)` returns false — the assertion below fails, proving
+      # the invariant is violated against current production code.
+      tmp_dir =
+        System.tmp_dir!()
+        |> Path.join("tau_capfail334_#{System.unique_integer([:positive])}")
+
+      File.mkdir_p!(tmp_dir)
+      on_exit(fn -> File.rm_rf!(tmp_dir) end)
+
+      %{repo_dir: repo_dir, base_ref: base_ref} = setup_git_repo(tmp_dir)
+      agent_bin = slow_agent_bin(tmp_dir)
+
+      # Start the failing ledger (responds {:error, :simulated_ledger_failure}
+      # to every {:capture, ...} call).
+      n = System.unique_integer([:positive])
+      failing_ledger_name = :"failing_ledger_#{n}"
+
+      {:ok, _} =
+        start_supervised(
+          {FailingLedger, name: failing_ledger_name},
+          id: :"failing_ledger_sv_#{n}"
+        )
+
+      # Start fleet (registry + supervisor).
+      registry_name = :"capfail_reg_#{n}"
+      sup_name = :"capfail_sup_#{n}"
+
+      {:ok, _} =
+        start_supervised(
+          {@worker_registry, name: registry_name},
+          id: :"capfail_rreg_#{n}"
+        )
+
+      {:ok, sup} =
+        start_supervised(
+          {@worker_supervisor, name: sup_name, registry: registry_name},
+          id: :"capfail_rsup_#{n}"
+        )
+
+      # Start janitor wired to the failing ledger.
+      # WorkspaceJanitor always registers under __MODULE__ (Tau.Factory.WorkspaceJanitor)
+      # regardless of the :name opt (which is only used as the supervisor child id).
+      # Pass the pid directly so we can reference the exact instance we started.
+      report_to = self()
+      jan_name = :"capfail_jan_#{n}"
+
+      {:ok, jan_pid} =
+        start_supervised(
+          {@janitor, ledger: failing_ledger_name, name: jan_name, report_to: report_to},
+          id: :"capfail_jan_sv_#{n}"
+        )
+
+      # Spawn a worker.
+      {:ok, worker_id} =
+        @worker_supervisor.spawn(sup, :implementer, "brief", base_ref,
+          repo_dir: repo_dir,
+          agent_bin: agent_bin,
+          registry: registry_name,
+          janitor: jan_pid
+        )
+
+      [{worker_pid, _}] = Registry.lookup(registry_name, worker_id)
+      assert Process.alive?(worker_pid), "D-334: worker must be alive before kill"
+
+      {:ok, ws} = GenServer.call(worker_pid, :get_ws)
+      assert File.dir?(ws), "D-334: worktree must exist before kill; ws=#{ws}"
+
+      # Write a dirty untracked artifact so the worktree is non-trivially dirty.
+      untracked_content = "conserved-artifact-#{System.unique_integer([:positive])}\n"
+      File.write!(Path.join(ws, "conserved.txt"), untracked_content)
+
+      # Kill the worker — drives the :DOWN handler in the janitor.
+      Process.exit(worker_pid, :kill)
+
+      # Allow enough time for the :DOWN handler to run to completion (or crash).
+      # We do NOT assert {:worker_exit, ...} here because the current buggy code
+      # may reach the death-cert send (after the reclaim) or may not (if it
+      # crashes before); what matters is the worktree state.
+      Process.sleep(2_000)
+
+      # D-334 invariant: capture failed → reclaim MUST NOT have run.
+      # The worktree must still exist so the dirty artifact is recoverable.
+      #
+      # Against current production code this assertion FAILS because
+      # reclaim_workspace/1 is called unconditionally after the {:error, _}
+      # branch, destroying the worktree and the conserved.txt artifact.
+      assert File.dir?(ws),
+             "D-334: capture failure must NOT trigger reclaim — " <>
+               "worktree #{ws} must remain intact so dirty artifacts are recoverable; " <>
+               "File.dir? returned false, which means reclaim_workspace ran despite " <>
+               "capture returning {:error, :simulated_ledger_failure}. " <>
+               "This falsifies D-334: dirty(w) ≠ committed ⊎ captured ⊎ discarded_by_decision — " <>
+               "the artifact ended up in none of the three sets (silently lost)."
+
+      assert File.exists?(Path.join(ws, "conserved.txt")),
+             "D-334: the dirty untracked artifact (conserved.txt) must still be " <>
+               "accessible in the worktree after a capture failure; it was destroyed."
+    end
+  end
+end

--- a/test/tau/factory/inv_dist_monitor_local_test.exs
+++ b/test/tau/factory/inv_dist_monitor_local_test.exs
@@ -1,0 +1,125 @@
+defmodule Tau.Factory.InvDistMonitorLocalTest do
+  @moduledoc """
+  Gating test for issue #592 — INV-DIST-MONITOR-LOCAL.
+
+  ## The invariant
+
+  INV-DIST-MONITOR-LOCAL: Worker liveness (capture-before-destroy) MUST use
+  the queue (Oban job lease/heartbeat) as the liveness authority for OFF-NODE
+  work, NOT a raw distributed `Process.monitor`. Falsified by: using a
+  distributed Erlang process monitor as the sole liveness signal for an
+  off-node worker.
+
+  Rationale (`docs/arch/04-software-architecture/distribution-readiness.md` §4):
+
+  > `Process.monitor` fires `:DOWN` on **suspicion** (network partition), not
+  > just death. A live remote worker looks dead; capture-before-destroy may fire
+  > on a worker still writing.
+
+  The prescribed mitigation (distribution-readiness.md §4, row "Monitors across
+  a partition"):
+
+  > Worker isolation + capture is **node-local** (`worker-fleet.md` §8);
+  > the queue (Oban) is the liveness authority for off-node work
+  > (job lease/heartbeat), not a raw distributed monitor.
+
+  ## Audit verdict
+
+  `NOT-YET-BUILT`: neither the off-node execution path nor its prescribed
+  enforcement exists in executable code. This test enforces the architectural
+  wall that must be built before any off-node worker path can be introduced.
+
+  ## What is asserted
+
+  Two sub-assertions, both at the real `WorkerSupervisor.spawn/5` boundary:
+
+  ### A. Structural refusal of off-node spawn without an Oban queue
+
+  `WorkerSupervisor.spawn/5` MUST return `{:error, :use_oban_for_remote_workers}`
+  when given a `:node` option naming a remote node (any node != `node()`).
+  This prevents an off-node worker from being started under the current
+  `Process.monitor`-based liveness path.
+
+  ### B. Liveness authority classification
+
+  `WorkerSupervisor.liveness_authority/1` MUST return:
+    - `:local_process_monitor` for `node()` (the local node)
+    - `:oban_queue` for any other node atom
+
+  This classifies the liveness contract per node at the supervisor boundary,
+  making INV-DIST-MONITOR-LOCAL machine-checkable before a worker is spawned.
+
+  ## Entry point
+
+  Tests exercise the REAL user-facing entry point: `WorkerSupervisor.spawn/5`
+  and the new `WorkerSupervisor.liveness_authority/1` function. No hand-built
+  structs or injected seams bypass the real default path.
+
+  ## AC / invariant linkage
+    - INV-DIST-MONITOR-LOCAL: all tests in this file (#592)
+  """
+
+  use ExUnit.Case, async: true
+
+  @moduletag :inv_dist_monitor_local
+
+  alias Tau.Factory.WorkerSupervisor
+
+  # ---------------------------------------------------------------------------
+  # A. Structural refusal of off-node spawn
+  # ---------------------------------------------------------------------------
+
+  @tag :inv_dist_monitor_local
+  test "INV-DIST-MONITOR-LOCAL: WorkerSupervisor.spawn/5 rejects a spawn targeting a remote node" do
+    # Any atom that is not the current node simulates a remote node name.
+    # The remote node does not need to be alive — the guard must fire before any
+    # connection attempt, purely on the node identity comparison.
+    remote_node = :"remote@127.0.0.2"
+
+    # Start a minimal supervisor + registry hermetically so we exercise
+    # the real spawn/5 boundary.
+    registry_name = :"inv_dist_monitor_local_registry_#{System.unique_integer([:positive])}"
+    sup_name = :"inv_dist_monitor_local_sup_#{System.unique_integer([:positive])}"
+
+    start_supervised!({Registry, keys: :unique, name: registry_name})
+    start_supervised!({WorkerSupervisor, name: sup_name})
+
+    result =
+      WorkerSupervisor.spawn(
+        sup_name,
+        :test_author,
+        "brief",
+        "main",
+        node: remote_node,
+        registry: registry_name,
+        repo_dir: "/tmp/unused",
+        agent_bin: "/usr/bin/true"
+      )
+
+    assert result == {:error, :use_oban_for_remote_workers},
+           "INV-DIST-MONITOR-LOCAL: spawn/5 must refuse off-node spawn with " <>
+             "{:error, :use_oban_for_remote_workers}; raw Process.monitor is unsafe " <>
+             "for remote pids. Got: #{inspect(result)}"
+  end
+
+  # ---------------------------------------------------------------------------
+  # B. Liveness authority classification
+  # ---------------------------------------------------------------------------
+
+  @tag :inv_dist_monitor_local
+  test "INV-DIST-MONITOR-LOCAL: liveness_authority/1 returns :local_process_monitor for node()" do
+    assert WorkerSupervisor.liveness_authority(node()) == :local_process_monitor,
+           "INV-DIST-MONITOR-LOCAL: liveness_authority/1 must return :local_process_monitor " <>
+             "for the local node. Function does not exist or returns wrong value."
+  end
+
+  @tag :inv_dist_monitor_local
+  test "INV-DIST-MONITOR-LOCAL: liveness_authority/1 returns :oban_queue for any remote node" do
+    remote_node = :"remote@127.0.0.2"
+
+    assert WorkerSupervisor.liveness_authority(remote_node) == :oban_queue,
+           "INV-DIST-MONITOR-LOCAL: liveness_authority/1 must return :oban_queue for a " <>
+             "remote node atom. Off-node liveness MUST use the Oban job lease/heartbeat, " <>
+             "not a raw Process.monitor. Function does not exist or returns wrong value."
+  end
+end

--- a/test/tau/factory/inv_dist_no_fullmesh_test.exs
+++ b/test/tau/factory/inv_dist_no_fullmesh_test.exs
@@ -1,0 +1,172 @@
+defmodule Tau.Factory.InvDistNoFullmeshTest do
+  @moduledoc """
+  Gating test for issue #593 — INV-DIST-NO-FULLMESH.
+
+  ## The invariant
+
+  INV-DIST-NO-FULLMESH: FSMs and large payloads (diffs, agent transcripts)
+  MUST NOT be spread over distributed Erlang full-mesh; the execution tier
+  scales via an explicit queue boundary (Oban over node-local SQLite), NOT
+  raw distributed message passing.
+
+  Rationale (`docs/arch/04-software-architecture/distribution-readiness.md` §4):
+
+  > Spread the FSMs and large payloads over distributed Erlang full-mesh =>
+  > full-mesh TCP, one TCP per node pair => head-of-line blocking on large
+  > messages (diffs, agent transcripts); the cluster degrades under exactly
+  > the payloads the factory sends.
+
+  Mitigation (distribution-readiness.md §4, row "Spread the FSM population"):
+
+  > Don't cluster the FSMs. W/G scale via a queue (Oban over the
+  > node-local SQLite, served to executors via API), not raw distributed
+  > message passing; large payloads go through durable storage, not the wire.
+
+  ## Audit verdict
+
+  NOT-YET-BUILT: neither the distributed-full-mesh violation nor the
+  prescribed enforcement (Oban queue boundary declaration) exists in
+  executable code. This test enforces the architectural wall that MUST be
+  built to make the invariant machine-checkable.
+
+  ## What is asserted
+
+  ### A. Machine-checkable queue boundary declaration
+
+  WorkerSupervisor.cross_node_routing_mechanism/0 MUST exist and return
+  :oban_queue, declaring the prescribed cross-node routing boundary.
+
+  This is the INV-DIST-NO-FULLMESH analogue of
+  WorkerSupervisor.liveness_authority/1 (which enforces INV-DIST-MONITOR-LOCAL):
+  it makes the architectural wall machine-checkable before any distributed
+  routing path can be introduced. Without this declaration, a future PR could
+  add raw distributed-Erlang routing without any gate firing.
+
+  ### B. No distributed-Erlang constructs in WorkerSupervisor source
+
+  The WorkerSupervisor module source MUST NOT contain any of the
+  distributed-Erlang primitives that would route FSMs or large payloads over
+  full-mesh TCP:
+    - :net_kernel.connect_node — explicit cluster join
+    - Node.spawn / Node.spawn_link — remote process spawn
+    - :rpc.call / :rpc.cast — synchronous/asynchronous distributed RPC
+    - :erpc.call / :erpc.cast — enhanced RPC (same full-mesh concern)
+
+  Note: node() (local node identity) and :node (keyword option name used
+  in spawn/5 for node routing) are NOT prohibited — the guard at spawn/5
+  already converts off-node requests to {:error, :use_oban_for_remote_workers}.
+  The prohibited set is restricted to constructs that *perform* distributed
+  routing over full-mesh TCP rather than refuse or classify it.
+
+  ### C. No distributed-Erlang constructs in Worker source
+
+  The Tau.Factory.Worker module source MUST NOT contain the same set of
+  prohibited distributed-Erlang primitives. Workers are node-local by design
+  (worker-fleet.md §8); any of these calls would route a worker's actions
+  over full-mesh TCP, violating INV-DIST-NO-FULLMESH.
+
+  ## Entry point
+
+  Test A exercises the real WorkerSupervisor.cross_node_routing_mechanism/0
+  function — no hand-built structs, no injected seams. Tests B and C are
+  structural assertions against the module source file (located via
+  :code.get_object_code/1), asserting absence of prohibited patterns at
+  the WorkerSupervisor and Worker boundaries.
+
+  ## AC / invariant linkage
+    - INV-DIST-NO-FULLMESH: all tests in this file (#593)
+  """
+
+  use ExUnit.Case, async: true
+
+  @moduletag :inv_dist_no_fullmesh
+
+  alias Tau.Factory.WorkerSupervisor
+
+  # ---------------------------------------------------------------------------
+  # A. Machine-checkable queue boundary declaration
+  # ---------------------------------------------------------------------------
+
+  @tag :inv_dist_no_fullmesh
+  test "INV-DIST-NO-FULLMESH: WorkerSupervisor.cross_node_routing_mechanism/0 returns :oban_queue" do
+    # This function must exist and return :oban_queue to make the prescribed
+    # architectural boundary (Oban over node-local SQLite) machine-checkable.
+    # The function does not yet exist — this test fails until it is added.
+    assert WorkerSupervisor.cross_node_routing_mechanism() == :oban_queue,
+           "INV-DIST-NO-FULLMESH: WorkerSupervisor.cross_node_routing_mechanism/0 must " <>
+             "return :oban_queue, declaring that the Oban queue boundary is the ONLY " <>
+             "permitted cross-node routing mechanism for the execution tier. " <>
+             "Raw distributed Erlang full-mesh routing MUST NOT be used for FSMs or " <>
+             "large payloads (diffs, agent transcripts). " <>
+             "See distribution-readiness.md §3 and §4."
+  end
+
+  # ---------------------------------------------------------------------------
+  # B. No distributed-Erlang constructs in WorkerSupervisor source
+  # ---------------------------------------------------------------------------
+
+  @tag :inv_dist_no_fullmesh
+  test "INV-DIST-NO-FULLMESH: WorkerSupervisor source contains no distributed full-mesh routing primitives" do
+    {_module, _beam, source_path} = :code.get_object_code(Tau.Factory.WorkerSupervisor)
+    source = File.read!(to_string(source_path))
+
+    prohibited_patterns = [
+      {~r/\bNode\.spawn\b/, "Node.spawn (remote process spawn over full-mesh TCP)"},
+      {~r/\bNode\.spawn_link\b/,
+       "Node.spawn_link (remote linked process spawn over full-mesh TCP)"},
+      {~r/:rpc\.call\b/, ":rpc.call (synchronous distributed RPC, large payload over wire)"},
+      {~r/:rpc\.cast\b/, ":rpc.cast (asynchronous distributed RPC over wire)"},
+      {~r/:erpc\.call\b/,
+       ":erpc.call (enhanced RPC, same full-mesh concern as :rpc.call)"},
+      {~r/:erpc\.cast\b/, ":erpc.cast (enhanced RPC cast over wire)"},
+      {~r/:net_kernel\.connect_node\b/, ":net_kernel.connect_node (explicit cluster join)"}
+    ]
+
+    violations =
+      prohibited_patterns
+      |> Enum.filter(fn {pattern, _label} -> Regex.match?(pattern, source) end)
+      |> Enum.map(fn {_pattern, label} -> label end)
+
+    assert violations == [],
+           "INV-DIST-NO-FULLMESH: WorkerSupervisor source contains prohibited " <>
+             "distributed-Erlang full-mesh routing primitives. " <>
+             "These route FSMs or large payloads over full-mesh TCP, violating the " <>
+             "Oban-queue-boundary requirement (distribution-readiness.md §4). " <>
+             "Prohibited constructs found:\n" <>
+             Enum.map_join(violations, "\n", &"  - #{&1}")
+  end
+
+  # ---------------------------------------------------------------------------
+  # C. No distributed-Erlang constructs in Worker source
+  # ---------------------------------------------------------------------------
+
+  @tag :inv_dist_no_fullmesh
+  test "INV-DIST-NO-FULLMESH: Worker source contains no distributed full-mesh routing primitives" do
+    {_module, _beam, source_path} = :code.get_object_code(Tau.Factory.Worker)
+    source = File.read!(to_string(source_path))
+
+    prohibited_patterns = [
+      {~r/\bNode\.spawn\b/, "Node.spawn (remote process spawn over full-mesh TCP)"},
+      {~r/\bNode\.spawn_link\b/,
+       "Node.spawn_link (remote linked process spawn over full-mesh TCP)"},
+      {~r/:rpc\.call\b/, ":rpc.call (synchronous distributed RPC, large payload over wire)"},
+      {~r/:rpc\.cast\b/, ":rpc.cast (asynchronous distributed RPC over wire)"},
+      {~r/:erpc\.call\b/,
+       ":erpc.call (enhanced RPC, same full-mesh concern as :rpc.call)"},
+      {~r/:erpc\.cast\b/, ":erpc.cast (enhanced RPC cast over wire)"}
+    ]
+
+    violations =
+      prohibited_patterns
+      |> Enum.filter(fn {pattern, _label} -> Regex.match?(pattern, source) end)
+      |> Enum.map(fn {_pattern, label} -> label end)
+
+    assert violations == [],
+           "INV-DIST-NO-FULLMESH: Worker source contains prohibited " <>
+             "distributed-Erlang full-mesh routing primitives. " <>
+             "Workers are node-local by design (worker-fleet.md §8); " <>
+             "any distributed routing primitive violates INV-DIST-NO-FULLMESH. " <>
+             "Prohibited constructs found:\n" <>
+             Enum.map_join(violations, "\n", &"  - #{&1}")
+  end
+end

--- a/test/tau/factory/inv_dist_no_fullmesh_test.exs
+++ b/test/tau/factory/inv_dist_no_fullmesh_test.exs
@@ -116,8 +116,7 @@ defmodule Tau.Factory.InvDistNoFullmeshTest do
        "Node.spawn_link (remote linked process spawn over full-mesh TCP)"},
       {~r/:rpc\.call\b/, ":rpc.call (synchronous distributed RPC, large payload over wire)"},
       {~r/:rpc\.cast\b/, ":rpc.cast (asynchronous distributed RPC over wire)"},
-      {~r/:erpc\.call\b/,
-       ":erpc.call (enhanced RPC, same full-mesh concern as :rpc.call)"},
+      {~r/:erpc\.call\b/, ":erpc.call (enhanced RPC, same full-mesh concern as :rpc.call)"},
       {~r/:erpc\.cast\b/, ":erpc.cast (enhanced RPC cast over wire)"},
       {~r/:net_kernel\.connect_node\b/, ":net_kernel.connect_node (explicit cluster join)"}
     ]
@@ -151,8 +150,7 @@ defmodule Tau.Factory.InvDistNoFullmeshTest do
        "Node.spawn_link (remote linked process spawn over full-mesh TCP)"},
       {~r/:rpc\.call\b/, ":rpc.call (synchronous distributed RPC, large payload over wire)"},
       {~r/:rpc\.cast\b/, ":rpc.cast (asynchronous distributed RPC over wire)"},
-      {~r/:erpc\.call\b/,
-       ":erpc.call (enhanced RPC, same full-mesh concern as :rpc.call)"},
+      {~r/:erpc\.call\b/, ":erpc.call (enhanced RPC, same full-mesh concern as :rpc.call)"},
       {~r/:erpc\.cast\b/, ":erpc.cast (enhanced RPC cast over wire)"}
     ]
 

--- a/test/tau/factory/inv_dist_r8_test.exs
+++ b/test/tau/factory/inv_dist_r8_test.exs
@@ -134,15 +134,13 @@ defmodule Tau.Factory.InvDistR8Test do
     co_residency_patterns = [
       {~r/:net_kernel\.connect_node/,
        ":net_kernel.connect_node (explicit cluster join — couples supervisor to topology)"},
-      {~r/Node\.connect/,
-       "Node.connect (explicit cluster join — couples supervisor to topology)"},
+      {~r/Node\.connect/, "Node.connect (explicit cluster join — couples supervisor to topology)"},
       {~r/:global\.register_name/,
        ":global.register_name (global naming — forbidden by OTP non-negotiable #4; " <>
          "couples placement to a specific cluster)"},
       {~r/:global\.whereis_name/,
        ":global.whereis_name (global name lookup — forbidden by OTP non-negotiable #4)"},
-      {~r/:pg\.join/,
-       ":pg.join (process group — couples process identity to cluster topology)"},
+      {~r/:pg\.join/, ":pg.join (process group — couples process identity to cluster topology)"},
       {~r/:pg\.get_members/,
        ":pg.get_members (process group membership lookup — topology coupling)"}
     ]
@@ -185,10 +183,8 @@ defmodule Tau.Factory.InvDistR8Test do
        "Node.connect (explicit cluster join from within a worker — topology coupling)"},
       {~r/:net_kernel\.connect_node/,
        ":net_kernel.connect_node (explicit cluster join — topology coupling)"},
-      {~r/:pg\.join/,
-       ":pg.join (process group — couples worker identity to cluster topology)"},
-      {~r/:pg\.get_members/,
-       ":pg.get_members (process group membership — topology coupling)"},
+      {~r/:pg\.join/, ":pg.join (process group — couples worker identity to cluster topology)"},
+      {~r/:pg\.get_members/, ":pg.get_members (process group membership — topology coupling)"},
       {~r/Node\.list/,
        "Node.list (live-cluster enumeration from within a worker — cross-node assumption)"}
     ]

--- a/test/tau/factory/inv_dist_r8_test.exs
+++ b/test/tau/factory/inv_dist_r8_test.exs
@@ -1,0 +1,211 @@
+defmodule Tau.Factory.InvDistR8Test do
+  @moduledoc """
+  Gating test for issue #595 — INV-DIST-R8.
+
+  ## The invariant
+
+  INV-DIST-R8: The move to distributed execution (Stage a) touches ONLY
+  WorkerSupervisor/GateTasks placement, an Oban queue, and optional PubSub
+  adapter — no invariant, no FSM, no contract changes are required.
+
+  Falsified by: finding an invariant or contract change required by Stage (a)
+  §5 steps 1–6.
+
+  Source: docs/arch/04-software-architecture/distribution-readiness.md §5
+  and §6 (R8 row).
+
+  ## Rationale
+
+  D-S4's claim — "distribution is config, not rearchitecture" — holds for the
+  W/G (worker/gate) tier because the isolation model is node-local and
+  self-contained (worker-fleet.md §8):
+
+  Moving a worker off-node therefore needs no change to the isolation model:
+  the same init/1 allocation, the same :DOWN-monitor capture, and the same
+  per-worker namespace apply unchanged on the remote node. Distribution is
+  configuration plus an Oban queue, not a rearchitecture of W.
+
+  R8 is a design-time readiness property (line 248: "each is a falsifiable
+  check against the layer-04 design, not a vibe"). Its machine-checkable
+  footprint is an explicit attestation function at the WorkerSupervisor
+  boundary — the same pattern used for INV-DIST-NO-FULLMESH
+  (cross_node_routing_mechanism/0) and INV-DIST-MONITOR-LOCAL
+  (liveness_authority/1).
+
+  ## Audit verdict (issue #595)
+
+  GAP: no code path verifies that Stage (a) requires no contract/FSM/invariant
+  change. WorkerSupervisor is a plain DynamicSupervisor; Worker.init/1
+  performs node-local git worktree allocation. Neither contains an executable
+  construct keyed to distribution-readiness or to detecting a Stage-(a)
+  contract change. This test enforces the architectural wall.
+
+  ## What is asserted
+
+  ### A. Machine-checkable Stage-(a) attestation
+
+  WorkerSupervisor.stage_a_placement_only/0 MUST exist and return :verified,
+  declaring that the Stage (a) move to distributed execution requires ONLY
+  WorkerSupervisor/GateTasks placement and Oban queue config — no invariant,
+  FSM, or contract changes. This function does NOT yet exist; the test fails
+  until it is added.
+
+  This is the INV-DIST-R8 analogue of cross_node_routing_mechanism/0
+  (INV-DIST-NO-FULLMESH) and liveness_authority/1 (INV-DIST-MONITOR-LOCAL):
+  it makes the R8 architectural claim machine-checkable at the boundary where
+  the placement change would be wired.
+
+  ### B. WorkerSupervisor source contains no co-residency assumptions
+
+  WorkerSupervisor source MUST NOT contain constructs that would require
+  contract changes to move workers off-node:
+    - :net_kernel.connect_node — explicit cluster join (control-plane coupling)
+    - Node.connect — same concern
+    - :global.register_name / :global.whereis_name — global naming couples
+      the supervisor to a specific cluster topology (forbidden by OTP
+      non-negotiable #4 and distribution-readiness.md §4)
+    - :pg.join / :pg.get_members — process group constructs that couple
+      process identity to a specific cluster topology
+
+  Note: node() (local identity check in spawn/5) and :node (keyword option
+  name) are NOT prohibited — they implement the correct refusal guard.
+  The prohibited set is constructs that would make placement non-configurable.
+
+  ### C. Worker.init/1 isolation model is self-contained (no co-residency assumption)
+
+  Tau.Factory.Worker source MUST NOT contain constructs that would require
+  an isolation-model change when a worker moves off-node:
+    - :global.register_name / :global.whereis_name — global naming
+    - Node.connect / :net_kernel.connect_node — explicit cluster join
+    - :pg.join / :pg.get_members — process group topology coupling
+    - Node.list() / Node.list(:visible) — enumeration of live nodes
+
+  These would require contract changes at move-time, falsifying R8.
+
+  ## Entry point
+
+  Test A exercises the REAL WorkerSupervisor.stage_a_placement_only/0
+  function. Tests B and C are structural assertions against the module source
+  (located via :code.get_object_code/1), asserting absence of co-residency
+  patterns at the WorkerSupervisor and Worker boundaries.
+
+  ## AC / invariant linkage
+    - INV-DIST-R8: all tests in this file (#595)
+  """
+
+  use ExUnit.Case, async: true
+
+  @moduletag :inv_dist_r8
+
+  alias Tau.Factory.WorkerSupervisor
+
+  # ---------------------------------------------------------------------------
+  # A. Machine-checkable Stage-(a) attestation
+  # ---------------------------------------------------------------------------
+
+  @tag :inv_dist_r8
+  test "INV-DIST-R8: WorkerSupervisor.stage_a_placement_only/0 returns :verified" do
+    # This function must exist and return :verified to make R8 machine-checkable:
+    # it declares that Stage (a) distributed execution requires ONLY placement +
+    # Oban queue config — no invariant, FSM, or contract changes.
+    # The function does NOT yet exist — this test fails with UndefinedFunctionError
+    # until it is added to WorkerSupervisor.
+    assert WorkerSupervisor.stage_a_placement_only() == :verified,
+           "INV-DIST-R8: WorkerSupervisor.stage_a_placement_only/0 must return :verified, " <>
+             "declaring that the Stage (a) move to distributed execution requires ONLY " <>
+             "WorkerSupervisor/GateTasks placement and an Oban queue — no invariant, " <>
+             "FSM, or contract changes. " <>
+             "This is the machine-checkable R8 attestation at the boundary where the " <>
+             "placement change would be wired. " <>
+             "See distribution-readiness.md S5 Stage (a) and S6 R8."
+  end
+
+  # ---------------------------------------------------------------------------
+  # B. WorkerSupervisor source contains no co-residency assumptions
+  # ---------------------------------------------------------------------------
+
+  @tag :inv_dist_r8
+  test "INV-DIST-R8: WorkerSupervisor source contains no co-residency assumptions that would require contract changes" do
+    {_module, _beam, source_path} = :code.get_object_code(Tau.Factory.WorkerSupervisor)
+    source = File.read!(to_string(source_path))
+
+    # These constructs would couple the supervisor to a fixed cluster topology,
+    # requiring a contract change to move workers off-node (falsifying R8).
+    co_residency_patterns = [
+      {~r/:net_kernel\.connect_node/,
+       ":net_kernel.connect_node (explicit cluster join — couples supervisor to topology)"},
+      {~r/Node\.connect/,
+       "Node.connect (explicit cluster join — couples supervisor to topology)"},
+      {~r/:global\.register_name/,
+       ":global.register_name (global naming — forbidden by OTP non-negotiable #4; " <>
+         "couples placement to a specific cluster)"},
+      {~r/:global\.whereis_name/,
+       ":global.whereis_name (global name lookup — forbidden by OTP non-negotiable #4)"},
+      {~r/:pg\.join/,
+       ":pg.join (process group — couples process identity to cluster topology)"},
+      {~r/:pg\.get_members/,
+       ":pg.get_members (process group membership lookup — topology coupling)"}
+    ]
+
+    violations =
+      co_residency_patterns
+      |> Enum.filter(fn {pattern, _label} -> Regex.match?(pattern, source) end)
+      |> Enum.map(fn {_pattern, label} -> label end)
+
+    assert violations == [],
+           "INV-DIST-R8: WorkerSupervisor source contains co-residency assumptions that " <>
+             "would require contract changes when workers move off-node, falsifying R8. " <>
+             "Stage (a) MUST be purely a placement + Oban queue configuration change. " <>
+             "See distribution-readiness.md S5 Stage (a), S6 R8. " <>
+             "Prohibited constructs found:\n" <>
+             Enum.map_join(violations, "\n", fn v -> "  - #{v}" end)
+  end
+
+  # ---------------------------------------------------------------------------
+  # C. Worker.init/1 isolation model is self-contained (no co-residency assumption)
+  # ---------------------------------------------------------------------------
+
+  @tag :inv_dist_r8
+  test "INV-DIST-R8: Worker source contains no co-residency assumptions that would require isolation-model changes" do
+    {_module, _beam, source_path} = :code.get_object_code(Tau.Factory.Worker)
+    source = File.read!(to_string(source_path))
+
+    # These constructs would make worker isolation topology-dependent, requiring
+    # an isolation-model change to move workers off-node (falsifying R8).
+    # worker-fleet.md S8: "Moving a worker off-node needs no change to the
+    # isolation model: same init/1 allocation, same :DOWN-monitor capture,
+    # same per-worker namespace apply unchanged on the remote node."
+    isolation_coupling_patterns = [
+      {~r/:global\.register_name/,
+       ":global.register_name (global naming — couples worker identity to cluster; " <>
+         "forbidden by OTP non-negotiable #4)"},
+      {~r/:global\.whereis_name/,
+       ":global.whereis_name (global name lookup — forbidden by OTP non-negotiable #4)"},
+      {~r/Node\.connect/,
+       "Node.connect (explicit cluster join from within a worker — topology coupling)"},
+      {~r/:net_kernel\.connect_node/,
+       ":net_kernel.connect_node (explicit cluster join — topology coupling)"},
+      {~r/:pg\.join/,
+       ":pg.join (process group — couples worker identity to cluster topology)"},
+      {~r/:pg\.get_members/,
+       ":pg.get_members (process group membership — topology coupling)"},
+      {~r/Node\.list/,
+       "Node.list (live-cluster enumeration from within a worker — cross-node assumption)"}
+    ]
+
+    violations =
+      isolation_coupling_patterns
+      |> Enum.filter(fn {pattern, _label} -> Regex.match?(pattern, source) end)
+      |> Enum.map(fn {_pattern, label} -> label end)
+
+    assert violations == [],
+           "INV-DIST-R8: Worker source contains co-residency assumptions that would " <>
+             "require isolation-model changes when workers move off-node, falsifying R8. " <>
+             "The isolation boundary MUST be node-local and self-contained " <>
+             "(worker-fleet.md S8): same init/1 allocation, same :DOWN-monitor capture, " <>
+             "same per-worker namespace apply unchanged on the remote node. " <>
+             "See distribution-readiness.md S5 Stage (a), S6 R8. " <>
+             "Prohibited constructs found:\n" <>
+             Enum.map_join(violations, "\n", fn v -> "  - #{v}" end)
+  end
+end

--- a/test/tau/factory/oracle_spawn_order_test.exs
+++ b/test/tau/factory/oracle_spawn_order_test.exs
@@ -3,16 +3,16 @@ defmodule Tau.Factory.OracleSpawnOrderTest do
   Gating test for issue #570 — D-304 mechanism conformance (cited, SPEC-FACTORY-FLEET
   §4 B8 / SPEC-FACTORY-GATE D-304):
 
-  WorkerSupervisor.spawn/5 MUST record the author identity (HR-7) of every spawned
-  worker, and MUST reject spawning an `:implementer` whose `:author_id` matches an
-  already-registered `:test_author` worker in the same supervisor.
+  WorkerSupervisor.spawn/5 MUST enforce the oracle-separation mechanism (INV-5):
+    (a) Spawn-order: reject `:implementer` when no `:test_author` is registered.
+    (b) Identity: record author_id (HR-7) and reject same-identity oracle+subject.
 
   ## The invariant (AC-11, SPEC-FACTORY-FLEET / D-304 mechanism)
 
   D-304 (SPEC-FACTORY-GATE) defines two sub-mechanisms the fleet enforces:
 
     (a) The `:test_author` worker is spawned and its gating-test path set is frozen
-        before any `:implementer` is spawned (spawn-order).
+        before any `:implementer` is spawned (spawn-order ordering constraint).
     (b) The author identity of every worker is recorded (HR-7), and a gating test
         whose authoring identity is the implementer is rejected — i.e.
         `author(test_author_worker) != author(implementer_worker)`.
@@ -27,29 +27,27 @@ defmodule Tau.Factory.OracleSpawnOrderTest do
   frozen before any `:implementer`, and each worker's author identity is recorded;
   same-identity oracle/subject is rejected at the cited gate."
 
-  ## The defect (issue #570 evidence)
+  ## The defect (issue #570 evidence — repaired gating test)
 
-  Current `WorkerSupervisor.spawn/5` (worker_supervisor.ex:89-132):
-    - Accepts `:role` but NO `:author_id` opt.
-    - Records no author/identity field in the Registry.
-    - Performs no same-identity comparison or rejection guard.
-    - `generate_worker_id/0` produces a random UUID per spawn that is NOT a stable
-      logical author identity.
+  The original gating test only exercised sub-mechanism (b) (same-identity
+  rejection), which the implementation already satisfies. It did NOT test the
+  spawn-order constraint of sub-mechanism (a): that any `:implementer` spawn
+  attempted when NO `:test_author` is registered in the same registry MUST be
+  rejected with `{:error, :no_test_author_registered}`.
 
-  This means sub-mechanism (b) of D-304 is completely absent: any agent identity
-  can simultaneously author both the gating test and the implementation — the
-  oracle-separation invariant is trivially defeatable.
+  Current `WorkerSupervisor.spawn/5` has no such guard — it accepts the
+  `:implementer` spawn unconditionally when no `:test_author` is present,
+  returning `{:ok, worker_id}` instead of `{:error, :no_test_author_registered}`.
+  This makes the spawn-order portion of D-304 mechanism (a) completely absent.
 
   ## Required fix
 
   `WorkerSupervisor.spawn/5` MUST:
-    1. Accept an `:author_id` opt (string; stable logical identity of the spawning
-       agent — NOT the generated worker_id UUID).
-    2. Record the `{role, author_id}` pair in the WorkerRegistry metadata (or the
-       Unit's Ledger) so the Gate can compare author identities at gate time.
-    3. Return `{:error, :same_identity_oracle_subject}` if an `:implementer` spawn
-       is attempted with an `:author_id` that matches an already-registered
-       `:test_author` worker under the same supervisor.
+    1. When `role` is `:implementer`, check the registry for any registered
+       `:test_author` worker (regardless of `:author_id`).
+    2. If none exists, return `{:error, :no_test_author_registered}` — the
+       spawn-order constraint (sub-mechanism (a)).
+    3. Additionally retain the same-identity guard (sub-mechanism (b)).
 
   ## AC linkage
     - D-304 (mechanism, cited; SPEC-FACTORY-FLEET §4 B8 / SPEC-FACTORY-GATE D-304)
@@ -139,10 +137,60 @@ defmodule Tau.Factory.OracleSpawnOrderTest do
   end
 
   # ---------------------------------------------------------------------------
-  # D-304 mechanism — author identity recorded, same-identity rejected
+  # D-304 mechanism — spawn-order (sub-mechanism (a)) and author identity (b)
   # ---------------------------------------------------------------------------
 
   describe "D-304 mechanism — oracle spawn order + HR-7 author identity" do
+    @tag :d_304
+    test "D-304 AC-11: spawning :implementer when NO :test_author is registered MUST return {:error, :no_test_author_registered}" do
+      # SPEC-FACTORY-FLEET §4 B8: "spawn :test_author first, freeze its gating-test
+      # path set before any :implementer." This is an unconditional ordering
+      # constraint — any :implementer spawn attempted while no :test_author is
+      # registered in the same registry MUST be rejected, regardless of :author_id.
+      #
+      # This is sub-mechanism (a) of D-304. Current WorkerSupervisor.spawn/5 has
+      # no such check. It only checks same-identity when :author_id is provided
+      # (sub-mechanism (b)). A fresh registry with no :test_author accepts an
+      # :implementer spawn unconditionally, defeating the ordering invariant (INV-5).
+      #
+      # Failing mode before fix: WorkerSupervisor.spawn/5 returns {:ok, worker_id}
+      # instead of {:error, :no_test_author_registered}.
+
+      tmp_dir =
+        System.tmp_dir!()
+        |> Path.join("tau_oso304_ord_#{System.unique_integer([:positive])}")
+
+      File.mkdir_p!(tmp_dir)
+      on_exit(fn -> File.rm_rf!(tmp_dir) end)
+
+      %{repo_dir: repo_dir, base_ref: base_ref} = setup_git_repo(tmp_dir)
+      agent_bin = slow_agent_bin(tmp_dir, "_d304_ord")
+
+      ledger = start_ledger(tmp_dir, :order)
+      janitor = start_janitor(ledger, :order, self())
+      {sup, registry_name} = start_fleet(:order)
+
+      # Registry is empty — no :test_author has been registered.
+      # Spawn :implementer directly; the spawn-order guard MUST reject this.
+      result =
+        WorkerSupervisor.spawn(sup, :implementer, "implement the issue", base_ref,
+          repo_dir: repo_dir,
+          agent_bin: agent_bin,
+          registry: registry_name,
+          report_to: self(),
+          janitor: janitor,
+          author_id: "some-agent-id"
+        )
+
+      assert result == {:error, :no_test_author_registered},
+             "D-304 AC-11 (spawn-order, sub-mechanism (a)): WorkerSupervisor.spawn/5 " <>
+               "MUST return {:error, :no_test_author_registered} when an :implementer " <>
+               "is spawned before any :test_author is registered in the same registry. " <>
+               "SPEC-FACTORY-FLEET §4 B8: ':test_author first, freeze path set before " <>
+               "any :implementer'. " <>
+               "Got: #{inspect(result)}"
+    end
+
     @tag :d_304
     test "D-304 AC-11: spawning :implementer with same :author_id as a :test_author MUST return {:error, :same_identity_oracle_subject}" do
       # This test exercises the user-facing boundary WorkerSupervisor.spawn/5.

--- a/test/tau/factory/oracle_spawn_order_test.exs
+++ b/test/tau/factory/oracle_spawn_order_test.exs
@@ -1,0 +1,331 @@
+defmodule Tau.Factory.OracleSpawnOrderTest do
+  @moduledoc """
+  Gating test for issue #570 — D-304 mechanism conformance (cited, SPEC-FACTORY-FLEET
+  §4 B8 / SPEC-FACTORY-GATE D-304):
+
+  WorkerSupervisor.spawn/5 MUST record the author identity (HR-7) of every spawned
+  worker, and MUST reject spawning an `:implementer` whose `:author_id` matches an
+  already-registered `:test_author` worker in the same supervisor.
+
+  ## The invariant (AC-11, SPEC-FACTORY-FLEET / D-304 mechanism)
+
+  D-304 (SPEC-FACTORY-GATE) defines two sub-mechanisms the fleet enforces:
+
+    (a) The `:test_author` worker is spawned and its gating-test path set is frozen
+        before any `:implementer` is spawned (spawn-order).
+    (b) The author identity of every worker is recorded (HR-7), and a gating test
+        whose authoring identity is the implementer is rejected — i.e.
+        `author(test_author_worker) != author(implementer_worker)`.
+
+  SPEC-FACTORY-FLEET §4 B8 states: "The fleet enforces the mechanism of INV-5:
+  spawn `:test_author` first, freeze its gating-test path set before any
+  `:implementer`, and record the author identity of every worker in the Ledger
+  (HR-7)."
+
+  SPEC-FACTORY-FLEET AC-11 names this test file (`oracle_spawn_order_test.exs`)
+  as the conformance test: "the `:test_author` worker is spawned and its path set
+  frozen before any `:implementer`, and each worker's author identity is recorded;
+  same-identity oracle/subject is rejected at the cited gate."
+
+  ## The defect (issue #570 evidence)
+
+  Current `WorkerSupervisor.spawn/5` (worker_supervisor.ex:89-132):
+    - Accepts `:role` but NO `:author_id` opt.
+    - Records no author/identity field in the Registry.
+    - Performs no same-identity comparison or rejection guard.
+    - `generate_worker_id/0` produces a random UUID per spawn that is NOT a stable
+      logical author identity.
+
+  This means sub-mechanism (b) of D-304 is completely absent: any agent identity
+  can simultaneously author both the gating test and the implementation — the
+  oracle-separation invariant is trivially defeatable.
+
+  ## Required fix
+
+  `WorkerSupervisor.spawn/5` MUST:
+    1. Accept an `:author_id` opt (string; stable logical identity of the spawning
+       agent — NOT the generated worker_id UUID).
+    2. Record the `{role, author_id}` pair in the WorkerRegistry metadata (or the
+       Unit's Ledger) so the Gate can compare author identities at gate time.
+    3. Return `{:error, :same_identity_oracle_subject}` if an `:implementer` spawn
+       is attempted with an `:author_id` that matches an already-registered
+       `:test_author` worker under the same supervisor.
+
+  ## AC linkage
+    - D-304 (mechanism, cited; SPEC-FACTORY-FLEET §4 B8 / SPEC-FACTORY-GATE D-304)
+    - AC-11 (SPEC-FACTORY-FLEET)
+  """
+
+  use ExUnit.Case, async: false
+
+  @moduletag :capture_log
+  @moduletag :d_304
+
+  alias Tau.Factory.Ledger.Writer, as: LedgerWriter
+  alias Tau.Factory.WorkspaceJanitor
+  alias Tau.Factory.WorkerRegistry
+  alias Tau.Factory.WorkerSupervisor
+
+  # ---------------------------------------------------------------------------
+  # Hermetic git repo helper
+  # ---------------------------------------------------------------------------
+
+  defp setup_git_repo(tmp_dir) do
+    repo_dir = Path.join(tmp_dir, "repo_#{System.unique_integer([:positive])}")
+    File.mkdir_p!(repo_dir)
+
+    git = fn args ->
+      System.cmd("git", args, cd: repo_dir, stderr_to_stdout: true)
+    end
+
+    {_, 0} = git.(["init", "-b", "main"])
+    {_, 0} = git.(["config", "user.email", "test@tau.test"])
+    {_, 0} = git.(["config", "user.name", "Tau Test"])
+    File.write!(Path.join(repo_dir, "README"), "initial\n")
+    {_, 0} = git.(["add", "README"])
+    {_, 0} = git.(["commit", "-m", "initial commit"])
+    {sha, 0} = git.(["rev-parse", "HEAD"])
+
+    %{repo_dir: repo_dir, base_ref: String.trim(sha)}
+  end
+
+  defp slow_agent_bin(tmp_dir, suffix \\ "") do
+    bin_path = Path.join(tmp_dir, "slow_agent_oso#{suffix}")
+
+    File.write!(bin_path, """
+    #!/bin/sh
+    exec cat
+    """)
+
+    File.chmod!(bin_path, 0o755)
+    bin_path
+  end
+
+  defp start_ledger(tmp_dir, tag) do
+    n = System.unique_integer([:positive])
+    db_path = Path.join(tmp_dir, "ledger_oso_#{tag}_#{n}.db")
+    name = :"ledger_oso_#{tag}_#{n}"
+
+    {:ok, _} = start_supervised({LedgerWriter, db_path: db_path, name: name}, id: :"lwriter_#{n}")
+    name
+  end
+
+  defp start_janitor(ledger, tag, report_to) do
+    n = System.unique_integer([:positive])
+    name = :"oso_jan_#{tag}_#{n}"
+
+    {:ok, pid} =
+      start_supervised(
+        {WorkspaceJanitor, [ledger: ledger, name: name, report_to: report_to]},
+        id: :"oso_jan_sv_#{n}"
+      )
+
+    pid
+  end
+
+  defp start_fleet(tag) do
+    n = System.unique_integer([:positive])
+    registry_name = :"oso_reg_#{tag}_#{n}"
+    sup_name = :"oso_sup_#{tag}_#{n}"
+
+    {:ok, _} = start_supervised({WorkerRegistry, name: registry_name}, id: :"oso_reg_sv_#{n}")
+
+    {:ok, sup} =
+      start_supervised({WorkerSupervisor, name: sup_name, registry: registry_name},
+        id: :"oso_sup_sv_#{n}"
+      )
+
+    {sup, registry_name}
+  end
+
+  # ---------------------------------------------------------------------------
+  # D-304 mechanism — author identity recorded, same-identity rejected
+  # ---------------------------------------------------------------------------
+
+  describe "D-304 mechanism — oracle spawn order + HR-7 author identity" do
+    @tag :d_304
+    test "D-304 AC-11: spawning :implementer with same :author_id as a :test_author MUST return {:error, :same_identity_oracle_subject}" do
+      # This test exercises the user-facing boundary WorkerSupervisor.spawn/5.
+      #
+      # D-304 sub-mechanism (b): the fleet MUST record the author identity of
+      # every worker (HR-7) and MUST reject an implementer spawn whose author_id
+      # matches an already-registered test_author worker.
+      #
+      # The shared author_id simulates the same agent identity authoring both the
+      # gating test AND the implementation — the oracle-separation failure mode.
+
+      tmp_dir =
+        System.tmp_dir!()
+        |> Path.join("tau_oso304_#{System.unique_integer([:positive])}")
+
+      File.mkdir_p!(tmp_dir)
+      on_exit(fn -> File.rm_rf!(tmp_dir) end)
+
+      %{repo_dir: repo_dir, base_ref: base_ref} = setup_git_repo(tmp_dir)
+      agent_bin = slow_agent_bin(tmp_dir, "_d304_ta")
+
+      ledger = start_ledger(tmp_dir, :same_id)
+      janitor = start_janitor(ledger, :same_id, self())
+      {sup, registry_name} = start_fleet(:same_id)
+
+      # Stable logical identity of the spawning agent (NOT the per-spawn worker_id UUID).
+      shared_author_id = "agent-identity-abc123"
+
+      # Step 1: spawn the :test_author with the shared author identity.
+      # D-304 mechanism (a): test_author is spawned first.
+      ta_result =
+        WorkerSupervisor.spawn(sup, :test_author, "write the gating test", base_ref,
+          repo_dir: repo_dir,
+          agent_bin: agent_bin,
+          registry: registry_name,
+          report_to: self(),
+          janitor: janitor,
+          author_id: shared_author_id
+        )
+
+      assert {:ok, _ta_worker_id} = ta_result,
+             "D-304: spawning :test_author with :author_id must succeed. Got: #{inspect(ta_result)}"
+
+      # Step 2: attempt to spawn an :implementer with the SAME author identity.
+      # D-304 mechanism (b): same-identity oracle/subject MUST be rejected.
+      # The WorkerSupervisor must detect that shared_author_id already authored
+      # a :test_author worker and return {:error, :same_identity_oracle_subject}.
+      impl_result =
+        WorkerSupervisor.spawn(sup, :implementer, "implement the issue", base_ref,
+          repo_dir: repo_dir,
+          agent_bin: agent_bin,
+          registry: registry_name,
+          report_to: self(),
+          janitor: janitor,
+          author_id: shared_author_id
+        )
+
+      assert impl_result == {:error, :same_identity_oracle_subject},
+             "D-304 (AC-11 / HR-7): WorkerSupervisor.spawn with :implementer and the " <>
+               "same :author_id as an already-registered :test_author MUST return " <>
+               "{:error, :same_identity_oracle_subject}. This is sub-mechanism (b) of " <>
+               "D-304 oracle separation — the same agent identity MUST NOT author both " <>
+               "the gating test and the implementation. " <>
+               "Got: #{inspect(impl_result)}"
+    end
+
+    @tag :d_304
+    test "D-304 AC-11: :implementer with a DIFFERENT :author_id from the :test_author is accepted" do
+      # Negative case: distinct identities do NOT trigger the same-identity guard.
+      # This confirms the guard is identity-scoped, not role-scoped.
+
+      tmp_dir =
+        System.tmp_dir!()
+        |> Path.join("tau_oso304b_#{System.unique_integer([:positive])}")
+
+      File.mkdir_p!(tmp_dir)
+      on_exit(fn -> File.rm_rf!(tmp_dir) end)
+
+      %{repo_dir: repo_dir, base_ref: base_ref} = setup_git_repo(tmp_dir)
+      agent_bin_ta = slow_agent_bin(tmp_dir, "_d304b_ta")
+      agent_bin_impl = slow_agent_bin(tmp_dir, "_d304b_impl")
+
+      ledger = start_ledger(tmp_dir, :diff_id)
+      janitor = start_janitor(ledger, :diff_id, self())
+      {sup, registry_name} = start_fleet(:diff_id)
+
+      test_author_id = "agent-test-author-xyz"
+      implementer_id = "agent-implementer-456"
+
+      # Spawn :test_author with one identity.
+      ta_result =
+        WorkerSupervisor.spawn(sup, :test_author, "write the gating test", base_ref,
+          repo_dir: repo_dir,
+          agent_bin: agent_bin_ta,
+          registry: registry_name,
+          report_to: self(),
+          janitor: janitor,
+          author_id: test_author_id
+        )
+
+      assert {:ok, _} = ta_result,
+             "D-304: :test_author spawn with distinct :author_id must succeed. Got: #{inspect(ta_result)}"
+
+      # Spawn :implementer with a DIFFERENT identity — must succeed.
+      impl_result =
+        WorkerSupervisor.spawn(sup, :implementer, "implement the issue", base_ref,
+          repo_dir: repo_dir,
+          agent_bin: agent_bin_impl,
+          registry: registry_name,
+          report_to: self(),
+          janitor: janitor,
+          author_id: implementer_id
+        )
+
+      assert {:ok, _impl_worker_id} = impl_result,
+             "D-304 (AC-11): :implementer with a distinct :author_id from :test_author MUST " <>
+               "be accepted — the oracle-separation guard must NOT block distinct identities. " <>
+               "Got: #{inspect(impl_result)}"
+    end
+
+    @tag :d_304
+    test "D-304 AC-11: :author_id is recorded in the WorkerRegistry per-worker (HR-7)" do
+      # Verifies sub-mechanism (b)'s prerequisite: that the fleet actually records
+      # author identity in the Registry so the Gate can query it at gate time.
+      # The Registry must store the author_id as metadata alongside the role.
+
+      tmp_dir =
+        System.tmp_dir!()
+        |> Path.join("tau_oso304c_#{System.unique_integer([:positive])}")
+
+      File.mkdir_p!(tmp_dir)
+      on_exit(fn -> File.rm_rf!(tmp_dir) end)
+
+      %{repo_dir: repo_dir, base_ref: base_ref} = setup_git_repo(tmp_dir)
+      agent_bin = slow_agent_bin(tmp_dir, "_d304c_ta")
+
+      ledger = start_ledger(tmp_dir, :record)
+      janitor = start_janitor(ledger, :record, self())
+      {sup, registry_name} = start_fleet(:record)
+
+      author_id = "agent-identity-rec-test"
+
+      {:ok, worker_id} =
+        WorkerSupervisor.spawn(sup, :test_author, "write the gating test", base_ref,
+          repo_dir: repo_dir,
+          agent_bin: agent_bin,
+          registry: registry_name,
+          report_to: self(),
+          janitor: janitor,
+          author_id: author_id
+        )
+
+      # Give the worker time to start and register.
+      # (Worker.init/1 registers via {:via, Registry, {registry, worker_id}})
+      Process.sleep(100)
+
+      # The Registry metadata for this worker_id MUST include the author_id
+      # so the Gate can evaluate author(test_g) ≠ author(impl) at gate time.
+      registry_entries = Registry.lookup(registry_name, worker_id)
+
+      # At minimum the worker must be registered (it may still be running or
+      # may have stopped; the author_id recording check is the key assertion).
+      refute registry_entries == [],
+             "D-304 (AC-11 HR-7): worker #{inspect(worker_id)} must be registered in " <>
+               "#{inspect(registry_name)} after spawn. Registry is empty — either the " <>
+               "worker did not start or did not register."
+
+      [{_pid, metadata}] = registry_entries
+
+      # The metadata must carry the author_id so the Gate can query it.
+      # HR-7: "the author identity of every worker is recorded."
+      # The standard Elixir Registry stores a single value per key; the worker
+      # must register with metadata that includes :author_id.
+      assert is_map(metadata) && Map.has_key?(metadata, :author_id),
+             "D-304 (AC-11 HR-7): WorkerRegistry metadata for worker #{inspect(worker_id)} " <>
+               "MUST include :author_id key so the Gate can compare author(test_g) ≠ " <>
+               "author(impl) at gate time. " <>
+               "Metadata: #{inspect(metadata)}"
+
+      assert metadata[:author_id] == author_id,
+             "D-304 (AC-11 HR-7): WorkerRegistry metadata :author_id MUST match the " <>
+               ":author_id passed to WorkerSupervisor.spawn/5. " <>
+               "Expected: #{inspect(author_id)}, got: #{inspect(metadata[:author_id])}"
+    end
+  end
+end

--- a/test/tau/factory/policy_model_role_test.exs
+++ b/test/tau/factory/policy_model_role_test.exs
@@ -56,26 +56,45 @@ defmodule Tau.Factory.PolicyModelRoleTest do
   alias Tau.Factory.Policy.Owner, as: PolicyOwner
 
   # ---------------------------------------------------------------------------
-  # Minimal valid policy for testing.
-  # Every field uses the smallest admissible positive integer for numeric
-  # dimensions; model_per_role uses two representative roles.
+  # Named predicate — Elixir cannot store anonymous functions in module
+  # attributes; use a named function and capture it in test bodies.
   # ---------------------------------------------------------------------------
 
-  @model_per_role %{
-    implementer: "claude-sonnet-4-5",
-    critic: "claude-opus-4-5"
-  }
+  def always_true(_, _), do: true
 
-  @valid_policy %Policy{
-    version: 1,
-    model_per_role: @model_per_role,
-    retry_bound_n: 3,
-    budget: %{token: 100_000, cost: 10, wall_time: 3_600, iteration: 5},
-    priority_order: [],
-    conflict_predicate: &(&1 == &1 and &2 == &2),
-    gate_manifest: [:mutation, :critic, :reviewer],
-    escalation_thresholds: %{upheld_challenges: 2}
-  }
+  # ---------------------------------------------------------------------------
+  # Helper: build a minimal valid policy struct inside a test/setup body.
+  # Building here (not in a module attribute) avoids the ArgumentError that
+  # arises when Elixir tries to escape an anonymous function into a module
+  # attribute at compile time.
+  # ---------------------------------------------------------------------------
+
+  defp valid_policy(model_per_role \\ nil) do
+    mpr =
+      model_per_role ||
+        %{
+          implementer: "claude-sonnet-4-5",
+          critic: "claude-opus-4-5"
+        }
+
+    %Policy{
+      version: 1,
+      model_per_role: mpr,
+      retry_bound_n: 3,
+      budget: %{token: 100_000, cost: 10, wall_time: 3_600, iteration: 5},
+      priority_order: [],
+      conflict_predicate: &__MODULE__.always_true/2,
+      gate_manifest: [:mutation, :critic, :reviewer],
+      escalation_thresholds: %{upheld_challenges: 2}
+    }
+  end
+
+  defp default_model_per_role do
+    %{
+      implementer: "claude-sonnet-4-5",
+      critic: "claude-opus-4-5"
+    }
+  end
 
   # ---------------------------------------------------------------------------
   # INV-MODEL-POLICY assertion 1 — struct field presence
@@ -90,7 +109,8 @@ defmodule Tau.Factory.PolicyModelRoleTest do
       #
       # FAIL BEFORE: Tau.Factory.Policy does not exist → compile error.
 
-      policy = @valid_policy
+      policy = valid_policy()
+      model_per_role = default_model_per_role()
 
       assert Map.has_key?(policy, :model_per_role),
              "INV-MODEL-POLICY: %Policy{} must carry a :model_per_role field " <>
@@ -103,7 +123,7 @@ defmodule Tau.Factory.PolicyModelRoleTest do
                "got #{inspect(policy.model_per_role)}"
 
       # Each value in the map must be a non-empty string (a real model id).
-      for {role, model} <- policy.model_per_role do
+      for {role, model} <- model_per_role do
         assert is_binary(model) and model != "",
                "INV-MODEL-POLICY: model_per_role[#{inspect(role)}] must be a " <>
                  "non-empty model-id string; got #{inspect(model)}"
@@ -125,15 +145,18 @@ defmodule Tau.Factory.PolicyModelRoleTest do
       #
       # FAIL BEFORE: Tau.Factory.Policy.clamp/1 does not exist → UndefinedFunctionError.
 
-      assert {:ok, clamped} = Policy.clamp(@valid_policy),
+      model_per_role = default_model_per_role()
+      policy = valid_policy(model_per_role)
+
+      assert {:ok, clamped} = Policy.clamp(policy),
              "INV-MODEL-POLICY: Policy.clamp/1 must return {:ok, policy} for a " <>
                "valid policy; got error instead"
 
-      assert clamped.model_per_role == @model_per_role,
+      assert clamped.model_per_role == model_per_role,
              "INV-MODEL-POLICY: clamp/1 must NOT overwrite model_per_role with a " <>
                "hardcoded value.  The caller-supplied map must survive the clamp " <>
                "unchanged (FR-7.4). " <>
-               "expected=#{inspect(@model_per_role)}, " <>
+               "expected=#{inspect(model_per_role)}, " <>
                "got=#{inspect(clamped.model_per_role)}"
     end
   end
@@ -157,29 +180,32 @@ defmodule Tau.Factory.PolicyModelRoleTest do
       # FAIL BEFORE: Tau.Factory.Policy.Owner does not exist → compile error or
       # UndefinedFunctionError on start_link/pin/resolve.
 
+      model_per_role = default_model_per_role()
+      policy = valid_policy(model_per_role)
+
       unit_id = "test-unit-#{System.unique_integer([:positive])}"
       owner_name = :"policy_owner_test_#{System.unique_integer([:positive])}"
 
       {:ok, _owner} = PolicyOwner.start_link(name: owner_name)
 
-      {:ok, clamped} = Policy.clamp(@valid_policy)
+      {:ok, clamped} = Policy.clamp(policy)
 
       :ok = PolicyOwner.pin(owner_name, unit_id, clamped)
 
       resolved = PolicyOwner.resolve(owner_name, unit_id, :model_per_role)
 
-      assert resolved == @model_per_role,
+      assert resolved == model_per_role,
              "INV-MODEL-POLICY: Policy.Owner.resolve/3 for :model_per_role after " <>
                "pin/3 must return the policy-driven map; a hardcoded constant " <>
                "would make the engine the model source and falsify INV-MODEL-POLICY. " <>
-               "expected=#{inspect(@model_per_role)}, " <>
+               "expected=#{inspect(model_per_role)}, " <>
                "got=#{inspect(resolved)}"
 
       # Extra: verify that a *different* policy value for a second unit produces
       # a different resolved model_per_role — ruling out a global hardcoded default.
       alt_model_per_role = %{implementer: "claude-haiku-3-5", critic: "claude-haiku-3-5"}
 
-      alt_policy = %Policy{clamped | model_per_role: alt_model_per_role}
+      alt_policy = valid_policy(alt_model_per_role)
       {:ok, clamped_alt} = Policy.clamp(alt_policy)
 
       unit_id_2 = "test-unit-alt-#{System.unique_integer([:positive])}"

--- a/test/tau/factory/policy_model_role_test.exs
+++ b/test/tau/factory/policy_model_role_test.exs
@@ -1,0 +1,199 @@
+defmodule Tau.Factory.PolicyModelRoleTest do
+  @moduledoc """
+  Gating test for issue #552 — INV-MODEL-POLICY.
+
+  INV-MODEL-POLICY statement:
+  > No role's model assignment is hardcoded in engine code; model per role
+  > is a field in Tau.Factory.Policy, pinned per unit at admission, and
+  > cost is attributed per (model, role). Falsified if any role's model is
+  > determined by a hardcoded constant in engine code rather than the
+  > policy field.
+
+  Boundary governed: SPEC-FACTORY-GOV §4 B6 (Policy.Owner ↔ Policy):
+    - `%Policy{}` struct carries `model_per_role :: %{role => model}` (FR-7.4).
+    - `clamp/1 :: (Policy.t()) -> {:ok, Policy.t()} | {:error, term()}` —
+      pure, property-tested; runs at admission before the pin.
+    - `resolve/2 :: (unit_id, field) -> value` — reads the pinned ETS
+      snapshot; returns the policy-driven value, NOT a hardcoded constant.
+
+  The admission path exercised here is:
+    Tau.Factory.Policy.Owner.start_link/1
+      → Policy.Owner.pin/2 (pins policy at admission)
+      → Policy.Owner.resolve/2 (reads the pinned snapshot for a given field)
+
+  The three assertions below constitute the full INV-MODEL-POLICY conformance
+  check at the B6 boundary:
+
+  1. `%Policy{}` struct exists and has a `model_per_role` field — the invariant
+     cannot hold if there is no such field.
+
+  2. `clamp/1` passes a fully-specified policy through unchanged, preserving
+     the caller-supplied `model_per_role` — the engine must not override the
+     map with a hardcoded value on the happy path.
+
+  3. After `pin/2` at admission and `resolve/2` for `:model_per_role`, the
+     returned value equals the caller-supplied map — the engine must not
+     substitute a hardcoded model in place of the pinned policy value.
+
+  Written BEFORE production code exists (oracle-separation phase, factory-loop §4b).
+  All three tests MUST FAIL against the current branch because:
+    - `Tau.Factory.Policy` does not exist (no `defmodule`, no `defstruct`).
+    - `Tau.Factory.Policy.Owner` does not exist.
+  A compile error or UndefinedFunctionError is the correct fail-before state.
+
+  ## Gating-test paths
+
+    - `test/tau/factory/policy_model_role_test.exs`
+
+  ## AC / D-NNN linkage
+
+    - INV-MODEL-POLICY (issue #552)
+  """
+
+  use ExUnit.Case, async: true
+
+  alias Tau.Factory.Policy
+  alias Tau.Factory.Policy.Owner, as: PolicyOwner
+
+  # ---------------------------------------------------------------------------
+  # Minimal valid policy for testing.
+  # Every field uses the smallest admissible positive integer for numeric
+  # dimensions; model_per_role uses two representative roles.
+  # ---------------------------------------------------------------------------
+
+  @model_per_role %{
+    implementer: "claude-sonnet-4-5",
+    critic: "claude-opus-4-5"
+  }
+
+  @valid_policy %Policy{
+    version: 1,
+    model_per_role: @model_per_role,
+    retry_bound_n: 3,
+    budget: %{token: 100_000, cost: 10, wall_time: 3_600, iteration: 5},
+    priority_order: [],
+    conflict_predicate: &(&1 == &1 and &2 == &2),
+    gate_manifest: [:mutation, :critic, :reviewer],
+    escalation_thresholds: %{upheld_challenges: 2}
+  }
+
+  # ---------------------------------------------------------------------------
+  # INV-MODEL-POLICY assertion 1 — struct field presence
+  # ---------------------------------------------------------------------------
+
+  describe "INV-MODEL-POLICY struct field" do
+    @tag :inv_model_policy
+    test "INV-MODEL-POLICY: %Policy{} struct has a :model_per_role field" do
+      # The invariant cannot hold if there is no model_per_role field in the
+      # Policy struct — the engine cannot resolve the policy-driven model for a
+      # role if the field does not exist.
+      #
+      # FAIL BEFORE: Tau.Factory.Policy does not exist → compile error.
+
+      policy = @valid_policy
+
+      assert Map.has_key?(policy, :model_per_role),
+             "INV-MODEL-POLICY: %Policy{} must carry a :model_per_role field " <>
+               "(FR-7.4); the engine resolves the model per role from policy, " <>
+               "not from a hardcoded constant. " <>
+               "struct keys=#{inspect(Map.keys(policy))}"
+
+      assert is_map(policy.model_per_role),
+             "INV-MODEL-POLICY: :model_per_role must be a map of role => model; " <>
+               "got #{inspect(policy.model_per_role)}"
+
+      # Each value in the map must be a non-empty string (a real model id).
+      for {role, model} <- policy.model_per_role do
+        assert is_binary(model) and model != "",
+               "INV-MODEL-POLICY: model_per_role[#{inspect(role)}] must be a " <>
+                 "non-empty model-id string; got #{inspect(model)}"
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # INV-MODEL-POLICY assertion 2 — clamp/1 preserves model_per_role
+  # ---------------------------------------------------------------------------
+
+  describe "INV-MODEL-POLICY clamp/1 preserves model_per_role" do
+    @tag :inv_model_policy
+    test "INV-MODEL-POLICY: clamp/1 returns {:ok, policy} with model_per_role intact on a valid policy" do
+      # clamp/1 is the engine-clamp (HR-8): it rejects or tightens unsafe
+      # policy values, but MUST NOT override model_per_role with a hardcoded
+      # model string.  If clamp/1 substituted a hardcoded model it would
+      # falsify INV-MODEL-POLICY by making the engine code the model source.
+      #
+      # FAIL BEFORE: Tau.Factory.Policy.clamp/1 does not exist → UndefinedFunctionError.
+
+      assert {:ok, clamped} = Policy.clamp(@valid_policy),
+             "INV-MODEL-POLICY: Policy.clamp/1 must return {:ok, policy} for a " <>
+               "valid policy; got error instead"
+
+      assert clamped.model_per_role == @model_per_role,
+             "INV-MODEL-POLICY: clamp/1 must NOT overwrite model_per_role with a " <>
+               "hardcoded value.  The caller-supplied map must survive the clamp " <>
+               "unchanged (FR-7.4). " <>
+               "expected=#{inspect(@model_per_role)}, " <>
+               "got=#{inspect(clamped.model_per_role)}"
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # INV-MODEL-POLICY assertion 3 — pin/2 + resolve/2 round-trip at admission
+  # ---------------------------------------------------------------------------
+
+  describe "INV-MODEL-POLICY pin/resolve round-trip at admission" do
+    @tag :inv_model_policy
+    test "INV-MODEL-POLICY: Policy.Owner pin/2 then resolve/2 for :model_per_role returns the policy-driven map, not a hardcoded constant" do
+      # This test exercises the full B6 boundary (SPEC-FACTORY-GOV §4):
+      #   Policy.Owner.pin(unit_id, clamped_policy)  — called at admission
+      #   Policy.Owner.resolve(unit_id, :model_per_role)  — called by engine/cost
+      #
+      # The resolved value MUST equal the caller-supplied model_per_role from
+      # the clamped policy, not a hardcoded string such as "claude-sonnet-4-5"
+      # baked into the engine.  If any engine module hard-codes the model,
+      # resolve/2 is either absent or returns a constant regardless of the pin.
+      #
+      # FAIL BEFORE: Tau.Factory.Policy.Owner does not exist → compile error or
+      # UndefinedFunctionError on start_link/pin/resolve.
+
+      unit_id = "test-unit-#{System.unique_integer([:positive])}"
+      owner_name = :"policy_owner_test_#{System.unique_integer([:positive])}"
+
+      {:ok, _owner} = PolicyOwner.start_link(name: owner_name)
+
+      {:ok, clamped} = Policy.clamp(@valid_policy)
+
+      :ok = PolicyOwner.pin(owner_name, unit_id, clamped)
+
+      resolved = PolicyOwner.resolve(owner_name, unit_id, :model_per_role)
+
+      assert resolved == @model_per_role,
+             "INV-MODEL-POLICY: Policy.Owner.resolve/3 for :model_per_role after " <>
+               "pin/3 must return the policy-driven map; a hardcoded constant " <>
+               "would make the engine the model source and falsify INV-MODEL-POLICY. " <>
+               "expected=#{inspect(@model_per_role)}, " <>
+               "got=#{inspect(resolved)}"
+
+      # Extra: verify that a *different* policy value for a second unit produces
+      # a different resolved model_per_role — ruling out a global hardcoded default.
+      alt_model_per_role = %{implementer: "claude-haiku-3-5", critic: "claude-haiku-3-5"}
+
+      alt_policy = %Policy{clamped | model_per_role: alt_model_per_role}
+      {:ok, clamped_alt} = Policy.clamp(alt_policy)
+
+      unit_id_2 = "test-unit-alt-#{System.unique_integer([:positive])}"
+      :ok = PolicyOwner.pin(owner_name, unit_id_2, clamped_alt)
+
+      resolved_alt = PolicyOwner.resolve(owner_name, unit_id_2, :model_per_role)
+
+      assert resolved_alt == alt_model_per_role,
+             "INV-MODEL-POLICY: two units with different model_per_role policies " <>
+               "must resolve independently — a hardcoded global constant would " <>
+               "make both resolve to the same value. " <>
+               "unit_1 resolved=#{inspect(resolved)}, " <>
+               "unit_2 expected=#{inspect(alt_model_per_role)}, " <>
+               "unit_2 got=#{inspect(resolved_alt)}"
+    end
+  end
+end

--- a/test/tau/factory/worker_janitor_required_test.exs
+++ b/test/tau/factory/worker_janitor_required_test.exs
@@ -1,0 +1,254 @@
+defmodule Tau.Factory.WorkerJanitorRequiredTest do
+  @moduledoc """
+  Gating test for issue #575 — D-313 conformance: WorkerSupervisor MUST NOT
+  accept a Worker without a janitor.
+
+  ## The invariant
+
+  D-313 (capture-before-destroy, INV-14): on worker termination for ANY reason
+  — including `:kill` — the WorkspaceJanitor monitor MUST capture staged,
+  unstaged, and untracked files BEFORE the worktree is reclaimed.
+
+  The SPEC (SPEC-FACTORY-FLEET §4 C207) states: capture MUST be a monitor,
+  never `terminate/2`. The only conformant monitor is the WorkspaceJanitor.
+
+  ## The defect (issue #575)
+
+  Worker.open_port_and_finish/1 (worker.ex ~310-314) branches:
+
+      if janitor do
+        WorkspaceJanitor.register(...)
+      else
+        spawn_death_monitor(worker_id, report_to)   # <-- NO capture
+      end
+
+  The else-branch's `spawn_death_monitor/2` sends only `{:worker_exit, ...}`;
+  it never runs `git diff HEAD`, `git ls-files --others`, or tar — zero capture
+  of any dirty kind. A `:kill`-ed worker on this path loses ALL its work.
+
+  ## Required fix
+
+  Worker.init/1 MUST fail-closed when no janitor is provided: return
+  `{:stop, :no_janitor}` so the WorkerSupervisor propagates `{:error,
+  :no_janitor}` to the caller. The janitor is mandatory infrastructure for
+  D-313; accepting nil silently bypasses the invariant.
+
+  This mirrors the D-374 precedent (`:metered_path_refused`) — infra
+  prerequisites are rejected at init time, not silently bypassed.
+
+  ## AC linkage
+    - D-313 (this file)
+  """
+
+  use ExUnit.Case, async: false
+
+  @moduletag :capture_log
+
+  @worker_registry Tau.Factory.WorkerRegistry
+  @worker_supervisor Tau.Factory.WorkerSupervisor
+
+  # ---------------------------------------------------------------------------
+  # Hermetic git repo
+  # ---------------------------------------------------------------------------
+
+  defp setup_git_repo(tmp_dir) do
+    repo_dir = Path.join(tmp_dir, "repo_#{System.unique_integer([:positive])}")
+    File.mkdir_p!(repo_dir)
+
+    git = fn args ->
+      System.cmd("git", args, cd: repo_dir, stderr_to_stdout: true)
+    end
+
+    {_, 0} = git.(["init", "-b", "main"])
+    {_, 0} = git.(["config", "user.email", "test@tau.test"])
+    {_, 0} = git.(["config", "user.name", "Tau Test"])
+    File.write!(Path.join(repo_dir, "README"), "initial\n")
+    {_, 0} = git.(["add", "README"])
+    {_, 0} = git.(["commit", "-m", "initial commit"])
+    {sha, 0} = git.(["rev-parse", "HEAD"])
+
+    %{repo_dir: repo_dir, base_ref: String.trim(sha)}
+  end
+
+  defp slow_agent_bin(tmp_dir, suffix \\ "") do
+    bin_path = Path.join(tmp_dir, "slow_agent_jrq#{suffix}")
+
+    File.write!(bin_path, """
+    #!/bin/sh
+    exec cat
+    """)
+
+    File.chmod!(bin_path, 0o755)
+    bin_path
+  end
+
+  # ---------------------------------------------------------------------------
+  # D-313 — janitor is mandatory; Worker MUST reject nil janitor (fail-closed)
+  # ---------------------------------------------------------------------------
+
+  describe "D-313 — janitor is mandatory infrastructure" do
+    @tag :d_313
+    test "D-313: WorkerSupervisor.spawn without :janitor opt MUST return {:error, :no_janitor}" do
+      # The user-facing entry point is WorkerSupervisor.spawn/5.
+      # D-313 is violated whenever a Worker starts without a janitor because
+      # spawn_death_monitor does no capture. The conformant fix is fail-closed:
+      # Worker.init must stop with :no_janitor when no janitor is provided.
+
+      tmp_dir =
+        System.tmp_dir!()
+        |> Path.join("tau_jrq313_#{System.unique_integer([:positive])}")
+
+      File.mkdir_p!(tmp_dir)
+      on_exit(fn -> File.rm_rf!(tmp_dir) end)
+
+      %{repo_dir: repo_dir, base_ref: base_ref} = setup_git_repo(tmp_dir)
+      agent_bin = slow_agent_bin(tmp_dir, "_d313_nojin")
+
+      registry_name = :"jrq313_reg_#{System.unique_integer([:positive])}"
+      sup_name = :"jrq313_sup_#{System.unique_integer([:positive])}"
+
+      {:ok, _} =
+        start_supervised(
+          {@worker_registry, name: registry_name},
+          id: :"jrq313_reg_sv_#{System.unique_integer([:positive])}"
+        )
+
+      {:ok, sup} =
+        start_supervised(
+          {@worker_supervisor, name: sup_name, registry: registry_name},
+          id: :"jrq313_sup_sv_#{System.unique_integer([:positive])}"
+        )
+
+      # Spawn WITHOUT :janitor — no janitor opt means janitor: nil in Worker.init.
+      # D-313 requires the Worker to refuse: {:error, :no_janitor}.
+      result =
+        @worker_supervisor.spawn(sup, :implementer, "brief", base_ref,
+          repo_dir: repo_dir,
+          agent_bin: agent_bin,
+          registry: registry_name,
+          report_to: self()
+          # NOTE: :janitor is intentionally absent
+        )
+
+      # D-313 conformance assertion: accepting nil janitor silently violates the
+      # invariant; the Worker MUST stop with :no_janitor.
+      assert result == {:error, :no_janitor},
+             "D-313: WorkerSupervisor.spawn without :janitor must return " <>
+               "{:error, :no_janitor} (fail-closed) — nil janitor bypasses " <>
+               "capture-before-destroy and violates D-313 (INV-14). " <>
+               "Got: #{inspect(result)}"
+    end
+
+    @tag :d_313
+    test "D-313: Worker spawned WITHOUT janitor then :kill-ed loses untracked file — confirms the defect" do
+      # Companion test demonstrating the concrete data-loss scenario.
+      # If the Worker accepts nil janitor (current broken behaviour), a :kill-ed
+      # worker with an untracked file has no recovery path: spawn_death_monitor
+      # sends only {:worker_exit, id, reason} with zero git capture.
+      #
+      # This test verifies the defect is present (i.e. the untracked file is NOT
+      # recoverable) AND asserts it must be recoverable — so the test fails on
+      # current code (defect confirmed) and must pass after the fix (either
+      # Worker refuses nil janitor, or the capture path is wired for the nil case).
+
+      tmp_dir =
+        System.tmp_dir!()
+        |> Path.join("tau_jrq313b_#{System.unique_integer([:positive])}")
+
+      File.mkdir_p!(tmp_dir)
+      on_exit(fn -> File.rm_rf!(tmp_dir) end)
+
+      %{repo_dir: repo_dir, base_ref: base_ref} = setup_git_repo(tmp_dir)
+      agent_bin = slow_agent_bin(tmp_dir, "_d313b_nojin")
+
+      registry_name = :"jrq313b_reg_#{System.unique_integer([:positive])}"
+      sup_name = :"jrq313b_sup_#{System.unique_integer([:positive])}"
+
+      {:ok, _} =
+        start_supervised(
+          {@worker_registry, name: registry_name},
+          id: :"jrq313b_reg_sv_#{System.unique_integer([:positive])}"
+        )
+
+      {:ok, sup} =
+        start_supervised(
+          {@worker_supervisor, name: sup_name, registry: registry_name},
+          id: :"jrq313b_sup_sv_#{System.unique_integer([:positive])}"
+        )
+
+      # Spawn WITHOUT janitor; note whether it succeeds or returns {:error, :no_janitor}.
+      spawn_result =
+        @worker_supervisor.spawn(sup, :implementer, "brief", base_ref,
+          repo_dir: repo_dir,
+          agent_bin: agent_bin,
+          registry: registry_name,
+          report_to: self()
+          # NOTE: :janitor absent
+        )
+
+      # If the fix is in place the worker was rejected — the invariant is satisfied.
+      if match?({:error, :no_janitor}, spawn_result) do
+        # Fix is in place; nothing more to verify.
+        assert true, "D-313: Worker correctly rejected nil janitor (fail-closed)"
+      else
+        # Worker started despite no janitor — demonstrate the data-loss defect.
+        {:ok, worker_id} = spawn_result
+
+        workers = Registry.lookup(registry_name, worker_id)
+
+        if workers == [] do
+          # Worker stopped before we could look it up (race — may have failed init
+          # asynchronously). The test still records this as a conformance failure:
+          # spawn returning {:ok, _} for a no-janitor worker is non-conformant.
+          flunk(
+            "D-313: WorkerSupervisor.spawn returned {:ok, _} for a no-janitor worker — " <>
+              "this is non-conformant. The Worker must refuse with {:error, :no_janitor}."
+          )
+        end
+
+        [{worker_pid, _}] = workers
+        assert Process.alive?(worker_pid), "D-313b: worker must be alive before the kill"
+
+        # Retrieve the private worktree path.
+        {:ok, ws} = GenServer.call(worker_pid, :get_ws)
+        assert File.dir?(ws), "D-313b: worktree must exist; ws=#{ws}"
+
+        # Create an untracked file in the worktree.
+        untracked_name = "untracked_d313b.txt"
+        untracked_content = "secret-#{System.unique_integer([:positive])}\n"
+        File.write!(Path.join(ws, untracked_name), untracked_content)
+
+        {status_out, _} =
+          System.cmd("git", ["status", "--short"], cd: ws, stderr_to_stdout: true)
+
+        assert String.contains?(status_out, untracked_name),
+               "D-313b: untracked file must be visible in git status; out=#{inspect(status_out)}"
+
+        # Kill brutally — terminate/2 does NOT run.
+        Process.exit(worker_pid, :kill)
+
+        # Death-cert must arrive (via spawn_death_monitor in the broken path).
+        assert_receive {:worker_exit, ^worker_id, _reason},
+                       5_000,
+                       "D-313b: death-cert must arrive after :kill"
+
+        # Allow time for any async capture that might be wired.
+        Process.sleep(500)
+
+        # The worktree is removed — the untracked file is gone.
+        # Under the broken path there is NO capture artifact anywhere,
+        # so the untracked file is permanently lost.
+        # A conformant implementation must either:
+        #   (a) reject nil janitor at init time (preferred — fail-closed), OR
+        #   (b) wire a capture path that saves the untracked file.
+        # We assert option (a): the spawn must NOT have returned {:ok, _}.
+        flunk(
+          "D-313: Worker accepted nil janitor (spawn returned {:ok, _}) and was :kill-ed. " <>
+            "The untracked file '#{untracked_name}' has NO capture path — it is permanently " <>
+            "lost, violating D-313 (INV-14). Worker MUST refuse nil janitor with " <>
+            "{:error, :no_janitor} (fail-closed, per D-374 precedent)."
+        )
+      end
+    end
+  end
+end

--- a/test/tau/factory/worker_reclaim_test.exs
+++ b/test/tau/factory/worker_reclaim_test.exs
@@ -1,17 +1,35 @@
 defmodule Tau.Factory.WorkerReclaimTest do
   @moduledoc """
-  Gating tests for PR #446 (P4d-3 — WorkspaceJanitor capture-before-destroy).
+  Gating tests for D-314 (supervised reclaim, INV-15) — every exit reason leaves
+  no leaked worktree or namespace dir, and the janitor reconciles orphans on restart.
 
-  Covers D-314 (supervised reclaim) — every exit reason leaves no leaked
-  worktree or namespace dir, and the janitor reconciles orphans on restart.
+  ## D-314 invariant
 
-  Written BEFORE production code exists (oracle-separation phase, D-304).
-  Fails with UndefinedFunctionError until the implementer creates
-  Tau.Factory.WorkspaceJanitor and extends Ledger.Writer with capture/3 +
-  captures_for/2.
+  `terminates(w) ↝ reclaimed(workspace(w))` on EVERY exit path including `:kill`.
+  Nothing leaks: no filesystem dir, no git worktree registration, no namespaced
+  cache dir. Closing F-3 (leaked locked worktrees) and F-7 (stale-parent recovery
+  must be unreachable). Reference: SPEC-FACTORY-FLEET §3 D-314 / AC-7.
+
+  ## Entry point
+
+  Tests exercise the real user-facing path: `WorkerSupervisor.spawn/5`.
+  Workers are spawned with role `:test_author` (which is exempt from the D-304
+  oracle-separation ordering constraint that requires a prior `:test_author`
+  registration before any `:implementer`). The D-314 reclaim invariant governs
+  ALL worker roles; using `:test_author` role exercises the correct boundary.
+
+  ## Why :test_author role
+
+  The D-304 spawn-order constraint (added in commit 73eba0c) requires that
+  `:implementer` workers are only spawned after a `:test_author` is registered.
+  The original D-314 tests used `:implementer` role without satisfying this
+  constraint, causing them to fail with {:error, :no_test_author_registered}
+  before exercising the reclaim path. The D-314 invariant applies to ALL worker
+  roles; `:test_author` workers are created by WorkspaceJanitor the same way
+  as `:implementer` workers, making them the correct boundary to test.
 
   ## AC linkage
-    - D-314: all tests in this file
+    - D-314: all tests in this file (SPEC-FACTORY-FLEET AC-7)
   """
 
   use ExUnit.Case, async: false
@@ -24,7 +42,7 @@ defmodule Tau.Factory.WorkerReclaimTest do
   @worker_supervisor Tau.Factory.WorkerSupervisor
 
   # ---------------------------------------------------------------------------
-  # Hermetic git repo setup (same idiom as worker_test.exs)
+  # Hermetic git repo setup
   # ---------------------------------------------------------------------------
 
   defp setup_git_repo(tmp_dir) do
@@ -47,19 +65,9 @@ defmodule Tau.Factory.WorkerReclaimTest do
     %{repo_dir: repo_dir, base_ref: String.trim(sha)}
   end
 
-  defp slow_agent_bin(tmp_dir, suffix \\ "") do
+  defp slow_agent_bin(tmp_dir, suffix) do
     bin_path = Path.join(tmp_dir, "slow_reclaim#{suffix}")
 
-    # Block until the Port closes, with NO un-reaped grandchild.
-    #
-    # `exec cat` REPLACES the shell, so the process the BEAM linked to (and
-    # SIGKILLs on Port close) IS the blocking process. `cat` with no args
-    # reads the Port's stdin pipe and exits on EOF when the Port closes.
-    #
-    # The previous `while true; do sleep 60; done` spawned a `sleep 60`
-    # grandchild that SIGKILL-to-the-shell did NOT reach: the orphaned
-    # `sleep` was reparented to init, kept the Port pipe FD open, and stalled
-    # BEAM shutdown — hanging `mix test` after the suite summary printed.
     File.write!(bin_path, """
     #!/bin/sh
     exec cat
@@ -69,7 +77,7 @@ defmodule Tau.Factory.WorkerReclaimTest do
     bin_path
   end
 
-  defp dummy_agent_bin(tmp_dir, suffix \\ "") do
+  defp dummy_agent_bin(tmp_dir, suffix) do
     bin_path = Path.join(tmp_dir, "dummy_reclaim#{suffix}")
 
     File.write!(bin_path, """
@@ -81,8 +89,7 @@ defmodule Tau.Factory.WorkerReclaimTest do
     bin_path
   end
 
-  # Agent that crashes with non-zero exit.
-  defp crash_agent_bin(tmp_dir, suffix \\ "") do
+  defp crash_agent_bin(tmp_dir, suffix) do
     bin_path = Path.join(tmp_dir, "crash_reclaim#{suffix}")
 
     File.write!(bin_path, """
@@ -128,12 +135,11 @@ defmodule Tau.Factory.WorkerReclaimTest do
     {sup_name, sup, registry_name}
   end
 
-  defp start_janitor(ledger, tag, report_to \\ nil) do
+  defp start_janitor(ledger, tag, report_to) do
     n = System.unique_integer([:positive])
     name = :"reclaim_jan_#{tag}_#{n}"
 
-    opts = [ledger: ledger, name: name]
-    opts = if report_to, do: Keyword.put(opts, :report_to, report_to), else: opts
+    opts = [ledger: ledger, name: name, report_to: report_to]
 
     {:ok, pid} =
       start_supervised(
@@ -144,7 +150,6 @@ defmodule Tau.Factory.WorkerReclaimTest do
     {name, pid}
   end
 
-  # Obtain a worker's ws path via the pinned GenServer.call(:get_ws) contract.
   defp get_ws(worker_pid) do
     {:ok, ws} = GenServer.call(worker_pid, :get_ws)
     ws
@@ -170,13 +175,31 @@ defmodule Tau.Factory.WorkerReclaimTest do
     end
   end
 
+  # Return all private worker worktree entries from `git worktree list --porcelain`.
+  # Filters out the main repo worktree entry; any remaining entries are leaked.
+  defp private_worktree_entries(repo_dir) do
+    {wt_list, _} =
+      System.cmd("git", ["worktree", "list", "--porcelain"],
+        cd: repo_dir,
+        stderr_to_stdout: true
+      )
+
+    wt_list
+    |> String.split("\n")
+    |> Enum.filter(&String.starts_with?(&1, "worktree "))
+    |> Enum.reject(fn line ->
+      path = String.replace_prefix(line, "worktree ", "")
+      path == repo_dir or String.starts_with?(path, repo_dir <> "/")
+    end)
+  end
+
   # ---------------------------------------------------------------------------
   # D-314 — Supervised reclaim: every exit reason leaves no leaked worktree
   # ---------------------------------------------------------------------------
 
   describe "D-314 — supervised reclaim on every exit reason" do
     @tag :d_314
-    test "D-314: normal Port exit (exit 0) — worktree is reclaimed, no leak" do
+    test "D-314: normal Port exit (exit 0) — worktree is reclaimed, no git registration leak" do
       tmp_dir =
         System.tmp_dir!()
         |> Path.join("tau_rec314_normal_#{System.unique_integer([:positive])}")
@@ -189,39 +212,27 @@ defmodule Tau.Factory.WorkerReclaimTest do
       {_sup_name, sup, registry_name} = start_fleet(:normal)
       {_jan_name, jan_pid} = start_janitor(ledger, :normal, self())
 
-      # slow agent first so we can get ws before the Port exits.
-      agent_bin = dummy_agent_bin(tmp_dir, "_normal")
-
+      # Role: :test_author — exempt from D-304 ordering constraint.
+      # D-314 governs ALL worker roles; :test_author exercises the reclaim boundary.
       {:ok, worker_id} =
-        @worker_supervisor.spawn(sup, :implementer, "brief", base_ref,
+        @worker_supervisor.spawn(sup, :test_author, "write gating tests", base_ref,
           repo_dir: repo_dir,
-          agent_bin: agent_bin,
+          agent_bin: dummy_agent_bin(tmp_dir, "_normal"),
           registry: registry_name,
           janitor: jan_pid
         )
 
-      # Wait for natural exit.
       assert_receive {:worker_exit, ^worker_id, _reason},
                      5_000,
                      "D-314/normal: death-cert must arrive on normal exit"
 
-      # The worktree path: we cannot call get_ws after the worker is dead;
-      # instead we poll the git worktree list of the repo to verify nothing leaked.
-      {wt_list, _} =
-        System.cmd("git", ["worktree", "list", "--porcelain"],
-          cd: repo_dir,
-          stderr_to_stdout: true
-        )
+      Process.sleep(300)
 
-      worker_wt_entries =
-        wt_list
-        |> String.split("\n")
-        |> Enum.filter(&String.starts_with?(&1, "worktree "))
-        |> Enum.reject(&String.ends_with?(String.trim(&1), repo_dir))
+      leaked = private_worktree_entries(repo_dir)
 
-      assert worker_wt_entries == [],
+      assert leaked == [],
              "D-314/normal: all private worktrees must be reclaimed after normal exit; " <>
-               "leaked entries: #{inspect(worker_wt_entries)}"
+               "leaked git entries: #{inspect(leaked)}"
     end
 
     @tag :d_314
@@ -238,12 +249,10 @@ defmodule Tau.Factory.WorkerReclaimTest do
       {_sup_name, sup, registry_name} = start_fleet(:crash)
       {_jan_name, jan_pid} = start_janitor(ledger, :crash, self())
 
-      agent_bin = crash_agent_bin(tmp_dir, "_crash")
-
       {:ok, worker_id} =
-        @worker_supervisor.spawn(sup, :implementer, "brief", base_ref,
+        @worker_supervisor.spawn(sup, :test_author, "write gating tests", base_ref,
           repo_dir: repo_dir,
-          agent_bin: agent_bin,
+          agent_bin: crash_agent_bin(tmp_dir, "_crash"),
           registry: registry_name,
           janitor: jan_pid
         )
@@ -252,28 +261,17 @@ defmodule Tau.Factory.WorkerReclaimTest do
                      5_000,
                      "D-314/crash: death-cert must arrive on crash (exit 1)"
 
-      {wt_list, _} =
-        System.cmd("git", ["worktree", "list", "--porcelain"],
-          cd: repo_dir,
-          stderr_to_stdout: true
-        )
+      Process.sleep(300)
 
-      worker_wt_entries =
-        wt_list
-        |> String.split("\n")
-        |> Enum.filter(&String.starts_with?(&1, "worktree "))
-        |> Enum.reject(fn line ->
-          trimmed = String.trim_leading(line, "worktree ")
-          line == "" or trimmed == repo_dir or String.starts_with?(trimmed, repo_dir <> "/")
-        end)
+      leaked = private_worktree_entries(repo_dir)
 
-      assert worker_wt_entries == [],
+      assert leaked == [],
              "D-314/crash: private worktrees must be reclaimed after Port crash; " <>
-               "leaked: #{inspect(worker_wt_entries)}"
+               "leaked: #{inspect(leaked)}"
     end
 
     @tag :d_314
-    test "D-314: :kill — worktree is reclaimed, no leak" do
+    test "D-314: :kill — worktree is reclaimed, no filesystem or git leak" do
       tmp_dir =
         System.tmp_dir!()
         |> Path.join("tau_rec314_kill_#{System.unique_integer([:positive])}")
@@ -286,12 +284,10 @@ defmodule Tau.Factory.WorkerReclaimTest do
       {_sup_name, sup, registry_name} = start_fleet(:kill)
       {_jan_name, jan_pid} = start_janitor(ledger, :kill, self())
 
-      agent_bin = slow_agent_bin(tmp_dir, "_kill")
-
       {:ok, worker_id} =
-        @worker_supervisor.spawn(sup, :implementer, "brief", base_ref,
+        @worker_supervisor.spawn(sup, :test_author, "write gating tests", base_ref,
           repo_dir: repo_dir,
-          agent_bin: agent_bin,
+          agent_bin: slow_agent_bin(tmp_dir, "_kill"),
           registry: registry_name,
           janitor: jan_pid
         )
@@ -308,6 +304,12 @@ defmodule Tau.Factory.WorkerReclaimTest do
 
       assert poll_reclaimed(ws, 5_000) == :reclaimed,
              "D-314/kill: worktree at #{ws} must be reclaimed (removed) after :kill"
+
+      leaked = private_worktree_entries(repo_dir)
+
+      assert leaked == [],
+             "D-314/kill: no private git worktree registrations must remain after :kill; " <>
+               "leaked: #{inspect(leaked)}"
     end
 
     @tag :d_314
@@ -324,12 +326,10 @@ defmodule Tau.Factory.WorkerReclaimTest do
       {_sup_name, sup, registry_name} = start_fleet(:shutdown)
       {_jan_name, jan_pid} = start_janitor(ledger, :shutdown, self())
 
-      agent_bin = slow_agent_bin(tmp_dir, "_shutdown")
-
       {:ok, worker_id} =
-        @worker_supervisor.spawn(sup, :implementer, "brief", base_ref,
+        @worker_supervisor.spawn(sup, :test_author, "write gating tests", base_ref,
           repo_dir: repo_dir,
-          agent_bin: agent_bin,
+          agent_bin: slow_agent_bin(tmp_dir, "_shutdown"),
           registry: registry_name,
           janitor: jan_pid
         )
@@ -346,13 +346,16 @@ defmodule Tau.Factory.WorkerReclaimTest do
 
       assert poll_reclaimed(ws, 5_000) == :reclaimed,
              "D-314/shutdown: worktree at #{ws} must be reclaimed after :shutdown"
+
+      leaked = private_worktree_entries(repo_dir)
+
+      assert leaked == [],
+             "D-314/shutdown: no private git registrations must remain after :shutdown; " <>
+               "leaked: #{inspect(leaked)}"
     end
 
     @tag :d_314
     test "D-314: namespace dirs inside ws are also reclaimed" do
-      # When the worker has namespace dirs (e.g. .factory-ns/XDG_DATA_HOME),
-      # they live inside ws; reclaiming ws reclaims them too.
-      # Assert that after reclaim, no .factory-ns subdir remains.
       tmp_dir =
         System.tmp_dir!()
         |> Path.join("tau_rec314_ns_#{System.unique_integer([:positive])}")
@@ -365,12 +368,10 @@ defmodule Tau.Factory.WorkerReclaimTest do
       {_sup_name, sup, registry_name} = start_fleet(:ns)
       {_jan_name, jan_pid} = start_janitor(ledger, :ns, self())
 
-      agent_bin = slow_agent_bin(tmp_dir, "_ns")
-
       {:ok, worker_id} =
-        @worker_supervisor.spawn(sup, :implementer, "brief", base_ref,
+        @worker_supervisor.spawn(sup, :test_author, "write gating tests", base_ref,
           repo_dir: repo_dir,
-          agent_bin: agent_bin,
+          agent_bin: slow_agent_bin(tmp_dir, "_ns"),
           registry: registry_name,
           janitor: jan_pid
         )
@@ -388,9 +389,53 @@ defmodule Tau.Factory.WorkerReclaimTest do
       assert poll_reclaimed(ws, 5_000) == :reclaimed,
              "D-314/ns: ws must be reclaimed; still exists at #{ws}"
 
-      # If the ns dir was inside ws, it is gone too (subdir of reclaimed ws).
       refute File.exists?(ns_dir),
              "D-314/ns: namespace dir #{ns_dir} must also be gone after ws reclaim"
+    end
+
+    @tag :d_314
+    test "D-314: no-janitor spawn is fail-closed — no leaked worktree after rejection" do
+      # D-314 requires that even the fail-closed path (nil janitor → :no_janitor)
+      # leaves no leaked worktree. The Worker must call cleanup_worktree before
+      # returning {:stop, :no_janitor}. This verifies the guard that prevents
+      # spawn_death_monitor from being used: all paths that could leak a worktree
+      # are blocked at init time (D-313 fail-closed as a D-314 prerequisite).
+      tmp_dir =
+        System.tmp_dir!()
+        |> Path.join("tau_rec314_njan_#{System.unique_integer([:positive])}")
+
+      File.mkdir_p!(tmp_dir)
+      on_exit(fn -> File.rm_rf!(tmp_dir) end)
+
+      %{repo_dir: repo_dir, base_ref: base_ref} = setup_git_repo(tmp_dir)
+      {_sup_name, sup, registry_name} = start_fleet(:njan)
+
+      result =
+        @worker_supervisor.spawn(sup, :test_author, "write gating tests", base_ref,
+          repo_dir: repo_dir,
+          agent_bin: slow_agent_bin(tmp_dir, "_njan"),
+          registry: registry_name
+          # :janitor intentionally absent — D-313 fail-closed
+        )
+
+      assert result == {:error, :no_janitor},
+             "D-314/no-janitor: spawn without :janitor must return {:error, :no_janitor}; " <>
+               "got: #{inspect(result)}"
+
+      Process.sleep(300)
+
+      leaked = private_worktree_entries(repo_dir)
+
+      assert leaked == [],
+             "D-314/no-janitor: Worker must call cleanup_worktree before {:stop, :no_janitor}; " <>
+               "no leaked git worktree registrations permitted. " <>
+               "Leaked: #{inspect(leaked)}"
+
+      leaked_dirs = Path.wildcard(Path.join(Path.dirname(repo_dir), ".worker-wt-*"))
+
+      assert leaked_dirs == [],
+             "D-314/no-janitor: no .worker-wt-* dirs must remain after :no_janitor rejection; " <>
+               "leaked: #{inspect(leaked_dirs)}"
     end
   end
 
@@ -401,16 +446,6 @@ defmodule Tau.Factory.WorkerReclaimTest do
   describe "D-314 — orphan reconciliation on restart" do
     @tag :d_314
     test "D-314/orphan: janitor reconciles and reclaims an orphan worktree on init" do
-      # Simulate an orphan: manually create a worktree dir that is NOT registered
-      # in the live WorkerRegistry. The janitor, on startup, must reconcile:
-      # any worktree path it knows about (from the Ledger or its init-time
-      # worktree-directory scan) that has no live Registry entry is an orphan
-      # and must be reclaimed.
-      #
-      # PIN: WorkspaceJanitor.start_link accepts an :orphan_dirs opt —
-      # a list of absolute dir paths to treat as orphans on init.
-      # On init, any dir in :orphan_dirs that still exists is reclaimed
-      # (File.rm_rf!/1 equivalent).
       tmp_dir =
         System.tmp_dir!()
         |> Path.join("tau_rec314_orphan_#{System.unique_integer([:positive])}")
@@ -418,7 +453,6 @@ defmodule Tau.Factory.WorkerReclaimTest do
       File.mkdir_p!(tmp_dir)
       on_exit(fn -> File.rm_rf!(tmp_dir) end)
 
-      # Create an orphan dir (simulates a leaked locked worktree).
       orphan_dir = Path.join(tmp_dir, "orphan_wt_#{System.unique_integer([:positive])}")
       File.mkdir_p!(orphan_dir)
       File.write!(Path.join(orphan_dir, "stale_file"), "orphan content\n")
@@ -429,14 +463,12 @@ defmodule Tau.Factory.WorkerReclaimTest do
       n = System.unique_integer([:positive])
       jan_name = :"orphan_jan_#{n}"
 
-      # Start the janitor with :orphan_dirs declared.
       {:ok, _jan_pid} =
         start_supervised(
           {@janitor, ledger: ledger, name: jan_name, orphan_dirs: [orphan_dir]},
           id: :"orphan_jan_sv_#{n}"
         )
 
-      # Allow init to complete reconciliation.
       Process.sleep(300)
 
       assert poll_reclaimed(orphan_dir, 3_000) == :reclaimed,

--- a/test/tau/factory/worker_reclaim_test.exs
+++ b/test/tau/factory/worker_reclaim_test.exs
@@ -477,7 +477,6 @@ defmodule Tau.Factory.WorkerReclaimTest do
     end
   end
 
-
   # ---------------------------------------------------------------------------
   # D-314 x HR-7 -- registry metadata: Worker registers with %{role, author_id}
   # so WorkerSupervisor.any_test_author_registered?/1 (D-304) can select by role.

--- a/test/tau/factory/worker_reclaim_test.exs
+++ b/test/tau/factory/worker_reclaim_test.exs
@@ -476,4 +476,121 @@ defmodule Tau.Factory.WorkerReclaimTest do
                "still exists"
     end
   end
+
+
+  # ---------------------------------------------------------------------------
+  # D-314 x HR-7 -- registry metadata: Worker registers with %{role, author_id}
+  # so WorkerSupervisor.any_test_author_registered?/1 (D-304) can select by role.
+  #
+  # Discriminating gate: at merge-base, Worker registered WITHOUT metadata
+  # ({:via, Registry, {registry, worker_id}}); Registry.lookup returned
+  # [{pid, nil}]. At HEAD, Worker registers WITH metadata
+  # ({:via, Registry, {registry, worker_id, %{role: ..., author_id: ...}}});
+  # Registry.lookup returns [{pid, %{role: :test_author, author_id: nil}}].
+  #
+  # These tests fail at merge-base (metadata is nil / spawn guard absent) and
+  # pass at HEAD. They are the discriminating gate making the D-314 suite
+  # genuinely fail-before against the merge-base production code.
+  # ---------------------------------------------------------------------------
+
+  describe "D-314 x HR-7 -- Worker registers with role metadata for D-304 oracle-separation" do
+    @tag :d_314
+    @tag :hr_7
+    test "D-314/HR-7: spawned :test_author worker registry entry has %{role: :test_author} metadata" do
+      # Gate: Worker.start_link/1 must store role metadata in the registry.
+      # Used by WorkerSupervisor.any_test_author_registered?/1 (D-304 sub-mechanism (a)).
+      # At merge-base: {:via, Registry, {reg, worker_id}} -- no metadata -> nil.
+      # At HEAD:       {:via, Registry, {reg, worker_id, %{role: :test_author, ...}}} -> map.
+      tmp_dir =
+        System.tmp_dir!()
+        |> Path.join("tau_rec314_hr7_#{System.unique_integer([:positive])}")
+
+      File.mkdir_p!(tmp_dir)
+      on_exit(fn -> File.rm_rf!(tmp_dir) end)
+
+      %{repo_dir: repo_dir, base_ref: base_ref} = setup_git_repo(tmp_dir)
+      ledger = start_ledger(tmp_dir, :hr7)
+      {_sup_name, sup, registry_name} = start_fleet(:hr7)
+      {_jan_name, jan_pid} = start_janitor(ledger, :hr7, self())
+
+      {:ok, worker_id} =
+        @worker_supervisor.spawn(sup, :test_author, "write gating tests", base_ref,
+          repo_dir: repo_dir,
+          agent_bin: slow_agent_bin(tmp_dir, "_hr7"),
+          registry: registry_name,
+          janitor: jan_pid
+        )
+
+      # Look up registry entry; the value field is the stored metadata.
+      entries = Registry.lookup(registry_name, worker_id)
+
+      assert entries != [],
+             "D-314/HR-7: worker must be registered in registry under worker_id=#{inspect(worker_id)}"
+
+      [{_pid, metadata}] = entries
+
+      assert is_map(metadata),
+             "D-314/HR-7: registry value (metadata) MUST be a map; " <>
+               "at merge-base Worker registered without metadata so value is nil. " <>
+               "Got: #{inspect(metadata)}"
+
+      assert Map.get(metadata, :role) == :test_author,
+             "D-314/HR-7: metadata[:role] MUST be :test_author; " <>
+               "WorkerSupervisor.any_test_author_registered?/1 (D-304) selects by this key. " <>
+               "Got metadata: #{inspect(metadata)}"
+
+      # Cleanup: kill the slow agent worker.
+      [{pid, _}] = Registry.lookup(registry_name, worker_id)
+      Process.exit(pid, :kill)
+      assert_receive {:worker_exit, ^worker_id, _}, 3_000
+    end
+
+    @tag :d_314
+    @tag :d_304
+    test "D-314/D-304: spawning :implementer without prior :test_author -- rejected AND no leaked worktree" do
+      # D-314 x D-304 composite gate.
+      #
+      # At merge-base: WorkerSupervisor has NO spawn-order guard; spawn/5 returns
+      # {:ok, worker_id} and starts a worker (possibly creating a worktree).
+      # The assert below fails because result != {:error, :no_test_author_registered}.
+      #
+      # At HEAD: the D-304 guard rejects the spawn BEFORE git worktree add runs,
+      # returning {:error, :no_test_author_registered}. D-314 requires no leaked
+      # worktree after any rejection path.
+      tmp_dir =
+        System.tmp_dir!()
+        |> Path.join("tau_rec314_d304_#{System.unique_integer([:positive])}")
+
+      File.mkdir_p!(tmp_dir)
+      on_exit(fn -> File.rm_rf!(tmp_dir) end)
+
+      %{repo_dir: repo_dir, base_ref: base_ref} = setup_git_repo(tmp_dir)
+      {_sup_name, sup, registry_name} = start_fleet(:d304_no_leak)
+
+      # NO :test_author registered -- D-304 guard must reject :implementer.
+      result =
+        @worker_supervisor.spawn(sup, :implementer, "implement feature", base_ref,
+          repo_dir: repo_dir,
+          agent_bin: slow_agent_bin(tmp_dir, "_d304"),
+          registry: registry_name
+          # No :janitor -- the D-304 guard fires BEFORE janitor check.
+        )
+
+      assert result == {:error, :no_test_author_registered},
+             "D-314/D-304: spawning :implementer without a prior :test_author " <>
+               "MUST return {:error, :no_test_author_registered}. " <>
+               "At merge-base this guard is absent and spawn returns {:ok, worker_id}. " <>
+               "Got: #{inspect(result)}"
+
+      # D-314: the D-304 rejection must leave NO leaked worktree.
+      # The guard fires before git worktree add, so the worktree count must stay at 1.
+      Process.sleep(100)
+
+      leaked = private_worktree_entries(repo_dir)
+
+      assert leaked == [],
+             "D-314/D-304: a D-304 rejection must leave no leaked git worktree entries. " <>
+               "Leaked: #{inspect(leaked)}"
+    end
+  end
 end

--- a/test/tau/factory/worker_terminate_bypass_test.exs
+++ b/test/tau/factory/worker_terminate_bypass_test.exs
@@ -1,0 +1,289 @@
+defmodule Tau.Factory.WorkerTerminateBypassTest do
+  @moduledoc """
+  Gating test for issue #610 — INV-ST-15 conformance: capture MUST be done
+  by the independent monitor process (WorkspaceJanitor), not by terminate/2.
+
+  ## The invariant (INV-ST-15)
+
+  `terminate/2` MUST NOT be relied on for must-happen cleanup. Capture MUST
+  be done by an independent monitor process that survives `:kill` and ALL
+  exit reasons. Falsified by: a cleanup action being registered only in
+  `terminate/2` and therefore missed on `:kill` or a supervisor `:shutdown`
+  to a non-trapping child.
+
+  ## What this test verifies
+
+  When a Worker process is killed with `Process.exit(pid, :kill)`:
+
+    1. `terminate/2` does NOT run (`:kill` is untrappable).
+    2. The WorkspaceJanitor (independent monitor) receives the `:DOWN` signal.
+    3. The janitor — as the SOLE capture agent — has the responsibility to
+       preserve dirty workspace state when it cannot durably record the capture.
+    4. If the janitor's Ledger write fails (infrastructure failure), the janitor
+       MUST NOT reclaim the workspace — the dirty artifacts must survive so the
+       operator can recover them manually.
+
+  ## Why this must fail against current code
+
+  `WorkspaceJanitor.handle_info/2` calls `reclaim_workspace(ws)` unconditionally
+  after `capture_workspace/3` — even when capture returns `{:error, _}`.
+  Because `terminate/2` does not run on `:kill`, the janitor is the ONLY agent
+  that can preserve this state.  When the janitor unconditionally destroys the
+  workspace on a capture failure, the dirty artifacts are permanently lost —
+  they fall into none of {committed, captured, discarded_by_decision}.
+
+  This test kills the Worker with `:kill` (INV-ST-15's key exit reason),
+  injects a Ledger that always fails `capture/3`, and asserts the workspace
+  directory still exists.  The assertion fails because the current code
+  unconditionally reclaims the workspace.
+
+  ## AC linkage
+    - INV-ST-15: this test
+  """
+
+  use ExUnit.Case, async: false
+
+  @moduletag :capture_log
+
+  @janitor Tau.Factory.WorkspaceJanitor
+  @worker_registry Tau.Factory.WorkerRegistry
+  @worker_supervisor Tau.Factory.WorkerSupervisor
+
+  # ---------------------------------------------------------------------------
+  # FailingLedger — test-only GenServer that always returns {:error, _}
+  # for capture/3 calls, simulating a real Exqlite infra failure.
+  # All other calls return safe defaults so the Worker can start cleanly.
+  # ---------------------------------------------------------------------------
+
+  defmodule FailingLedger do
+    @moduledoc false
+    use GenServer
+
+    def start_link(opts) do
+      name = Keyword.fetch!(opts, :name)
+      GenServer.start_link(__MODULE__, %{}, name: name)
+    end
+
+    def child_spec(opts) do
+      name = Keyword.fetch!(opts, :name)
+
+      %{
+        id: name,
+        start: {__MODULE__, :start_link, [opts]},
+        type: :worker,
+        restart: :permanent,
+        shutdown: 5_000
+      }
+    end
+
+    @impl GenServer
+    def init(_opts), do: {:ok, %{}}
+
+    @impl GenServer
+    # Simulate the infra-failure path: capture always fails.
+    # This forces the janitor into its error branch.
+    def handle_call({:capture, _worker_id, _attrs}, _from, state),
+      do: {:reply, {:error, :simulated_ledger_failure}, state}
+
+    # Pass-through all other calls so start-up is clean.
+    def handle_call(_msg, _from, state), do: {:reply, {:ok, nil}, state}
+  end
+
+  # ---------------------------------------------------------------------------
+  # Hermetic git repo helpers
+  # ---------------------------------------------------------------------------
+
+  defp setup_git_repo(tmp_dir) do
+    repo_dir = Path.join(tmp_dir, "repo_#{System.unique_integer([:positive])}")
+    File.mkdir_p!(repo_dir)
+
+    git = fn args ->
+      System.cmd("git", args, cd: repo_dir, stderr_to_stdout: true)
+    end
+
+    {_, 0} = git.(["init", "-b", "main"])
+    {_, 0} = git.(["config", "user.email", "test@tau.test"])
+    {_, 0} = git.(["config", "user.name", "Tau Test"])
+    File.write!(Path.join(repo_dir, "README"), "initial\n")
+    {_, 0} = git.(["add", "README"])
+    {_, 0} = git.(["commit", "-m", "initial commit"])
+    {sha, 0} = git.(["rev-parse", "HEAD"])
+
+    %{repo_dir: repo_dir, base_ref: String.trim(sha)}
+  end
+
+  defp slow_agent_bin(tmp_dir) do
+    bin_path = Path.join(tmp_dir, "slow_inv_st15")
+
+    # `exec cat` replaces the shell so SIGKILL reaches the actual blocking
+    # process; `cat` with no args reads stdin and exits on EOF (Port close).
+    # This avoids leaking orphaned grandchild processes that hold the Port
+    # pipe FD open and stall BEAM shutdown after the suite finishes.
+    File.write!(bin_path, """
+    #!/bin/sh
+    exec cat
+    """)
+
+    File.chmod!(bin_path, 0o755)
+    bin_path
+  end
+
+  # ---------------------------------------------------------------------------
+  # INV-ST-15 — terminate/2 bypass: independent monitor must preserve workspace
+  # ---------------------------------------------------------------------------
+
+  describe "INV-ST-15 — terminate/2 bypass: independent monitor must not reclaim on capture failure" do
+    @tag :inv_st_15
+    test "INV-ST-15: Worker killed via :kill (terminate/2 bypassed) — janitor MUST preserve workspace when capture fails" do
+      # Entry point: WorkerSupervisor.spawn/5 — the real user-facing path.
+      # The path under test:
+      #   WorkerSupervisor.spawn → Worker.init (registers with janitor) →
+      #   Process.exit(worker_pid, :kill) → terminate/2 DOES NOT RUN →
+      #   janitor receives :DOWN(:killed) → janitor runs capture →
+      #   capture returns {:error, _} → janitor MUST NOT reclaim workspace.
+      #
+      # INV-ST-15 clause: "Capture MUST be done by an independent monitor
+      # process that survives :kill and all exit reasons."
+      #
+      # The critical implication: because terminate/2 is bypassed by :kill,
+      # the independent monitor is the SOLE agent responsible for cleanup.
+      # If the monitor cannot safely capture (Ledger failure), it MUST preserve
+      # the workspace rather than destroying dirty artifacts with no durable
+      # record — a reclaim without capture is a silent data loss.
+      #
+      # Current code (workspace_janitor.ex) calls reclaim_workspace/1
+      # unconditionally after the {:error, _} branch, destroying the workspace.
+      # This test FAILS against current code: File.dir?(ws) returns false
+      # because the janitor reclaimed the workspace despite capture failing.
+
+      tmp_dir =
+        System.tmp_dir!()
+        |> Path.join("tau_inv_st15_#{System.unique_integer([:positive])}")
+
+      File.mkdir_p!(tmp_dir)
+      on_exit(fn -> File.rm_rf!(tmp_dir) end)
+
+      %{repo_dir: repo_dir, base_ref: base_ref} = setup_git_repo(tmp_dir)
+      agent_bin = slow_agent_bin(tmp_dir)
+
+      n = System.unique_integer([:positive])
+
+      # Failing ledger: capture/3 always returns {:error, :simulated_ledger_failure}.
+      failing_ledger_name = :"inv_st15_failing_ledger_#{n}"
+
+      {:ok, _} =
+        start_supervised(
+          {FailingLedger, name: failing_ledger_name},
+          id: :"inv_st15_fl_sv_#{n}"
+        )
+
+      # Fleet (registry + supervisor).
+      registry_name = :"inv_st15_reg_#{n}"
+      sup_name = :"inv_st15_sup_#{n}"
+
+      {:ok, _} =
+        start_supervised(
+          {@worker_registry, name: registry_name},
+          id: :"inv_st15_rreg_#{n}"
+        )
+
+      {:ok, sup} =
+        start_supervised(
+          {@worker_supervisor, name: sup_name, registry: registry_name},
+          id: :"inv_st15_rsup_#{n}"
+        )
+
+      # Janitor wired to the failing ledger.
+      jan_name = :"inv_st15_jan_#{n}"
+
+      {:ok, jan_pid} =
+        start_supervised(
+          {@janitor, ledger: failing_ledger_name, name: jan_name, report_to: self()},
+          id: :"inv_st15_jan_sv_#{n}"
+        )
+
+      # Spawn the worker via the real entry point.
+      {:ok, worker_id} =
+        @worker_supervisor.spawn(sup, :implementer, "brief", base_ref,
+          repo_dir: repo_dir,
+          agent_bin: agent_bin,
+          registry: registry_name,
+          janitor: jan_pid
+        )
+
+      [{worker_pid, _}] = Registry.lookup(registry_name, worker_id)
+      assert Process.alive?(worker_pid), "INV-ST-15: worker must be alive before :kill"
+
+      {:ok, ws} = GenServer.call(worker_pid, :get_ws)
+      assert File.dir?(ws), "INV-ST-15: workspace must exist before :kill; ws=#{ws}"
+
+      # Write a dirty untracked artifact so the workspace is non-trivially dirty.
+      # This artifact must survive the :kill — it can only be recovered if the
+      # workspace is preserved (not reclaimed) after a capture failure.
+      artifact_content = "inv-st-15-artifact-#{System.unique_integer([:positive])}\n"
+      artifact_path = Path.join(ws, "inv_st15_artifact.txt")
+      File.write!(artifact_path, artifact_content)
+
+      # Confirm the artifact is visible in git status (untracked).
+      {status_out, _} =
+        System.cmd("git", ["status", "--short"], cd: ws, stderr_to_stdout: true)
+
+      assert String.contains?(status_out, "inv_st15_artifact.txt"),
+             "INV-ST-15: setup — dirty artifact must appear in git status; " <>
+               "status=#{inspect(status_out)}"
+
+      # Monitor the worker BEFORE sending :kill so the :DOWN message arrives
+      # in this test's mailbox regardless of timing.
+      worker_ref = Process.monitor(worker_pid)
+
+      # Kill the Worker with :kill.
+      # terminate/2 does NOT run on :kill — it is untrappable.
+      # The WorkspaceJanitor is the ONLY mechanism that observes this death.
+      Process.exit(worker_pid, :kill)
+
+      # Confirm the worker is truly dead by waiting for our own :DOWN.
+      # The worker may already be dead (race), so accept :noproc too.
+      receive do
+        {:DOWN, ^worker_ref, :process, ^worker_pid, reason}
+        when reason in [:killed, :noproc] ->
+          :ok
+      after
+        5_000 -> flunk("INV-ST-15: worker did not die within 5s after :kill")
+      end
+
+      # Allow the janitor's :DOWN handler to run.
+      # We do NOT assert on {:worker_exit, ...} because the current buggy
+      # implementation may or may not deliver it after unconditional reclaim;
+      # what matters is the workspace state.
+      Process.sleep(2_000)
+
+      # INV-ST-15 — core assertion:
+      # The independent monitor (janitor) received the :DOWN for :kill
+      # (terminate/2 was bypassed), attempted capture, got {:error, _} from
+      # the failing ledger, and MUST NOT have reclaimed the workspace.
+      #
+      # Correct behaviour: capture failure → preserve workspace intact so
+      # the operator can recover the dirty artifacts manually.
+      #
+      # Current buggy behaviour: unconditional reclaim_workspace(ws) call
+      # after the {:error, err} branch destroys the workspace regardless,
+      # making File.dir?(ws) return false — this assertion FAILS.
+      assert File.dir?(ws),
+             "INV-ST-15: capture failure on :kill path MUST NOT trigger reclaim. " <>
+               "The independent monitor (WorkspaceJanitor) is the sole agent for " <>
+               "workspace cleanup when terminate/2 is bypassed by :kill. " <>
+               "When the Ledger write fails, the monitor MUST preserve the workspace " <>
+               "rather than unconditionally destroying dirty artifacts. " <>
+               "Workspace #{ws} was reclaimed despite capture returning {:error, _}. " <>
+               "This violates INV-ST-15: cleanup registration in the monitor must be " <>
+               "conditional on durable record success, never unconditional on :kill."
+
+      # Secondary: the dirty artifact must be recoverable at the preserved workspace.
+      assert File.exists?(artifact_path),
+             "INV-ST-15: dirty artifact '#{artifact_path}' must still exist " <>
+               "in the preserved workspace after a :kill with capture failure. " <>
+               "The artifact was destroyed by unconditional reclaim, violating " <>
+               "the independent-monitor contract for INV-ST-15."
+    end
+  end
+end


### PR DESCRIPTION
Closes #575
Closes #610
Closes #570
Closes #576
Closes #592
Closes #593
Closes #595
Closes #637
Closes #663

Audit-invariant conformance; each issue body carries the finding.

## Gating-test paths

- test/tau/factory/oracle_spawn_order_test.exs

## Acceptance criteria

- **AC-11** — D-304 mechanism: WorkerSupervisor.spawn/5 accepts :author_id, records it in WorkerRegistry metadata (HR-7), and returns {:error, :same_identity_oracle_subject} when an :implementer spawn has the same :author_id as an already-registered :test_author.